### PR TITLE
test(anthropic): cover legacy embeddedHarness migration path

### DIFF
--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -96,6 +96,33 @@ describe("anthropic cli migration", () => {
     expect(readClaudeCliCredentialsForSetupNonInteractive).toHaveBeenCalledTimes(1);
   });
 
+  it("migrates a 4.23-carry-over config (legacy embeddedHarness.runtime) without conflicting with the canonical agentRuntime.id", () => {
+    // Regression coverage for openclaw#72434: configs carried over from
+    // 2026.4.23 ship with `agents.defaults.embeddedHarness.runtime:
+    // "claude-cli"`, which was an unregistered harness id in 2026.4.24 and
+    // broke channel startup for every gateway. The fix in
+    // 5b9be2cdb1 ("fix: migrate agent runtime config") introduced the
+    // canonical `agentRuntime.id` key. Pin that buildAnthropicCliMigrationResult
+    // emits the canonical key when given a legacy-shape input, so the
+    // migration path stays green even if a future refactor stops wiring
+    // it through.
+    const result = buildAnthropicCliMigrationResult({
+      agents: {
+        defaults: {
+          model: "anthropic/claude-opus-4-7",
+          embeddedHarness: { runtime: "claude-cli" },
+          models: {
+            "anthropic/claude-opus-4-7": { alias: "Opus" },
+          },
+        },
+      },
+    } as never);
+
+    expect(result.configPatch?.agents?.defaults?.agentRuntime).toEqual({
+      id: "claude-cli",
+    });
+  });
+
   it("keeps anthropic defaults and selects the claude-cli runtime", () => {
     const result = buildAnthropicCliMigrationResult({
       agents: {


### PR DESCRIPTION
## What

Adds a single test inside `extensions/anthropic/cli-migration.test.ts` that gives `buildAnthropicCliMigrationResult` a 4.23-carry-over config — `agents.defaults.embeddedHarness.runtime: "claude-cli"` — and asserts the output `configPatch` emits the canonical `agentRuntime.id`. ~27 net lines, no behavior change.

## Why

Regression coverage for #72434. `buildAnthropicCliMigrationResult` is well-tested for clean-config inputs (the existing `it("keeps anthropic defaults and selects the claude-cli runtime", ...)` passes a config with no `embeddedHarness` block). The 5b9be2cdb1 fix introduced the canonical `agentRuntime.id` key, but the legacy-input-shape path it's actually fixing has no explicit test pinning it.

This addresses part of #72576 (claude-cli backend regression-prevention test). Test-only; no production code touched.

## Reproducer / verification

Locally on this branch:

```
$ pnpm test extensions/anthropic/cli-migration.test.ts -- -t 'migrates a 4.23-carry-over'
 Test Files  1 passed (1)
      Tests  1 passed | 11 skipped (12)
   Duration  4.22s
```

Environment: macOS 25.3.0, Node 22.22.2, openclaw repo at `6c1cffa7f8` (`origin/main` head at PR open time).

## Why this passes "test-only / refactor" per CLAUDE.md

CODEOWNERS line: "maint/refactor/tests ok". This is a test-only change inside the `anthropic` extension package boundary; no plugin SDK seams added; no public contract change.
