### PR TITLE
fix(qqbot): skip PlatformAdapter lookup in resolveQQBotAccount when adapter not registered (#72465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/QQBot: skip the PlatformAdapter lookup in `resolveQQBotAccount` when no adapter is registered so `openclaw status` and other CLI surfaces no longer crash with `PlatformAdapter not registered. Call registerPlatformAdapter() during bootstrap.` when the bundled qqbot extension is walked through `resolveAccount` without the Gateway bootstrap path having run. Fixes #72465.
 - macOS Gateway: write launchd services with a state-dir `WorkingDirectory`, use a durable state-dir temp path instead of freezing macOS session `TMPDIR`, create that temp directory before bootstrap, and label abort-shaped launchd exits as `SIGABRT/abort` in status output. Fixes #53679 and #70223; refs #71848. Thanks @dlturock, @stammi922, and @palladius.
 - Exec approvals: accept runtime-owned `source: "allow-always"` and `commandText` allowlist metadata in gateway and node approval-set payloads so Control UI round-trips no longer fail with `unexpected property 'source'`. Fixes #60000; carries forward #60064. Thanks @sd1471123, @sharkqwy, and @luoyanglang.
 - Exec/node: skip approval-plan preparation for full-trust `host=node` runs so interpreter and script commands no longer fail with `SYSTEM_RUN_DENIED: approval cannot safely bind` when effective policy is `security=full` and `ask=off`. Fixes #48457 and duplicate #69251. Thanks @ajtran303, @jaserNo1, @Blakeshannon, @lesliefag, and @AvIsBeastMC.

--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { getPlatformAdapter } from "../engine/adapter/index.js";
+import { getPlatformAdapter, hasPlatformAdapter } from "../engine/adapter/index.js";
 import {
   DEFAULT_ACCOUNT_ID as ENGINE_DEFAULT_ACCOUNT_ID,
   applyAccountConfig,
@@ -50,23 +50,36 @@ export function resolveQQBotAccount(
       ? "channels.qqbot.clientSecret"
       : `channels.qqbot.accounts.${base.accountId}.clientSecret`;
 
-  const adapter = getPlatformAdapter();
-  if (adapter.hasConfiguredSecret(accountConfig.clientSecret)) {
-    clientSecret = opts?.allowUnresolvedSecretRef
-      ? (adapter.normalizeSecretInputString(accountConfig.clientSecret) ?? "")
-      : (adapter.resolveSecretInputString({
-          value: accountConfig.clientSecret,
-          path: clientSecretPath,
-        }) ?? "");
-    secretSource = "config";
-  } else if (accountConfig.clientSecretFile) {
+  // Skip the PlatformAdapter call when no adapter is registered. CLI surfaces
+  // (e.g. `openclaw status`) walk every bundled channel through `resolveAccount`
+  // even when qqbot is not configured; the adapter is only registered during
+  // Gateway bootstrap, so an unconditional call crashes status commands with
+  // `PlatformAdapter not registered`. The clientSecretFile / env fallbacks
+  // below still work without the adapter. Issue #72465.
+  if (hasPlatformAdapter()) {
+    const adapter = getPlatformAdapter();
+    if (adapter.hasConfiguredSecret(accountConfig.clientSecret)) {
+      clientSecret = opts?.allowUnresolvedSecretRef
+        ? (adapter.normalizeSecretInputString(accountConfig.clientSecret) ?? "")
+        : (adapter.resolveSecretInputString({
+            value: accountConfig.clientSecret,
+            path: clientSecretPath,
+          }) ?? "");
+      secretSource = "config";
+    }
+  }
+  if (secretSource === "none" && accountConfig.clientSecretFile) {
     try {
       clientSecret = fs.readFileSync(accountConfig.clientSecretFile, "utf8").trim();
       secretSource = "file";
     } catch {
       secretSource = "none";
     }
-  } else if (process.env.QQBOT_CLIENT_SECRET && base.accountId === DEFAULT_ACCOUNT_ID) {
+  } else if (
+    secretSource === "none" &&
+    process.env.QQBOT_CLIENT_SECRET &&
+    base.accountId === DEFAULT_ACCOUNT_ID
+  ) {
     clientSecret = process.env.QQBOT_CLIENT_SECRET;
     secretSource = "env";
   }


### PR DESCRIPTION
Fixes #72465.

## Summary

\`openclaw status\` walks every bundled channel through
\`resolveAccount\`, including the bundled qqbot extension, even when the
channel is not configured in \`openclaw.json\`. \`resolveQQBotAccount\`
in \`extensions/qqbot/src/bridge/config.ts\` calls \`getPlatformAdapter()\`
unconditionally, but the adapter is only registered via
\`bridge/bootstrap.ts\` during Gateway startup — CLI surfaces never
import bootstrap, so every status command on a fresh install crashes
with:

\`\`\`
[openclaw] Failed to start CLI: Error: PlatformAdapter not registered.
Call registerPlatformAdapter() during bootstrap.
\`\`\`

The reporter spent considerable time ruling this out as an external
plugin issue (uninstalled openclaw-qqbot, deleted ~/.openclaw, fresh
reinstall, \`config set channels.qqbot.enabled false\`) before tracing
it to the bundled qqbot adapter being initialized regardless of
configuration.

## Fix

Guard the \`getPlatformAdapter()\` call with the existing
\`hasPlatformAdapter()\` predicate (already exported from
\`extensions/qqbot/src/engine/adapter/index.ts\` for exactly this kind
of use case). When no adapter is registered, fall through to the
existing \`clientSecretFile\` / \`QQBOT_CLIENT_SECRET\` env paths, which
both work without the adapter — the result is an unconfigured account
snapshot (\`secretSource: \"none\"\`) suitable for status display.

Also tightens the fallback chain so the env \`else if\` does not fire
when \`clientSecretFile\` has already produced a \`clientSecret\`,
matching the original control-flow intent now that the config branch
is no longer the head of an \`if/else if\` chain.

## Behavior

- **Gateway path (existing)**: \`bridge/bootstrap.ts\` side-effect
  registers the built-in adapter → \`hasPlatformAdapter()\` returns
  true → secret resolution runs as before.
- **CLI status path (new)**: bootstrap not imported → adapter not
  registered → adapter branch is skipped → falls through to
  \`clientSecretFile\` / env or returns an unconfigured account.

## Tests

Existing 15/15 \`extensions/qqbot/src/config.test.ts\` tests pass with
the new control flow. No new regression test added because exercising
the \"no adapter registered\" path requires resetting the module-level
adapter state, which would conflict with the side-effect registration
in \`bridge/bootstrap.ts\`. The fix is structurally minimal and the
adapter guard is self-documenting via the existing
\`hasPlatformAdapter()\` predicate.