### PR TITLE
fix(cron): preserve Telegram direct-thread cron delivery inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Telegram: preserve direct-chat thread IDs and optional account IDs when inferring reminder delivery from Telegram direct-thread session keys. Fixes #44270; carries forward #44325, #44351, and #44412. Thanks @RunMintOn, @arkyu2077, and @0xsline.
 - Process/Windows: decode command stdout and stderr from raw bytes with console-codepage awareness, while preserving valid UTF-8 output and multibyte characters split across chunks. Fixes #50519. Thanks @iready, @kevinten10, @zhangyongjie1997, @knightplat-blip, @heiqishi666, and @slepybear.
 - macOS Gateway: detect installed-but-unloaded LaunchAgent split-brain states during status, doctor, and restart, and re-bootstrap launchd supervision before falling back to unmanaged listener restarts. Fixes #67335, #53475, and #71060; refs #58890, #60885, and #70801. Thanks @ze1tgeist88, @dafacto, and @vishutdhar.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup, drain update restarts, and materialize plugin-owned root chunks in external mirrors so staged deps resolve under native ESM. Fixes #72058; supersedes #72084. Thanks @amnesia106 and @drvoss.

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -429,6 +429,48 @@ describe("cron tool", () => {
     });
   });
 
+  it("preserves telegram direct-chat thread ids when inferring delivery", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-direct-thread",
+        agentSessionKey: "agent:main:telegram:direct:123456789:thread:123456789:99",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "123456789",
+      threadId: "99",
+    });
+  });
+
+  it("preserves telegram account ids with direct-chat thread inference", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-account-direct-thread",
+        agentSessionKey: "agent:main:telegram:bot-a:direct:123456789:thread:123456789:99",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "123456789",
+      accountId: "bot-a",
+      threadId: "99",
+    });
+  });
+
+  it("drops mismatched telegram direct-chat thread ids when inferring delivery", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-telegram-mismatched-direct-thread",
+        agentSessionKey: "agent:main:telegram:direct:123456789:thread:987654321:99",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "telegram",
+      to: "123456789",
+    });
+  });
+
   it("prefers current delivery context over lowercased session-key targets", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -3,11 +3,15 @@ import { loadConfig } from "../../config/config.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
 import type { CronDelivery, CronMessageChannel } from "../../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../../cron/webhook-url.js";
-import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import {
+  parseAgentSessionKey,
+  parseThreadSessionSuffix,
+} from "../../sessions/session-key-utils.js";
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
+  normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import { isRecord, truncateUtf16Safe } from "../../utils.js";
 import {
@@ -398,11 +402,34 @@ function stripThreadSuffixFromSessionKey(sessionKey: string): string {
   return parent ? parent : sessionKey;
 }
 
+function resolveTelegramDirectThreadId(params: {
+  peerId: string;
+  threadId?: string;
+}): string | undefined {
+  const threadId = normalizeOptionalString(params.threadId);
+  if (!threadId) {
+    return undefined;
+  }
+  const peerId = normalizeOptionalString(params.peerId);
+  if (!peerId) {
+    return undefined;
+  }
+  const [threadChatId, ...threadIdParts] = threadId.split(":");
+  if (threadIdParts.length > 0) {
+    if (threadChatId !== peerId) {
+      return undefined;
+    }
+    return normalizeOptionalString(threadIdParts.join(":"));
+  }
+  return threadId;
+}
+
 function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | null {
   const rawSessionKey = agentSessionKey?.trim();
   if (!rawSessionKey) {
     return null;
   }
+  const threadSuffix = parseThreadSessionSuffix(rawSessionKey);
   const parsed = parseAgentSessionKey(stripThreadSuffixFromSessionKey(rawSessionKey));
   if (!parsed || !parsed.rest) {
     return null;
@@ -444,9 +471,25 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
     channel = normalizeOptionalLowercaseString(parts[0]) as CronMessageChannel | undefined;
   }
 
+  const marker = parts[markerIndex];
   const delivery: CronDelivery = { mode: "announce", to: peerId };
   if (channel) {
     delivery.channel = channel;
+  }
+  if (channel === "telegram" && markerIndex === 2) {
+    const accountId = normalizeOptionalString(parts[1]);
+    if (accountId) {
+      delivery.accountId = accountId;
+    }
+  }
+  if (channel === "telegram" && (marker === "direct" || marker === "dm")) {
+    const threadId = resolveTelegramDirectThreadId({
+      peerId,
+      threadId: threadSuffix.threadId,
+    });
+    if (threadId) {
+      delivery.threadId = threadId;
+    }
   }
   return delivery;
 }


### PR DESCRIPTION
## Summary
- Repair the canonical Telegram direct-thread cron inference fix for #44270 on PR #44412.
- Preserve Telegram direct-chat `:thread:` context when cron delivery is inferred from the session key.
- Add the missing optional accountId session-key regression requested by Greptile.

## Credit
This carries forward and credits the contributor work from #44325 by @RunMintOn, #44351 by @arkyu2077 / Jasmine Zhang, and #44412 by @0xsline.

## Validation
- `pnpm -s vitest run src/agents/tools/cron-tool.test.ts`
- `pnpm check:changed`
- Codex `/review` must pass clean before merge.

## Notes
Related Telegram forum-topic PRs #43808, #49704, #59069, and #64708 remain separate subfamilies and should not be closed until the landed fix path is explicit.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156599-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/44325, https://github.com/openclaw/openclaw/pull/44351, https://github.com/openclaw/openclaw/pull/44412
- Credit: Preserve credit for @RunMintOn and source PR https://github.com/openclaw/openclaw/pull/44325, which identified the direct-chat thread inference fix for #44270.; Preserve credit for @arkyu2077 / Jasmine Zhang and source PR https://github.com/openclaw/openclaw/pull/44351, which supplied the focused direct-thread helper path.; Preserve credit for @0xsline and source PR https://github.com/openclaw/openclaw/pull/44412, which carried the review-requested casing, optional accountId, and thread-chatId hardening.
- Validation: pnpm -s vitest run src/agents/tools/cron-tool.test.ts; pnpm check:changed
- Repair fallback: source PR #44325 is closed
