### PR TITLE
fix(gateway): point plugin override error to valid docs page

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -709,7 +709,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }


### PR DESCRIPTION
## Summary
- update plugin fallback override error guidance URL from a dead anchor
- point users to the canonical docs page: https://docs.openclaw.ai/plugins/sdk-runtime
- keep the existing config search hint for plugins.entries.<id>.subagent.allowModelOverride
- update the corresponding test assertion

## Notes
- Resolves broken docs guidance in this runtime error path.

Fixes #65860
