### PR TITLE
test(plugins): guard command cold registry paths

### DIFF
--- a/src/commands/plugin-control-plane-cold-imports.test.ts
+++ b/src/commands/plugin-control-plane-cold-imports.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { clearPluginDiscoveryCache } from "../plugins/discovery.js";
+import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
+import { refreshPluginRegistry } from "../plugins/plugin-registry.js";
+import { buildAuthChoiceOptions, formatAuthChoiceChoicesForCli } from "./auth-choice-options.js";
+import { listManifestInstalledChannelIds } from "./channel-setup/discovery.js";
+import { resolveProviderCatalogPluginIdsForFilter } from "./models/list.provider-catalog.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-command-cold-imports-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function hermeticEnv(
+  homeDir: string,
+  options: { disablePersistedRegistry?: boolean } = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    OPENCLAW_HOME: path.join(homeDir, "home"),
+    OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+    OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY:
+      options.disablePersistedRegistry === false ? undefined : "1",
+    OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+    OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
+    OPENCLAW_VERSION: "2026.4.25",
+    VITEST: "true",
+  };
+}
+
+function createColdControlPlanePlugin() {
+  const rootDir = makeTempDir();
+  const runtimeMarker = path.join(rootDir, "runtime-loaded.txt");
+  fs.writeFileSync(
+    path.join(rootDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "@example/openclaw-cold-control-plane",
+        version: "1.0.0",
+        openclaw: { extensions: ["./index.cjs"] },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: "cold-control-plane",
+        name: "Cold Control Plane",
+        configSchema: { type: "object" },
+        providers: ["cold-model-provider"],
+        channels: ["cold-channel"],
+        channelConfigs: {
+          "cold-channel": {
+            schema: { type: "object" },
+          },
+        },
+        providerAuthChoices: [
+          {
+            provider: "cold-model-provider",
+            method: "api-key",
+            choiceId: "cold-provider-api-key",
+            choiceLabel: "Cold Provider API key",
+            groupId: "cold-model-provider",
+            groupLabel: "Cold Provider",
+            optionKey: "coldProviderApiKey",
+            cliFlag: "--cold-provider-api-key",
+            cliOption: "--cold-provider-api-key <key>",
+            onboardingScopes: ["text-inference"],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "index.cjs"),
+    `require("node:fs").writeFileSync(${JSON.stringify(runtimeMarker)}, "loaded", "utf8");\nthrow new Error("runtime entry should not load for command control-plane discovery");\n`,
+    "utf8",
+  );
+  return { rootDir, runtimeMarker };
+}
+
+function createColdConfig(pluginDir: string): OpenClawConfig {
+  return {
+    plugins: {
+      load: { paths: [pluginDir] },
+      entries: {
+        "cold-control-plane": { enabled: true },
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  clearPluginDiscoveryCache();
+  clearPluginManifestRegistryCache();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("command control-plane plugin discovery", () => {
+  it("resolves channel setup metadata without importing plugin runtime", () => {
+    const plugin = createColdControlPlanePlugin();
+    const workspaceDir = makeTempDir();
+    const cfg = createColdConfig(plugin.rootDir);
+    const env = hermeticEnv(workspaceDir);
+
+    expect(
+      listManifestInstalledChannelIds({
+        cfg,
+        workspaceDir,
+        env,
+      }),
+    ).toContain("cold-channel");
+    expect(fs.existsSync(plugin.runtimeMarker)).toBe(false);
+  });
+
+  it("builds onboarding auth choices from manifest metadata without importing plugin runtime", () => {
+    const plugin = createColdControlPlanePlugin();
+    const workspaceDir = makeTempDir();
+    const cfg = createColdConfig(plugin.rootDir);
+    const env = hermeticEnv(workspaceDir);
+
+    expect(
+      buildAuthChoiceOptions({
+        store: {} as never,
+        includeSkip: false,
+        config: cfg,
+        workspaceDir,
+        env,
+      }),
+    ).toContainEqual(
+      expect.objectContaining({
+        value: "cold-provider-api-key",
+        label: "Cold Provider API key",
+        groupId: "cold-model-provider",
+      }),
+    );
+    expect(
+      formatAuthChoiceChoicesForCli({
+        config: cfg,
+        workspaceDir,
+        env,
+      }).split("|"),
+    ).toContain("cold-provider-api-key");
+    expect(fs.existsSync(plugin.runtimeMarker)).toBe(false);
+  });
+
+  it("resolves models-list provider ownership without importing plugin runtime", async () => {
+    const plugin = createColdControlPlanePlugin();
+    const workspaceDir = makeTempDir();
+    const cfg = createColdConfig(plugin.rootDir);
+    const env = hermeticEnv(workspaceDir, { disablePersistedRegistry: false });
+
+    await refreshPluginRegistry({
+      config: cfg,
+      workspaceDir,
+      env,
+      reason: "manual",
+    });
+    expect(fs.existsSync(plugin.runtimeMarker)).toBe(false);
+
+    await expect(
+      resolveProviderCatalogPluginIdsForFilter({
+        cfg,
+        env,
+        providerFilter: "cold-model-provider",
+      }),
+    ).resolves.toEqual(["cold-control-plane"]);
+    expect(fs.existsSync(plugin.runtimeMarker)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: command setup/list paths can regress into importing plugin runtime while they only need manifest/registry metadata.
- Why it matters: plugin registry scale makes cold control-plane paths sensitive to accidental runtime fanout.
- What changed: added a command-level sentinel test fixture whose runtime writes a marker and throws if imported.
- What did NOT change (scope boundary): no runtime, product behavior, docs, or plugin manifest semantics changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A.

- Root cause: N/A
- Missing detection / guardrail: command surfaces did not have one shared fixture proving channel setup, onboarding auth choices, and models-list ownership stay on manifest/registry metadata.
- Contributing context (if known): plugin registry volume increased, so accidental cold-path runtime import fanout is more expensive.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/plugin-control-plane-cold-imports.test.ts`
- Scenario the test should lock in: command control-plane discovery reads manifest/registry metadata for channel setup, auth choice onboarding, and models-list provider ownership without importing plugin runtime.
- Why this is the smallest reliable guardrail: one temp plugin fixture covers the relevant command seams and catches both thrown imports and swallowed imports via a runtime marker.
- Existing test that already covers this (if any): partial coverage existed in plugin-registry/status/provider-discovery tests, but not across these command flows.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): plugin registry command surfaces
- Relevant config (redacted): temp plugin fixture only

### Steps

1. Run `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/commands/plugin-control-plane-cold-imports.test.ts`.
2. Run `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`.
3. Rebase on `origin/main` and run `git diff --check origin/main...HEAD`.

### Expected

- New sentinel tests pass and the runtime marker is never written.

### Actual

- Targeted test and changed gate passed locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted serial test, formatter, changed gate, clean rebase sanity.
- Edge cases checked: persisted registry path for models-list ownership and disabled persisted registry path for derived command metadata.
- What you did **not** verify: full `pnpm check`, full `pnpm test`, UI/browser flows.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
