### PR TITLE
feat(sessions_send): add agent-to-agent call tracing

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -4,6 +4,7 @@ import { isRequesterParentOfBackgroundAcpSession } from "../../acp/session-inter
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -33,6 +34,8 @@ import {
 } from "./sessions-helpers.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+
+const log = createSubsystemLogger("agents/sessions-send");
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
@@ -246,6 +249,12 @@ export function createSessionsSendTool(opts?: {
       });
       const access = visibilityGuard.check(resolvedKey);
       if (!access.allowed) {
+        log.info("sessions_send access denied", {
+          callerSessionKey: effectiveRequesterKey,
+          targetSessionKey: displayKey,
+          status: access.status,
+          error: access.error,
+        });
         return jsonResult({
           runId: crypto.randomUUID(),
           status: access.status,
@@ -253,6 +262,14 @@ export function createSessionsSendTool(opts?: {
           sessionKey: displayKey,
         });
       }
+
+      log.info("sessions_send call", {
+        callerSessionKey: effectiveRequesterKey,
+        targetSessionKey: displayKey,
+        messageLength: message.length,
+        timeoutSeconds,
+      });
+      const callStartMs = Date.now();
 
       // Capture the pre-run assistant snapshot before starting the nested run.
       // Fast in-process test doubles and short-circuit agent paths can finish
@@ -347,6 +364,12 @@ export function createSessionsSendTool(opts?: {
         }
         runId = start.runId;
         startA2AFlow(undefined, runId);
+        log.info("sessions_send fire-and-forget accepted", {
+          callerSessionKey: effectiveRequesterKey,
+          targetSessionKey: displayKey,
+          runId,
+          durationMs: Date.now() - callStartMs,
+        });
         return jsonResult({
           runId,
           status: "accepted",
@@ -375,6 +398,12 @@ export function createSessionsSendTool(opts?: {
       });
 
       if (result.status === "timeout") {
+        log.info("sessions_send timeout", {
+          callerSessionKey: effectiveRequesterKey,
+          targetSessionKey: displayKey,
+          runId,
+          durationMs: Date.now() - callStartMs,
+        });
         return jsonResult({
           runId,
           status: "timeout",
@@ -383,6 +412,13 @@ export function createSessionsSendTool(opts?: {
         });
       }
       if (result.status === "error") {
+        log.info("sessions_send error", {
+          callerSessionKey: effectiveRequesterKey,
+          targetSessionKey: displayKey,
+          runId,
+          durationMs: Date.now() - callStartMs,
+          error: result.error,
+        });
         return jsonResult({
           runId,
           status: "error",
@@ -393,6 +429,14 @@ export function createSessionsSendTool(opts?: {
       const reply = result.replyText;
       startA2AFlow(reply ?? undefined);
 
+      log.info("sessions_send completed", {
+        callerSessionKey: effectiveRequesterKey,
+        targetSessionKey: displayKey,
+        runId,
+        status: "ok",
+        replyLength: reply?.length ?? 0,
+        durationMs: Date.now() - callStartMs,
+      });
       return jsonResult({
         runId,
         status: "ok",


### PR DESCRIPTION
## Summary

Add structured call tracing to `sessions_send` so every agent-to-agent call is logged with audit-relevant metadata.

## What changes

- Added `createSubsystemLogger('agents/sessions-send')` to the sessions_send tool
- Log at entry: caller session key, target session key, message length, timeout
- Log at every exit: status (ok/error/timeout/accepted/forbidden), duration, reply length
- Access denied events are also traced for security audit

## Logged fields per call

| Field | Description |
|---|---|
| `callerSessionKey` | Agent session that initiated the send |
| `targetSessionKey` | Destination session |
| `messageLength` | Length of the sent message (not the payload itself — privacy) |
| `status` | ok / error / timeout / accepted / forbidden |
| `durationMs` | Wall-clock time for synchronous calls |
| `runId` | Correlation ID for the agent run |

## Why

- Audit trail for cross-fleet communication
- Visibility into failed auth attempts (key for ILL-95 enforcement model)
- Foundation for governance dashboards
- Uses OpenClaw's standard log pipeline (retention, rotation, queryable via `openclaw logs`)

## Testing

- TypeScript compilation clean
- No behavioral changes — purely additive observability
- Logger uses existing `createSubsystemLogger` infrastructure

Closes AI-364
Addresses cross-fleet observability gap from ILL-95