### PR TITLE
Fix preflight compaction rotated run state

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -67,8 +67,15 @@ describe("runMemoryFlushIfNeeded", () => {
       };
       if (typeof params.newSessionId === "string" && params.newSessionId) {
         nextEntry.sessionId = params.newSessionId;
-        const storePath = typeof params.storePath === "string" ? params.storePath : rootDir;
-        nextEntry.sessionFile = path.join(path.dirname(storePath), `${params.newSessionId}.jsonl`);
+        if (typeof params.newSessionFile === "string" && params.newSessionFile) {
+          nextEntry.sessionFile = params.newSessionFile;
+        } else {
+          const storePath = typeof params.storePath === "string" ? params.storePath : rootDir;
+          nextEntry.sessionFile = path.join(
+            path.dirname(storePath),
+            `${params.newSessionId}.jsonl`,
+          );
+        }
       }
       params.sessionStore[sessionKey] = nextEntry;
       if (typeof params.storePath === "string") {
@@ -285,6 +292,76 @@ describe("runMemoryFlushIfNeeded", () => {
         sandboxSessionKey: "agent:main:telegram:default:direct:12345",
       }),
     );
+  });
+
+  it("updates the active preflight run after transcript rotation", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    const successorFile = path.join(rootDir, "session-rotated.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolver(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        tokensAfter: 42,
+        sessionId: "session-rotated",
+        sessionFile: successorFile,
+      },
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokensFresh: false,
+    };
+    const sessionStore = { "agent:main:main": sessionEntry };
+    const followupRun = createTestFollowupRun({
+      sessionId: "session",
+      sessionFile,
+      sessionKey: "agent:main:main",
+    });
+    const updateSessionId = vi.fn();
+    const replyOperation = {
+      abortSignal: new AbortController().signal,
+      setPhase: vi.fn(),
+      updateSessionId,
+    } as never;
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation,
+    });
+
+    expect(entry?.sessionId).toBe("session-rotated");
+    expect(entry?.sessionFile).toBe(successorFile);
+    expect(followupRun.run.sessionId).toBe("session-rotated");
+    expect(followupRun.run.sessionFile).toBe(successorFile);
+    expect(updateSessionId).toHaveBeenCalledWith("session-rotated");
+    expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      previousSessionId: "session",
+      nextSessionId: "session-rotated",
+      nextSessionFile: successorFile,
+    });
   });
 
   it("uses configured prompts and stored bootstrap warning signatures", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -514,6 +514,23 @@ export async function runPreflightCompactionIfNeeded(params: {
     followupRun: params.followupRun,
   });
   entry = params.sessionStore?.[params.sessionKey] ?? entry;
+  if (entry) {
+    const previousSessionId = params.followupRun.run.sessionId;
+    params.followupRun.run.sessionId = entry.sessionId;
+    params.replyOperation.updateSessionId(entry.sessionId);
+    if (entry.sessionFile) {
+      params.followupRun.run.sessionFile = entry.sessionFile;
+    }
+    const queueKey = params.followupRun.run.sessionKey ?? params.sessionKey;
+    if (queueKey) {
+      memoryDeps.refreshQueuedFollowupSession({
+        key: queueKey,
+        previousSessionId,
+        nextSessionId: entry.sessionId,
+        nextSessionFile: entry.sessionFile,
+      });
+    }
+  }
   return entry ?? params.sessionEntry;
 }
 


### PR DESCRIPTION
## Summary

Fix the remaining rotated-transcript handoff gap in the preflight compaction path.

#72435 changed `truncateAfterCompaction` from in-place JSONL truncation to successor transcript rotation: after compaction, OpenClaw writes a compacted successor transcript with a new `sessionId`/`sessionFile`, archives the old full transcript, and updates session-store metadata to point at the successor.

This PR fixes the preflight auto-compaction path that persisted that successor metadata but kept the in-flight agent turn attached to the archived transcript. Without this, the immediate next turn could append to the old JSONL while `sessions.json` already pointed at the successor, so later context reloads would miss that turn.

## What Changed

- After successful preflight compaction, refresh the active session entry from the session store.
- Update the live `followupRun.run.sessionId` and `followupRun.run.sessionFile` to the rotated successor.
- Update the reply operation session id so downstream bookkeeping uses the same active session.
- Refresh queued follow-ups with the successor metadata, matching the memory-flush rotation path.
- Add regression coverage proving a rotated preflight compaction updates the live run, reply operation, and queued follow-up session state.

## Scope

This is intentionally narrow. It does not add new pruning policy, change compaction thresholds, or solve ordinary transcript growth before compaction. Those remain separate from the successor-rotation correctness path.

Related context:

- Follow-up to #72435.
- Completes the preflight live-run state update missed by the initial successor transcript rotation work.
- No additional open issue is closed by this PR; broader transcript-size work remains tracked separately, especially #52133.

## Verification

- `pnpm test src/auto-reply/reply/agent-runner-memory.test.ts`
- `pnpm check:changed`
