### PR TITLE
test(live): accept current Codex status text

### DIFF
--- a/src/gateway/gateway-codex-harness.live-helpers.test.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, it } from "vitest";
 import {
   EXPECTED_CODEX_MODELS_COMMAND_TEXT,
+  EXPECTED_CODEX_STATUS_COMMAND_TEXT,
   isExpectedCodexModelsCommandText,
+  isExpectedCodexStatusCommandText,
 } from "./gateway-codex-harness.live-helpers.js";
 
 describe("gateway codex harness live helpers", () => {
+  it("accepts the current codex status prose from the live harness", () => {
+    const text =
+      "OpenClaw is running on `openai/gpt-5.5` with low reasoning/text settings. Context is at `22k/272k` tokens, no compactions, and the current session is `agent:dev:live-codex-harness`.";
+
+    expect(
+      EXPECTED_CODEX_STATUS_COMMAND_TEXT.some((expectedText) => text.includes(expectedText)),
+    ).toBe(false);
+    expect(isExpectedCodexStatusCommandText(text)).toBe(true);
+  });
+
+  it("rejects status prose for a different codex session", () => {
+    const text =
+      "OpenClaw is running on `openai/gpt-5.5` with low reasoning/text settings. Context is at `22k/272k` tokens, no compactions, and the current session is `agent:dev:other`.";
+
+    expect(isExpectedCodexStatusCommandText(text)).toBe(false);
+  });
+
   it("accepts the interactive model-selection summary emitted by current codex", () => {
     const text = [
       "`/codex models` opened an interactive model-selection prompt rather than printing a plain list.",

--- a/src/gateway/gateway-codex-harness.live-helpers.ts
+++ b/src/gateway/gateway-codex-harness.live-helpers.ts
@@ -71,6 +71,39 @@ export const EXPECTED_CODEX_MODELS_COMMAND_TEXT = [
   "Current OpenClaw session status reports the active model as:",
 ] as const;
 
+export const EXPECTED_CODEX_STATUS_COMMAND_TEXT = [
+  "Codex app-server:",
+  "Model: `codex/",
+  "Model: codex/",
+  "Session: `agent:dev:live-codex-harness`",
+  "Session: agent:dev:live-codex-harness",
+  "OpenClaw `",
+  "OpenClaw status:",
+  "model `codex/",
+  "session `agent:dev:live-codex-harness`",
+  "Model/status card shown above",
+  "Status shown above.",
+] as const;
+
+export function isExpectedCodexStatusCommandText(text: string): boolean {
+  const normalized = text.toLowerCase();
+  const mentionsOpenClawStatus =
+    normalized.includes("openclaw is running on") || normalized.includes("openclaw status:");
+  const mentionsHarnessSession =
+    normalized.includes("session: `agent:dev:live-codex-harness`") ||
+    normalized.includes("session: agent:dev:live-codex-harness") ||
+    normalized.includes("session `agent:dev:live-codex-harness`") ||
+    normalized.includes("current session is `agent:dev:live-codex-harness`") ||
+    normalized.includes("current session is agent:dev:live-codex-harness");
+  const mentionsModel =
+    normalized.includes("`openai/") ||
+    normalized.includes(" openai/") ||
+    normalized.includes("`codex/") ||
+    normalized.includes(" codex/");
+
+  return mentionsOpenClawStatus && mentionsHarnessSession && mentionsModel;
+}
+
 export function isExpectedCodexModelsCommandText(text: string): boolean {
   const normalized = text.toLowerCase();
   const mentionsCodexModelsCommand =

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -17,7 +17,9 @@ import {
 } from "./gateway-cli-backend.live-helpers.js";
 import {
   EXPECTED_CODEX_MODELS_COMMAND_TEXT,
+  EXPECTED_CODEX_STATUS_COMMAND_TEXT,
   isExpectedCodexModelsCommandText,
+  isExpectedCodexStatusCommandText,
 } from "./gateway-codex-harness.live-helpers.js";
 import {
   assertCronJobMatches,
@@ -790,19 +792,8 @@ describeLive("gateway live (Codex harness)", () => {
             client,
             sessionKey,
             command: "/codex status",
-            expectedText: [
-              "Codex app-server:",
-              "Model: `codex/",
-              "Model: codex/",
-              "Session: `agent:dev:live-codex-harness`",
-              "Session: agent:dev:live-codex-harness",
-              "OpenClaw `",
-              "OpenClaw status:",
-              "model `codex/",
-              "session `agent:dev:live-codex-harness`",
-              "Model/status card shown above",
-              "Status shown above.",
-            ],
+            expectedText: [...EXPECTED_CODEX_STATUS_COMMAND_TEXT],
+            isExpectedText: isExpectedCodexStatusCommandText,
           });
           logCodexLiveStep("codex-status-command", { statusText });
 


### PR DESCRIPTION
## Summary
- accept the current `/codex status` prose emitted by the live Codex harness when it still proves OpenClaw status, the active model, and the live harness session
- move the status expectation into the existing Codex live helper module with focused unit coverage

## Proof
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/gateway/gateway-codex-harness.live-helpers.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- original failing live job: https://github.com/openclaw/openclaw/actions/runs/24974875920/job/73124858441
- fixed live proof: https://github.com/openclaw/openclaw/actions/runs/24975628908/job/73126983405

## Notes
- The separate Docker scheduler lane `live-codex-harness` currently fails before the harness because that path forces `OPENCLAW_SKIP_DOCKER_BUILD=1` and then cannot find `openclaw:local-live`; the release-check `validate_live_provider_suites` path is the matching proof for this failure.
