### PR TITLE
fix(agents): stop duplicating subagent task in system prompt to cut input token cost

### DIFF
--- a/src/agents/subagent-system-prompt.ts
+++ b/src/agents/subagent-system-prompt.ts
@@ -38,7 +38,7 @@ export function buildSubagentSystemPrompt(params: {
     `You are a **subagent** spawned by the ${parentLabel} for a specific task.`,
     "",
     "## Your Role",
-    `- You were created to handle: ${taskText}`,
+    `- You were created to handle the task described in your first message.`,
     "- Complete this task. That's your entire purpose.",
     `- You are NOT the ${parentLabel}. Don't try to be.`,
     "",


### PR DESCRIPTION
## Problem

Every `session_spawn` sends the subagent task prompt **twice** in the API request:

- In `role: system` — `"- You were created to handle: <task>"`
- In `role: user` — `"[Subagent Task]: <task>"`

This doubles input token cost on every subagent invocation. Reported in #72019 with reproduction via OpenRouter request logs.

## Fix

The system prompt's role is to define the agent's standing instructions and context. The task itself belongs in the user turn (where it already appears via `childTaskMessage`). This PR changes the system prompt line to reference the first message instead of repeating the task text verbatim.

**One-line change in `src/agents/subagent-system-prompt.ts`:**

```diff
-    `- You were created to handle: ${taskText}`,
+    `- You were created to handle the task described in your first message.`,
```

62 existing `system-prompt.test.ts` tests pass unchanged.

Fixes #72019