### PR TITLE
Add append-only session recovery log

### DIFF
--- a/src/auto-reply/reply/commands-compact.runtime.ts
+++ b/src/auto-reply/reply/commands-compact.runtime.ts
@@ -5,6 +5,7 @@ export {
   waitForEmbeddedPiRunEnd,
 } from "../../agents/pi-embedded.js";
 export {
+  appendSessionRecoveryEvent,
   resolveFreshSessionTotalTokens,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,

--- a/src/auto-reply/reply/commands-compact.test.ts
+++ b/src/auto-reply/reply/commands-compact.test.ts
@@ -8,6 +8,7 @@ import type { HandleCommandsParams } from "./commands-types.js";
 
 vi.mock("./commands-compact.runtime.js", () => ({
   abortEmbeddedPiRun: vi.fn(),
+  appendSessionRecoveryEvent: vi.fn().mockResolvedValue(undefined),
   compactEmbeddedPiSession: vi.fn(),
   enqueueSystemEvent: vi.fn(),
   formatContextUsageShort: vi.fn(() => "Context 12.1k"),
@@ -20,8 +21,12 @@ vi.mock("./commands-compact.runtime.js", () => ({
   waitForEmbeddedPiRunEnd: vi.fn().mockResolvedValue(undefined),
 }));
 
-const { compactEmbeddedPiSession, incrementCompactionCount, resolveSessionFilePathOptions } =
-  await import("./commands-compact.runtime.js");
+const {
+  appendSessionRecoveryEvent,
+  compactEmbeddedPiSession,
+  incrementCompactionCount,
+  resolveSessionFilePathOptions,
+} = await import("./commands-compact.runtime.js");
 const { handleCompactCommand } = await import("./commands-compact.js");
 
 function buildCompactParams(
@@ -151,6 +156,121 @@ describe("handleCompactCommand", () => {
         senderUsername: "alice_u",
         senderE164: "+15551234567",
         agentDir: "/tmp/openclaw-agent-compact",
+      }),
+    );
+  });
+
+  it("records compact recovery lifecycle events around manual compaction", async () => {
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "compacted",
+        firstKeptEntryId: "entry-2",
+        tokensBefore: 1000,
+        tokensAfter: 200,
+      },
+    });
+
+    await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        storePath: "/tmp/openclaw-session-store.json",
+        ctx: {
+          Provider: "whatsapp",
+          Surface: "whatsapp",
+          ChatType: "direct",
+          CommandSource: "text",
+          CommandBody: "/compact: focus on decisions",
+        },
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          contextTokens: 4096,
+        },
+        contextTokens: 4096,
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(vi.mocked(appendSessionRecoveryEvent)).toHaveBeenCalledTimes(3);
+    expect(
+      vi.mocked(appendSessionRecoveryEvent).mock.calls.map(([event]) => event.eventType),
+    ).toEqual(["compact.requested", "compact.started", "compact.completed"]);
+    expect(vi.mocked(appendSessionRecoveryEvent)).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        storePath: "/tmp/openclaw-session-store.json",
+        eventType: "compact.requested",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        agentId: "main",
+        source: expect.objectContaining({
+          kind: "compact",
+          provider: "whatsapp",
+          surface: "whatsapp",
+          channel: "whatsapp",
+          chatType: "direct",
+        }),
+        details: expect.objectContaining({
+          trigger: "manual",
+          commandSource: "text",
+          customInstructionsPresent: true,
+          sessionFile: "/tmp/session.json",
+          contextTokens: 4096,
+        }),
+      }),
+    );
+    expect(vi.mocked(appendSessionRecoveryEvent)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        eventType: "compact.completed",
+        details: expect.objectContaining({
+          ok: true,
+          compacted: true,
+          tokensBefore: 1000,
+          tokensAfter: 200,
+          firstKeptEntryId: "entry-2",
+        }),
+      }),
+    );
+  });
+
+  it("records compact failed recovery event when compaction returns a failure", async () => {
+    vi.mocked(compactEmbeddedPiSession).mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "model unavailable",
+    });
+
+    await handleCompactCommand(
+      {
+        ...buildCompactParams("/compact", {
+          commands: { text: true },
+          channels: { whatsapp: { allowFrom: ["*"] } },
+        } as OpenClawConfig),
+        storePath: "/tmp/openclaw-session-store.json",
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+        },
+      } as HandleCommandsParams,
+      true,
+    );
+
+    expect(
+      vi.mocked(appendSessionRecoveryEvent).mock.calls.map(([event]) => event.eventType),
+    ).toEqual(["compact.requested", "compact.started", "compact.failed"]);
+    expect(vi.mocked(appendSessionRecoveryEvent)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        eventType: "compact.failed",
+        details: expect.objectContaining({
+          ok: false,
+          compacted: false,
+          reason: "model unavailable",
+        }),
       }),
     );
   });

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -75,6 +75,49 @@ function formatCompactionReason(reason?: string): string | undefined {
   return text;
 }
 
+async function appendCompactRecoveryEvent(params: {
+  runtime: Awaited<ReturnType<typeof loadCompactRuntime>>;
+  storePath?: string;
+  eventType:
+    | "compact.requested"
+    | "compact.started"
+    | "compact.completed"
+    | "compact.failed";
+  sessionKey: string;
+  sessionId: string;
+  agentId: string;
+  source: {
+    provider?: string;
+    surface?: string;
+    channel?: string;
+    chatType?: string;
+  };
+  details?: Record<string, unknown>;
+}): Promise<void> {
+  if (!params.storePath) {
+    return;
+  }
+  await params.runtime
+    .appendSessionRecoveryEvent({
+      storePath: params.storePath,
+      eventType: params.eventType,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      source: {
+        kind: "compact",
+        provider: params.source.provider,
+        surface: params.source.surface,
+        channel: params.source.channel,
+        chatType: params.source.chatType,
+      },
+      details: params.details,
+    })
+    .catch((err) => {
+      logVerbose(`Failed to append compact recovery event: ${String(err)}`);
+    });
+}
+
 export const handleCompactCommand: CommandHandler = async (params) => {
   const compactRequested =
     params.command.commandBodyNormalized === "/compact" ||
@@ -116,45 +159,109 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     agentId: sessionAgentId,
     isGroup: params.isGroup,
   });
-  const result = await runtime.compactEmbeddedPiSession({
+  const sessionFile = runtime.resolveSessionFilePath(
     sessionId,
+    targetSessionEntry,
+    runtime.resolveSessionFilePathOptions({
+      agentId: sessionAgentId,
+      storePath: params.storePath,
+    }),
+  );
+  const compactRecoveryBase = {
+    runtime,
+    storePath: params.storePath,
     sessionKey: params.sessionKey,
-    allowGatewaySubagentBinding: true,
-    messageChannel: params.command.channel,
+    sessionId,
+    agentId: sessionAgentId,
+    source: {
+      provider: params.ctx.Provider,
+      surface: params.ctx.Surface,
+      channel: params.command.channel,
+      chatType: params.ctx.ChatType,
+    },
+  };
+  const compactRecoveryDetails = {
+    trigger: "manual",
+    commandSource: params.ctx.CommandSource,
+    customInstructionsPresent: Boolean(customInstructions),
+    sessionFile,
     groupId: targetSessionEntry.groupId,
     groupChannel: targetSessionEntry.groupChannel,
     groupSpace: targetSessionEntry.space,
     spawnedBy: targetSessionEntry.spawnedBy,
-    senderId: params.command.senderId,
-    senderName: params.ctx.SenderName,
-    senderUsername: params.ctx.SenderUsername,
-    senderE164: params.ctx.SenderE164,
-    sessionFile: runtime.resolveSessionFilePath(
+    contextTokens: params.contextTokens ?? targetSessionEntry.contextTokens,
+  };
+  await appendCompactRecoveryEvent({
+    ...compactRecoveryBase,
+    eventType: "compact.requested",
+    details: compactRecoveryDetails,
+  });
+  await appendCompactRecoveryEvent({
+    ...compactRecoveryBase,
+    eventType: "compact.started",
+    details: compactRecoveryDetails,
+  });
+  let result: Awaited<ReturnType<typeof runtime.compactEmbeddedPiSession>>;
+  try {
+    result = await runtime.compactEmbeddedPiSession({
       sessionId,
-      targetSessionEntry,
-      runtime.resolveSessionFilePathOptions({
-        agentId: sessionAgentId,
-        storePath: params.storePath,
-      }),
-    ),
-    workspaceDir: params.workspaceDir,
-    agentDir: sessionAgentDir,
-    config: params.cfg,
-    skillsSnapshot: targetSessionEntry.skillsSnapshot,
-    provider: params.provider,
-    model: params.model,
-    agentHarnessId:
-      targetSessionEntry.sessionId === sessionId ? targetSessionEntry.agentHarnessId : undefined,
-    thinkLevel: params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel()),
-    bashElevated: {
-      enabled: false,
-      allowed: false,
-      defaultLevel: "off",
+      sessionKey: params.sessionKey,
+      allowGatewaySubagentBinding: true,
+      messageChannel: params.command.channel,
+      groupId: targetSessionEntry.groupId,
+      groupChannel: targetSessionEntry.groupChannel,
+      groupSpace: targetSessionEntry.space,
+      spawnedBy: targetSessionEntry.spawnedBy,
+      senderId: params.command.senderId,
+      senderName: params.ctx.SenderName,
+      senderUsername: params.ctx.SenderUsername,
+      senderE164: params.ctx.SenderE164,
+      sessionFile,
+      workspaceDir: params.workspaceDir,
+      agentDir: sessionAgentDir,
+      config: params.cfg,
+      skillsSnapshot: targetSessionEntry.skillsSnapshot,
+      provider: params.provider,
+      model: params.model,
+      agentHarnessId:
+        targetSessionEntry.sessionId === sessionId ? targetSessionEntry.agentHarnessId : undefined,
+      thinkLevel: params.resolvedThinkLevel ?? (await params.resolveDefaultThinkingLevel()),
+      bashElevated: {
+        enabled: false,
+        allowed: false,
+        defaultLevel: "off",
+      },
+      customInstructions,
+      trigger: "manual",
+      senderIsOwner: params.command.senderIsOwner,
+      ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
+    });
+  } catch (err) {
+    await appendCompactRecoveryEvent({
+      ...compactRecoveryBase,
+      eventType: "compact.failed",
+      details: {
+        ...compactRecoveryDetails,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+    throw err;
+  }
+
+  const compactTerminalEventType =
+    result.ok || isCompactionSkipReason(result.reason) ? "compact.completed" : "compact.failed";
+  await appendCompactRecoveryEvent({
+    ...compactRecoveryBase,
+    eventType: compactTerminalEventType,
+    details: {
+      ...compactRecoveryDetails,
+      ok: result.ok,
+      compacted: result.compacted,
+      reason: result.reason,
+      tokensBefore: result.result?.tokensBefore,
+      tokensAfter: result.result?.tokensAfter,
+      firstKeptEntryId: result.result?.firstKeptEntryId,
     },
-    customInstructions,
-    trigger: "manual",
-    senderIsOwner: params.command.senderIsOwner,
-    ownerNumbers: params.command.ownerList.length > 0 ? params.command.ownerList : undefined,
   });
 
   const compactLabel =

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -7,6 +7,7 @@ export * from "./sessions/main-session.runtime.js";
 export * from "./sessions/lifecycle.js";
 export * from "./sessions/paths.js";
 export * from "./sessions/reset.js";
+export * from "./sessions/recovery-log.js";
 export * from "./sessions/session-key.js";
 export * from "./sessions/store.js";
 export * from "./sessions/types.js";

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -7,7 +7,20 @@ export * from "./sessions/main-session.runtime.js";
 export * from "./sessions/lifecycle.js";
 export * from "./sessions/paths.js";
 export * from "./sessions/reset.js";
-export * from "./sessions/recovery-log.js";
+export {
+  SESSION_RECOVERY_LOG_FILE,
+  SESSION_RECOVERY_MAX_STRING_LENGTH,
+  SESSION_RECOVERY_REDACTED_VALUE,
+  appendSessionRecoveryEvent,
+  buildSessionRecoveryEvent,
+  resolveSessionRecoveryLogPath,
+} from "./sessions/recovery-log.js";
+export type {
+  AppendSessionRecoveryEventParams,
+  SessionRecoveryEvent,
+  SessionRecoveryEventSource,
+  SessionRecoveryEventType,
+} from "./sessions/recovery-log.js";
 export * from "./sessions/session-key.js";
 export * from "./sessions/store.js";
 export * from "./sessions/types.js";

--- a/src/config/sessions/recovery-log.test.ts
+++ b/src/config/sessions/recovery-log.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   clearSessionStoreCacheForTest,
   recordSessionMetaFromInbound,
+  updateLastRoute,
 } from "./store.js";
 
 const suiteRootTracker = createSuiteTempRootTracker({
@@ -121,6 +122,75 @@ describe("session recovery log", () => {
           nativeChannelId: "dm-1",
         },
       });
+    }
+  });
+
+  it("records routing resolution as an append-only recovery event", async () => {
+    const storePath = await createStorePath();
+    const entry = await updateLastRoute({
+      storePath,
+      sessionKey: "Agent:Main:Discord:DM:User-1",
+      channel: "discord",
+      to: "user-1",
+      accountId: "default",
+      threadId: "thread-1",
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "direct",
+        From: "user-1",
+        To: "bot-1",
+        MessageSid: "message-1",
+      },
+    });
+
+    const events = await readSessionRecoveryEventsForTest(storePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      version: 1,
+      eventType: "routing.resolved",
+      sessionKey: "agent:main:discord:dm:user-1",
+      sessionId: entry.sessionId,
+      source: {
+        kind: "routing",
+        provider: "discord",
+        surface: "discord",
+        channel: "discord",
+        chatType: "direct",
+      },
+      details: {
+        accountId: "default",
+        to: "user-1",
+        threadId: "thread-1",
+        deliveryContext: {
+          channel: "discord",
+          to: "user-1",
+          accountId: "default",
+          threadId: "thread-1",
+        },
+        inbound: {
+          from: "user-1",
+          to: "bot-1",
+          messageSid: "message-1",
+        },
+      },
+    });
+  });
+
+  it("does not fail route updates when recovery event append fails", async () => {
+    const storePath = await createStorePath();
+    const appendSpy = vi.spyOn(fs, "appendFile").mockRejectedValueOnce(new Error("disk full"));
+    try {
+      await expect(
+        updateLastRoute({
+          storePath,
+          sessionKey: "agent:main:webchat:dm:user-1",
+          channel: "webchat",
+          to: "user-1",
+        }),
+      ).resolves.toMatchObject({ sessionId: expect.any(String), lastTo: "user-1" });
+    } finally {
+      appendSpy.mockRestore();
     }
   });
 

--- a/src/config/sessions/recovery-log.test.ts
+++ b/src/config/sessions/recovery-log.test.ts
@@ -57,7 +57,8 @@ describe("session recovery log", () => {
     const logPath = resolveSessionRecoveryLogPath(storePath);
     const raw = await fs.readFile(logPath, "utf-8");
     expect(raw.trim().split(/\r?\n/)).toHaveLength(1);
-    await expect(fs.stat(logPath)).resolves.toMatchObject({ mode: expect.any(Number) });
+    const stat = await fs.stat(logPath);
+    expect(stat.mode & 0o077).toBe(0);
 
     const events = await readSessionRecoveryEventsForTest(storePath);
     expect(events).toEqual([
@@ -72,6 +73,27 @@ describe("session recovery log", () => {
         details: { messageSid: "msg-1" },
       },
     ]);
+  });
+
+  it("tightens permissions when appending to an existing recovery log", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const storePath = await createStorePath();
+    const logPath = resolveSessionRecoveryLogPath(storePath);
+    await fs.writeFile(logPath, "", { encoding: "utf-8", mode: 0o666 });
+    await fs.chmod(logPath, 0o666);
+
+    await appendSessionRecoveryEvent({
+      storePath,
+      eventId: "event-existing-file",
+      eventType: "session.bound",
+      timestamp: 123,
+      sessionKey: "agent:main:discord:dm:user-1",
+    });
+
+    const stat = await fs.stat(logPath);
+    expect(stat.mode & 0o077).toBe(0);
   });
 
   it("sanitizes recovery details before events are serialized", () => {

--- a/src/config/sessions/recovery-log.test.ts
+++ b/src/config/sessions/recovery-log.test.ts
@@ -94,29 +94,34 @@ describe("session recovery log", () => {
 
     expect(entry?.sessionId).toBeTruthy();
     const events = await readSessionRecoveryEventsForTest(storePath);
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      version: 1,
-      eventType: "session.meta.recorded",
-      sessionKey: "agent:main:discord:dm:user-1",
-      sessionId: entry?.sessionId,
-      source: {
-        kind: "inbound",
-        provider: "discord",
-        surface: "discord",
-        channel: "discord",
-        chatType: "direct",
-      },
-      details: {
-        accountId: "default",
-        from: "user-1",
-        to: "bot-1",
-        originatingTo: "user-1",
-        messageSid: "message-1",
-        messageThreadId: "thread-1",
-        nativeChannelId: "dm-1",
-      },
-    });
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.eventType)).toEqual([
+      "inbound.received",
+      "session.meta.recorded",
+    ]);
+    for (const event of events) {
+      expect(event).toMatchObject({
+        version: 1,
+        sessionKey: "agent:main:discord:dm:user-1",
+        sessionId: entry?.sessionId,
+        source: {
+          kind: "inbound",
+          provider: "discord",
+          surface: "discord",
+          channel: "discord",
+          chatType: "direct",
+        },
+        details: {
+          accountId: "default",
+          from: "user-1",
+          to: "bot-1",
+          originatingTo: "user-1",
+          messageSid: "message-1",
+          messageThreadId: "thread-1",
+          nativeChannelId: "dm-1",
+        },
+      });
+    }
   });
 
   it("does not fail inbound metadata recording when recovery event append fails", async () => {

--- a/src/config/sessions/recovery-log.test.ts
+++ b/src/config/sessions/recovery-log.test.ts
@@ -4,7 +4,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import {
+  SESSION_RECOVERY_MAX_STRING_LENGTH,
+  SESSION_RECOVERY_REDACTED_VALUE,
   appendSessionRecoveryEvent,
+  buildSessionRecoveryEvent,
   readSessionRecoveryEventsForTest,
   resolveSessionRecoveryLogPath,
 } from "./recovery-log.js";
@@ -69,6 +72,41 @@ describe("session recovery log", () => {
         details: { messageSid: "msg-1" },
       },
     ]);
+  });
+
+  it("sanitizes recovery details before events are serialized", () => {
+    const longBody = "x".repeat(SESSION_RECOVERY_MAX_STRING_LENGTH + 10);
+    const event = buildSessionRecoveryEvent({
+      eventId: "event-redaction",
+      eventType: "outbound.sent",
+      timestamp: 123,
+      sessionKey: "agent:main:discord:dm:user-1",
+      details: {
+        contextTokens: 1234,
+        accessToken: "secret-token",
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=secret",
+        },
+        nested: [{ apiKey: "secret-key" }, { body: longBody }],
+      },
+    });
+
+    expect(event.details).toMatchObject({
+      contextTokens: 1234,
+      accessToken: SESSION_RECOVERY_REDACTED_VALUE,
+      headers: {
+        authorization: SESSION_RECOVERY_REDACTED_VALUE,
+        cookie: SESSION_RECOVERY_REDACTED_VALUE,
+      },
+      nested: [
+        { apiKey: SESSION_RECOVERY_REDACTED_VALUE },
+        { body: expect.stringContaining("…[truncated]") },
+      ],
+    });
+    expect((event.details?.nested as Array<{ body?: string }>)[1]?.body?.length).toBeGreaterThan(
+      SESSION_RECOVERY_MAX_STRING_LENGTH,
+    );
   });
 
   it("records inbound session metadata as an append-only recovery event", async () => {

--- a/src/config/sessions/recovery-log.test.ts
+++ b/src/config/sessions/recovery-log.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
+import {
+  appendSessionRecoveryEvent,
+  readSessionRecoveryEventsForTest,
+  resolveSessionRecoveryLogPath,
+} from "./recovery-log.js";
+import {
+  clearSessionStoreCacheForTest,
+  recordSessionMetaFromInbound,
+} from "./store.js";
+
+const suiteRootTracker = createSuiteTempRootTracker({
+  prefix: "openclaw-session-recovery-log-",
+});
+
+describe("session recovery log", () => {
+  beforeAll(async () => {
+    await suiteRootTracker.setup();
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+  });
+
+  afterAll(async () => {
+    await suiteRootTracker.cleanup();
+  });
+
+  async function createStorePath() {
+    const dir = await suiteRootTracker.make("case");
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(storePath, "{}", "utf-8");
+    return storePath;
+  }
+
+  it("appends JSONL recovery events next to the session store", async () => {
+    const storePath = await createStorePath();
+    await appendSessionRecoveryEvent({
+      storePath,
+      eventId: "event-1",
+      eventType: "session.bound",
+      timestamp: 123,
+      sessionKey: "agent:main:discord:dm:user-1",
+      sessionId: "sess-1",
+      source: { kind: "inbound", provider: "discord", channel: undefined },
+      details: { messageSid: "msg-1", omitted: undefined },
+    });
+
+    const logPath = resolveSessionRecoveryLogPath(storePath);
+    const raw = await fs.readFile(logPath, "utf-8");
+    expect(raw.trim().split(/\r?\n/)).toHaveLength(1);
+    await expect(fs.stat(logPath)).resolves.toMatchObject({ mode: expect.any(Number) });
+
+    const events = await readSessionRecoveryEventsForTest(storePath);
+    expect(events).toEqual([
+      {
+        version: 1,
+        eventId: "event-1",
+        eventType: "session.bound",
+        timestamp: 123,
+        sessionKey: "agent:main:discord:dm:user-1",
+        sessionId: "sess-1",
+        source: { kind: "inbound", provider: "discord" },
+        details: { messageSid: "msg-1" },
+      },
+    ]);
+  });
+
+  it("records inbound session metadata as an append-only recovery event", async () => {
+    const storePath = await createStorePath();
+    const ctx: MsgContext = {
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+      From: "user-1",
+      To: "bot-1",
+      AccountId: "default",
+      OriginatingChannel: "discord" as MsgContext["OriginatingChannel"],
+      OriginatingTo: "user-1",
+      MessageSid: "message-1",
+      MessageThreadId: "thread-1",
+      NativeChannelId: "dm-1",
+    };
+
+    const entry = await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: "Agent:Main:Discord:DM:User-1",
+      ctx,
+    });
+
+    expect(entry?.sessionId).toBeTruthy();
+    const events = await readSessionRecoveryEventsForTest(storePath);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      version: 1,
+      eventType: "session.meta.recorded",
+      sessionKey: "agent:main:discord:dm:user-1",
+      sessionId: entry?.sessionId,
+      source: {
+        kind: "inbound",
+        provider: "discord",
+        surface: "discord",
+        channel: "discord",
+        chatType: "direct",
+      },
+      details: {
+        accountId: "default",
+        from: "user-1",
+        to: "bot-1",
+        originatingTo: "user-1",
+        messageSid: "message-1",
+        messageThreadId: "thread-1",
+        nativeChannelId: "dm-1",
+      },
+    });
+  });
+
+  it("does not fail inbound metadata recording when recovery event append fails", async () => {
+    const storePath = await createStorePath();
+    const appendSpy = vi.spyOn(fs, "appendFile").mockRejectedValueOnce(new Error("disk full"));
+    try {
+      await expect(
+        recordSessionMetaFromInbound({
+          storePath,
+          sessionKey: "agent:main:webchat:dm:user-1",
+          ctx: { Provider: "webchat", ChatType: "direct" },
+        }),
+      ).resolves.toMatchObject({ sessionId: expect.any(String) });
+    } finally {
+      appendSpy.mockRestore();
+    }
+  });
+});

--- a/src/config/sessions/recovery-log.ts
+++ b/src/config/sessions/recovery-log.ts
@@ -73,6 +73,13 @@ export function resolveSessionRecoveryLogPath(storePath: string): string {
   return path.join(path.dirname(path.resolve(trimmed)), SESSION_RECOVERY_LOG_FILE);
 }
 
+async function tightenSessionRecoveryLogMode(logPath: string): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  await fs.chmod(logPath, 0o600);
+}
+
 function isSensitiveRecoveryKey(key: string): boolean {
   const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
   if (
@@ -180,6 +187,7 @@ export async function appendSessionRecoveryEvent(
   const event = buildSessionRecoveryEvent(params);
   await fs.mkdir(path.dirname(logPath), { recursive: true });
   await fs.appendFile(logPath, `${JSON.stringify(event)}\n`, { encoding: "utf-8", mode: 0o600 });
+  await tightenSessionRecoveryLogMode(logPath);
   return event;
 }
 

--- a/src/config/sessions/recovery-log.ts
+++ b/src/config/sessions/recovery-log.ts
@@ -62,6 +62,8 @@ export type AppendSessionRecoveryEventParams = {
 };
 
 export const SESSION_RECOVERY_LOG_FILE = "recovery-events.jsonl";
+export const SESSION_RECOVERY_REDACTED_VALUE = "[redacted]";
+export const SESSION_RECOVERY_MAX_STRING_LENGTH = 4096;
 
 export function resolveSessionRecoveryLogPath(storePath: string): string {
   const trimmed = storePath.trim();
@@ -71,14 +73,82 @@ export function resolveSessionRecoveryLogPath(storePath: string): string {
   return path.join(path.dirname(path.resolve(trimmed)), SESSION_RECOVERY_LOG_FILE);
 }
 
+function isSensitiveRecoveryKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  if (
+    normalized === "token" ||
+    normalized.endsWith("token") ||
+    normalized.includes("tokenvalue")
+  ) {
+    return true;
+  }
+  return [
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "password",
+    "passwd",
+    "secret",
+  ].some((needle) => normalized.includes(needle));
+}
+
+function truncateRecoveryString(value: string): string {
+  if (value.length <= SESSION_RECOVERY_MAX_STRING_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, SESSION_RECOVERY_MAX_STRING_LENGTH)}…[truncated]`;
+}
+
+function sanitizeRecoveryValue(
+  value: unknown,
+  key: string | undefined,
+  seen: WeakSet<object>,
+): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (key && isSensitiveRecoveryKey(key)) {
+    return SESSION_RECOVERY_REDACTED_VALUE;
+  }
+  if (typeof value === "string") {
+    return truncateRecoveryString(value);
+  }
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => sanitizeRecoveryValue(entry, undefined, seen))
+      .filter((entry) => entry !== undefined);
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
+  const clean = Object.fromEntries(
+    Object.entries(value)
+      .map(([entryKey, entryValue]) => [
+        entryKey,
+        sanitizeRecoveryValue(entryValue, entryKey, seen),
+      ])
+      .filter(([, entryValue]) => entryValue !== undefined),
+  );
+  seen.delete(value);
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}
+
 function cleanRecord<T extends Record<string, unknown>>(record: T | undefined): T | undefined {
   if (!record) {
     return undefined;
   }
-  const clean = Object.fromEntries(
-    Object.entries(record).filter(([, value]) => value !== undefined),
-  ) as T;
-  return Object.keys(clean).length > 0 ? clean : undefined;
+  return sanitizeRecoveryValue(record, undefined, new WeakSet()) as T | undefined;
 }
 
 export function buildSessionRecoveryEvent(

--- a/src/config/sessions/recovery-log.ts
+++ b/src/config/sessions/recovery-log.ts
@@ -1,0 +1,133 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type SessionRecoveryEventType =
+  | "session.bound"
+  | "session.meta.recorded"
+  | "inbound.received"
+  | "inbound.finalized"
+  | "routing.resolved"
+  | "approval.requested"
+  | "approval.delivered"
+  | "approval.accepted"
+  | "approval.denied"
+  | "approval.expired"
+  | "compact.requested"
+  | "compact.started"
+  | "compact.completed"
+  | "compact.failed"
+  | "subagent.spawn.accepted"
+  | "subagent.child.completed"
+  | "outbound.sent"
+  | "outbound.failed"
+  | "wake.scheduled"
+  | "wake.fired"
+  | (string & {});
+
+export type SessionRecoveryEventSource = {
+  kind?: string;
+  provider?: string;
+  surface?: string;
+  channel?: string;
+  chatType?: string;
+};
+
+export type SessionRecoveryEvent = {
+  version: 1;
+  eventId: string;
+  eventType: SessionRecoveryEventType;
+  timestamp: number;
+  sessionKey: string;
+  sessionId?: string;
+  agentId?: string;
+  runId?: string;
+  turnId?: string;
+  source?: SessionRecoveryEventSource;
+  details?: Record<string, unknown>;
+};
+
+export type AppendSessionRecoveryEventParams = {
+  storePath: string;
+  eventType: SessionRecoveryEventType;
+  sessionKey: string;
+  sessionId?: string;
+  agentId?: string;
+  runId?: string;
+  turnId?: string;
+  timestamp?: number;
+  eventId?: string;
+  source?: SessionRecoveryEventSource;
+  details?: Record<string, unknown>;
+};
+
+export const SESSION_RECOVERY_LOG_FILE = "recovery-events.jsonl";
+
+export function resolveSessionRecoveryLogPath(storePath: string): string {
+  const trimmed = storePath.trim();
+  if (!trimmed) {
+    throw new Error("resolveSessionRecoveryLogPath requires a non-empty storePath");
+  }
+  return path.join(path.dirname(path.resolve(trimmed)), SESSION_RECOVERY_LOG_FILE);
+}
+
+function cleanRecord<T extends Record<string, unknown>>(record: T | undefined): T | undefined {
+  if (!record) {
+    return undefined;
+  }
+  const clean = Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined),
+  ) as T;
+  return Object.keys(clean).length > 0 ? clean : undefined;
+}
+
+export function buildSessionRecoveryEvent(
+  params: Omit<AppendSessionRecoveryEventParams, "storePath">,
+): SessionRecoveryEvent {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error("buildSessionRecoveryEvent requires a non-empty sessionKey");
+  }
+  return {
+    version: 1,
+    eventId: params.eventId?.trim() || crypto.randomUUID(),
+    eventType: params.eventType,
+    timestamp: params.timestamp ?? Date.now(),
+    sessionKey,
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(params.runId ? { runId: params.runId } : {}),
+    ...(params.turnId ? { turnId: params.turnId } : {}),
+    ...(cleanRecord(params.source) ? { source: cleanRecord(params.source) } : {}),
+    ...(cleanRecord(params.details) ? { details: cleanRecord(params.details) } : {}),
+  };
+}
+
+export async function appendSessionRecoveryEvent(
+  params: AppendSessionRecoveryEventParams,
+): Promise<SessionRecoveryEvent> {
+  const logPath = resolveSessionRecoveryLogPath(params.storePath);
+  const event = buildSessionRecoveryEvent(params);
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  await fs.appendFile(logPath, `${JSON.stringify(event)}\n`, { encoding: "utf-8", mode: 0o600 });
+  return event;
+}
+
+export async function readSessionRecoveryEventsForTest(
+  storePath: string,
+): Promise<SessionRecoveryEvent[]> {
+  const logPath = resolveSessionRecoveryLogPath(storePath);
+  let raw = "";
+  try {
+    raw = await fs.readFile(logPath, "utf-8");
+  } catch (err) {
+    if ((err as { code?: unknown }).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as SessionRecoveryEvent);
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -34,6 +34,7 @@ import {
   type SessionStoreLockQueue,
   type SessionStoreLockTask,
 } from "./store-lock-state.js";
+import { appendSessionRecoveryEvent } from "./recovery-log.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -677,7 +678,7 @@ export async function recordSessionMetaFromInbound(params: {
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, ctx } = params;
   const createIfMissing = params.createIfMissing ?? true;
-  return await updateSessionStore(
+  const result = await updateSessionStore(
     storePath,
     (store) => {
       const resolved = resolveSessionStoreEntry({ store, sessionKey });
@@ -713,6 +714,37 @@ export async function recordSessionMetaFromInbound(params: {
     },
     { activeSessionKey: normalizeStoreSessionKey(sessionKey) },
   );
+  if (result) {
+    await appendSessionRecoveryEvent({
+      storePath,
+      eventType: "session.meta.recorded",
+      sessionKey: normalizeStoreSessionKey(sessionKey),
+      sessionId: result.sessionId,
+      source: {
+        kind: "inbound",
+        provider: ctx.Provider,
+        surface: ctx.Surface,
+        channel: ctx.OriginatingChannel,
+        chatType: ctx.ChatType,
+      },
+      details: {
+        accountId: ctx.AccountId,
+        from: ctx.From,
+        to: ctx.To,
+        originatingTo: ctx.OriginatingTo,
+        messageSid: ctx.MessageSid,
+        messageSidFull: ctx.MessageSidFull,
+        messageThreadId: ctx.MessageThreadId,
+        replyToId: ctx.ReplyToId,
+        rootMessageId: ctx.RootMessageId,
+        nativeChannelId: ctx.NativeChannelId,
+        nativeDirectUserId: ctx.NativeDirectUserId,
+      },
+    }).catch((err) => {
+      log.warn(`Failed to append session recovery event: ${String(err)}`);
+    });
+  }
+  return result;
 }
 
 export async function updateLastRoute(params: {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -695,6 +695,14 @@ function sessionRecoveryDetailsFromInbound(ctx: MsgContext) {
   };
 }
 
+async function appendSessionRecoveryEventSafe(
+  params: Parameters<typeof appendSessionRecoveryEvent>[0],
+): Promise<void> {
+  await appendSessionRecoveryEvent(params).catch((err) => {
+    log.warn(`Failed to append session recovery event: ${String(err)}`);
+  });
+}
+
 async function appendInboundSessionRecoveryEvent(params: {
   storePath: string;
   eventType: "inbound.received" | "session.meta.recorded";
@@ -702,15 +710,42 @@ async function appendInboundSessionRecoveryEvent(params: {
   sessionId: string;
   ctx: MsgContext;
 }): Promise<void> {
-  await appendSessionRecoveryEvent({
+  await appendSessionRecoveryEventSafe({
     storePath: params.storePath,
     eventType: params.eventType,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     source: sessionRecoverySourceFromInbound(params.ctx),
     details: sessionRecoveryDetailsFromInbound(params.ctx),
-  }).catch((err) => {
-    log.warn(`Failed to append session recovery event: ${String(err)}`);
+  });
+}
+
+async function appendRoutingResolvedRecoveryEvent(params: {
+  storePath: string;
+  sessionKey: string;
+  entry: SessionEntry;
+  ctx?: MsgContext;
+}): Promise<void> {
+  const { entry, ctx } = params;
+  await appendSessionRecoveryEventSafe({
+    storePath: params.storePath,
+    eventType: "routing.resolved",
+    sessionKey: params.sessionKey,
+    sessionId: entry.sessionId,
+    source: {
+      kind: "routing",
+      provider: ctx?.Provider,
+      surface: ctx?.Surface,
+      channel: entry.lastChannel,
+      chatType: ctx?.ChatType,
+    },
+    details: {
+      accountId: entry.lastAccountId,
+      to: entry.lastTo,
+      threadId: entry.lastThreadId,
+      deliveryContext: entry.deliveryContext,
+      inbound: ctx ? sessionRecoveryDetailsFromInbound(ctx) : undefined,
+    },
   });
 }
 
@@ -791,7 +826,7 @@ export async function updateLastRoute(params: {
   groupResolution?: import("./types.js").GroupKeyResolution | null;
 }) {
   const { storePath, sessionKey, channel, to, accountId, threadId, ctx } = params;
-  return await withSessionStoreLock(storePath, async () => {
+  const result = await withSessionStoreLock(storePath, async () => {
     const store = loadSessionStore(storePath);
     const resolved = resolveSessionStoreEntry({ store, sessionKey });
     const existing = resolved.existing;
@@ -859,4 +894,11 @@ export async function updateLastRoute(params: {
       next,
     });
   });
+  await appendRoutingResolvedRecoveryEvent({
+    storePath,
+    sessionKey: normalizeStoreSessionKey(sessionKey),
+    entry: result,
+    ctx,
+  });
+  return result;
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -669,6 +669,51 @@ export async function updateSessionStoreEntry(params: {
   });
 }
 
+function sessionRecoverySourceFromInbound(ctx: MsgContext) {
+  return {
+    kind: "inbound",
+    provider: ctx.Provider,
+    surface: ctx.Surface,
+    channel: ctx.OriginatingChannel,
+    chatType: ctx.ChatType,
+  };
+}
+
+function sessionRecoveryDetailsFromInbound(ctx: MsgContext) {
+  return {
+    accountId: ctx.AccountId,
+    from: ctx.From,
+    to: ctx.To,
+    originatingTo: ctx.OriginatingTo,
+    messageSid: ctx.MessageSid,
+    messageSidFull: ctx.MessageSidFull,
+    messageThreadId: ctx.MessageThreadId,
+    replyToId: ctx.ReplyToId,
+    rootMessageId: ctx.RootMessageId,
+    nativeChannelId: ctx.NativeChannelId,
+    nativeDirectUserId: ctx.NativeDirectUserId,
+  };
+}
+
+async function appendInboundSessionRecoveryEvent(params: {
+  storePath: string;
+  eventType: "inbound.received" | "session.meta.recorded";
+  sessionKey: string;
+  sessionId: string;
+  ctx: MsgContext;
+}): Promise<void> {
+  await appendSessionRecoveryEvent({
+    storePath: params.storePath,
+    eventType: params.eventType,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    source: sessionRecoverySourceFromInbound(params.ctx),
+    details: sessionRecoveryDetailsFromInbound(params.ctx),
+  }).catch((err) => {
+    log.warn(`Failed to append session recovery event: ${String(err)}`);
+  });
+}
+
 export async function recordSessionMetaFromInbound(params: {
   storePath: string;
   sessionKey: string;
@@ -715,33 +760,20 @@ export async function recordSessionMetaFromInbound(params: {
     { activeSessionKey: normalizeStoreSessionKey(sessionKey) },
   );
   if (result) {
-    await appendSessionRecoveryEvent({
+    const recoverySessionKey = normalizeStoreSessionKey(sessionKey);
+    await appendInboundSessionRecoveryEvent({
+      storePath,
+      eventType: "inbound.received",
+      sessionKey: recoverySessionKey,
+      sessionId: result.sessionId,
+      ctx,
+    });
+    await appendInboundSessionRecoveryEvent({
       storePath,
       eventType: "session.meta.recorded",
-      sessionKey: normalizeStoreSessionKey(sessionKey),
+      sessionKey: recoverySessionKey,
       sessionId: result.sessionId,
-      source: {
-        kind: "inbound",
-        provider: ctx.Provider,
-        surface: ctx.Surface,
-        channel: ctx.OriginatingChannel,
-        chatType: ctx.ChatType,
-      },
-      details: {
-        accountId: ctx.AccountId,
-        from: ctx.From,
-        to: ctx.To,
-        originatingTo: ctx.OriginatingTo,
-        messageSid: ctx.MessageSid,
-        messageSidFull: ctx.MessageSidFull,
-        messageThreadId: ctx.MessageThreadId,
-        replyToId: ctx.ReplyToId,
-        rootMessageId: ctx.RootMessageId,
-        nativeChannelId: ctx.NativeChannelId,
-        nativeDirectUserId: ctx.NativeDirectUserId,
-      },
-    }).catch((err) => {
-      log.warn(`Failed to append session recovery event: ${String(err)}`);
+      ctx,
     });
   }
   return result;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -48,6 +48,9 @@ const queueMocks = vi.hoisted(() => ({
     ) => Promise<{ status: "claimed"; value: unknown } | { status: "claimed-by-other-owner" }>
   >(async (_entryId, fn) => ({ status: "claimed", value: await fn() })),
 }));
+const recoveryMocks = vi.hoisted(() => ({
+  appendSessionRecoveryEvent: vi.fn(async () => undefined),
+}));
 const logMocks = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
@@ -82,6 +85,9 @@ vi.mock("./delivery-queue.js", () => ({
   ackDelivery: queueMocks.ackDelivery,
   failDelivery: queueMocks.failDelivery,
   withActiveDeliveryClaim: queueMocks.withActiveDeliveryClaim,
+}));
+vi.mock("../../config/sessions/recovery-log.js", () => ({
+  appendSessionRecoveryEvent: recoveryMocks.appendSessionRecoveryEvent,
 }));
 vi.mock("../../logging/subsystem.js", () => ({
   createSubsystemLogger: () => {
@@ -284,6 +290,8 @@ describe("deliverOutboundPayloads", () => {
       status: "claimed",
       value: await fn(),
     }));
+    recoveryMocks.appendSessionRecoveryEvent.mockClear();
+    recoveryMocks.appendSessionRecoveryEvent.mockResolvedValue(undefined);
     logMocks.warn.mockClear();
   });
 
@@ -291,6 +299,92 @@ describe("deliverOutboundPayloads", () => {
     resetDiagnosticEventsForTest();
     releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("records outbound.sent recovery events for delivered payloads", async () => {
+    const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
+
+    await deliverOutboundPayloads({
+      cfg: {
+        ...matrixChunkConfig,
+        session: { store: "/tmp/openclaw-{agentId}-sessions.json" },
+      } as OpenClawConfig,
+      channel: "matrix",
+      to: "!room:example",
+      accountId: "work",
+      threadId: "thread-1",
+      replyToId: "reply-1",
+      payloads: [{ text: "secret delivery body" }],
+      deps: { matrix: sendMatrix },
+      session: {
+        key: "agent:main:matrix:direct:user-1",
+        agentId: "main",
+      },
+    });
+
+    expect(recoveryMocks.appendSessionRecoveryEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/openclaw-main-sessions.json",
+        eventType: "outbound.sent",
+        sessionKey: "agent:main:matrix:direct:user-1",
+        agentId: "main",
+        source: { kind: "outbound", channel: "matrix" },
+        details: expect.objectContaining({
+          channel: "matrix",
+          to: "!room:example",
+          accountId: "work",
+          threadId: "thread-1",
+          replyToId: "reply-1",
+          deliveryKind: "text",
+          textLength: "secret delivery body".length,
+          mediaCount: 0,
+          resultCount: 1,
+          messageIds: ["m1"],
+        }),
+      }),
+    );
+  });
+
+  it("records outbound.failed recovery events without blocking best-effort delivery", async () => {
+    const sendMatrix = vi.fn().mockRejectedValue(new Error("network down"));
+    const onError = vi.fn();
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {
+          ...matrixChunkConfig,
+          session: { store: "/tmp/openclaw-{agentId}-sessions.json" },
+        } as OpenClawConfig,
+        channel: "matrix",
+        to: "!room:example",
+        payloads: [{ text: "failed body" }],
+        deps: { matrix: sendMatrix },
+        bestEffort: true,
+        onError,
+        session: {
+          key: "agent:main:matrix:direct:user-1",
+          agentId: "main",
+        },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(recoveryMocks.appendSessionRecoveryEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath: "/tmp/openclaw-main-sessions.json",
+        eventType: "outbound.failed",
+        sessionKey: "agent:main:matrix:direct:user-1",
+        agentId: "main",
+        details: expect.objectContaining({
+          channel: "matrix",
+          to: "!room:example",
+          deliveryKind: "text",
+          textLength: "failed body".length,
+          mediaCount: 0,
+          error: "network down",
+        }),
+      }),
+    );
   });
 
   it("emits bounded delivery diagnostics for successful outbound sends", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -7,6 +7,8 @@ import type {
   ChannelOutboundPayloadContext,
   ChannelOutboundTargetRef,
 } from "../../channels/plugins/types.adapters.js";
+import { appendSessionRecoveryEvent } from "../../config/sessions/recovery-log.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import type { ReplyToMode } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -435,6 +437,74 @@ function emitMessageDeliveryError(params: {
     durationMs: params.durationMs,
     errorCategory: diagnosticErrorCategory(params.error),
     ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}
+
+function resolveOutboundRecoveryContext(params: DeliverOutboundPayloadsCoreParams):
+  | {
+      storePath: string;
+      sessionKey: string;
+      agentId: string;
+    }
+  | undefined {
+  const sessionKey = params.mirror?.sessionKey ?? params.session?.key ?? params.session?.policyKey;
+  const agentId = params.session?.agentId ?? params.mirror?.agentId;
+  if (!sessionKey || !agentId) {
+    return undefined;
+  }
+  return {
+    storePath: resolveStorePath(params.cfg.session?.store, { agentId }),
+    sessionKey,
+    agentId,
+  };
+}
+
+async function appendOutboundRecoveryEvent(params: {
+  context?: ReturnType<typeof resolveOutboundRecoveryContext>;
+  eventType: "outbound.sent" | "outbound.failed";
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  accountId?: string;
+  threadId?: string | number | null;
+  replyToId?: string | null;
+  payloadSummary: NormalizedOutboundPayload;
+  deliveryKind: DiagnosticMessageDeliveryKind;
+  results?: readonly OutboundDeliveryResult[];
+  error?: unknown;
+}): Promise<void> {
+  const context = params.context;
+  if (!context) {
+    return;
+  }
+  await appendSessionRecoveryEvent({
+    storePath: context.storePath,
+    eventType: params.eventType,
+    sessionKey: context.sessionKey,
+    agentId: context.agentId,
+    source: {
+      kind: "outbound",
+      channel: params.channel,
+    },
+    details: {
+      channel: params.channel,
+      to: params.to,
+      accountId: params.accountId,
+      threadId: params.threadId,
+      replyToId: params.replyToId,
+      deliveryKind: params.deliveryKind,
+      textLength: params.payloadSummary.text.length,
+      mediaCount: params.payloadSummary.mediaUrls.length,
+      hasHookContent: Boolean(params.payloadSummary.hookContent),
+      resultCount: params.results?.length,
+      messageIds: params.results?.map((entry) => entry.messageId).filter(Boolean),
+      error: params.error ? formatErrorMessage(params.error) : undefined,
+    },
+  }).catch((err) => {
+    log.warn("Failed to append outbound recovery event.", {
+      channel: params.channel,
+      to: params.to,
+      error: formatErrorMessage(err),
+    });
   });
 }
 
@@ -941,6 +1011,7 @@ async function deliverOutboundPayloadsCore(
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   const diagnosticSessionKey = sessionKeyForDeliveryDiagnostics(params);
+  const outboundRecoveryContext = resolveOutboundRecoveryContext(params);
   if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
@@ -1041,6 +1112,20 @@ async function deliverOutboundPayloadsCore(
           consumeImplicitReply: replyToResolution.source === "implicit",
         });
       const deliveryTarget = handler.buildTargetRef({ threadId: sendOverrides.threadId });
+      const recordOutboundSent = async (deliveredResults: readonly OutboundDeliveryResult[]) => {
+        await appendOutboundRecoveryEvent({
+          context: outboundRecoveryContext,
+          eventType: "outbound.sent",
+          channel,
+          to,
+          accountId,
+          threadId: sendOverrides.threadId,
+          replyToId: sendOverrides.replyToId,
+          payloadSummary,
+          deliveryKind,
+          results: deliveredResults,
+        });
+      };
       if (
         handler.sendPayload &&
         (hasReplyPayloadContent({
@@ -1068,6 +1153,7 @@ async function deliverOutboundPayloadsCore(
           results: [delivery],
         });
         completeDeliveryDiagnostics(1);
+        await recordOutboundSent([delivery]);
         emitMessageSent({
           success: true,
           content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -1103,6 +1189,7 @@ async function deliverOutboundPayloadsCore(
           results: deliveredResults,
         });
         completeDeliveryDiagnostics(deliveredResults.length);
+        await recordOutboundSent(deliveredResults);
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -1144,6 +1231,7 @@ async function deliverOutboundPayloadsCore(
           results: deliveredResults,
         });
         completeDeliveryDiagnostics(deliveredResults.length);
+        await recordOutboundSent(deliveredResults);
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -1185,7 +1273,9 @@ async function deliverOutboundPayloadsCore(
         target: deliveryTarget,
         results: results.slice(beforeCount),
       });
-      completeDeliveryDiagnostics(results.length - beforeCount);
+      const deliveredResults = results.slice(beforeCount);
+      completeDeliveryDiagnostics(deliveredResults.length);
+      await recordOutboundSent(deliveredResults);
       emitMessageSent({
         success: true,
         content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -1193,6 +1283,18 @@ async function deliverOutboundPayloadsCore(
       });
     } catch (err) {
       errorDeliveryDiagnostics(err);
+      await appendOutboundRecoveryEvent({
+        context: outboundRecoveryContext,
+        eventType: "outbound.failed",
+        channel,
+        to,
+        accountId,
+        threadId: params.threadId,
+        replyToId: params.replyToId,
+        payloadSummary,
+        deliveryKind,
+        error: err,
+      });
       emitMessageSent({
         success: false,
         content: payloadSummary.hookContent ?? payloadSummary.text,


### PR DESCRIPTION
## Summary

Adds an append-only `recovery-events.jsonl` sidecar for best-effort session recovery breadcrumbs. The log is written next to the session store and records lightweight lifecycle metadata for:

- inbound session metadata recording
- route resolution
- manual `/compact` lifecycle events
- outbound delivery success/failure

This is intentionally **best-effort forensic/recovery metadata**, not a strict write-ahead log or crash-consistent delivery guarantee.

## Safety / privacy notes

- Message bodies are not written to the recovery log.
- Outbound entries record text length and delivery metadata instead of content.
- Sensitive keys such as tokens, authorization, cookies, passwords, secrets, and API keys are redacted recursively.
- Long strings are truncated and circular references are guarded.
- The recovery log can still include sensitive local routing metadata such as account IDs, channel targets, native message/thread IDs, session files, and group IDs, so it should be treated as local sensitive session metadata.
- Log files are created with `0600`; appends also tighten existing log files to `0600` on non-Windows platforms.

## Validation

- `git diff --check`
- `node scripts/test-projects.mjs src/config/sessions/recovery-log.test.ts src/auto-reply/reply/commands-compact.test.ts src/infra/outbound/deliver.test.ts`
  - 69 tests passed
- `pnpm tsgo:core`

Note: `pnpm test:changed:focused` currently fails in unchanged `queue.collect.test.ts` and `session-delivery.test.ts` cases. Those files are not touched by this branch, and direct reruns reproduce the same failures outside the recovery-log diff scope.
