### PR TITLE
fix(fs-safe): fallback when pinned write helper cannot spawn

### DIFF
--- a/src/infra/fs-pinned-write-helper.spawn-fallback.test.ts
+++ b/src/infra/fs-pinned-write-helper.spawn-fallback.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Readable, PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: PassThrough;
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stdin = new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = vi.fn();
+
+    setImmediate(() => {
+      const error = new Error("spawn python3 ENOENT") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      error.syscall = "spawn python3";
+      error.path = "python3";
+      child.emit("error", error);
+      child.emit("close", -2, null);
+    });
+
+    return child;
+  }),
+}));
+
+const { runPinnedWriteHelper } = await import("./fs-pinned-write-helper.js");
+
+const tempDirs = createTrackedTempDirs();
+
+afterEach(async () => {
+  await tempDirs.cleanup();
+});
+
+describe.runIf(process.platform !== "win32")("fs pinned write helper spawn fallback", () => {
+  it("falls back to the local writer when python3 cannot spawn", async () => {
+    const root = await tempDirs.make("openclaw-fs-pinned-root-");
+
+    const identity = await runPinnedWriteHelper({
+      rootPath: root,
+      relativeParentPath: "nested/deeper",
+      basename: "note.txt",
+      mkdir: true,
+      mode: 0o600,
+      input: {
+        kind: "buffer",
+        data: "hello",
+      },
+    });
+
+    await expect(
+      fs.readFile(path.join(root, "nested", "deeper", "note.txt"), "utf8"),
+    ).resolves.toBe("hello");
+    expect(identity.dev).toBeGreaterThanOrEqual(0);
+    expect(identity.ino).toBeGreaterThan(0);
+  });
+
+  it("does not consume streams before falling back after a python3 spawn failure", async () => {
+    const root = await tempDirs.make("openclaw-fs-pinned-root-");
+
+    await runPinnedWriteHelper({
+      rootPath: root,
+      relativeParentPath: "",
+      basename: "stream.txt",
+      mkdir: true,
+      mode: 0o600,
+      input: {
+        kind: "stream",
+        stream: Readable.from(["streamed"]),
+      },
+    });
+
+    await expect(fs.readFile(path.join(root, "stream.txt"), "utf8")).resolves.toBe("streamed");
+  });
+});

--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { once } from "node:events";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -133,6 +132,19 @@ function resolvePinnedWritePython(): string {
   return cachedPinnedWritePython;
 }
 
+export function isPinnedWriteHelperSpawnError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const maybeErrno = error as NodeJS.ErrnoException;
+  if (typeof maybeErrno.syscall !== "string" || !maybeErrno.syscall.startsWith("spawn")) {
+    return false;
+  }
+
+  return ["EACCES", "ENOENT", "ENOEXEC"].includes(maybeErrno.code ?? "");
+}
+
 function parsePinnedIdentity(stdout: string): FileIdentityStat {
   const line = stdout
     .trim()
@@ -186,9 +198,24 @@ export async function runPinnedWriteHelper(params: {
     stderr += chunk;
   });
 
-  const exitPromise = once(child, "close") as Promise<[number | null, NodeJS.Signals | null]>;
+  let spawnError: unknown;
+  child.once("error", (error) => {
+    spawnError = error;
+  });
+  const exitPromise = new Promise<[number | null, NodeJS.Signals | null]>((resolve) => {
+    child.once("close", (code, signal) => resolve([code, signal]));
+  });
   try {
     if (!child.stdin) {
+      const identity = await runPinnedWriteFallback(params);
+      await exitPromise.catch(() => {});
+      return identity;
+    }
+
+    // spawn(2) failures such as missing python3 are reported asynchronously. Give
+    // Node one turn to surface them before consuming streams into the child stdin.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (isPinnedWriteHelperSpawnError(spawnError)) {
       const identity = await runPinnedWriteFallback(params);
       await exitPromise.catch(() => {});
       return identity;
@@ -209,6 +236,9 @@ export async function runPinnedWriteHelper(params: {
     }
 
     const [code, signal] = await exitPromise;
+    if (isPinnedWriteHelperSpawnError(spawnError)) {
+      return await runPinnedWriteFallback(params);
+    }
     if (code !== 0) {
       throw new Error(
         stderr.trim() ||


### PR DESCRIPTION
## Summary

Fixes #72362 by making pinned writes continue to work when `python3` is missing from `PATH` in slim Docker images.

Instead of surfacing the misleading generic safe-open error, `runPinnedWriteHelper()` now detects spawn failures for the Python helper (`ENOENT`, `EACCES`, `ENOEXEC`) and falls back to the existing local writer before any input stream is consumed.

## Why this approach

There is already a narrower PR (#72531) that improves the error message. This PR fixes the underlying Docker behavior for write paths: agents using `tools.fs.workspaceOnly: true` can still write/edit/apply patches even when the image does not include Python.

The fallback is intentionally limited to helper spawn failures. If Python starts and reports a real path/symlink/boundary error, that error still flows through the existing pinned-helper path.

## Testing

- `pnpm exec vitest run src/infra/fs-pinned-write-helper.test.ts src/infra/fs-pinned-write-helper.spawn-fallback.test.ts src/infra/fs-safe.test.ts`
- `pnpm exec oxfmt --check src/infra/fs-pinned-write-helper.ts src/infra/fs-pinned-write-helper.spawn-fallback.test.ts`

Also attempted full typecheck:

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit`

That fails on existing unrelated test typing errors in:

- `src/agents/pi-embedded-runner.sanitize-session-history.test.ts(986,13)`
- `src/agents/pi-embedded-runner/run/attempt.test.ts(91,20)`

