### PR TITLE
test(plugins): guard persisted status replay

### DIFF
--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { clearPluginDiscoveryCache } from "./discovery.js";
 import { clearPluginManifestRegistryCache } from "./manifest-registry.js";
+import { refreshPluginRegistry } from "./plugin-registry.js";
 import { buildPluginRegistrySnapshotReport, buildPluginSnapshotReport } from "./status.js";
 import {
   createColdPluginConfig,
@@ -65,6 +66,59 @@ describe("buildPluginRegistrySnapshotReport", () => {
       source: fs.realpathSync(fixture.runtimeSource),
       status: "loaded",
     });
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  });
+
+  it("replays persisted list metadata without importing plugin runtime", async () => {
+    const fixture = createColdPluginFixture({
+      rootDir: makeTempDir(),
+      pluginId: "persisted-demo",
+      packageName: "@example/openclaw-persisted-demo",
+      packageVersion: "2.0.0",
+      manifest: {
+        id: "persisted-demo",
+        name: "Persisted Demo",
+        description: "Persisted registry metadata",
+        providers: ["persisted-provider"],
+        commandAliases: [{ name: "persisted-demo" }],
+      },
+    });
+    const workspaceDir = makeTempDir();
+    const config = createColdPluginConfig(fixture.rootDir, fixture.pluginId);
+    const env = createColdPluginHermeticEnv(workspaceDir, {
+      bundledPluginsDir: makeTempDir(),
+      disablePersistedRegistry: false,
+    });
+
+    await refreshPluginRegistry({
+      config,
+      workspaceDir,
+      env,
+      reason: "manual",
+    });
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+
+    const report = buildPluginRegistrySnapshotReport({
+      config,
+      workspaceDir,
+      env,
+    });
+
+    expect(report.registrySource).toBe("persisted");
+    expect(report.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "persisted-demo",
+          name: "Persisted Demo",
+          description: "Persisted registry metadata",
+          version: "2.0.0",
+          providerIds: ["persisted-provider"],
+          commands: ["persisted-demo"],
+          source: fs.realpathSync(fixture.runtimeSource),
+          status: "loaded",
+        }),
+      ]),
+    );
     expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Problem: status/list coverage did not prove persisted plugin registry replay stays on manifest metadata.
- Why it matters: plugin registry growth makes accidental runtime imports in list/status paths expensive.
- What changed: added a cold-runtime sentinel test that refreshes the persisted registry, then verifies `buildPluginRegistrySnapshotReport` replays that persisted metadata without importing the plugin runtime.
- What did NOT change (scope boundary): no production code, runtime loading behavior, plugin manifests, CLI output, or docs changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A.
- Missing detection / guardrail: persisted registry replay was covered at the registry layer, but not at the plugin status/list report seam.
- Contributing context (if known): bundled plugin volume is growing, so read-only plugin surfaces need cold-path guardrails.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/status.registry-snapshot.test.ts`.
- Scenario the test should lock in: persisted plugin registry metadata can be replayed for status/list reporting without importing the plugin runtime entry.
- Why this is the smallest reliable guardrail: it exercises the status report seam directly with a runtime module that writes a marker and throws if imported.
- Existing test that already covers this (if any): registry-level persisted read tests exist, but they do not cover the status report surface.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin registry/status
- Relevant config (redacted): hermetic temp OpenClaw home/state

### Steps

1. Run focused formatter.
2. Run focused plugin status snapshot test shard.
3. Run changed gate.
4. Rebase on latest `origin/main` and run diff sanity.

### Expected

- Persisted registry status replay reports metadata and leaves the plugin runtime marker absent.

### Actual

- Verified locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm exec oxfmt --check --threads=1 src/plugins/status.registry-snapshot.test.ts`; `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/plugins/status.registry-snapshot.test.ts`; `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`; `git diff --check origin/main...HEAD` after clean rebase.
- Edge cases checked: persisted registry refresh, persisted status replay, runtime marker remains absent.
- What you did **not** verify: full repo `pnpm check` / `pnpm test`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

None.

AI-assisted: yes.
