### PR TITLE
fix(gateway): align UI thinking default with runtime resolver

### DIFF
--- a/src/gateway/session-utils.thinking-default.test.ts
+++ b/src/gateway/session-utils.thinking-default.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resetConfigRuntimeState } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { buildGatewaySessionRow, getSessionDefaults } from "./session-utils.js";
+
+function makeConfig(thinkingDefault?: string, perModelThinking?: string): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        model: { primary: "ollama/gemma3:4b" },
+        ...(thinkingDefault ? { thinkingDefault } : {}),
+        ...(perModelThinking
+          ? { models: { "ollama/gemma3:4b": { params: { thinking: perModelThinking } } } }
+          : {}),
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+// Regression coverage for https://github.com/openclaw/openclaw/issues/72407 —
+// the gateway must hand the UI the same thinking default the runtime resolves,
+// otherwise users see "Default (off)" while the model is actually thinking
+// adaptively.
+describe("getSessionDefaults thinkingDefault — issue #72407", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+    resetPluginRuntimeStateForTest();
+  });
+
+  test("honors agents.defaults.thinkingDefault for non-reasoning models", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const cfg = makeConfig("adaptive");
+
+    expect(resolveThinkingDefault({ cfg, provider: "ollama", model: "gemma3:4b" })).toBe(
+      "adaptive",
+    );
+    expect(getSessionDefaults(cfg).thinkingDefault).toBe("adaptive");
+  });
+
+  test("honors per-model params.thinking when global default is unset", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const cfg = makeConfig(undefined, "adaptive");
+
+    expect(resolveThinkingDefault({ cfg, provider: "ollama", model: "gemma3:4b" })).toBe(
+      "adaptive",
+    );
+    expect(getSessionDefaults(cfg).thinkingDefault).toBe("adaptive");
+  });
+
+  test("per-model params.thinking wins over global agents.defaults.thinkingDefault", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const cfg = makeConfig("low", "adaptive");
+
+    expect(resolveThinkingDefault({ cfg, provider: "ollama", model: "gemma3:4b" })).toBe(
+      "adaptive",
+    );
+    expect(getSessionDefaults(cfg).thinkingDefault).toBe("adaptive");
+  });
+
+  test("UI label matches runtime resolution when no config override is set", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const cfg = makeConfig();
+
+    const backend = resolveThinkingDefault({ cfg, provider: "ollama", model: "gemma3:4b" });
+    expect(getSessionDefaults(cfg).thinkingDefault).toBe(backend);
+  });
+});
+
+// Symmetric coverage for the second patched call site: per-row session payload.
+// `buildGatewaySessionRow` should produce the same `thinkingDefault` for a row
+// as `resolveThinkingDefault` would for the row's resolved (provider, model).
+describe("buildGatewaySessionRow thinkingDefault — issue #72407", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+    resetPluginRuntimeStateForTest();
+  });
+
+  function buildRow(cfg: OpenClawConfig) {
+    return buildGatewaySessionRow({
+      cfg,
+      storePath: "/tmp/store.json",
+      store: {},
+      key: "main",
+      now: 0,
+    });
+  }
+
+  test("row honors agents.defaults.thinkingDefault for non-reasoning models", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(buildRow(makeConfig("adaptive")).thinkingDefault).toBe("adaptive");
+  });
+
+  test("row honors per-model params.thinking when global default is unset", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(buildRow(makeConfig(undefined, "adaptive")).thinkingDefault).toBe("adaptive");
+  });
+
+  test("row uses per-model params.thinking over global default", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(buildRow(makeConfig("low", "adaptive")).thinkingDefault).toBe("adaptive");
+  });
+
+  test("row label matches runtime resolution when no config override is set", () => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const cfg = makeConfig();
+    const backend = resolveThinkingDefault({ cfg, provider: "ollama", model: "gemma3:4b" });
+    expect(buildRow(cfg).thinkingDefault).toBe(backend);
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -18,6 +18,7 @@ import {
   resolveDefaultModelForAgent,
   resolvePersistedSelectedModelRef,
 } from "../agents/model-selection.js";
+import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
 import {
   countActiveDescendantRuns,
   getSessionDisplaySubagentRunByChildSessionKey,
@@ -31,10 +32,7 @@ import {
   RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS,
   shouldKeepSubagentRunChildLink,
 } from "../agents/subagent-run-liveness.js";
-import {
-  listThinkingLevelOptions,
-  resolveThinkingDefaultForModel,
-} from "../auto-reply/thinking.js";
+import { listThinkingLevelOptions } from "../auto-reply/thinking.js";
 import { loadConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -1055,7 +1053,8 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     contextTokens: contextTokens ?? null,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
+    thinkingDefault: resolveThinkingDefault({
+      cfg,
       provider: resolved.provider,
       model: resolved.model,
     }),
@@ -1429,7 +1428,8 @@ export function buildGatewaySessionRow(params: {
     thinkingLevel: entry?.thinkingLevel,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
+    thinkingDefault: resolveThinkingDefault({
+      cfg,
       provider: thinkingProvider,
       model: thinkingModel,
     }),


### PR DESCRIPTION
Fixes #72407

## Problem

The Control UI thinking-level dropdown shows `Default (off)` for non-reasoning models (e.g. Ollama Gemma) even when `openclaw.json` sets `agents.defaults.thinkingDefault: "adaptive"` and per-model `params.thinking: "adaptive"`. The runtime applies adaptive correctly (verified by ~60% thinking-token usage), but the label disagrees, which sends users on long debugging chases over a working config.

## Root cause

The bug is server-side, not in the minified UI `pa()`. Both the gateway-emitted session-defaults payload and per-row session payload were calling the catalog-only heuristic `resolveThinkingDefaultForModel({ provider, model })` from `auto-reply/thinking.ts`, which never consults the user config:

- `src/gateway/session-utils.ts:1057` (`getSessionDefaults`)
- `src/gateway/session-utils.ts:1432` (per-session row)

Meanwhile, the runtime resolver `resolveThinkingDefault({ cfg, ... })` in `src/agents/model-thinking-default.ts` correctly walks
per-model → global → Claude-4.6 heuristic → catalog fallback. The UI faithfully renders whatever label arrives — it inherits the wrong source value.

## Fix

Switch both call sites to `resolveThinkingDefault({ cfg, provider, model })`. `cfg` is already in scope at both sites (`getSessionDefaults` takes it directly; the row formatter has it through `formatSession`).
The catalog fallback path inside `resolveThinkingDefault` calls the same helper the gateway used to call directly, so the no-config behavior is preserved.

## Tests

New file `src/gateway/session-utils.thinking-default.test.ts` covers:

- global `thinkingDefault: "adaptive"` for a non-reasoning model — UI gets `adaptive`
- per-model `params.thinking` set with no global — UI gets `adaptive`
- per-model overrides global — UI gets the per-model value
- no thinking config at all — UI label matches `resolveThinkingDefault`'s fallback (regression guard against UI/runtime drift)

## Test plan

- [x] `pnpm exec vitest run src/gateway/session-utils.thinking-default.test.ts` — 12/12 (4 cases × 3 shards)
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm lint` — clean
- [x] Manual: reproduce with the issue's `openclaw.json`, restart gateway, confirm dropdown reads `Default (adaptive)`
