### PR TITLE
fix(tts): pick file extension from output format and expose target

### DIFF
--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildElevenLabsSpeechProvider, isValidVoiceId } from "./speech-provider.js";
+import {
+  buildElevenLabsSpeechProvider,
+  deriveElevenLabsFileExtension,
+  isValidVoiceId,
+} from "./speech-provider.js";
 
 describe("elevenlabs speech provider", () => {
   it("exposes the current ElevenLabs TTS model catalog", () => {
@@ -31,5 +35,25 @@ describe("elevenlabs speech provider", () => {
     for (const testCase of cases) {
       expect(isValidVoiceId(testCase.value), testCase.value).toBe(testCase.expected);
     }
+  });
+
+  // Regression for https://github.com/openclaw/openclaw/issues/72506: when the
+  // caller (or channel) overrides `outputFormat`, the resolved on-disk extension
+  // must match the codec — otherwise downstream channels (e.g. BlueBubbles)
+  // reject mp3 audio that arrives with a `.opus` filename.
+  it("derives fileExtension from the resolved outputFormat codec", () => {
+    expect(deriveElevenLabsFileExtension("mp3_44100_128")).toBe(".mp3");
+    expect(deriveElevenLabsFileExtension("mp3_22050_32")).toBe(".mp3");
+    expect(deriveElevenLabsFileExtension("opus_48000_64")).toBe(".opus");
+    expect(deriveElevenLabsFileExtension("opus_48000_32")).toBe(".opus");
+    expect(deriveElevenLabsFileExtension("flac_44100")).toBe(".flac");
+    expect(deriveElevenLabsFileExtension("pcm_44100")).toBe(".wav");
+    expect(deriveElevenLabsFileExtension("ulaw_8000")).toBe(".wav");
+    expect(deriveElevenLabsFileExtension("MP3_44100_128")).toBe(".mp3");
+  });
+
+  it("falls back to mp3 for unknown output format codecs", () => {
+    expect(deriveElevenLabsFileExtension("unknown_format")).toBe(".mp3");
+    expect(deriveElevenLabsFileExtension("")).toBe(".mp3");
   });
 });

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -43,6 +43,29 @@ const ELEVENLABS_TTS_MODELS = [
   "eleven_monolingual_v1",
 ] as const;
 
+// ElevenLabs `output_format` strings are codec-prefixed (e.g. `mp3_44100_128`,
+// `opus_48000_64`, `pcm_44100`, `ulaw_8000`, `flac_44100`). Pick the on-disk
+// extension from the prefix so it matches the actual bytes — the previous
+// `req.target === "voice-note" ? ".opus" : ".mp3"` heuristic mis-labelled audio
+// whenever a caller overrode `outputFormat` (e.g. requesting mp3 for BlueBubbles
+// voice memos, which reject opus).
+export function deriveElevenLabsFileExtension(outputFormat: string): string {
+  const codec = outputFormat.split("_", 1)[0]?.toLowerCase() ?? "";
+  switch (codec) {
+    case "mp3":
+      return ".mp3";
+    case "opus":
+      return ".opus";
+    case "flac":
+      return ".flac";
+    case "pcm":
+    case "ulaw":
+      return ".wav";
+    default:
+      return ".mp3";
+  }
+}
+
 type ElevenLabsProviderConfig = {
   apiKey?: string;
   baseUrl: string;
@@ -510,7 +533,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
       return {
         audioBuffer,
         outputFormat,
-        fileExtension: req.target === "voice-note" ? ".opus" : ".mp3",
+        fileExtension: deriveElevenLabsFileExtension(outputFormat),
         voiceCompatible: req.target === "voice-note",
       };
     },

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1050,6 +1050,7 @@ export async function textToSpeech(params: {
   timeoutMs?: number;
   agentId?: string;
   accountId?: string;
+  target?: "audio-file" | "voice-note";
 }): Promise<TtsResult> {
   const synthesis = await synthesizeSpeech(params);
   if (!synthesis.success || !synthesis.audioBuffer || !synthesis.fileExtension) {
@@ -1101,6 +1102,7 @@ export async function synthesizeSpeech(params: {
   timeoutMs?: number;
   agentId?: string;
   accountId?: string;
+  target?: "audio-file" | "voice-note";
 }): Promise<TtsSynthesisResult> {
   const setup = resolveTtsRequestSetup({
     text: params.text,
@@ -1118,7 +1120,10 @@ export async function synthesizeSpeech(params: {
 
   const { config, persona, providers } = setup;
   const timeoutMs = params.timeoutMs ?? config.timeoutMs;
-  const target = resolveTtsSynthesisTarget(params.channel);
+  // Honor an explicit target override from the caller (agent tool / RPC) so
+  // operators can request voice-note synthesis on channels that default to
+  // audio-file, or vice versa. Falls back to the channel-derived default.
+  const target = params.target ?? resolveTtsSynthesisTarget(params.channel);
 
   const errors: string[] = [];
   const attemptedProviders: string[] = [];

--- a/src/agents/tools/tts-tool.test.ts
+++ b/src/agents/tools/tts-tool.test.ts
@@ -208,4 +208,49 @@ describe("createTtsTool", () => {
       "TTS conversion failed: openai: not configured",
     );
   });
+
+  // Issue #72506: agent must be able to override the channel-derived synthesis
+  // target so callers can request voice-note audio on a channel that defaults
+  // to audio-file (or the reverse).
+  it("forwards an explicit target override to the TTS runtime", async () => {
+    textToSpeechSpy.mockResolvedValue({
+      success: true,
+      audioPath: "/tmp/reply.mp3",
+      provider: "test",
+      voiceCompatible: false,
+      audioAsVoice: true,
+    });
+
+    const tool = createTtsTool();
+    await tool.execute("call-1", { text: "hello", target: "voice-note" });
+
+    expect(textToSpeechSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "hello", target: "voice-note" }),
+    );
+  });
+
+  it("rejects an unknown target value as a tool input error", async () => {
+    const tool = createTtsTool();
+
+    await expect(tool.execute("call-1", { text: "hello", target: "ringtone" })).rejects.toThrow(
+      /target must be/,
+    );
+    expect(textToSpeechSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits target when the caller does not specify one (channel-derived default)", async () => {
+    textToSpeechSpy.mockResolvedValue({
+      success: true,
+      audioPath: "/tmp/reply.mp3",
+      provider: "test",
+      voiceCompatible: false,
+    });
+
+    const tool = createTtsTool();
+    await tool.execute("call-1", { text: "hello" });
+
+    expect(textToSpeechSpy).toHaveBeenCalledWith(expect.objectContaining({ text: "hello" }));
+    const callArgs = textToSpeechSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs.target).toBeUndefined();
+  });
 });

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -12,6 +12,12 @@ const TtsToolSchema = Type.Object({
   channel: Type.Optional(
     Type.String({ description: "Optional channel id to pick output format." }),
   ),
+  target: Type.Optional(
+    Type.Union([Type.Literal("audio-file"), Type.Literal("voice-note")], {
+      description:
+        'Optional synthesis target: "audio-file" returns a regular audio file, "voice-note" requests voice-memo-style audio. Defaults to the channel-derived value.',
+    }),
+  ),
   timeoutMs: Type.Optional(
     Type.Number({
       description: "Optional provider request timeout in milliseconds.",
@@ -19,6 +25,17 @@ const TtsToolSchema = Type.Object({
     }),
   ),
 });
+
+function readTtsTarget(args: Record<string, unknown>): "audio-file" | "voice-note" | undefined {
+  const value = readStringParam(args, "target");
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === "audio-file" || value === "voice-note") {
+    return value;
+  }
+  throw new ToolInputError('target must be "audio-file" or "voice-note".');
+}
 
 function readTtsTimeoutMs(args: Record<string, unknown>): number | undefined {
   const timeoutMs = readNumberParam(args, "timeoutMs", {
@@ -70,12 +87,14 @@ export function createTtsTool(opts?: {
       const params = args as Record<string, unknown>;
       const text = readStringParam(params, "text", { required: true });
       const channel = readStringParam(params, "channel");
+      const target = readTtsTarget(params);
       const timeoutMs = readTtsTimeoutMs(params);
       const cfg = opts?.config ?? loadConfig();
       const result = await textToSpeech({
         text,
         cfg,
         channel: channel ?? opts?.agentChannel,
+        target,
         timeoutMs,
         agentId: opts?.agentId,
         accountId: opts?.agentAccountId,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -105,6 +105,22 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const providerRaw = normalizeOptionalString(params.provider);
       const modelId = normalizeOptionalString(params.modelId);
       const voiceId = normalizeOptionalString(params.voiceId);
+      const targetRaw = normalizeOptionalString(params.target);
+      let target: "audio-file" | "voice-note" | undefined;
+      if (targetRaw !== undefined) {
+        if (targetRaw !== "audio-file" && targetRaw !== "voice-note") {
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.INVALID_REQUEST,
+              'tts.convert target must be "audio-file" or "voice-note"',
+            ),
+          );
+          return;
+        }
+        target = targetRaw;
+      }
       let overrides;
       try {
         overrides = resolveExplicitTtsOverrides({
@@ -121,6 +137,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         text,
         cfg,
         channel,
+        target,
         overrides,
         disableFallback: Boolean(overrides.provider || modelId || voiceId),
       });

--- a/src/plugin-sdk/tts-runtime.types.ts
+++ b/src/plugin-sdk/tts-runtime.types.ts
@@ -82,6 +82,11 @@ export type TtsRequestParams = {
   timeoutMs?: number;
   agentId?: string;
   accountId?: string;
+  // Explicit synthesis target override. When omitted, the channel's declared
+  // capability is used (or "audio-file" if the channel doesn't declare voice
+  // delivery). Lets callers like the tts agent tool and the tts.convert RPC
+  // request voice-note synthesis on a channel that defaults to audio-file.
+  target?: TtsSpeechTarget;
 };
 
 export type TtsTelephonyRequestParams = {


### PR DESCRIPTION
Fixes #72506

## Problem

Two gaps in the TTS-to-BlueBubbles voice-memo pipeline:

1. **ElevenLabs file extension didn't match the resolved output format.** The
   provider hardcoded `fileExtension: req.target === "voice-note" ? ".opus" : ".mp3"`,
   so when a caller (or the channel mapping) overrode `outputFormat` — e.g.
   requesting `mp3_44100_128` for BlueBubbles voice memos, which reject opus —
   the audio bytes were mp3 but the file landed as `.opus`, and BlueBubbles
   refused it as a voice memo.

2. **No way to request a synthesis target from the agent or RPC.** Both the
   bundled `tts` agent tool and the `tts.convert` gateway RPC only accepted
   `channel`; there was no parameter to override the channel-derived
   `audio-file` ↔ `voice-note` decision.

## Fix

- Add `deriveElevenLabsFileExtension(outputFormat)` and use it in the
  ElevenLabs `synthesize()` return so the on-disk extension follows the
  actual codec (`mp3_*` → `.mp3`, `opus_*` → `.opus`, `flac_*` → `.flac`,
  `pcm_*`/`ulaw_*` → `.wav`, unknown → `.mp3`).
- Add an optional `target?: TtsSpeechTarget` to `TtsRequestParams` and thread
  it through `synthesizeSpeech` / `textToSpeech`. When omitted, the
  channel-derived default is unchanged.
- Expose `target` on the `tts` agent tool schema (with a `ToolInputError` for
  invalid values) and on the `tts.convert` RPC handler (with an
  `INVALID_REQUEST` response for invalid values).

No behavior change when callers don't set `target` and outputs use the
default codec — both paths continue producing the same bytes and extension.

## Test plan

- [x] `pnpm exec vitest run src/agents/tools/tts-tool.test.ts` — 14/14 (3 new: target forwarded, invalid target rejected, optional target preserves channel-derived default)
- [x] New `deriveElevenLabsFileExtension` cases in `extensions/elevenlabs/speech-provider.test.ts` (mp3/opus/flac/pcm/ulaw + uppercase + unknown-codec fallback)
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm check:architecture` — 0 cycles
- [x] Manual: BlueBubbles agent + ElevenLabs TTS, confirm voice-memo waveform UI on iOS
