### PR TITLE
UI: refine chat wheel follow handling

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2320,6 +2320,7 @@ export function renderApp(state: AppViewState) {
                 });
               },
               onChatScroll: (event) => state.handleChatScroll(event),
+              onChatWheelIntent: (event) => state.handleChatWheelIntent(event),
               getDraft: () => state.chatMessage,
               onDraftChange: (next) => (state.chatMessage = next),
               onRequestUpdate: requestHostUpdate,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,9 +1,11 @@
+/* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                            */
-/* ------------------------------------------------------------------ */
+import {
+  handleChatScroll,
+  handleChatWheelIntent,
+  resetChatScroll,
+  scheduleChatScroll,
+} from "./app-scroll.ts";
 
 /** Minimal ScrollHost stub for unit tests. */
 function createScrollHost(
@@ -28,7 +30,6 @@ function createScrollHost(
     style: { overflowY } as unknown as CSSStyleDeclaration,
   };
 
-  // Make getComputedStyle return the overflowY value
   vi.spyOn(window, "getComputedStyle").mockReturnValue({
     overflowY,
   } as unknown as CSSStyleDeclaration);
@@ -41,6 +42,9 @@ function createScrollHost(
     chatScrollTimeout: null as number | null,
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
+    chatFollowLocked: false,
+    chatSmoothAutoScrolling: false,
+    chatLastScrollTop: scrollTop,
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
@@ -56,56 +60,285 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   } as unknown as Event;
 }
 
-/* ------------------------------------------------------------------ */
-/*  handleChatScroll – threshold tests                                 */
-/* ------------------------------------------------------------------ */
+function createWheelEvent(
+  deltaY: number,
+  scrollHeight: number,
+  clientHeight: number,
+  target: EventTarget | null = null,
+) {
+  return {
+    deltaY,
+    target,
+    currentTarget: { scrollHeight, clientHeight },
+  } as unknown as WheelEvent;
+}
 
 describe("handleChatScroll", () => {
   it("sets chatUserNearBottom=true when within the 450px threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1600 - 400 = 0 → clearly near bottom
-    const event = createScrollEvent(2000, 1600, 400);
-    handleChatScroll(host, event);
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
+
+    handleChatScroll(host, createScrollEvent(2000, 1600, 400));
+
     expect(host.chatUserNearBottom).toBe(true);
   });
 
   it("sets chatUserNearBottom=true when distance is just under threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1151 - 400 = 449 → just under threshold
-    const event = createScrollEvent(2000, 1151, 400);
-    handleChatScroll(host, event);
+    host.chatUserNearBottom = false;
+    host.chatLastScrollTop = 0;
+
+    handleChatScroll(host, createScrollEvent(2000, 1151, 400));
+
     expect(host.chatUserNearBottom).toBe(true);
   });
 
   it("sets chatUserNearBottom=false when distance is exactly at threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1150 - 400 = 450 → at threshold (uses strict <)
-    const event = createScrollEvent(2000, 1150, 400);
-    handleChatScroll(host, event);
+
+    handleChatScroll(host, createScrollEvent(2000, 1150, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
   });
 
   it("sets chatUserNearBottom=false when scrolled well above threshold", () => {
     const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 500 - 400 = 1100 → way above threshold
-    const event = createScrollEvent(2000, 500, 400);
-    handleChatScroll(host, event);
+
+    handleChatScroll(host, createScrollEvent(2000, 500, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
   });
 
-  it("sets chatUserNearBottom=false when user scrolled up past one long message (>200px <450px)", () => {
-    const { host } = createScrollHost({});
-    // distanceFromBottom = 2000 - 1250 - 400 = 350 → old threshold would say "near", new says "near"
-    // distanceFromBottom = 2000 - 1100 - 400 = 500 → old threshold would say "not near", new also "not near"
-    const event = createScrollEvent(2000, 1100, 400);
-    handleChatScroll(host, event);
+  it("releases auto-follow immediately when the user scrolls upward away from bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1600,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
     expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("does NOT re-enable follow just because a post-wheel scroll event is still near bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 2000;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1540, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+
+  it("re-enables follow once the user actually returns to the bottom", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1576,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1540;
+    host.chatNewMessagesBelow = true;
+
+    handleChatScroll(host, createScrollEvent(2000, 1576, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1200;
+
+    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
+
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
   });
 });
 
-/* ------------------------------------------------------------------ */
-/*  scheduleChatScroll – respects user scroll position                 */
-/* ------------------------------------------------------------------ */
+describe("handleChatWheelIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("cancels pending auto-follow when the user wheels upward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+
+  it("does not cancel auto-follow when wheeling downward", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(120, 2000, 500));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow when the chat cannot actually scroll", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 400,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 400, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not disengage follow for bubbled wheel events from nested scrollables that can still scroll up", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    const container = document.createElement("div");
+    const nestedScrollable = document.createElement("div");
+    container.appendChild(nestedScrollable);
+    Object.defineProperty(container, "scrollHeight", { value: 2000, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(nestedScrollable, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(nestedScrollable, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(nestedScrollable, "scrollTop", { value: 120, configurable: true });
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      currentTarget: container,
+      target: nestedScrollable,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatScrollFrame).toBe(99);
+    expect(host.chatScrollTimeout).not.toBeNull();
+  });
+
+  it("does not ignore wheel intent when a nested scrollable is already at the top", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    const container = document.createElement("div");
+    const nestedScrollable = document.createElement("div");
+    container.appendChild(nestedScrollable);
+    Object.defineProperty(container, "scrollHeight", { value: 2000, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(nestedScrollable, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(nestedScrollable, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(nestedScrollable, "scrollTop", { value: 0, configurable: true });
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () => ({ overflowY: "auto" }) as CSSStyleDeclaration,
+    );
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      currentTarget: container,
+      target: nestedScrollable,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+
+  it("does not ignore wheel intent for a clipped descendant that cannot scroll vertically", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatScrollFrame = 99;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 1000);
+
+    const container = document.createElement("div");
+    const clippedBlock = document.createElement("div");
+    container.appendChild(clippedBlock);
+    Object.defineProperty(container, "scrollHeight", { value: 2000, configurable: true });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true });
+    Object.defineProperty(clippedBlock, "scrollHeight", { value: 600, configurable: true });
+    Object.defineProperty(clippedBlock, "clientHeight", { value: 300, configurable: true });
+
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      (element) =>
+        ({ overflowY: element === clippedBlock ? "hidden" : "auto" }) as CSSStyleDeclaration,
+    );
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      currentTarget: container,
+      target: clippedBlock,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+  });
+});
 
 describe("scheduleChatScroll", () => {
   beforeEach(() => {
@@ -127,7 +360,6 @@ describe("scheduleChatScroll", () => {
       scrollTop: 1600,
       clientHeight: 400,
     });
-    // distanceFromBottom = 2000 - 1600 - 400 = 0 → near bottom
     host.chatUserNearBottom = true;
 
     scheduleChatScroll(host);
@@ -142,7 +374,6 @@ describe("scheduleChatScroll", () => {
       scrollTop: 500,
       clientHeight: 400,
     });
-    // distanceFromBottom = 2000 - 500 - 400 = 1100 → not near bottom
     host.chatUserNearBottom = false;
     const originalScrollTop = container.scrollTop;
 
@@ -158,31 +389,48 @@ describe("scheduleChatScroll", () => {
       scrollTop: 500,
       clientHeight: 400,
     });
-    // User has scrolled up — chatUserNearBottom is false
     host.chatUserNearBottom = false;
-    host.chatHasAutoScrolled = true; // Already past initial load
+    host.chatHasAutoScrolled = true;
     const originalScrollTop = container.scrollTop;
 
     scheduleChatScroll(host, true);
     await host.updateComplete;
 
-    // force=true should still NOT override explicit user scroll-up after initial load
     expect(container.scrollTop).toBe(originalScrollTop);
   });
 
-  it("DOES scroll with force=true on initial load (chatHasAutoScrolled=false)", async () => {
+  it("reacquires follow when the chat is no longer scrollable", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 400,
+      scrollTop: 0,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatHasAutoScrolled = true;
+    host.chatNewMessagesBelow = true;
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(container.scrollHeight);
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("DOES scroll with force=true on initial load", async () => {
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
       scrollTop: 500,
       clientHeight: 400,
     });
     host.chatUserNearBottom = false;
-    host.chatHasAutoScrolled = false; // Initial load
+    host.chatHasAutoScrolled = false;
 
     scheduleChatScroll(host, true);
     await host.updateComplete;
 
-    // On initial load, force should work regardless
     expect(container.scrollTop).toBe(container.scrollHeight);
   });
 
@@ -201,11 +449,43 @@ describe("scheduleChatScroll", () => {
 
     expect(host.chatNewMessagesBelow).toBe(true);
   });
+
+  it("does NOT snap back when the user manually scrolls up but is still within the old near-bottom threshold", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1540,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatHasAutoScrolled = true;
+    host.chatLastScrollTop = 1540;
+    const originalScrollTop = container.scrollTop;
+
+    scheduleChatScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(originalScrollTop);
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
 });
 
-/* ------------------------------------------------------------------ */
-/*  Streaming: rapid chatStream changes should not reset scroll        */
-/* ------------------------------------------------------------------ */
+describe("handleChatWheelIntent + handleChatScroll interaction", () => {
+  it("preserves the wheel-intent lock for small upward deltas that still land within the bottom threshold", () => {
+    const { host } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 2000,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatWheelIntent(host, createWheelEvent(-5, 2000, 400));
+    handleChatScroll(host, createScrollEvent(2000, 1592, 400));
+
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+});
 
 describe("streaming scroll behavior", () => {
   beforeEach(() => {
@@ -231,7 +511,6 @@ describe("streaming scroll behavior", () => {
     host.chatHasAutoScrolled = true;
     const originalScrollTop = container.scrollTop;
 
-    // Simulate rapid streaming token updates
     scheduleChatScroll(host);
     scheduleChatScroll(host);
     scheduleChatScroll(host);
@@ -249,7 +528,6 @@ describe("streaming scroll behavior", () => {
     host.chatUserNearBottom = true;
     host.chatHasAutoScrolled = true;
 
-    // Simulate streaming
     scheduleChatScroll(host);
     await host.updateComplete;
 
@@ -257,19 +535,19 @@ describe("streaming scroll behavior", () => {
   });
 });
 
-/* ------------------------------------------------------------------ */
-/*  resetChatScroll                                                    */
-/* ------------------------------------------------------------------ */
-
 describe("resetChatScroll", () => {
   it("resets state for new chat session", () => {
     const { host } = createScrollHost({});
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+    host.chatLastScrollTop = 1234;
 
     resetChatScroll(host);
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatLastScrollTop).toBe(0);
   });
 });

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -1,5 +1,9 @@
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+/** Small upward movement should stop auto-follow before the user fully leaves the old threshold. */
+const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
+/** Re-enable follow only once the user is effectively back at the bottom. */
+const FOLLOW_REACQUIRE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -9,26 +13,60 @@ type ScrollHost = {
   chatScrollTimeout: number | null;
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
+  chatFollowLocked: boolean;
+  chatSmoothAutoScrolling: boolean;
+  chatLastScrollTop: number;
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
 };
 
-function queryHost(host: Partial<ScrollHost>, selectors: string): Element | null {
-  return typeof host.querySelector === "function" ? host.querySelector(selectors) : null;
-}
-
-export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+function cancelPendingChatScroll(host: ScrollHost) {
   if (host.chatScrollFrame) {
     cancelAnimationFrame(host.chatScrollFrame);
+    host.chatScrollFrame = null;
   }
   if (host.chatScrollTimeout != null) {
     clearTimeout(host.chatScrollTimeout);
     host.chatScrollTimeout = null;
   }
+}
+
+function canConsumeVerticalWheelDelta(node: HTMLElement, deltaY: number) {
+  const overflowY = getComputedStyle(node).overflowY;
+  const hasVerticalScrollRange = node.scrollHeight - node.clientHeight > 1;
+  const canScrollVertically =
+    (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+    hasVerticalScrollRange;
+  if (!canScrollVertically) {
+    return false;
+  }
+  if (deltaY < 0) {
+    return node.scrollTop > 1;
+  }
+  return node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+}
+
+function hasNestedScrollableAncestor(
+  target: EventTarget | null,
+  container: HTMLElement,
+  deltaY: number,
+) {
+  let node = target instanceof HTMLElement ? target : null;
+  while (node && node !== container) {
+    if (canConsumeVerticalWheelDelta(node, deltaY)) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
+export function scheduleChatScroll(host: ScrollHost, force = false, smooth = false) {
+  cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
-    const container = queryHost(host, ".chat-thread") as HTMLElement | null;
+    const container = host.querySelector(".chat-thread") as HTMLElement | null;
     if (container) {
       const overflowY = getComputedStyle(container).overflowY;
       const canScroll =
@@ -49,13 +87,14 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
       if (!target) {
         return;
       }
-      const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
-
       // force=true only overrides when we haven't auto-scrolled yet (initial load).
       // After initial load, respect the user's scroll position.
       const effectiveForce = force && !host.chatHasAutoScrolled;
+      const hasVerticalScrollRange = target.scrollHeight - target.clientHeight > 1;
       const shouldStick =
-        effectiveForce || host.chatUserNearBottom || distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+        effectiveForce ||
+        (host.chatUserNearBottom && !host.chatFollowLocked) ||
+        !hasVerticalScrollRange;
 
       if (!shouldStick) {
         // User is scrolled up — flag that new content arrived below.
@@ -77,6 +116,11 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         target.scrollTop = scrollTop;
       }
       host.chatUserNearBottom = true;
+      host.chatFollowLocked = false;
+      host.chatSmoothAutoScrolling = smoothEnabled;
+      host.chatLastScrollTop = smoothEnabled
+        ? Math.max(target.scrollTop, 0)
+        : Math.max(0, target.scrollHeight - target.clientHeight);
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -85,17 +129,16 @@ export function scheduleChatScroll(host: ScrollHost, force = false, smooth = fal
         if (!latest) {
           return;
         }
-        const latestDistanceFromBottom =
-          latest.scrollHeight - latest.scrollTop - latest.clientHeight;
         const shouldStickRetry =
-          effectiveForce ||
-          host.chatUserNearBottom ||
-          latestDistanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+          effectiveForce || (host.chatUserNearBottom && !host.chatFollowLocked);
         if (!shouldStickRetry) {
           return;
         }
         latest.scrollTop = latest.scrollHeight;
         host.chatUserNearBottom = true;
+        host.chatFollowLocked = false;
+        host.chatSmoothAutoScrolling = false;
+        host.chatLastScrollTop = Math.max(0, latest.scrollHeight - latest.clientHeight);
       }, retryDelay);
     });
   });
@@ -108,7 +151,7 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   void host.updateComplete.then(() => {
     host.logsScrollFrame = requestAnimationFrame(() => {
       host.logsScrollFrame = null;
-      const container = queryHost(host, ".log-stream") as HTMLElement | null;
+      const container = host.querySelector(".log-stream") as HTMLElement | null;
       if (!container) {
         return;
       }
@@ -128,12 +171,59 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   if (!container) {
     return;
   }
+  const currentScrollTop = container.scrollTop;
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  host.chatUserNearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const nearBottom = distanceFromBottom < NEAR_BOTTOM_THRESHOLD;
+  const scrollingUp = currentScrollTop < host.chatLastScrollTop;
+  const backAtBottom = distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD;
+
+  if (host.chatSmoothAutoScrolling) {
+    if (scrollingUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+      host.chatSmoothAutoScrolling = false;
+      host.chatUserNearBottom = false;
+      host.chatFollowLocked = true;
+    } else if (backAtBottom || !scrollingUp) {
+      host.chatSmoothAutoScrolling = false;
+    }
+  } else if (
+    host.chatUserNearBottom &&
+    scrollingUp &&
+    distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD
+  ) {
+    host.chatUserNearBottom = false;
+    host.chatFollowLocked = true;
+  } else if (backAtBottom && (!host.chatFollowLocked || !scrollingUp)) {
+    host.chatUserNearBottom = true;
+    host.chatFollowLocked = false;
+  } else if (!host.chatFollowLocked && nearBottom) {
+    host.chatUserNearBottom = true;
+  }
+
+  host.chatLastScrollTop = Math.max(currentScrollTop, 0);
   // Clear the "new messages below" indicator when user scrolls back to bottom.
-  if (host.chatUserNearBottom) {
+  if (host.chatUserNearBottom && !host.chatFollowLocked) {
     host.chatNewMessagesBelow = false;
   }
+}
+
+export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
+  if (event.deltaY >= 0) {
+    return;
+  }
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
+  if (hasNestedScrollableAncestor(event.target, container, event.deltaY)) {
+    return;
+  }
+  if (!host.chatUserNearBottom && host.chatFollowLocked) {
+    return;
+  }
+  cancelPendingChatScroll(host);
+  host.chatSmoothAutoScrolling = false;
+  host.chatUserNearBottom = false;
+  host.chatFollowLocked = true;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -148,6 +238,9 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
 export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
+  host.chatFollowLocked = false;
+  host.chatSmoothAutoScrolling = false;
+  host.chatLastScrollTop = 0;
   host.chatNewMessagesBelow = false;
 }
 
@@ -169,7 +262,7 @@ export function observeTopbar(host: ScrollHost) {
   if (typeof ResizeObserver === "undefined") {
     return;
   }
-  const topbar = queryHost(host, ".topbar");
+  const topbar = host.querySelector(".topbar");
   if (!topbar) {
     return;
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -452,6 +452,7 @@ export type AppViewState = {
     handleAbortChat: () => Promise<void>;
     removeQueuedMessage: (id: string) => void;
     handleChatScroll: (event: Event) => void;
+    handleChatWheelIntent: (event: WheelEvent) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -33,6 +33,7 @@ import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleChatWheelIntent as handleChatWheelIntentInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
@@ -538,6 +539,9 @@ export class OpenClawApp extends LitElement {
   private chatScrollTimeout: number | null = null;
   private chatHasAutoScrolled = false;
   private chatUserNearBottom = true;
+  private chatFollowLocked = false;
+  private chatSmoothAutoScrolling = false;
+  private chatLastScrollTop = 0;
   @state() chatNewMessagesBelow = false;
   private nodesPollInterval: number | null = null;
   private logsPollInterval: number | null = null;
@@ -627,6 +631,13 @@ export class OpenClawApp extends LitElement {
   handleChatScroll(event: Event) {
     handleChatScrollInternal(
       this as unknown as Parameters<typeof handleChatScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleChatWheelIntent(event: WheelEvent) {
+    handleChatWheelIntentInternal(
+      this as unknown as Parameters<typeof handleChatWheelIntentInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -121,6 +121,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onChatWheelIntent?: (event: WheelEvent) => void;
   basePath?: string;
 };
 
@@ -783,6 +784,7 @@ export function renderChat(props: ChatProps) {
       role="log"
       aria-live="polite"
       @scroll=${props.onChatScroll}
+      @wheel=${props.onChatWheelIntent}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Chat auto-follow in the Control UI could re-engage too aggressively when the user manually scrolled slightly upward during streaming, because the logic only used a broad "near bottom" threshold.
- Why it matters: Users trying to read slightly older messages could get pulled back to the bottom, which makes streaming chats feel jumpy and hard to control.
- What changed: Added an explicit manual-scroll release lock, only reacquire follow when the user is truly back at the bottom, ignore upward wheel intent from nested scrollables, and cover the smooth auto-scroll edge cases in `ui/src/ui/app-scroll.test.ts`.
- What did NOT change (scope boundary): No session-management refactors, no tool-call visibility changes, no settings/auth/token behavior changes, and no unrelated UI restructuring.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37500
- Closes #60837
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The chat scroll state treated "near bottom" as equivalent to "should still auto-follow", so a small upward manual scroll could still satisfy follow conditions and snap the user back down on subsequent updates.
- Missing detection / guardrail: There was no explicit "user took over scrolling" lock and no test coverage for slight upward manual scrolling during streaming.
- Contributing context (if known): Smooth auto-scroll progress and user-driven upward scroll were both funneled through the same scroll-state path, which made intent ambiguous.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-scroll.test.ts`
- Scenario the test should lock in: When the user wheels or scrolls slightly upward from the bottom during chat streaming, auto-follow disengages immediately and does not re-enable until the user actually returns to the bottom.
- Why this is the smallest reliable guardrail: The behavior is contained in the chat scroll state machine and can be deterministically exercised with direct scroll/wheel events.
- Existing test that already covers this (if any): Existing tests covered broad near-bottom behavior, but not manual release/reacquire intent or the smooth auto-scroll edge cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- Chat no longer snaps back to the bottom as easily when the user manually scrolls slightly upward during streaming.
- Auto-follow resumes only when the user truly returns to the bottom.
- Wheel events coming from nested scrollable content inside the chat do not incorrectly disable or fight chat scroll state.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user scrolls slightly up] -> [still "near bottom"] -> [next stream update] -> [auto-follow re-engages]

After:
[user scrolls slightly up] -> [follow locked off] -> [next stream update] -> [stays in place]
[user returns to bottom] -> [follow unlocked] -> [next stream update] -> [auto-follow resumes]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Vite dev setup
- Model/provider: N/A
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): local gateway on `ws://127.0.0.1:18789`

### Steps

1. Open the Control UI chat while a response is streaming.
2. Scroll slightly upward from the bottom or wheel upward during streaming.
3. Continue streaming, then return fully to the bottom.

### Expected

- Slight upward manual scrolling disengages auto-follow.
- Streaming updates do not snap the view back down.
- Auto-follow resumes only after returning to the bottom.

### Actual

- Before fix: chat could snap back down while the user was still trying to read upward.
- After fix: chat stays released until the bottom is reached again.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm test ui/src/ui/app-scroll.test.ts` and manually checked the scroll behavior on multiple devices.
- Edge cases checked: Slight upward scroll near bottom, re-enable only at the bottom, nested scrollable wheel intent, post-wheel near-bottom lock behavior, and smooth auto-scroll transition handling.
- What you did **not** verify: Full end-to-end multi-browser matrix, full UI suite, and non-chat surfaces.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The new release/reacquire thresholds could feel slightly different than before for some users near the bottom of the thread.
  - Mitigation: Thresholds are small and targeted, and focused unit tests lock in the intended behavior.
- Risk: Wheel-based intent handling could interfere with nested scrollable UI inside messages.
  - Mitigation: Nested scrollable ancestors are explicitly ignored and covered by tests.
