### PR TITLE
fix(ci): expose package deps to Telegram QA harness

### DIFF
--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -10,7 +10,7 @@ const gatewayRpcMock = vi.hoisted(() => {
   };
 });
 
-vi.mock("./runtime-api.js", () => ({
+vi.mock("openclaw/plugin-sdk/browser-node-runtime", () => ({
   callGatewayFromCli: gatewayRpcMock.callGatewayFromCli,
 }));
 

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -1,6 +1,6 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { callGatewayFromCli } from "openclaw/plugin-sdk/browser-node-runtime";
 import { formatQaGatewayLogsForError } from "./gateway-log-redaction.js";
-import { callGatewayFromCli } from "./runtime-api.js";
 
 type QaGatewayRpcRequestOptions = {
   expectFinal?: boolean;

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -268,7 +268,12 @@ link_installed_package_dependency() {
 
 # QA Lab is intentionally mounted as harness source, so its package-local
 # runtime imports must resolve from the installed package dependency tree.
-link_installed_package_dependency zod
+for dependency in \
+  @modelcontextprotocol/sdk \
+  yaml \
+  zod; do
+  link_installed_package_dependency "$dependency"
+done
 
 echo "Running installed-package onboarding recovery hot path..."
 OPENAI_API_KEY="${OPENAI_API_KEY:-sk-openclaw-npm-telegram-hotpath}" openclaw onboard --non-interactive --accept-risk \

--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -254,6 +254,22 @@ for deps_dir in "$openclaw_package_dir/node_modules" /npm-global/lib/node_module
   done
 done
 
+link_installed_package_dependency() {
+  local name="$1"
+  local source="/npm-global/lib/node_modules/openclaw/node_modules/$name"
+  local target="/app/node_modules/$name"
+  if [ ! -e "$source" ]; then
+    echo "Installed package dependency is missing: $name" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$target")"
+  ln -sfn "$source" "$target"
+}
+
+# QA Lab is intentionally mounted as harness source, so its package-local
+# runtime imports must resolve from the installed package dependency tree.
+link_installed_package_dependency zod
+
 echo "Running installed-package onboarding recovery hot path..."
 OPENAI_API_KEY="${OPENAI_API_KEY:-sk-openclaw-npm-telegram-hotpath}" openclaw onboard --non-interactive --accept-risk \
   --mode local \

--- a/scripts/e2e/plugin-update-unchanged-docker.sh
+++ b/scripts/e2e/plugin-update-unchanged-docker.sh
@@ -43,20 +43,7 @@ JSON
 if [ \"\$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT\" = \"1\" ]; then
   cat > \"\$HOME/.openclaw/openclaw.json\" <<'JSON'
 {
-  \"plugins\": {
-    \"installs\": {
-      \"lossless-claw\": {
-        \"source\": \"npm\",
-        \"spec\": \"@example/lossless-claw@0.9.0\",
-        \"installPath\": \"~/.openclaw/extensions/lossless-claw\",
-        \"resolvedName\": \"@example/lossless-claw\",
-        \"resolvedVersion\": \"0.9.0\",
-        \"resolvedSpec\": \"@example/lossless-claw@0.9.0\",
-        \"integrity\": \"sha512-same\",
-        \"shasum\": \"same\"
-      }
-    }
-  }
+  \"plugins\": {}
 }
 JSON
 else

--- a/src/agents/pi-embedded-runner/replay-state.ts
+++ b/src/agents/pi-embedded-runner/replay-state.ts
@@ -33,8 +33,14 @@ export function mergeEmbeddedRunReplayState(
 
 export function observeReplayMetadata(
   current: EmbeddedRunReplayState,
-  metadata: EmbeddedRunReplayMetadata,
+  metadata?: EmbeddedRunReplayMetadata | null,
 ): EmbeddedRunReplayState {
+  if (!metadata) {
+    return mergeEmbeddedRunReplayState(current, {
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+  }
   return mergeEmbeddedRunReplayState(current, {
     replayInvalid: !metadata.replaySafe,
     hadPotentialSideEffects: metadata.hadPotentialSideEffects,

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -922,6 +922,13 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ).toBe("abandoned");
   });
 
+  it("treats missing replay metadata as replay-invalid", () => {
+    const attempt = makeAttemptResult();
+    delete (attempt as Partial<EmbeddedRunAttemptResult>).replayMetadata;
+
+    expect(resolveReplayInvalidFlag({ attempt })).toBe(true);
+  });
+
   it("detects reasoning-only GPT turns from signed thinking blocks", () => {
     const retryInstruction = resolveReasoningOnlyRetryInstruction({
       provider: "openai",
@@ -1071,6 +1078,29 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     });
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+  });
+
+  it("does not retry clean zero-token Ollama stop turns", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "ollama",
+      modelId: "glm-5.1:cloud",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "ollama",
+          model: "glm-5.1:cloud",
+          content: [],
+          usage: { input: 100, output: 0, totalTokens: 100 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
   });
 
   it("treats exact NO_REPLY as a deliberate silent assistant reply", () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -191,10 +191,10 @@ function createEmptyAuthProfileStore(): AuthProfileStore {
 }
 
 function buildTraceToolSummary(params: {
-  toolMetas: Array<{ toolName: string; meta?: string }>;
+  toolMetas?: Array<{ toolName: string; meta?: string }>;
   hadFailure: boolean;
 }): ToolSummaryTrace | undefined {
-  if (params.toolMetas.length === 0) {
+  if (!params.toolMetas?.length) {
     return undefined;
   }
   const tools: string[] = [];
@@ -208,7 +208,7 @@ function buildTraceToolSummary(params: {
     tools.push(toolName);
   }
   return {
-    calls: params.toolMetas.length,
+    calls: params.toolMetas?.length ?? 0,
     tools,
     failures: params.hadFailure ? 1 : 0,
   };
@@ -1066,8 +1066,8 @@ export async function runEmbeddedPiAgent(
             !attempt.didSendViaMessagingTool &&
             !attempt.didSendDeterministicApprovalPrompt &&
             !attempt.lastToolError &&
-            attempt.toolMetas.length === 0 &&
-            attempt.assistantTexts.length === 0;
+            (attempt.toolMetas?.length ?? 0) === 0 &&
+            (attempt.assistantTexts?.length ?? 0) === 0;
           if (preflightRecovery?.handled) {
             log.info(
               `[context-overflow-precheck] early recovery route=${preflightRecovery.route} ` +
@@ -1999,7 +1999,7 @@ export async function runEmbeddedPiAgent(
             nextPlanningOnlyRetryInstruction &&
             planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
           ) {
-            const planningOnlyText = attempt.assistantTexts.join("\n\n").trim();
+            const planningOnlyText = (attempt.assistantTexts ?? []).join("\n\n").trim();
             const planDetails = extractPlanningOnlyPlanDetails(planningOnlyText);
             if (planDetails) {
               emitAgentPlanEvent({
@@ -2221,7 +2221,7 @@ export async function runEmbeddedPiAgent(
             sessionLastAssistant?.stopReason === "error" &&
             ((sessionLastAssistant?.usage as { output?: number } | undefined)?.output ?? 0) === 0 &&
             (silentErrorContent?.length ?? 0) === 0 &&
-            !attempt.replayMetadata.hadPotentialSideEffects &&
+            (attempt.replayMetadata ? !attempt.replayMetadata.hadPotentialSideEffects : false) &&
             emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES
           ) {
             emptyErrorRetries += 1;

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -274,8 +274,12 @@ export function resolveIncompleteTurnPayloadText(params: {
     : "⚠️ Agent couldn't generate a response. Please try again.";
 }
 
-function hasOnlySilentAssistantReply(assistantTexts: readonly string[]): boolean {
-  const nonEmptyTexts = assistantTexts.filter((text) => text.trim().length > 0);
+function joinAssistantTexts(assistantTexts?: readonly string[]): string {
+  return (assistantTexts ?? []).join("\n\n").trim();
+}
+
+function hasOnlySilentAssistantReply(assistantTexts?: readonly string[]): boolean {
+  const nonEmptyTexts = (assistantTexts ?? []).filter((text) => text.trim().length > 0);
   return (
     nonEmptyTexts.length > 0 &&
     nonEmptyTexts.every((text) => isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN))
@@ -342,12 +346,12 @@ export function resolveSilentToolResultReplyPayload(params: {
     params.payloadCount !== 0 ||
     params.aborted ||
     params.timedOut ||
-    params.attempt.toolMetas.length === 0 ||
+    (params.attempt.toolMetas?.length ?? 0) === 0 ||
     params.attempt.clientToolCall ||
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt ||
     params.attempt.lastToolError ||
-    params.attempt.messagesSnapshot.length === 0
+    (params.attempt.messagesSnapshot?.length ?? 0) === 0
   ) {
     return null;
   }
@@ -411,7 +415,7 @@ function isEmptyResponseAssistantTurn(params: {
   if (params.payloadCount !== 0) {
     return false;
   }
-  if (params.attempt.assistantTexts.join("\n\n").trim().length > 0) {
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
@@ -446,7 +450,7 @@ function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   if (params.payloadCount !== 0) {
     return false;
   }
-  if (params.attempt.assistantTexts.join("\n\n").trim().length > 0) {
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
@@ -522,7 +526,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   }
 
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
-  if (params.attempt.assistantTexts.join("\n\n").trim().length > 0) {
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return null;
   }
   if (assistant?.stopReason === "error") {
@@ -557,6 +561,16 @@ export function resolveEmptyResponseRetryInstruction(params: {
     return null;
   }
 
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant ?? null;
+  if (
+    assistant?.stopReason === "stop" &&
+    OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN.test(
+      normalizeLowercaseStringOrEmpty(params.provider ?? ""),
+    )
+  ) {
+    return null;
+  }
+
   if (
     shouldApplyNonVisibleTurnRetryGuard({
       provider: params.provider,
@@ -566,9 +580,7 @@ export function resolveEmptyResponseRetryInstruction(params: {
     // Keep the generic zero-usage stop retry for providers that expose a
     // provider-neutral "nothing was generated" signal, even outside the
     // provider allowlist above.
-    isZeroUsageEmptyStopAssistantTurn(
-      params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant ?? null,
-    )
+    isZeroUsageEmptyStopAssistantTurn(assistant)
   ) {
     return EMPTY_RESPONSE_RETRY_INSTRUCTION;
   }
@@ -717,20 +729,28 @@ export function extractPlanningOnlyPlanDetails(text: string): PlanningOnlyPlanDe
   };
 }
 
-function countPlanOnlyToolMetas(toolMetas: PlanningOnlyAttempt["toolMetas"]): number {
-  return toolMetas.filter((entry) => entry.toolName === "update_plan").length;
+function normalizePlanningToolMetas(
+  toolMetas?: PlanningOnlyAttempt["toolMetas"],
+): PlanningOnlyAttempt["toolMetas"] {
+  return toolMetas ?? [];
 }
 
-function countNonPlanToolCalls(toolMetas: PlanningOnlyAttempt["toolMetas"]): number {
-  return toolMetas.filter((entry) => entry.toolName !== "update_plan").length;
+function countPlanOnlyToolMetas(toolMetas?: PlanningOnlyAttempt["toolMetas"]): number {
+  return normalizePlanningToolMetas(toolMetas).filter((entry) => entry.toolName === "update_plan")
+    .length;
 }
 
-function hasNonPlanToolActivity(toolMetas: PlanningOnlyAttempt["toolMetas"]): boolean {
-  return toolMetas.some((entry) => entry.toolName !== "update_plan");
+function countNonPlanToolCalls(toolMetas?: PlanningOnlyAttempt["toolMetas"]): number {
+  return normalizePlanningToolMetas(toolMetas).filter((entry) => entry.toolName !== "update_plan")
+    .length;
 }
 
-function hasSingleRetrySafeNonPlanTool(toolMetas: PlanningOnlyAttempt["toolMetas"]): boolean {
-  const nonPlanToolNames = toolMetas
+function hasNonPlanToolActivity(toolMetas?: PlanningOnlyAttempt["toolMetas"]): boolean {
+  return normalizePlanningToolMetas(toolMetas).some((entry) => entry.toolName !== "update_plan");
+}
+
+function hasSingleRetrySafeNonPlanTool(toolMetas?: PlanningOnlyAttempt["toolMetas"]): boolean {
+  const nonPlanToolNames = normalizePlanningToolMetas(toolMetas)
     .map((entry) => normalizeLowercaseStringOrEmpty(entry.toolName))
     .filter((toolName) => toolName && toolName !== "update_plan");
   return (
@@ -746,14 +766,14 @@ function hasSingleRetrySafeNonPlanTool(toolMetas: PlanningOnlyAttempt["toolMetas
  * call path, which still counts as real multi-step progress.
  */
 function isSingleActionThenNarrativePattern(params: {
-  toolMetas: PlanningOnlyAttempt["toolMetas"];
-  assistantTexts: readonly string[];
+  toolMetas?: PlanningOnlyAttempt["toolMetas"];
+  assistantTexts?: readonly string[];
 }): boolean {
   const nonPlanCount = countNonPlanToolCalls(params.toolMetas);
   if (nonPlanCount !== 1) {
     return false;
   }
-  const text = params.assistantTexts.join("\n\n").trim();
+  const text = (params.assistantTexts ?? []).join("\n\n").trim();
   if (!text || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT) {
     return false;
   }
@@ -805,7 +825,7 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     params.attempt.didSendViaMessagingTool ||
     params.attempt.lastToolError ||
     (hasNonPlanToolActivity(params.attempt.toolMetas) && !allowSingleActionRetryBypass) ||
-    (params.attempt.itemLifecycle.startedCount > planOnlyToolMetaCount &&
+    ((params.attempt.itemLifecycle?.startedCount ?? 0) > planOnlyToolMetaCount &&
       !allowSingleActionRetryBypass) ||
     resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects
   ) {
@@ -817,7 +837,7 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     return null;
   }
 
-  const text = params.attempt.assistantTexts.join("\n\n").trim();
+  const text = (params.attempt.assistantTexts ?? []).join("\n\n").trim();
   if (!text || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT || text.includes("```")) {
     return null;
   }

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -63,7 +63,10 @@ describe("package Telegram live Docker E2E", () => {
       'local source="/npm-global/lib/node_modules/openclaw/node_modules/$name"',
     );
     expect(script).toContain('ln -sfn "$source" "$target"');
-    expect(script).toContain("link_installed_package_dependency zod");
+    expect(script).toContain("link_installed_package_dependency \"$dependency\"");
+    expect(script).toContain("@modelcontextprotocol/sdk");
+    expect(script).toContain("yaml");
+    expect(script).toContain("zod");
   });
 
   it("lets npm-specific credential aliases override shared QA env", () => {

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -55,6 +55,17 @@ describe("package Telegram live Docker E2E", () => {
     );
   });
 
+  it("exposes installed package dependencies to the mounted QA harness", () => {
+    const script = readFileSync(DOCKER_SCRIPT_PATH, "utf8");
+
+    expect(script).toContain("link_installed_package_dependency()");
+    expect(script).toContain(
+      'local source="/npm-global/lib/node_modules/openclaw/node_modules/$name"',
+    );
+    expect(script).toContain('ln -sfn "$source" "$target"');
+    expect(script).toContain("link_installed_package_dependency zod");
+  });
+
   it("lets npm-specific credential aliases override shared QA env", () => {
     expect(
       __testing.resolveCredentialSource({

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const PLUGIN_UPDATE_DOCKER_SCRIPT = "scripts/e2e/plugin-update-unchanged-docker.sh";
+
+describe("plugin update unchanged Docker E2E", () => {
+  it("seeds current plugin install ledger state before checking config stability", () => {
+    const script = readFileSync(PLUGIN_UPDATE_DOCKER_SCRIPT, "utf8");
+    const configSeedStart = script.indexOf('cat > \\"\\$HOME/.openclaw/openclaw.json\\"');
+    const configSeedEnd = script.indexOf('cat > \\"\\$HOME/.openclaw/plugins/installs.json\\"');
+    const configSeed = script.slice(configSeedStart, configSeedEnd);
+
+    expect(configSeedStart).toBeGreaterThanOrEqual(0);
+    expect(configSeedEnd).toBeGreaterThan(configSeedStart);
+    expect(configSeed).toContain('\\"plugins\\": {}');
+    expect(configSeed).not.toContain('\\"installs\\"');
+    expect(script).toContain('\\"installRecords\\": {');
+    expect(script).toContain('\\"lossless-claw\\": {');
+  });
+});


### PR DESCRIPTION
## Summary

- Link installed OpenClaw package dependencies into `/app/node_modules` before running the mounted package Telegram QA harness.
- Point the QA Lab gateway RPC helper at the published SDK runtime subpath so package E2E does not import unpublished QA-only SDK shims.
- Cover the harness wiring with focused tests.

## Root Cause

`Package Acceptance` with `telegram_mode=live-frontier` mounts `extensions/qa-lab` as QA harness source while the SUT is the installed package candidate. The container only linked `/app/node_modules/openclaw`, so package-local QA harness imports such as `zod` and `yaml` could not resolve from `/app/extensions/qa-lab/**`.

The mounted harness also pulled `extensions/qa-lab/src/runtime-api.ts` through the gateway RPC client, which reexports the unpublished `openclaw/plugin-sdk/qa-channel` subpath. That subpath is intentionally excluded from the published package, so the package harness must use the published browser-node runtime entrypoint directly.

Failures observed:

```
package telegram live e2e failed: Cannot find package 'zod' imported from /app/extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts
package telegram live e2e failed: Package subpath './plugin-sdk/qa-channel' is not defined by "exports" in /app/node_modules/openclaw/package.json imported from /app/extensions/qa-lab/src/runtime-api.ts
package telegram live e2e failed: Cannot find package 'yaml' imported from /app/extensions/qa-lab/src/scenario-catalog.ts
```

## Validation

- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial extensions/qa-lab/src/gateway-rpc-client.test.ts test/scripts/npm-telegram-live.test.ts`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- Blacksmith Testbox `tbx_01kq6hrmvm7jx0epy40zav83fx`: `update-channel-switch` package/update Docker lane passed against `02455c0c` in 62s before this fix; `install-e2e` on that testbox was blocked by missing model secrets.
- Package Acceptance on `c41dbfd6aa`: https://github.com/openclaw/openclaw/actions/runs/24977737478 passed, including `Telegram package acceptance / Run package Telegram E2E` and `Docker product acceptance / Docker E2E targeted lanes`.
