### PR TITLE
fix(lsp): kill entire process group on LSP session cleanup

### DIFF
--- a/src/agents/pi-bundle-lsp-runtime.test.ts
+++ b/src/agents/pi-bundle-lsp-runtime.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe("pi-bundle-lsp-runtime: process group cleanup", () => {
   it.runIf(process.platform !== "win32")(
-    "sends SIGTERM to the process group before falling back to direct kill",
+    "sends SIGTERM to the process group and skips the direct kill on success",
     () => {
       // Spawn a real, harmless child in its own process group so we can verify
       // the negative-PID signaling path actually targets the group.
@@ -35,9 +35,11 @@ describe("pi-bundle-lsp-runtime: process group cleanup", () => {
 
         __killSessionProcessTreeForTest(session as never);
 
-        // Group SIGTERM to -pid must come first, then direct kill().
+        // Group SIGTERM to -pid is the only kill we expect when it succeeds:
+        // the leader is part of the group, so a direct kill would be a
+        // redundant duplicate signal.
         expect(killSpy).toHaveBeenCalledWith(-pid!, "SIGTERM");
-        expect(directKillSpy).toHaveBeenCalledTimes(1);
+        expect(directKillSpy).not.toHaveBeenCalled();
       } finally {
         try {
           child.kill("SIGKILL");
@@ -71,29 +73,26 @@ describe("pi-bundle-lsp-runtime: process group cleanup", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
-    "does not call process.kill when pid is null",
-    () => {
-      const fakeChild = {
-        pid: undefined,
-        kill: vi.fn().mockReturnValue(true),
-      };
-      const killSpy = vi.spyOn(process, "kill");
-      const session = {
-        serverName: "test",
-        process: fakeChild,
-        requestId: 0,
-        pendingRequests: new Map(),
-        buffer: "",
-        initialized: false,
-        capabilities: {},
-      };
+  it.runIf(process.platform !== "win32")("does not call process.kill when pid is null", () => {
+    const fakeChild = {
+      pid: undefined,
+      kill: vi.fn().mockReturnValue(true),
+    };
+    const killSpy = vi.spyOn(process, "kill");
+    const session = {
+      serverName: "test",
+      process: fakeChild,
+      requestId: 0,
+      pendingRequests: new Map(),
+      buffer: "",
+      initialized: false,
+      capabilities: {},
+    };
 
-      __killSessionProcessTreeForTest(session as never);
+    __killSessionProcessTreeForTest(session as never);
 
-      // Only direct kill, no negative-pid call.
-      expect(killSpy).not.toHaveBeenCalled();
-      expect(fakeChild.kill).toHaveBeenCalledTimes(1);
-    },
-  );
+    // Only direct kill, no negative-pid call.
+    expect(killSpy).not.toHaveBeenCalled();
+    expect(fakeChild.kill).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/pi-bundle-lsp-runtime.test.ts
+++ b/src/agents/pi-bundle-lsp-runtime.test.ts
@@ -1,0 +1,99 @@
+import { spawn } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __killSessionProcessTreeForTest } from "./pi-bundle-lsp-runtime.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pi-bundle-lsp-runtime: process group cleanup", () => {
+  it.runIf(process.platform !== "win32")(
+    "sends SIGTERM to the process group before falling back to direct kill",
+    () => {
+      // Spawn a real, harmless child in its own process group so we can verify
+      // the negative-PID signaling path actually targets the group.
+      const child = spawn("/bin/sh", ["-c", "sleep 30"], {
+        stdio: ["ignore", "ignore", "ignore"],
+        detached: true,
+      });
+      try {
+        const pid = child.pid;
+        expect(pid).toBeTypeOf("number");
+
+        const killSpy = vi.spyOn(process, "kill");
+        const directKillSpy = vi.spyOn(child, "kill").mockReturnValue(true);
+
+        const session = {
+          serverName: "test",
+          process: child,
+          requestId: 0,
+          pendingRequests: new Map(),
+          buffer: "",
+          initialized: false,
+          capabilities: {},
+        };
+
+        __killSessionProcessTreeForTest(session as never);
+
+        // Group SIGTERM to -pid must come first, then direct kill().
+        expect(killSpy).toHaveBeenCalledWith(-pid!, "SIGTERM");
+        expect(directKillSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "swallows ESRCH when the process group is already gone",
+    () => {
+      const fakeChild = {
+        pid: 999_999_99, // Almost-certainly nonexistent pid.
+        kill: vi.fn().mockReturnValue(true),
+      };
+      const session = {
+        serverName: "test",
+        process: fakeChild,
+        requestId: 0,
+        pendingRequests: new Map(),
+        buffer: "",
+        initialized: false,
+        capabilities: {},
+      };
+
+      // Should not throw even though both calls likely fail.
+      expect(() => __killSessionProcessTreeForTest(session as never)).not.toThrow();
+      expect(fakeChild.kill).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not call process.kill when pid is null",
+    () => {
+      const fakeChild = {
+        pid: undefined,
+        kill: vi.fn().mockReturnValue(true),
+      };
+      const killSpy = vi.spyOn(process, "kill");
+      const session = {
+        serverName: "test",
+        process: fakeChild,
+        requestId: 0,
+        pendingRequests: new Map(),
+        buffer: "",
+        initialized: false,
+        capabilities: {},
+      };
+
+      __killSessionProcessTreeForTest(session as never);
+
+      // Only direct kill, no negative-pid call.
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(fakeChild.kill).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -173,6 +173,16 @@ async function disposeSession(session: LspSession) {
     pending.reject(new Error("LSP session disposed"));
   }
   session.pendingRequests.clear();
+  // Kill the entire process group to clean up nested child processes (e.g. tsserver)
+  // spawned by the LSP server. On Windows, process.kill() already terminates the
+  // process tree, so we only use negative PID (process group) on Unix.
+  if (session.process.pid != null && process.platform !== "win32") {
+    try {
+      process.kill(-session.process.pid, "SIGTERM");
+    } catch {
+      // Process group may already be gone — fall through to direct kill.
+    }
+  }
   session.process.kill();
 }
 
@@ -327,10 +337,12 @@ export async function createBundleLspToolRuntime(params: {
       const launchConfig = launch.config;
 
       try {
+        const isWindows = process.platform === "win32";
         const child = spawn(launchConfig.command, launchConfig.args ?? [], {
           stdio: ["pipe", "pipe", "pipe"],
           env: { ...process.env, ...launchConfig.env },
           cwd: launchConfig.cwd,
+          detached: !isWindows,
         });
 
         const session: LspSession = {

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -199,6 +199,10 @@ function killSessionProcessTree(session: LspSession): void {
   if (pid != null && process.platform !== "win32") {
     try {
       process.kill(-pid, "SIGTERM");
+      // Process-group SIGTERM was delivered; the child (and its descendants)
+      // will receive it. Avoid sending an extra direct SIGTERM to the leader,
+      // which would just be redundant and may race the exit handler.
+      return;
     } catch {
       // Process group may already be gone — fall through to direct kill.
     }
@@ -383,6 +387,14 @@ export async function createBundleLspToolRuntime(params: {
         // (e.g. unhandled exception), still kill the LSP process group so
         // detached children (typescript-language-server -> tsserver) do not
         // outlive us.
+        //
+        // Trade-off: process.once("exit") only fires for graceful Node exits.
+        // Hard crashes (SIGKILL on the parent, OOM, segfault) skip it, so a
+        // detached LSP server can be orphaned in those rare cases. We accept
+        // this because there is no cross-platform way to be notified of an
+        // ungraceful parent death from inside the parent itself; users on
+        // POSIX who need stricter guarantees can run OpenClaw under a process
+        // supervisor that reaps orphaned children.
         const exitCleanup = () => {
           if (session.disposed) {
             return;

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -384,7 +384,9 @@ export async function createBundleLspToolRuntime(params: {
         // detached children (typescript-language-server -> tsserver) do not
         // outlive us.
         const exitCleanup = () => {
-          if (session.disposed) return;
+          if (session.disposed) {
+            return;
+          }
           session.disposed = true;
           killSessionProcessTree(session);
         };

--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -21,6 +21,8 @@ type LspSession = {
   buffer: string;
   initialized: boolean;
   capabilities: LspServerCapabilities;
+  disposed?: boolean;
+  exitCleanup?: () => void;
 };
 
 type LspServerCapabilities = {
@@ -43,6 +45,11 @@ type LspPositionParams = {
   line: number;
   character: number;
 };
+
+// Test-only export: kill an already-launched session's process tree.
+// Used by unit tests to verify the SIGTERM-to-process-group path without
+// requiring a real LSP server.
+export const __killSessionProcessTreeForTest = killSessionProcessTree;
 
 function encodeLspMessage(body: unknown): string {
   const json = JSON.stringify(body);
@@ -158,6 +165,14 @@ async function initializeSession(session: LspSession): Promise<LspServerCapabili
 }
 
 async function disposeSession(session: LspSession) {
+  if (session.disposed) {
+    return;
+  }
+  session.disposed = true;
+  if (session.exitCleanup) {
+    process.removeListener("exit", session.exitCleanup);
+    session.exitCleanup = undefined;
+  }
   if (session.initialized) {
     try {
       await sendRequest(session, "shutdown").catch(() => {});
@@ -173,17 +188,26 @@ async function disposeSession(session: LspSession) {
     pending.reject(new Error("LSP session disposed"));
   }
   session.pendingRequests.clear();
-  // Kill the entire process group to clean up nested child processes (e.g. tsserver)
-  // spawned by the LSP server. On Windows, process.kill() already terminates the
-  // process tree, so we only use negative PID (process group) on Unix.
-  if (session.process.pid != null && process.platform !== "win32") {
+  killSessionProcessTree(session);
+}
+
+// Kill the entire process group to clean up nested child processes (e.g.
+// tsserver) spawned by the LSP server. On Windows, ChildProcess.kill()
+// terminates the process tree, so negative-PID signaling is a no-op there.
+function killSessionProcessTree(session: LspSession): void {
+  const pid = session.process.pid;
+  if (pid != null && process.platform !== "win32") {
     try {
-      process.kill(-session.process.pid, "SIGTERM");
+      process.kill(-pid, "SIGTERM");
     } catch {
       // Process group may already be gone — fall through to direct kill.
     }
   }
-  session.process.kill();
+  try {
+    session.process.kill();
+  } catch {
+    // Process may already have exited.
+  }
 }
 
 function createLspPositionTool(params: {
@@ -354,6 +378,23 @@ export async function createBundleLspToolRuntime(params: {
           initialized: false,
           capabilities: {},
         };
+
+        // Best-effort: if the host process exits before disposeSession runs
+        // (e.g. unhandled exception), still kill the LSP process group so
+        // detached children (typescript-language-server -> tsserver) do not
+        // outlive us.
+        const exitCleanup = () => {
+          if (session.disposed) return;
+          session.disposed = true;
+          killSessionProcessTree(session);
+        };
+        session.exitCleanup = exitCleanup;
+        process.once("exit", exitCleanup);
+        // If the child exits on its own, drop the listener so we don’t
+        // accumulate one per session forever.
+        child.once("exit", () => {
+          process.removeListener("exit", exitCleanup);
+        });
 
         child.stdout?.setEncoding("utf-8");
         child.stdout?.on("data", (chunk: string) => handleIncomingData(session, chunk));


### PR DESCRIPTION
## Summary

Fixes #72357 — bundled LSP `tsserver` child processes persist after gateway stop.

## Root cause

`typescript-language-server` spawns `tsserver` as a nested child process. The current cleanup code calls `session.process.kill()` which only sends SIGTERM to the direct child (`typescript-language-server`), leaving `tsserver` orphaned and consuming memory.

## Fix

1. **Spawn LSP processes in their own process group** (`detached: true` on Unix) so the entire tree can be addressed with a single signal
2. **Send SIGTERM to the process group** (`process.kill(-pid, 'SIGTERM')`) in `disposeSession()` before falling through to the direct `process.kill()`

On Windows, `ChildProcess.kill()` already terminates the process tree, so `detached` and negative-PID signaling are skipped.

## Changes

- `src/agents/pi-bundle-lsp-runtime.ts`: Added `detached: !isWindows` to spawn options; added process group kill in `disposeSession()`

## Testing

- TypeScript compilation passes with no errors
- Process group kill is wrapped in try/catch for robustness (group may already be gone)