### PR TITLE
fix: use runtime snapshot for TTS SecretRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS Gateway: detect installed-but-unloaded LaunchAgent split-brain states during status, doctor, and restart, and re-bootstrap launchd supervision before falling back to unmanaged listener restarts. Fixes #67335, #53475, and #71060; refs #58890, #60885, and #70801. Thanks @ze1tgeist88, @dafacto, and @vishutdhar.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
+- TTS/SecretRef: resolve `messages.tts.providers.*.apiKey` from the active runtime snapshot so SecretRef-backed MiniMax and other TTS provider keys work in runtime reply/audio paths. Fixes #68690. Thanks @joshavant.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.
 - Web search: route plugin-scoped web_search SecretRefs through the active runtime config snapshot so provider execution receives resolved credentials across app/runtime paths, including `plugins.entries.brave.config.webSearch.apiKey`. Fixes #68690. Thanks @VACInc.

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -1,6 +1,10 @@
 import { rmSync } from "node:fs";
 import path from "node:path";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type {
   SpeechProviderPlugin,
@@ -163,6 +167,7 @@ async function expectTtsPayloadResult(params: {
 
 describe("speech-core native voice-note routing", () => {
   afterEach(() => {
+    clearRuntimeConfigSnapshot();
     synthesizeMock.mockClear();
     prepareSynthesisMock.mockClear();
     installSpeechProviders([createMockSpeechProvider()]);
@@ -212,6 +217,63 @@ describe("speech-core native voice-note routing", () => {
       target: "audio-file",
       audioAsVoice: undefined,
     });
+  });
+
+  it("uses the active runtime snapshot when source config still contains TTS SecretRefs", async () => {
+    const sourceConfig = {
+      messages: {
+        tts: {
+          enabled: true,
+          provider: "mock",
+          providers: {
+            mock: {
+              apiKey: { source: "exec", provider: "mockexec", id: "minimax/tts/apiKey" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      messages: {
+        tts: {
+          enabled: true,
+          provider: "mock",
+          providers: {
+            mock: {
+              apiKey: "resolved-minimax-key",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    installSpeechProviders([
+      createMockSpeechProvider("mock", {
+        isConfigured: ({ providerConfig }) => providerConfig.apiKey === "resolved-minimax-key",
+        resolveConfig: ({ rawConfig }) => {
+          const providers = rawConfig.providers as Record<string, { apiKey?: unknown }> | undefined;
+          return {
+            apiKey: providers?.mock?.apiKey,
+          };
+        },
+      }),
+    ]);
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const result = await synthesizeSpeech({
+      text: "Runtime snapshot TTS SecretRef",
+      cfg: sourceConfig,
+      disableFallback: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(synthesizeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: runtimeConfig,
+        providerConfig: expect.objectContaining({
+          apiKey: "resolved-minimax-key",
+        }),
+      }),
+    );
   });
 
   it.each(["feishu", "whatsapp"] as const)(

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -10,13 +10,16 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { resolveChannelTtsVoiceDelivery } from "openclaw/plugin-sdk/channel-targets";
-import type {
-  OpenClawConfig,
-  ResolvedTtsPersona,
-  TtsAutoMode,
-  TtsConfig,
-  TtsModelOverrideConfig,
-  TtsProvider,
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+  type OpenClawConfig,
+  type ResolvedTtsPersona,
+  type TtsAutoMode,
+  type TtsConfig,
+  type TtsModelOverrideConfig,
+  type TtsProvider,
 } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
@@ -230,6 +233,16 @@ function _resolveRegistryDefaultSpeechProviderId(cfg?: OpenClawConfig): TtsProvi
   return sortSpeechProvidersForAutoSelection(cfg)[0]?.id ?? "";
 }
 
+function resolveTtsRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return (
+    selectApplicableRuntimeConfig({
+      inputConfig: cfg,
+      runtimeConfig: getRuntimeConfigSnapshot(),
+      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+    }) ?? cfg
+  );
+}
+
 function asProviderConfig(value: unknown): SpeechProviderConfig {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as SpeechProviderConfig)
@@ -343,7 +356,7 @@ function resolveLazyProviderConfig(
   const canonical =
     normalizeConfiguredSpeechProviderId(providerId) ?? normalizeLowercaseStringOrEmpty(providerId);
   const existing = config.providerConfigs[canonical];
-  const effectiveCfg = cfg ?? config.sourceConfig;
+  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
   if (existing && !effectiveCfg) {
     return existing;
   }
@@ -403,17 +416,19 @@ export function getResolvedSpeechProviderConfig(
   providerId: string,
   cfg?: OpenClawConfig,
 ): SpeechProviderConfig {
+  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
   const canonical =
-    canonicalizeSpeechProviderId(providerId, cfg) ??
+    canonicalizeSpeechProviderId(providerId, effectiveCfg) ??
     normalizeConfiguredSpeechProviderId(providerId) ??
     normalizeLowercaseStringOrEmpty(providerId);
-  return resolveLazyProviderConfig(config, canonical, cfg);
+  return resolveLazyProviderConfig(config, canonical, effectiveCfg);
 }
 
 export function resolveTtsConfig(
   cfg: OpenClawConfig,
   contextOrAgentId?: string | TtsConfigResolutionContext,
 ): ResolvedTtsConfig {
+  cfg = resolveTtsRuntimeConfig(cfg);
   const raw: TtsConfig = resolveEffectiveTtsConfig(cfg, contextOrAgentId);
   const providerSource = raw.provider ? "config" : "default";
   const timeoutMs = raw.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -504,6 +519,7 @@ export function buildTtsSystemPromptHint(
   cfg: OpenClawConfig,
   agentId?: string,
 ): string | undefined {
+  cfg = resolveTtsRuntimeConfig(cfg);
   const { autoMode, prefsPath } = resolveEffectiveTtsAutoState({ cfg, agentId });
   if (autoMode === "off") {
     return undefined;
@@ -667,17 +683,18 @@ export function resolveExplicitTtsOverrides(params: {
   channelId?: string;
   accountId?: string;
 }): TtsDirectiveOverrides {
+  const cfg = resolveTtsRuntimeConfig(params.cfg);
   const providerInput = params.provider?.trim();
   const modelId = params.modelId?.trim();
   const voiceId = params.voiceId?.trim();
-  const config = resolveTtsConfig(params.cfg, {
+  const config = resolveTtsConfig(cfg, {
     agentId: params.agentId,
     channelId: params.channelId,
     accountId: params.accountId,
   });
   const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
   const selectedProvider =
-    canonicalizeSpeechProviderId(providerInput, params.cfg) ??
+    canonicalizeSpeechProviderId(providerInput, cfg) ??
     (modelId || voiceId ? getTtsProvider(config, prefsPath) : undefined);
 
   if (providerInput && !selectedProvider) {
@@ -692,7 +709,7 @@ export function resolveExplicitTtsOverrides(params: {
     throw new Error("TTS model or voice overrides require a resolved provider.");
   }
 
-  const provider = getSpeechProvider(selectedProvider, params.cfg);
+  const provider = getSpeechProvider(selectedProvider, cfg);
   if (!provider) {
     throw new Error(`speech provider ${selectedProvider} is not registered`);
   }
@@ -812,9 +829,10 @@ function shouldDeliverTtsAsVoice(params: {
 }
 
 export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConfig): TtsProvider[] {
-  const normalizedPrimary = canonicalizeSpeechProviderId(primary, cfg) ?? primary;
+  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
+  const normalizedPrimary = canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
   const ordered = new Set<TtsProvider>([normalizedPrimary]);
-  for (const provider of sortSpeechProvidersForAutoSelection(cfg)) {
+  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg)) {
     const normalized = provider.id;
     if (normalized !== normalizedPrimary) {
       ordered.add(normalized);
@@ -828,14 +846,15 @@ export function isTtsProviderConfigured(
   provider: TtsProvider,
   cfg?: OpenClawConfig,
 ): boolean {
-  const resolvedProvider = getSpeechProvider(provider, cfg);
+  const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
+  const resolvedProvider = getSpeechProvider(provider, effectiveCfg);
   if (!resolvedProvider) {
     return false;
   }
   return (
     resolvedProvider.isConfigured({
-      cfg,
-      providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, cfg),
+      cfg: effectiveCfg,
+      providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, effectiveCfg),
       timeoutMs: config.timeoutMs,
     }) ?? false
   );
@@ -1011,6 +1030,7 @@ function resolveTtsRequestSetup(params: {
   accountId?: string;
 }):
   | {
+      cfg: OpenClawConfig;
       config: ResolvedTtsConfig;
       persona?: ResolvedTtsPersona;
       providers: TtsProvider[];
@@ -1018,7 +1038,8 @@ function resolveTtsRequestSetup(params: {
   | {
       error: string;
     } {
-  const config = resolveTtsConfig(params.cfg, {
+  const cfg = resolveTtsRuntimeConfig(params.cfg);
+  const config = resolveTtsConfig(cfg, {
     agentId: params.agentId,
     channelId: params.channelId,
     accountId: params.accountId,
@@ -1031,12 +1052,12 @@ function resolveTtsRequestSetup(params: {
   }
 
   const userProvider = getTtsProvider(config, prefsPath);
-  const provider =
-    canonicalizeSpeechProviderId(params.providerOverride, params.cfg) ?? userProvider;
+  const provider = canonicalizeSpeechProviderId(params.providerOverride, cfg) ?? userProvider;
   return {
+    cfg,
     config,
     persona: getTtsPersona(config, prefsPath),
-    providers: params.disableFallback ? [provider] : resolveTtsProviderOrder(provider, params.cfg),
+    providers: params.disableFallback ? [provider] : resolveTtsProviderOrder(provider, cfg),
   };
 }
 
@@ -1116,7 +1137,7 @@ export async function synthesizeSpeech(params: {
     return { success: false, error: setup.error };
   }
 
-  const { config, persona, providers } = setup;
+  const { cfg, config, persona, providers } = setup;
   const timeoutMs = params.timeoutMs ?? config.timeoutMs;
   const target = resolveTtsSynthesisTarget(params.channel);
 
@@ -1134,7 +1155,7 @@ export async function synthesizeSpeech(params: {
     try {
       const resolvedProvider = resolveReadySpeechProvider({
         provider,
-        cfg: params.cfg,
+        cfg,
         config,
         persona,
       });
@@ -1156,7 +1177,7 @@ export async function synthesizeSpeech(params: {
       const prepared = await prepareSpeechSynthesis({
         provider: resolvedProvider.provider,
         text: params.text,
-        cfg: params.cfg,
+        cfg,
         providerConfig: resolvedProvider.providerConfig,
         providerOverrides: params.overrides?.providerOverrides?.[resolvedProvider.provider.id],
         persona: resolvedProvider.synthesisPersona,
@@ -1166,7 +1187,7 @@ export async function synthesizeSpeech(params: {
       });
       const synthesis = await resolvedProvider.provider.synthesize({
         text: prepared.text,
-        cfg: params.cfg,
+        cfg,
         providerConfig: prepared.providerConfig,
         target,
         providerOverrides: prepared.providerOverrides,
@@ -1243,7 +1264,7 @@ export async function textToSpeechTelephony(params: {
     return { success: false, error: setup.error };
   }
 
-  const { config, persona, providers } = setup;
+  const { cfg, config, persona, providers } = setup;
   const errors: string[] = [];
   const attemptedProviders: string[] = [];
   const attempts: TtsProviderAttempt[] = [];
@@ -1258,7 +1279,7 @@ export async function textToSpeechTelephony(params: {
     try {
       const resolvedProvider = resolveReadySpeechProvider({
         provider,
-        cfg: params.cfg,
+        cfg,
         config,
         persona,
         requireTelephony: true,
@@ -1284,7 +1305,7 @@ export async function textToSpeechTelephony(params: {
       const prepared = await prepareSpeechSynthesis({
         provider: resolvedProvider.provider,
         text: params.text,
-        cfg: params.cfg,
+        cfg,
         providerConfig: resolvedProvider.providerConfig,
         persona: resolvedProvider.synthesisPersona,
         personaProviderConfig: resolvedProvider.personaProviderConfig,
@@ -1293,7 +1314,7 @@ export async function textToSpeechTelephony(params: {
       });
       const synthesis = await synthesizeTelephony({
         text: prepared.text,
-        cfg: params.cfg,
+        cfg,
         providerConfig: prepared.providerConfig,
         timeoutMs: config.timeoutMs,
       });
@@ -1360,15 +1381,16 @@ export async function listSpeechVoices(params: {
   apiKey?: string;
   baseUrl?: string;
 }): Promise<SpeechVoiceOption[]> {
-  const provider = canonicalizeSpeechProviderId(params.provider, params.cfg);
+  const cfg = params.cfg ? resolveTtsRuntimeConfig(params.cfg) : undefined;
+  const provider = canonicalizeSpeechProviderId(params.provider, cfg);
   if (!provider) {
     throw new Error("speech provider id is required");
   }
-  const config = params.config ?? (params.cfg ? resolveTtsConfig(params.cfg) : undefined);
+  const config = params.config ?? (cfg ? resolveTtsConfig(cfg) : undefined);
   if (!config) {
     throw new Error(`speech provider ${provider} requires cfg or resolved config`);
   }
-  const resolvedProvider = getSpeechProvider(provider, params.cfg);
+  const resolvedProvider = getSpeechProvider(provider, cfg);
   if (!resolvedProvider) {
     throw new Error(`speech provider ${provider} is not registered`);
   }
@@ -1376,8 +1398,8 @@ export async function listSpeechVoices(params: {
     throw new Error(`speech provider ${provider} does not support voice listing`);
   }
   return await resolvedProvider.listVoices({
-    cfg: params.cfg,
-    providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, params.cfg),
+    cfg,
+    providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, cfg),
     apiKey: params.apiKey,
     baseUrl: params.baseUrl,
   });
@@ -1396,8 +1418,9 @@ export async function maybeApplyTtsToPayload(params: {
   if (params.payload.isCompactionNotice) {
     return params.payload;
   }
+  const cfg = resolveTtsRuntimeConfig(params.cfg);
   const { autoMode, prefsPath } = resolveEffectiveTtsAutoState({
-    cfg: params.cfg,
+    cfg,
     sessionAuto: params.ttsAuto,
     agentId: params.agentId,
     channelId: params.channel,
@@ -1406,7 +1429,7 @@ export async function maybeApplyTtsToPayload(params: {
   if (autoMode === "off") {
     return params.payload;
   }
-  const config = resolveTtsConfig(params.cfg, {
+  const config = resolveTtsConfig(cfg, {
     agentId: params.agentId,
     channelId: params.channel,
     accountId: params.accountId,
@@ -1416,7 +1439,7 @@ export async function maybeApplyTtsToPayload(params: {
   const reply = resolveSendableOutboundReplyParts(params.payload);
   const text = reply.text;
   const directives = parseTtsDirectives(text, config.modelOverrides, {
-    cfg: params.cfg,
+    cfg,
     providerConfigs: config.providerConfigs,
     preferredProviderId: activeProvider,
   });
@@ -1426,7 +1449,7 @@ export async function maybeApplyTtsToPayload(params: {
 
   if (isVerbose()) {
     const effectiveProvider = directives.overrides?.provider
-      ? (canonicalizeSpeechProviderId(directives.overrides.provider, params.cfg) ?? activeProvider)
+      ? (canonicalizeSpeechProviderId(directives.overrides.provider, cfg) ?? activeProvider)
       : activeProvider;
     logVerbose(
       `TTS: auto mode enabled (${autoMode}), channel=${params.channel}, selected provider=${effectiveProvider}, config.provider=${config.provider}, config.providerSource=${config.providerSource}`,
@@ -1486,7 +1509,7 @@ export async function maybeApplyTtsToPayload(params: {
         const summary = await summarizeText({
           text: textForAudio,
           targetLength: maxLength,
-          cfg: params.cfg,
+          cfg,
           config,
           timeoutMs: config.timeoutMs,
         });
@@ -1514,7 +1537,7 @@ export async function maybeApplyTtsToPayload(params: {
   const ttsStart = Date.now();
   const result = await textToSpeech({
     text: textForAudio,
-    cfg: params.cfg,
+    cfg,
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -13,7 +13,6 @@ import { resolveChannelTtsVoiceDelivery } from "openclaw/plugin-sdk/channel-targ
 import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
-  selectApplicableRuntimeConfig,
   type OpenClawConfig,
   type ResolvedTtsPersona,
   type TtsAutoMode,
@@ -233,14 +232,41 @@ function _resolveRegistryDefaultSpeechProviderId(cfg?: OpenClawConfig): TtsProvi
   return sortSpeechProvidersForAutoSelection(cfg)[0]?.id ?? "";
 }
 
+function stableConfigStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableConfigStringify(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .toSorted()
+    .map((key) => `${JSON.stringify(key)}:${stableConfigStringify(record[key])}`)
+    .join(",")}}`;
+}
+
+function configSnapshotsMatch(left: OpenClawConfig, right: OpenClawConfig): boolean {
+  if (left === right) {
+    return true;
+  }
+  try {
+    return stableConfigStringify(left) === stableConfigStringify(right);
+  } catch {
+    return false;
+  }
+}
+
 function resolveTtsRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return (
-    selectApplicableRuntimeConfig({
-      inputConfig: cfg,
-      runtimeConfig: getRuntimeConfigSnapshot(),
-      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
-    }) ?? cfg
-  );
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  if (!runtimeConfig || cfg === runtimeConfig) {
+    return cfg;
+  }
+  const sourceConfig = getRuntimeConfigSourceSnapshot();
+  if (!sourceConfig || configSnapshotsMatch(cfg, sourceConfig)) {
+    return runtimeConfig;
+  }
+  return cfg;
 }
 
 function asProviderConfig(value: unknown): SpeechProviderConfig {

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -52,7 +52,6 @@ export {
   getRuntimeConfigSnapshot,
   loadConfig,
   readConfigFileSnapshotForWrite,
-  selectApplicableRuntimeConfig,
   setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "../config/io.js";

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -52,6 +52,7 @@ export {
   getRuntimeConfigSnapshot,
   loadConfig,
   readConfigFileSnapshotForWrite,
+  selectApplicableRuntimeConfig,
   setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "../config/io.js";


### PR DESCRIPTION
## Summary

- Problem: fixing `messages.tts.providers.minimax.apiKey` only in `infer tts convert` was too narrow; TTS runtime paths can still receive a source config that contains unresolved SecretRefs while a resolved runtime snapshot is active.
- Why it matters: request/runtime TTS paths should read the atomic in-memory runtime snapshot, not re-read unresolved source credentials on hot paths.
- What changed: speech-core now selects the applicable active runtime config snapshot before resolving TTS config, provider config, provider order, voice listing, synthesis, telephony, and auto-TTS payload handling.
- What did NOT change (scope boundary): no lazy per-request SecretRef provider execution was added; unsupported non-static credential surfaces remain unsupported.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #68690
- Supersedes the narrower approach in #72549, which was reverted on `main`
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: speech-core trusted the caller-provided config object directly. Some application/runtime callers can pass the source config while the resolved SecretRef snapshot is active, leaving provider `apiKey` values as unresolved SecretRef objects.
- Missing detection / guardrail: coverage existed for command-level SecretRef resolution, but not for TTS runtime code selecting the active runtime snapshot before provider synthesis.
- Contributing context (if known): MiniMax TTS correctly fails when its provider config contains an unresolved `apiKey` SecretRef object instead of the resolved string.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/speech-core/src/tts.test.ts`
- Scenario the test should lock in: source config still contains a TTS API-key SecretRef, active runtime snapshot contains the resolved API key, and speech synthesis uses the runtime snapshot config.
- Why this is the smallest reliable guardrail: it tests the shared TTS runtime seam rather than one CLI command path.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

TTS runtime paths now honor the active resolved runtime snapshot for SecretRef-backed TTS provider credentials, including `messages.tts.providers.minimax.apiKey`.

## Diagram (if applicable)

```text
Before:
TTS runtime caller -> source config -> unresolved provider apiKey SecretRef -> provider failure

After:
TTS runtime caller -> select active runtime snapshot -> resolved provider apiKey -> provider synthesis
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: TTS now follows the existing runtime snapshot selection model. It does not execute SecretRef providers on request paths; it only uses the already active in-memory resolved snapshot when it matches the caller's source config.

## Repro + Verification

### Environment

- OS: Linux container and local macOS workspace
- Runtime/container: Docker `node:22-bookworm`, Node 22
- Model/provider: MiniMax TTS shape with mock resolved key in tests
- Integration/channel (if any): shared speech-core TTS runtime
- Relevant config (redacted): `messages.tts.providers.minimax.apiKey` as SecretRef in source config, resolved string in active runtime snapshot

### Steps

1. Prepare a source config with a TTS provider API-key SecretRef.
2. Set the active runtime snapshot with the same source config and resolved provider API key.
3. Call speech-core synthesis with the source config.
4. Assert provider configuration and synthesis receive the resolved runtime snapshot value.

### Expected

- TTS runtime uses the resolved runtime snapshot config.
- Provider config contains the resolved API key string.

### Actual

- Before: TTS runtime could keep using the unresolved source config SecretRef.
- After: TTS runtime uses the resolved runtime snapshot for matching source config.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `pnpm test extensions/speech-core/src/tts.test.ts src/plugin-sdk/config-runtime.test.ts`
- `pnpm test src/cli/capability-cli.test.ts src/cli/command-secret-targets.test.ts src/cli/command-secret-resolution.coverage.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm check:changed`
- `pnpm build`
- Docker `node:22-bookworm`: `OPENCLAW_STATE_DIR=/workspace/repro/state pnpm openclaw secrets audit --allow-exec --json`
- Docker `node:22-bookworm`: `OPENCLAW_STATE_DIR=/workspace/repro/state pnpm test extensions/speech-core/src/tts.test.ts src/plugin-sdk/config-runtime.test.ts`

## Human Verification (required)

- Verified scenarios: source config with TTS SecretRef plus active runtime snapshot with resolved key; provider synthesis receives resolved key; SecretRef audit remains clean in Docker.
- Edge cases checked: direct `infer`-specific resolver wiring was removed from the branch; local TTS runtime direct and auto payload paths now select runtime snapshots centrally.
- What you did **not** verify: real MiniMax API credentials/service response.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: TTS callers that intentionally pass a config different from the active source snapshot should not be overwritten by a stale runtime snapshot.
  - Mitigation: uses the existing `selectApplicableRuntimeConfig` comparison helper, which only selects the runtime snapshot when the input config matches the runtime source snapshot.
