### PR TITLE
docs: clarify daemon vs foreground quick start and Node service runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,17 @@ Runtime: **Node 24 (recommended) or Node 22.14+**.
 
 Full beginner guide (auth, pairing, channels): [Getting started](https://docs.openclaw.ai/start/getting-started)
 
+### Recommended: daemon mode
+
 ```bash
 openclaw onboard --install-daemon
+openclaw gateway status
+```
 
+### Foreground/debug mode
+
+```bash
+openclaw gateway stop
 openclaw gateway --port 18789 --verbose
 
 # Send a message
@@ -177,7 +185,7 @@ Run `openclaw doctor` to surface risky/misconfigured DM policies.
 - Remote + web: [Gateway](https://docs.openclaw.ai/gateway), [Remote access](https://docs.openclaw.ai/gateway/remote), [Tailscale](https://docs.openclaw.ai/gateway/tailscale), [Web surfaces](https://docs.openclaw.ai/web)
 - Tools + automation: [Tools](https://docs.openclaw.ai/tools), [Skills](https://docs.openclaw.ai/tools/skills), [Cron jobs](https://docs.openclaw.ai/automation/cron-jobs), [Webhooks](https://docs.openclaw.ai/automation/webhook), [Gmail Pub/Sub](https://docs.openclaw.ai/automation/gmail-pubsub)
 - Internals: [Architecture](https://docs.openclaw.ai/concepts/architecture), [Agent](https://docs.openclaw.ai/concepts/agent), [Session model](https://docs.openclaw.ai/concepts/session), [Gateway protocol](https://docs.openclaw.ai/reference/rpc)
-- Troubleshooting: [Channel troubleshooting](https://docs.openclaw.ai/channels/troubleshooting), [Logging](https://docs.openclaw.ai/logging), [Docs home](https://docs.openclaw.ai)
+- Troubleshooting: [Channel troubleshooting](https://docs.openclaw.ai/channels/troubleshooting), [Gateway logging](https://docs.openclaw.ai/gateway/logging), [Docs home](https://docs.openclaw.ai)
 
 ## Apps (optional)
 

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -86,6 +86,34 @@ fnm use 24
 
 ## Troubleshooting
 
+### Shell Node vs service Node mismatch
+
+If you use `nvm`/`fnm`/`mise`/`asdf`, your interactive shell may use a different Node binary than the daemon/service (launchd/systemd/Task Scheduler). Verify both paths when debugging startup/runtime issues.
+
+```bash
+node -v
+npm -v
+which node
+which openclaw
+openclaw gateway status
+```
+
+For service-managed installs, also inspect the service definition/runtime path:
+
+```bash
+# Linux (systemd user service)
+systemctl --user cat openclaw-gateway.service
+
+# macOS (LaunchAgent)
+launchctl print "gui/$(id -u)/ai.openclaw.gateway" | grep -E "program|program arguments" -i
+```
+
+After Node upgrades or switching Node managers, restart the gateway service so it picks up the intended runtime:
+
+```bash
+openclaw gateway restart
+```
+
 ### `openclaw: command not found`
 
 This almost always means npm's global bin directory isn't on your PATH.


### PR DESCRIPTION
## Summary\n- split README quick start into explicit daemon and foreground/debug paths\n- add Service: LaunchAgent (loaded)
File logs: /tmp/openclaw/openclaw-2026-04-27.log
Command: /Users/sunny/.nvm/versions/node/v22.22.0/bin/node /Users/sunny/.nvm/versions/node/v22.22.0/lib/node_modules/openclaw/dist/index.js gateway --port 18789
Service file: ~/Library/LaunchAgents/ai.openclaw.gateway.plist
Service env: OPENCLAW_GATEWAY_PORT=18789

Config (cli): ~/.openclaw/openclaw.json
Config (service): ~/.openclaw/openclaw.json

Gateway: bind=loopback (127.0.0.1), port=18789 (service args)
Probe target: ws://127.0.0.1:18789
Dashboard: http://127.0.0.1:18789/
Probe note: Loopback-only gateway; only local clients can connect.

Runtime: running (pid 36042, state active)
Connectivity probe: ok
Capability: admin-capable

Listening: 127.0.0.1:18789
Troubles: run openclaw status
Troubleshooting: https://docs.openclaw.ai/troubleshooting to the daemon path\n- add │
◇  Config warnings ──────────────────────────────────────────────────────╮
│                                                                        │
│  - plugins.entries.runway: plugin runway: providerAuthEnvVars is       │
│    deprecated compatibility metadata for provider env-var lookup;      │
│    mirror runway env vars to setup.providers[].envVars before the      │
│    deprecation window closes                                           │
│  - plugins.entries.openclaw-weixin: plugin openclaw-weixin: channel    │
│    plugin manifest declares openclaw-weixin without channelConfigs     │
│    metadata; add openclaw.plugin.json#channelConfigs so config schema  │
│    and setup surfaces work before runtime loads                        │
│                                                                        │
├────────────────────────────────────────────────────────────────────────╯
Warning: launchctl stop did not fully stop the service; used bootout fallback and left service unloaded
Stopped LaunchAgent (degraded): gui/501/ai.openclaw.gateway before foreground debug run to avoid double-run confusion\n- add a Node troubleshooting section for shell-vs-service runtime mismatch ()\n- update README troubleshooting link to canonical \n\n## Why\nThis addresses confusion where users install the daemon then also run a foreground gateway without realizing the mode difference, and adds concrete checks for Node/runtime path mismatches in service-managed installs.\n\nFixes #72265\n