### PR TITLE
fix(gateway): strip trailing assistant messages before context-engine assembly returns

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -8,6 +8,7 @@ import {
   installContextEngineLoopHook,
   installToolResultContextGuard,
   PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+  stripTrailingAssistantMessages,
 } from "./tool-result-context-guard.js";
 
 function makeUser(text: string): AgentMessage {
@@ -115,6 +116,53 @@ function expectPiStyleTruncation(text: string): void {
 describe("formatContextLimitTruncationNotice", () => {
   it("formats pi-style truncation wording with a count", () => {
     expect(formatContextLimitTruncationNotice(123)).toBe("[... 123 more characters truncated]");
+  });
+});
+
+describe("stripTrailingAssistantMessages", () => {
+  it("returns input reference when last message is not assistant (fast path)", () => {
+    const messages = [makeUser("hi"), makeAssistant("ok"), makeUser("more")];
+    const result = stripTrailingAssistantMessages(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("drops a single trailing assistant message", () => {
+    const u = makeUser("hi");
+    const result = stripTrailingAssistantMessages([u, makeAssistant("ok")]);
+    expect(result).toEqual([u]);
+  });
+
+  it("drops multiple consecutive trailing assistant messages (#72556)", () => {
+    const u = makeUser("hi");
+    const result = stripTrailingAssistantMessages([
+      u,
+      makeAssistant("first"),
+      makeAssistant("second"),
+      makeAssistant("third"),
+    ]);
+    expect(result).toEqual([u]);
+  });
+
+  it("returns empty array when conversation is entirely assistant turns", () => {
+    const result = stripTrailingAssistantMessages([makeAssistant("a"), makeAssistant("b")]);
+    expect(result).toEqual([]);
+  });
+
+  it("preserves earlier assistant turns interleaved with user/tool messages", () => {
+    const messages = [
+      makeUser("q1"),
+      makeAssistant("a1"),
+      makeUser("q2"),
+      makeAssistant("a2"),
+      makeAssistant("a2-prefill"),
+    ];
+    const result = stripTrailingAssistantMessages(messages);
+    expect(result).toEqual(messages.slice(0, 3));
+  });
+
+  it("returns empty input unchanged", () => {
+    const empty: AgentMessage[] = [];
+    expect(stripTrailingAssistantMessages(empty)).toBe(empty);
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -185,6 +185,43 @@ function enforceToolResultLimitInPlace(params: {
 }
 
 /**
+ * Drop trailing assistant-role messages from a transcript view before it
+ * is handed to a provider SDK.
+ *
+ * Anthropic in particular hard-rejects conversations that end on an
+ * assistant turn (`This model does not support assistant message
+ * prefill...`). This can happen via two routes the loop hook below sits
+ * directly between:
+ *
+ * 1. A context engine plugin returning the source array unchanged from
+ *    a short-circuit / bail-out path (so the prior reference-equality
+ *    check in `installContextEngineLoopHook` falsely concluded "no
+ *    transform" and the raw messages — possibly ending on an assistant
+ *    turn — flowed through).
+ * 2. A heartbeat / system-event injection racing with the conversation
+ *    state, leaving the active transcript ending on an assistant turn
+ *    when the loop hook is invoked.
+ *
+ * Stripping is provider-agnostic — other providers may also misbehave
+ * with a trailing assistant turn — so the guard runs unconditionally.
+ *
+ * Returns the input array reference when no trimming is needed (cheap
+ * fast path; preserves identity-equality assumptions downstream).
+ *
+ * Refs #72556.
+ */
+export function stripTrailingAssistantMessages(messages: AgentMessage[]): AgentMessage[] {
+  let lastNonAssistant = messages.length - 1;
+  while (lastNonAssistant >= 0 && messages[lastNonAssistant]?.role === "assistant") {
+    lastNonAssistant -= 1;
+  }
+  if (lastNonAssistant === messages.length - 1) {
+    return messages;
+  }
+  return messages.slice(0, lastNonAssistant + 1);
+}
+
+/**
  * Per-iteration `afterTurn` + `assemble` wrapper for sessions where
  * the context engine owns compaction. Lets the engine compact inside
  * a long tool loop instead of only at end of attempt.
@@ -229,7 +266,7 @@ export function installContextEngineLoopHook(params: {
 
     const hasNewMessages = sourceMessages.length > prePromptMessageCount;
     if (!hasNewMessages) {
-      return lastAssembledView ?? sourceMessages;
+      return stripTrailingAssistantMessages(lastAssembledView ?? sourceMessages);
     }
 
     try {
@@ -276,7 +313,7 @@ export function installContextEngineLoopHook(params: {
       });
       if (assembled && Array.isArray(assembled.messages) && assembled.messages !== sourceMessages) {
         lastAssembledView = assembled.messages;
-        return assembled.messages;
+        return stripTrailingAssistantMessages(assembled.messages);
       }
       lastAssembledView = null;
     } catch {
@@ -284,7 +321,7 @@ export function installContextEngineLoopHook(params: {
       // messages so the tool loop still makes forward progress.
     }
 
-    return sourceMessages;
+    return stripTrailingAssistantMessages(sourceMessages);
   }) as GuardableTransformContext;
 
   return () => {


### PR DESCRIPTION
Fixes #72556.

## Problem

\`installContextEngineLoopHook\` (the per-iteration \`afterTurn\` + \`assemble\` wrapper for sessions where the context engine owns compaction) returns whatever the engine's \`assemble\` produced, falling back to the raw source messages on three paths: short-circuit (\`hasNewMessages === false\`), engine-failure (caught and swallowed), and assemble-returned-same-reference. **None of those paths previously guarded against the transcript ending on an assistant turn.**

When that view reaches the Anthropic SDK, the API hard-rejects with:

\`\`\`
This model does not support assistant message prefill. The conversation must end with a user message.
\`\`\`

The same defect breaks heartbeat injections, system-event bridge calls, and any session whose last persisted turn happens to be assistant. The reference-equality check (\`assembled.messages !== sourceMessages\`) the existing code uses to detect "no transform" has the additional sharp edge that plugins which short-circuit by returning the source array unchanged are silently treated as no-op — passing the raw, possibly-assistant-ending transcript straight through.

## Fix

Add a small provider-agnostic helper \`stripTrailingAssistantMessages\` and apply it on all three return paths of the loop hook:

\`\`\`ts
export function stripTrailingAssistantMessages(messages: AgentMessage[]): AgentMessage[] {
  let lastNonAssistant = messages.length - 1;
  while (lastNonAssistant >= 0 && messages[lastNonAssistant]?.role === \"assistant\") {
    lastNonAssistant -= 1;
  }
  if (lastNonAssistant === messages.length - 1) {
    return messages;
  }
  return messages.slice(0, lastNonAssistant + 1);
}
\`\`\`

The helper preserves reference-equality on the no-trim fast path so downstream identity assumptions (\`assembled.messages !== sourceMessages\`) keep working unchanged. Stripping is provider-agnostic — Anthropic is the loudest case but other providers may also misbehave.

Scope is intentionally narrow: only the context-engine loop hook is touched. \`installToolResultContextGuard\` is left alone (its outputs always end on the inbound message which is whatever the agent loop just appended, not a separately-assembled view).

## Tests

6 new unit tests for the helper:
- Fast path returns input reference when last is non-assistant
- Single trailing assistant dropped
- Multiple consecutive trailing assistants dropped (matches the #72556 \"raw assistant prefill\" reproducer)
- All-assistant input → empty array
- Interleaved (preserves middle assistants, drops only trailing run)
- Empty input returned unchanged

All 29 pre-existing tests in the file continue to pass (35/35 total). \`pnpm tsgo:test\` clean.

## Diff

+89 / -3 across 1 production file + 1 test file + CHANGELOG (92 lines).