### PR TITLE
fix: honor alsoAllow in plugin tool allowlists

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -606,8 +606,8 @@ export function createOpenClawCodingTools(options?: {
       sandboxed: !!sandbox,
       config: options?.config,
       pluginToolAllowlist: collectExplicitAllowlist([
-        profilePolicy,
-        providerProfilePolicy,
+        profilePolicyWithAlsoAllow,
+        providerProfilePolicyWithAlsoAllow,
         globalPolicy,
         globalProviderPolicy,
         agentPolicy,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -93,8 +93,8 @@ export function resolveGatewayScopedTools(params: {
     config: params.cfg,
     workspaceDir,
     pluginToolAllowlist: collectExplicitAllowlist([
-      profilePolicy,
-      providerProfilePolicy,
+      profilePolicyWithAlsoAllow,
+      providerProfilePolicyWithAlsoAllow,
       globalPolicy,
       globalProviderPolicy,
       agentPolicy,


### PR DESCRIPTION
## Summary

Propagate merged `alsoAllow` tool policy entries into `pluginToolAllowlist` during shared/plugin tool construction.

This fixes cases where a tool is allowed by merged profile policy during final tool filtering, but is still excluded earlier from shared/plugin tool creation.

## Root cause

`profilePolicyWithAlsoAllow` and `providerProfilePolicyWithAlsoAllow` were already used in the final `applyToolPolicyPipeline(...)` stage.

However, `createOpenClawTools(... pluginToolAllowlist: ...)` still used the unmerged:

- `profilePolicy`
- `providerProfilePolicy`

That meant tools granted via `tools.alsoAllow` could still be filtered out before later policy stages had a chance to allow them.

## Changes

Updated both call sites to use merged policies when building `pluginToolAllowlist`:

- `src/agents/pi-tools.ts`
- `src/gateway/tool-resolution.ts`

## Validation

Passed related tests:

- `src/agents/pi-embedded-runner/effective-tool-policy.test.ts`
- `src/agents/pi-tools.message-provider-policy.test.ts`

Passed type check:

- `pnpm tsgo:core`
