### PR TITLE
fix: clean up bundled LSP process trees on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Docs: https://docs.openclaw.ai
 - Channels/Yuanbao: register the Tencent Yuanbao external channel plugin (`openclaw-plugin-yuanbao`) in the official channel catalog, contract suites, and community plugin docs, with a new `docs/channels/yuanbao.md` quick-start guide for WebSocket bot DMs and group chats. (#72756) Thanks @loongfay.
 - Channels/QQBot: add full group chat support (history tracking, @-mention gating, activation modes, per-group config, FIFO message queue with deliver debounce), C2C `stream_messages` streaming with a `StreamingController` lifecycle manager, unified `sendMedia` with chunked upload for large files, and refactor the engine into pipeline stages, focused outbound submodules, builtin slash-command modules, and explicit DI ports via `createEngineAdapters()`. (#70624) Thanks @cxyhhhhh.
 
+### Fixes
+
+- Agents/LSP: terminate bundled stdio LSP process trees during runtime disposal and Gateway shutdown, so nested children such as `tsserver` do not survive stop or restart. Fixes #72357. Thanks @ai-hpc and @bittoby.
+
 ## 2026.4.26
 
 ### Changes

--- a/src/agents/pi-bundle-lsp-runtime.test.ts
+++ b/src/agents/pi-bundle-lsp-runtime.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+const killProcessTreeMock = vi.hoisted(() => vi.fn());
+const loadEmbeddedPiLspConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => ({
+  ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
+  spawn: spawnMock,
+}));
+
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
+
+vi.mock("./embedded-pi-lsp.js", () => ({
+  loadEmbeddedPiLspConfig: loadEmbeddedPiLspConfigMock,
+}));
+
+vi.mock("../logger.js", () => ({
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+function encodeLspMessage(body: unknown): string {
+  const json = JSON.stringify(body);
+  return `Content-Length: ${Buffer.byteLength(json, "utf-8")}\r\n\r\n${json}`;
+}
+
+function parseWrittenLspBody(text: string): Record<string, unknown> | null {
+  const bodyStart = text.indexOf("\r\n\r\n");
+  if (bodyStart === -1) {
+    return null;
+  }
+  return JSON.parse(text.slice(bodyStart + 4)) as Record<string, unknown>;
+}
+
+class MockChildProcess extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  pid = 4321;
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly stdin: Writable;
+
+  constructor() {
+    super();
+    this.stdin = new Writable({
+      write: (chunk, _encoding, callback) => {
+        this.respondToRequest(chunk.toString("utf8"));
+        callback();
+      },
+    });
+  }
+
+  kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
+    this.killed = true;
+    this.signalCode = signal;
+    this.emit("exit", null, signal);
+    this.emit("close", null, signal);
+    return true;
+  });
+
+  private respondToRequest(text: string): void {
+    const body = parseWrittenLspBody(text);
+    if (!body || typeof body.id !== "number" || typeof body.method !== "string") {
+      return;
+    }
+    const result = body.method === "initialize" ? { capabilities: { hoverProvider: true } } : null;
+    queueMicrotask(() => {
+      this.stdout.write(encodeLspMessage({ jsonrpc: "2.0", id: body.id, result }));
+    });
+  }
+}
+
+function configureSingleLspServer(): void {
+  loadEmbeddedPiLspConfigMock.mockReturnValue({
+    lspServers: {
+      typescript: {
+        command: "typescript-language-server",
+        args: ["--stdio"],
+      },
+    },
+    diagnostics: [],
+  });
+}
+
+describe("bundle LSP runtime", () => {
+  afterEach(async () => {
+    const { disposeAllBundleLspRuntimes } = await import("./pi-bundle-lsp-runtime.js");
+    await disposeAllBundleLspRuntimes();
+    spawnMock.mockReset();
+    killProcessTreeMock.mockReset();
+    loadEmbeddedPiLspConfigMock.mockReset();
+  });
+
+  it("starts LSP servers in a disposable process group", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime } = await import("./pi-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "typescript-language-server",
+      ["--stdio"],
+      expect.objectContaining({
+        detached: process.platform !== "win32",
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: process.platform === "win32",
+      }),
+    );
+    expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
+
+    await runtime.dispose();
+
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
+  });
+
+  it("disposes active LSP sessions from the global shutdown sweep", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime, disposeAllBundleLspRuntimes } =
+      await import("./pi-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+
+    await disposeAllBundleLspRuntimes();
+
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
+
+    killProcessTreeMock.mockClear();
+    await runtime.dispose();
+    expect(killProcessTreeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -3,11 +3,13 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logDebug, logWarn } from "../logger.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import { killProcessTree } from "../process/kill-tree.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { loadEmbeddedPiLspConfig } from "./embedded-pi-lsp.js";
 import {
   resolveStdioMcpServerLaunchConfig,
   describeStdioMcpServerLaunchConfig,
+  type StdioMcpServerLaunchConfig,
 } from "./mcp-stdio.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -17,10 +19,17 @@ type LspSession = {
   serverName: string;
   process: ChildProcess;
   requestId: number;
-  pendingRequests: Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>;
+  pendingRequests: Map<number, PendingLspRequest>;
   buffer: string;
   initialized: boolean;
   capabilities: LspServerCapabilities;
+  disposed: boolean;
+};
+
+type PendingLspRequest = {
+  resolve: (v: unknown) => void;
+  reject: (e: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
 };
 
 type LspServerCapabilities = {
@@ -43,6 +52,55 @@ type LspPositionParams = {
   line: number;
   character: number;
 };
+
+const LSP_SHUTDOWN_GRACE_MS = 500;
+const LSP_PROCESS_TREE_KILL_GRACE_MS = 1_000;
+const activeBundleLspSessions = new Set<LspSession>();
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, Math.max(1, ms));
+    timeout.unref?.();
+  });
+}
+
+function spawnLspServerProcess(config: StdioMcpServerLaunchConfig): ChildProcess {
+  return spawn(config.command, config.args ?? [], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, ...config.env },
+    cwd: config.cwd,
+    detached: process.platform !== "win32",
+    windowsHide: process.platform === "win32",
+  });
+}
+
+function createLspSession(serverName: string, child: ChildProcess): LspSession {
+  return {
+    serverName,
+    process: child,
+    requestId: 0,
+    pendingRequests: new Map(),
+    buffer: "",
+    initialized: false,
+    capabilities: {},
+    disposed: false,
+  };
+}
+
+function registerActiveLspSession(session: LspSession): void {
+  activeBundleLspSessions.add(session);
+}
+
+function attachLspProcessHandlers(session: LspSession): void {
+  session.process.stdout?.setEncoding("utf-8");
+  session.process.stdout?.on("data", (chunk: string) => handleIncomingData(session, chunk));
+  session.process.stderr?.setEncoding("utf-8");
+  session.process.stderr?.on("data", (chunk: string) => {
+    for (const line of chunk.split(/\r?\n/).filter(Boolean)) {
+      logDebug(`bundle-lsp:${session.serverName}: ${line.trim()}`);
+    }
+  });
+}
 
 function encodeLspMessage(body: unknown): string {
   const json = JSON.stringify(body);
@@ -89,18 +147,17 @@ function parseLspMessages(buffer: string): { messages: unknown[]; remaining: str
 function sendRequest(session: LspSession, method: string, params?: unknown): Promise<unknown> {
   const id = ++session.requestId;
   return new Promise((resolve, reject) => {
-    session.pendingRequests.set(id, { resolve, reject });
-    const message = { jsonrpc: "2.0", id, method, params };
-    const encoded = encodeLspMessage(message);
-    session.process.stdin?.write(encoded, "utf-8");
-
-    // Timeout after 10 seconds
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       if (session.pendingRequests.has(id)) {
         session.pendingRequests.delete(id);
         reject(new Error(`LSP request ${method} timed out`));
       }
     }, 10_000);
+    timeout.unref?.();
+    session.pendingRequests.set(id, { resolve, reject, timeout });
+    const message = { jsonrpc: "2.0", id, method, params };
+    const encoded = encodeLspMessage(message);
+    session.process.stdin?.write(encoded, "utf-8");
   });
 }
 
@@ -119,6 +176,7 @@ function handleIncomingData(session: LspSession, chunk: string) {
       const pending = session.pendingRequests.get(record.id);
       if (pending) {
         session.pendingRequests.delete(record.id);
+        clearTimeout(pending.timeout);
         if ("error" in record) {
           pending.reject(new Error(JSON.stringify(record.error)));
         } else {
@@ -157,10 +215,32 @@ async function initializeSession(session: LspSession): Promise<LspServerCapabili
   return result?.capabilities ?? {};
 }
 
+function hasLspProcessExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function terminateLspProcessTree(session: LspSession): void {
+  const pid = session.process.pid;
+  if (pid && !hasLspProcessExited(session.process)) {
+    killProcessTree(pid, { graceMs: LSP_PROCESS_TREE_KILL_GRACE_MS });
+    return;
+  }
+  if (!hasLspProcessExited(session.process)) {
+    session.process.kill("SIGTERM");
+  }
+}
+
 async function disposeSession(session: LspSession) {
+  if (session.disposed) {
+    return;
+  }
+  session.disposed = true;
+  activeBundleLspSessions.delete(session);
+
   if (session.initialized) {
     try {
-      await sendRequest(session, "shutdown").catch(() => {});
+      const shutdown = sendRequest(session, "shutdown").catch(() => undefined);
+      await Promise.race([shutdown, delay(LSP_SHUTDOWN_GRACE_MS)]);
       session.process.stdin?.write(
         encodeLspMessage({ jsonrpc: "2.0", method: "exit", params: null }),
         "utf-8",
@@ -170,10 +250,15 @@ async function disposeSession(session: LspSession) {
     }
   }
   for (const [, pending] of session.pendingRequests) {
+    clearTimeout(pending.timeout);
     pending.reject(new Error("LSP session disposed"));
   }
   session.pendingRequests.clear();
-  session.process.kill();
+  terminateLspProcessTree(session);
+}
+
+async function disposeSessions(sessions: Iterable<LspSession>): Promise<void> {
+  await Promise.allSettled(Array.from(sessions, (session) => disposeSession(session)));
 }
 
 function createLspPositionTool(params: {
@@ -325,32 +410,12 @@ export async function createBundleLspToolRuntime(params: {
         continue;
       }
       const launchConfig = launch.config;
+      let session: LspSession | undefined;
 
       try {
-        const child = spawn(launchConfig.command, launchConfig.args ?? [], {
-          stdio: ["pipe", "pipe", "pipe"],
-          env: { ...process.env, ...launchConfig.env },
-          cwd: launchConfig.cwd,
-        });
-
-        const session: LspSession = {
-          serverName,
-          process: child,
-          requestId: 0,
-          pendingRequests: new Map(),
-          buffer: "",
-          initialized: false,
-          capabilities: {},
-        };
-
-        child.stdout?.setEncoding("utf-8");
-        child.stdout?.on("data", (chunk: string) => handleIncomingData(session, chunk));
-        child.stderr?.setEncoding("utf-8");
-        child.stderr?.on("data", (chunk: string) => {
-          for (const line of chunk.split(/\r?\n/).filter(Boolean)) {
-            logDebug(`bundle-lsp:${serverName}: ${line.trim()}`);
-          }
-        });
+        session = createLspSession(serverName, spawnLspServerProcess(launchConfig));
+        registerActiveLspSession(session);
+        attachLspProcessHandlers(session);
 
         const capabilities = await initializeSession(session);
         session.capabilities = capabilities;
@@ -380,6 +445,9 @@ export async function createBundleLspToolRuntime(params: {
           `bundle-lsp: started "${serverName}" (${describeStdioMcpServerLaunchConfig(launchConfig)}) with ${serverTools.length} tools`,
         );
       } catch (error) {
+        if (session) {
+          await disposeSession(session);
+        }
         logWarn(
           `bundle-lsp: failed to start server "${serverName}" (${describeStdioMcpServerLaunchConfig(launchConfig)}): ${String(error)}`,
         );
@@ -393,11 +461,15 @@ export async function createBundleLspToolRuntime(params: {
         capabilities: s.capabilities,
       })),
       dispose: async () => {
-        await Promise.allSettled(sessions.map((session) => disposeSession(session)));
+        await disposeSessions(sessions);
       },
     };
   } catch (error) {
-    await Promise.allSettled(sessions.map((session) => disposeSession(session)));
+    await disposeSessions(sessions);
     throw error;
   }
+}
+
+export async function disposeAllBundleLspRuntimes(): Promise<void> {
+  await disposeSessions(activeBundleLspSessions);
 }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -65,6 +65,12 @@ const { createGatewayCloseHandler } = await import("./server-close.js");
 type GatewayCloseHandlerParams = Parameters<typeof createGatewayCloseHandler>[0];
 type GatewayCloseClient = GatewayCloseHandlerParams["clients"] extends Set<infer T> ? T : never;
 
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 function createGatewayCloseTestDeps(
   overrides: Partial<GatewayCloseHandlerParams> = {},
 ): GatewayCloseHandlerParams {
@@ -217,6 +223,32 @@ describe("createGatewayCloseHandler", () => {
     expect(mocks.disposeAgentHarnesses).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllBundleLspRuntimes).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts bundle MCP and LSP runtime disposal concurrently", async () => {
+    const disposalOrder: string[] = [];
+    let releaseMcp: (() => void) | undefined;
+    const mcpBlocked = new Promise<void>((resolve) => {
+      releaseMcp = resolve;
+    });
+    mocks.disposeAllSessionMcpRuntimes.mockImplementation(async () => {
+      disposalOrder.push("mcp-start");
+      await mcpBlocked;
+      disposalOrder.push("mcp-end");
+    });
+    mocks.disposeAllBundleLspRuntimes.mockImplementation(async () => {
+      disposalOrder.push("lsp-start");
+    });
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+
+    const closePromise = close({ reason: "test shutdown" });
+    try {
+      await flushMicrotasks();
+      expect(disposalOrder).toEqual(["mcp-start", "lsp-start"]);
+    } finally {
+      releaseMcp?.();
+      await closePromise;
+    }
   });
 
   it("continues shutdown when bundle MCP runtime disposal hangs", async () => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -8,6 +8,7 @@ const mocks = {
   disposeAgentHarnesses: vi.fn(async () => undefined),
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_event) => undefined),
+  disposeAllBundleLspRuntimes: vi.fn(async () => undefined),
 };
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
@@ -45,6 +46,13 @@ vi.mock("../agents/pi-bundle-mcp-tools.js", async () => ({
     "../agents/pi-bundle-mcp-tools.js",
   )),
   disposeAllSessionMcpRuntimes: mocks.disposeAllSessionMcpRuntimes,
+}));
+
+vi.mock("../agents/pi-bundle-lsp-runtime.js", async () => ({
+  ...(await vi.importActual<typeof import("../agents/pi-bundle-lsp-runtime.js")>(
+    "../agents/pi-bundle-lsp-runtime.js",
+  )),
+  disposeAllBundleLspRuntimes: mocks.disposeAllBundleLspRuntimes,
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
@@ -105,6 +113,8 @@ describe("createGatewayCloseHandler", () => {
     mocks.disposeAllSessionMcpRuntimes.mockResolvedValue(undefined);
     mocks.triggerInternalHook.mockReset();
     mocks.triggerInternalHook.mockResolvedValue(undefined);
+    mocks.disposeAllBundleLspRuntimes.mockClear();
+    mocks.disposeAllBundleLspRuntimes.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -206,6 +216,7 @@ describe("createGatewayCloseHandler", () => {
     expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAgentHarnesses).toHaveBeenCalledTimes(1);
     expect(mocks.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
+    expect(mocks.disposeAllBundleLspRuntimes).toHaveBeenCalledTimes(1);
   });
 
   it("continues shutdown when bundle MCP runtime disposal hangs", async () => {
@@ -220,6 +231,22 @@ describe("createGatewayCloseHandler", () => {
     expect(
       mocks.logWarn.mock.calls.some(([message]) =>
         String(message).includes("bundle-mcp runtime disposal exceeded 5000ms"),
+      ),
+    ).toBe(true);
+  });
+
+  it("continues shutdown when bundle LSP runtime disposal hangs", async () => {
+    vi.useFakeTimers();
+    mocks.disposeAllBundleLspRuntimes.mockReturnValue(new Promise(() => undefined));
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+
+    const closePromise = close({ reason: "test shutdown" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await closePromise;
+
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("bundle-lsp runtime disposal exceeded 5000ms"),
       ),
     ).toBe(true);
   });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -65,12 +65,6 @@ const { createGatewayCloseHandler } = await import("./server-close.js");
 type GatewayCloseHandlerParams = Parameters<typeof createGatewayCloseHandler>[0];
 type GatewayCloseClient = GatewayCloseHandlerParams["clients"] extends Set<infer T> ? T : never;
 
-async function flushMicrotasks(times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await Promise.resolve();
-  }
-}
-
 function createGatewayCloseTestDeps(
   overrides: Partial<GatewayCloseHandlerParams> = {},
 ): GatewayCloseHandlerParams {
@@ -243,7 +237,9 @@ describe("createGatewayCloseHandler", () => {
 
     const closePromise = close({ reason: "test shutdown" });
     try {
-      await flushMicrotasks();
+      await vi.waitFor(() => {
+        expect(disposalOrder).toContain("lsp-start");
+      });
       expect(disposalOrder).toEqual(["mcp-start", "lsp-start"]);
     } finally {
       releaseMcp?.();

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -223,16 +223,18 @@ export function createGatewayCloseHandler(params: {
         await params.stopChannel(plugin.id);
       }
       await disposeRegisteredAgentHarnesses();
-      await disposeRuntimeWithShutdownGrace({
-        label: "bundle-mcp",
-        dispose: params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes,
-        graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
-      });
-      await disposeRuntimeWithShutdownGrace({
-        label: "bundle-lsp",
-        dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimes,
-        graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
-      });
+      await Promise.all([
+        disposeRuntimeWithShutdownGrace({
+          label: "bundle-mcp",
+          dispose: params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes,
+          graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
+        }),
+        disposeRuntimeWithShutdownGrace({
+          label: "bundle-lsp",
+          dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimes,
+          graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
+        }),
+      ]);
       if (params.pluginServices) {
         await params.pluginServices.stop().catch(() => {});
       }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,6 +1,7 @@
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
+import { disposeAllBundleLspRuntimes } from "../agents/pi-bundle-lsp-runtime.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -19,6 +20,7 @@ const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
 const HTTP_CLOSE_GRACE_MS = 1_000;
 const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
 const MCP_RUNTIME_CLOSE_GRACE_MS = 5_000;
+const LSP_RUNTIME_CLOSE_GRACE_MS = 5_000;
 
 function createTimeoutRace<T>(timeoutMs: number, onTimeout: () => T) {
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -75,6 +77,25 @@ async function triggerGatewayLifecycleHookWithTimeout(params: {
   }
 }
 
+async function disposeRuntimeWithShutdownGrace(params: {
+  label: "bundle-mcp" | "bundle-lsp";
+  dispose: () => Promise<void>;
+  graceMs: number;
+}): Promise<void> {
+  const disposePromise = Promise.resolve()
+    .then(params.dispose)
+    .catch((err: unknown) => {
+      shutdownLog.warn(`${params.label} runtime disposal failed during shutdown: ${String(err)}`);
+    });
+  const disposeTimeout = createTimeoutRace(params.graceMs, () => {
+    shutdownLog.warn(
+      `${params.label} runtime disposal exceeded ${params.graceMs}ms; continuing shutdown`,
+    );
+  });
+  await Promise.race([disposePromise, disposeTimeout.promise]);
+  disposeTimeout.clear();
+}
+
 export async function runGatewayClosePrelude(params: {
   stopDiagnostics?: () => void;
   clearSkillsRefreshTimer?: () => void;
@@ -115,6 +136,7 @@ export function createGatewayCloseHandler(params: {
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
   disposeSessionMcpRuntimes?: () => Promise<void>;
+  disposeBundleLspRuntimes?: () => Promise<void>;
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
@@ -201,17 +223,16 @@ export function createGatewayCloseHandler(params: {
         await params.stopChannel(plugin.id);
       }
       await disposeRegisteredAgentHarnesses();
-      const disposeMcpRuntimes = params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes;
-      const mcpDisposePromise = disposeMcpRuntimes().catch((err: unknown) => {
-        shutdownLog.warn(`bundle-mcp runtime disposal failed during shutdown: ${String(err)}`);
+      await disposeRuntimeWithShutdownGrace({
+        label: "bundle-mcp",
+        dispose: params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes,
+        graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
       });
-      const mcpDisposeTimeout = createTimeoutRace(MCP_RUNTIME_CLOSE_GRACE_MS, () => {
-        shutdownLog.warn(
-          `bundle-mcp runtime disposal exceeded ${MCP_RUNTIME_CLOSE_GRACE_MS}ms; continuing shutdown`,
-        );
+      await disposeRuntimeWithShutdownGrace({
+        label: "bundle-lsp",
+        dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimes,
+        graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
       });
-      await Promise.race([mcpDisposePromise, mcpDisposeTimeout.promise]);
-      mcpDisposeTimeout.clear();
       if (params.pluginServices) {
         await params.pluginServices.stop().catch(() => {});
       }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,7 +1,6 @@
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
-import { disposeAllBundleLspRuntimes } from "../agents/pi-bundle-lsp-runtime.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -94,6 +93,11 @@ async function disposeRuntimeWithShutdownGrace(params: {
   });
   await Promise.race([disposePromise, disposeTimeout.promise]);
   disposeTimeout.clear();
+}
+
+async function disposeAllBundleLspRuntimesOnDemand(): Promise<void> {
+  const { disposeAllBundleLspRuntimes } = await import("../agents/pi-bundle-lsp-runtime.js");
+  await disposeAllBundleLspRuntimes();
 }
 
 export async function runGatewayClosePrelude(params: {
@@ -231,7 +235,7 @@ export function createGatewayCloseHandler(params: {
         }),
         disposeRuntimeWithShutdownGrace({
           label: "bundle-lsp",
-          dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimes,
+          dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimesOnDemand,
           graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
         }),
       ]);


### PR DESCRIPTION
## Summary

- Problem: Bundled stdio LSP servers could leave nested child processes such as `tsserver` running after run cleanup or Gateway shutdown.
- Why it matters: Orphaned language-server children can keep consuming memory after OpenClaw has stopped or restarted.
- What changed: Bundle LSP servers now spawn as disposable process groups, cleanup terminates the process tree, and Gateway shutdown sweeps active bundle LSP runtimes with bounded grace handling.
- What did NOT change (scope boundary): No plugin manifest format, LSP tool schema, model/provider routing, or user config behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72357
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Bundle LSP disposal only terminated the immediate LSP process, and Gateway shutdown did not have a global active bundle-LSP runtime sweep.
- Missing detection / guardrail: There was no regression test proving nested LSP process trees are terminated or that Gateway shutdown invokes bundle-LSP cleanup.
- Contributing context (if known): Existing Gateway shutdown already swept bundle MCP runtimes, but bundle LSP runtimes were per-run only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/pi-bundle-lsp-runtime.test.ts`, `src/gateway/server-close.test.ts`
- Scenario the test should lock in: Bundle LSP processes are spawned as disposable process groups, cleanup uses process-tree termination, and Gateway shutdown calls the active bundle-LSP sweep.
- Why this is the smallest reliable guardrail: The bug is in local runtime lifecycle and Gateway shutdown plumbing, so mocked process and shutdown tests cover the failing contract without a live TypeScript server.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Stopping or restarting the Gateway now also cleans up active bundled LSP process trees, including nested children such as `tsserver`.

## Diagram (if applicable)

```text
Before:
[Gateway stop] -> [run/gateway cleanup] -> [immediate LSP process killed] -> [nested tsserver may remain]

After:
[Gateway stop] -> [bundle LSP shutdown sweep] -> [process tree terminated] -> [nested tsserver exits]
