### PR TITLE
fix(memory-lancedb): force float embedding encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Discord/gateway: count failed health-monitor restart attempts toward cooldown and hourly caps, and evict stale account lifecycle state during channel reloads so repeated Discord gateway recovery cannot loop on old status. Fixes #38596. (#40413) Thanks @jellyAI-dev and @vashquez.
 - Cron/context engine: run isolated cron jobs under run-scoped context-engine session keys so prior runs of the same job are not inherited unless the job is explicitly session-bound. (#72292) Thanks @jalehman.
 - Control UI: localize command palette labels, categories, skill shortcuts, footer hints, and connect-command copy labels while preserving localized command palette search matching. (#61130, #61119) Thanks @rubensfox20.
+- Plugins/memory-lancedb: request float embedding responses from OpenAI-compatible servers so local providers that default SDK requests to base64 no longer return dimension-mismatched LanceDB vectors while preserving configured dimensions. Fixes #45982. (#59048, #46069, #45986) Thanks @deep-introspection, @xiaokhkh, @caicongyang, and @thiswind.
 
 ## 2026.4.26
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -386,6 +386,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "what editor should i use?",
+        encoding_format: "float",
       });
       expect(vectorSearch).toHaveBeenCalledWith([0.1, 0.2, 0.3]);
       expect(limit).toHaveBeenCalledWith(3);
@@ -535,6 +536,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "what editor should i use?",
+        encoding_format: "float",
       });
       expect(result).toMatchObject({
         prependContext: expect.stringContaining("I prefer Helix for editing code."),
@@ -871,6 +873,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "I prefer Helix for editing code every day.",
+        encoding_format: "float",
       });
       expect(vectorSearch).toHaveBeenCalledTimes(1);
       expect(add).toHaveBeenCalledTimes(1);
@@ -1012,6 +1015,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "I prefer Helix for editing code every day.",
+        encoding_format: "float",
       });
       expect(add).toHaveBeenCalledWith([
         expect.objectContaining({
@@ -1349,6 +1353,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "hello dimensions",
+        encoding_format: "float",
         dimensions: 1024,
       });
     } finally {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -177,9 +177,10 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number } = {
+    const params: OpenAI.EmbeddingCreateParams = {
       model: this.model,
       input: text,
+      encoding_format: "float",
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;


### PR DESCRIPTION
Repair the existing contributor branch for #59048 rather than replacing it. Keep the patch narrow to memory-lancedb's embedding request path and focused tests. The fix should force float embedding responses for local/OpenAI-compatible embedding servers where SDK base64 defaults produce dimension-mismatched vectors, while preserving configured dimensions behavior. Credit deep-introspection for #59048 and preserve historical attribution for the earlier #46069 and #45986 implementations. Before merge, refresh mergeability, run the focused memory-lancedb test, run pnpm check:changed, run Codex /review, address every finding, and only then allow post-merge closeout for #45982.

ProjectClownfish replacement details:
- Cluster: ghcrawl-199230-agentic-merge
- Source PRs: https://github.com/openclaw/openclaw/pull/59048, https://github.com/openclaw/openclaw/pull/46069, https://github.com/openclaw/openclaw/pull/45986
- Credit: Canonical contributor PR: deep-introspection in https://github.com/openclaw/openclaw/pull/59048.; Earlier scoped float-encoding work should be credited where relevant: xiaokhkh in https://github.com/openclaw/openclaw/pull/46069 and caicongyang in https://github.com/openclaw/openclaw/pull/45986.; Issue reporter thiswind in #45982 supplied the Ollama dimension-mismatch reproduction that anchors the bug family.
- Validation: pnpm -s vitest run extensions/memory-lancedb/index.test.ts; pnpm check:changed
- Repair fallback: validation command failed (pnpm check:changed): undefined ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "check:changed" not found Did you mean "pnpm test:changed"?
