### PR TITLE
fix: resolve local TTS SecretRefs before conversion

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -97,6 +97,13 @@ const mocks = vi.hoisted(() => ({
         : {}),
     }),
   ),
+  resolveCommandSecretRefsViaGateway: vi.fn(async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [],
+    targetStatesByPath: {},
+    hadUnresolvedTargets: false,
+  })),
+  getTtsCommandSecretTargetIds: vi.fn(() => new Set(["messages.tts.providers.*.apiKey"])),
   createEmbeddingProvider: vi.fn(async () => ({
     provider: {
       id: "openai",
@@ -186,6 +193,14 @@ vi.mock("../gateway/connection-details.js", () => ({
     urlSource: "local loopback",
     message: "Gateway target: ws://127.0.0.1:18789",
   })),
+}));
+
+vi.mock("./command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway,
+}));
+
+vi.mock("./command-secret-targets.js", () => ({
+  getTtsCommandSecretTargetIds: mocks.getTtsCommandSecretTargetIds,
 }));
 
 vi.mock("../media-understanding/runtime.js", () => ({
@@ -311,6 +326,15 @@ describe("capability cli", () => {
     mocks.generateVideo.mockReset();
     mocks.transcribeAudioFile.mockClear();
     mocks.textToSpeech.mockClear();
+    mocks.resolveCommandSecretRefsViaGateway
+      .mockReset()
+      .mockImplementation(async ({ config }: { config: unknown }) => ({
+        resolvedConfig: config,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      }));
+    mocks.getTtsCommandSecretTargetIds.mockClear();
     mocks.setTtsProvider.mockClear();
     mocks.resolveExplicitTtsOverrides.mockClear();
     mocks.buildMediaUnderstandingRegistry.mockReset().mockReturnValue(new Map());
@@ -1055,6 +1079,58 @@ describe("capability cli", () => {
       }),
     );
     expect(mocks.setTtsProvider).not.toHaveBeenCalled();
+  });
+
+  it("resolves static TTS SecretRefs before local conversion", async () => {
+    const sourceConfig = {
+      messages: {
+        tts: {
+          providers: {
+            minimax: {
+              apiKey: { source: "exec", provider: "mockexec", id: "minimax/tts/apiKey" },
+            },
+          },
+        },
+      },
+    };
+    const resolvedConfig = {
+      messages: {
+        tts: {
+          providers: {
+            minimax: {
+              apiKey: "resolved-minimax-key",
+            },
+          },
+        },
+      },
+    };
+    mocks.loadConfig.mockReturnValueOnce(sourceConfig);
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValueOnce({
+      resolvedConfig,
+      diagnostics: [],
+      targetStatesByPath: {
+        "messages.tts.providers.minimax.apiKey": "resolved_local",
+      },
+      hadUnresolvedTargets: false,
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "tts", "convert", "--text", "hello", "--json"],
+    });
+
+    expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith({
+      config: sourceConfig,
+      commandName: "infer tts convert",
+      targetIds: new Set(["messages.tts.providers.*.apiKey"]),
+      mode: "enforce_resolved",
+    });
+    expect(mocks.resolveExplicitTtsOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: resolvedConfig }),
+    );
+    expect(mocks.textToSpeech).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: resolvedConfig }),
+    );
   });
 
   it("disables TTS fallback when explicit provider or voice/model selection is requested", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -79,6 +79,8 @@ import {
   runWebSearch,
 } from "../web-search/runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
+import { resolveCommandSecretRefsViaGateway } from "./command-secret-gateway.js";
+import { getTtsCommandSecretTargetIds } from "./command-secret-targets.js";
 import { createDefaultDeps } from "./deps.js";
 import { removeCommandByName } from "./program/command-tree.js";
 import { collectOption } from "./program/helpers.js";
@@ -1111,7 +1113,12 @@ async function runTtsConvert(params: {
     } satisfies CapabilityEnvelope;
   }
 
-  const cfg = loadConfig();
+  const { resolvedConfig: cfg } = await resolveCommandSecretRefsViaGateway({
+    config: loadConfig(),
+    commandName: "infer tts convert",
+    targetIds: getTtsCommandSecretTargetIds(),
+    mode: "enforce_resolved",
+  });
   const overrides = resolveExplicitTtsOverrides({
     cfg,
     provider: params.provider,

--- a/src/cli/command-secret-resolution.coverage.test.ts
+++ b/src/cli/command-secret-resolution.coverage.test.ts
@@ -4,6 +4,7 @@ import { readCommandSource } from "./command-source.test-helpers.js";
 
 const SECRET_TARGET_CALLSITES = [
   bundledPluginFile("memory-core", "src/cli.runtime.ts"),
+  "src/cli/capability-cli.ts",
   "src/cli/qr-cli.ts",
   "src/agents/agent-runtime-config.ts",
   "src/commands/agent.ts",

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -58,6 +58,7 @@ import {
   getQrRemoteCommandSecretTargetIds,
   getScopedChannelsCommandSecretTargets,
   getSecurityAuditCommandSecretTargetIds,
+  getTtsCommandSecretTargetIds,
 } from "./command-secret-targets.js";
 
 describe("command secret target ids", () => {
@@ -71,6 +72,11 @@ describe("command secret target ids", () => {
     expect(ids.has("models.providers.*.apiKey")).toBe(true);
     expect(ids.has("models.providers.*.request.tls.key")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
+  });
+
+  it("keeps static TTS targets out of the registry path", () => {
+    const ids = getTtsCommandSecretTargetIds();
+    expect(ids).toEqual(new Set(["messages.tts.providers.*.apiKey"]));
   });
 
   it("includes memorySearch remote targets for agent runtime commands", () => {

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -23,12 +23,13 @@ const STATIC_MODEL_TARGET_IDS = [
   "models.providers.*.request.tls.key",
   "models.providers.*.request.tls.passphrase",
 ] as const;
+const STATIC_TTS_TARGET_IDS = ["messages.tts.providers.*.apiKey"] as const;
 const STATIC_AGENT_RUNTIME_BASE_TARGET_IDS = [
   ...STATIC_MODEL_TARGET_IDS,
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
   "agents.list[].tts.providers.*.apiKey",
-  "messages.tts.providers.*.apiKey",
+  ...STATIC_TTS_TARGET_IDS,
   "skills.entries.*.apiKey",
   "tools.web.search.apiKey",
 ] as const;
@@ -219,6 +220,10 @@ export function getConfiguredChannelsCommandSecretTargetIds(
 
 export function getModelsCommandSecretTargetIds(): Set<string> {
   return toTargetIdSet(STATIC_MODEL_TARGET_IDS);
+}
+
+export function getTtsCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet(STATIC_TTS_TARGET_IDS);
 }
 
 export function getAgentRuntimeCommandSecretTargetIds(params?: {


### PR DESCRIPTION
## Summary

- Problem: local `infer tts convert` loaded source config directly, so `messages.tts.providers.minimax.apiKey` stayed as a SecretRef object instead of the resolved startup/reload snapshot value.
- Why it matters: MiniMax TTS could fail locally and fall back to another provider even when the SecretRef audit was clean.
- What changed: route local TTS conversion through command SecretRef resolution for `messages.tts.providers.*.apiKey` before computing TTS overrides and calling the runtime.
- What did NOT change (scope boundary): gateway TTS behavior and other SecretRef coverage gaps in #68690 are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #68690
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the local TTS CLI path used `loadConfig()` directly, while SecretRef-backed command paths need the shared command SecretRef resolver to read the active gateway snapshot or local fallback resolution.
- Missing detection / guardrail: `src/cli/capability-cli.ts` was not listed in command SecretRef resolution callsite coverage.
- Contributing context (if known): MiniMax validates `apiKey` through normalized resolved secret input and fails when it receives an unresolved SecretRef object.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/capability-cli.test.ts`, `src/cli/command-secret-resolution.coverage.test.ts`, `src/cli/command-secret-targets.test.ts`
- Scenario the test should lock in: local `capability tts convert` resolves `messages.tts.providers.*.apiKey` SecretRefs and passes the resolved config to TTS override/runtime code.
- Why this is the smallest reliable guardrail: it exercises the CLI seam that regressed without requiring live MiniMax credentials.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Local `openclaw infer tts convert` now supports SecretRef-backed `messages.tts.providers.minimax.apiKey` through the shared command SecretRef resolution path.

## Diagram (if applicable)

```text
Before:
local infer tts convert -> source config -> unresolved MiniMax apiKey SecretRef -> provider failure/fallback

After:
local infer tts convert -> command SecretRef resolver -> resolved config -> MiniMax TTS request
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: local TTS now uses the same command SecretRef resolver already used by other supported command paths, scoped only to static TTS provider API-key targets and `enforce_resolved` mode.

## Repro + Verification

### Environment

- OS: Linux container
- Runtime/container: Docker `node:22-bookworm`
- Model/provider: MiniMax TTS, mock local T2A v2 endpoint
- Integration/channel (if any): local CLI TTS
- Relevant config (redacted): `messages.tts.provider: "minimax"`; `messages.tts.providers.minimax.apiKey` as an exec SecretRef resolving to a mock static key

### Steps

1. Configure `messages.tts.providers.minimax.apiKey` as an exec SecretRef and point MiniMax TTS `baseUrl` to a local mock endpoint.
2. Run `OPENCLAW_STATE_DIR=/workspace/repro/state pnpm openclaw secrets audit --allow-exec --json`.
3. Run `OPENCLAW_STATE_DIR=/workspace/repro/state pnpm openclaw infer tts convert --text "SecretRef reproduction sample" --json`.
4. Run `OPENCLAW_STATE_DIR=/workspace/repro/state pnpm openclaw infer tts convert --text "SecretRef explicit MiniMax sample" --model minimax/speech-2.8-hd --json`.

### Expected

- SecretRef audit is clean.
- Both TTS commands use MiniMax and send the resolved bearer token to the mock endpoint.

### Actual

- Before: local TTS failed MiniMax with unresolved SecretRef and fell back, or failed directly for explicit MiniMax.
- After: both local TTS commands succeed with `provider: "minimax"`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Docker mock endpoint received two requests with `Authorization: Bearer mock-minimax-static-key` after the fix.

Local validation:

- `pnpm test src/cli/capability-cli.test.ts src/cli/command-secret-targets.test.ts src/cli/command-secret-targets.import.test.ts src/cli/command-secret-resolution.coverage.test.ts`
- `pnpm check:changed`

## Human Verification (required)

- Verified scenarios: clean SecretRef audit, local default MiniMax TTS, local explicit MiniMax model TTS, mock endpoint bearer-token request capture.
- Edge cases checked: explicit provider/model selection disables fallback and still succeeds with the resolved SecretRef.
- What you did **not** verify: real MiniMax API credentials/service response.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: local TTS now attempts command SecretRef resolution for configured TTS API-key refs.
  - Mitigation: resolution is scoped to `messages.tts.providers.*.apiKey` and uses the existing shared resolver with `enforce_resolved` behavior.
