### PR TITLE
fix(bonjour): raise STUCK_ANNOUNCING_MS from 8s to 20s to avoid false-positive teardowns

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -448,7 +448,7 @@ describe("gateway bonjour advertiser", () => {
 
     // watchdog first retries, then recreates the advertiser after the service
     // stays unhealthy across multiple 5s ticks.
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(25_000);
     expect(advertise).toHaveBeenCalledTimes(3);
     expect(createService).toHaveBeenCalledTimes(2);
 
@@ -605,7 +605,7 @@ describe("gateway bonjour advertiser", () => {
     expect(registerUncaughtExceptionHandler).toHaveBeenCalledTimes(1);
     expect(registerUnhandledRejectionHandler).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(25_000);
 
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("restarting advertiser"));
     expect(createService).toHaveBeenCalledTimes(2);
@@ -650,7 +650,7 @@ describe("gateway bonjour advertiser", () => {
     expect(createService).toHaveBeenCalledTimes(1);
     expect(advertise).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(25_000);
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("service stuck in announcing"),
@@ -678,7 +678,7 @@ describe("gateway bonjour advertiser", () => {
       sshPort: 2222,
     });
 
-    await vi.advanceTimersByTimeAsync(65_000);
+    await vi.advanceTimersByTimeAsync(105_000);
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("disabling advertiser after 3 failed restarts"),

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -80,7 +80,12 @@ type BonjourAdvertiserDeps = {
 
 const WATCHDOG_INTERVAL_MS = 5_000;
 const REPAIR_DEBOUNCE_MS = 30_000;
-const STUCK_ANNOUNCING_MS = 8_000;
+// Real-world LAN announce phase typically takes 12-13s on Mac/iOS networks. The
+// previous 8s threshold was triggering false-positive teardowns on every gateway
+// restart in such environments. 20s gives healthy networks plenty of room while
+// still catching genuinely stuck advertisers (announce that never completes).
+// See https://github.com/openclaw/openclaw/issues/72481
+const STUCK_ANNOUNCING_MS = 20_000;
 const MAX_CONSECUTIVE_RESTARTS = 3;
 const BONJOUR_ANNOUNCED_STATE = "announced";
 const CIAO_SELF_PROBE_RETRY_FRAGMENT =


### PR DESCRIPTION
## Summary

Raises the bonjour advertiser watchdog's stuck-announcing threshold from **8s to 20s** to eliminate false-positive teardowns on healthy LAN networks where the mDNS announce phase legitimately takes 12-13s.

## Background

Issue #72481 reported that the bonjour watchdog was tearing down the advertiser on every gateway restart, producing 'CIAO ANNOUNCEMENT CANCELLED' unhandled rejections that crashed the gateway.

The **primary** issue (unhandled-rejection handler not plumbed through) was already fixed in commit `63241bf1` (post 2026.4.24). However, the issue reporter noted a **secondary** problem: even with the rejection swallowed, the watchdog was still firing false-positive teardowns on every restart because `STUCK_ANNOUNCING_MS = 8000` is shorter than ciao's typical announce phase on real-world LANs (~12-13s on Mac/iOS networks).

## Fix

Raise the threshold to 20s. This:
- ✅ Eliminates the false-positive teardown on healthy networks (announce typically completes in 12-13s, well under 20s)
- ✅ Still catches genuinely stuck advertisers (announce that never completes)
- ✅ No behavior change for advertisers that announce quickly (most cases)

## Verification

The reporter empirically observed announce phases consistently taking 12-13s on a single Mac Mini host on a normal LAN — well under the new 20s threshold but well over the old 8s threshold. Three reproductions in 24h on 2026.4.24.

## Refs

- Closes secondary issue in #72481
- Related: `63241bf1 fix(bonjour): suppress ciao cancellation across plugin runtime copies` (primary fix)