### PR TITLE
fix: shouldSkipBackendSelfPairing allows loopback clients to...

### DIFF
--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -92,11 +92,10 @@ Treat Gateway and node as one operator trust domain, with different roles:
 - **Gateway** is the control plane and policy surface (`gateway.auth`, tool policy, routing).
 - **Node** is remote execution surface paired to that Gateway (commands, device actions, host-local capabilities).
 - A caller authenticated to the Gateway is trusted at Gateway scope. After pairing, node actions are trusted operator actions on that node.
-- Direct loopback backend clients authenticated with the shared gateway
-  token/password can make internal control-plane RPCs without presenting a user
-  device identity. This is not a remote or browser pairing bypass: network
-  clients, node clients, device-token clients, and explicit device identities
-  still go through pairing and scope-upgrade enforcement.
+- Direct loopback backend clients can skip device pairing only when they prove a
+  dedicated bootstrap or device credential. Shared gateway token/password auth
+  alone is not enough to bypass pairing. Remote and browser clients still go
+  through pairing and scope-upgrade enforcement.
 - `sessionKey` is routing/context selection, not per-user auth.
 - Exec approvals (allowlist + ask) are guardrails for operator intent, not hostile multi-tenant isolation.
 - OpenClaw's product default for trusted single-operator setups is that host exec on `gateway`/`node` is allowed without approval prompts (`security="full"`, `ask="off"` unless you tighten it). That default is intentional UX, not a vulnerability by itself.

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -382,6 +382,15 @@ describe("handshake auth helpers", () => {
         connectParams,
         locality: "direct_local",
         hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
         sharedAuthOk: true,
         authMethod: "bootstrap-token",
       }),

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -343,7 +343,7 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients with bootstrap-token auth", () => {
+  it("skips backend self-pairing only for direct-local backend clients", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -356,7 +356,7 @@ describe("handshake auth helpers", () => {
         locality: "direct_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "bootstrap-token",
+        authMethod: "token",
       }),
     ).toBe(true);
     expect(
@@ -365,22 +365,13 @@ describe("handshake auth helpers", () => {
         locality: "remote",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "bootstrap-token",
-      }),
-    ).toBe(false);
-    expect(
-      shouldSkipLocalBackendSelfPairing({
-        connectParams,
-        locality: "direct_local",
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
         authMethod: "token",
       }),
     ).toBe(false);
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
-        locality: "direct_local",
+        locality: "remote",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
         authMethod: "password",
@@ -391,17 +382,35 @@ describe("handshake auth helpers", () => {
         connectParams,
         locality: "direct_local",
         hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
         sharedAuthOk: false,
         authMethod: "device-token",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
         locality: "cli_container_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "bootstrap-token",
+        authMethod: "token",
       }),
     ).toBe(false);
   });
@@ -437,7 +446,7 @@ describe("handshake auth helpers", () => {
         locality: "direct_local",
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
-        authMethod: "bootstrap-token",
+        authMethod: "token",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -343,7 +343,7 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients", () => {
+  it("skips backend self-pairing only for direct-local backend clients with bootstrap-token auth", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -356,7 +356,7 @@ describe("handshake auth helpers", () => {
         locality: "direct_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "token",
+        authMethod: "bootstrap-token",
       }),
     ).toBe(true);
     expect(
@@ -365,13 +365,22 @@ describe("handshake auth helpers", () => {
         locality: "remote",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authMethod: "bootstrap-token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
         authMethod: "token",
       }),
     ).toBe(false);
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
-        locality: "remote",
+        locality: "direct_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
         authMethod: "password",
@@ -385,15 +394,6 @@ describe("handshake auth helpers", () => {
         sharedAuthOk: false,
         authMethod: "device-token",
       }),
-    ).toBe(true);
-    expect(
-      shouldSkipLocalBackendSelfPairing({
-        connectParams,
-        locality: "remote",
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: false,
-        authMethod: "device-token",
-      }),
     ).toBe(false);
     expect(
       shouldSkipLocalBackendSelfPairing({
@@ -401,7 +401,7 @@ describe("handshake auth helpers", () => {
         locality: "cli_container_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
-        authMethod: "token",
+        authMethod: "bootstrap-token",
       }),
     ).toBe(false);
   });
@@ -437,7 +437,7 @@ describe("handshake auth helpers", () => {
         locality: "direct_local",
         hasBrowserOriginHeader: true,
         sharedAuthOk: true,
-        authMethod: "token",
+        authMethod: "bootstrap-token",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -398,12 +398,12 @@ describe("handshake auth helpers", () => {
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
-        locality: "direct_local",
+        locality: "remote",
         hasBrowserOriginHeader: false,
         sharedAuthOk: false,
         authMethod: "device-token",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -343,7 +343,7 @@ describe("handshake auth helpers", () => {
     ).toBe("shared_secret_loopback_local");
   });
 
-  it("skips backend self-pairing only for direct-local backend clients", () => {
+  it("skips backend self-pairing only for direct-local backend clients with dedicated credentials", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
@@ -358,7 +358,16 @@ describe("handshake auth helpers", () => {
         sharedAuthOk: true,
         authMethod: "token",
       }),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "password",
+      }),
+    ).toBe(false);
     expect(
       shouldSkipLocalBackendSelfPairing({
         connectParams,
@@ -382,15 +391,6 @@ describe("handshake auth helpers", () => {
         connectParams,
         locality: "direct_local",
         hasBrowserOriginHeader: false,
-        sharedAuthOk: false,
-        authMethod: "device-token",
-      }),
-    ).toBe(true);
-    expect(
-      shouldSkipLocalBackendSelfPairing({
-        connectParams,
-        locality: "direct_local",
-        hasBrowserOriginHeader: false,
         sharedAuthOk: true,
         authMethod: "bootstrap-token",
       }),
@@ -401,6 +401,15 @@ describe("handshake auth helpers", () => {
         locality: "direct_local",
         hasBrowserOriginHeader: false,
         sharedAuthOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipLocalBackendSelfPairing({
+        connectParams,
+        locality: "direct_local",
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
         authMethod: "device-token",
       }),
     ).toBe(true);

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -262,9 +262,13 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (!isBackendClient) {
     return false;
   }
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesBootstrapTokenAuth = params.authMethod === "bootstrap-token";
+  const usesDeviceTokenAuth = params.authMethod === "device-token";
   return (
-    params.locality === "direct_local" && !params.hasBrowserOriginHeader && usesBootstrapTokenAuth
+    params.locality === "direct_local" &&
+    !params.hasBrowserOriginHeader &&
+    ((params.sharedAuthOk && usesSharedSecretAuth) || usesBootstrapTokenAuth || usesDeviceTokenAuth)
   );
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -265,6 +265,11 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesBootstrapTokenAuth = params.authMethod === "bootstrap-token";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
+  // bootstrap-token and device-token bypass sharedAuthOk because they represent
+  // dedicated, scoped credentials (device identity / bootstrap handshake) that are
+  // not exposed to general operator use and therefore do not depend on the
+  // shared-secret trust signal (sharedAuthOk). Only the shared-secret path
+  // (token/password) requires sharedAuthOk to be true.
   return (
     params.locality === "direct_local" &&
     !params.hasBrowserOriginHeader &&

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -262,12 +262,9 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (!isBackendClient) {
     return false;
   }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
-  const usesDeviceTokenAuth = params.authMethod === "device-token";
+  const usesBootstrapTokenAuth = params.authMethod === "bootstrap-token";
   return (
-    params.locality === "direct_local" &&
-    !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth)
+    params.locality === "direct_local" && !params.hasBrowserOriginHeader && usesBootstrapTokenAuth
   );
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -262,18 +262,12 @@ export function shouldSkipLocalBackendSelfPairing(params: {
   if (!isBackendClient) {
     return false;
   }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesBootstrapTokenAuth = params.authMethod === "bootstrap-token";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
-  // bootstrap-token and device-token bypass sharedAuthOk because they represent
-  // dedicated, scoped credentials (device identity / bootstrap handshake) that are
-  // not exposed to general operator use and therefore do not depend on the
-  // shared-secret trust signal (sharedAuthOk). Only the shared-secret path
-  // (token/password) requires sharedAuthOk to be true.
   return (
     params.locality === "direct_local" &&
     !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || usesBootstrapTokenAuth || usesDeviceTokenAuth)
+    (usesBootstrapTokenAuth || usesDeviceTokenAuth)
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -649,10 +649,9 @@ export function attachGatewayWsMessageHandler(params: {
             hasSharedAuth,
             isLocalClient,
           });
-          // Shared token/password auth can bypass pairing for trusted operators.
           // Device-less clients still clear self-declared scopes by default, with
-          // one narrow exception: the direct-local backend gateway-client shared-
-          // auth handoff used for in-process control-plane coordination.
+          // one narrow exception: the direct-local backend gateway-client handoff
+          // that proves a dedicated bootstrap or device credential.
           if (
             !device &&
             !skipLocalBackendSelfPairing &&


### PR DESCRIPTION
## Summary

- Problem: direct loopback clients could self-declare the backend gateway client identity and use the shared gateway token or password to skip device pairing.
- Why it matters: any local token-holder that can open a loopback WebSocket could impersonate the backend path and retain privileged control-plane access without proving device identity.
- What changed: backend self-pairing now requires a dedicated credential (`bootstrap-token` or `device-token`). Shared gateway `token` and `password` no longer trigger the bypass, and the gateway security docs now describe that narrower trust boundary.
- What did NOT change (scope boundary): remote clients, browser-origin clients, and non-backend clients still do not get the bypass; no unrelated auth defaults or migrations changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72418
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `shouldSkipLocalBackendSelfPairing()` trusted a client-declared backend identity plus shared gateway auth on direct loopback connections, so the pairing bypass was reachable with general shared secrets instead of dedicated backend-only credentials.
- Missing detection / guardrail: the regression test still expected `authMethod: "token"` to return `true` for direct-local backend clients.
- Contributing context (if known): the gateway security docs also documented the broader shared-token bypass as intended behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: targeted gateway handshake helper coverage plus normal build validation.
- Target test or file: `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- Scenario the test should lock in: shared gateway `token`/`password` auth must not skip pairing for self-declared backend clients; only `bootstrap-token` or `device-token` may do so on the direct-local path.
- Why this is the smallest reliable guardrail: it exercises the exact helper that controls the bypass decision without widening test scope.

## User-visible / Behavior Changes

- Direct loopback backend clients now need a dedicated bootstrap or device credential to skip device pairing.
- Shared gateway token/password auth alone no longer bypasses pairing on that path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: this narrows an existing local control-plane auth bypass so that only dedicated credentials can use it. Validation: `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts` and `pnpm build` both passed.

## Repro + Verification

### Steps

1. Open a direct loopback WebSocket and self-declare `GATEWAY_CLIENT` + `BACKEND`.
2. Authenticate with the shared gateway `token` or `password` and omit device identity.
3. Confirm pairing is no longer skipped.
4. Authenticate with `bootstrap-token` or `device-token` on the same direct-local backend path.
5. Confirm the dedicated-credential bypass still works.

### Verification

- `pnpm test src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- `pnpm build`

## Evidence

- Updated files:
- `src/gateway/server/ws-connection/handshake-auth-helpers.ts`
- `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- `src/gateway/server/ws-connection/message-handler.ts`
- `docs/gateway/security/index.md`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): No
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: legitimate in-process backend flows that were incorrectly relying on shared gateway token/password auth will now need to use bootstrap/device credentials instead.
  - Mitigation: dedicated credential paths remain explicitly allowed and covered by the regression test.
