### PR TITLE
docs(changelog): credit update fixture repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Docs: https://docs.openclaw.ai
 - Control UI: localize command palette labels, categories, skill shortcuts, footer hints, and connect-command copy labels while preserving localized command palette search matching. (#61130, #61119) Thanks @rubensfox20.
 - Plugins/memory-lancedb: request float embedding responses from OpenAI-compatible servers so local providers that default SDK requests to base64 no longer return dimension-mismatched LanceDB vectors while preserving configured dimensions. Fixes #45982. (#59048, #46069, #45986) Thanks @deep-introspection, @xiaokhkh, @caicongyang, and @thiswind.
 - Plugins/memory-core: respect configured memory-search embedding concurrency during non-batch indexing so local Ollama embedding backends can serialize indexing instead of flooding the server. Fixes #66822. (#66931) Thanks @oliviareid-svg and @LyraInTheFlesh.
+- Docker/update smoke: keep the package-derived update-channel fixture on package-shipped files and make its UI build stub create the asset the updater verifies. Thanks @vincentkoc.
+
 
 ## 2026.4.26
 


### PR DESCRIPTION
## Summary
- add the Unreleased changelog entry for the Docker update-channel fixture repair
- credit the work with `Thanks @vincentkoc`

## Notes
- The script-side repair is already on current `main`; after rebasing, this PR is intentionally changelog-only.

## Tests
- `git diff --check origin/main...HEAD`
- Prior exact-SHA GitHub targeted live/e2e run 24973291069 validated the repair before it was superseded on `main`: `update-channel-switch` pass in 67s, `install-e2e` pass in 1008s