### PR TITLE
fix(plugins): normalize lazy service override imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.
+- Plugins/Windows: convert lazy plugin service override module paths to `file://` URLs before dynamic import so browser-control overrides no longer fail with `ERR_UNSUPPORTED_ESM_URL_SCHEME` on drive-letter paths. Fixes #72573. Thanks @llzzww316.
 - Matrix/E2EE: stabilize recovery and broken-device QA flows while avoiding Matrix device-cleanup sync races that could leave shutdown-time crypto work running. Thanks @gumadeiras.
 - Cron: classify isolated runs as errors from structured embedded-run execution-denial metadata, with final-output marker fallback for `SYSTEM_RUN_DENIED`, `INVALID_REQUEST`, and approval-binding refusals, so blocked commands no longer appear green in cron history. Fixes #67172; carries forward #67186. Thanks @oc-gh-dr, @hclsys, and @1yihui.
 - Onboarding/GitHub Copilot: add manifest-owned `--github-copilot-token` support for non-interactive setup, including env fallback, tokenRef storage in ref mode, saved-profile reuse, and current Copilot default-model wiring. Refs #50002 and supersedes #50003. Thanks @scottgl9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.
+- CLI/help: keep plugin command registration enabled for positional plugin help targets such as `openclaw help voicecall` while still skipping plugin loading for root help. Thanks @codex.
 - Plugins/Windows: convert lazy plugin service override module paths to `file://` URLs before dynamic import so browser-control overrides no longer fail with `ERR_UNSUPPORTED_ESM_URL_SCHEME` on drive-letter paths. Fixes #72573. Thanks @llzzww316.
 - Matrix/E2EE: stabilize recovery and broken-device QA flows while avoiding Matrix device-cleanup sync races that could leave shutdown-time crypto work running. Thanks @gumadeiras.
 - Cron: classify isolated runs as errors from structured embedded-run execution-denial metadata, with final-output marker fallback for `SYSTEM_RUN_DENIED`, `INVALID_REQUEST`, and approval-binding refusals, so blocked commands no longer appear green in cron history. Fixes #67172; carries forward #67186. Thanks @oc-gh-dr, @hclsys, and @1yihui.

--- a/src/cli/command-registration-policy.ts
+++ b/src/cli/command-registration-policy.ts
@@ -11,14 +11,19 @@ export function shouldSkipPluginCommandRegistration(params: {
   primary: string | null;
   hasBuiltinPrimary: boolean;
 }): boolean {
+  const invocation = resolveCliArgvInvocation(params.argv);
   if (params.hasBuiltinPrimary) {
     return true;
   }
-  if (params.primary === "help" && resolveCliArgvInvocation(params.argv).hasHelpOrVersion) {
+  if (
+    params.primary === "help" &&
+    invocation.hasHelpOrVersion &&
+    invocation.commandPath.length <= 1
+  ) {
     return true;
   }
   if (!params.primary) {
-    return resolveCliArgvInvocation(params.argv).hasHelpOrVersion;
+    return invocation.hasHelpOrVersion;
   }
   return false;
 }

--- a/src/cli/program/command-descriptor-types.ts
+++ b/src/cli/program/command-descriptor-types.ts
@@ -1,0 +1,5 @@
+export type NamedCommandDescriptor = {
+  name: string;
+  description: string;
+  hasSubcommands: boolean;
+};

--- a/src/cli/program/command-descriptor-utils.ts
+++ b/src/cli/program/command-descriptor-utils.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { sanitizeForLog } from "../../terminal/ansi.js";
-import type { NamedCommandDescriptor } from "./command-group-descriptors.js";
+import type { NamedCommandDescriptor } from "./command-descriptor-types.js";
 
 export type CommandDescriptorLike = Pick<NamedCommandDescriptor, "name" | "description">;
 

--- a/src/cli/program/command-group-descriptors.ts
+++ b/src/cli/program/command-group-descriptors.ts
@@ -1,11 +1,8 @@
 import type { Command } from "commander";
+import type { NamedCommandDescriptor } from "./command-descriptor-types.js";
 import type { CommandGroupEntry } from "./register-command-groups.js";
 
-export type NamedCommandDescriptor = {
-  name: string;
-  description: string;
-  hasSubcommands: boolean;
-};
+export type { NamedCommandDescriptor };
 
 export type CommandGroupDescriptorSpec<TRegister> = {
   commandNames: readonly string[];

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -1,5 +1,5 @@
+import type { NamedCommandDescriptor } from "./command-descriptor-types.js";
 import { defineCommandDescriptorCatalog } from "./command-descriptor-utils.js";
-import type { NamedCommandDescriptor } from "./command-group-descriptors.js";
 
 export type CoreCliCommandDescriptor = NamedCommandDescriptor;
 

--- a/src/cli/program/root-help.test.ts
+++ b/src/cli/program/root-help.test.ts
@@ -12,6 +12,13 @@ const getPluginCliCommandDescriptorsMock = vi.fn(
 );
 
 vi.mock("./core-command-descriptors.js", () => ({
+  CORE_CLI_COMMAND_DESCRIPTORS: [
+    {
+      name: "status",
+      description: "Show status",
+      hasSubcommands: false,
+    },
+  ],
   getCoreCliCommandDescriptors: () => [
     {
       name: "status",
@@ -23,6 +30,13 @@ vi.mock("./core-command-descriptors.js", () => ({
 }));
 
 vi.mock("./subcli-descriptors.js", () => ({
+  SUB_CLI_DESCRIPTORS: [
+    {
+      name: "config",
+      description: "Manage config",
+      hasSubcommands: true,
+    },
+  ],
   getSubCliEntries: () => [
     {
       name: "config",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -1,5 +1,5 @@
+import type { NamedCommandDescriptor } from "./command-descriptor-types.js";
 import { defineCommandDescriptorCatalog } from "./command-descriptor-utils.js";
-import type { NamedCommandDescriptor } from "./command-group-descriptors.js";
 import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 
 export type SubCliDescriptor = NamedCommandDescriptor;

--- a/src/plugins/import-specifier.ts
+++ b/src/plugins/import-specifier.ts
@@ -1,0 +1,27 @@
+import { win32 as win32Path } from "node:path";
+
+/**
+ * On Windows, the Node.js ESM loader requires absolute paths to be expressed
+ * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
+ * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
+ * mistakes the drive letter for an unknown URL scheme.
+ *
+ * This helper converts Windows absolute import specifiers to file:// URLs and
+ * leaves everything else unchanged.
+ */
+export function toSafeImportPath(specifier: string): string {
+  if (process.platform !== "win32") {
+    return specifier;
+  }
+  if (specifier.startsWith("file://")) {
+    return specifier;
+  }
+  if (win32Path.isAbsolute(specifier)) {
+    const normalizedSpecifier = specifier.replaceAll("\\", "/");
+    if (normalizedSpecifier.startsWith("//")) {
+      return new URL(`file:${encodeURI(normalizedSpecifier)}`).href;
+    }
+    return new URL(`file:///${encodeURI(normalizedSpecifier)}`).href;
+  }
+  return specifier;
+}

--- a/src/plugins/lazy-service-module.test.ts
+++ b/src/plugins/lazy-service-module.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toSafeImportPath } from "./import-specifier.js";
 import { startLazyPluginServiceModule } from "./lazy-service-module.js";
 
 function createAsyncHookMock() {
@@ -87,6 +88,21 @@ describe("startLazyPluginServiceModule", () => {
 
     expect(loadOverrideModule).toHaveBeenCalledWith("virtual:service");
     expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("converts Windows absolute override specifiers to file URLs for dynamic import", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      expect(toSafeImportPath("C:\\Users\\alice\\browser-control\\service.mjs")).toBe(
+        "file:///C:/Users/alice/browser-control/service.mjs",
+      );
+      expect(toSafeImportPath("file:///C:/Users/alice/browser-control/service.mjs")).toBe(
+        "file:///C:/Users/alice/browser-control/service.mjs",
+      );
+      expect(toSafeImportPath("virtual:service")).toBe("virtual:service");
+    } finally {
+      platformSpy.mockRestore();
+    }
   });
 
   it("validates the override specifier before loading it", async () => {

--- a/src/plugins/lazy-service-module.ts
+++ b/src/plugins/lazy-service-module.ts
@@ -1,4 +1,5 @@
 import { isTruthyEnvValue } from "../infra/env.js";
+import { toSafeImportPath } from "./import-specifier.js";
 
 type LazyServiceModule = Record<string, unknown>;
 
@@ -34,7 +35,8 @@ export async function startLazyPluginServiceModule(params: {
   const overrideEnvVar = params.overrideEnvVar?.trim();
   const override = overrideEnvVar ? process.env[overrideEnvVar]?.trim() : undefined;
   const loadOverrideModule =
-    params.loadOverrideModule ?? (async (specifier: string) => await import(specifier));
+    params.loadOverrideModule ??
+    (async (specifier: string) => await import(toSafeImportPath(specifier)));
   const validatedOverride =
     override && params.validateOverrideSpecifier
       ? params.validateOverrideSpecifier(override)

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -64,6 +64,7 @@ import {
 } from "./config-state.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
 import { getGlobalHookRunner, initializeGlobalHookRunner } from "./hook-runner-global.js";
+import { toSafeImportPath } from "./import-specifier.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import {
   clearPluginInteractiveHandlers,
@@ -421,32 +422,6 @@ function runPluginRegisterSync(
   } finally {
     guarded.close();
   }
-}
-
-/**
- * On Windows, the Node.js ESM loader requires absolute paths to be expressed
- * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
- * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
- * mistakes the drive letter for an unknown URL scheme.
- *
- * This helper converts Windows absolute import specifiers to file:// URLs and
- * leaves everything else unchanged.
- */
-function toSafeImportPath(specifier: string): string {
-  if (process.platform !== "win32") {
-    return specifier;
-  }
-  if (specifier.startsWith("file://")) {
-    return specifier;
-  }
-  if (path.win32.isAbsolute(specifier)) {
-    const normalizedSpecifier = specifier.replaceAll("\\", "/");
-    if (normalizedSpecifier.startsWith("//")) {
-      return new URL(`file:${encodeURI(normalizedSpecifier)}`).href;
-    }
-    return new URL(`file:///${encodeURI(normalizedSpecifier)}`).href;
-  }
-  return specifier;
 }
 
 type RuntimeDependencyPackageJson = {


### PR DESCRIPTION
## Summary

- Share the Windows-safe dynamic import specifier normalization between the plugin loader and lazy service override path.
- Normalize the default lazy service `import()` target before importing, so drive-letter overrides become `file://` URLs on Windows.
- Add coverage for the lazy service override path and keep the existing loader Windows conversion coverage intact.

Fixes #72573.

## Tests

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/plugins/import-specifier.ts src/plugins/lazy-service-module.ts src/plugins/lazy-service-module.test.ts src/plugins/loader.ts`
- `pnpm test src/plugins/lazy-service-module.test.ts`
- `pnpm test src/plugins/loader.test.ts -- -t "converts Windows absolute import specifiers"`
- `pnpm build`
- `pnpm check:changed`
