### PR TITLE
fix(process): decode Windows command output with console codepage awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Process/Windows: decode command stdout and stderr from raw bytes with console-codepage awareness, while preserving valid UTF-8 output and multibyte characters split across chunks. Fixes #50519. Thanks @iready, @kevinten10, @zhangyongjie1997, @knightplat-blip, @heiqishi666, and @slepybear.
 - macOS Gateway: detect installed-but-unloaded LaunchAgent split-brain states during status, doctor, and restart, and re-bootstrap launchd supervision before falling back to unmanaged listener restarts. Fixes #67335, #53475, and #71060; refs #58890, #60885, and #70801. Thanks @ze1tgeist88, @dafacto, and @vishutdhar.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  createWindowsOutputDecoder,
+  decodeWindowsOutputBuffer,
+  parseWindowsCodePage,
+} from "./windows-encoding.js";
+
+describe("windows output encoding", () => {
+  it("parses code pages from chcp output text", () => {
+    expect(parseWindowsCodePage("Active code page: 936")).toBe(936);
+    expect(parseWindowsCodePage("活动代码页: 65001")).toBe(65001);
+    expect(parseWindowsCodePage("no code page")).toBeNull();
+  });
+
+  it("decodes GBK output on Windows when UTF-8 is invalid and code page is known", () => {
+    const raw = Buffer.from([0xb2, 0xe2, 0xca, 0xd4, 0xa1, 0xab, 0xa3, 0xbb]);
+
+    expect(
+      decodeWindowsOutputBuffer({
+        buffer: raw,
+        platform: "win32",
+        windowsEncoding: "gbk",
+      }),
+    ).toBe("测试～；");
+  });
+
+  it("prefers valid UTF-8 output on Windows even when the console code page is legacy", () => {
+    const raw = Buffer.from("测试", "utf8");
+
+    expect(
+      decodeWindowsOutputBuffer({
+        buffer: raw,
+        platform: "win32",
+        windowsEncoding: "gbk",
+      }),
+    ).toBe("测试");
+  });
+
+  it("keeps multibyte Windows codepage characters intact across chunk boundaries", () => {
+    const decoder = createWindowsOutputDecoder({
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+
+    expect(decoder.decode(Buffer.from([0xb2]))).toBe("");
+    expect(decoder.decode(Buffer.from([0xe2, 0xca]))).toBe("测");
+    expect(decoder.decode(Buffer.from([0xd4]))).toBe("试");
+    expect(decoder.flush()).toBe("");
+  });
+
+  it("keeps split valid UTF-8 output on the UTF-8 path for streaming decode", () => {
+    const decoder = createWindowsOutputDecoder({
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+    const raw = Buffer.from("测试", "utf8");
+
+    expect(decoder.decode(raw.subarray(0, 1))).toBe("");
+    expect(decoder.decode(raw.subarray(1, 3))).toBe("测");
+    expect(decoder.decode(raw.subarray(3))).toBe("试");
+    expect(decoder.flush()).toBe("");
+  });
+});

--- a/src/infra/windows-encoding.test.ts
+++ b/src/infra/windows-encoding.test.ts
@@ -48,6 +48,17 @@ describe("windows output encoding", () => {
     expect(decoder.flush()).toBe("");
   });
 
+  it("replays buffered UTF-8 lead bytes when split GBK output falls back to the console code page", () => {
+    const decoder = createWindowsOutputDecoder({
+      platform: "win32",
+      windowsEncoding: "gbk",
+    });
+
+    expect(decoder.decode(Buffer.from([0xc4]))).toBe("");
+    expect(decoder.decode(Buffer.from([0xe3]))).toBe("你");
+    expect(decoder.flush()).toBe("");
+  });
+
   it("keeps split valid UTF-8 output on the UTF-8 path for streaming decode", () => {
     const decoder = createWindowsOutputDecoder({
       platform: "win32",

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -1,0 +1,137 @@
+import { spawnSync } from "node:child_process";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+
+const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
+  65001: "utf-8",
+  54936: "gb18030",
+  936: "gbk",
+  950: "big5",
+  932: "shift_jis",
+  949: "euc-kr",
+  1252: "windows-1252",
+};
+
+let cachedWindowsConsoleEncoding: string | null | undefined;
+
+export function parseWindowsCodePage(raw: string): number | null {
+  if (!raw) {
+    return null;
+  }
+  const match = raw.match(/\b(\d{3,5})\b/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const codePage = Number.parseInt(match[1], 10);
+  if (!Number.isFinite(codePage) || codePage <= 0) {
+    return null;
+  }
+  return codePage;
+}
+
+export function resolveWindowsConsoleEncoding(): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+  if (cachedWindowsConsoleEncoding !== undefined) {
+    return cachedWindowsConsoleEncoding;
+  }
+  try {
+    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
+      windowsHide: true,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const codePage = parseWindowsCodePage(raw);
+    cachedWindowsConsoleEncoding =
+      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
+  } catch {
+    cachedWindowsConsoleEncoding = null;
+  }
+  return cachedWindowsConsoleEncoding;
+}
+
+export function decodeWindowsOutputBuffer(params: {
+  buffer: Buffer;
+  platform?: NodeJS.Platform;
+  windowsEncoding?: string | null;
+}): string {
+  const platform = params.platform ?? process.platform;
+  if (platform !== "win32") {
+    return params.buffer.toString("utf8");
+  }
+
+  const utf8 = decodeStrictUtf8(params.buffer);
+  if (utf8 !== null) {
+    return utf8;
+  }
+
+  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
+  if (!encoding || normalizeLowercaseStringOrEmpty(encoding) === "utf-8") {
+    return params.buffer.toString("utf8");
+  }
+  try {
+    return new TextDecoder(encoding).decode(params.buffer);
+  } catch {
+    return params.buffer.toString("utf8");
+  }
+}
+
+export function createWindowsOutputDecoder(params?: {
+  platform?: NodeJS.Platform;
+  windowsEncoding?: string | null;
+}): {
+  decode(chunk: Buffer | string): string;
+  flush(): string;
+} {
+  const platform = params?.platform ?? process.platform;
+  const encoding =
+    platform === "win32" ? (params?.windowsEncoding ?? resolveWindowsConsoleEncoding()) : null;
+  const normalizedEncoding = normalizeLowercaseStringOrEmpty(encoding);
+  const legacyDecoder =
+    platform === "win32" && encoding && normalizedEncoding !== "utf-8"
+      ? new TextDecoder(encoding)
+      : null;
+  const utf8Decoder =
+    platform === "win32" && legacyDecoder ? new TextDecoder("utf-8", { fatal: true }) : null;
+  let useLegacyDecoder = false;
+
+  return {
+    decode(chunk) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (!legacyDecoder || !utf8Decoder) {
+        return buffer.toString("utf8");
+      }
+      if (useLegacyDecoder) {
+        return legacyDecoder.decode(buffer, { stream: true });
+      }
+      try {
+        return utf8Decoder.decode(buffer, { stream: true });
+      } catch {
+        useLegacyDecoder = true;
+        return legacyDecoder.decode(buffer, { stream: true });
+      }
+    },
+    flush() {
+      if (!legacyDecoder || !utf8Decoder) {
+        return "";
+      }
+      if (useLegacyDecoder) {
+        return legacyDecoder.decode();
+      }
+      try {
+        return utf8Decoder.decode();
+      } catch {
+        return "";
+      }
+    },
+  };
+}
+
+function decodeStrictUtf8(buffer: Buffer): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    return null;
+  }
+}

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -95,6 +95,7 @@ export function createWindowsOutputDecoder(params?: {
   const utf8Decoder =
     platform === "win32" && legacyDecoder ? new TextDecoder("utf-8", { fatal: true }) : null;
   let useLegacyDecoder = false;
+  let pendingUtf8Bytes = Buffer.alloc(0);
 
   return {
     decode(chunk) {
@@ -105,11 +106,16 @@ export function createWindowsOutputDecoder(params?: {
       if (useLegacyDecoder) {
         return legacyDecoder.decode(buffer, { stream: true });
       }
+      const replayBuffer =
+        pendingUtf8Bytes.length > 0 ? Buffer.concat([pendingUtf8Bytes, buffer]) : buffer;
       try {
-        return utf8Decoder.decode(buffer, { stream: true });
+        const decoded = utf8Decoder.decode(buffer, { stream: true });
+        pendingUtf8Bytes = Buffer.from(getTrailingIncompleteUtf8Bytes(replayBuffer));
+        return decoded;
       } catch {
         useLegacyDecoder = true;
-        return legacyDecoder.decode(buffer, { stream: true });
+        pendingUtf8Bytes = Buffer.alloc(0);
+        return legacyDecoder.decode(replayBuffer, { stream: true });
       }
     },
     flush() {
@@ -120,12 +126,57 @@ export function createWindowsOutputDecoder(params?: {
         return legacyDecoder.decode();
       }
       try {
-        return utf8Decoder.decode();
+        const decoded = utf8Decoder.decode();
+        pendingUtf8Bytes = Buffer.alloc(0);
+        return decoded;
       } catch {
-        return "";
+        useLegacyDecoder = true;
+        const replayBuffer = pendingUtf8Bytes;
+        pendingUtf8Bytes = Buffer.alloc(0);
+        return replayBuffer.length > 0 ? legacyDecoder.decode(replayBuffer) : "";
       }
     },
   };
+}
+
+function getTrailingIncompleteUtf8Bytes(buffer: Buffer): Buffer {
+  let index = buffer.length - 1;
+  let continuationBytes = 0;
+  while (
+    index >= 0 &&
+    buffer[index] !== undefined &&
+    buffer[index] >= 0x80 &&
+    buffer[index] <= 0xbf &&
+    continuationBytes < 3
+  ) {
+    continuationBytes += 1;
+    index -= 1;
+  }
+  if (index < 0) {
+    return buffer;
+  }
+
+  const leadByte = buffer[index];
+  const sequenceLength = getUtf8SequenceLength(leadByte);
+  if (sequenceLength <= 1) {
+    return Buffer.alloc(0);
+  }
+
+  const availableBytes = continuationBytes + 1;
+  return availableBytes < sequenceLength ? buffer.subarray(index) : Buffer.alloc(0);
+}
+
+function getUtf8SequenceLength(byte: number): number {
+  if (byte >= 0xc2 && byte <= 0xdf) {
+    return 2;
+  }
+  if (byte >= 0xe0 && byte <= 0xef) {
+    return 3;
+  }
+  if (byte >= 0xf0 && byte <= 0xf4) {
+    return 4;
+  }
+  return 1;
 }
 
 function decodeStrictUtf8(buffer: Buffer): string | null {

--- a/src/node-host/invoke.sanitize-env.test.ts
+++ b/src/node-host/invoke.sanitize-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { parseWindowsCodePage } from "../infra/windows-encoding.js";
 import { withEnv } from "../test-utils/env.js";
-import { decodeCapturedOutputBuffer, parseWindowsCodePage, sanitizeEnv } from "./invoke.js";
+import { decodeCapturedOutputBuffer, sanitizeEnv } from "./invoke.js";
 import { buildNodeInvokeResultParams } from "./runner.js";
 
 describe("node-host sanitizeEnv", () => {

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { GatewayClient } from "../gateway/client.js";
@@ -19,6 +19,10 @@ import {
   type ExecHostResponse,
 } from "../infra/exec-host.js";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
+import {
+  decodeWindowsOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../infra/windows-encoding.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { buildSystemRunApprovalPlan, handleSystemRunInvoke } from "./invoke-system-run.js";
 import type {
@@ -33,16 +37,6 @@ import { invokeRegisteredNodeHostCommand } from "./plugin-node-host.js";
 const OUTPUT_CAP = 200_000;
 const OUTPUT_EVENT_TAIL = 20_000;
 const DEFAULT_NODE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-const WINDOWS_CODEPAGE_ENCODING_MAP: Record<number, string> = {
-  65001: "utf-8",
-  54936: "gb18030",
-  936: "gbk",
-  950: "big5",
-  932: "shift_jis",
-  949: "euc-kr",
-  1252: "windows-1252",
-};
-let cachedWindowsConsoleEncoding: string | null | undefined;
 
 const execHostEnforced =
   normalizeLowercaseStringOrEmpty(process.env.OPENCLAW_NODE_EXEC_HOST ?? "") === "app";
@@ -105,63 +99,12 @@ function truncateOutput(raw: string, maxChars: number): { text: string; truncate
   return { text: `... (truncated) ${raw.slice(raw.length - maxChars)}`, truncated: true };
 }
 
-export function parseWindowsCodePage(raw: string): number | null {
-  if (!raw) {
-    return null;
-  }
-  const match = raw.match(/\b(\d{3,5})\b/);
-  if (!match?.[1]) {
-    return null;
-  }
-  const codePage = Number.parseInt(match[1], 10);
-  if (!Number.isFinite(codePage) || codePage <= 0) {
-    return null;
-  }
-  return codePage;
-}
-
-function resolveWindowsConsoleEncoding(): string | null {
-  if (process.platform !== "win32") {
-    return null;
-  }
-  if (cachedWindowsConsoleEncoding !== undefined) {
-    return cachedWindowsConsoleEncoding;
-  }
-  try {
-    const result = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], {
-      windowsHide: true,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const raw = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-    const codePage = parseWindowsCodePage(raw);
-    cachedWindowsConsoleEncoding =
-      codePage !== null ? (WINDOWS_CODEPAGE_ENCODING_MAP[codePage] ?? null) : null;
-  } catch {
-    cachedWindowsConsoleEncoding = null;
-  }
-  return cachedWindowsConsoleEncoding;
-}
-
 export function decodeCapturedOutputBuffer(params: {
   buffer: Buffer;
   platform?: NodeJS.Platform;
   windowsEncoding?: string | null;
 }): string {
-  const utf8 = params.buffer.toString("utf8");
-  const platform = params.platform ?? process.platform;
-  if (platform !== "win32") {
-    return utf8;
-  }
-  const encoding = params.windowsEncoding ?? resolveWindowsConsoleEncoding();
-  if (!encoding || normalizeLowercaseStringOrEmpty(encoding) === "utf-8") {
-    return utf8;
-  }
-  try {
-    return new TextDecoder(encoding).decode(params.buffer);
-  } catch {
-    return utf8;
-  }
+  return decodeWindowsOutputBuffer(params);
 }
 
 function redactExecApprovals(file: ExecApprovalsFile): ExecApprovalsFile {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -5,6 +5,10 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
+import {
+  decodeWindowsOutputBuffer,
+  resolveWindowsConsoleEncoding,
+} from "../infra/windows-encoding.js";
 import { logDebug, logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
@@ -135,30 +139,49 @@ export async function runExec(
 ): Promise<{ stdout: string; stderr: string }> {
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: "utf8" as const }
+      ? { timeout: opts, encoding: "buffer" as const }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
-          encoding: "utf8" as const,
+          encoding: "buffer" as const,
         };
   try {
     const invocation = resolveChildProcessInvocation({ argv: [command, ...args] });
-    const { stdout, stderr } = await execFileAsync(invocation.command, invocation.args, {
+    const { stdout, stderr } = (await execFileAsync(invocation.command, invocation.args, {
       ...options,
       windowsHide: invocation.windowsHide,
       windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    });
+    })) as { stdout: Buffer; stderr: Buffer };
+    const windowsEncoding = resolveWindowsConsoleEncoding();
+    const decodedStdout = decodeWindowsOutputBuffer({ buffer: stdout, windowsEncoding });
+    const decodedStderr = decodeWindowsOutputBuffer({ buffer: stderr, windowsEncoding });
     if (shouldLogVerbose()) {
-      if (stdout.trim()) {
-        logDebug(stdout.trim());
+      if (decodedStdout.trim()) {
+        logDebug(decodedStdout.trim());
       }
-      if (stderr.trim()) {
-        logError(stderr.trim());
+      if (decodedStderr.trim()) {
+        logError(decodedStderr.trim());
       }
     }
-    return { stdout, stderr };
+    return { stdout: decodedStdout, stderr: decodedStderr };
   } catch (err) {
+    const windowsEncoding = resolveWindowsConsoleEncoding();
+    if (err && typeof err === "object") {
+      const errorWithOutput = err as { stdout?: unknown; stderr?: unknown };
+      if (Buffer.isBuffer(errorWithOutput.stdout)) {
+        errorWithOutput.stdout = decodeWindowsOutputBuffer({
+          buffer: errorWithOutput.stdout,
+          windowsEncoding,
+        });
+      }
+      if (Buffer.isBuffer(errorWithOutput.stderr)) {
+        errorWithOutput.stderr = decodeWindowsOutputBuffer({
+          buffer: errorWithOutput.stderr,
+          windowsEncoding,
+        });
+      }
+    }
     if (shouldLogVerbose()) {
       logError(danger(`Command failed: ${command} ${args.join(" ")}`));
     }
@@ -274,8 +297,9 @@ export async function runCommandWithTimeout(
   });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {
-    let stdout = "";
-    let stderr = "";
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    const windowsEncoding = resolveWindowsConsoleEncoding();
     let settled = false;
     let timedOut = false;
     let noOutputTimedOut = false;
@@ -338,11 +362,11 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+      stdoutChunks.push(Buffer.isBuffer(d) ? d : Buffer.from(d));
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      stderrChunks.push(Buffer.isBuffer(d) ? d : Buffer.from(d));
       armNoOutputTimer();
     });
     child.on("error", (err) => {
@@ -401,8 +425,14 @@ export async function runCommandWithTimeout(
           : resolvedCode;
       resolve({
         pid: child.pid ?? undefined,
-        stdout,
-        stderr,
+        stdout: decodeWindowsOutputBuffer({
+          buffer: Buffer.concat(stdoutChunks),
+          windowsEncoding,
+        }),
+        stderr: decodeWindowsOutputBuffer({
+          buffer: Buffer.concat(stderrChunks),
+          windowsEncoding,
+        }),
         code: normalizedCode,
         signal: resolvedSignal,
         killed: child.killed,

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -4,12 +4,19 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const spawnMock = vi.hoisted(() => vi.fn());
-const execFileMock = vi.hoisted(() =>
-  Object.assign(vi.fn(), {
-    __promisify__: vi.fn(),
-  }),
-);
+const { spawnMock, spawnSyncMock, execFileMock, execFilePromisifyMock } = vi.hoisted(() => {
+  const execFilePromisifyMock = vi.fn();
+  const execFileMock = Object.assign(vi.fn(), {
+    [Symbol.for("nodejs.util.promisify.custom")]: execFilePromisifyMock,
+    __promisify__: execFilePromisifyMock,
+  });
+  return {
+    spawnMock: vi.fn(),
+    spawnSyncMock: vi.fn(),
+    execFileMock,
+    execFilePromisifyMock,
+  };
+});
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -17,6 +24,7 @@ vi.mock("node:child_process", async () => {
     () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
     {
       spawn: spawnMock,
+      spawnSync: spawnSyncMock,
       execFile: execFileMock as unknown as typeof execFileType,
     },
   );
@@ -43,6 +51,7 @@ function createMockChild(params?: {
   exitCodeAfterClose?: number | null;
   exitCodeAfterCloseDelayMs?: number;
   signal?: NodeJS.Signals | null;
+  autoClose?: boolean;
 }): MockChild {
   const child = new EventEmitter() as MockChild;
   child.stdout = new EventEmitter();
@@ -56,14 +65,16 @@ function createMockChild(params?: {
   child.kill = vi.fn(() => true);
   child.pid = 1234;
   child.killed = false;
-  queueMicrotask(() => {
-    child.emit("close", params?.closeCode ?? 0, params?.closeSignal ?? params?.signal ?? null);
-    if (params?.exitCodeAfterClose !== undefined) {
-      setTimeout(() => {
-        child.exitCode = params.exitCodeAfterClose ?? null;
-      }, params.exitCodeAfterCloseDelayMs ?? 0);
-    }
-  });
+  if (params?.autoClose !== false) {
+    queueMicrotask(() => {
+      child.emit("close", params?.closeCode ?? 0, params?.closeSignal ?? params?.signal ?? null);
+      if (params?.exitCodeAfterClose !== undefined) {
+        setTimeout(() => {
+          child.exitCode = params.exitCodeAfterClose ?? null;
+        }, params.exitCodeAfterCloseDelayMs ?? 0);
+      }
+    });
+  }
   return child;
 }
 
@@ -117,7 +128,27 @@ describe("windows command wrapper behavior", () => {
 
   beforeEach(() => {
     spawnMock.mockReset();
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ stdout: "Active code page: 936", stderr: "" });
     execFileMock.mockReset();
+    execFilePromisifyMock.mockReset();
+    execFilePromisifyMock.mockImplementation(
+      (command: string, args: string[], options: Record<string, unknown>) =>
+        new Promise((resolve, reject) => {
+          execFileMock(
+            command,
+            args,
+            options,
+            (err: Error | null, stdout: string | Buffer, stderr: string | Buffer) => {
+              if (err) {
+                reject(err);
+                return;
+              }
+              resolve({ stdout, stderr });
+            },
+          );
+        }),
+    );
   });
 
   afterEach(() => {
@@ -334,6 +365,80 @@ describe("windows command wrapper behavior", () => {
       expect(captured[1]).toEqual(["--version"]);
       expect(captured[2].windowsHide).toBe(true);
       expect(captured[2].windowsVerbatimArguments).toBeUndefined();
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("decodes GBK stdout and stderr from runExec on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const stdout = Buffer.from([0xb2, 0xe2, 0xca, 0xd4]);
+    const stderr = Buffer.from([0xa3, 0xbb]);
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: Buffer, stderr: Buffer) => void,
+      ) => {
+        cb(null, stdout, stderr);
+      },
+    );
+
+    try {
+      const result = await runExec("node", ["gbk-output.js"], 1000);
+      expect(result.stdout).toBe("测试");
+      expect(result.stderr).toBe("；");
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      expect(captured?.[2].encoding).toBe("buffer");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("prefers valid UTF-8 stdout from runExec on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: Buffer, stderr: Buffer) => void,
+      ) => {
+        cb(null, Buffer.from("测试", "utf8"), Buffer.alloc(0));
+      },
+    );
+
+    try {
+      await expect(runExec("node", ["utf8-output.js"], 1000)).resolves.toMatchObject({
+        stdout: "测试",
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("decodes spawn stdout once so GBK characters split across chunks survive", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const child = createMockChild({ autoClose: false });
+    spawnMock.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", Buffer.from([0xb2]));
+        child.stdout.emit("data", Buffer.from([0xe2, 0xca]));
+        child.stdout.emit("data", Buffer.from([0xd4]));
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+
+    try {
+      await expect(
+        runCommandWithTimeout(["node", "gbk-output.js"], { timeoutMs: 1000 }),
+      ).resolves.toMatchObject({
+        stdout: "测试",
+      });
     } finally {
       platformSpy.mockRestore();
     }

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -7,10 +7,16 @@ import {
   expectWaitStaysPendingUntilSigkillFallback,
 } from "./test-support.js";
 
-const { spawnWithFallbackMock, killProcessTreeMock } = vi.hoisted(() => ({
-  spawnWithFallbackMock: vi.fn(),
-  killProcessTreeMock: vi.fn(),
-}));
+const { spawnWithFallbackMock, killProcessTreeMock, createWindowsOutputDecoderMock } = vi.hoisted(
+  () => ({
+    spawnWithFallbackMock: vi.fn(),
+    killProcessTreeMock: vi.fn(),
+    createWindowsOutputDecoderMock: vi.fn(() => ({
+      decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
+      flush: () => "",
+    })),
+  }),
+);
 
 vi.mock("../../spawn-utils.js", () => ({
   spawnWithFallback: spawnWithFallbackMock,
@@ -18,6 +24,10 @@ vi.mock("../../spawn-utils.js", () => ({
 
 vi.mock("../../kill-tree.js", () => ({
   killProcessTree: killProcessTreeMock,
+}));
+
+vi.mock("../../../infra/windows-encoding.js", () => ({
+  createWindowsOutputDecoder: createWindowsOutputDecoderMock,
 }));
 
 let createChildAdapter: typeof import("./child.js").createChildAdapter;
@@ -84,6 +94,11 @@ describe("createChildAdapter", () => {
   beforeEach(() => {
     spawnWithFallbackMock.mockClear();
     killProcessTreeMock.mockClear();
+    createWindowsOutputDecoderMock.mockClear();
+    createWindowsOutputDecoderMock.mockImplementation(() => ({
+      decode: (chunk: Buffer | string) => (Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk),
+      flush: () => "",
+    }));
     delete process.env.OPENCLAW_SERVICE_MARKER;
     vi.useRealTimers();
   });
@@ -326,5 +341,35 @@ describe("createChildAdapter", () => {
       options?: { env?: Record<string, string> };
     };
     expect(spawnArgs.options?.env).toEqual({ FOO: "bar", COUNT: "12" });
+  });
+
+  it("uses a separate stdout decoder for each listener", async () => {
+    const decoderOutputs = ["first", "second"];
+    createWindowsOutputDecoderMock.mockImplementation(() => {
+      const output = decoderOutputs.shift() ?? "";
+      return {
+        decode: () => output,
+        flush: () => "",
+      };
+    });
+    const { child } = createStubChild(5555);
+    spawnWithFallbackMock.mockResolvedValue({
+      child,
+      usedFallback: false,
+    });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "process.exit(0)"],
+      stdinMode: "pipe-open",
+    });
+    const first = vi.fn();
+    const second = vi.fn();
+
+    adapter.onStdout(first);
+    adapter.onStdout(second);
+    child.stdout?.emit("data", Buffer.from([0xb2]));
+
+    expect(createWindowsOutputDecoderMock).toHaveBeenCalledTimes(2);
+    expect(first).toHaveBeenCalledWith("first");
+    expect(second).toHaveBeenCalledWith("second");
   });
 });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,4 +1,5 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
+import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
 import { killProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
@@ -109,15 +110,49 @@ export async function createChildAdapter(params: {
     : undefined;
 
   const onStdout = (listener: (chunk: string) => void) => {
+    const stdoutDecoder = createWindowsOutputDecoder();
+    let flushed = false;
+    const flush = () => {
+      if (flushed) {
+        return;
+      }
+      flushed = true;
+      const tail = stdoutDecoder.flush();
+      if (tail) {
+        listener(tail);
+      }
+    };
     child.stdout.on("data", (chunk) => {
-      listener(chunk.toString());
+      const text = stdoutDecoder.decode(chunk);
+      if (text) {
+        listener(text);
+      }
     });
+    child.stdout.once("end", flush);
+    child.stdout.once("close", flush);
   };
 
   const onStderr = (listener: (chunk: string) => void) => {
+    const stderrDecoder = createWindowsOutputDecoder();
+    let flushed = false;
+    const flush = () => {
+      if (flushed) {
+        return;
+      }
+      flushed = true;
+      const tail = stderrDecoder.flush();
+      if (tail) {
+        listener(tail);
+      }
+    };
     child.stderr.on("data", (chunk) => {
-      listener(chunk.toString());
+      const text = stderrDecoder.decode(chunk);
+      if (text) {
+        listener(text);
+      }
     });
+    child.stderr.once("end", flush);
+    child.stderr.once("close", flush);
   };
 
   let waitResult: { code: number | null; signal: NodeJS.Signals | null } | null = null;


### PR DESCRIPTION
## Summary
- Fix Windows CJK mojibake for exec output by preserving raw bytes and decoding with a Windows console-codepage-aware helper.
- Prefer valid UTF-8 output when tools emit UTF-8 on Windows, and only fall back to detected console encodings when needed.
- Avoid per-chunk multibyte corruption by using a stateful decoder or whole-buffer decode for chunked output paths.

## Credit
This replacement carries forward and credits ideas and tests from #43611 by @iready, #50586 by @kevinten10, #50885 by @zhangyongjie1997, #56538 by @knightplat-blip / heiqishi666, and #64661/#64709 by @slepybear.

## Validation
- pnpm check:changed

Fixes #50519. Supersedes #43611, #50586, #50885, #56538, #64661, and #64709 after this PR lands and validation passes.

ProjectClownfish replacement details:
- Cluster: ghcrawl-199248-agentic-merge
- Source PRs: https://github.com/openclaw/openclaw/pull/43611, https://github.com/openclaw/openclaw/pull/50586, https://github.com/openclaw/openclaw/pull/50885, https://github.com/openclaw/openclaw/pull/56538, https://github.com/openclaw/openclaw/pull/64661, https://github.com/openclaw/openclaw/pull/64709
- Credit: Credit @iready for https://github.com/openclaw/openclaw/pull/43611 and its shared Windows console encoding helper direction.; Credit @kevinten10 for https://github.com/openclaw/openclaw/pull/50586 and its tests/analysis of cmd.exe wrapper output handling.; Credit @zhangyongjie1997 for https://github.com/openclaw/openclaw/pull/50885 and its focused regression coverage around cmd-wrapper behavior.; Credit @knightplat-blip and commit author heiqishi666 for https://github.com/openclaw/openclaw/pull/56538 and the TextDecoder/codepage-aware repair direction.; Credit @slepybear for https://github.com/openclaw/openclaw/pull/64661 and https://github.com/openclaw/openclaw/pull/64709 and the shared infra/windows-encoding extraction direction.
- Validation: pnpm check:changed
