### PR TITLE
Fix stale model provider API config recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/memory-lancedb: request float embedding responses from OpenAI-compatible servers so local providers that default SDK requests to base64 no longer return dimension-mismatched LanceDB vectors while preserving configured dimensions. Fixes #45982. (#59048, #46069, #45986) Thanks @deep-introspection, @xiaokhkh, @caicongyang, and @thiswind.
 - Plugins/memory-core: respect configured memory-search embedding concurrency during non-batch indexing so local Ollama embedding backends can serialize indexing instead of flooding the server. Fixes #66822. (#66931) Thanks @oliviareid-svg and @LyraInTheFlesh.
 - Docker/update smoke: keep the package-derived update-channel fixture on package-shipped files and make its UI build stub create the asset the updater verifies. Thanks @vincentkoc.
+- Gateway/models: repair legacy `models.providers.*.api = "openai"` config values to `openai-completions`, and skip providers with future stale API enum values during startup instead of bricking the gateway. Fixes #72477. (#72542) Thanks @JooyoungChoi14 and @obviyus.
 
 ## 2026.4.26
 

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -342,6 +342,40 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("migrates legacy OpenAI provider api values to OpenAI completions", () => {
+    const res = normalizeCompatibilityConfigValues({
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai",
+            models: [
+              {
+                id: "openai/gpt-4o-mini",
+                name: "OpenRouter GPT-4o Mini",
+                api: "openai",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(res.config.models?.providers?.openrouter?.api).toBe("openai-completions");
+    expect(res.config.models?.providers?.openrouter?.models?.[0]?.api).toBe("openai-completions");
+    expect(res.changes).toContain(
+      'Moved models.providers.openrouter.api "openai" → "openai-completions".',
+    );
+    expect(res.changes).toContain(
+      'Moved models.providers.openrouter.models[0].api "openai" → "openai-completions".',
+    );
+  });
+
   it("marks legacy untagged /models add OpenAI Codex metadata rows for doctor repair", () => {
     const res = normalizeCompatibilityConfigValues({
       models: {

--- a/src/commands/doctor/shared/legacy-config-compatibility-base.ts
+++ b/src/commands/doctor/shared/legacy-config-compatibility-base.ts
@@ -4,6 +4,7 @@ import {
   normalizeLegacyCrossContextMessageConfig,
   normalizeLegacyMediaProviderOptions,
   normalizeLegacyMistralModelMaxTokens,
+  normalizeLegacyOpenAIModelProviderApi,
   normalizeLegacyRuntimeModelRefs,
   normalizeLegacyNanoBananaSkill,
   normalizeLegacyTalkConfig,
@@ -37,6 +38,7 @@ export function normalizeBaseCompatibilityConfigValues(
 
   next = normalizeLegacyNanoBananaSkill(next, changes);
   next = normalizeLegacyTalkConfig(next, changes);
+  next = normalizeLegacyOpenAIModelProviderApi(next, changes);
   next = normalizeLegacyRuntimeModelRefs(next, changes);
   next = normalizeLegacyCrossContextMessageConfig(next, changes);
   next = normalizeLegacyMediaProviderOptions(next, changes);

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -390,9 +390,10 @@ export function normalizeLegacyOpenAICodexModelsAddMetadata(
     return cfg;
   }
 
+  const rawProviders: Record<string, unknown> = rawModels.providers;
   let providersChanged = false;
-  const nextProviders = { ...rawModels.providers };
-  for (const [providerId, rawProvider] of Object.entries(rawModels.providers)) {
+  const nextProviders: Record<string, unknown> = { ...rawProviders };
+  for (const [providerId, rawProvider] of Object.entries(rawProviders)) {
     if (normalizeProviderId(providerId) !== "openai-codex" || !isRecord(rawProvider)) {
       continue;
     }
@@ -413,7 +414,7 @@ export function normalizeLegacyOpenAICodexModelsAddMetadata(
       ) {
         providerChanged = true;
         const safeProviderId = sanitizeForLog(providerId);
-        const safeModelId = sanitizeForLog(model.id);
+        const safeModelId = sanitizeForLog(normalizeOptionalString(model.id) ?? "unknown");
         changes.push(
           `Marked models.providers.${safeProviderId}.models.${safeModelId} as /models add metadata so official OpenAI Codex metadata can override it.`,
         );
@@ -430,6 +431,77 @@ export function normalizeLegacyOpenAICodexModelsAddMetadata(
       ...rawProvider,
       models: nextModels,
     } as (typeof nextProviders)[string];
+    providersChanged = true;
+  }
+
+  if (!providersChanged) {
+    return cfg;
+  }
+
+  return {
+    ...cfg,
+    models: {
+      ...rawModels,
+      providers: nextProviders as NonNullable<OpenClawConfig["models"]>["providers"],
+    },
+  };
+}
+
+export function normalizeLegacyOpenAIModelProviderApi(
+  cfg: OpenClawConfig,
+  changes: string[],
+): OpenClawConfig {
+  const rawModels = cfg.models;
+  if (!isRecord(rawModels) || !isRecord(rawModels.providers)) {
+    return cfg;
+  }
+
+  const rawProviders: Record<string, unknown> = rawModels.providers;
+  let providersChanged = false;
+  const nextProviders: Record<string, unknown> = { ...rawProviders };
+  for (const [providerId, rawProvider] of Object.entries(rawProviders)) {
+    if (!isRecord(rawProvider)) {
+      continue;
+    }
+
+    let providerChanged = false;
+    const nextProvider: Record<string, unknown> = { ...rawProvider };
+    if (nextProvider.api === "openai") {
+      nextProvider.api = "openai-completions";
+      providerChanged = true;
+      changes.push(
+        `Moved models.providers.${sanitizeForLog(providerId)}.api "openai" → "openai-completions".`,
+      );
+    }
+
+    const rawProviderModels = rawProvider.models;
+    if (Array.isArray(rawProviderModels)) {
+      let modelsChanged = false;
+      const nextModels: unknown[] = [];
+      rawProviderModels.forEach((model, index) => {
+        if (!isRecord(model) || model.api !== "openai") {
+          nextModels.push(model);
+          return;
+        }
+        modelsChanged = true;
+        changes.push(
+          `Moved models.providers.${sanitizeForLog(providerId)}.models[${index}].api "openai" → "openai-completions".`,
+        );
+        nextModels.push({
+          ...model,
+          api: "openai-completions",
+        });
+      });
+      if (modelsChanged) {
+        nextProvider.models = nextModels;
+        providerChanged = true;
+      }
+    }
+
+    if (!providerChanged) {
+      continue;
+    }
+    nextProviders[providerId] = nextProvider;
     providersChanged = true;
   }
 

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -18,6 +18,11 @@ vi.mock("../config/config.js", () => ({
       snapshot.issues.every((issue) => issue.path.startsWith("plugins.entries."))
     );
   }),
+  validateConfigObjectWithPlugins: vi.fn((config: OpenClawConfig) => ({
+    ok: true,
+    config,
+    warnings: [],
+  })),
   writeConfigFile: vi.fn(),
 }));
 
@@ -174,6 +179,78 @@ describe("gateway startup config recovery", () => {
       `gateway: last-known-good recovery skipped for plugin-local config invalidity: ${configPath}`,
     );
     expect(recoveryNotice.enqueueConfigRecoveryNotice).not.toHaveBeenCalled();
+  });
+
+  it("skips providers with stale model api enum values during startup", async () => {
+    const config = {
+      gateway: { mode: "local" },
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai",
+            models: [
+              {
+                id: "openai/gpt-4o-mini",
+                name: "OpenRouter GPT-4o Mini",
+                api: "openai",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128_000,
+                maxTokens: 16_384,
+              },
+            ],
+          },
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            api: "anthropic-messages",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const invalidSnapshot = buildTestConfigSnapshot({
+      path: configPath,
+      exists: true,
+      raw: `${JSON.stringify(config)}\n`,
+      parsed: config,
+      valid: false,
+      config,
+      issues: [
+        {
+          path: "models.providers.openrouter.api",
+          message:
+            'Invalid option: expected one of "openai-completions"|"openai-responses"|"openai-codex-responses"|"anthropic-messages"|"google-generative-ai"|"github-copilot"|"bedrock-converse-stream"|"ollama"|"azure-openai-responses"',
+        },
+        {
+          path: "models.providers.openrouter.models.0.api",
+          message:
+            'Invalid option: expected one of "openai-completions"|"openai-responses"|"openai-codex-responses"|"anthropic-messages"|"google-generative-ai"|"github-copilot"|"bedrock-converse-stream"|"ollama"|"azure-openai-responses"',
+        },
+      ],
+      legacyIssues: [],
+    });
+    vi.mocked(configIo.readConfigFileSnapshot).mockResolvedValueOnce(invalidSnapshot);
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    const result = await loadGatewayStartupConfigSnapshot({
+      minimalTestGateway: false,
+      log,
+    });
+
+    expect(result.wroteConfig).toBe(false);
+    expect(result.degradedProviderApi).toBe(true);
+    expect(result.snapshot.valid).toBe(true);
+    expect(result.snapshot.sourceConfig.models?.providers?.openrouter).toBeUndefined();
+    expect(result.snapshot.sourceConfig.models?.providers?.anthropic).toEqual(
+      config.models?.providers?.anthropic,
+    );
+    expect(configIo.recoverConfigFromLastKnownGood).not.toHaveBeenCalled();
+    expect(configIo.writeConfigFile).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      'gateway: skipped model provider openrouter; configured provider api is invalid. Run "openclaw doctor --fix" to repair the config.',
+    );
   });
 
   it("strips a valid JSON suffix when last-known-good recovery is unavailable", async () => {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -10,9 +10,11 @@ import {
   recoverConfigFromLastKnownGood,
   recoverConfigFromJsonRootSuffix,
   shouldAttemptLastKnownGoodRecovery,
+  validateConfigObjectWithPlugins,
   writeConfigFile,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { asResolvedSourceConfig, materializeRuntimeConfig } from "../config/materialize.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import {
@@ -56,7 +58,98 @@ type GatewayStartupConfigOverrides = {
 export type GatewayStartupConfigSnapshotLoadResult = {
   snapshot: ConfigFileSnapshot;
   wroteConfig: boolean;
+  degradedProviderApi?: boolean;
 };
+
+const MODEL_PROVIDER_API_PATH_RE = /^models\.providers\.([^.]+)\.api$/;
+const MODEL_PROVIDER_MODEL_API_PATH_RE = /^models\.providers\.([^.]+)\.models\.\d+\.api$/;
+
+function resolveInvalidModelProviderApiIssueProviderId(issue: {
+  path: string;
+  message: string;
+}): string | null {
+  if (!issue.message.startsWith("Invalid option:")) {
+    return null;
+  }
+  const providerMatch =
+    issue.path.match(MODEL_PROVIDER_API_PATH_RE) ??
+    issue.path.match(MODEL_PROVIDER_MODEL_API_PATH_RE);
+  return providerMatch?.[1] ?? null;
+}
+
+function cloneConfigWithoutModelProviders(
+  config: OpenClawConfig,
+  providerIds: ReadonlySet<string>,
+): OpenClawConfig {
+  const providers = config.models?.providers;
+  if (!providers) {
+    return config;
+  }
+  let changed = false;
+  const nextProviders = { ...providers };
+  for (const providerId of providerIds) {
+    if (!Object.hasOwn(nextProviders, providerId)) {
+      continue;
+    }
+    delete nextProviders[providerId];
+    changed = true;
+  }
+  if (!changed) {
+    return config;
+  }
+  return {
+    ...config,
+    models: {
+      ...config.models,
+      providers: nextProviders,
+    },
+  };
+}
+
+function resolveGatewayStartupConfigWithoutInvalidModelProviders(params: {
+  snapshot: ConfigFileSnapshot;
+  log: GatewayStartupLog;
+}): ConfigFileSnapshot | null {
+  if (params.snapshot.valid || params.snapshot.legacyIssues.length > 0) {
+    return null;
+  }
+  const providerIds = new Set<string>();
+  for (const issue of params.snapshot.issues) {
+    const providerId = resolveInvalidModelProviderApiIssueProviderId(issue);
+    if (!providerId) {
+      return null;
+    }
+    providerIds.add(providerId);
+  }
+  if (providerIds.size === 0) {
+    return null;
+  }
+
+  const prunedSourceConfig = cloneConfigWithoutModelProviders(
+    params.snapshot.sourceConfig,
+    providerIds,
+  );
+  const validated = validateConfigObjectWithPlugins(prunedSourceConfig);
+  if (!validated.ok) {
+    return null;
+  }
+  const runtimeConfig = materializeRuntimeConfig(validated.config, "load");
+  for (const providerId of providerIds) {
+    params.log.warn(
+      `gateway: skipped model provider ${providerId}; configured provider api is invalid. Run "openclaw doctor --fix" to repair the config.`,
+    );
+  }
+  return {
+    ...params.snapshot,
+    sourceConfig: asResolvedSourceConfig(validated.config),
+    resolved: asResolvedSourceConfig(validated.config),
+    valid: true,
+    runtimeConfig,
+    config: runtimeConfig,
+    issues: [],
+    warnings: validated.warnings,
+  };
+}
 
 export async function loadGatewayStartupConfigSnapshot(params: {
   minimalTestGateway: boolean;
@@ -64,12 +157,23 @@ export async function loadGatewayStartupConfigSnapshot(params: {
 }): Promise<GatewayStartupConfigSnapshotLoadResult> {
   let configSnapshot = await readConfigFileSnapshot();
   let wroteConfig = false;
+  let degradedStartupConfig = false;
   if (configSnapshot.legacyIssues.length > 0 && isNixMode) {
     throw new Error(
       "Legacy config entries detected while running in Nix mode. Update your Nix config to the latest schema and restart.",
     );
   }
   if (configSnapshot.exists) {
+    if (!configSnapshot.valid) {
+      const providerApiPrunedSnapshot = resolveGatewayStartupConfigWithoutInvalidModelProviders({
+        snapshot: configSnapshot,
+        log: params.log,
+      });
+      if (providerApiPrunedSnapshot) {
+        degradedStartupConfig = true;
+        configSnapshot = providerApiPrunedSnapshot;
+      }
+    }
     if (!configSnapshot.valid) {
       const canRecoverFromLastKnownGood = shouldAttemptLastKnownGoodRecovery(configSnapshot);
       const recovered = canRecoverFromLastKnownGood
@@ -109,11 +213,16 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
   }
 
-  const autoEnable = params.minimalTestGateway
-    ? { config: configSnapshot.config, changes: [] as string[] }
-    : applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
+  const autoEnable =
+    params.minimalTestGateway || degradedStartupConfig
+      ? { config: configSnapshot.config, changes: [] as string[] }
+      : applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length === 0) {
-    return { snapshot: configSnapshot, wroteConfig };
+    return {
+      snapshot: configSnapshot,
+      wroteConfig,
+      ...(degradedStartupConfig ? { degradedProviderApi: true } : {}),
+    };
   }
 
   try {
@@ -128,7 +237,11 @@ export async function loadGatewayStartupConfigSnapshot(params: {
     params.log.warn(`gateway: failed to persist plugin auto-enable changes: ${String(err)}`);
   }
 
-  return { snapshot: configSnapshot, wroteConfig };
+  return {
+    snapshot: configSnapshot,
+    wroteConfig,
+    ...(degradedStartupConfig ? { degradedProviderApi: true } : {}),
+  };
 }
 
 export function createRuntimeSecretsActivator(params: {
@@ -226,6 +339,7 @@ export async function prepareGatewayStartupConfig(params: {
   authOverride?: GatewayAuthConfig;
   tailscaleOverride?: GatewayTailscaleConfig;
   activateRuntimeSecrets: ActivateRuntimeSecrets;
+  persistStartupAuth?: boolean;
 }): Promise<Awaited<ReturnType<typeof ensureGatewayStartupAuth>>> {
   assertValidGatewayStartupConfigSnapshot(params.configSnapshot);
 
@@ -262,7 +376,7 @@ export async function prepareGatewayStartupConfig(params: {
     env: process.env,
     authOverride: preflightAuthOverride,
     tailscaleOverride: params.tailscaleOverride,
-    persist: true,
+    persist: params.persistStartupAuth ?? true,
     baseHash: params.configSnapshot.hash,
   });
   const runtimeStartupConfig = applyGatewayAuthOverridesForStartupPreflight(authBootstrap.cfg, {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -296,6 +296,7 @@ export async function startGatewayServer(
       authOverride: opts.auth,
       tailscaleOverride: opts.tailscale,
       activateRuntimeSecrets,
+      persistStartupAuth: startupConfigLoad.degradedProviderApi !== true,
     }),
   );
   cfgAtStart = authBootstrap.cfg;


### PR DESCRIPTION
## Summary
- Migrate legacy `models.providers.*.api = "openai"` values to `openai-completions` in doctor/runtime compat.
- Let gateway startup skip providers with stale provider API enum values instead of aborting boot.

## Tests
- `pnpm test src/commands/doctor-legacy-config.migrations.test.ts src/gateway/server-startup-config.recovery.test.ts`
- `pnpm check:changed`
- Temp gateway smoke with invalid provider API reached ready after logging the skipped provider.


Fixes #72477
