### PR TITLE
fix(gateway): talk.config no longer throws on SecretRef apiKey (#72496)

### DIFF
--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -360,28 +360,50 @@ function resolveTalkResponseFromConfig(params: {
   const speechProvider = getSpeechProvider(provider, params.runtimeConfig);
   const sourceBaseTts = asRecord(params.sourceConfig.messages?.tts) ?? {};
   const runtimeBaseTts = asRecord(params.runtimeConfig.messages?.tts) ?? {};
-  const talkProviderConfig = sourceResolved?.config ?? runtimeResolved?.config ?? {};
+  const sourceProviderConfig = sourceResolved?.config ?? {};
+  const runtimeProviderConfig = runtimeResolved?.config ?? {};
+  // Prefer runtime-resolved provider config (already-substituted secrets) and
+  // fall back to source. Strip any apiKey that is still a SecretRef wrapper —
+  // provider plugins (ElevenLabs/OpenAI) call strict secret helpers that throw
+  // on unresolved wrappers, and the discovery path doesn't need the resolved
+  // value: the response's apiKey is restored from source so the UI keeps the
+  // SecretRef shape, and redaction strips the value when includeSecrets=false.
+  const providerInputConfig = stripUnresolvedSecretApiKey(
+    Object.keys(runtimeProviderConfig).length > 0 ? runtimeProviderConfig : sourceProviderConfig,
+  );
   const resolvedConfig =
     speechProvider?.resolveTalkConfig?.({
       cfg: params.runtimeConfig,
       baseTtsConfig: Object.keys(sourceBaseTts).length > 0 ? sourceBaseTts : runtimeBaseTts,
-      talkProviderConfig,
+      talkProviderConfig: providerInputConfig,
       timeoutMs:
         typeof sourceBaseTts.timeoutMs === "number"
           ? sourceBaseTts.timeoutMs
           : typeof runtimeBaseTts.timeoutMs === "number"
             ? runtimeBaseTts.timeoutMs
             : 30_000,
-    }) ?? talkProviderConfig;
+    }) ?? providerInputConfig;
+  const responseConfig =
+    sourceProviderConfig.apiKey === undefined
+      ? resolvedConfig
+      : { ...resolvedConfig, apiKey: sourceProviderConfig.apiKey };
 
   return {
     ...payload,
     provider,
     resolved: {
       provider,
-      config: resolvedConfig,
+      config: responseConfig,
     },
   };
+}
+
+function stripUnresolvedSecretApiKey(config: TalkProviderConfig): TalkProviderConfig {
+  if (config.apiKey === undefined || typeof config.apiKey === "string") {
+    return config;
+  }
+  const { apiKey: _omit, ...rest } = config;
+  return rest;
 }
 
 export const talkHandlers: GatewayRequestHandlers = {

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -318,6 +319,87 @@ describe("gateway talk.config", () => {
               providerApiKey: undefined,
             });
           });
+        },
+      );
+    });
+  });
+
+  it("does not throw when SecretRef apiKey flows through a strict provider resolver", async () => {
+    // Regression for #72496: ElevenLabs/OpenAI speech providers call the strict
+    // normalizeResolvedSecretInputString helper inside resolveTalkConfig. The
+    // discovery path used to hand them the raw source config (with the SecretRef
+    // wrapper still intact), causing talk.config to throw "unresolved SecretRef"
+    // and pushing iOS/macOS Talk overlays onto local AVSpeechSynthesizer.
+    const apiKeyPath = `talk.providers.${GENERIC_TALK_PROVIDER_ID}.apiKey`;
+    await writeTalkConfig({
+      apiKey: { source: "env", provider: "default", id: GENERIC_TALK_API_ENV },
+      voiceId: "voice-secretref",
+    });
+
+    await withEnvAsync({ [GENERIC_TALK_API_ENV]: "env-acme-key" }, async () => {
+      await withSpeechProviders(
+        [
+          {
+            pluginId: "acme-strict-talk-provider-test",
+            source: "test",
+            provider: {
+              id: GENERIC_TALK_PROVIDER_ID,
+              label: "Acme Strict Speech",
+              isConfigured: () => true,
+              resolveTalkConfig: ({ talkProviderConfig }) => {
+                const apiKey = normalizeResolvedSecretInputString({
+                  value: talkProviderConfig.apiKey,
+                  path: apiKeyPath,
+                });
+                return {
+                  ...talkProviderConfig,
+                  ...(apiKey === undefined ? {} : { apiKey }),
+                };
+              },
+              synthesize: async () => ({
+                audioBuffer: Buffer.from([1]),
+                outputFormat: "mp3",
+                fileExtension: ".mp3",
+                voiceCompatible: false,
+              }),
+            },
+          },
+        ],
+        async () => {
+          const secretRef = {
+            source: "env",
+            provider: "default",
+            id: GENERIC_TALK_API_ENV,
+          } satisfies SecretRef;
+
+          await withTalkConfigConnection(["operator.read"], async (ws) => {
+            const res = await fetchTalkConfig(ws);
+            expect(res.ok, JSON.stringify(res.error)).toBe(true);
+            const talk = res.payload?.config?.talk;
+            expect(talk?.provider).toBe(GENERIC_TALK_PROVIDER_ID);
+            expect(talk?.providers?.[GENERIC_TALK_PROVIDER_ID]?.voiceId).toBe("voice-secretref");
+            // SecretRef apiKey is redacted in-place; the wrapper shape stays so
+            // the UI keeps the SecretRef context, but every field becomes the
+            // sentinel so no credential material leaks to read-scope callers.
+            const redactedApiKey = talk?.providers?.[GENERIC_TALK_PROVIDER_ID]?.apiKey;
+            expect(redactedApiKey).toBeTypeOf("object");
+            expect((redactedApiKey as SecretRef).id).toBe("__OPENCLAW_REDACTED__");
+            expect(talk?.resolved?.config?.apiKey).toEqual(redactedApiKey);
+          });
+
+          await withTalkConfigConnection(
+            ["operator.read", "operator.write", "operator.talk.secrets"],
+            async (ws) => {
+              const res = await fetchTalkConfig(ws, { includeSecrets: true });
+              expect(res.ok, JSON.stringify(res.error)).toBe(true);
+              expect(validateTalkConfigResult(res.payload)).toBe(true);
+              expectTalkConfig(res.payload?.config?.talk, {
+                provider: GENERIC_TALK_PROVIDER_ID,
+                voiceId: "voice-secretref",
+                apiKey: secretRef,
+              });
+            },
+          );
         },
       );
     });


### PR DESCRIPTION
## Summary

Fixes #72496. `talk.config` was throwing `unresolved SecretRef` whenever `talk.providers.<id>.apiKey` was configured as a SecretRef object, so iOS / macOS / Control UI Talk overlays never received a provider snapshot and silently fell back to local on-device TTS (the "robot voice" symptom). The credential itself was healthy — `talk.realtime.session` and `talk.speak` both worked with the same SecretRef — so this was purely a discovery-path bug.

Root cause: `resolveTalkResponseFromConfig` in `src/gateway/server-methods/talk.ts` handed the source-snapshot's `talkProviderConfig` (with the SecretRef wrapper still on `apiKey`) to `speechProvider.resolveTalkConfig({...})`. ElevenLabs's resolver (and OpenAI's, and any provider that uses the strict secret-input helpers) then called `normalizeResolvedSecretInputString` on the wrapper, which threw on the unresolved SecretRef.

## Fix

- Prefer the runtime-resolved provider config when calling `resolveTalkConfig` (substituted strings in production paths).
- Strip the `apiKey` field if it's still a SecretRef wrapper before handing it to the provider, so strict secret-input helpers never see an unresolved wrapper.
- Restore the source-shaped `apiKey` (the SecretRef) onto `resolved.config` in the response so the UI keeps the SecretRef context. Existing redaction sentinels the value when `includeSecrets: false`.

Adds a regression test that registers a speech provider mirroring ElevenLabs/OpenAI's strict resolver behavior and drives a SecretRef apiKey through `talk.config` for both read-only and `includeSecrets: true` callers.

## Test plan

- [x] `pnpm test src/gateway/server.talk-config.test.ts` — 9/9 pass; new test fails on `unresolved SecretRef` without the fix
- [x] `pnpm check:changed` (typecheck core/core-tests, lint, import cycles, guards) — green
- [x] `pnpm test:changed` — green
- [ ] Manual: file-backed SecretRef ElevenLabs apiKey → `openclaw gateway call talk.config` returns provider snapshot → iOS/macOS Talk overlays use ElevenLabs voice instead of AVSpeechSynthesizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
