### PR TITLE
fix(qwen): allow explicit qwen3.6-plus on Coding Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,11 +66,9 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify CJK provider transport, quota, billing, auth, and overload error text so Chinese-language provider failures trigger fallback and user-facing transport copy instead of surfacing as unclassified raw errors. (#56242) Thanks @tomcatzh.
 - Agents/failover: seed non-claude-cli fallback prompts with Claude Code session context when a claude-cli attempt fails, so fallback models do not restart cold after billing or quota failover. (#72069) Thanks @stainlu.
 - Agents/CLI runner: transfer bundle-MCP tempDir cleanup from the per-turn runner finally to the Claude live-session lifecycle, so persistent Claude CLI sessions keep their `--mcp-config` directory until the live subprocess closes. Fixes #73244. Thanks @edwin-rivera-dev.
-
-### Fixes
-
 - Gateway/nodes: allow Windows companion nodes to use safe declared commands such as canvas, camera list, location, device info, and screen snapshot by default while keeping dangerous media commands opt-in. (#71884) Thanks @shanselman.
 - Agents/cron: clarify agent-tool and CLI cron timezone guidance so supplied `tz` values use local wall-clock cron fields and omitted cron `tz` falls back to the Gateway host local timezone. Fixes #53669; carries forward #46177. (#73372) Thanks @chen-zhang-cs-code and @maranello-o.
+- Providers/Qwen: allow explicitly configured `qwen/qwen3.6-plus` to resolve on Qwen Coding Plan endpoints while keeping the built-in catalog from advertising it there. Fixes #63654; carries forward #63987. Thanks @jepson-liu.
 
 ## 2026.4.27
 

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -1,12 +1,28 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
+import { QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./api.js";
 import qwenPlugin from "./index.js";
 
 async function registerQwenProvider() {
+  // The test runtime asserts the plugin registers exactly one provider and returns it.
   return registerSingleProviderPlugin(qwenPlugin);
 }
 
 describe("qwen provider plugin", () => {
+  it("keeps qwen3.6-plus out of Coding Plan normalized catalogs", async () => {
+    const provider = await registerQwenProvider();
+
+    const normalized = provider.normalizeConfig?.({
+      provider: "qwen",
+      providerConfig: {
+        baseUrl: QWEN_BASE_URL,
+        models: [{ id: "qwen3.5-plus" }, { id: QWEN_36_PLUS_MODEL_ID }],
+      },
+    } as never);
+
+    expect(normalized?.models?.map((model) => model.id)).toEqual(["qwen3.5-plus"]);
+  });
+
   it("does not expose runtime model suppression hooks", async () => {
     const provider = await registerQwenProvider();
 

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -109,11 +109,12 @@ export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
 ];
 
 export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
-  if (!baseUrl?.trim()) {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
     return false;
   }
   try {
-    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    const hostname = new URL(trimmed).hostname.toLowerCase().replace(/\.+$/, "");
     return (
       hostname === "coding.dashscope.aliyuncs.com" ||
       hostname === "coding-intl.dashscope.aliyuncs.com"

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -20,9 +20,13 @@ describe("qwen provider catalog", () => {
 
   it("only advertises qwen3.6-plus on Standard endpoints", () => {
     const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
+    const codingTrailingDot = buildQwenProvider({
+      baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
+    });
     const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
 
     expect(coding.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
+    expect(codingTrailingDot.models?.find((model) => model.id === "qwen3.6-plus")).toBeFalsy();
     expect(standard.models?.find((model) => model.id === "qwen3.6-plus")).toBeTruthy();
   });
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -2,28 +2,104 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
-vi.mock("../model-suppression.js", () => ({
-  shouldSuppressBuiltInModel: ({ provider, id }: { provider?: string; id?: string }) =>
-    ((provider === "openai" ||
-      provider === "azure-openai-responses" ||
-      provider === "openai-codex") &&
-      id?.trim().toLowerCase() === "gpt-5.3-codex-spark") ||
-    (provider === "openai-codex" && id?.trim().toLowerCase() === "gpt-5.4-mini"),
-  buildSuppressedBuiltInModelError: ({ provider, id }: { provider?: string; id?: string }) => {
-    if (provider === "openai-codex" && id?.trim().toLowerCase() === "gpt-5.4-mini") {
-      return "Unknown model: openai-codex/gpt-5.4-mini. gpt-5.4-mini is not supported by the OpenAI Codex OAuth route. Use openai/gpt-5.4-mini with an OpenAI API key or openai-codex/gpt-5.5 with Codex OAuth.";
+vi.mock("../model-suppression.js", () => {
+  // Mirrors the canonical manifest-driven suppression in
+  // extensions/qwen/openclaw.plugin.json and src/plugins/manifest-model-suppression.ts.
+  function isQwenCodingPlanBaseUrl(value: string | undefined): boolean {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return false;
     }
-    if (
-      (provider !== "openai" &&
-        provider !== "azure-openai-responses" &&
-        provider !== "openai-codex") ||
-      id?.trim().toLowerCase() !== "gpt-5.3-codex-spark"
-    ) {
+    try {
+      const hostname = new URL(trimmed).hostname.toLowerCase().replace(/\.+$/, "");
+      return (
+        hostname === "coding.dashscope.aliyuncs.com" ||
+        hostname === "coding-intl.dashscope.aliyuncs.com"
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  function resolveConfiguredQwenBaseUrl(config: unknown): string | undefined {
+    const providers = (config as { models?: { providers?: Record<string, { baseUrl?: string }> } })
+      ?.models?.providers;
+    if (!providers) {
       return undefined;
     }
-    return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
-  },
-}));
+    for (const [provider, entry] of Object.entries(providers)) {
+      const normalizedProvider = provider.trim().toLowerCase();
+      if (normalizedProvider !== "qwen" && normalizedProvider !== "modelstudio") {
+        continue;
+      }
+      const baseUrl = entry?.baseUrl?.trim();
+      if (baseUrl) {
+        return baseUrl;
+      }
+    }
+    return undefined;
+  }
+
+  return {
+    shouldSuppressBuiltInModel: ({
+      provider,
+      id,
+      baseUrl,
+      config,
+    }: {
+      provider?: string;
+      id?: string;
+      baseUrl?: string;
+      config?: unknown;
+    }) => {
+      if (
+        (provider === "openai" ||
+          provider === "azure-openai-responses" ||
+          provider === "openai-codex") &&
+        id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
+      ) {
+        return true;
+      }
+      if (provider === "openai-codex" && id?.trim().toLowerCase() === "gpt-5.4-mini") {
+        return true;
+      }
+      return (
+        (provider === "qwen" || provider === "modelstudio") &&
+        id?.trim().toLowerCase() === "qwen3.6-plus" &&
+        isQwenCodingPlanBaseUrl(baseUrl ?? resolveConfiguredQwenBaseUrl(config))
+      );
+    },
+    buildSuppressedBuiltInModelError: ({
+      provider,
+      id,
+      config,
+    }: {
+      provider?: string;
+      id?: string;
+      config?: unknown;
+    }) => {
+      if (
+        (provider === "qwen" || provider === "modelstudio") &&
+        id?.trim().toLowerCase() === "qwen3.6-plus" &&
+        isQwenCodingPlanBaseUrl(resolveConfiguredQwenBaseUrl(config))
+      ) {
+        return "Unknown model: qwen/qwen3.6-plus. qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.";
+      }
+      if (provider === "openai-codex" && id?.trim().toLowerCase() === "gpt-5.4-mini") {
+        return "Unknown model: openai-codex/gpt-5.4-mini. gpt-5.4-mini is not supported by the OpenAI Codex OAuth route. Use openai/gpt-5.4-mini with an OpenAI API key or openai-codex/gpt-5.5 with Codex OAuth.";
+      }
+      if (
+        (provider === "openai" ||
+          provider === "azure-openai-responses" ||
+          provider === "openai-codex") &&
+        id?.trim().toLowerCase() === "gpt-5.3-codex-spark"
+      ) {
+        return `Unknown model: ${provider}/gpt-5.3-codex-spark. gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.`;
+      }
+      return undefined;
+    },
+  };
+});
 
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: vi.fn(() => ({ mocked: true })),
@@ -220,6 +296,63 @@ describe("resolveModel", () => {
       baseUrl: "http://127.0.0.1:3000/v1",
     });
     expect(getModelProviderRequestTransport(result.model ?? {})).toBeUndefined();
+  });
+
+  it("resolves explicitly configured qwen3.6-plus before Coding Plan built-in suppression", () => {
+    const cfg = {
+      models: {
+        providers: {
+          qwen: {
+            baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "qwen3.6-plus",
+                name: "qwen3.6-plus",
+                input: ["text", "image"],
+                reasoning: false,
+                contextWindow: 1_000_000,
+                maxTokens: 65_536,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("qwen", "qwen3.6-plus", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "qwen",
+      id: "qwen3.6-plus",
+      api: "openai-completions",
+      baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+      input: ["text", "image"],
+      contextWindow: 1_000_000,
+      maxTokens: 65_536,
+    });
+  });
+
+  it("keeps unconfigured qwen3.6-plus suppressed on Coding Plan endpoints", () => {
+    const cfg = {
+      models: {
+        providers: {
+          qwen: {
+            baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("qwen", "qwen3.6-plus", "/tmp/agent", cfg);
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe(
+      "Unknown model: qwen/qwen3.6-plus. qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.",
+    );
   });
 
   it("normalizes Google fallback baseUrls for custom providers", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -591,16 +591,6 @@ function resolveExplicitModelWithRegistry(params: {
   const { provider, modelId, modelRegistry, cfg, agentDir, runtimeHooks } = params;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
-  if (
-    shouldSuppressBuiltInModel({
-      provider,
-      id: modelId,
-      baseUrl: providerConfig?.baseUrl,
-      config: cfg,
-    })
-  ) {
-    return { kind: "suppressed" };
-  }
   const inlineMatch = findInlineModelMatch({
     providers: cfg?.models?.providers ?? {},
     provider,
@@ -627,6 +617,16 @@ function resolveExplicitModelWithRegistry(params: {
         runtimeHooks,
       }),
     };
+  }
+  if (
+    shouldSuppressBuiltInModel({
+      provider,
+      id: modelId,
+      baseUrl: providerConfig?.baseUrl,
+      config: cfg,
+    })
+  ) {
+    return { kind: "suppressed" };
   }
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
@@ -1099,6 +1099,7 @@ function buildUnknownModelError(params: {
   const suppressed = buildSuppressedBuiltInModelError({
     provider: params.provider,
     id: params.modelId,
+    config: params.cfg,
   });
   if (suppressed) {
     return suppressed;

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -128,6 +128,14 @@ describe("manifest model suppression", () => {
       resolveManifestBuiltInModelSuppression({
         provider: "qwen",
         id: "qwen3.6-plus",
+        baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
+        env: process.env,
+      })?.suppress,
+    ).toBe(true);
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "qwen",
+        id: "qwen3.6-plus",
         baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         env: process.env,
       }),

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -78,14 +78,19 @@ function buildManifestSuppressionError(params: {
 }
 
 function normalizeBaseUrlHost(baseUrl: string | null | undefined): string {
-  if (!baseUrl?.trim()) {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
     return "";
   }
   try {
-    return new URL(baseUrl).hostname.toLowerCase();
+    return normalizeSuppressionHost(new URL(trimmed).hostname);
   } catch {
     return "";
   }
+}
+
+function normalizeSuppressionHost(host: string): string {
+  return normalizeLowercaseStringOrEmpty(host).replace(/\.+$/, "");
 }
 
 function resolveConfiguredProviderValue(params: {
@@ -133,7 +138,7 @@ function manifestSuppressionMatchesConditions(params: {
     if (!baseUrlHost) {
       return false;
     }
-    const allowedHosts = new Set(when.baseUrlHosts.map(normalizeLowercaseStringOrEmpty));
+    const allowedHosts = new Set(when.baseUrlHosts.map(normalizeSuppressionHost));
     if (!allowedHosts.has(baseUrlHost)) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Repairs #63987 for #63654 by making explicit user-configured `qwen/qwen3.6-plus` resolve on Qwen Coding Plan endpoints.
- Keeps the built-in catalog suppression boundary unless maintainers choose a broader provider-truth change separately.
- Strengthens tests so they assert runtime explicit-model resolution, not just hook removal.

## Credit
This carries forward the focused fix from @jepson-liu in source PR https://github.com/openclaw/openclaw/pull/63987.

## Validation
- `pnpm check:changed`
- `pnpm -s vitest run extensions/qwen/index.test.ts src/agents/pi-embedded-runner/model.test.ts`

## Notes
#66367 is routed to central security handling by this cluster and is not used as an autonomous mutation target.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156617-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/63987
- Credit: Repair contributor PR https://github.com/openclaw/openclaw/pull/63987 by @jepson-liu in place when possible; preserve author credit in the final PR/merge notes.; Do not use quarantined #66367 as a mutation target in ProjectClownfish. Mention it only as routed security context if needed.; Closed PR https://github.com/openclaw/openclaw/pull/70957 by @Sanjays2402 is historical context for catalog filtering only; do not reopen or mutate it.
- Validation: pnpm check:changed; pnpm -s vitest run extensions/qwen/index.test.ts src/agents/pi-embedded-runner/model.test.ts
- Repair fallback: Found 0 warnings and 0 errors.
Finished in 897ms on 4 files using 4 threads.

> openclaw@2026.4.10 check /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> pnpm check:no-conflict-markers && pnpm tool-display:check && pnpm check:host-env-policy:swift && pnpm tsgo && node scripts/prepare-extension-package-boundary-artifacts.mjs && pnpm lint && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope


> openclaw@2026.4.10 check:no-conflict-markers /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node scripts/check-no-conflict-markers.mjs


> openclaw@2026.4.10 tool-display:check /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node --import tsx scripts/tool-display.ts --check

tool-display snapshot is up to date

> openclaw@2026.4.10 check:host-env-policy:swift /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node scripts/generate-host-env-security-policy-swift.mjs --check

OK apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift

> openclaw@2026.4.10 tsgo /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node scripts/run-tsgo.mjs


> openclaw@2026.4.10 lint /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node scripts/run-oxlint.mjs

Found 0 warnings and 0 errors.

> openclaw@2026.4.10 lint:webhook:no-low-level-body-read /tmp/projectclownfish-fix-4065D4/openclaw-openclaw
> node scripts/check-webhook-auth-body-order.mjs

Found forbidden low-level body reads in auth-sensitive webhook handlers:
- extensions/feishu/src/monitor.transport.ts:193
Use plugin-sdk webhook guards (`readJsonWebhookBodyOrReject` / `readWebhookBodyOrReject`) with explicit pre-auth/post-auth profiles.
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
