### PR TITLE
fix(slack): preserve button blocks in final updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack: preserve shared presentation/button blocks when finalizing draft preview edits so final updates keep Block Kit controls without reintroducing unconditional inline button prompt injection. Fixes #46647; carries forward #47362 and #56955. Thanks @jeremykoerber, @EfeDurmaz16, and @xinbenlv.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Slack: preserve shared presentation/button blocks when finalizing draft preview edits so final updates keep Block Kit controls without reintroducing unconditional inline button prompt injection. Fixes #46647; carries forward #47362 and #56955. Thanks @jeremykoerber, @EfeDurmaz16, and @xinbenlv.
+- Slack: preserve shared presentation/button blocks when finalizing draft preview edits and recognize Slack interactive replies in inline-button prompt guidance so final updates keep Block Kit controls without reintroducing unconditional inline button prompt injection. Fixes #46647; carries forward #47362 and #56955. Thanks @jeremykoerber, @EfeDurmaz16, and @xinbenlv.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.

--- a/extensions/slack/src/blocks.test.ts
+++ b/extensions/slack/src/blocks.test.ts
@@ -5,6 +5,7 @@ import {
   encodeSlackModalPrivateMetadata,
   parseSlackModalPrivateMetadata,
 } from "./modal-metadata.js";
+import { resolveSlackReplyBlocks } from "./reply-blocks.js";
 
 describe("buildSlackBlocksFallbackText", () => {
   it("prefers header text", () => {
@@ -87,6 +88,50 @@ describe("parseSlackBlocksInput", () => {
         testCase.expectedMessage,
       );
     }
+  });
+});
+
+describe("resolveSlackReplyBlocks", () => {
+  it("renders shared presentation buttons for monitor reply delivery", () => {
+    const blocks = resolveSlackReplyBlocks({
+      text: "Choose an action",
+      presentation: {
+        blocks: [
+          { type: "text", text: "Choose an action" },
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Retry", value: "retry" },
+              { label: "Cancel", value: "cancel", style: "danger" },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(blocks).toEqual([
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "Choose an action" },
+      },
+      {
+        type: "actions",
+        block_id: "openclaw_reply_buttons_1",
+        elements: [
+          expect.objectContaining({
+            type: "button",
+            text: { type: "plain_text", text: "Retry", emoji: true },
+            value: "retry",
+          }),
+          expect.objectContaining({
+            type: "button",
+            text: { type: "plain_text", text: "Cancel", emoji: true },
+            value: "cancel",
+            style: "danger",
+          }),
+        ],
+      },
+    ]);
   });
 });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -40,12 +40,30 @@ let mockedDispatchSequence: Array<{
     isReasoning?: boolean;
     mediaUrl?: string;
     mediaUrls?: string[];
+    presentation?: {
+      blocks?: Array<{
+        type: string;
+        text?: string;
+        buttons?: Array<{ label: string; value: string }>;
+      }>;
+    };
   };
 }> = [];
 let mockedProgressEvents: string[] = [];
 
 const noop = () => {};
 const noopAsync = async () => {};
+
+type MockSlackBlock =
+  | { type: "section"; text: { type: "mrkdwn"; text: string } }
+  | {
+      type: "actions";
+      elements: Array<{
+        type: "button";
+        text: { type: "plain_text"; text: string; emoji: true };
+        value: string;
+      }>;
+    };
 
 function createDraftStreamStub() {
   return {
@@ -272,7 +290,34 @@ vi.mock("../replies.js", () => ({
     markSent: () => {},
   }),
   deliverReplies: deliverRepliesMock,
-  readSlackReplyBlocks: () => undefined,
+  readSlackReplyBlocks: (payload: {
+    presentation?: {
+      blocks?: Array<{
+        type: string;
+        text?: string;
+        buttons?: Array<{ label: string; value: string }>;
+      }>;
+    };
+  }) => {
+    const rendered: MockSlackBlock[] = [];
+    for (const block of payload.presentation?.blocks ?? []) {
+      if (block.type === "text" && block.text?.trim()) {
+        rendered.push({ type: "section", text: { type: "mrkdwn", text: block.text.trim() } });
+        continue;
+      }
+      if (block.type === "buttons" && block.buttons?.length) {
+        rendered.push({
+          type: "actions",
+          elements: block.buttons.map((button) => ({
+            type: "button",
+            text: { type: "plain_text", text: button.label, emoji: true },
+            value: button.value,
+          })),
+        });
+      }
+    }
+    return rendered.length ? rendered : undefined;
+  },
   resolveDeliveredSlackReplyThreadTs: (params: {
     replyToMode: "off" | "first" | "all" | "batched";
     payloadReplyToId?: string;
@@ -400,6 +445,61 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
         channelId: "C123",
         messageId: "171234.567",
         text: "✅",
+      }),
+    );
+    expect(deliverRepliesMock).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("includes presentation button blocks when finalizing draft preview edits", async () => {
+    const draftStream = {
+      ...createDraftStreamStub(),
+      flush: vi.fn(noopAsync),
+      clear: vi.fn(noopAsync),
+      discardPending: vi.fn(noopAsync),
+      seal: vi.fn(noopAsync),
+    };
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: {
+          text: "Choose an action",
+          presentation: {
+            blocks: [
+              { type: "text", text: "Choose an action" },
+              {
+                type: "buttons",
+                buttons: [{ label: "Retry", value: "retry" }],
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Choose an action",
+        blocks: [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: "Choose an action" },
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "Retry", emoji: true },
+                value: "retry",
+              },
+            ],
+          },
+        ],
       }),
     );
     expect(deliverRepliesMock).not.toHaveBeenCalled();

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -1,16 +1,23 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
-import { buildSlackInteractiveBlocks, type SlackBlock } from "./blocks-render.js";
+import {
+  buildSlackInteractiveBlocks,
+  buildSlackPresentationBlocks,
+  type SlackBlock,
+} from "./blocks-render.js";
 
 export function resolveSlackReplyBlocks(payload: ReplyPayload): SlackBlock[] | undefined {
-  const slackData = payload.channelData?.slack;
+  const slackData = payload.channelData?.slack as
+    | { blocks?: unknown; presentationBlocks?: SlackBlock[] }
+    | undefined;
+  const presentationBlocks =
+    slackData?.presentationBlocks ?? buildSlackPresentationBlocks(payload.presentation);
   const interactiveBlocks = buildSlackInteractiveBlocks(payload.interactive);
   let channelBlocks: SlackBlock[] = [];
   if (slackData && typeof slackData === "object" && !Array.isArray(slackData)) {
-    channelBlocks =
-      (parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks) as SlackBlock[]) ?? [];
+    channelBlocks = (parseSlackBlocksInput(slackData.blocks) as SlackBlock[]) ?? [];
   }
-  const blocks = [...channelBlocks, ...interactiveBlocks];
+  const blocks = [...channelBlocks, ...presentationBlocks, ...interactiveBlocks];
   if (blocks.length > SLACK_MAX_BLOCKS) {
     throw new Error(
       `Slack blocks cannot exceed ${SLACK_MAX_BLOCKS} items after interactive render`,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -744,6 +744,21 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
   });
 
+  it("includes inline button style guidance for Slack interactive replies", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "slack",
+        capabilities: ["interactiveReplies"],
+      },
+    });
+
+    expect(prompt).toContain("buttons=[[{text,callback_data,style?}]]");
+    expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
+    expect(prompt).not.toContain("Inline buttons not enabled for slack");
+  });
+
   it("suppresses plain chat approval commands when inline approval UI is available", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -52,6 +52,7 @@ const CONTEXT_FILE_ORDER = new Map<string, number>([
 ]);
 
 const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set(["heartbeat.md"]);
+const INLINE_BUTTON_CAPABILITY_IDS = new Set(["inlinebuttons", "interactivereplies"]);
 const DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK =
   "Default heartbeat prompt:\n`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`";
 function normalizeContextFilePath(pathValue: string): string {
@@ -651,7 +652,9 @@ export function buildAgentSystemPrompt(params: {
   const runtimeCapabilitiesLower = new Set(
     runtimeCapabilities.map((cap) => normalizeLowercaseStringOrEmpty(cap)).filter(Boolean),
   );
-  const inlineButtonsEnabled = runtimeCapabilitiesLower.has("inlinebuttons");
+  const inlineButtonsEnabled = [...runtimeCapabilitiesLower].some((capability) =>
+    INLINE_BUTTON_CAPABILITY_IDS.has(capability),
+  );
   const messageChannelOptions = listDeliverableMessageChannels().join("|");
   const promptMode = params.promptMode ?? "full";
   const isMinimal = promptMode === "minimal" || promptMode === "none";


### PR DESCRIPTION
## Summary
- Fix Slack interactive reply/button final delivery so the final update preserves rendered Block Kit blocks instead of sending text-only output.
- Keep the fix on the current presentation/message-tool contract rather than reintroducing generic inlineButtons capability injection.
- Add focused regression coverage for the streaming final-edit Slack path.

## Credit
- Builds on #46647 by @jeremykoerber.
- Preserves credit for @EfeDurmaz16's #47362 and @xinbenlv's #56955 for the original Slack inline-button reports, while replacing their obsolete implementation direction.

## Validation
- `pnpm check:changed`

ProjectClownfish replacement details:
- Cluster: ghcrawl-156586-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/47362, https://github.com/openclaw/openclaw/pull/56955
- Credit: Credit @jeremykoerber for #46647's final-edit root-cause report.; Credit @EfeDurmaz16 and https://github.com/openclaw/openclaw/pull/47362 for identifying the Slack interactiveReplies prompt mismatch.; Credit @xinbenlv and https://github.com/openclaw/openclaw/pull/56955 for the default Slack buttons motivation, while noting the replacement avoids unconditional inlineButtons injection.
- Validation: pnpm check:changed
