### PR TITLE
[codex] Keep markdown image badges in Discord replies

### DIFF
--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -319,7 +319,10 @@ export async function deliverAgentCommandResult(params: {
           accountId: resolvedAccountId,
         })
       : normalizedReplyPayloads;
-  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads);
+  const outboundPayloadPlan = createOutboundPayloadPlan(mediaNormalizedReplyPayloads, {
+    cfg,
+    surface: deliveryChannel,
+  });
   const normalizedPayloads = projectOutboundPayloadPlanForJson(outboundPayloadPlan);
   if (opts.json) {
     runtime.log(

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -15,9 +15,15 @@ export type ReplyDirectiveParseResult = {
 
 export function parseReplyDirectives(
   raw: string,
-  options: { currentMessageId?: string; silentToken?: string } = {},
+  options: {
+    currentMessageId?: string;
+    silentToken?: string;
+    extractMarkdownImages?: boolean;
+  } = {},
 ): ReplyDirectiveParseResult {
-  const split = splitMediaFromOutput(raw);
+  const split = splitMediaFromOutput(raw, {
+    extractMarkdownImages: options.extractMarkdownImages,
+  });
   let text = split.text ?? "";
 
   const replyParsed = parseInlineDirectives(text, {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -468,7 +468,10 @@ export const sendHandlers: GatewayRequestHandlers = {
         const deliveryTarget = idLikeTarget?.to ?? resolvedTarget.to;
         const outboundDeps = context.deps ? createOutboundSendDeps(context.deps) : undefined;
         const outboundPayloads = [{ text: message, mediaUrl, mediaUrls }];
-        const outboundPayloadPlan = createOutboundPayloadPlan(outboundPayloads);
+        const outboundPayloadPlan = createOutboundPayloadPlan(outboundPayloads, {
+          cfg,
+          surface: channel,
+        });
         const mirrorProjection = projectOutboundPayloadPlanForMirror(outboundPayloadPlan);
         const mirrorText = mirrorProjection.text;
         const mirrorMediaUrls = mirrorProjection.mediaUrls;

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -237,13 +237,16 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
-  const outboundPlan = createOutboundPayloadPlan([
-    {
-      text: params.content,
-      mediaUrl: params.mediaUrl,
-      mediaUrls: params.mediaUrls,
-    },
-  ]);
+  const outboundPlan = createOutboundPayloadPlan(
+    [
+      {
+        text: params.content,
+        mediaUrl: params.mediaUrl,
+        mediaUrls: params.mediaUrls,
+      },
+    ],
+    { cfg, surface: channel },
+  );
   const normalizedPayloads = projectOutboundPayloadPlanForDelivery(outboundPlan);
   const mirrorProjection = projectOutboundPayloadPlanForMirror(outboundPlan);
   const mirrorText = mirrorProjection.text;

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -54,6 +54,46 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it("keeps markdown images as text for discord outbound replies", () => {
+    const input = "tech: ![Node.js](https://img.shields.io/badge/Node.js-339933)";
+
+    expect(
+      projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([{ text: input }], { surface: "discord" }),
+      ),
+    ).toEqual([
+      {
+        text: input,
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: undefined,
+        replyToTag: false,
+        audioAsVoice: false,
+      },
+    ]);
+  });
+
+  it("continues lifting markdown images for non-discord outbound replies", () => {
+    expect(
+      projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([{ text: "Caption ![chart](https://example.com/chart.png)" }], {
+          surface: "telegram",
+        }),
+      ),
+    ).toEqual([
+      {
+        text: "Caption",
+        mediaUrls: ["https://example.com/chart.png"],
+        mediaUrl: "https://example.com/chart.png",
+        replyToId: undefined,
+        replyToCurrent: undefined,
+        replyToTag: false,
+        audioAsVoice: false,
+      },
+    ]);
+  });
+
   it("drops silent payloads without media and suppresses reasoning payloads", () => {
     expect(
       normalizeReplyPayloadsForDelivery([

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -129,13 +129,20 @@ type PreparedOutboundPayloadPlanEntry = {
   isSilent: boolean;
 };
 
+function shouldExtractMarkdownImageMediaForSurface(surface?: string): boolean {
+  return surface?.toLowerCase() !== "discord";
+}
+
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
+  context: OutboundPayloadPlanContext,
 ): PreparedOutboundPayloadPlanEntry | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
-  const parsed = parseReplyDirectives(payload.text ?? "");
+  const parsed = parseReplyDirectives(payload.text ?? "", {
+    extractMarkdownImages: shouldExtractMarkdownImageMediaForSurface(context.surface),
+  });
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
   const mergedMedia = mergeMediaUrls(
@@ -193,7 +200,7 @@ export function createOutboundPayloadPlan(
     context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);
   const prepared: PreparedOutboundPayloadPlanEntry[] = [];
   for (const payload of payloads) {
-    const entry = createOutboundPayloadPlanEntry(payload);
+    const entry = createOutboundPayloadPlanEntry(payload, context);
     if (!entry) {
       continue;
     }

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -140,6 +140,14 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("can leave markdown image urls in text when extraction is disabled", () => {
+    const input = "Look ![chart](https://example.com/chart.png) now";
+
+    expect(splitMediaFromOutput(input, { extractMarkdownImages: false })).toEqual({
+      text: input,
+    });
+  });
+
   it("extracts multiple markdown image urls in order", () => {
     expectParsedMediaOutputCase(
       "Before\n![one](https://example.com/one.png)\nMiddle\n![two](https://example.com/two.png)\nAfter",

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -462,7 +462,14 @@ function isInsideFence(fenceSpans: Array<{ start: number; end: number }>, offset
   return fenceSpans.some((span) => offset >= span.start && offset < span.end);
 }
 
-export function splitMediaFromOutput(raw: string): {
+export type SplitMediaFromOutputOptions = {
+  extractMarkdownImages?: boolean;
+};
+
+export function splitMediaFromOutput(
+  raw: string,
+  options: SplitMediaFromOutputOptions = {},
+): {
   text: string;
   mediaUrls?: string[];
   mediaUrl?: string; // legacy first item for backward compatibility
@@ -476,7 +483,8 @@ export function splitMediaFromOutput(raw: string): {
     return { text: "" };
   }
   const mayContainMediaToken = /media:/i.test(trimmedRaw);
-  const mayContainMarkdownImage = /!\[[^\]]*]\(/.test(trimmedRaw);
+  const shouldExtractMarkdownImages = options.extractMarkdownImages !== false;
+  const mayContainMarkdownImage = shouldExtractMarkdownImages && /!\[[^\]]*]\(/.test(trimmedRaw);
   const mayContainAudioTag = trimmedRaw.includes("[[");
   if (!mayContainMediaToken && !mayContainMarkdownImage && !mayContainAudioTag) {
     return { text: trimmedRaw };
@@ -518,6 +526,12 @@ export function splitMediaFromOutput(raw: string): {
 
     const trimmedStart = line.trimStart();
     if (!trimmedStart.toUpperCase().startsWith("MEDIA:")) {
+      if (!shouldExtractMarkdownImages) {
+        keptLines.push(line);
+        pushTextSegment(line);
+        lineOffset += line.length + 1; // +1 for newline
+        continue;
+      }
       const markdownImageResult = collectMarkdownImageSegments({ line, media });
       if (!markdownImageResult.foundMedia) {
         keptLines.push(line);


### PR DESCRIPTION
## Summary
- add an opt-out for Markdown-image media extraction in the shared media parser
- disable Markdown-image lifting for Discord outbound payload planning while keeping explicit MEDIA/mediaUrls handling intact
- thread outbound surface context through Discord-capable send paths and add regression coverage

Fixes #72642.

## Root Cause
#66471 made `splitMediaFromOutput()` lift Markdown image destinations into outbound media for final replies. That helped Telegram group-media replies, but the shared outbound normalization path also runs for Discord. As a result, incidental Markdown images such as README shields.io badges were promoted into `mediaUrls` and sent as Discord attachments.

## Validation
- `pnpm vitest run src/media/parse.test.ts src/infra/outbound/payloads.test.ts`
- `git diff --check`
- `pnpm check:changed` currently fails before reaching this change because local/core typecheck has existing dependency and typing errors such as missing `typebox` and model compat type mismatches.
