### PR TITLE
fix(runtime-deps): stage core logger dependency

### DIFF
--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -720,6 +720,40 @@ describe("scanBundledPluginRuntimeDeps config policy", () => {
       readFileSyncSpy.mock.calls.filter((call) => path.resolve(String(call[0])) === manifestPath),
     ).toHaveLength(1);
   });
+
+  it("reports missing mirrored core runtime deps for doctor repair", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.4.25",
+        dependencies: { tslog: "^4.10.2" },
+      }),
+    );
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "discord",
+      deps: { "discord-runtime": "1.0.0" },
+      enabledByDefault: true,
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {},
+      env: { OPENCLAW_PLUGIN_STAGE_DIR: stageDir },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "discord-runtime@1.0.0",
+      "tslog@^4.10.2",
+    ]);
+    expect(result.missing.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "discord-runtime@1.0.0",
+      "tslog@^4.10.2",
+    ]);
+  });
 });
 
 describe("ensureBundledPluginRuntimeDeps", () => {
@@ -816,6 +850,47 @@ describe("ensureBundledPluginRuntimeDeps", () => {
       },
     ]);
     expect(installRoot).not.toBe(pluginRoot);
+  });
+
+  it("installs mirrored core logger deps even when the plugin has no external deps", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.4.25",
+        dependencies: { tslog: "^4.10.2" },
+      }),
+    );
+    const pluginRoot = path.join(packageRoot, "dist", "extensions", "slack");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, "package.json"), JSON.stringify({ dependencies: {} }));
+
+    const calls: BundledRuntimeDepsInstallParams[] = [];
+    const result = ensureBundledPluginRuntimeDeps({
+      env: { OPENCLAW_PLUGIN_STAGE_DIR: stageDir },
+      installDeps: (params) => {
+        calls.push(params);
+      },
+      pluginId: "slack",
+      pluginRoot,
+    });
+
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, {
+      env: { OPENCLAW_PLUGIN_STAGE_DIR: stageDir },
+    });
+    expect(result).toEqual({
+      installedSpecs: ["tslog@^4.10.2"],
+      retainSpecs: ["tslog@^4.10.2"],
+    });
+    expect(calls).toEqual([
+      {
+        installRoot,
+        missingSpecs: ["tslog@^4.10.2"],
+        installSpecs: ["tslog@^4.10.2"],
+      },
+    ]);
   });
 
   it("uses external staging when a packaged plugin declares workspace:* deps", () => {

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -754,6 +754,37 @@ describe("scanBundledPluginRuntimeDeps config policy", () => {
       "tslog@^4.10.2",
     ]);
   });
+
+  it("deduplicates mirrored core runtime deps already declared by a plugin", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.4.25",
+        dependencies: { tslog: "^4.10.2" },
+      }),
+    );
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "logger-plugin",
+      deps: { tslog: "^4.10.2" },
+      enabledByDefault: true,
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {},
+      env: { OPENCLAW_PLUGIN_STAGE_DIR: stageDir },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual(["tslog@^4.10.2"]);
+    expect(result.deps[0]?.pluginIds).toEqual(["logger-plugin", "openclaw-core"]);
+    expect(result.missing.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "tslog@^4.10.2",
+    ]);
+  });
 });
 
 describe("ensureBundledPluginRuntimeDeps", () => {

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -1173,7 +1173,8 @@ export function scanBundledPluginRuntimeDeps(params: {
   const packageRuntimeDeps =
     deps.length > 0
       ? collectMirroredPackageRuntimeDeps(params.packageRoot).map((dep) => ({
-          ...dep,
+          name: dep.name,
+          version: dep.version,
           pluginIds: [MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID],
         }))
       : [];

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -438,6 +438,25 @@ function mergeInstallableRuntimeDeps(
   });
 }
 
+function mergeRuntimeDepEntries(deps: readonly RuntimeDepEntry[]): RuntimeDepEntry[] {
+  const bySpec = new Map<string, RuntimeDepEntry>();
+  for (const dep of deps) {
+    const spec = `${dep.name}@${dep.version}`;
+    const existing = bySpec.get(spec);
+    if (!existing) {
+      bySpec.set(spec, { ...dep, pluginIds: [...dep.pluginIds] });
+      continue;
+    }
+    existing.pluginIds = [...new Set([...existing.pluginIds, ...dep.pluginIds])].toSorted(
+      (left, right) => left.localeCompare(right),
+    );
+  }
+  return [...bySpec.values()].toSorted((left, right) => {
+    const nameOrder = left.name.localeCompare(right.name);
+    return nameOrder === 0 ? left.version.localeCompare(right.version) : nameOrder;
+  });
+}
+
 function isSourceCheckoutRoot(packageRoot: string): boolean {
   return (
     (fs.existsSync(path.join(packageRoot, ".git")) ||
@@ -1178,9 +1197,7 @@ export function scanBundledPluginRuntimeDeps(params: {
           pluginIds: [MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID],
         }))
       : [];
-  const allDeps = [...deps, ...packageRuntimeDeps].toSorted((left, right) =>
-    left.name.localeCompare(right.name),
-  );
+  const allDeps = mergeRuntimeDepEntries([...deps, ...packageRuntimeDeps]);
   const packageInstallRoot = resolveBundledRuntimeDependencyPackageInstallRoot(params.packageRoot, {
     env: params.env,
   });

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -60,6 +60,8 @@ const BUNDLED_RUNTIME_DEPS_LOCK_WAIT_MS = 100;
 const BUNDLED_RUNTIME_DEPS_LOCK_TIMEOUT_MS = 5 * 60_000;
 const BUNDLED_RUNTIME_DEPS_LOCK_STALE_MS = 10 * 60_000;
 const BUNDLED_RUNTIME_DEPS_OWNERLESS_LOCK_STALE_MS = 30_000;
+const MIRRORED_PACKAGE_RUNTIME_DEP_NAMES = ["tslog"] as const;
+const MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID = "openclaw-core";
 
 const registeredBundledRuntimeDepNodePaths = new Set<string>();
 
@@ -403,6 +405,37 @@ function collectRuntimeDeps(packageJson: JsonObject): Record<string, unknown> {
     ...(packageJson.dependencies as Record<string, unknown> | undefined),
     ...(packageJson.optionalDependencies as Record<string, unknown> | undefined),
   };
+}
+
+function collectMirroredPackageRuntimeDeps(packageRoot: string | null): {
+  name: string;
+  version: string;
+}[] {
+  if (!packageRoot) {
+    return [];
+  }
+  const packageJson = readJsonObject(path.join(packageRoot, "package.json"));
+  if (!packageJson) {
+    return [];
+  }
+  const runtimeDeps = collectRuntimeDeps(packageJson);
+  return MIRRORED_PACKAGE_RUNTIME_DEP_NAMES.flatMap((name) => {
+    const dep = parseInstallableRuntimeDep(name, runtimeDeps[name]);
+    return dep ? [dep] : [];
+  });
+}
+
+function mergeInstallableRuntimeDeps(
+  deps: readonly { name: string; version: string }[],
+): { name: string; version: string }[] {
+  const bySpec = new Map<string, { name: string; version: string }>();
+  for (const dep of deps) {
+    bySpec.set(`${dep.name}@${dep.version}`, dep);
+  }
+  return [...bySpec.values()].toSorted((left, right) => {
+    const nameOrder = left.name.localeCompare(right.name);
+    return nameOrder === 0 ? left.version.localeCompare(right.version) : nameOrder;
+  });
 }
 
 function isSourceCheckoutRoot(packageRoot: string): boolean {
@@ -1137,22 +1170,36 @@ export function scanBundledPluginRuntimeDeps(params: {
     pluginIds: normalizePluginIdSet(params.pluginIds),
     includeConfiguredChannels: params.includeConfiguredChannels,
   });
+  const packageRuntimeDeps =
+    deps.length > 0
+      ? collectMirroredPackageRuntimeDeps(params.packageRoot).map((dep) => ({
+          ...dep,
+          pluginIds: [MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID],
+        }))
+      : [];
+  const allDeps = [...deps, ...packageRuntimeDeps].toSorted((left, right) =>
+    left.name.localeCompare(right.name),
+  );
   const packageInstallRoot = resolveBundledRuntimeDependencyPackageInstallRoot(params.packageRoot, {
     env: params.env,
   });
   const packageSearchRoots = [packageInstallRoot];
-  const missing = deps.filter(
-    (dep) =>
-      !hasDependencySentinel(packageSearchRoots, dep) &&
-      dep.pluginIds.every((pluginId) => {
-        const pluginRoot = path.join(extensionsDir, pluginId);
-        const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, {
-          env: params.env,
-        });
-        return !hasDependencySentinel([installRoot], dep);
-      }),
-  );
-  return { deps, missing, conflicts };
+  const missing = allDeps.filter((dep) => {
+    if (hasDependencySentinel(packageSearchRoots, dep)) {
+      return false;
+    }
+    if (dep.pluginIds.includes(MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID)) {
+      return true;
+    }
+    return dep.pluginIds.every((pluginId) => {
+      const pluginRoot = path.join(extensionsDir, pluginId);
+      const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, {
+        env: params.env,
+      });
+      return !hasDependencySentinel([installRoot], dep);
+    });
+  });
+  return { deps: allDeps, missing, conflicts };
 }
 
 export function resolveBundledRuntimeDependencyPackageInstallRoot(
@@ -1377,16 +1424,22 @@ export function ensureBundledPluginRuntimeDeps(params: {
   if (!packageJson) {
     return { installedSpecs: [], retainSpecs: [] };
   }
-  const deps = Object.entries(collectRuntimeDeps(packageJson))
+  const pluginDeps = Object.entries(collectRuntimeDeps(packageJson))
     .map(([name, rawVersion]) => parseInstallableRuntimeDep(name, rawVersion))
     .filter((entry): entry is { name: string; version: string } => Boolean(entry));
-  if (deps.length === 0) {
-    return { installedSpecs: [], retainSpecs: [] };
-  }
 
   const installRoot = resolveBundledRuntimeDependencyInstallRoot(params.pluginRoot, {
     env: params.env,
   });
+  const packageRoot = resolveBundledRuntimeDependencyPackageRoot(params.pluginRoot);
+  const packageRuntimeDeps =
+    packageRoot && path.resolve(installRoot) !== path.resolve(params.pluginRoot)
+      ? collectMirroredPackageRuntimeDeps(packageRoot)
+      : [];
+  const deps = mergeInstallableRuntimeDeps([...pluginDeps, ...packageRuntimeDeps]);
+  if (deps.length === 0) {
+    return { installedSpecs: [], retainSpecs: [] };
+  }
   return withBundledRuntimeDepsInstallRootLock(installRoot, () => {
     const persistRetainedManifest = shouldPersistRetainedRuntimeDepsManifest({
       pluginRoot: params.pluginRoot,


### PR DESCRIPTION
Fixes #72228.

## Summary

- verify mirrored package-level runtime deps include the core logger dependency (`tslog`)
- make `openclaw doctor --fix` report and repair missing mirrored core runtime deps alongside bundled plugin deps
- add regression coverage for both doctor detection and runtime staging when a bundled plugin has no external deps of its own

## Validation

- `pnpm test -- src/plugins/bundled-runtime-deps.test.ts` (passes; rerun outside sandbox because the existing tests create `~/.openclaw/plugin-runtime-deps/*`)
- `pnpm lint:core`
- `git diff --check`
- `pnpm format:check` could not run locally because `oxfmt` is not installed (`sh: oxfmt: command not found`)
