### PR TITLE
fix(daemon): reconcile macOS LaunchAgent supervision state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- macOS Gateway: detect installed-but-unloaded LaunchAgent split-brain states during status, doctor, and restart, and re-bootstrap launchd supervision before falling back to unmanaged listener restarts. Fixes #67335, #53475, and #71060; refs #58890, #60885, and #70801. Thanks @ze1tgeist88, @dafacto, and @vishutdhar.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -370,17 +370,22 @@ describe("runDaemonRestart health checks", () => {
     expect(service.restart).not.toHaveBeenCalled();
   });
 
-  it("prefers unmanaged restart over launchd repair when a gateway listener is present", async () => {
+  it("prefers launchd repair over unmanaged restart when an installed LaunchAgent is unloaded", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    recoverInstalledLaunchAgent.mockResolvedValue({
+      result: "restarted",
+      loaded: true,
+      message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+    });
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
     mockUnmanagedRestart({ runPostRestartCheck: true });
 
     await runDaemonRestart({ json: true });
 
-    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGUSR1");
-    expect(recoverInstalledLaunchAgent).not.toHaveBeenCalled();
-    expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
-    expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
+    expect(recoverInstalledLaunchAgent).toHaveBeenCalledWith({ result: "restarted" });
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(waitForGatewayHealthyListener).not.toHaveBeenCalled();
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
   });
 
   it("re-bootstraps an installed LaunchAgent on restart when no unmanaged listener exists", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -201,12 +201,18 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     opts,
     checkTokenDrift: true,
     onNotLoaded: async () => {
+      if (process.platform === "darwin") {
+        const recovered = await recoverInstalledLaunchAgent({ result: "restarted" });
+        if (recovered) {
+          return recovered;
+        }
+      }
       const handled = await restartGatewayWithoutServiceManager(restartPort);
       if (handled) {
         restartedWithoutServiceManager = true;
         return handled;
       }
-      return await recoverInstalledLaunchAgent({ result: "restarted" });
+      return null;
     },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
       if (restartedWithoutServiceManager) {

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -144,7 +144,7 @@ export function normalizeListenerAddress(raw: string): string {
 }
 
 export function renderRuntimeHints(
-  runtime: { missingUnit?: boolean; status?: string } | undefined,
+  runtime: { missingUnit?: boolean; missingSupervision?: boolean; status?: string } | undefined,
   env: NodeJS.ProcessEnv = process.env,
   logFile?: string | null,
 ): string[] {
@@ -155,6 +155,15 @@ export function renderRuntimeHints(
   const fileLog = logFile ?? null;
   if (runtime.missingUnit) {
     hints.push(`Service not installed. Run: ${formatCliCommand("openclaw gateway install", env)}`);
+    if (fileLog) {
+      hints.push(`File logs: ${fileLog}`);
+    }
+    return hints;
+  }
+  if (runtime.missingSupervision) {
+    hints.push(
+      `LaunchAgent installed but not loaded. Run: ${formatCliCommand("openclaw gateway restart", env)}`,
+    );
     if (fileLog) {
       hints.push(`File logs: ${fileLog}`);
     }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -251,6 +251,15 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     for (const hint of renderRuntimeHints(service.runtime, process.env, status.logFile)) {
       defaultRuntime.error(errorText(hint));
     }
+  } else if (service.runtime?.missingSupervision) {
+    defaultRuntime.error(errorText("LaunchAgent plist exists but launchd has no loaded job."));
+    for (const hint of renderRuntimeHints(
+      service.runtime,
+      service.command?.environment ?? process.env,
+      status.logFile,
+    )) {
+      defaultRuntime.error(errorText(hint));
+    }
   } else if (service.loaded && service.runtime?.status === "stopped") {
     defaultRuntime.error(
       errorText("Service is loaded but not running (likely exited immediately)."),

--- a/src/commands/doctor-format.ts
+++ b/src/commands/doctor-format.ts
@@ -72,6 +72,15 @@ export function buildGatewayRuntimeHints(
     }
     return hints;
   }
+  if (runtime.missingSupervision && platform === "darwin") {
+    hints.push(
+      `LaunchAgent installed but not loaded. Run: ${formatCliCommand("openclaw gateway restart", env)}`,
+    );
+    if (fileLog) {
+      hints.push(`File logs: ${fileLog}`);
+    }
+    return hints;
+  }
   if (runtime.status === "stopped") {
     hints.push("Service is loaded but not running (likely exited immediately).");
     if (fileLog) {

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -294,7 +294,6 @@ describe("maybeRepairGatewayDaemon", () => {
   it("skips LaunchAgent bootstrap repair when service repair policy is external", async () => {
     setPlatform("darwin");
     service.isLoaded.mockResolvedValue(false);
-    vi.mocked(launchd.isLaunchAgentListed).mockResolvedValue(true);
     vi.mocked(launchd.isLaunchAgentLoaded).mockResolvedValue(false);
     vi.mocked(launchd.launchAgentPlistExists).mockResolvedValue(true);
 

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -7,7 +7,6 @@ import {
 } from "../daemon/constants.js";
 import { readLastGatewayErrorLine } from "../daemon/diagnostics.js";
 import {
-  isLaunchAgentListed,
   isLaunchAgentLoaded,
   launchAgentPlistExists,
   repairLaunchAgentBootstrap,
@@ -49,8 +48,8 @@ async function maybeRepairLaunchAgentBootstrap(params: {
     return false;
   }
 
-  const listed = await isLaunchAgentListed({ env: params.env });
-  if (!listed) {
+  const plistExists = await launchAgentPlistExists(params.env);
+  if (!plistExists) {
     return false;
   }
 
@@ -59,12 +58,7 @@ async function maybeRepairLaunchAgentBootstrap(params: {
     return false;
   }
 
-  const plistExists = await launchAgentPlistExists(params.env);
-  if (!plistExists) {
-    return false;
-  }
-
-  note("LaunchAgent is listed but not loaded in launchd.", `${params.title} LaunchAgent`);
+  note("LaunchAgent is installed but not loaded in launchd.", `${params.title} LaunchAgent`);
   if (params.serviceRepairExternal) {
     note(EXTERNAL_SERVICE_REPAIR_NOTE, `${params.title} LaunchAgent`);
     return false;

--- a/src/daemon/launchd.integration.e2e.test.ts
+++ b/src/daemon/launchd.integration.e2e.test.ts
@@ -187,6 +187,19 @@ describeLaunchdIntegration("launchd integration", () => {
     await expectRuntimePidReplaced({ env: launchEnv, previousPid: before.pid });
   }, 60_000);
 
+  it("keeps LaunchAgent supervision after a raw SIGTERM", async () => {
+    const launchEnv = launchEnvOrThrow(env);
+    try {
+      await initializeLaunchdRuntime(launchEnv, stdout);
+    } catch {
+      return;
+    }
+
+    const before = await waitForRunningRuntime({ env: launchEnv });
+    process.kill(before.pid, "SIGTERM");
+    await expectRuntimePidReplaced({ env: launchEnv, previousPid: before.pid });
+  }, 60_000);
+
   it("stops persistently without reinstall and starts later", async () => {
     const launchEnv = launchEnvOrThrow(env);
     try {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -8,6 +8,7 @@ import {
   installLaunchAgent,
   isLaunchAgentListed,
   parseLaunchctlPrint,
+  readLaunchAgentRuntime,
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
@@ -345,6 +346,30 @@ describe("launchd runtime parsing", () => {
     expect(parseLaunchctlPrint(output)).toEqual({
       state: "waiting",
       lastExitReason: "exited",
+    });
+  });
+});
+
+describe("launchd runtime state", () => {
+  it("marks installed plist split-brain when launchd no longer has the job", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.files.set(resolveLaunchAgentPlistPath(env), "<plist/>");
+    state.serviceLoaded = false;
+
+    await expect(readLaunchAgentRuntime(env)).resolves.toMatchObject({
+      status: "unknown",
+      missingSupervision: true,
+      detail: "Could not find service",
+    });
+  });
+
+  it("marks a missing unit when launchd has no job and no plist exists", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.serviceLoaded = false;
+
+    await expect(readLaunchAgentRuntime(env)).resolves.toMatchObject({
+      status: "unknown",
+      missingUnit: true,
     });
   });
 });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -305,10 +305,11 @@ export async function readLaunchAgentRuntime(
   const label = resolveLaunchAgentLabel({ env });
   const res = await execLaunchctl(["print", `${domain}/${label}`]);
   if (res.code !== 0) {
+    const plistExists = await launchAgentPlistExists(env);
     return {
       status: "unknown",
       detail: (res.stderr || res.stdout).trim() || undefined,
-      missingUnit: true,
+      ...(plistExists ? { missingSupervision: true } : { missingUnit: true }),
     };
   }
   const parsed = parseLaunchctlPrint(res.stdout || res.stderr || "");

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -10,4 +10,5 @@ export type GatewayServiceRuntime = {
   detail?: string;
   cachedLabel?: boolean;
   missingUnit?: boolean;
+  missingSupervision?: boolean;
 };


### PR DESCRIPTION
## Summary
- detect macOS LaunchAgent split-brain states where the plist exists and the gateway listener/RPC is healthy but launchd no longer has the job loaded
- make restart/repair restore launchd supervision instead of continuing as an unmanaged gateway process
- add regression coverage for raw SIGTERM and long drain stop/restart paths that leave the LaunchAgent unloaded

## Context
This carries forward the open launchd lifecycle reports in #67335, #53475, and #71060, with related auto-update context from #58890/#60885 and restart sequencing notes from #70801.

## Validation
- pnpm check:changed
- pnpm -s vitest run src/daemon/launchd.test.ts

## Credit
Thanks to @ze1tgeist88, @dafacto, and @vishutdhar for the concrete macOS LaunchAgent repro data.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156577-autonomous-smoke
- Source PRs: none
- Credit: Credit reporters @ze1tgeist88 in #67335, @dafacto in #53475, and @vishutdhar in #71060 for the launchd supervision and raw SIGTERM/drain repro data.; Mention #58890 and #60885 as related auto-update/ThrottleInterval context if the patch touches update handoff behavior.; Do not claim #58070's ProcessType/WorkingDirectory work unless the replacement patch actually borrows that approach; #58070 remains a separate open PR by @zssggle-rgb.
- Validation: pnpm check:changed; pnpm -s vitest run src/daemon/launchd.test.ts
