### PR TITLE
fix(ui): make chat attachment uploads append safely

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -11,6 +11,7 @@ export type ControlUiBootstrapConfig = {
   assistantAvatarReason?: string | null;
   assistantAgentId: string;
   serverVersion?: string;
+  chatAttachmentMaxBytes?: number;
   localMediaPreviewRoots?: string[];
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -36,6 +36,7 @@ describe("handleControlUiHttpRequest", () => {
       assistantName: string;
       assistantAvatar: string;
       assistantAgentId: string;
+      chatAttachmentMaxBytes?: number;
       localMediaPreviewRoots?: string[];
     };
   }
@@ -593,7 +594,7 @@ describe("handleControlUiHttpRequest", () => {
           {
             root: { kind: "resolved", path: tmp },
             config: {
-              agents: { defaults: { workspace: tmp } },
+              agents: { defaults: { workspace: tmp, mediaMaxMb: 7 } },
               ui: { assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" } },
             },
           },
@@ -604,6 +605,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("</script><script>alert(1)//");
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+        expect(parsed.chatAttachmentMaxBytes).toBe(7 * 1024 * 1024);
         expect(Array.isArray(parsed.localMediaPreviewRoots)).toBe(true);
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -28,6 +28,7 @@ import {
   type AuthRateLimiter,
 } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import { resolveChatAttachmentMaxBytes } from "./chat-attachments.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
   type ControlUiBootstrapConfig,
@@ -797,6 +798,7 @@ export async function handleControlUiHttpRequest(
       assistantAvatarReason: avatarMeta.avatarReason,
       assistantAgentId: identity.agentId,
       serverVersion: resolveRuntimeServiceVersion(process.env),
+      chatAttachmentMaxBytes: resolveChatAttachmentMaxBytes(config ?? {}),
       localMediaPreviewRoots: [...getAgentScopedMediaLocalRoots(config ?? {}, identity.agentId)],
       embedSandbox:
         config?.gateway?.controlUi?.embedSandbox === "trusted"

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -157,6 +157,7 @@ function createHost(): TestGatewayHost {
     assistantName: "OpenClaw",
     assistantAvatar: null,
     assistantAgentId: null,
+    chatAttachmentMaxBytes: null,
     localMediaPreviewRoots: [],
     serverVersion: null,
     pendingUpdateExpectedVersion: null,

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -12,6 +12,7 @@ function createHost() {
     assistantName: "OpenClaw",
     assistantAvatar: null,
     assistantAgentId: null,
+    chatAttachmentMaxBytes: null,
     localMediaPreviewRoots: [],
     chatHasAutoScrolled: false,
     chatManualRefreshInFlight: false,

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -31,6 +31,7 @@ type LifecycleHost = {
   assistantAvatarReason?: string | null;
   assistantAgentId: string | null;
   serverVersion: string | null;
+  chatAttachmentMaxBytes?: number | null;
   localMediaPreviewRoots: string[];
   embedSandboxMode: "strict" | "scripts" | "trusted";
   allowExternalEmbedUrls: boolean;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2347,6 +2347,12 @@ export function renderApp(state: AppViewState) {
               onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
               attachments: state.chatAttachments,
               onAttachmentsChange: (next) => (state.chatAttachments = next),
+              onAttachmentsAppend: (next) => {
+                state.chatAttachments = [...state.chatAttachments, ...next];
+              },
+              onAttachmentError: (message) => {
+                state.lastError = message;
+              },
               onSend: () => state.handleSendChat(),
               onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
               onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
@@ -2401,6 +2407,7 @@ export function renderApp(state: AppViewState) {
               assistantAvatar: effectiveAssistantAvatar,
               userName: state.userName ?? null,
               userAvatar: state.userAvatar ?? null,
+              chatAttachmentMaxBytes: state.chatAttachmentMaxBytes,
               localMediaPreviewRoots: state.localMediaPreviewRoots,
               embedSandboxMode: state.embedSandboxMode,
               allowExternalEmbedUrls: state.allowExternalEmbedUrls,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -1,5 +1,5 @@
-import type { EventLogEntry } from "./app-events.ts";
 import type { ChatSendOptions } from "./app-chat.ts";
+import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./chat/input-history.ts";
 import type { RealtimeTalkStatus } from "./chat/realtime-talk.ts";
@@ -81,6 +81,7 @@ export type AppViewState = {
   assistantAgentId: string | null;
   userName?: string | null;
   userAvatar?: string | null;
+  chatAttachmentMaxBytes: number | null;
   localMediaPreviewRoots: string[];
   embedSandboxMode: EmbedSandboxMode;
   allowExternalEmbedUrls: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -185,6 +185,7 @@ export class OpenClawApp extends LitElement {
   @state() assistantAgentId = bootAssistantIdentity.agentId ?? null;
   @state() userName = bootLocalUserIdentity.name;
   @state() userAvatar = bootLocalUserIdentity.avatar;
+  @state() chatAttachmentMaxBytes: number | null = null;
   @state() localMediaPreviewRoots: string[] = [];
   @state() embedSandboxMode: "strict" | "scripts" | "trusted" = "scripts";
   @state() allowExternalEmbedUrls = false;

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -17,6 +17,7 @@ describe("loadControlUiBootstrapConfig", () => {
         assistantAvatarReason: "missing",
         assistantAgentId: "main",
         serverVersion: "2026.3.7",
+        chatAttachmentMaxBytes: 7 * 1024 * 1024,
         localMediaPreviewRoots: ["/tmp/openclaw"],
         embedSandbox: "scripts",
         allowExternalEmbedUrls: true,
@@ -32,6 +33,7 @@ describe("loadControlUiBootstrapConfig", () => {
       assistantAvatarStatus: null,
       assistantAvatarReason: null,
       assistantAgentId: null,
+      chatAttachmentMaxBytes: null,
       localMediaPreviewRoots: [],
       embedSandboxMode: "scripts" as const,
       allowExternalEmbedUrls: false,
@@ -51,6 +53,7 @@ describe("loadControlUiBootstrapConfig", () => {
     expect(state.assistantAvatarReason).toBe("missing");
     expect(state.assistantAgentId).toBe("main");
     expect(state.serverVersion).toBe("2026.3.7");
+    expect(state.chatAttachmentMaxBytes).toBe(7 * 1024 * 1024);
     expect(state.localMediaPreviewRoots).toEqual(["/tmp/openclaw"]);
     expect(state.embedSandboxMode).toBe("scripts");
     expect(state.allowExternalEmbedUrls).toBe(true);

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -19,6 +19,7 @@ export type ControlUiBootstrapState = {
   assistantAvatarReason?: string | null;
   assistantAgentId: string | null;
   serverVersion: string | null;
+  chatAttachmentMaxBytes?: number | null;
   localMediaPreviewRoots: string[];
   embedSandboxMode: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
@@ -120,6 +121,12 @@ export async function loadControlUiBootstrapConfig(
       applyLocalAssistantAvatarOverride(state);
     }
     state.serverVersion = parsed.serverVersion ?? null;
+    state.chatAttachmentMaxBytes =
+      typeof parsed.chatAttachmentMaxBytes === "number" &&
+      Number.isFinite(parsed.chatAttachmentMaxBytes) &&
+      parsed.chatAttachmentMaxBytes > 0
+        ? Math.floor(parsed.chatAttachmentMaxBytes)
+        : null;
     state.localMediaPreviewRoots = Array.isArray(parsed.localMediaPreviewRoots)
       ? parsed.localMediaPreviewRoots.filter((value): value is string => typeof value === "string")
       : [];

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -483,6 +483,123 @@ describe("chat attachment picker", () => {
     expect(preview.textContent).toContain("brief.pdf");
   });
 
+  it("appends concurrent file selections without overwriting earlier attachments", async () => {
+    const attachments: ChatQueueItem["attachments"] = [];
+    const onAttachmentsAppend = vi.fn((next: NonNullable<ChatQueueItem["attachments"]>) => {
+      attachments.push(...next);
+    });
+    const container = renderChatView({ onAttachmentsAppend });
+    const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
+    const first = new File(["first"], "first.txt", { type: "text/plain" });
+    const second = new File(["second"], "second.txt", { type: "text/plain" });
+
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [first],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [second],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(
+        attachments
+          .map((att) => att.fileName)
+          .toSorted((a, b) => String(a).localeCompare(String(b))),
+      ).toEqual(["first.txt", "second.txt"]);
+    });
+    expect(onAttachmentsAppend).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects oversized files before reading them", async () => {
+    const onAttachmentsAppend = vi.fn();
+    const onAttachmentError = vi.fn();
+    const container = renderChatView({ onAttachmentsAppend, onAttachmentError });
+    const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
+    const file = new File(["small contents"], "huge.pdf", { type: "application/pdf" });
+    Object.defineProperty(file, "size", {
+      configurable: true,
+      value: 20 * 1024 * 1024 + 1,
+    });
+
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [file],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(onAttachmentError).toHaveBeenCalledWith(expect.stringContaining("exceeds 20 MB"));
+    });
+    expect(onAttachmentsAppend).not.toHaveBeenCalled();
+  });
+
+  it("uses the gateway-provided attachment limit when available", async () => {
+    const onAttachmentsAppend = vi.fn();
+    const onAttachmentError = vi.fn();
+    const container = renderChatView({
+      chatAttachmentMaxBytes: 60 * 1024 * 1024,
+      onAttachmentsAppend,
+      onAttachmentError,
+    });
+    const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
+    const file = new File(["small contents"], "configured-limit.pdf", {
+      type: "application/pdf",
+    });
+    Object.defineProperty(file, "size", {
+      configurable: true,
+      value: 50 * 1024 * 1024 + 1,
+    });
+
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [file],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(onAttachmentsAppend).toHaveBeenCalledWith([
+        expect.objectContaining({ fileName: "configured-limit.pdf" }),
+      ]);
+    });
+    expect(onAttachmentError).not.toHaveBeenCalled();
+  });
+
+  it("reports all oversized file errors without Error prefixes", async () => {
+    const onAttachmentsAppend = vi.fn();
+    const onAttachmentError = vi.fn();
+    const container = renderChatView({ onAttachmentsAppend, onAttachmentError });
+    const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
+    const first = new File(["small contents"], "huge-one.pdf", { type: "application/pdf" });
+    const second = new File(["small contents"], "huge-two.pdf", { type: "application/pdf" });
+    for (const file of [first, second]) {
+      Object.defineProperty(file, "size", {
+        configurable: true,
+        value: 20 * 1024 * 1024 + 1,
+      });
+    }
+
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [first, second],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(onAttachmentError).toHaveBeenCalledWith(
+        'File "huge-one.pdf" exceeds 20 MB.\nFile "huge-two.pdf" exceeds 20 MB.',
+      );
+    });
+    expect(onAttachmentsAppend).not.toHaveBeenCalled();
+  });
+
   it("filters video file attachments", () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -92,11 +92,14 @@ export type ChatProps = {
   assistantAvatar: string | null;
   userName?: string | null;
   userAvatar?: string | null;
+  chatAttachmentMaxBytes?: number | null;
   localMediaPreviewRoots?: string[];
   assistantAttachmentAuthToken?: string | null;
   autoExpandToolCalls?: boolean;
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
+  onAttachmentsAppend?: (attachments: ChatAttachment[]) => void;
+  onAttachmentError?: (message: string) => void;
   showNewMessages?: boolean;
   onScrollToBottom?: () => void;
   onRefresh: () => void;
@@ -209,10 +212,26 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+const MB_BYTES = 1024 * 1024;
+const DEFAULT_CHAT_ATTACHMENT_MAX_BYTES = 20 * MB_BYTES;
+
+function resolveChatAttachmentMaxBytes(props: ChatProps): number {
+  const configured = props.chatAttachmentMaxBytes;
+  return typeof configured === "number" && Number.isFinite(configured) && configured > 0
+    ? Math.floor(configured)
+    : DEFAULT_CHAT_ATTACHMENT_MAX_BYTES;
+}
+
+function formatAttachmentSizeLimit(bytes: number): string {
+  const mb = bytes / MB_BYTES;
+  return `${Number.isInteger(mb) ? mb.toFixed(0) : mb.toFixed(1)} MB`;
+}
+
 function chatAttachmentFromFile(file: File, dataUrl: string): ChatAttachment {
+  const dataUrlMimeType = /^data:([^;]+);base64,/i.exec(dataUrl)?.[1];
   const attachment = {
     id: generateAttachmentId(),
-    mimeType: file.type || "application/octet-stream",
+    mimeType: file.type || dataUrlMimeType || "application/octet-stream",
     fileName: file.name || undefined,
     sizeBytes: file.size,
   };
@@ -220,91 +239,112 @@ function chatAttachmentFromFile(file: File, dataUrl: string): ChatAttachment {
 }
 
 function isImageAttachment(att: ChatAttachment): boolean {
-  return att.mimeType.startsWith("image/");
+  return att.mimeType.toLowerCase().startsWith("image/");
+}
+
+function readFileAsAttachment(file: File, maxBytes: number): Promise<ChatAttachment> {
+  if (file.size > maxBytes) {
+    return Promise.reject(
+      new Error(`File "${file.name || "unnamed"}" exceeds ${formatAttachmentSizeLimit(maxBytes)}.`),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error(`Failed to read file "${file.name || "unnamed"}".`));
+    });
+    reader.addEventListener("load", () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error(`Failed to read file "${file.name || "unnamed"}".`));
+        return;
+      }
+      resolve(chatAttachmentFromFile(file, reader.result));
+    });
+    reader.readAsDataURL(file);
+  });
+}
+
+function attachmentErrorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+async function appendFiles(props: ChatProps, files: Iterable<File>) {
+  const append =
+    props.onAttachmentsAppend ??
+    ((attachments: ChatAttachment[]) => {
+      props.onAttachmentsChange?.([...(props.attachments ?? []), ...attachments]);
+    });
+  if (!props.onAttachmentsAppend && !props.onAttachmentsChange) {
+    return;
+  }
+
+  const supported = Array.from(files).filter(isSupportedChatAttachmentFile);
+  if (supported.length === 0) {
+    return;
+  }
+
+  const maxBytes = resolveChatAttachmentMaxBytes(props);
+  const settled = await Promise.allSettled(
+    supported.map((file) => readFileAsAttachment(file, maxBytes)),
+  );
+  const attachments = settled
+    .filter(
+      (result): result is PromiseFulfilledResult<ChatAttachment> => result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+  const errors = settled.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+
+  if (attachments.length > 0) {
+    append(attachments);
+  }
+  if (errors.length > 0) {
+    props.onAttachmentError?.(
+      errors.map((error) => attachmentErrorMessage(error.reason)).join("\n"),
+    );
+  }
 }
 
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const items = e.clipboardData?.items;
-  if (!items || !props.onAttachmentsChange) {
+  if (!items || (!props.onAttachmentsAppend && !props.onAttachmentsChange)) {
     return;
   }
-  const imageItems: DataTransferItem[] = [];
+  const files: File[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (item.type.startsWith("image/")) {
-      imageItems.push(item);
+      const file = item.getAsFile();
+      if (file) {
+        files.push(file);
+      }
     }
   }
-  if (imageItems.length === 0) {
+  if (files.length === 0) {
     return;
   }
   e.preventDefault();
-  for (const item of imageItems) {
-    const file = item.getAsFile();
-    if (!file) {
-      continue;
-    }
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment = chatAttachmentFromFile(file, dataUrl);
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
-    });
-    reader.readAsDataURL(file);
-  }
+  void appendFiles(props, files);
 }
 
 function handleFileSelect(e: Event, props: ChatProps) {
   const input = e.target as HTMLInputElement;
-  if (!input.files || !props.onAttachmentsChange) {
+  if (!input.files || (!props.onAttachmentsAppend && !props.onAttachmentsChange)) {
     return;
   }
-  const current = props.attachments ?? [];
-  const additions: ChatAttachment[] = [];
-  let pending = 0;
-  for (const file of input.files) {
-    if (!isSupportedChatAttachmentFile(file)) {
-      continue;
-    }
-    pending++;
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      additions.push(chatAttachmentFromFile(file, reader.result as string));
-      pending--;
-      if (pending === 0) {
-        props.onAttachmentsChange?.([...current, ...additions]);
-      }
-    });
-    reader.readAsDataURL(file);
-  }
+  void appendFiles(props, input.files);
   input.value = "";
 }
 
 function handleDrop(e: DragEvent, props: ChatProps) {
   e.preventDefault();
   const files = e.dataTransfer?.files;
-  if (!files || !props.onAttachmentsChange) {
+  if (!files || (!props.onAttachmentsAppend && !props.onAttachmentsChange)) {
     return;
   }
-  const current = props.attachments ?? [];
-  const additions: ChatAttachment[] = [];
-  let pending = 0;
-  for (const file of files) {
-    if (!isSupportedChatAttachmentFile(file)) {
-      continue;
-    }
-    pending++;
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      additions.push(chatAttachmentFromFile(file, reader.result as string));
-      pending--;
-      if (pending === 0) {
-        props.onAttachmentsChange?.([...current, ...additions]);
-      }
-    });
-    reader.readAsDataURL(file);
-  }
+  void appendFiles(props, files);
 }
 
 function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof nothing {


### PR DESCRIPTION
## Summary


- Problem: chat attachment uploads could lose files when multiple async file-read paths completed out of order, and large files were read into memory before any size guard.
- Why it matters: users can paste/select/drop files in quick succession; stale attachment state risks silent data loss, while unbounded reads can freeze or crash the browser tab.
- What changed: added an append-only attachment update path, rejected files over the effective gateway attachment limit (`agents.defaults.mediaMaxMb`, default 20 MB) before `FileReader.readAsDataURL()`, surfaced attachment errors in chat, retained attachment size metadata, and exposed that effective limit to the Control UI bootstrap config.
- What did NOT change (scope boundary): this does not expand supported file types, change transport/API semantics beyond attachment metadata, alter model/tool execution behavior, or supersede the separate local assistant-media bootstrap fix in #67916.

## Change Type 

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope 

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #33404
- Related #67916 (separate Control UI attachment/media preview issue; not superseded by this PR)
- [x] This PR fixes a bug or regression

## Root Cause 

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: async attachment reads appended to the `props.attachments` snapshot captured when each handler ran, so overlapping paste/select/drop operations could overwrite attachments added by another in-flight read. The read path also invoked `FileReader.readAsDataURL()` without checking file size first.
- Missing detection / guardrail: there was no regression test for concurrent attachment appends or oversized-file rejection before reading into memory.
- Contributing context (if known): the previous broader file-upload PR drifted from current `main` and accumulated conflicts, so this PR narrows the fix to the concrete review findings.

## Regression Test Plan 

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
 - [x] Unit test
 - [ ] Seam / integration test
 - [ ] End-to-end test
 - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: concurrent file selections append all completed attachments without overwriting earlier ones; oversized files reject before being read and surface an attachment error.
- Why this is the smallest reliable guardrail: the bug is in the Control UI compose-view state/update boundary, so a view-level unit test can exercise the file handlers without needing a gateway or browser E2E harness.
- Existing test that already covers this (if any): existing attachment picker/filter tests covered happy-path file acceptance and video rejection, but not concurrency or size rejection.
- If no new test is added, why not: N/A — new regression coverage was added.

## User-visible / Behavior Changes

Users now see an attachment error when a selected/pasted/dropped file cannot be attached, including when it exceeds the gateway-configured per-file limit. Concurrent attachment actions should keep all accepted files instead of losing earlier selections.

## Diagram (if applicable)

```text
Before:
[paste/select/drop A] -> [async read A from stale props.attachments]
[paste/select/drop B] -> [async read B from stale props.attachments]
                    -> [last completion wins; earlier files can disappear]

After:
[paste/select/drop A] -> [async read A] -> [append to current attachment state]
[paste/select/drop B] -> [async read B] -> [append to current attachment state]
                                      -> [all accepted files remain attached]
```

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local development workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI chat composer
- Relevant config (redacted): N/A

### Steps

1. Start from current `main` and open the Control UI chat composer attachment flow.
2. Trigger overlapping attachment additions, for example two file-selection operations that resolve asynchronously.
3. Try attaching a file larger than the effective gateway attachment limit (`agents.defaults.mediaMaxMb`, default 20 MB).

### Expected

- All accepted attachments remain in the composer after overlapping async reads complete.
- Files larger than the effective gateway attachment limit are rejected before being read into memory.
- Rejection is visible to the user as an attachment error.

### Actual

- Before this PR, overlapping async reads could rebuild attachment state from stale props and drop files from another in-flight operation.
- Before this PR, oversized files reached `FileReader.readAsDataURL()` without a pre-read size guard.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

```text
pnpm check:changed
cd ui && ../node_modules/.bin/vitest run --config vitest.config.ts src/ui/views/chat.test.ts --project unit
```

Focused test result: `ui/src/ui/views/chat.test.ts` passed with 19 tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: concurrent file selections append without overwriting earlier attachments; oversized files are rejected against the effective gateway limit; a raised configured limit is honored by the UI pre-read guard; multiple oversized-file errors are surfaced without `Error:` prefixes; existing non-video file acceptance and video filtering still pass.
- Edge cases checked: MIME fallback metadata remains intact; attachment size is retained; existing `onAttachmentsChange` callers still have a compatibility fallback when `onAttachmentsAppend` is not supplied.
- What you did **not** verify: manual browser E2E drag/drop behavior in a running packaged app.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: attachment update plumbing now has both append-only and legacy replace-style callbacks.
 - Mitigation: `onAttachmentsAppend` is preferred only where available, while `onAttachmentsChange` remains as a fallback for existing callers.
- Risk: the Control UI bootstrap value may be unavailable during startup or on older gateways.
 - Mitigation: the UI falls back to the gateway default of 20 MB, while the server remains authoritative.


Follow-up update: replaced the temporary fixed client guard with the gateway’s effective attachment limit (`agents.defaults.mediaMaxMb`, default 20 MB), exposed through Control UI bootstrap, so the browser pre-read guard matches server validation instead of blocking configured larger limits.