### PR TITLE
fix(codex): default app-server to guardian mode

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -445,14 +445,14 @@ version tied to the bundled plugin instead of whichever separate Codex CLI
 happens to be installed locally. Set `appServer.command` only when you
 intentionally want to run a different executable.
 
-By default, OpenClaw starts local Codex harness sessions in YOLO mode:
-`approvalPolicy: "never"`, `approvalsReviewer: "user"`, and
-`sandbox: "danger-full-access"`. This is the trusted local operator posture used
-for autonomous heartbeats: Codex can use shell and network tools without
-stopping on native approval prompts that nobody is around to answer.
+By default, OpenClaw starts local Codex harness sessions in guardian mode:
+`approvalPolicy: "on-request"`, `approvalsReviewer: "auto_review"`, and
+`sandbox: "workspace-write"`. This keeps native Codex tool use bounded to the
+workspace and routes sandbox escapes, network access, and other native
+permission requests through Codex's reviewer.
 
-To opt in to Codex guardian-reviewed approvals, set `appServer.mode:
-"guardian"`:
+To opt in to fully unchained local execution for a trusted local-only
+deployment, set `appServer.mode: "yolo"`:
 
 ```json5
 {
@@ -462,7 +462,7 @@ To opt in to Codex guardian-reviewed approvals, set `appServer.mode:
         enabled: true,
         config: {
           appServer: {
-            mode: "guardian",
+            mode: "yolo",
             serviceTier: "fast",
           },
         },
@@ -472,12 +472,16 @@ To opt in to Codex guardian-reviewed approvals, set `appServer.mode:
 }
 ```
 
+YOLO mode expands to `approvalPolicy: "never"`, `approvalsReviewer: "user"`,
+and `sandbox: "danger-full-access"`. Use it only when prompts reaching the
+Codex harness are trusted enough to run native shell, filesystem, and network
+tools on the host without approval prompts.
+
 Guardian mode uses Codex's native auto-review approval path. When Codex asks to
 leave the sandbox, write outside the workspace, or add permissions like network
 access, Codex routes that approval request to the native reviewer instead of a
 human prompt. The reviewer applies Codex's risk framework and approves or denies
-the specific request. Use Guardian when you want more guardrails than YOLO mode
-but still need unattended agents to make progress.
+the specific request.
 
 The `guardian` preset expands to `approvalPolicy: "on-request"`,
 `approvalsReviewer: "auto_review"`, and `sandbox: "workspace-write"`.
@@ -519,10 +523,10 @@ Supported `appServer` fields:
 | `authToken`         | unset                                    | Bearer token for WebSocket transport.                                                                        |
 | `headers`           | `{}`                                     | Extra WebSocket headers.                                                                                     |
 | `requestTimeoutMs`  | `60000`                                  | Timeout for app-server control-plane calls.                                                                  |
-| `mode`              | `"yolo"`                                 | Preset for YOLO or guardian-reviewed execution.                                                              |
-| `approvalPolicy`    | `"never"`                                | Native Codex approval policy sent to thread start/resume/turn.                                               |
-| `sandbox`           | `"danger-full-access"`                   | Native Codex sandbox mode sent to thread start/resume.                                                       |
-| `approvalsReviewer` | `"user"`                                 | Use `"auto_review"` to let Codex review native approval prompts. `guardian_subagent` remains a legacy alias. |
+| `mode`              | `"guardian"`                             | Preset for guardian-reviewed execution or explicit YOLO local execution.                                     |
+| `approvalPolicy`    | mode-derived                             | Native Codex approval policy sent to thread start/resume/turn.                                               |
+| `sandbox`           | mode-derived                             | Native Codex sandbox mode sent to thread start/resume.                                                       |
+| `approvalsReviewer` | mode-derived                             | Use `"auto_review"` to let Codex review native approval prompts. `guardian_subagent` remains a legacy alias. |
 | `serviceTier`       | unset                                    | Optional Codex app-server service tier: `"fast"`, `"flex"`, or `null`. Invalid legacy values are ignored.    |
 
 Environment overrides remain available for local testing:

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -86,7 +86,7 @@
           "mode": {
             "type": "string",
             "enum": ["yolo", "guardian"],
-            "default": "yolo"
+            "default": "guardian"
           },
           "transport": {
             "type": "string",
@@ -200,7 +200,7 @@
     },
     "appServer.mode": {
       "label": "Execution Mode",
-      "help": "Use yolo for unchained local execution or guardian for Codex guardian-reviewed approvals.",
+      "help": "Use guardian for Codex guardian-reviewed approvals or yolo for explicitly unchained local execution.",
       "advanced": true
     },
     "appServer.transport": {
@@ -241,17 +241,17 @@
     },
     "appServer.approvalPolicy": {
       "label": "Approval Policy",
-      "help": "Codex native approval policy sent to thread start, resume, and turns.",
+      "help": "Codex native approval policy sent to thread start, resume, and turns. Defaults are derived from appServer.mode.",
       "advanced": true
     },
     "appServer.sandbox": {
       "label": "Sandbox",
-      "help": "Codex native sandbox mode sent to thread start and resume.",
+      "help": "Codex native sandbox mode sent to thread start and resume. Defaults are derived from appServer.mode.",
       "advanced": true
     },
     "appServer.approvalsReviewer": {
       "label": "Approvals Reviewer",
-      "help": "Use user approvals or Codex auto_review for native app-server approvals. guardian_subagent remains accepted for compatibility.",
+      "help": "Use Codex auto_review or user approvals for native app-server approvals. Defaults are derived from appServer.mode; guardian_subagent remains accepted for compatibility.",
       "advanced": true
     },
     "appServer.serviceTier": {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -87,7 +87,7 @@ describe("Codex app-server config", () => {
     ).toThrow("appServer.url is required");
   });
 
-  it("defaults native Codex approvals to unchained local execution", () => {
+  it("defaults native Codex approvals to guardian-reviewed workspace execution", () => {
     const runtime = resolveCodexAppServerRuntimeOptions({
       pluginConfig: {},
       env: {},
@@ -95,9 +95,9 @@ describe("Codex app-server config", () => {
 
     expect(runtime).toEqual(
       expect.objectContaining({
-        approvalPolicy: "never",
-        sandbox: "danger-full-access",
-        approvalsReviewer: "user",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        approvalsReviewer: "auto_review",
         start: expect.objectContaining({
           command: "codex",
           commandSource: "managed",
@@ -174,11 +174,11 @@ describe("Codex app-server config", () => {
     );
   });
 
-  it("allows plugin config to opt in to guardian-reviewed local execution", () => {
+  it("allows plugin config to opt in to unchained local execution", () => {
     const runtime = resolveCodexAppServerRuntimeOptions({
       pluginConfig: {
         appServer: {
-          mode: "guardian",
+          mode: "yolo",
         },
       },
       env: {},
@@ -186,24 +186,24 @@ describe("Codex app-server config", () => {
 
     expect(runtime).toEqual(
       expect.objectContaining({
-        approvalPolicy: "on-request",
-        sandbox: "workspace-write",
-        approvalsReviewer: "auto_review",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        approvalsReviewer: "user",
       }),
     );
   });
 
-  it("allows environment mode fallback to opt in to guardian-reviewed local execution", () => {
+  it("allows environment mode fallback to opt in to unchained local execution", () => {
     const runtime = resolveCodexAppServerRuntimeOptions({
       pluginConfig: {},
-      env: { OPENCLAW_CODEX_APP_SERVER_MODE: "guardian" },
+      env: { OPENCLAW_CODEX_APP_SERVER_MODE: "yolo" },
     });
 
     expect(runtime).toEqual(
       expect.objectContaining({
-        approvalPolicy: "on-request",
-        sandbox: "workspace-write",
-        approvalsReviewer: "auto_review",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        approvalsReviewer: "user",
       }),
     );
   });
@@ -223,7 +223,7 @@ describe("Codex app-server config", () => {
     ).toBe("guardian_subagent");
   });
 
-  it("ignores removed OPENCLAW_CODEX_APP_SERVER_GUARDIAN fallback", () => {
+  it("ignores removed OPENCLAW_CODEX_APP_SERVER_GUARDIAN fallback without downgrading defaults", () => {
     const runtime = resolveCodexAppServerRuntimeOptions({
       pluginConfig: {},
       env: { OPENCLAW_CODEX_APP_SERVER_GUARDIAN: "1" },
@@ -231,9 +231,9 @@ describe("Codex app-server config", () => {
 
     expect(runtime).toEqual(
       expect.objectContaining({
-        approvalPolicy: "never",
-        sandbox: "danger-full-access",
-        approvalsReviewer: "user",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        approvalsReviewer: "auto_review",
       }),
     );
   });
@@ -327,6 +327,7 @@ describe("Codex app-server config", () => {
     const appServerProperties = manifest.configSchema.properties.appServer.properties;
 
     expect(appServerProperties.command?.default).toBeUndefined();
+    expect(appServerProperties.mode?.default).toBe("guardian");
     expect(appServerProperties.approvalPolicy?.default).toBeUndefined();
     expect(appServerProperties.sandbox?.default).toBeUndefined();
     expect(appServerProperties.approvalsReviewer?.default).toBeUndefined();

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -193,7 +193,7 @@ export function resolveCodexAppServerRuntimeOptions(
   const policyMode =
     resolvePolicyMode(config.mode) ??
     resolvePolicyMode(env.OPENCLAW_CODEX_APP_SERVER_MODE) ??
-    "yolo";
+    "guardian";
   const serviceTier = resolveServiceTier(config.serviceTier);
   if (transport === "websocket" && !url) {
     throw new Error(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -784,9 +784,9 @@ describe("runCodexAppServerAttempt", () => {
           method: "thread/start",
           params: expect.objectContaining({
             model: "gpt-5.4-codex",
-            approvalPolicy: "never",
-            sandbox: "danger-full-access",
-            approvalsReviewer: "user",
+            approvalPolicy: "on-request",
+            sandbox: "workspace-write",
+            approvalsReviewer: "auto_review",
             developerInstructions: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
           }),
         },
@@ -1358,9 +1358,9 @@ describe("runCodexAppServerAttempt", () => {
     expectResumeRequest(requests, {
       threadId: "thread-existing",
       model: "gpt-5.4-codex",
-      approvalPolicy: "never",
-      approvalsReviewer: "user",
-      sandbox: "danger-full-access",
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+      sandbox: "workspace-write",
       developerInstructions: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
       persistExtendedHistory: true,
     });


### PR DESCRIPTION
## Summary

- Problem: Codex app-server defaulted to YOLO mode, which resolved to `approvalPolicy: "never"` and `sandbox: "danger-full-access"` when operators did not set explicit config.
- Why it matters: enabling the Codex harness could expose native shell/filesystem/network tool use without approvals or workspace sandboxing by default.
- What changed: default app-server mode is now `guardian`, resolving to `on-request`, `workspace-write`, and `auto_review`; `yolo` remains available as an explicit opt-in.
- What did NOT change (scope boundary): explicit `approvalPolicy`, `sandbox`, `approvalsReviewer`, and `mode: "yolo"` settings still override the default.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the app-server policy preset default fell back to `yolo`, and the derived runtime defaults disabled native Codex approvals and sandboxing.
- Missing detection / guardrail: config tests asserted the unsafe default instead of locking in the guarded default.
- Contributing context (if known): guardian mode existed but required opt-in.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/config.test.ts`, `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: empty config/env resolves to guardian-reviewed workspace execution and thread start/resume requests carry the guarded defaults.
- Why this is the smallest reliable guardrail: these tests cover the resolver and the app-server request boundary where the defaults become runtime behavior.
- Existing test that already covers this (if any): existing config/run-attempt tests were updated from unsafe expectations.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex app-server sessions now default to `guardian` mode. Operators who want previous unchained behavior must set `plugins.entries.codex.config.appServer.mode: "yolo"` or equivalent explicit policy fields.

## Diagram (if applicable)

```text
Before:
[empty appServer config] -> [mode yolo] -> [never approvals + danger-full-access]

After:
[empty appServer config] -> [mode guardian] -> [on-request approvals + workspace-write + auto_review]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: this reduces the default Codex native command/tool surface by requiring approvals for permission expansion and using workspace-write sandboxing unless the operator explicitly opts into YOLO mode.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm checkout
- Model/provider: Codex app-server config resolver/tests
- Integration/channel (if any): N/A
- Relevant config (redacted): empty `pluginConfig` and empty env for default-policy checks

### Steps

1. Resolve `resolveCodexAppServerRuntimeOptions({ pluginConfig: {}, env: {} })`.
2. Start/resume a Codex app-server attempt with no app-server policy config.
3. Inspect request payloads sent to `thread/start` and `thread/resume`.

### Expected

- Defaults resolve to `approvalPolicy: "on-request"`, `sandbox: "workspace-write"`, and `approvalsReviewer: "auto_review"`.

### Actual

- Before this patch, defaults resolved to `approvalPolicy: "never"`, `sandbox: "danger-full-access"`, and `approvalsReviewer: "user"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: default resolver output, explicit `mode: "yolo"` opt-in, env `OPENCLAW_CODEX_APP_SERVER_MODE=yolo`, thread start/resume default payloads.
- Edge cases checked: explicit policy fields still override `guardian`; removed `OPENCLAW_CODEX_APP_SERVER_GUARDIAN=1` does not downgrade defaults; manifest does not schema-default mode-derived fields.
- What you did **not** verify: full app-server end-to-end execution against a live Codex binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes, for explicit configs; default behavior changes intentionally.
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) Only for operators relying on implicit YOLO behavior.
- If yes, exact upgrade steps: set `plugins.entries.codex.config.appServer.mode: "yolo"` to keep prior unchained defaults, or set explicit `approvalPolicy`, `sandbox`, and `approvalsReviewer` values.

## Risks and Mitigations

- Risk: unattended Codex runs may pause or take safer paths where they previously ran without native approval gates.
  - Mitigation: document explicit `mode: "yolo"` opt-in for trusted local-only deployments that need the old behavior.
