### PR TITLE
refactor(plugins): drop provider discovery alias

### DIFF
--- a/src/plugins/provider-discovery.test.ts
+++ b/src/plugins/provider-discovery.test.ts
@@ -10,6 +10,7 @@ import {
   runProviderCatalog,
   runProviderStaticCatalog,
 } from "./provider-discovery.js";
+import * as providerDiscoveryModule from "./provider-discovery.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 import type { ProviderCatalogResult, ProviderDiscoveryOrder, ProviderPlugin } from "./types.js";
 
@@ -177,6 +178,10 @@ describe("resolveInstalledPluginProviderContributionIds", () => {
         "resolvePluginDiscoveryProviders",
       );
     }
+  });
+
+  it("does not keep exporting the ambiguous runtime-discovery alias", () => {
+    expect(Object.keys(providerDiscoveryModule)).not.toContain("resolvePluginDiscoveryProviders");
   });
 
   it("reads provider ids from the installed plugin index without importing runtime entries", () => {

--- a/src/plugins/provider-discovery.ts
+++ b/src/plugins/provider-discovery.ts
@@ -79,18 +79,6 @@ export async function resolveRuntimePluginDiscoveryProviders(
     .filter((provider) => resolveProviderCatalogOrderHook(provider));
 }
 
-/**
- * @deprecated Runtime-backed provider discovery must be explicit at call sites.
- * Use `resolveRuntimePluginDiscoveryProviders(...)` for paths that intentionally
- * import provider plugin runtime, or `resolveInstalledPluginProviderContributionIds(...)`
- * for cold installed-index reads.
- */
-export async function resolvePluginDiscoveryProviders(
-  params: ResolveRuntimePluginDiscoveryProvidersParams,
-): Promise<ProviderPlugin[]> {
-  return resolveRuntimePluginDiscoveryProviders(params);
-}
-
 export function groupPluginDiscoveryProvidersByOrder(
   providers: ProviderPlugin[],
 ): Record<ProviderDiscoveryOrder, ProviderPlugin[]> {


### PR DESCRIPTION
## Summary

- remove the deprecated `resolvePluginDiscoveryProviders` alias now that production callers use explicit cold/runtime APIs
- add a guard that keeps the ambiguous alias from being exported again

## Verification

- `pnpm exec oxfmt --check --threads=1 src/plugins/provider-discovery.ts src/plugins/provider-discovery.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/plugins/provider-discovery.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `git diff --check`

AI-assisted: yes.
