### PR TITLE
fix(telegram): suppress tool progress in non-streaming mode

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -765,7 +765,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("keeps default tool progress messages when answer preview streaming is off", async () => {
+  it("suppresses default tool progress messages when answer preview streaming is off", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       await replyOptions?.onItemEvent?.({ progressText: "exec ls ~/Desktop" });
@@ -778,7 +778,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyOptions: expect.objectContaining({
-          suppressDefaultToolProgressMessages: false,
+          suppressDefaultToolProgressMessages: true,
         }),
       }),
     );

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1067,7 +1067,8 @@ export const dispatchTelegramMessage = async ({
                   previewToolProgressLines = [];
                 })
             : undefined,
-          suppressDefaultToolProgressMessages: Boolean(answerLane.stream),
+          suppressDefaultToolProgressMessages:
+            !previewStreamingEnabled || Boolean(answerLane.stream),
           onToolStart: async (payload) => {
             const toolName = payload.name?.trim();
             if (statusReactionController && toolName) {


### PR DESCRIPTION
## Summary
- Stop forwarding default tool-progress messages in Telegram when `streamMode`/preview streaming is off.
- Keep existing behavior for streaming-enabled turns and for non-text tool outputs that must still route through runtime controls.
- Update the Telegram dispatch test to assert the corrected non-streaming behavior.

## Root Cause
Telegram only suppressed default tool-progress messages when an answer draft stream existed. In non-streaming mode there is no draft stream, so tool progress remained visible even though the turn should be final-only from the user perspective.

## Why This Fix Is Safe
The change only adjusts the `suppressDefaultToolProgressMessages` flag in Telegram dispatch setup for the non-streaming path. It does not alter delivery ordering, final-reply routing, approval handling, or media/tool-result fallback behavior.

## Security/Runtime Controls Unchanged
- Exec approval prompts and approval gating remain runtime-enforced and unchanged.
- Existing tool/media fallback delivery rules in `dispatch-from-config` are unchanged.
- Error handling, silent-reply policy, and abort-fence behavior are unchanged.

## Test Plan
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose -t "tool progress messages when answer preview streaming is off|tool progress by default when preview streaming is active|suppresses Telegram tool progress when explicitly disabled"`
- `pnpm test extensions/telegram/src/reasoning-lane-coordinator.test.ts -- --reporter=verbose`
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose -t "tool progress messages when answer preview streaming is off"`
- `git diff --check`
- `pnpm check:changed`

## Additional Notes
- AI-assisted: yes

Closes #72363

Made with [Cursor](https://cursor.com)