### PR TITLE
fix(runtime-deps): hide bundled npm staging windows

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -819,6 +819,7 @@ export function runBundledPluginPostinstall(params = {}) {
       stdio: "pipe",
       shell: npmRunner.shell,
       windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
+      windowsHide: true,
     });
     if (result.status !== 0) {
       const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -885,6 +885,7 @@ function runNpmInstall(params) {
     stdio: ["ignore", "pipe", "pipe"],
     timeout: params.timeoutMs ?? 5 * 60 * 1000,
     windowsVerbatimArguments: params.npmRunner.windowsVerbatimArguments,
+    windowsHide: true,
   });
   if (result.status === 0) {
     return;

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -260,6 +260,7 @@ describe("installBundledRuntimeDeps", () => {
       ["C:\\node\\node_modules\\npm\\bin\\npm-cli.js", "install", "--ignore-scripts", "acpx@0.5.3"],
       expect.objectContaining({
         cwd: installRoot,
+        windowsHide: true,
         env: expect.objectContaining({
           npm_config_legacy_peer_deps: "true",
           npm_config_package_lock: "false",

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -1294,6 +1294,7 @@ export function installBundledRuntimeDeps(params: {
       encoding: "utf8",
       env: npmRunner.env ?? installEnv,
       stdio: "pipe",
+      windowsHide: true,
     });
     if (result.status !== 0 || result.error) {
       const output = [result.error?.message, result.stderr, result.stdout]

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -80,6 +80,7 @@ describe("bundled plugin postinstall", () => {
       shell: false,
       stdio: "pipe",
       windowsVerbatimArguments: undefined,
+      windowsHide: true,
     });
   }
 

--- a/test/scripts/stage-bundled-plugin-runtime-deps.windows-hide.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.windows-hide.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawnSync: vi.fn(),
+}));
+
+const { stageBundledPluginRuntimeDeps } =
+  await import("../../scripts/stage-bundled-plugin-runtime-deps.mjs");
+
+const spawnSyncMock = vi.mocked(spawnSync);
+const { createTempDir } = createScriptTestHarness();
+
+describe("stageBundledPluginRuntimeDeps npm spawn options", () => {
+  it("hides npm install windows while staging fallback runtime deps", () => {
+    const repoRoot = createTempDir("openclaw-runtime-deps-windows-hide-");
+    const pluginDir = path.join(repoRoot, "dist", "extensions", "fixture-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      `${JSON.stringify(
+        {
+          name: "@openclaw/fixture-plugin",
+          version: "1.0.0",
+          dependencies: { "left-pad": "1.3.0" },
+          openclaw: { bundle: { stageRuntimeDependencies: true } },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    spawnSyncMock.mockImplementation((_command, _args, options) => {
+      const cwd = String(options?.cwd ?? "");
+      const depDir = path.join(cwd, "node_modules", "left-pad");
+      fs.mkdirSync(depDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(depDir, "package.json"),
+        '{"name":"left-pad","version":"1.3.0"}\n',
+        "utf8",
+      );
+      return { status: 0, stdout: "", stderr: "" } as ReturnType<typeof spawnSync>;
+    });
+
+    stageBundledPluginRuntimeDeps({ cwd: repoRoot });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({
+        cwd: expect.stringContaining(path.join("fixture-plugin", ".openclaw-runtime-deps-install")),
+        windowsHide: true,
+      }),
+    );
+    expect(fs.existsSync(path.join(pluginDir, "node_modules", "left-pad", "package.json"))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

On Windows 11, bundled plugin runtime dependency staging can flash visible npm command windows while installing Telegram grammY / Anthropic runtime dependencies. This is disruptive during gateway/postinstall/runtime staging and is tracked in #72315.

## Root cause

The bundled runtime-deps npm child-process calls did not pass `windowsHide: true`, even though the npm runner already preserves Windows-specific `shell` / `windowsVerbatimArguments` behavior.

## Complete fix boundary

This sets `windowsHide: true` on every bundled runtime dependency npm staging execution path found by tracing `resolveNpmRunner` / `resolveBundledRuntimeDepsNpmRunner` to actual spawn calls:

- `src/plugins/bundled-runtime-deps.ts` for runtime / doctor repair installs.
- `scripts/postinstall-bundled-plugins.mjs` for packaged postinstall eager installs.
- `scripts/stage-bundled-plugin-runtime-deps.mjs` for build/runtime-postbuild staging installs.

Regression coverage checks the runtime Windows npm shim path, the postinstall spawn helper, and a real `stageBundledPluginRuntimeDeps()` fallback install path that reaches the mocked npm spawn and materializes staged deps.

## What intentionally did not change

- `scripts/npm-runner.mjs` is unchanged because it only resolves command/args/options metadata; it does not spawn npm.
- Active-plugin scoping, stale version detection, and temp cleanup behavior are unchanged because those are separate runtime-deps issues with existing open PRs.
- Other process-spawn callers are unchanged because this PR is scoped to bundled plugin runtime dependency npm staging.

## Tests run

- `pnpm install --frozen-lockfile --offline`
- `pnpm test src/plugins/bundled-runtime-deps.test.ts test/scripts/stage-bundled-plugin-runtime-deps.windows-hide.test.ts`
- `pnpm exec vitest run test/scripts/postinstall-bundled-plugins.test.ts -t "runs nested local installs with sanitized env when the sentinel package is missing"`
- `pnpm exec oxfmt --check scripts/postinstall-bundled-plugins.mjs scripts/stage-bundled-plugin-runtime-deps.mjs src/plugins/bundled-runtime-deps.ts src/plugins/bundled-runtime-deps.test.ts test/scripts/postinstall-bundled-plugins.test.ts test/scripts/stage-bundled-plugin-runtime-deps.windows-hide.test.ts`
- `pnpm check:changed`
- `git diff --check HEAD~1..HEAD`

Local note: running the whole `test/scripts/postinstall-bundled-plugins.test.ts` file on this Windows worktree still fails in existing packaged-dist/symlink tests (`unsafe dist entry`, symlink EPERM, stale unlink expectation). The targeted postinstall regression for this diff passes, and the failures do not touch the npm spawn option path changed here.

## CI status

Greptile passed with confidence 5/5 and no requested changes.

CI currently has unrelated red checks:

- `check-additional-runtime-topology-architecture` fails `check:madge-import-cycles` on an existing `src/cli/argv.ts -> src/cli/program/...` cycle. This PR does not touch `src/cli/**`.
- `checks-node-core-fast-support` fails `src/cli/command-registration-policy.test.ts` (`matches plugin registration skip policy`). This PR does not touch that test or command registration code.
- `checks-node-agentic-commands` fails `src/cli/program/root-help.test.ts` because a mock is missing `CORE_CLI_COMMAND_DESCRIPTORS`. This PR does not touch CLI root help or descriptor mocks.
- `check-additional` and `checks-node-core` are aggregate failures caused by the leaf jobs above.

The changed files are limited to bundled runtime-deps npm spawn options and their focused tests:

- `scripts/postinstall-bundled-plugins.mjs`
- `scripts/stage-bundled-plugin-runtime-deps.mjs`
- `src/plugins/bundled-runtime-deps.ts`
- `src/plugins/bundled-runtime-deps.test.ts`
- `test/scripts/postinstall-bundled-plugins.test.ts`
- `test/scripts/stage-bundled-plugin-runtime-deps.windows-hide.test.ts`

## Linked issue

Fixes #72315
