### PR TITLE
fix: AgentParamsSchema must accept paperclip property in wake payload

### DIFF
--- a/src/gateway/protocol/schema/agent.test.ts
+++ b/src/gateway/protocol/schema/agent.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { validateAgentParams } from "../index.js";
+
+const minimalAgentParams = {
+  message: "wake",
+  idempotencyKey: "idem-1234",
+} as const;
+
+describe("AgentParamsSchema", () => {
+  it("accepts minimal params", () => {
+    expect(validateAgentParams(minimalAgentParams)).toBe(true);
+  });
+
+  it("accepts a paperclip context object in the payload", () => {
+    // Paperclip ≥ 2026.416.0 includes a `paperclip` field in wake payloads.
+    // The gateway must not reject it as an unexpected property.
+    expect(
+      validateAgentParams({
+        ...minimalAgentParams,
+        paperclip: {
+          runId: "run-abc123",
+          companyId: "13808fb1-a29b-4465-9796-b8b200845155",
+          agentId: "agent-xyz",
+          issueId: "issue-001",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a paperclip field with arbitrary shape", () => {
+    expect(
+      validateAgentParams({
+        ...minimalAgentParams,
+        paperclip: { nested: { deep: true }, list: [1, 2, 3] },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a payload missing idempotencyKey", () => {
+    expect(validateAgentParams({ message: "wake" })).toBe(false);
+  });
+
+  it("rejects a payload missing message", () => {
+    expect(validateAgentParams({ idempotencyKey: "idem-1234" })).toBe(false);
+  });
+
+  it("rejects unknown top-level properties other than paperclip", () => {
+    expect(validateAgentParams({ ...minimalAgentParams, notAKnownField: "value" })).toBe(false);
+  });
+});

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -169,6 +169,8 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    /** Paperclip-originated wake payloads include a `paperclip` context object. */
+    paperclip: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Problem

Paperclip ≥ 2026.416.0 includes a `paperclip` context object in agent wake payloads:

```json
{
  "message": "wake",
  "idempotencyKey": "...",
  "paperclip": {
    "runId": "run-abc123",
    "companyId": "13808fb1-...",
    "agentId": "agent-xyz",
    "issueId": "issue-001"
  }
}
```

`AgentParamsSchema` uses `additionalProperties: false`, so the gateway rejects these payloads with:

```
INVALID_REQUEST: unexpected property 'paperclip'
```

This breaks every agent wake triggered by Paperclip ≥ 2026.416.0.

Related: paperclipai/paperclip#4566

## Fix

Add `paperclip: Type.Optional(Type.Unknown())` to `AgentParamsSchema`. Using `Type.Unknown()` (rather than a typed sub-schema) because the shape of the Paperclip context object is Paperclip's concern — the gateway only needs to pass it through without rejection.

## Tests

Added `src/gateway/protocol/schema/agent.test.ts` covering:

- Accepts minimal params (baseline)
- Accepts a `paperclip` context object with the standard Paperclip shape
- Accepts a `paperclip` field with arbitrary nested shape (forwards-compatible)
- Rejects payload missing `idempotencyKey`
- Rejects payload missing `message`
- Rejects unknown top-level properties other than `paperclip`

All 6 pass.