### PR TITLE
fix(doctor): auto-migrate stale provider `api` enum values

### DIFF
--- a/src/commands/doctor/shared/legacy-config-compatibility-base.ts
+++ b/src/commands/doctor/shared/legacy-config-compatibility-base.ts
@@ -9,6 +9,7 @@ import {
   normalizeLegacyTalkConfig,
   seedMissingDefaultAccountsFromSingleAccountBase,
 } from "./legacy-config-core-normalizers.js";
+import { normalizeLegacyProviderApi } from "./legacy-config-provider-api-migrate.js";
 import { migrateLegacyWebFetchConfig } from "./legacy-web-fetch-migrate.js";
 import { migrateLegacyWebSearchConfig } from "./legacy-web-search-migrate.js";
 import { migrateLegacyXSearchConfig } from "./legacy-x-search-migrate.js";
@@ -40,5 +41,6 @@ export function normalizeBaseCompatibilityConfigValues(
   next = normalizeLegacyRuntimeModelRefs(next, changes);
   next = normalizeLegacyCrossContextMessageConfig(next, changes);
   next = normalizeLegacyMediaProviderOptions(next, changes);
+  next = normalizeLegacyProviderApi(next, changes);
   return normalizeLegacyMistralModelMaxTokens(next, changes);
 }

--- a/src/commands/doctor/shared/legacy-config-provider-api-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-provider-api-migrate.test.ts
@@ -71,7 +71,7 @@ describe("normalizeLegacyProviderApi", () => {
     expect(changes).toHaveLength(0);
   });
 
-  it("migrates multiple providers with stale api values", () => {
+  it("migrates stale provider while leaving valid providers untouched", () => {
     const cfg = {
       models: {
         providers: {

--- a/src/commands/doctor/shared/legacy-config-provider-api-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-provider-api-migrate.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeLegacyProviderApi } from "./legacy-config-provider-api-migrate.js";
+
+function makeConfigWithProviderApi(providerId: string, api: string): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        [providerId]: {
+          baseUrl: "https://example.com/v1",
+          api,
+          models: [
+            {
+              id: "test-model",
+              name: "Test Model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 4096,
+              maxTokens: 4096,
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("normalizeLegacyProviderApi", () => {
+  it("migrates stale 'openai' api value to 'openai-completions'", () => {
+    const cfg = makeConfigWithProviderApi("openrouter", "openai");
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+
+    expect(result.models!.providers!["openrouter"].api).toBe("openai-completions");
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toContain('"openai" → "openai-completions"');
+  });
+
+  it("does not migrate already-valid api values", () => {
+    const cfg = makeConfigWithProviderApi("openrouter", "openai-completions");
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+
+    expect(result.models!.providers!["openrouter"].api).toBe("openai-completions");
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does not migrate unknown stale values", () => {
+    const cfg = makeConfigWithProviderApi("custom", "some-unknown-api");
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+
+    expect(result.models!.providers!["custom"].api).toBe("some-unknown-api");
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles config without providers gracefully", () => {
+    const cfg = { models: {} } as unknown as OpenClawConfig;
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+    expect(result).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles config without models gracefully", () => {
+    const cfg = {} as unknown as OpenClawConfig;
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+    expect(result).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("migrates multiple providers with stale api values", () => {
+    const cfg = {
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai",
+            models: [],
+          },
+          custom: {
+            baseUrl: "https://custom.api/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+
+    expect(result.models!.providers!["openrouter"].api).toBe("openai-completions");
+    expect(result.models!.providers!["custom"].api).toBe("openai-completions");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("skips providers without an api field", () => {
+    const cfg = {
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const changes: string[] = [];
+    const result = normalizeLegacyProviderApi(cfg, changes);
+    expect(result).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-provider-api-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-provider-api-migrate.ts
@@ -1,0 +1,66 @@
+import { MODEL_APIS } from "../../../config/types.models.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { isRecord } from "./legacy-config-record-shared.js";
+
+/**
+ * Known stale `api` values and their modern replacements.
+ * When the `api` enum was refined (e.g. `"openai"` split into
+ * `"openai-completions"` / `"openai-responses"` / `"openai-codex-responses"`),
+ * configs retaining old values would cause a fatal validation error on startup.
+ * This mapping allows `doctor --fix` to migrate them automatically.
+ */
+const STALE_PROVIDER_API_MIGRATIONS: Record<string, string> = {
+  openai: "openai-completions",
+};
+
+export function normalizeLegacyProviderApi(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const rawModels = cfg.models;
+  if (!isRecord(rawModels) || !isRecord(rawModels.providers)) {
+    return cfg;
+  }
+
+  const validApis = new Set<string>(MODEL_APIS);
+  let providersChanged = false;
+  const nextProviders = { ...rawModels.providers };
+
+  for (const [providerId, rawProvider] of Object.entries(rawModels.providers)) {
+    if (!isRecord(rawProvider) || !("api" in rawProvider)) {
+      continue;
+    }
+
+    const currentApi = rawProvider.api;
+    if (typeof currentApi !== "string") {
+      continue;
+    }
+
+    // Already valid — no migration needed
+    if (validApis.has(currentApi)) {
+      continue;
+    }
+
+    const replacement = STALE_PROVIDER_API_MIGRATIONS[currentApi];
+    if (!replacement) {
+      // Unknown stale value — skip; will be caught by config validation
+      continue;
+    }
+
+    nextProviders[providerId] = {
+      ...rawProvider,
+      api: replacement,
+    } as (typeof nextProviders)[string];
+    providersChanged = true;
+    changes.push(`Migrated models.providers.${providerId}.api "${currentApi}" → "${replacement}".`);
+  }
+
+  if (!providersChanged) {
+    return cfg;
+  }
+
+  return {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      providers: nextProviders as NonNullable<OpenClawConfig["models"]>["providers"],
+    },
+  };
+}

--- a/src/commands/doctor/shared/legacy-config-provider-api-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-provider-api-migrate.ts
@@ -9,7 +9,7 @@ import { isRecord } from "./legacy-config-record-shared.js";
  * configs retaining old values would cause a fatal validation error on startup.
  * This mapping allows `doctor --fix` to migrate them automatically.
  */
-const STALE_PROVIDER_API_MIGRATIONS: Record<string, string> = {
+const STALE_PROVIDER_API_MIGRATIONS: Record<string, string | undefined> = {
   openai: "openai-completions",
 };
 


### PR DESCRIPTION
## Problem

When the `models.providers.<id>.api` enum is refined across versions (e.g., `"openai"` → `"openai-completions"` / `"openai-responses"` / `"openai-codex-responses"`), existing configs retain stale values that cause a fatal validation error and crash loop on startup.

`doctor --fix` already has a `legacyConfigRules` + `normalizeCompatibilityConfig` migration framework, but was missing a rule for the `api` enum. See #72477 for full context.

## Fix

Adds `normalizeLegacyProviderApi()` to the existing doctor migration pipeline (`legacy-config-compatibility-base.ts`), mapping stale `"openai"` → `"openai-completions"` (the most common adapter for OpenAI-compatible proxies like OpenRouter).

### Migration table

| Old value | New value | Rationale |
|-----------|-----------|-----------|
| `"openai"` | `"openai-completions"` | Matches Chat Completions endpoint used by OpenRouter and compatible proxies |

**Note:** Users targeting OpenAI Responses API or Codex API would need `"openai-responses"` or `"openai-codex-responses"` respectively. The migration logs a change message so users are informed and can manually adjust if needed. Unknown stale values are left untouched for config validation to catch.

### Files changed

- **`src/commands/doctor/shared/legacy-config-provider-api-migrate.ts`** — new normalizer that iterates `models.providers`, checks each `api` against `MODEL_APIS`, and replaces known stale values
- **`src/commands/doctor/shared/legacy-config-provider-api-migrate.test.ts`** — unit tests covering: migration of `"openai"`, no-op for valid values, skip for unknown stale values, graceful handling of missing `models`/`providers`
- **`src/commands/doctor/shared/legacy-config-compatibility-base.ts`** — wires the new normalizer into the existing pipeline

### Design decisions

- Uses `MODEL_APIS` from `types.models.ts` as the source of truth for valid values, not a hardcoded list
- Follows the same pattern as other normalizers (`normalizeLegacyMistralModelMaxTokens`, `normalizeLegacyBrowserConfig`, etc.)
- Only handles known stale values with deterministic mappings; unknown stale values fall through to config validation (which will produce a clear error message with the list of valid options)

## Related

- #72477