### PR TITLE
fix(discord): preserve explicit outbound target prefixes

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -105,6 +105,34 @@ beforeAll(async () => {
   ({ setDiscordRuntime } = await import("./runtime.js"));
 });
 
+describe("discordPlugin messaging", () => {
+  it("preserves explicit user targets when parsing outbound recipients", () => {
+    const parseExplicitTarget = discordPlugin.messaging?.parseExplicitTarget;
+    const inferTargetChatType = discordPlugin.messaging?.inferTargetChatType;
+    if (!parseExplicitTarget || !inferTargetChatType) {
+      throw new Error("Expected discordPlugin messaging target helpers to be defined");
+    }
+
+    expect(parseExplicitTarget({ raw: "user:1234567890" })).toEqual({
+      to: "user:1234567890",
+      chatType: "direct",
+    });
+    expect(inferTargetChatType({ to: "user:1234567890" })).toBe("direct");
+  });
+
+  it("normalizes bare numeric outbound recipients as channel targets", () => {
+    const parseExplicitTarget = discordPlugin.messaging?.parseExplicitTarget;
+    if (!parseExplicitTarget) {
+      throw new Error("Expected discordPlugin messaging.parseExplicitTarget to be defined");
+    }
+
+    expect(parseExplicitTarget({ raw: "1234567890" })).toEqual({
+      to: "channel:1234567890",
+      chatType: "channel",
+    });
+  });
+});
+
 describe("discordPlugin outbound", () => {
   it("avoids local require calls for bundled-only sibling modules", async () => {
     const source = await readFile(

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -353,7 +353,7 @@ function parseDiscordExplicitTarget(raw: string) {
       return null;
     }
     return {
-      to: target.id,
+      to: target.normalized,
       chatType: target.kind === "user" ? ("direct" as const) : ("channel" as const),
     };
   } catch {


### PR DESCRIPTION
## Summary

Fix Discord explicit target parsing so direct-message recipients keep their `user:` prefix instead of being downgraded to a bare numeric ID.

Closes #62024.

## Problem

Discord explicit target parsing currently strips the normalized prefix and returns only `target.id`.

For DM targets like `user:123`, that turns the parsed target into bare `123`, which can later be re-normalized as `channel:123` by outbound delivery code that treats bare numeric Discord IDs as channels by default.

## Root cause

`parseDiscordExplicitTarget(...)` in `extensions/discord/src/channel.ts` returns:

```ts
{
  to: target.id,
  chatType: target.kind === "user" ? "direct" : "channel",
}
```

That loses the canonical normalized target form produced by `parseDiscordTarget(...)`.

## What changed

- changed `parseDiscordExplicitTarget(...)` to return `target.normalized`
- added focused regression tests covering:
  - explicit `user:<id>` targets stay `user:<id>` with `chatType: "direct"`
  - bare numeric IDs still normalize to `channel:<id>` with `chatType: "channel"`

## Why this is safe

This is a narrow normalization fix.

- explicit DM targets now preserve the canonical representation already produced by the Discord target parser
- explicit channel targets continue to work
- bare numeric IDs still default to channel targets exactly as before

## Test plan

Ran:

```bash
pnpm exec vitest run \
  extensions/discord/src/channel.test.ts \
  extensions/discord/src/targets.test.ts \
  extensions/discord/src/normalize.test.ts
```

Result: 3 test files passed, 34 tests passed.

## AI disclosure

This patch was prepared with AI assistance and reviewed locally before submission.
