### PR TITLE
Add structured Matrix approval metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/runtime: reuse the current plugin metadata snapshot for provider discovery so repeated model-provider discovery avoids rebuilding plugin manifest metadata. Thanks @shakkernerd.
 - Gateway/startup: pass the plugin metadata snapshot from config validation into plugin bootstrap so startup reuses one manifest product instead of rebuilding plugin metadata. Thanks @shakkernerd.
 - ACP/runtime: add an opt-in bundled Coven backend extension that routes ACP coding sessions through a local Coven daemon when `acp.backend="coven"`, while preserving the existing ACPX backend as the default fallback path. Thanks @BunsDev.
+- Matrix: attach versioned structured approval metadata to pending approval messages so capable Matrix clients can render richer approval UI while body text and reaction fallback keep working. (#72432) Thanks @kakahu2015.
 
 ### Fixes
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -208,6 +208,12 @@ Notes:
 - Media replies always send attachments normally. If a stale preview can no longer be reused safely, OpenClaw redacts it before sending the final media reply.
 - Preview edits cost extra Matrix API calls. Leave `streaming: "off"` if you want the most conservative rate-limit profile.
 
+## Approval metadata
+
+Matrix native approval prompts are normal `m.room.message` events with OpenClaw-specific custom event content under `com.openclaw.approval`. Matrix permits custom event-content keys, so stock clients still render the text body while OpenClaw-aware clients can read the structured approval id, kind, state, available decisions, and exec/plugin details.
+
+When an approval prompt is too long for one Matrix event, OpenClaw chunks the visible text and attaches `com.openclaw.approval` to the first chunk only. Reactions for allow/deny decisions are bound to that first event, so long prompts keep the same approval target as single-event prompts.
+
 ### Self-hosted push rules for quiet finalized previews
 
 `streaming: "quiet"` only notifies recipients once a block or turn is finalized — a per-user push rule has to match the finalized preview marker. See [Matrix push rules for quiet previews](/channels/matrix-push-rules) for the full recipe (recipient token, pusher check, rule install, per-homeserver notes).

--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -301,6 +301,9 @@ Shared behavior:
   without a second Slack-local fallback layer
 - Matrix native DM/channel routing and reaction shortcuts handle both exec and plugin approvals;
   plugin authorization still comes from `channels.matrix.dm.allowFrom`
+- Matrix native prompts include `com.openclaw.approval` custom event content on the first prompt
+  event so OpenClaw-aware Matrix clients can read structured approval state while stock clients
+  keep the plain-text `/approve` fallback
 - the requester does not need to be an approver
 - the originating chat can approve directly with `/approve` when that chat already supports commands and replies
 - native Discord approval buttons route by approval id kind: `plugin:` ids go

--- a/extensions/matrix/src/approval-handler.runtime.test.ts
+++ b/extensions/matrix/src/approval-handler.runtime.test.ts
@@ -228,6 +228,7 @@ describe("matrixApprovalNativeRuntime", () => {
       pendingPayload.text,
       expect.objectContaining({
         accountId: "default",
+        extraContent: pendingPayload.extraContent,
       }),
     );
     expect(reactMessage).toHaveBeenCalledWith(

--- a/extensions/matrix/src/approval-handler.runtime.test.ts
+++ b/extensions/matrix/src/approval-handler.runtime.test.ts
@@ -1,7 +1,250 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { matrixApprovalNativeRuntime } from "./approval-handler.runtime.js";
 
 describe("matrixApprovalNativeRuntime", () => {
+  it("sends versioned Matrix approval content with pending exec approvals", async () => {
+    const sendSingleTextMessage = vi.fn().mockResolvedValue({
+      messageId: "$approval",
+      primaryMessageId: "$approval",
+      messageIds: ["$approval"],
+      roomId: "!room:example.org",
+    });
+    const reactMessage = vi.fn().mockResolvedValue(undefined);
+    const pendingPayload = await matrixApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { client: {} as never },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+          cwd: "/repo",
+          host: "gateway",
+          agentId: "agent-1",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      approvalKind: "exec",
+      nowMs: 100,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        phase: "pending",
+        title: "Exec Approval Required",
+        description: "A command needs your approval.",
+        metadata: [],
+        ask: "on-request",
+        agentId: "agent-1",
+        commandText: "echo hi",
+        commandPreview: "echo hi",
+        cwd: "/repo",
+        host: "gateway",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            style: "success",
+            command: "/approve req-1 allow-once",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            style: "danger",
+            command: "/approve req-1 deny",
+          },
+        ],
+        expiresAtMs: 1_000,
+      } as never,
+    });
+
+    await matrixApprovalNativeRuntime.transport.deliverPending({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        client: {} as never,
+        deps: {
+          sendSingleTextMessage,
+          reactMessage,
+        },
+      },
+      request: {} as never,
+      approvalKind: "exec",
+      preparedTarget: {
+        to: "room:!room:example.org",
+        roomId: "!room:example.org",
+      },
+      pendingPayload,
+    });
+
+    expect(sendSingleTextMessage).toHaveBeenCalledWith(
+      "room:!room:example.org",
+      expect.stringContaining("echo hi"),
+      expect.objectContaining({
+        extraContent: {
+          "com.openclaw.approval": expect.objectContaining({
+            version: 1,
+            type: "approval.request",
+            state: "pending",
+            id: "req-1",
+            kind: "exec",
+            commandText: "echo hi",
+            cwd: "/repo",
+            agentId: "agent-1",
+            allowedDecisions: ["allow-once", "deny"],
+          }),
+        },
+      }),
+    );
+  });
+
+  it("includes plugin approval fields in Matrix approval content", async () => {
+    const pendingPayload = await matrixApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { client: {} as never },
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Plugin Approval Required",
+          description: "Approve the tool call.",
+          severity: "critical",
+          toolName: "deploy",
+          pluginId: "ops",
+          agentId: "agent-1",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      approvalKind: "plugin",
+      nowMs: 100,
+      view: {
+        approvalKind: "plugin",
+        approvalId: "plugin:req-1",
+        phase: "pending",
+        title: "Plugin Approval Required",
+        description: "Approve the tool call.",
+        metadata: [],
+        agentId: "agent-1",
+        pluginId: "ops",
+        toolName: "deploy",
+        severity: "critical",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            style: "success",
+            command: "/approve plugin:req-1 allow-once",
+          },
+        ],
+        expiresAtMs: 1_000,
+      } as never,
+    });
+
+    expect(pendingPayload).toMatchObject({
+      extraContent: {
+        "com.openclaw.approval": {
+          version: 1,
+          type: "approval.request",
+          state: "pending",
+          id: "plugin:req-1",
+          kind: "plugin",
+          pluginId: "ops",
+          toolName: "deploy",
+          agentId: "agent-1",
+          severity: "critical",
+        },
+      },
+    });
+  });
+
+  it("falls back to chunked Matrix delivery when approval content exceeds one event", async () => {
+    const sendSingleTextMessage = vi
+      .fn()
+      .mockRejectedValue(new Error("Matrix single-message text exceeds limit (5000 > 4000)"));
+    const sendMessage = vi.fn().mockResolvedValue({
+      messageId: "$last",
+      primaryMessageId: "$primary",
+      messageIds: ["$primary", "$last"],
+      roomId: "!room:example.org",
+    });
+    const reactMessage = vi.fn().mockResolvedValue(undefined);
+    const pendingPayload = await matrixApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: { client: {} as never },
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1_000,
+      },
+      approvalKind: "exec",
+      nowMs: 100,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-1",
+        phase: "pending",
+        title: "Exec Approval Required",
+        description: "A command needs your approval.",
+        metadata: [],
+        commandText: "echo hi",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            style: "success",
+            command: "/approve req-1 allow-once",
+          },
+        ],
+        expiresAtMs: 1_000,
+      } as never,
+    });
+
+    const entry = await matrixApprovalNativeRuntime.transport.deliverPending({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        client: {} as never,
+        deps: {
+          sendSingleTextMessage,
+          sendMessage,
+          reactMessage,
+        },
+      },
+      request: {} as never,
+      approvalKind: "exec",
+      preparedTarget: {
+        to: "room:!room:example.org",
+        roomId: "!room:example.org",
+      },
+      pendingPayload,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!room:example.org",
+      pendingPayload.text,
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expect(reactMessage).toHaveBeenCalledWith(
+      "!room:example.org",
+      "$primary",
+      expect.any(String),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+    expect(entry).toMatchObject({
+      roomId: "!room:example.org",
+      messageIds: ["$primary", "$last"],
+      reactionEventId: "$primary",
+    });
+  });
+
   it("uses a longer code fence when resolved commands contain triple backticks", async () => {
     const result = await matrixApprovalNativeRuntime.presentation.buildResolvedResult({
       cfg: {} as never,

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -47,11 +47,58 @@ type PreparedMatrixTarget = {
   roomId: string;
   threadId?: string;
 };
+type MatrixApprovalMetadataAction = {
+  decision: ExecApprovalReplyDecision;
+  label: string;
+  style: PendingApprovalView["actions"][number]["style"];
+  command: string;
+};
+type MatrixApprovalMetadataBase = {
+  version: 1;
+  type: "approval.request";
+  id: string;
+  state: "pending";
+  kind: PendingApprovalView["approvalKind"];
+  phase: "pending";
+  title: string;
+  description?: string;
+  expiresAtMs: number;
+  metadata: PendingApprovalView["metadata"];
+  allowedDecisions: ExecApprovalReplyDecision[];
+  actions: MatrixApprovalMetadataAction[];
+};
+type MatrixExecApprovalMetadata = MatrixApprovalMetadataBase & {
+  kind: "exec";
+  ask?: string;
+  agentId?: string;
+  commandText: string;
+  commandPreview?: string;
+  cwd?: string;
+  envKeys?: readonly string[];
+  host?: string;
+  nodeId?: string;
+  sessionKey?: string;
+};
+type MatrixPluginApprovalSeverity = Extract<
+  PendingApprovalView,
+  { approvalKind: "plugin" }
+>["severity"];
+type MatrixPluginApprovalMetadata = MatrixApprovalMetadataBase & {
+  kind: "plugin";
+  agentId?: string;
+  pluginId?: string;
+  toolName?: string;
+  severity: MatrixPluginApprovalSeverity;
+};
+type MatrixApprovalMetadata = MatrixExecApprovalMetadata | MatrixPluginApprovalMetadata;
+type MatrixApprovalExtraContent = {
+  [MATRIX_APPROVAL_METADATA_KEY]: MatrixApprovalMetadata;
+};
 type PendingApprovalContent = {
   approvalId: string;
   text: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
-  extraContent: Record<string, unknown>;
+  extraContent: MatrixApprovalExtraContent;
 };
 type ReactionTargetRef = {
   roomId: string;
@@ -159,15 +206,11 @@ async function prepareTarget(
   };
 }
 
-function removeUndefinedValues(value: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
-}
-
 function buildMatrixApprovalMetadata(params: {
   view: PendingApprovalView;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
-}): Record<string, unknown> {
-  const base = removeUndefinedValues({
+}): MatrixApprovalMetadata {
+  const base: MatrixApprovalMetadataBase = {
     version: 1,
     type: "approval.request",
     id: params.view.approvalId,
@@ -185,30 +228,33 @@ function buildMatrixApprovalMetadata(params: {
       style: action.style,
       command: action.command,
     })),
-  });
+    ...(params.view.description != null ? { description: params.view.description } : {}),
+  };
 
   if (params.view.approvalKind === "plugin") {
-    return removeUndefinedValues({
+    return {
       ...base,
-      agentId: params.view.agentId ?? undefined,
-      pluginId: params.view.pluginId ?? undefined,
-      toolName: params.view.toolName ?? undefined,
+      kind: "plugin",
       severity: params.view.severity,
-    });
+      ...(params.view.agentId != null ? { agentId: params.view.agentId } : {}),
+      ...(params.view.pluginId != null ? { pluginId: params.view.pluginId } : {}),
+      ...(params.view.toolName != null ? { toolName: params.view.toolName } : {}),
+    };
   }
 
-  return removeUndefinedValues({
+  return {
     ...base,
-    ask: params.view.ask ?? undefined,
-    agentId: params.view.agentId ?? undefined,
+    kind: "exec",
     commandText: params.view.commandText,
-    commandPreview: params.view.commandPreview ?? undefined,
-    cwd: params.view.cwd ?? undefined,
-    envKeys: params.view.envKeys,
-    host: params.view.host ?? undefined,
-    nodeId: params.view.nodeId ?? undefined,
-    sessionKey: params.view.sessionKey ?? undefined,
-  });
+    ...(params.view.ask != null ? { ask: params.view.ask } : {}),
+    ...(params.view.agentId != null ? { agentId: params.view.agentId } : {}),
+    ...(params.view.commandPreview != null ? { commandPreview: params.view.commandPreview } : {}),
+    ...(params.view.cwd != null ? { cwd: params.view.cwd } : {}),
+    ...(params.view.envKeys != null ? { envKeys: params.view.envKeys } : {}),
+    ...(params.view.host != null ? { host: params.view.host } : {}),
+    ...(params.view.nodeId != null ? { nodeId: params.view.nodeId } : {}),
+    ...(params.view.sessionKey != null ? { sessionKey: params.view.sessionKey } : {}),
+  };
 }
 
 function buildPendingApprovalContent(params: {

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -218,7 +218,6 @@ function buildMatrixApprovalMetadata(params: {
     kind: params.view.approvalKind,
     phase: params.view.phase,
     title: params.view.title,
-    description: params.view.description ?? undefined,
     expiresAtMs: params.view.expiresAtMs,
     metadata: params.view.metadata,
     allowedDecisions: Array.from(params.allowedDecisions),
@@ -433,6 +432,7 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
           accountId: resolved.accountId,
           client: resolved.context.client,
           threadId: preparedTarget.threadId,
+          extraContent: pendingPayload.extraContent,
         });
       }
       const messageIds = Array.from(

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -71,6 +71,7 @@ type MatrixPrepareTargetParams = {
 export type MatrixApprovalHandlerDeps = {
   nowMs?: () => number;
   sendMessage?: typeof sendMessageMatrix;
+  sendSingleTextMessage?: typeof sendSingleTextMessageMatrix;
   reactMessage?: typeof reactMatrixMessage;
   editMessage?: typeof editMatrixMessage;
   deleteMessage?: typeof deleteMatrixMessage;
@@ -110,6 +111,10 @@ function normalizeReactionTargetRef(params: ReactionTargetRef): ReactionTargetRe
 function normalizeThreadId(value?: string | number | null): string | undefined {
   const trimmed = value == null ? "" : String(value).trim();
   return trimmed || undefined;
+}
+
+function isSingleMatrixMessageLimitError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Matrix single-message text exceeds limit");
 }
 
 async function prepareTarget(
@@ -355,22 +360,30 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
       if (!resolved) {
         return null;
       }
-      const sendMessage = resolved.context.deps?.sendMessage;
+      const sendSingleTextMessage =
+        resolved.context.deps?.sendSingleTextMessage ?? sendSingleTextMessageMatrix;
       const reactMessage = resolved.context.deps?.reactMessage ?? reactMatrixMessage;
-      const result = sendMessage
-        ? await sendMessage(preparedTarget.to, pendingPayload.text, {
-            cfg: cfg as CoreConfig,
-            accountId: resolved.accountId,
-            client: resolved.context.client,
-            threadId: preparedTarget.threadId,
-          })
-        : await sendSingleTextMessageMatrix(preparedTarget.to, pendingPayload.text, {
-            cfg: cfg as CoreConfig,
-            accountId: resolved.accountId,
-            client: resolved.context.client,
-            threadId: preparedTarget.threadId,
-            extraContent: pendingPayload.extraContent,
-          });
+      let result;
+      try {
+        result = await sendSingleTextMessage(preparedTarget.to, pendingPayload.text, {
+          cfg: cfg as CoreConfig,
+          accountId: resolved.accountId,
+          client: resolved.context.client,
+          threadId: preparedTarget.threadId,
+          extraContent: pendingPayload.extraContent,
+        });
+      } catch (error) {
+        if (!isSingleMatrixMessageLimitError(error)) {
+          throw error;
+        }
+        const sendMessage = resolved.context.deps?.sendMessage ?? sendMessageMatrix;
+        result = await sendMessage(preparedTarget.to, pendingPayload.text, {
+          cfg: cfg as CoreConfig,
+          accountId: resolved.accountId,
+          client: resolved.context.client,
+          threadId: preparedTarget.threadId,
+        });
+      }
       const messageIds = Array.from(
         new Set(
           (result.messageIds ?? [result.messageId])

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -26,9 +26,15 @@ import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { deleteMatrixMessage, editMatrixMessage } from "./matrix/actions/messages.js";
 import { repairMatrixDirectRooms } from "./matrix/direct-management.js";
 import type { MatrixClient } from "./matrix/sdk.js";
-import { reactMatrixMessage, sendMessageMatrix } from "./matrix/send.js";
+import {
+  reactMatrixMessage,
+  sendMessageMatrix,
+  sendSingleTextMessageMatrix,
+} from "./matrix/send.js";
 import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
 import type { CoreConfig } from "./types.js";
+
+const MATRIX_APPROVAL_METADATA_KEY = "com.openclaw.approval" as const;
 
 type PendingMessage = {
   roomId: string;
@@ -44,6 +50,7 @@ type PendingApprovalContent = {
   approvalId: string;
   text: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  extraContent: Record<string, unknown>;
 };
 type ReactionTargetRef = {
   roomId: string;
@@ -144,6 +151,56 @@ async function prepareTarget(
   };
 }
 
+function removeUndefinedValues(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function buildMatrixApprovalMetadata(params: {
+  view: PendingApprovalView;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+}): Record<string, unknown> {
+  const base = removeUndefinedValues({
+    version: 1,
+    id: params.view.approvalId,
+    kind: params.view.approvalKind,
+    phase: params.view.phase,
+    title: params.view.title,
+    description: params.view.description ?? undefined,
+    expiresAtMs: params.view.expiresAtMs,
+    metadata: params.view.metadata,
+    allowedDecisions: Array.from(params.allowedDecisions),
+    actions: params.view.actions.map((action) => ({
+      decision: action.decision,
+      label: action.label,
+      style: action.style,
+      command: action.command,
+    })),
+  });
+
+  if (params.view.approvalKind === "plugin") {
+    return removeUndefinedValues({
+      ...base,
+      agentId: params.view.agentId ?? undefined,
+      pluginId: params.view.pluginId ?? undefined,
+      toolName: params.view.toolName ?? undefined,
+      severity: params.view.severity,
+    });
+  }
+
+  return removeUndefinedValues({
+    ...base,
+    ask: params.view.ask ?? undefined,
+    agentId: params.view.agentId ?? undefined,
+    commandText: params.view.commandText,
+    commandPreview: params.view.commandPreview ?? undefined,
+    cwd: params.view.cwd ?? undefined,
+    envKeys: params.view.envKeys,
+    host: params.view.host ?? undefined,
+    nodeId: params.view.nodeId ?? undefined,
+    sessionKey: params.view.sessionKey ?? undefined,
+  });
+}
+
 function buildPendingApprovalContent(params: {
   view: PendingApprovalView;
   nowMs: number;
@@ -189,6 +246,12 @@ function buildPendingApprovalContent(params: {
     approvalId: params.view.approvalId,
     text: hint ? (text ? `${hint}\n\n${text}` : hint) : text,
     allowedDecisions,
+    extraContent: {
+      [MATRIX_APPROVAL_METADATA_KEY]: buildMatrixApprovalMetadata({
+        view: params.view,
+        allowedDecisions,
+      }),
+    },
   };
 }
 
@@ -292,14 +355,22 @@ export const matrixApprovalNativeRuntime = createChannelApprovalNativeRuntimeAda
       if (!resolved) {
         return null;
       }
-      const sendMessage = resolved.context.deps?.sendMessage ?? sendMessageMatrix;
+      const sendMessage = resolved.context.deps?.sendMessage;
       const reactMessage = resolved.context.deps?.reactMessage ?? reactMatrixMessage;
-      const result = await sendMessage(preparedTarget.to, pendingPayload.text, {
-        cfg: cfg as CoreConfig,
-        accountId: resolved.accountId,
-        client: resolved.context.client,
-        threadId: preparedTarget.threadId,
-      });
+      const result = sendMessage
+        ? await sendMessage(preparedTarget.to, pendingPayload.text, {
+            cfg: cfg as CoreConfig,
+            accountId: resolved.accountId,
+            client: resolved.context.client,
+            threadId: preparedTarget.threadId,
+          })
+        : await sendSingleTextMessageMatrix(preparedTarget.to, pendingPayload.text, {
+            cfg: cfg as CoreConfig,
+            accountId: resolved.accountId,
+            client: resolved.context.client,
+            threadId: preparedTarget.threadId,
+            extraContent: pendingPayload.extraContent,
+          });
       const messageIds = Array.from(
         new Set(
           (result.messageIds ?? [result.messageId])

--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -34,6 +34,7 @@ import {
 import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
 import type { CoreConfig } from "./types.js";
 
+// OpenClaw Matrix custom event content for capable clients; body and reactions remain fallback.
 const MATRIX_APPROVAL_METADATA_KEY = "com.openclaw.approval" as const;
 
 type PendingMessage = {
@@ -114,7 +115,9 @@ function normalizeThreadId(value?: string | number | null): string | undefined {
 }
 
 function isSingleMatrixMessageLimitError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("Matrix single-message text exceeds limit");
+  return (
+    error instanceof Error && error.message.includes("Matrix single-message text exceeds limit")
+  );
 }
 
 async function prepareTarget(
@@ -166,7 +169,9 @@ function buildMatrixApprovalMetadata(params: {
 }): Record<string, unknown> {
   const base = removeUndefinedValues({
     version: 1,
+    type: "approval.request",
     id: params.view.approvalId,
+    state: "pending",
     kind: params.view.approvalKind,
     phase: params.view.phase,
     title: params.view.title,

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -630,6 +630,28 @@ describe("sendMessageMatrix threads", () => {
       messageIds: ["$m1", "$m2", "$m3"],
     });
   });
+
+  it("merges extra content into only the first chunked text event", async () => {
+    const { client, sendMessage } = makeClient();
+    convertMarkdownTablesMock.mockImplementation(() => "first|second|third");
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+
+    await sendMessageMatrix("room:!room:example", "ignored", {
+      client,
+      cfg: {} as never,
+      extraContent: { "com.openclaw.approval": { id: "req-1" } },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      body: "first",
+      "com.openclaw.approval": { id: "req-1" },
+    });
+    expect(sendMessage.mock.calls[1]?.[1]).toMatchObject({ body: "second" });
+    expect(sendMessage.mock.calls[1]?.[1]).not.toHaveProperty("com.openclaw.approval");
+    expect(sendMessage.mock.calls[2]?.[1]).toMatchObject({ body: "third" });
+    expect(sendMessage.mock.calls[2]?.[1]).not.toHaveProperty("com.openclaw.approval");
+  });
 });
 
 describe("sendSingleTextMessageMatrix", () => {

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -211,8 +211,11 @@ export async function sendMessageMatrix(
       const relation = threadId
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
+      let pendingExtraContent = opts.extraContent;
       const sendContent = async (content: MatrixOutboundContent) => {
-        const eventId = await client.sendMessage(roomId, content);
+        const contentWithExtra = withMatrixExtraContentFields(content, pendingExtraContent);
+        pendingExtraContent = undefined;
+        const eventId = await client.sendMessage(roomId, contentWithExtra);
         return eventId;
       };
 

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   replyToId?: string;
   threadId?: string | number | null;
   timeoutMs?: number;
+  /** Additional Matrix event content fields to merge into the first sent event. */
+  extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
 };


### PR DESCRIPTION
## Summary

Adds a structured `com.openclaw.approval` payload to Matrix approval request messages while keeping the existing text and reaction-based approval flow intact.

This lets native Matrix clients render richer approval UI, such as fixed approve/deny buttons, without breaking existing clients. Clients that do not understand the custom content field continue to see the normal Matrix message body and reactions.

## Details

- Adds `com.openclaw.approval` metadata to pending Matrix approval messages.
- Includes approval id, kind, phase, title, description, expiry, metadata, allowed decisions, and action descriptors.
- Includes exec-specific fields like command text, cwd, host, node id, and session key.
- Includes plugin-specific fields like plugin id, tool name, agent id, and severity.
- Uses the existing single-message Matrix sender so the extra content is attached to the `m.room.message` event.
- Preserves the existing reaction fallback and native approval binding behavior.

## Compatibility

This is backwards compatible:

- Existing Matrix clients still render the `body` fallback.
- Existing reaction approvals keep working.
- Web UI / terminal UI approval paths are unchanged.
- Native clients may optionally detect `com.openclaw.approval` and render approval cards/buttons.

## Testing

Not run here.