### PR TITLE
MCH-61: Action Sink Policy Enforcement

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -13,6 +13,7 @@ import { isDangerousHostInheritedEnvVarName } from "../infra/host-env-security.j
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { enforceActionSinkPolicy } from "../security/action-sink-runtime.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -555,6 +556,21 @@ export async function runExecProcess(opts: {
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
+  await enforceActionSinkPolicy({
+    policyVersion: "v1",
+    actionType: "shell_exec",
+    toolName: "exec",
+    targetResource: opts.workdir,
+    payloadSummary: opts.command,
+    actor: { sessionKey: opts.sessionKey },
+    context: {
+      command: opts.command,
+      execCommand: opts.execCommand,
+      cwd: opts.workdir,
+      sandbox: Boolean(opts.sandbox),
+    },
+  });
+
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -17,9 +17,14 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { copyPluginToolMeta } from "../plugins/tools.js";
 import { PluginApprovalResolutions, type PluginApprovalResolution } from "../plugins/types.js";
+import {
+  actionSinkTargetFromParams,
+  enforceActionSinkPolicy,
+} from "../security/action-sink-runtime.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { isMutatingToolCall } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -181,6 +186,27 @@ export async function runBeforeToolCallHook(args: {
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
+
+  if (isMutatingToolCall(toolName, params)) {
+    await enforceActionSinkPolicy({
+      policyVersion: "v1",
+      actionType:
+        toolName === "message" || toolName.startsWith("message_") ? "message_send" : "file_write",
+      toolName,
+      targetResource: actionSinkTargetFromParams(params),
+      payloadSummary: params,
+      correlationId: args.toolCallId,
+      actor: {
+        id: args.ctx?.agentId,
+        sessionKey: args.ctx?.sessionKey,
+        sessionId: args.ctx?.sessionId,
+      },
+      context: {
+        runId: args.ctx?.runId,
+        toolCallId: args.toolCallId,
+      },
+    });
+  }
 
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =

--- a/src/infra/outbound/action-sink-policy.test.ts
+++ b/src/infra/outbound/action-sink-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMessageActionPolicyRequest,
+  buildOutboundDeliveryPolicyRequest,
+} from "./action-sink-policy.js";
+
+describe("outbound action-sink policy request builders", () => {
+  it("builds message_send requests for ordinary outbound delivery", () => {
+    const request = buildOutboundDeliveryPolicyRequest({
+      cfg: {} as never,
+      channel: "telegram",
+      to: "chat-1",
+      payloads: [{ text: "hello" }],
+      session: { key: "session-1", agentId: "agent-1" },
+    });
+
+    expect(request.actionType).toBe("message_send");
+    expect(request.targetResource).toBe("telegram:chat-1");
+    expect(request.actor).toEqual({ id: "agent-1", sessionKey: "session-1" });
+  });
+
+  it("classifies outbound completion claims before delivery", () => {
+    const request = buildOutboundDeliveryPolicyRequest({
+      cfg: {} as never,
+      channel: "telegram",
+      to: "chat-1",
+      payloads: [{ text: "The implementation is done." }],
+    });
+
+    expect(request.actionType).toBe("completion_claim");
+  });
+
+  it("builds message action policy requests from normalized tool args", () => {
+    const request = buildMessageActionPolicyRequest({
+      channel: "discord",
+      action: "send",
+      to: "channel-1",
+      accountId: "acct-1",
+      args: { message: "ready to ship" },
+      sessionKey: "session-1",
+      sessionId: "session-id",
+      agentId: "agent-1",
+      requesterSenderId: "sender-1",
+    });
+
+    expect(request.actionType).toBe("completion_claim");
+    expect(request.toolName).toBe("message.send");
+    expect(request.targetResource).toBe("discord:channel-1");
+    expect(request.context).toMatchObject({
+      channel: "discord",
+      action: "send",
+      requesterSenderId: "sender-1",
+    });
+  });
+});

--- a/src/infra/outbound/action-sink-policy.ts
+++ b/src/infra/outbound/action-sink-policy.ts
@@ -1,0 +1,97 @@
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import type { PolicyRequest } from "../../security/action-sink-policy.js";
+import { containsCompletionClaim } from "../../security/completion-claim-policy.js";
+import type { DeliverOutboundPayloadsParams } from "./deliver.js";
+
+function textFromPayload(payload: ReplyPayload): string {
+  const parts: string[] = [];
+  const record = payload as ReplyPayload & { message?: unknown; caption?: unknown };
+  if (typeof record.text === "string") {
+    parts.push(record.text);
+  }
+  if (typeof record.message === "string") {
+    parts.push(record.message);
+  }
+  if (typeof record.caption === "string") {
+    parts.push(record.caption);
+  }
+  return parts.join("\n");
+}
+
+export function buildOutboundDeliveryPolicyRequest(
+  params: DeliverOutboundPayloadsParams,
+): PolicyRequest {
+  const text = params.payloads.map(textFromPayload).filter(Boolean).join("\n");
+  return {
+    policyVersion: "v1",
+    actionType: containsCompletionClaim(text) ? "completion_claim" : "message_send",
+    toolName: "outbound.deliver",
+    targetResource: `${params.channel}:${params.to}`,
+    payloadSummary: {
+      channel: params.channel,
+      to: params.to,
+      accountId: params.accountId,
+      payloadCount: params.payloads.length,
+      text,
+      hasMedia: params.payloads.some(
+        (payload) => Boolean(payload.mediaUrl) || Boolean(payload.mediaUrls?.length),
+      ),
+      skipQueue: params.skipQueue === true,
+    },
+    actor: {
+      id: params.session?.agentId ?? params.mirror?.agentId,
+      sessionKey: params.session?.key ?? params.session?.policyKey ?? params.mirror?.sessionKey,
+    },
+    context: {
+      channel: params.channel,
+      to: params.to,
+      accountId: params.accountId,
+      sessionKey: params.session?.key,
+      policySessionKey: params.session?.policyKey,
+      threadId: params.threadId,
+      replyToId: params.replyToId,
+    },
+  };
+}
+
+export function buildMessageActionPolicyRequest(params: {
+  channel: string;
+  action: string;
+  to?: string;
+  accountId?: string | null;
+  args: Record<string, unknown>;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  requesterSenderId?: string | null;
+}): PolicyRequest {
+  const text =
+    (typeof params.args.message === "string" ? params.args.message : undefined) ??
+    (typeof params.args.caption === "string" ? params.args.caption : "");
+  return {
+    policyVersion: "v1",
+    actionType: containsCompletionClaim(text) ? "completion_claim" : "message_send",
+    toolName: `message.${params.action}`,
+    targetResource: params.to ? `${params.channel}:${params.to}` : params.channel,
+    payloadSummary: {
+      channel: params.channel,
+      action: params.action,
+      to: params.to,
+      accountId: params.accountId,
+      args: params.args,
+      text,
+    },
+    actor: {
+      id: params.agentId,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+    },
+    context: {
+      channel: params.channel,
+      action: params.action,
+      to: params.to,
+      accountId: params.accountId,
+      requesterSenderId: params.requesterSenderId,
+    },
+  };
+}

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -28,10 +28,12 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { enforceActionSinkPolicy } from "../../security/action-sink-runtime.js";
 import { diagnosticErrorCategory } from "../diagnostic-error-metadata.js";
 import { emitDiagnosticEvent, type DiagnosticMessageDeliveryKind } from "../diagnostic-events.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
+import { buildOutboundDeliveryPolicyRequest } from "./action-sink-policy.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
 import {
   ackDelivery,
@@ -758,6 +760,8 @@ export async function deliverOutboundPayloads(
   params: DeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
   const { channel, to, payloads } = params;
+
+  await enforceActionSinkPolicy(buildOutboundDeliveryPolicyRequest(params));
 
   // Write-ahead delivery queue: persist before sending, remove after success.
   const queueId = params.skipQueue

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -27,6 +27,7 @@ import { hasPollCreationParams } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { enforceActionSinkPolicy } from "../../security/action-sink-runtime.js";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -39,6 +40,7 @@ import {
 } from "../../utils/message-channel.js";
 import { formatErrorMessage } from "../errors.js";
 import { throwIfAborted } from "./abort.js";
+import { buildMessageActionPolicyRequest } from "./action-sink-policy.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
@@ -929,6 +931,20 @@ export async function runMessageAction(
   }
 
   const gateway = resolveGateway(input);
+
+  await enforceActionSinkPolicy(
+    buildMessageActionPolicyRequest({
+      channel,
+      action,
+      to: typeof params.to === "string" ? params.to : undefined,
+      accountId,
+      args: params,
+      sessionKey: input.sessionKey,
+      sessionId: input.sessionId,
+      agentId: resolvedAgentId,
+      requesterSenderId: input.requesterSenderId,
+    }),
+  );
 
   if (action === "send") {
     return handleSendAction({

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
+import { enforceActionSinkPolicy } from "../security/action-sink-runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
 import { resolveWindowsCommandShim } from "./windows-command.js";
@@ -143,6 +144,15 @@ export async function runExec(
           encoding: "utf8" as const,
         };
   try {
+    const commandText = [command, ...args].join(" ");
+    await enforceActionSinkPolicy({
+      policyVersion: "v1",
+      actionType: "shell_exec",
+      toolName: "process.execFile",
+      targetResource: typeof opts === "number" ? undefined : opts.cwd,
+      payloadSummary: commandText,
+      context: { command: commandText, cwd: typeof opts === "number" ? undefined : opts.cwd },
+    });
     const invocation = resolveChildProcessInvocation({ argv: [command, ...args] });
     const { stdout, stderr } = await execFileAsync(invocation.command, invocation.args, {
       ...options,
@@ -254,6 +264,15 @@ export async function runCommandWithTimeout(
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
   const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const commandText = argv.join(" ");
+  await enforceActionSinkPolicy({
+    policyVersion: "v1",
+    actionType: "shell_exec",
+    toolName: "process.exec",
+    targetResource: cwd,
+    payloadSummary: commandText,
+    context: { command: commandText, cwd },
+  });
   const hasInput = input !== undefined;
   const resolvedEnv = resolveCommandEnv({ argv, env });
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });

--- a/src/security/action-sink-audit.test.ts
+++ b/src/security/action-sink-audit.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendActionSinkAuditRecord,
+  auditPolicyDecision,
+  createActionSinkAuditRecord,
+  readActionSinkAuditRecords,
+} from "./action-sink-audit.js";
+import { policyResult } from "./action-sink-policy.js";
+
+const request = {
+  policyVersion: "v1",
+  actionType: "message_send" as const,
+  targetResource: "telegram",
+  payloadSummary: { token: "secret" },
+  correlationId: "c1",
+};
+const result = policyResult({
+  policyId: "p",
+  decision: "block",
+  reasonCode: "external_write",
+  reason: "no",
+  mode: "enforce",
+  correlationId: "c1",
+});
+
+describe("action sink audit", () => {
+  it("validates required fields and bounded summaries", () => {
+    const record = createActionSinkAuditRecord({
+      request,
+      result,
+      now: new Date("2026-04-26T00:00:00Z"),
+    });
+    expect(record).toMatchObject({
+      policyVersion: "v1",
+      policyId: "p",
+      decision: "block",
+      actionType: "message_send",
+      correlationId: "c1",
+    });
+    expect(JSON.stringify(record)).not.toContain("secret");
+  });
+
+  it("atomically appends concurrent ndjson records", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "action-sink-audit-"));
+    const file = path.join(dir, "audit.ndjson");
+    const record = createActionSinkAuditRecord({ request, result });
+    await Promise.all(Array.from({ length: 10 }, () => appendActionSinkAuditRecord(file, record)));
+    expect(await readActionSinkAuditRecords(file)).toHaveLength(10);
+  });
+
+  it("fails closed for high risk audit append failures", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "action-sink-audit-"));
+    await expect(
+      auditPolicyDecision({ auditPath: dir, request, result, highRisk: true }),
+    ).rejects.toThrow(/failed closed/);
+  });
+});

--- a/src/security/action-sink-audit.ts
+++ b/src/security/action-sink-audit.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  PolicyActionType,
+  PolicyDecision,
+  PolicyMode,
+  PolicyRequest,
+  PolicyResult,
+} from "./action-sink-policy.js";
+import { summarizePolicyPayload } from "./action-sink-policy.js";
+
+export type ActionSinkAuditRecord = {
+  timestamp: string;
+  policyVersion: string;
+  actor?: PolicyRequest["actor"];
+  policyId: string;
+  decision: PolicyDecision;
+  actionType: PolicyActionType;
+  targetSummary?: unknown;
+  payloadSummary?: unknown;
+  reasonCode: string;
+  reason: string;
+  mode: PolicyMode;
+  correlationId: string;
+};
+
+export function createActionSinkAuditRecord(params: {
+  request: PolicyRequest;
+  result: PolicyResult;
+  now?: Date;
+}): ActionSinkAuditRecord {
+  return {
+    timestamp: (params.now ?? new Date()).toISOString(),
+    policyVersion: params.request.policyVersion,
+    actor: params.request.actor,
+    policyId: params.result.policyId,
+    decision: params.result.decision,
+    actionType: params.request.actionType,
+    targetSummary: summarizePolicyPayload(params.request.targetResource),
+    payloadSummary: summarizePolicyPayload(params.request.payloadSummary),
+    reasonCode: params.result.reasonCode,
+    reason: params.result.reason,
+    mode: params.result.mode ?? "enforce",
+    correlationId: params.result.correlationId ?? params.request.correlationId ?? randomUUID(),
+  };
+}
+
+export function validateActionSinkAuditRecord(
+  record: Partial<ActionSinkAuditRecord>,
+): asserts record is ActionSinkAuditRecord {
+  for (const field of [
+    "timestamp",
+    "policyVersion",
+    "policyId",
+    "decision",
+    "actionType",
+    "reasonCode",
+    "reason",
+    "mode",
+    "correlationId",
+  ] as const) {
+    if (typeof record[field] !== "string" || !record[field]) {
+      throw new Error(`audit record missing ${field}`);
+    }
+  }
+}
+
+export async function appendActionSinkAuditRecord(
+  filePath: string,
+  record: ActionSinkAuditRecord,
+): Promise<void> {
+  validateActionSinkAuditRecord(record);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "a" });
+}
+
+export async function auditPolicyDecision(params: {
+  auditPath: string;
+  request: PolicyRequest;
+  result: PolicyResult;
+  highRisk?: boolean;
+}): Promise<ActionSinkAuditRecord> {
+  const record = createActionSinkAuditRecord(params);
+  try {
+    await appendActionSinkAuditRecord(params.auditPath, record);
+    return record;
+  } catch (err) {
+    if (params.highRisk) {
+      throw new Error(
+        `Action sink audit append failed closed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    console.warn(`Action sink audit append failed open: ${String(err)}`);
+    return record;
+  }
+}
+
+export async function readActionSinkAuditRecords(
+  filePath: string,
+): Promise<ActionSinkAuditRecord[]> {
+  const text = await fs.readFile(filePath, "utf8").catch((err: NodeJS.ErrnoException) => {
+    if (err.code === "ENOENT") return "";
+    throw err;
+  });
+  return text.trim()
+    ? text
+        .trim()
+        .split(/\n+/)
+        .map((line) => JSON.parse(line) as ActionSinkAuditRecord)
+    : [];
+}

--- a/src/security/action-sink-audit.ts
+++ b/src/security/action-sink-audit.ts
@@ -89,6 +89,7 @@ export async function auditPolicyDecision(params: {
     if (params.highRisk) {
       throw new Error(
         `Action sink audit append failed closed: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
     console.warn(`Action sink audit append failed open: ${String(err)}`);
@@ -100,7 +101,9 @@ export async function readActionSinkAuditRecords(
   filePath: string,
 ): Promise<ActionSinkAuditRecord[]> {
   const text = await fs.readFile(filePath, "utf8").catch((err: NodeJS.ErrnoException) => {
-    if (err.code === "ENOENT") return "";
+    if (err.code === "ENOENT") {
+      return "";
+    }
     throw err;
   });
   return text.trim()

--- a/src/security/action-sink-evidence.test.ts
+++ b/src/security/action-sink-evidence.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  parseActionSinkEvidenceArtifact,
+  verifyActionSinkEvidence,
+  type ActionSinkEvidenceArtifact,
+} from "./action-sink-evidence.js";
+
+const repoRoot = process.cwd();
+const branch = "agent/forge-mch-61-action-sink-policy-20260426-1940";
+const commitSha = "4a3030df9efa72c44bab567a4390ac0c4876a73f";
+const thisFile = fileURLToPath(import.meta.url);
+
+function artifact(overrides: Partial<ActionSinkEvidenceArtifact> = {}): ActionSinkEvidenceArtifact {
+  return {
+    briefId: "MCH-61",
+    repoRoot,
+    branch,
+    commitSha,
+    review: { path: thisFile, result: "pass", timestamp: "2999-01-01T00:00:00.000Z" },
+    qa: { path: thisFile, result: "pass", timestamp: "2999-01-01T00:00:00.000Z" },
+    timestamp: "2999-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("action sink evidence", () => {
+  it("validates a minimal good artifact and rejects missing required fields", () => {
+    expect(parseActionSinkEvidenceArtifact(artifact()).briefId).toBe("MCH-61");
+    expect(() => parseActionSinkEvidenceArtifact({})).toThrow(/missing/);
+  });
+
+  it("verifies git provenance and rejects fake/wrong branch evidence", () => {
+    const result = verifyActionSinkEvidence(artifact(), { repoRoot, branch, commitSha });
+    expect(result.ok).toBe(true);
+    expect(
+      verifyActionSinkEvidence(artifact({ branch: "main" }), { repoRoot, branch, commitSha }),
+    ).toMatchObject({ ok: false });
+    expect(fs.existsSync(repoRoot)).toBe(true);
+  });
+
+  it("rejects stale, fake, wrong-commit, and vague text artifacts", () => {
+    expect(
+      verifyActionSinkEvidence(artifact({ commitSha: "deadbeef" }), {
+        repoRoot,
+        branch,
+        commitSha,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      verifyActionSinkEvidence(
+        artifact({
+          review: { path: thisFile, result: "pass", timestamp: "2000-01-01T00:00:00.000Z" },
+        }),
+        { repoRoot, branch, commitSha },
+      ),
+    ).toMatchObject({ ok: false });
+    expect(() => parseActionSinkEvidenceArtifact("looks good")).toThrow();
+  });
+});

--- a/src/security/action-sink-evidence.ts
+++ b/src/security/action-sink-evidence.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+export type ActionSinkEvidenceArtifact = {
+  briefId: string;
+  repoRoot: string;
+  branch: string;
+  commitSha?: string;
+  commitRange?: string;
+  review: { path: string; result: "pass" | "fail"; timestamp: string };
+  qa: { path: string; result: "pass" | "fail"; timestamp: string };
+  timestamp: string;
+};
+
+export type EvidenceVerificationResult = { ok: true } | { ok: false; reason: string };
+
+export function parseActionSinkEvidenceArtifact(value: unknown): ActionSinkEvidenceArtifact {
+  if (!value || typeof value !== "object") throw new Error("evidence artifact must be an object");
+  const artifact = value as Partial<ActionSinkEvidenceArtifact>;
+  for (const field of ["briefId", "repoRoot", "branch", "timestamp"] as const) {
+    if (typeof artifact[field] !== "string" || !artifact[field])
+      throw new Error(`evidence missing ${field}`);
+  }
+  if (!artifact.commitSha && !artifact.commitRange)
+    throw new Error("evidence missing commitSha or commitRange");
+  for (const field of ["review", "qa"] as const) {
+    const item = artifact[field];
+    if (
+      !item ||
+      typeof item.path !== "string" ||
+      item.result !== "pass" ||
+      typeof item.timestamp !== "string"
+    ) {
+      throw new Error(`evidence ${field} must have path, pass result, and timestamp`);
+    }
+  }
+  return artifact as ActionSinkEvidenceArtifact;
+}
+
+function git(repoRoot: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+export function verifyActionSinkEvidence(
+  artifact: ActionSinkEvidenceArtifact,
+  expected: {
+    repoRoot: string;
+    branch: string;
+    commitSha?: string;
+    commitRange?: string;
+    now?: Date;
+  },
+): EvidenceVerificationResult {
+  try {
+    parseActionSinkEvidenceArtifact(artifact);
+    if (!fs.existsSync(artifact.repoRoot) || artifact.repoRoot !== expected.repoRoot)
+      return { ok: false, reason: "wrong repo root" };
+    if (artifact.branch !== expected.branch) return { ok: false, reason: "wrong branch" };
+    if (expected.commitSha && artifact.commitSha !== expected.commitSha)
+      return { ok: false, reason: "wrong commit" };
+    if (expected.commitRange && artifact.commitRange !== expected.commitRange)
+      return { ok: false, reason: "wrong commit range" };
+    const currentBranch = git(artifact.repoRoot, ["branch", "--show-current"]);
+    if (currentBranch !== artifact.branch)
+      return { ok: false, reason: "branch does not match repo" };
+    const sha = artifact.commitSha ?? artifact.commitRange?.split("..").pop();
+    if (sha) git(artifact.repoRoot, ["cat-file", "-e", `${sha}^{commit}`]);
+    const commitTime = sha
+      ? new Date(git(artifact.repoRoot, ["show", "-s", "--format=%cI", sha])).getTime()
+      : 0;
+    const reviewTime = Date.parse(artifact.review.timestamp);
+    const qaTime = Date.parse(artifact.qa.timestamp);
+    if (
+      !Number.isFinite(reviewTime) ||
+      !Number.isFinite(qaTime) ||
+      reviewTime < commitTime ||
+      qaTime < commitTime
+    ) {
+      return { ok: false, reason: "stale evidence" };
+    }
+    if (!fs.existsSync(artifact.review.path) || !fs.existsSync(artifact.qa.path))
+      return { ok: false, reason: "evidence file missing" };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/src/security/action-sink-evidence.ts
+++ b/src/security/action-sink-evidence.ts
@@ -15,14 +15,18 @@ export type ActionSinkEvidenceArtifact = {
 export type EvidenceVerificationResult = { ok: true } | { ok: false; reason: string };
 
 export function parseActionSinkEvidenceArtifact(value: unknown): ActionSinkEvidenceArtifact {
-  if (!value || typeof value !== "object") throw new Error("evidence artifact must be an object");
+  if (!value || typeof value !== "object") {
+    throw new Error("evidence artifact must be an object");
+  }
   const artifact = value as Partial<ActionSinkEvidenceArtifact>;
   for (const field of ["briefId", "repoRoot", "branch", "timestamp"] as const) {
-    if (typeof artifact[field] !== "string" || !artifact[field])
+    if (typeof artifact[field] !== "string" || !artifact[field]) {
       throw new Error(`evidence missing ${field}`);
+    }
   }
-  if (!artifact.commitSha && !artifact.commitRange)
+  if (!artifact.commitSha && !artifact.commitRange) {
     throw new Error("evidence missing commitSha or commitRange");
+  }
   for (const field of ["review", "qa"] as const) {
     const item = artifact[field];
     if (
@@ -57,18 +61,26 @@ export function verifyActionSinkEvidence(
 ): EvidenceVerificationResult {
   try {
     parseActionSinkEvidenceArtifact(artifact);
-    if (!fs.existsSync(artifact.repoRoot) || artifact.repoRoot !== expected.repoRoot)
+    if (!fs.existsSync(artifact.repoRoot) || artifact.repoRoot !== expected.repoRoot) {
       return { ok: false, reason: "wrong repo root" };
-    if (artifact.branch !== expected.branch) return { ok: false, reason: "wrong branch" };
-    if (expected.commitSha && artifact.commitSha !== expected.commitSha)
+    }
+    if (artifact.branch !== expected.branch) {
+      return { ok: false, reason: "wrong branch" };
+    }
+    if (expected.commitSha && artifact.commitSha !== expected.commitSha) {
       return { ok: false, reason: "wrong commit" };
-    if (expected.commitRange && artifact.commitRange !== expected.commitRange)
+    }
+    if (expected.commitRange && artifact.commitRange !== expected.commitRange) {
       return { ok: false, reason: "wrong commit range" };
+    }
     const currentBranch = git(artifact.repoRoot, ["branch", "--show-current"]);
-    if (currentBranch !== artifact.branch)
+    if (currentBranch !== artifact.branch) {
       return { ok: false, reason: "branch does not match repo" };
+    }
     const sha = artifact.commitSha ?? artifact.commitRange?.split("..").pop();
-    if (sha) git(artifact.repoRoot, ["cat-file", "-e", `${sha}^{commit}`]);
+    if (sha) {
+      git(artifact.repoRoot, ["cat-file", "-e", `${sha}^{commit}`]);
+    }
     const commitTime = sha
       ? new Date(git(artifact.repoRoot, ["show", "-s", "--format=%cI", sha])).getTime()
       : 0;
@@ -82,8 +94,9 @@ export function verifyActionSinkEvidence(
     ) {
       return { ok: false, reason: "stale evidence" };
     }
-    if (!fs.existsSync(artifact.review.path) || !fs.existsSync(artifact.qa.path))
+    if (!fs.existsSync(artifact.review.path) || !fs.existsSync(artifact.qa.path)) {
       return { ok: false, reason: "evidence file missing" };
+    }
     return { ok: true };
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/src/security/action-sink-policy-config.test.ts
+++ b/src/security/action-sink-policy-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  createMissionControlActionSinkPolicyFixture,
+  parseActionSinkPolicyConfig,
+} from "./action-sink-policy-config.js";
+
+describe("action sink policy config", () => {
+  it("parses minimal/default config", () => {
+    expect(parseActionSinkPolicyConfig({}).defaultMode).toBe("shadow");
+  });
+
+  it("rejects malformed modes", () => {
+    expect(() => parseActionSinkPolicyConfig({ defaultMode: "warn" })).toThrow(/shadow/);
+  });
+
+  it("adds Mission Control fixture paths without kernel constants", () => {
+    const fixture = createMissionControlActionSinkPolicyFixture();
+    expect(fixture.protectedRoots).toContain("/Users/admin/Projects/mission-control-production");
+    expect(fixture.assignedWorktrees[0]?.worktreeRoot).toBe("/Users/admin/Projects/mc-workers/");
+  });
+});

--- a/src/security/action-sink-policy-config.ts
+++ b/src/security/action-sink-policy-config.ts
@@ -30,7 +30,9 @@ export type ActionSinkPolicyConfig = {
 const MODES = new Set(["shadow", "enforce", "disabled"]);
 
 function asStringArray(value: unknown, field: string): string[] {
-  if (value === undefined) return [];
+  if (value === undefined) {
+    return [];
+  }
   if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
     throw new Error(`${field} must be an array of strings`);
   }
@@ -38,7 +40,9 @@ function asStringArray(value: unknown, field: string): string[] {
 }
 
 function parseMode(value: unknown, field: string, fallback: PolicyMode): PolicyMode {
-  if (value === undefined) return fallback;
+  if (value === undefined) {
+    return fallback;
+  }
   if (typeof value !== "string" || !MODES.has(value)) {
     throw new Error(`${field} must be shadow, enforce, or disabled`);
   }

--- a/src/security/action-sink-policy-config.ts
+++ b/src/security/action-sink-policy-config.ts
@@ -1,0 +1,131 @@
+import type { PolicyMode, PolicyActionType } from "./action-sink-policy.js";
+
+export type WorktreeAssignment = {
+  issueId?: string;
+  repoRoot?: string;
+  worktreeRoot: string;
+  branchPattern?: string;
+};
+
+export type ExternalAllowlistRule = {
+  targetPattern: string;
+  actionTypes?: PolicyActionType[];
+};
+
+export type ActionSinkPolicyConfig = {
+  defaultMode: PolicyMode;
+  moduleModes: Record<string, PolicyMode>;
+  protectedRoots: string[];
+  protectedRepoPatterns: string[];
+  assignedWorktrees: WorktreeAssignment[];
+  externalAllowlist: ExternalAllowlistRule[];
+  deniedTargetPatterns: string[];
+  riskTiers: Record<string, "internal" | "external" | "customer" | "operator">;
+  recovery: {
+    operatorIds: string[];
+    emergencyLogPath?: string;
+  };
+};
+
+const MODES = new Set(["shadow", "enforce", "disabled"]);
+
+function asStringArray(value: unknown, field: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+  return [...value];
+}
+
+function parseMode(value: unknown, field: string, fallback: PolicyMode): PolicyMode {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string" || !MODES.has(value)) {
+    throw new Error(`${field} must be shadow, enforce, or disabled`);
+  }
+  return value as PolicyMode;
+}
+
+export function parseActionSinkPolicyConfig(input: unknown = {}): ActionSinkPolicyConfig {
+  const record = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const moduleModes: Record<string, PolicyMode> = {};
+  const rawModuleModes = record.moduleModes;
+  if (rawModuleModes !== undefined) {
+    if (!rawModuleModes || typeof rawModuleModes !== "object" || Array.isArray(rawModuleModes)) {
+      throw new Error("moduleModes must be an object");
+    }
+    for (const [key, value] of Object.entries(rawModuleModes as Record<string, unknown>)) {
+      moduleModes[key] = parseMode(value, `moduleModes.${key}`, "enforce");
+    }
+  }
+
+  return {
+    defaultMode: parseMode(record.defaultMode, "defaultMode", "shadow"),
+    moduleModes,
+    protectedRoots: asStringArray(record.protectedRoots, "protectedRoots"),
+    protectedRepoPatterns: asStringArray(record.protectedRepoPatterns, "protectedRepoPatterns"),
+    assignedWorktrees: Array.isArray(record.assignedWorktrees)
+      ? record.assignedWorktrees.map((item, index) => {
+          if (
+            !item ||
+            typeof item !== "object" ||
+            typeof (item as { worktreeRoot?: unknown }).worktreeRoot !== "string"
+          ) {
+            throw new Error(`assignedWorktrees.${index}.worktreeRoot must be a string`);
+          }
+          return { ...(item as WorktreeAssignment) };
+        })
+      : [],
+    externalAllowlist: Array.isArray(record.externalAllowlist)
+      ? record.externalAllowlist.map((item, index) => {
+          if (
+            !item ||
+            typeof item !== "object" ||
+            typeof (item as { targetPattern?: unknown }).targetPattern !== "string"
+          ) {
+            throw new Error(`externalAllowlist.${index}.targetPattern must be a string`);
+          }
+          return { ...(item as ExternalAllowlistRule) };
+        })
+      : [],
+    deniedTargetPatterns: asStringArray(record.deniedTargetPatterns, "deniedTargetPatterns"),
+    riskTiers:
+      record.riskTiers && typeof record.riskTiers === "object" && !Array.isArray(record.riskTiers)
+        ? {
+            ...(record.riskTiers as Record<
+              string,
+              "internal" | "external" | "customer" | "operator"
+            >),
+          }
+        : {},
+    recovery: {
+      operatorIds: asStringArray(
+        (record.recovery as { operatorIds?: unknown } | undefined)?.operatorIds,
+        "recovery.operatorIds",
+      ),
+      emergencyLogPath:
+        typeof (record.recovery as { emergencyLogPath?: unknown } | undefined)?.emergencyLogPath ===
+        "string"
+          ? (record.recovery as { emergencyLogPath: string }).emergencyLogPath
+          : undefined,
+    },
+  };
+}
+
+export function createMissionControlActionSinkPolicyFixture(): ActionSinkPolicyConfig {
+  return parseActionSinkPolicyConfig({
+    defaultMode: "shadow",
+    protectedRoots: ["/Users/admin/Projects/mission-control-production"],
+    assignedWorktrees: [
+      {
+        repoRoot: "/Users/admin/Projects/mission-control-production",
+        worktreeRoot: "/Users/admin/Projects/mc-workers/",
+        branchPattern: "agent/*",
+      },
+    ],
+    moduleModes: {
+      protectedWorktree: "enforce",
+      externalActionFirewall: "shadow",
+      evidenceGate: "shadow",
+    },
+  });
+}

--- a/src/security/action-sink-policy.test.ts
+++ b/src/security/action-sink-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateActionSinkPolicy,
+  policyResult,
+  summarizePolicyPayload,
+} from "./action-sink-policy.js";
+
+describe("action sink policy kernel", () => {
+  const request = { policyVersion: "v1", actionType: "file_write" as const, correlationId: "c1" };
+
+  it("serializes allow/block/requireApproval decisions", () => {
+    expect(policyResult({ decision: "allow", reasonCode: "allowed", reason: "ok" }).decision).toBe(
+      "allow",
+    );
+    expect(
+      policyResult({ decision: "block", reasonCode: "protected_worktree", reason: "no" }).decision,
+    ).toBe("block");
+    expect(
+      policyResult({ decision: "requireApproval", reasonCode: "approval_required", reason: "ask" })
+        .decision,
+    ).toBe("requireApproval");
+  });
+
+  it("redacts secret-like keys, truncates long text, and is deterministic", () => {
+    const value = { z: "ok", token: "secret", nested: { password: "pw", text: "x".repeat(200) } };
+    expect(summarizePolicyPayload(value)).toEqual(summarizePolicyPayload(value));
+    expect(JSON.stringify(summarizePolicyPayload(value))).not.toContain("secret");
+    expect(JSON.stringify(summarizePolicyPayload(value))).toContain("truncated");
+  });
+
+  it("allows by default and preserves reasons", () => {
+    expect(evaluateActionSinkPolicy(request).decision).toBe("allow");
+    const result = evaluateActionSinkPolicy(request, {}, [
+      {
+        id: "m",
+        evaluate: () =>
+          policyResult({
+            policyId: "m",
+            decision: "block",
+            reasonCode: "invalid_request",
+            reason: "bad",
+          }),
+      },
+    ]);
+    expect(result).toMatchObject({ decision: "block", policyId: "m", reason: "bad" });
+  });
+
+  it("uses first block/approval and applies shadow semantics", () => {
+    const modules = [
+      {
+        id: "a",
+        evaluate: () =>
+          policyResult({
+            policyId: "a",
+            decision: "requireApproval",
+            reasonCode: "approval_required",
+            reason: "ask",
+          }),
+      },
+      {
+        id: "b",
+        evaluate: () =>
+          policyResult({
+            policyId: "b",
+            decision: "block",
+            reasonCode: "invalid_request",
+            reason: "bad",
+          }),
+      },
+    ];
+    expect(evaluateActionSinkPolicy(request, {}, modules).decision).toBe("requireApproval");
+    expect(evaluateActionSinkPolicy(request, { defaultMode: "shadow" }, modules).decision).toBe(
+      "allow",
+    );
+  });
+});

--- a/src/security/action-sink-policy.ts
+++ b/src/security/action-sink-policy.ts
@@ -1,0 +1,168 @@
+export type PolicyActionType =
+  | "file_write"
+  | "shell_exec"
+  | "git_mutation"
+  | "message_send"
+  | "external_api_write"
+  | "status_transition"
+  | "completion_claim";
+
+export type PolicyDecision = "allow" | "block" | "requireApproval";
+export type PolicyMode = "shadow" | "enforce" | "disabled";
+
+export type PolicyReasonCode =
+  | "allowed"
+  | "policy_disabled"
+  | "shadow_allowed"
+  | "protected_worktree"
+  | "unassigned_worktree"
+  | "audit_failed"
+  | "approval_required"
+  | "missing_evidence"
+  | "stale_evidence"
+  | "external_write"
+  | "shell_risk"
+  | "invalid_request";
+
+export type PolicyActor = {
+  id?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  role?: string;
+};
+
+export type PolicyRequest = {
+  policyVersion: string;
+  actor?: PolicyActor;
+  actionType: PolicyActionType;
+  toolName?: string;
+  targetResource?: string;
+  payloadSummary?: unknown;
+  context?: Record<string, unknown>;
+  correlationId?: string;
+};
+
+export type PolicyResult = {
+  decision: PolicyDecision;
+  policyId: string;
+  reasonCode: PolicyReasonCode | string;
+  reason: string;
+  mode?: PolicyMode;
+  correlationId?: string;
+  payloadSummary?: unknown;
+};
+
+export type PolicyModule = {
+  id: string;
+  evaluate: (request: PolicyRequest, config: PolicyKernelConfig) => PolicyResult | undefined | null;
+};
+
+export type PolicyKernelConfig = {
+  defaultMode?: PolicyMode;
+  moduleModes?: Record<string, PolicyMode>;
+};
+
+const SECRET_KEY_RE = /(token|secret|password|passwd|api[_-]?key|authorization|credential|cookie)/i;
+const MAX_STRING_LENGTH = 160;
+const MAX_ARRAY_LENGTH = 8;
+const MAX_OBJECT_KEYS = 16;
+const MAX_DEPTH = 4;
+
+function truncateString(value: string): string {
+  return value.length > MAX_STRING_LENGTH
+    ? `${value.slice(0, MAX_STRING_LENGTH)}…[truncated]`
+    : value;
+}
+
+function summarizeValue(value: unknown, depth: number): unknown {
+  if (depth > MAX_DEPTH) return "[max-depth]";
+  if (value == null) return value;
+  if (typeof value === "string") return truncateString(value);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (Array.isArray(value)) {
+    return value.slice(0, MAX_ARRAY_LENGTH).map((item) => summarizeValue(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)
+      .sort()
+      .slice(0, MAX_OBJECT_KEYS)) {
+      out[key] = SECRET_KEY_RE.test(key)
+        ? "[redacted]"
+        : summarizeValue((value as Record<string, unknown>)[key], depth + 1);
+    }
+    return out;
+  }
+  return `[${typeof value}]`;
+}
+
+export function summarizePolicyPayload(value: unknown): unknown {
+  return summarizeValue(value, 0);
+}
+
+export function policyResult(
+  params: Omit<PolicyResult, "policyId"> & { policyId?: string },
+): PolicyResult {
+  return {
+    policyId: params.policyId ?? "action-sink-policy",
+    decision: params.decision,
+    reasonCode: params.reasonCode,
+    reason: params.reason,
+    mode: params.mode,
+    correlationId: params.correlationId,
+    payloadSummary: params.payloadSummary,
+  };
+}
+
+function applyMode(result: PolicyResult, mode: PolicyMode): PolicyResult {
+  if (mode === "disabled") {
+    return policyResult({
+      policyId: result.policyId,
+      decision: "allow",
+      reasonCode: "policy_disabled",
+      reason: `Policy ${result.policyId} disabled`,
+      mode,
+      correlationId: result.correlationId,
+      payloadSummary: result.payloadSummary,
+    });
+  }
+  if (mode === "shadow" && result.decision !== "allow") {
+    return policyResult({
+      policyId: result.policyId,
+      decision: "allow",
+      reasonCode: "shadow_allowed",
+      reason: `Shadow mode would have ${result.decision}: ${result.reason}`,
+      mode,
+      correlationId: result.correlationId,
+      payloadSummary: result.payloadSummary,
+    });
+  }
+  return { ...result, mode };
+}
+
+export function evaluateActionSinkPolicy(
+  request: PolicyRequest,
+  config: PolicyKernelConfig = {},
+  modules: PolicyModule[] = [],
+): PolicyResult {
+  const defaultMode = config.defaultMode ?? "enforce";
+  for (const module of modules) {
+    const mode = config.moduleModes?.[module.id] ?? defaultMode;
+    if (mode === "disabled") continue;
+    const result = module.evaluate(request, config);
+    if (!result || result.decision === "allow") continue;
+    return applyMode(
+      { ...result, correlationId: result.correlationId ?? request.correlationId },
+      mode,
+    );
+  }
+  return policyResult({
+    decision: "allow",
+    reasonCode: defaultMode === "disabled" ? "policy_disabled" : "allowed",
+    reason: defaultMode === "disabled" ? "Policy disabled" : "No policy module blocked the action",
+    mode: defaultMode,
+    correlationId: request.correlationId,
+    payloadSummary: summarizePolicyPayload(request.payloadSummary),
+  });
+}

--- a/src/security/action-sink-policy.ts
+++ b/src/security/action-sink-policy.ts
@@ -45,7 +45,7 @@ export type PolicyRequest = {
 export type PolicyResult = {
   decision: PolicyDecision;
   policyId: string;
-  reasonCode: PolicyReasonCode | string;
+  reasonCode: PolicyReasonCode;
   reason: string;
   mode?: PolicyMode;
   correlationId?: string;
@@ -75,18 +75,28 @@ function truncateString(value: string): string {
 }
 
 function summarizeValue(value: unknown, depth: number): unknown {
-  if (depth > MAX_DEPTH) return "[max-depth]";
-  if (value == null) return value;
-  if (typeof value === "string") return truncateString(value);
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  if (typeof value === "bigint") return value.toString();
+  if (depth > MAX_DEPTH) {
+    return "[max-depth]";
+  }
+  if (value == null) {
+    return value;
+  }
+  if (typeof value === "string") {
+    return truncateString(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
   if (Array.isArray(value)) {
     return value.slice(0, MAX_ARRAY_LENGTH).map((item) => summarizeValue(item, depth + 1));
   }
   if (typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>)
-      .sort()
+      .toSorted()
       .slice(0, MAX_OBJECT_KEYS)) {
       out[key] = SECRET_KEY_RE.test(key)
         ? "[redacted]"
@@ -149,9 +159,13 @@ export function evaluateActionSinkPolicy(
   const defaultMode = config.defaultMode ?? "enforce";
   for (const module of modules) {
     const mode = config.moduleModes?.[module.id] ?? defaultMode;
-    if (mode === "disabled") continue;
+    if (mode === "disabled") {
+      continue;
+    }
     const result = module.evaluate(request, config);
-    if (!result || result.decision === "allow") continue;
+    if (!result || result.decision === "allow") {
+      continue;
+    }
     return applyMode(
       { ...result, correlationId: result.correlationId ?? request.correlationId },
       mode,

--- a/src/security/action-sink-recovery.test.ts
+++ b/src/security/action-sink-recovery.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import { disableActionSinkModule, setActionSinkGlobalMode } from "./action-sink-recovery.js";
+import { buildActionSinkShadowReport } from "./action-sink-shadow-report.js";
+
+describe("action sink recovery", () => {
+  const config = parseActionSinkPolicyConfig({ recovery: { operatorIds: ["ceo"] } });
+
+  it("denies non-operators", async () => {
+    await expect(
+      setActionSinkGlobalMode(config, "shadow", { actorId: "agent", reason: "test" }),
+    ).rejects.toThrow(/operators/);
+  });
+
+  it("allows operator global rollback and per-module disable with emergency log", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "action-sink-recovery-"));
+    const emergencyLogPath = path.join(dir, "emergency.ndjson");
+    await expect(
+      setActionSinkGlobalMode(config, "shadow", {
+        actorId: "ceo",
+        reason: "rollback",
+        emergencyLogPath,
+      }),
+    ).resolves.toMatchObject({ defaultMode: "shadow" });
+    await expect(
+      disableActionSinkModule(config, "protectedWorktree", {
+        actorId: "ceo",
+        reason: "breakglass",
+        emergencyLogPath,
+      }),
+    ).resolves.toMatchObject({ moduleModes: { protectedWorktree: "disabled" } });
+    expect(await fs.readFile(emergencyLogPath, "utf8")).toContain("breakglass");
+  });
+
+  it("summarizes shadow mode report", () => {
+    expect(
+      buildActionSinkShadowReport([
+        {
+          timestamp: "t",
+          policyVersion: "v1",
+          policyId: "p",
+          decision: "allow",
+          actionType: "file_write",
+          reasonCode: "shadow_allowed",
+          reason: "Shadow mode would have block: x",
+          mode: "shadow",
+          correlationId: "c",
+        },
+      ]).wouldBlock,
+    ).toBe(1);
+  });
+});

--- a/src/security/action-sink-recovery.ts
+++ b/src/security/action-sink-recovery.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import type { PolicyMode } from "./action-sink-policy.js";
+
+export type RecoveryRequest = {
+  actorId: string;
+  reason: string;
+  emergencyLogPath?: string;
+};
+
+function assertOperator(config: ActionSinkPolicyConfig, actorId: string): void {
+  if (!config.recovery.operatorIds.includes(actorId)) {
+    throw new Error("Only configured operators may change action-sink recovery mode");
+  }
+}
+
+async function logRecovery(filePath: string | undefined, message: string): Promise<void> {
+  if (!filePath) return;
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(
+    filePath,
+    `${JSON.stringify({ timestamp: new Date().toISOString(), message })}\n`,
+  );
+}
+
+export async function setActionSinkGlobalMode(
+  config: ActionSinkPolicyConfig,
+  mode: PolicyMode,
+  request: RecoveryRequest,
+): Promise<ActionSinkPolicyConfig> {
+  assertOperator(config, request.actorId);
+  const next = { ...config, defaultMode: mode };
+  await logRecovery(
+    request.emergencyLogPath ?? config.recovery.emergencyLogPath,
+    `global mode set to ${mode}: ${request.reason}`,
+  );
+  return next;
+}
+
+export async function disableActionSinkModule(
+  config: ActionSinkPolicyConfig,
+  moduleId: string,
+  request: RecoveryRequest,
+): Promise<ActionSinkPolicyConfig> {
+  assertOperator(config, request.actorId);
+  const next = {
+    ...config,
+    moduleModes: { ...config.moduleModes, [moduleId]: "disabled" as const },
+  };
+  await logRecovery(
+    request.emergencyLogPath ?? config.recovery.emergencyLogPath,
+    `module ${moduleId} disabled: ${request.reason}`,
+  );
+  return next;
+}

--- a/src/security/action-sink-recovery.ts
+++ b/src/security/action-sink-recovery.ts
@@ -16,7 +16,9 @@ function assertOperator(config: ActionSinkPolicyConfig, actorId: string): void {
 }
 
 async function logRecovery(filePath: string | undefined, message: string): Promise<void> {
-  if (!filePath) return;
+  if (!filePath) {
+    return;
+  }
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.appendFile(
     filePath,

--- a/src/security/action-sink-runtime.test.ts
+++ b/src/security/action-sink-runtime.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { PolicyModule } from "./action-sink-policy.js";
+import { policyResult } from "./action-sink-policy.js";
+import {
+  __testing,
+  enforceActionSinkPolicy,
+  enforceActionSinkPolicySync,
+} from "./action-sink-runtime.js";
+
+const blockingModule: PolicyModule = {
+  id: "test-block",
+  evaluate(request) {
+    return policyResult({
+      policyId: "test-block",
+      decision: "block",
+      reasonCode: "invalid_request",
+      reason: `blocked ${request.actionType}`,
+      correlationId: request.correlationId,
+    });
+  },
+};
+
+describe("action sink runtime enforcement", () => {
+  afterEach(() => {
+    __testing.setActionSinkEnforcementOverride(null);
+  });
+
+  it("throws before async execution when policy blocks", async () => {
+    __testing.setActionSinkEnforcementOverride({ modules: [blockingModule] });
+
+    await expect(
+      enforceActionSinkPolicy({
+        policyVersion: "v1",
+        actionType: "message_send",
+        payloadSummary: "hello",
+      }),
+    ).rejects.toThrow("blocked message_send");
+  });
+
+  it("throws before sync execution when policy blocks", () => {
+    __testing.setActionSinkEnforcementOverride({ modules: [blockingModule] });
+
+    expect(() =>
+      enforceActionSinkPolicySync({
+        policyVersion: "v1",
+        actionType: "status_transition",
+        context: { status: "succeeded" },
+      }),
+    ).toThrow("blocked status_transition");
+  });
+
+  it("blocks completion claims without evidence by default", async () => {
+    await expect(
+      enforceActionSinkPolicy({
+        policyVersion: "v1",
+        actionType: "completion_claim",
+        payloadSummary: "This is done.",
+      }),
+    ).rejects.toThrow("Completion/status claim requires review and QA evidence");
+  });
+});

--- a/src/security/action-sink-runtime.ts
+++ b/src/security/action-sink-runtime.ts
@@ -1,0 +1,217 @@
+import path from "node:path";
+import { auditPolicyDecision } from "./action-sink-audit.js";
+import type { ActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import {
+  createMissionControlActionSinkPolicyFixture,
+  parseActionSinkPolicyConfig,
+} from "./action-sink-policy-config.js";
+import type { PolicyModule, PolicyRequest, PolicyResult } from "./action-sink-policy.js";
+import {
+  evaluateActionSinkPolicy,
+  policyResult,
+  summarizePolicyPayload,
+} from "./action-sink-policy.js";
+import { classifyShellCommand } from "./action-sink-shell-policy.js";
+import { createEvidenceGatePolicyModule } from "./completion-claim-policy.js";
+import { createExternalActionFirewallModule } from "./external-action-firewall.js";
+import { createProtectedWorktreePolicyModule } from "./protected-worktree-policy.js";
+
+export type ActionSinkEnforcementOptions = {
+  config?: ActionSinkPolicyConfig;
+  modules?: PolicyModule[];
+  auditPath?: string;
+};
+
+let testingOverride: ActionSinkEnforcementOptions | null = null;
+
+function createShellRiskPolicyModule(): PolicyModule {
+  return {
+    id: "shellRisk",
+    evaluate(request) {
+      if (request.actionType !== "shell_exec") {
+        return undefined;
+      }
+      const command =
+        (typeof request.context?.command === "string" ? request.context.command : undefined) ??
+        (typeof request.payloadSummary === "string" ? request.payloadSummary : "");
+      const shell = classifyShellCommand({
+        command,
+        cwd: typeof request.context?.cwd === "string" ? request.context.cwd : undefined,
+        elevated: request.context?.elevated === true,
+      });
+      if (!shell.riskTags.includes("network_write")) {
+        return undefined;
+      }
+      return policyResult({
+        policyId: "shellRisk",
+        decision: "requireApproval",
+        reasonCode: "shell_risk",
+        reason: "External network shell command requires approval",
+        correlationId: request.correlationId,
+      });
+    },
+  };
+}
+
+function expectedEvidenceFromRequest(request: PolicyRequest): {
+  repoRoot: string;
+  branch: string;
+  commitSha?: string;
+  commitRange?: string;
+} {
+  return {
+    repoRoot:
+      (typeof request.context?.repoRoot === "string" ? request.context.repoRoot : undefined) ??
+      process.cwd(),
+    branch:
+      (typeof request.context?.branch === "string" ? request.context.branch : undefined) ??
+      "agent/forge-mch-61-action-sink-policy-20260426-1940",
+    commitSha:
+      typeof request.context?.commitSha === "string" ? request.context.commitSha : undefined,
+    commitRange:
+      typeof request.context?.commitRange === "string" ? request.context.commitRange : undefined,
+  };
+}
+
+export function createDefaultActionSinkPolicyConfig(): ActionSinkPolicyConfig {
+  const fixture = createMissionControlActionSinkPolicyFixture();
+  return parseActionSinkPolicyConfig({
+    ...fixture,
+    defaultMode: "enforce",
+    moduleModes: {
+      ...fixture.moduleModes,
+      protectedWorktree: "enforce",
+      externalActionFirewall: "enforce",
+      evidenceGate: "enforce",
+      shellRisk: "enforce",
+    },
+  });
+}
+
+export function createDefaultActionSinkPolicyModules(
+  config: ActionSinkPolicyConfig,
+  request: PolicyRequest,
+): PolicyModule[] {
+  const modules: PolicyModule[] = [
+    createProtectedWorktreePolicyModule(config),
+    createExternalActionFirewallModule(config),
+    createShellRiskPolicyModule(),
+  ];
+  if (request.actionType === "completion_claim") {
+    modules.push(createEvidenceGatePolicyModule(expectedEvidenceFromRequest(request)));
+  }
+  return modules;
+}
+
+function isHighRiskAction(request: PolicyRequest): boolean {
+  return [
+    "file_write",
+    "git_mutation",
+    "shell_exec",
+    "message_send",
+    "external_api_write",
+    "status_transition",
+    "completion_claim",
+  ].includes(request.actionType);
+}
+
+function resolveEffectivePolicyEvaluation(
+  request: PolicyRequest,
+  options: ActionSinkEnforcementOptions,
+) {
+  const effectiveOptions = testingOverride ? { ...options, ...testingOverride } : options;
+  const config = effectiveOptions.config ?? createDefaultActionSinkPolicyConfig();
+  const modules = effectiveOptions.modules ?? createDefaultActionSinkPolicyModules(config, request);
+  const normalizedRequest: PolicyRequest = {
+    ...request,
+    payloadSummary: summarizePolicyPayload(request.payloadSummary),
+  };
+  const result = evaluateActionSinkPolicy(normalizedRequest, config, modules);
+  return { effectiveOptions, normalizedRequest, result };
+}
+
+export async function evaluateConfiguredActionSinkPolicy(
+  request: PolicyRequest,
+  options: ActionSinkEnforcementOptions = {},
+): Promise<PolicyResult> {
+  const { effectiveOptions, normalizedRequest, result } = resolveEffectivePolicyEvaluation(
+    request,
+    options,
+  );
+  if (effectiveOptions.auditPath) {
+    try {
+      await auditPolicyDecision({
+        auditPath: effectiveOptions.auditPath,
+        request: normalizedRequest,
+        result,
+        highRisk: isHighRiskAction(normalizedRequest),
+      });
+    } catch (err) {
+      if (isHighRiskAction(normalizedRequest)) {
+        return policyResult({
+          decision: "block",
+          policyId: "action-sink-audit",
+          reasonCode: "audit_failed",
+          reason: `Action-sink audit append failed: ${String(err)}`,
+          correlationId: normalizedRequest.correlationId,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+function throwIfPolicyDenied(result: PolicyResult): void {
+  if (result.decision === "block") {
+    throw new Error(result.reason);
+  }
+  if (result.decision === "requireApproval") {
+    throw new Error(result.reason);
+  }
+}
+
+export function evaluateConfiguredActionSinkPolicySync(
+  request: PolicyRequest,
+  options: ActionSinkEnforcementOptions = {},
+): PolicyResult {
+  return resolveEffectivePolicyEvaluation(request, options).result;
+}
+
+export async function enforceActionSinkPolicy(
+  request: PolicyRequest,
+  options: ActionSinkEnforcementOptions = {},
+): Promise<PolicyResult> {
+  const result = await evaluateConfiguredActionSinkPolicy(request, options);
+  throwIfPolicyDenied(result);
+  return result;
+}
+
+export function enforceActionSinkPolicySync(
+  request: PolicyRequest,
+  options: ActionSinkEnforcementOptions = {},
+): PolicyResult {
+  const result = evaluateConfiguredActionSinkPolicySync(request, options);
+  throwIfPolicyDenied(result);
+  return result;
+}
+
+export function actionSinkTargetFromParams(params: unknown): string | undefined {
+  if (!params || typeof params !== "object") {
+    return undefined;
+  }
+  const record = params as Record<string, unknown>;
+  for (const key of ["path", "filePath", "file_path", "cwd", "workdir", "target", "to"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return key === "to" ? value.trim() : path.resolve(value.trim());
+    }
+  }
+  return undefined;
+}
+
+export const __testing = {
+  setActionSinkEnforcementOverride(override: ActionSinkEnforcementOptions | null) {
+    testingOverride = override;
+  },
+  createShellRiskPolicyModule,
+};

--- a/src/security/action-sink-shadow-report.ts
+++ b/src/security/action-sink-shadow-report.ts
@@ -1,0 +1,24 @@
+import type { ActionSinkAuditRecord } from "./action-sink-audit.js";
+
+export type ShadowReport = {
+  total: number;
+  wouldBlock: number;
+  wouldRequireApproval: number;
+  byReason: Record<string, number>;
+};
+
+export function buildActionSinkShadowReport(records: ActionSinkAuditRecord[]): ShadowReport {
+  const report: ShadowReport = {
+    total: records.length,
+    wouldBlock: 0,
+    wouldRequireApproval: 0,
+    byReason: {},
+  };
+  for (const record of records) {
+    report.byReason[record.reasonCode] = (report.byReason[record.reasonCode] ?? 0) + 1;
+    if (record.mode === "shadow" && /would have block/i.test(record.reason)) report.wouldBlock += 1;
+    if (record.mode === "shadow" && /would have requireApproval/i.test(record.reason))
+      report.wouldRequireApproval += 1;
+  }
+  return report;
+}

--- a/src/security/action-sink-shadow-report.ts
+++ b/src/security/action-sink-shadow-report.ts
@@ -16,9 +16,12 @@ export function buildActionSinkShadowReport(records: ActionSinkAuditRecord[]): S
   };
   for (const record of records) {
     report.byReason[record.reasonCode] = (report.byReason[record.reasonCode] ?? 0) + 1;
-    if (record.mode === "shadow" && /would have block/i.test(record.reason)) report.wouldBlock += 1;
-    if (record.mode === "shadow" && /would have requireApproval/i.test(record.reason))
+    if (record.mode === "shadow" && /would have block/i.test(record.reason)) {
+      report.wouldBlock += 1;
+    }
+    if (record.mode === "shadow" && /would have requireApproval/i.test(record.reason)) {
       report.wouldRequireApproval += 1;
+    }
   }
   return report;
 }

--- a/src/security/action-sink-shell-policy.test.ts
+++ b/src/security/action-sink-shell-policy.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { classifyShellCommand } from "./action-sink-shell-policy.js";
+
+describe("shell command classifier", () => {
+  it("classifies safe read-only command", () => {
+    expect(classifyShellCommand({ command: "git status --short" })).toMatchObject({
+      highRisk: false,
+      riskTags: ["safe_readonly"],
+    });
+  });
+
+  it("classifies unknown commands", () => {
+    expect(classifyShellCommand({ command: "custom-deployer arg" }).riskTags).toContain(
+      "unknown_command",
+    );
+  });
+
+  it("covers redirection heredoc and tee writes", () => {
+    expect(classifyShellCommand({ command: "echo hi > file" }).riskTags).toContain("redirection");
+    expect(classifyShellCommand({ command: "cat <<EOF\nhi\nEOF" }).riskTags).toContain("heredoc");
+    expect(classifyShellCommand({ command: "echo hi | tee file" }).riskTags).toContain(
+      "pipe_to_mutator",
+    );
+  });
+
+  it("covers inline scripts and wrappers", () => {
+    expect(
+      classifyShellCommand({ command: 'node -e \'require("fs").writeFileSync("x","y")\'' })
+        .riskTags,
+    ).toContain("inline_script");
+    expect(classifyShellCommand({ command: "bash -c 'rm x'" }).riskTags).toContain("shell_wrapper");
+  });
+
+  it("covers chains traversal mutators and network/external clients", () => {
+    expect(classifyShellCommand({ command: "find . -exec rm {} \\;" }).riskTags).toContain(
+      "find_exec",
+    );
+    expect(classifyShellCommand({ command: "git add . && git commit -m x" }).riskTags).toContain(
+      "compound",
+    );
+    expect(
+      classifyShellCommand({ command: "curl -X POST https://example.test" }).riskTags,
+    ).toContain("network_write");
+  });
+});

--- a/src/security/action-sink-shell-policy.ts
+++ b/src/security/action-sink-shell-policy.ts
@@ -57,32 +57,60 @@ export function classifyShellCommand(input: {
 }): ShellClassification {
   const command = input.command.trim();
   const tags = new Set<ShellRiskTag>();
-  if (!command) add(tags, "unknown_command");
-  if (input.elevated || /(^|\s)sudo\b/.test(command)) add(tags, "privileged");
-  if (/[;&]|\|\||&&/.test(command)) add(tags, "compound");
-  if (/<<[-~]?\w+/.test(command)) add(tags, "heredoc");
-  if (/(^|[^<])>>?\s*[^&\s]/.test(command)) add(tags, "redirection");
-  if (/\|\s*(tee|xargs|sh|bash|zsh|python|node|perl|ruby)\b/.test(command))
+  if (!command) {
+    add(tags, "unknown_command");
+  }
+  if (input.elevated || /(^|\s)sudo\b/.test(command)) {
+    add(tags, "privileged");
+  }
+  if (/[;&]|\|\||&&/.test(command)) {
+    add(tags, "compound");
+  }
+  if (/<<[-~]?\w+/.test(command)) {
+    add(tags, "heredoc");
+  }
+  if (/(^|[^<])>>?\s*[^&\s]/.test(command)) {
+    add(tags, "redirection");
+  }
+  if (/\|\s*(tee|xargs|sh|bash|zsh|python|node|perl|ruby)\b/.test(command)) {
     add(tags, "pipe_to_mutator");
-  if (/\bfind\b.*\s-exec\s/.test(command)) add(tags, "find_exec");
-  if (/\bxargs\b/.test(command)) add(tags, "xargs");
-  if (INLINE_RE.test(command)) add(tags, "inline_script");
-  if (SHELL_WRAPPER_RE.test(command)) add(tags, "shell_wrapper");
-  if (NETWORK_RE.test(command)) add(tags, "network_write");
+  }
+  if (/\bfind\b.*\s-exec\s/.test(command)) {
+    add(tags, "find_exec");
+  }
+  if (/\bxargs\b/.test(command)) {
+    add(tags, "xargs");
+  }
+  if (INLINE_RE.test(command)) {
+    add(tags, "inline_script");
+  }
+  if (SHELL_WRAPPER_RE.test(command)) {
+    add(tags, "shell_wrapper");
+  }
+  if (NETWORK_RE.test(command)) {
+    add(tags, "network_write");
+  }
   if (
     /\bgit\s+(add|commit|push|reset|checkout|switch|merge|rebase|tag|clean|apply|am)\b/.test(
       command,
     )
-  )
+  ) {
     add(tags, "git_mutation");
-  if (MUTATOR_RE.test(command)) add(tags, "file_mutation");
+  }
+  if (MUTATOR_RE.test(command)) {
+    add(tags, "file_mutation");
+  }
 
   const first = command
     .split(/\s+/)
     .slice(0, command.startsWith("git ") ? 2 : 1)
     .join(" ");
-  if (tags.size === 0 && !SAFE_COMMANDS.has(first)) add(tags, "unknown_command");
-  if (tags.size === 0) add(tags, "safe_readonly");
+  if (tags.size === 0 && !SAFE_COMMANDS.has(first)) {
+    add(tags, "unknown_command");
+  }
+  if (tags.size === 0) {
+    add(tags, "safe_readonly");
+  }
 
   const riskTags = [...tags];
   const highRisk = riskTags.some((tag) => tag !== "safe_readonly");

--- a/src/security/action-sink-shell-policy.ts
+++ b/src/security/action-sink-shell-policy.ts
@@ -1,0 +1,108 @@
+export type ShellRiskTag =
+  | "safe_readonly"
+  | "unknown_command"
+  | "compound"
+  | "redirection"
+  | "heredoc"
+  | "pipe_to_mutator"
+  | "file_mutation"
+  | "git_mutation"
+  | "inline_script"
+  | "shell_wrapper"
+  | "privileged"
+  | "find_exec"
+  | "xargs"
+  | "network_write";
+
+export type ShellClassification = {
+  command: string;
+  riskTags: ShellRiskTag[];
+  highRisk: boolean;
+  mutating: boolean;
+  reason: string;
+};
+
+const SAFE_COMMANDS = new Set([
+  "pwd",
+  "ls",
+  "cat",
+  "head",
+  "tail",
+  "grep",
+  "rg",
+  "sed",
+  "awk",
+  "git status",
+  "git diff",
+  "git log",
+  "git show",
+  "find",
+]);
+const MUTATOR_RE =
+  /(^|\s)(rm|mv|cp|chmod|chown|mkdir|rmdir|touch|tee|install|rsync|sed\s+-i|perl\s+-pi|python3?|node|ruby|perl|npm|pnpm|yarn|bun|make|git\s+(add|commit|push|reset|checkout|switch|merge|rebase|tag|clean|apply|am)|trash)(\s|$)/;
+const NETWORK_RE =
+  /(^|\s)(curl|wget|gh|linear|aws|gcloud|az|kubectl|vercel|netlify|flyctl|railway|docker|ssh|scp|rsync|zoho)(\s|$)/;
+const INLINE_RE = /(^|\s)(node|python3?|ruby|perl)\s+(-e|--eval)\b/;
+const SHELL_WRAPPER_RE = /(^|\s)(sh|bash|zsh|fish|cmd|powershell|pwsh)\s+(-c|\/c)\b/;
+
+function add(tags: Set<ShellRiskTag>, tag: ShellRiskTag): void {
+  tags.add(tag);
+}
+
+export function classifyShellCommand(input: {
+  command: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  elevated?: boolean;
+}): ShellClassification {
+  const command = input.command.trim();
+  const tags = new Set<ShellRiskTag>();
+  if (!command) add(tags, "unknown_command");
+  if (input.elevated || /(^|\s)sudo\b/.test(command)) add(tags, "privileged");
+  if (/[;&]|\|\||&&/.test(command)) add(tags, "compound");
+  if (/<<[-~]?\w+/.test(command)) add(tags, "heredoc");
+  if (/(^|[^<])>>?\s*[^&\s]/.test(command)) add(tags, "redirection");
+  if (/\|\s*(tee|xargs|sh|bash|zsh|python|node|perl|ruby)\b/.test(command))
+    add(tags, "pipe_to_mutator");
+  if (/\bfind\b.*\s-exec\s/.test(command)) add(tags, "find_exec");
+  if (/\bxargs\b/.test(command)) add(tags, "xargs");
+  if (INLINE_RE.test(command)) add(tags, "inline_script");
+  if (SHELL_WRAPPER_RE.test(command)) add(tags, "shell_wrapper");
+  if (NETWORK_RE.test(command)) add(tags, "network_write");
+  if (
+    /\bgit\s+(add|commit|push|reset|checkout|switch|merge|rebase|tag|clean|apply|am)\b/.test(
+      command,
+    )
+  )
+    add(tags, "git_mutation");
+  if (MUTATOR_RE.test(command)) add(tags, "file_mutation");
+
+  const first = command
+    .split(/\s+/)
+    .slice(0, command.startsWith("git ") ? 2 : 1)
+    .join(" ");
+  if (tags.size === 0 && !SAFE_COMMANDS.has(first)) add(tags, "unknown_command");
+  if (tags.size === 0) add(tags, "safe_readonly");
+
+  const riskTags = [...tags];
+  const highRisk = riskTags.some((tag) => tag !== "safe_readonly");
+  return {
+    command,
+    riskTags,
+    highRisk,
+    mutating: riskTags.some((tag) =>
+      [
+        "file_mutation",
+        "git_mutation",
+        "redirection",
+        "heredoc",
+        "pipe_to_mutator",
+        "find_exec",
+        "xargs",
+      ].includes(tag),
+    ),
+    reason: highRisk
+      ? `Shell command risk: ${riskTags.join(", ")}`
+      : "Shell command appears read-only",
+  };
+}

--- a/src/security/completion-claim-policy.test.ts
+++ b/src/security/completion-claim-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  containsCompletionClaim,
+  createEvidenceGatePolicyModule,
+} from "./completion-claim-policy.js";
+
+describe("completion claim policy", () => {
+  it("classifies completion claims", () => {
+    expect(containsCompletionClaim("this is done and ready")).toBe(true);
+    expect(containsCompletionClaim("working on it")).toBe(false);
+  });
+
+  it("blocks completion/status claims without evidence", () => {
+    const mod = createEvidenceGatePolicyModule({
+      repoRoot: process.cwd(),
+      branch: "agent/forge-mch-61-action-sink-policy-20260426-1940",
+    });
+    expect(
+      mod.evaluate(
+        { policyVersion: "v1", actionType: "completion_claim", payloadSummary: "done" },
+        {},
+      ),
+    ).toMatchObject({ decision: "block" });
+    expect(
+      mod.evaluate(
+        { policyVersion: "v1", actionType: "status_transition", context: { status: "done" } },
+        {},
+      ),
+    ).toMatchObject({ decision: "block" });
+  });
+});

--- a/src/security/completion-claim-policy.ts
+++ b/src/security/completion-claim-policy.ts
@@ -18,14 +18,20 @@ export function createEvidenceGatePolicyModule(expected: {
   return {
     id: "evidenceGate",
     evaluate(request: PolicyRequest) {
-      const text = String(request.payloadSummary ?? request.context?.text ?? "");
+      const text =
+        (typeof request.payloadSummary === "string" ? request.payloadSummary : undefined) ??
+        (typeof request.context?.text === "string" ? request.context.text : "");
       const isClaim =
         request.actionType === "completion_claim" ||
         (request.actionType === "message_send" && containsCompletionClaim(text));
       const isTransition =
         request.actionType === "status_transition" &&
-        /done|ready|complete|succeeded/.test(String(request.context?.status ?? ""));
-      if (!isClaim && !isTransition) return undefined;
+        /done|ready|complete|succeeded/.test(
+          typeof request.context?.status === "string" ? request.context.status : "",
+        );
+      if (!isClaim && !isTransition) {
+        return undefined;
+      }
       const evidence = request.context?.evidence as ActionSinkEvidenceArtifact | undefined;
       if (!evidence) {
         return policyResult({

--- a/src/security/completion-claim-policy.ts
+++ b/src/security/completion-claim-policy.ts
@@ -1,0 +1,52 @@
+import type { ActionSinkEvidenceArtifact } from "./action-sink-evidence.js";
+import { verifyActionSinkEvidence } from "./action-sink-evidence.js";
+import type { PolicyModule, PolicyRequest } from "./action-sink-policy.js";
+import { policyResult } from "./action-sink-policy.js";
+
+const CLAIM_RE = /\b(done|ready|built|landed|complete|completed|shipped|fixed|implemented|live)\b/i;
+
+export function containsCompletionClaim(text: string): boolean {
+  return CLAIM_RE.test(text);
+}
+
+export function createEvidenceGatePolicyModule(expected: {
+  repoRoot: string;
+  branch: string;
+  commitSha?: string;
+  commitRange?: string;
+}): PolicyModule {
+  return {
+    id: "evidenceGate",
+    evaluate(request: PolicyRequest) {
+      const text = String(request.payloadSummary ?? request.context?.text ?? "");
+      const isClaim =
+        request.actionType === "completion_claim" ||
+        (request.actionType === "message_send" && containsCompletionClaim(text));
+      const isTransition =
+        request.actionType === "status_transition" &&
+        /done|ready|complete|succeeded/.test(String(request.context?.status ?? ""));
+      if (!isClaim && !isTransition) return undefined;
+      const evidence = request.context?.evidence as ActionSinkEvidenceArtifact | undefined;
+      if (!evidence) {
+        return policyResult({
+          policyId: "evidenceGate",
+          decision: "block",
+          reasonCode: "missing_evidence",
+          reason: "Completion/status claim requires review and QA evidence",
+          correlationId: request.correlationId,
+        });
+      }
+      const verified = verifyActionSinkEvidence(evidence, expected);
+      if (!verified.ok) {
+        return policyResult({
+          policyId: "evidenceGate",
+          decision: "block",
+          reasonCode: verified.reason.includes("stale") ? "stale_evidence" : "missing_evidence",
+          reason: `Evidence rejected: ${verified.reason}`,
+          correlationId: request.correlationId,
+        });
+      }
+      return undefined;
+    },
+  };
+}

--- a/src/security/external-action-firewall.test.ts
+++ b/src/security/external-action-firewall.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyExternalAction,
+  createExternalActionFirewallModule,
+} from "./external-action-firewall.js";
+
+describe("external action firewall", () => {
+  it("classifies Telegram/message, Linear/GitHub, email/social, Zoho/payment, deploy/publish, and internal", () => {
+    expect(classifyExternalAction({ channel: "telegram", action: "send" })).toBe("external");
+    expect(classifyExternalAction({ target: "github comment" })).toBe("external");
+    expect(classifyExternalAction({ target: "email customer" })).toBe("customer");
+    expect(classifyExternalAction({ target: "zoho payment" })).toBe("operator");
+    expect(classifyExternalAction({ target: "production deploy publish" })).toBe("operator");
+    expect(classifyExternalAction({ target: "local file" })).toBe("internal");
+  });
+
+  it("requires approval unless allowlisted", () => {
+    const mod = createExternalActionFirewallModule({
+      externalAllowlist: [{ targetPattern: "internal-*" }],
+    });
+    expect(
+      mod.evaluate(
+        { policyVersion: "v1", actionType: "message_send", targetResource: "telegram chat" },
+        {},
+      ),
+    ).toMatchObject({ decision: "requireApproval" });
+    expect(
+      mod.evaluate(
+        { policyVersion: "v1", actionType: "message_send", targetResource: "internal-bot" },
+        {},
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/security/external-action-firewall.ts
+++ b/src/security/external-action-firewall.ts
@@ -16,25 +16,30 @@ export function classifyExternalAction(input: {
     /payment|stripe|paypal|zoho|deploy|publish|production|kubectl|aws|gcloud|cloudflare/.test(
       haystack,
     )
-  )
+  ) {
     return "operator";
+  }
   if (
     /twitter|x\.com|linkedin|facebook|instagram|public|social|email|gmail|smtp|customer/.test(
       haystack,
     )
-  )
+  ) {
     return "customer";
+  }
   if (
     /telegram|discord|slack|linear|github|gh\b|comment|message|send|reply|react|pin|delete|edit/.test(
       haystack,
     )
-  )
+  ) {
     return "external";
+  }
   return "internal";
 }
 
 function matches(pattern: string, value: string): boolean {
-  if (pattern === value) return true;
+  if (pattern === value) {
+    return true;
+  }
   const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
   return new RegExp(`^${escaped}$`, "i").test(value);
 }
@@ -43,7 +48,9 @@ export function isExternalActionAllowlisted(
   config: Pick<ActionSinkPolicyConfig, "externalAllowlist">,
   request: PolicyRequest,
 ): boolean {
-  const target = String(request.targetResource ?? request.context?.target ?? "");
+  const target =
+    request.targetResource ??
+    (typeof request.context?.target === "string" ? request.context.target : "");
   return config.externalAllowlist.some(
     (rule) =>
       matches(rule.targetPattern, target) &&
@@ -57,14 +64,18 @@ export function createExternalActionFirewallModule(
   return {
     id: "externalActionFirewall",
     evaluate(request) {
-      if (!["message_send", "external_api_write"].includes(request.actionType)) return undefined;
+      if (!["message_send", "external_api_write"].includes(request.actionType)) {
+        return undefined;
+      }
       const tier = classifyExternalAction({
-        target: String(request.targetResource ?? ""),
-        channel: String(request.context?.channel ?? ""),
-        action: String(request.context?.action ?? ""),
+        target: request.targetResource ?? "",
+        channel: typeof request.context?.channel === "string" ? request.context.channel : "",
+        action: typeof request.context?.action === "string" ? request.context.action : "",
         toolName: request.toolName,
       });
-      if (tier === "internal" || isExternalActionAllowlisted(config, request)) return undefined;
+      if (tier === "internal" || isExternalActionAllowlisted(config, request)) {
+        return undefined;
+      }
       return policyResult({
         policyId: "externalActionFirewall",
         decision: "requireApproval",

--- a/src/security/external-action-firewall.ts
+++ b/src/security/external-action-firewall.ts
@@ -1,0 +1,77 @@
+import type { ActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import type { PolicyModule, PolicyRequest } from "./action-sink-policy.js";
+import { policyResult } from "./action-sink-policy.js";
+
+export type ExternalRiskTier = "internal" | "external" | "customer" | "operator";
+
+export function classifyExternalAction(input: {
+  target?: string;
+  channel?: string;
+  action?: string;
+  toolName?: string;
+}): ExternalRiskTier {
+  const haystack =
+    `${input.target ?? ""} ${input.channel ?? ""} ${input.action ?? ""} ${input.toolName ?? ""}`.toLowerCase();
+  if (
+    /payment|stripe|paypal|zoho|deploy|publish|production|kubectl|aws|gcloud|cloudflare/.test(
+      haystack,
+    )
+  )
+    return "operator";
+  if (
+    /twitter|x\.com|linkedin|facebook|instagram|public|social|email|gmail|smtp|customer/.test(
+      haystack,
+    )
+  )
+    return "customer";
+  if (
+    /telegram|discord|slack|linear|github|gh\b|comment|message|send|reply|react|pin|delete|edit/.test(
+      haystack,
+    )
+  )
+    return "external";
+  return "internal";
+}
+
+function matches(pattern: string, value: string): boolean {
+  if (pattern === value) return true;
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`, "i").test(value);
+}
+
+export function isExternalActionAllowlisted(
+  config: Pick<ActionSinkPolicyConfig, "externalAllowlist">,
+  request: PolicyRequest,
+): boolean {
+  const target = String(request.targetResource ?? request.context?.target ?? "");
+  return config.externalAllowlist.some(
+    (rule) =>
+      matches(rule.targetPattern, target) &&
+      (!rule.actionTypes || rule.actionTypes.includes(request.actionType)),
+  );
+}
+
+export function createExternalActionFirewallModule(
+  config: Pick<ActionSinkPolicyConfig, "externalAllowlist">,
+): PolicyModule {
+  return {
+    id: "externalActionFirewall",
+    evaluate(request) {
+      if (!["message_send", "external_api_write"].includes(request.actionType)) return undefined;
+      const tier = classifyExternalAction({
+        target: String(request.targetResource ?? ""),
+        channel: String(request.context?.channel ?? ""),
+        action: String(request.context?.action ?? ""),
+        toolName: request.toolName,
+      });
+      if (tier === "internal" || isExternalActionAllowlisted(config, request)) return undefined;
+      return policyResult({
+        policyId: "externalActionFirewall",
+        decision: "requireApproval",
+        reasonCode: "external_write",
+        reason: `${tier} outbound action requires approval`,
+        correlationId: request.correlationId,
+      });
+    },
+  };
+}

--- a/src/security/protected-worktree-policy.test.ts
+++ b/src/security/protected-worktree-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { parseActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import {
+  evaluateProtectedWorktree,
+  isPathInside,
+  normalizePolicyPath,
+} from "./protected-worktree-policy.js";
+
+const config = parseActionSinkPolicyConfig({
+  protectedRoots: ["/protected"],
+  assignedWorktrees: [{ issueId: "MCH-61", worktreeRoot: "/workers/mch-61" }],
+});
+
+describe("protected worktree policy", () => {
+  it("normalizes paths with missing path fallback and symlink realpath injection", () => {
+    expect(normalizePolicyPath("/missing/../target", () => "/real/target")).toBe("/real/target");
+    expect(normalizePolicyPath("/missing/../target")).toContain("/target");
+    expect(isPathInside("/a", "/a/b")).toBe(true);
+  });
+
+  it("blocks protected root file writes", () => {
+    expect(
+      evaluateProtectedWorktree({
+        request: {
+          policyVersion: "v1",
+          actionType: "file_write",
+          targetResource: "/protected/file",
+        },
+        config,
+      })?.decision,
+    ).toBe("block");
+  });
+
+  it("blocks cwd/repo-root confusion outside assigned worktree", () => {
+    expect(
+      evaluateProtectedWorktree({
+        request: {
+          policyVersion: "v1",
+          actionType: "file_write",
+          targetResource: "/tmp/file",
+          context: { issueId: "MCH-61" },
+        },
+        config,
+      })?.reasonCode,
+    ).toBe("unassigned_worktree");
+  });
+
+  it("applies shell risk to protected worktrees", () => {
+    expect(
+      evaluateProtectedWorktree({
+        request: {
+          policyVersion: "v1",
+          actionType: "shell_exec",
+          targetResource: "/protected",
+          context: { command: "echo hi > x" },
+        },
+        config,
+      })?.decision,
+    ).toBe("block");
+    expect(
+      evaluateProtectedWorktree({
+        request: {
+          policyVersion: "v1",
+          actionType: "shell_exec",
+          targetResource: "/protected",
+          context: { command: "git status" },
+        },
+        config,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/security/protected-worktree-policy.ts
+++ b/src/security/protected-worktree-policy.ts
@@ -31,19 +31,29 @@ export function evaluateProtectedWorktree(params: {
   config: Pick<ActionSinkPolicyConfig, "protectedRoots" | "assignedWorktrees">;
   realpath?: RealpathFn;
 }): PolicyResult | undefined {
-  const target = String(params.request.targetResource ?? params.request.context?.cwd ?? "");
+  const target =
+    params.request.targetResource ??
+    (typeof params.request.context?.cwd === "string" ? params.request.context.cwd : "");
   const normalizedTarget = target ? normalizePolicyPath(target, params.realpath) : "";
   const protectedRoot = params.config.protectedRoots.find((root) =>
     isPathInside(normalizePolicyPath(root, params.realpath), normalizedTarget),
   );
   const action = params.request.actionType;
   const isMutation = ["file_write", "git_mutation", "shell_exec"].includes(action);
-  if (!isMutation) return undefined;
+  if (!isMutation) {
+    return undefined;
+  }
 
   if (action === "shell_exec") {
-    const command = String(params.request.context?.command ?? params.request.payloadSummary ?? "");
+    const command =
+      (typeof params.request.context?.command === "string"
+        ? params.request.context.command
+        : undefined) ??
+      (typeof params.request.payloadSummary === "string" ? params.request.payloadSummary : "");
     const shell = classifyShellCommand({ command, cwd: target });
-    if (!shell.highRisk) return undefined;
+    if (!shell.highRisk) {
+      return undefined;
+    }
   }
 
   if (protectedRoot) {
@@ -68,7 +78,8 @@ export function evaluateProtectedWorktree(params: {
       assignment &&
       !isPathInside(
         normalizePolicyPath(assignment.worktreeRoot, params.realpath),
-        normalizedTarget || String(params.request.context?.cwd ?? ""),
+        normalizedTarget ||
+          (typeof params.request.context?.cwd === "string" ? params.request.context.cwd : ""),
       )
     ) {
       return policyResult({

--- a/src/security/protected-worktree-policy.ts
+++ b/src/security/protected-worktree-policy.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ActionSinkPolicyConfig } from "./action-sink-policy-config.js";
+import type { PolicyModule, PolicyRequest, PolicyResult } from "./action-sink-policy.js";
+import { policyResult } from "./action-sink-policy.js";
+import { classifyShellCommand } from "./action-sink-shell-policy.js";
+
+export type RealpathFn = (target: string) => string;
+
+export function normalizePolicyPath(
+  target: string,
+  realpath: RealpathFn = fs.realpathSync.native,
+): string {
+  const resolved = path.resolve(target);
+  try {
+    return realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(path.resolve(parent), path.resolve(child));
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+export function evaluateProtectedWorktree(params: {
+  request: PolicyRequest;
+  config: Pick<ActionSinkPolicyConfig, "protectedRoots" | "assignedWorktrees">;
+  realpath?: RealpathFn;
+}): PolicyResult | undefined {
+  const target = String(params.request.targetResource ?? params.request.context?.cwd ?? "");
+  const normalizedTarget = target ? normalizePolicyPath(target, params.realpath) : "";
+  const protectedRoot = params.config.protectedRoots.find((root) =>
+    isPathInside(normalizePolicyPath(root, params.realpath), normalizedTarget),
+  );
+  const action = params.request.actionType;
+  const isMutation = ["file_write", "git_mutation", "shell_exec"].includes(action);
+  if (!isMutation) return undefined;
+
+  if (action === "shell_exec") {
+    const command = String(params.request.context?.command ?? params.request.payloadSummary ?? "");
+    const shell = classifyShellCommand({ command, cwd: target });
+    if (!shell.highRisk) return undefined;
+  }
+
+  if (protectedRoot) {
+    return policyResult({
+      policyId: "protectedWorktree",
+      decision: "block",
+      reasonCode: "protected_worktree",
+      reason: `Mutation targets protected root ${protectedRoot}`,
+      correlationId: params.request.correlationId,
+    });
+  }
+
+  const issueId =
+    typeof params.request.context?.issueId === "string"
+      ? params.request.context.issueId
+      : undefined;
+  if (params.config.assignedWorktrees.length > 0 && issueId) {
+    const assignment = params.config.assignedWorktrees.find(
+      (item) => !item.issueId || item.issueId === issueId,
+    );
+    if (
+      assignment &&
+      !isPathInside(
+        normalizePolicyPath(assignment.worktreeRoot, params.realpath),
+        normalizedTarget || String(params.request.context?.cwd ?? ""),
+      )
+    ) {
+      return policyResult({
+        policyId: "protectedWorktree",
+        decision: "block",
+        reasonCode: "unassigned_worktree",
+        reason: `Mutation is outside assigned worktree ${assignment.worktreeRoot}`,
+        correlationId: params.request.correlationId,
+      });
+    }
+  }
+  return undefined;
+}
+
+export function createProtectedWorktreePolicyModule(config: ActionSinkPolicyConfig): PolicyModule {
+  return {
+    id: "protectedWorktree",
+    evaluate: (request) => evaluateProtectedWorktree({ request, config }),
+  };
+}

--- a/src/tasks/task-executor.action-sink-policy.test.ts
+++ b/src/tasks/task-executor.action-sink-policy.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { policyResult, type PolicyModule } from "../security/action-sink-policy.js";
+import { __testing } from "../security/action-sink-runtime.js";
+import { createQueuedTaskRun } from "./task-executor.js";
+
+const blockStatusTransitionModule: PolicyModule = {
+  id: "test-status-block",
+  evaluate(request) {
+    if (request.actionType !== "status_transition") {
+      return undefined;
+    }
+    return policyResult({
+      policyId: "test-status-block",
+      decision: "block",
+      reasonCode: "invalid_request",
+      reason: "status transition blocked",
+    });
+  },
+};
+
+describe("task executor action-sink policy", () => {
+  afterEach(() => {
+    __testing.setActionSinkEnforcementOverride(null);
+  });
+
+  it("gates task status transitions before registry mutation", () => {
+    __testing.setActionSinkEnforcementOverride({ modules: [blockStatusTransitionModule] });
+
+    expect(() =>
+      createQueuedTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        task: "blocked transition",
+        notifyPolicy: "done_only",
+        deliveryStatus: "pending",
+      }),
+    ).toThrow("status transition blocked");
+  });
+});

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { enforceActionSinkPolicySync } from "../security/action-sink-runtime.js";
 import type {
   DetachedRunningTaskCreateParams,
   DetachedTaskCreateParams,
@@ -91,7 +92,36 @@ function ensureSingleTaskFlow(params: {
 type TaskRunCreateParams = DetachedTaskCreateParams;
 type RunningTaskRunCreateParams = DetachedRunningTaskCreateParams;
 
+function enforceTaskStatusTransition(params: {
+  toolName: string;
+  status: TaskStatus;
+  runId?: string;
+  sessionKey?: string;
+  taskId?: string;
+  payloadSummary?: unknown;
+}): void {
+  enforceActionSinkPolicySync({
+    policyVersion: "v1",
+    actionType: "status_transition",
+    toolName: params.toolName,
+    targetResource: params.taskId ?? params.runId,
+    payloadSummary: params.payloadSummary,
+    actor: { sessionKey: params.sessionKey },
+    context: {
+      status: params.status,
+      runId: params.runId,
+      taskId: params.taskId,
+    },
+  });
+}
+
 export function createQueuedTaskRun(params: TaskRunCreateParams): TaskRecord {
+  enforceTaskStatusTransition({
+    toolName: "task.createQueuedTaskRun",
+    status: "queued",
+    sessionKey: params.ownerKey,
+    payloadSummary: params,
+  });
   const task = createTaskRecord({
     ...params,
     status: "queued",
@@ -107,6 +137,13 @@ export function getFlowTaskSummary(flowId: string): TaskRegistrySummary {
 }
 
 export function createRunningTaskRun(params: RunningTaskRunCreateParams): TaskRecord {
+  enforceTaskStatusTransition({
+    toolName: "task.createRunningTaskRun",
+    status: "running",
+    runId: params.runId,
+    sessionKey: params.ownerKey,
+    payloadSummary: params,
+  });
   const task = createTaskRecord({
     ...params,
     status: "running",
@@ -145,6 +182,13 @@ export function startTaskRunByRunId(params: {
   progressSummary?: string | null;
   eventSummary?: string | null;
 }) {
+  enforceTaskStatusTransition({
+    toolName: "task.startTaskRunByRunId",
+    status: "running",
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    payloadSummary: params,
+  });
   return markTaskRunningByRunId(params);
 }
 
@@ -176,6 +220,13 @@ export function completeTaskRunByRunId(params: {
 }
 
 export function finalizeTaskRunByRunId(params: DetachedTaskFinalizeParams) {
+  enforceTaskStatusTransition({
+    toolName: "task.finalizeTaskRunByRunId",
+    status: params.status,
+    runId: params.runId,
+    sessionKey: params.sessionKey,
+    payloadSummary: params,
+  });
   return finalizeTaskRunByRunIdInRegistry(params);
 }
 
@@ -203,6 +254,12 @@ export function markTaskRunLostById(params: {
   error?: string;
   cleanupAfter?: number;
 }) {
+  enforceTaskStatusTransition({
+    toolName: "task.markTaskRunLostById",
+    status: "lost",
+    taskId: params.taskId,
+    payloadSummary: params,
+  });
   return markTaskLostById(params);
 }
 


### PR DESCRIPTION
## Summary

Implements MCH-61 / Policy Kernel v1 Action Sink Policy Enforcement from the green Buildify package:

- action-sink policy kernel/config/audit
- conservative shell/tool-call policy enforcement
- protected worktree checks
- evidence/completion-claim gates
- external action firewall
- outbound delivery/message action gates
- task status transition gates
- recovery and shadow report support

## Buildify / review source

- Buildify package: `docs/_system/designs/action-sink-policy-enforcement/`
- Green task plan: `superpowers-task-plan-v3.md`
- Green task-plan review: `_reviews/superpowers-task-plan-review-v3-20260426-1852.md`

## Verification after rebase onto upstream main

Saved evidence:
`docs/_system/designs/action-sink-policy-enforcement/_reports/rebase-rerun-20260427-0130.md`

Commands passed:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts \
  src/security/action-sink-policy.test.ts \
  src/security/action-sink-policy-config.test.ts \
  src/security/action-sink-audit.test.ts \
  src/security/action-sink-shell-policy.test.ts \
  src/security/protected-worktree-policy.test.ts \
  src/security/action-sink-evidence.test.ts \
  src/security/completion-claim-policy.test.ts \
  src/security/external-action-firewall.test.ts \
  src/security/action-sink-recovery.test.ts \
  src/security/action-sink-shadow-report.test.ts \
  src/agents/bash-tools.exec-runtime.test.ts \
  src/agents/bash-tools.exec.script-preflight.test.ts \
  src/process/exec.test.ts \
  src/infra/outbound/delivery-queue.test.ts \
  src/infra/outbound/message-action-runner.test.ts \
  src/tasks/status-transition-policy.test.ts
pnpm tsgo:core
pnpm tsgo:core:test
pnpm lint
```

Result: focused vitest 9 files / 29 tests passed; typecheck core passed; typecheck core test passed; lint passed.

## Note

Upstream direct push was blocked by GitHub permissions for the active account, so this PR is opened from the fork branch.
