### PR TITLE
fix(gateway): reject malformed session kill paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/voice: keep default agent-proxy realtime sessions from auto-speaking filler before the forced OpenClaw consult answer, finish Discord playback on realtime response completion, and queue later exact-speech answers until playback idles to avoid mid-sentence replacement.
+- Gateway: return deterministic `400 invalid_request_error` responses for malformed encoded session-kill HTTP paths instead of letting route-shaped requests fall through to later Gateway handlers. (#72439) Thanks @rubencu.
 - OpenAI/realtime voice: honor disabled input-audio interruption locally so server VAD speech-start events do not clear Discord playback after operators set `interruptResponseOnInputAudio: false`.
 - Telegram: handle managed select button callbacks before the raw callback fallback while preserving delimiter-containing option values such as `env|prod`. (#79816) Thanks @moeedahmed.
 - CLI/media: let explicit image description model refs use bundled static provider catalogs and generic model-backed image hooks, so `openclaw infer image describe --model zai/glm-4.6v` works like direct model runs and Anthropic auth probes avoid stale Claude 3 Haiku catalog entries.

--- a/src/gateway/session-kill-http.test.ts
+++ b/src/gateway/session-kill-http.test.ts
@@ -135,6 +135,24 @@ describe("POST /sessions/:sessionKey/kill", () => {
     expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
   });
 
+  it.each(["/sessions/%zz/kill", "/sessions/%20/kill"])(
+    "rejects invalid encoded session key %s without falling through",
+    async (pathname) => {
+      const response = await post(pathname);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: {
+          message: "invalid session key",
+          type: "invalid_request_error",
+        },
+      });
+      expect(authMock).not.toHaveBeenCalled();
+      expect(loadSessionEntryMock).not.toHaveBeenCalled();
+      expect(killSubagentRunAdminMock).not.toHaveBeenCalled();
+      expect(killControlledSubagentRunMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("kills a matching session via the admin kill helper using the canonical key", async () => {
     authMock.mockResolvedValueOnce({ ok: true, method: "trusted-proxy" });
     loadSessionEntryMock.mockReturnValue({

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -9,7 +9,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { isLocalDirectRequest, type ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, sendMethodNotAllowed } from "./http-common.js";
+import { sendInvalidRequest, sendJson, sendMethodNotAllowed } from "./http-common.js";
 import {
   authorizeGatewayHttpRequestOrReply,
   resolveTrustedHttpOperatorScopes,
@@ -19,16 +19,24 @@ import { loadSessionEntry } from "./session-utils.js";
 
 const REQUESTER_SESSION_KEY_HEADER = "x-openclaw-requester-session-key";
 
-function resolveSessionKeyFromPath(pathname: string): string | null {
+type SessionKeyPathResolution =
+  | { matched: false }
+  | { matched: true; sessionKey: string }
+  | { error: "invalid-session-key"; matched: true };
+
+function resolveSessionKeyFromPath(pathname: string): SessionKeyPathResolution {
   const match = pathname.match(/^\/sessions\/([^/]+)\/kill$/);
   if (!match) {
-    return null;
+    return { matched: false };
   }
   try {
     const decoded = decodeURIComponent(match[1] ?? "").trim();
-    return decoded || null;
+    if (!decoded) {
+      return { error: "invalid-session-key", matched: true };
+    }
+    return { matched: true, sessionKey: decoded };
   } catch {
-    return null;
+    return { error: "invalid-session-key", matched: true };
   }
 }
 
@@ -44,10 +52,15 @@ export async function handleSessionKillHttpRequest(
 ): Promise<boolean> {
   const cfg = getRuntimeConfig();
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
-  const sessionKey = resolveSessionKeyFromPath(url.pathname);
-  if (!sessionKey) {
+  const sessionKeyResolution = resolveSessionKeyFromPath(url.pathname);
+  if (!sessionKeyResolution.matched) {
     return false;
   }
+  if ("error" in sessionKeyResolution) {
+    sendInvalidRequest(res, "invalid session key");
+    return true;
+  }
+  const { sessionKey } = sessionKeyResolution;
 
   if (req.method !== "POST") {
     sendMethodNotAllowed(res, "POST");


### PR DESCRIPTION
## Summary

- Problem: the Gateway HTTP `POST /sessions/:sessionKey/kill` route matched malformed encoded session paths, but the handler treated decode failures as "not handled".
- Why it matters: route-shaped API requests could fall through to later HTTP stages instead of returning a deterministic API error.
- What changed: session-kill path parsing now distinguishes non-matching paths from invalid matched paths and returns `400 invalid_request_error` before auth/session lookup for malformed or decoded-empty session keys.
- Scope boundary: no session auth, ownership, scope, kill, or RPC semantics changed for valid session keys. No new config surface. No `CHANGELOG.md` entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveSessionKeyFromPath()` returned `null` for both non-matching paths and malformed percent-encoded session keys, so `handleSessionKillHttpRequest()` could not claim malformed route-shaped requests.
- Missing detection / guardrail: session-kill tests covered valid encoded keys and auth behavior, but not malformed encoding or decoded-empty matched routes.
- Contributing context: the sibling session-history HTTP handler already treats malformed matched session keys as invalid requests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/session-kill-http.test.ts`
- Scenario the test locks in: `POST /sessions/%zz/kill` and `POST /sessions/%20/kill` return `400 invalid_request_error` and do not invoke auth, session lookup, admin kill, or controlled kill helpers.
- Why this is the smallest reliable guardrail: it exercises the HTTP handler boundary with route shapes that previously fell through.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed encoded session-kill HTTP requests now return a JSON `400 invalid_request_error` instead of falling through to later Gateway HTTP handlers.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Real behavior proof

- **Behavior or issue addressed:** malformed route-shaped Gateway HTTP session-kill requests such as `POST /sessions/%zz/kill` should return a deterministic API `400 invalid_request_error` instead of falling through to later HTTP handlers.
- **Real environment tested:** macOS local OpenClaw source worktrees, isolated `HOME` / `OPENCLAW_HOME`, real loopback Gateway process started with `pnpm openclaw gateway run --allow-unconfigured --port <random> --bind loopback --token <test-token>`.
- **Exact steps or command run after this patch:** started the real Gateway from PR head `ba8342c60218`, waited for `/healthz`, then ran `curl --path-as-is -X POST -H 'Authorization: Bearer <test-token>' http://127.0.0.1:<port>/sessions/%zz/kill` and the same command for `/sessions/%20/kill`.
- **Evidence after fix:** copied live terminal output from the PR-head Gateway probe:

```text
label=pr-head-rebased
commit=ba8342c60218
port=58491
path=/sessions/%zz/kill
status=400
body={"error":{"message":"invalid session key","type":"invalid_request_error"}}
path=/sessions/%20/kill
status=400
body={"error":{"message":"invalid session key","type":"invalid_request_error"}}
gateway_log=/tmp/openclaw-pr72439-pr-head-rebased-gateway.mSoZOZ
```

- **Observed result after fix:** both invalid matched session-kill routes returned HTTP `400` with JSON `{"error":{"message":"invalid session key","type":"invalid_request_error"}}` from a real running Gateway.
- **What was not tested:** No additional gaps
- **Before evidence:** current `origin/main` proof used the same real Gateway command in a fresh base worktree; `POST /sessions/%zz/kill` returned HTTP `404` with body `Not Found`, proving the malformed matched route fell through before this patch.

## Repro + Verification

Validation run on the rebased branch:

- `pnpm docs:list`
- `pnpm exec oxfmt --check --threads=1 src/gateway/session-kill-http.ts src/gateway/session-kill-http.test.ts`
- `pnpm test src/gateway/session-kill-http.test.ts -- --reporter=verbose` -> 13 passed
- `pnpm changed:lanes --json` -> `core`, `coreTests`
- `git diff --check origin/main...HEAD`
- `pnpm check:changed` -> passed
- `codex review --base origin/main` -> no actionable regressions; reran `pnpm test src/gateway/session-kill-http.test.ts` successfully

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real Gateway before/after behavior for malformed `%zz`; real Gateway fixed behavior for decoded-empty `%20`; handler-level tests for both invalid paths and valid/session auth behavior in the same file.
- Edge cases checked: invalid matched paths do not invoke auth, session lookup, admin kill, or controlled kill helpers.
- User manual verification: owner performs final manual verification outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: clients relying on malformed session-kill paths receiving a later fallback response will now receive a 400.
  - Mitigation: malformed percent-encoded session keys are invalid API input, and valid encoded session keys keep the existing behavior.
