### PR TITLE
[codex] stabilize agentic agents CI shard

### DIFF
--- a/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
+++ b/src/agents/pi-embedded-runner/run.empty-error-retry.test.ts
@@ -131,6 +131,7 @@ describe("runEmbeddedPiAgent silent-error retry", () => {
       provider: "ollama",
       model: "glm-5.1:cloud",
       runId: "run-empty-error-retry-skip-clean-stop",
+      allowEmptyAssistantReplyAsSilent: true,
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -51,15 +51,6 @@ export function makeAttemptResult(
     toolMetas,
     lastAssistant: undefined,
     messagesSnapshot: [],
-    replayMetadata:
-      overrides.replayMetadata ??
-      buildAttemptReplayMetadata({
-        toolMetas,
-        didSendViaMessagingTool,
-        messagingToolSentTexts,
-        messagingToolSentMediaUrls,
-        successfulCronAdds,
-      }),
     itemLifecycle: {
       startedCount: 0,
       completedCount: 0,
@@ -71,6 +62,15 @@ export function makeAttemptResult(
     messagingToolSentTargets: [],
     cloudCodeAssistFormatError: false,
     ...overrides,
+    replayMetadata:
+      overrides.replayMetadata ??
+      buildAttemptReplayMetadata({
+        toolMetas,
+        didSendViaMessagingTool,
+        messagingToolSentTexts,
+        messagingToolSentMediaUrls,
+        successfulCronAdds,
+      }),
   };
 }
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -855,7 +855,7 @@ export async function runEmbeddedPiAgent(
             },
           });
 
-          const attempt = await runEmbeddedAttemptWithBackend({
+          const rawAttempt = await runEmbeddedAttemptWithBackend({
             sessionId: activeSessionId,
             sessionKey: resolvedSessionKey,
             sandboxSessionKey: params.sandboxSessionKey,
@@ -960,6 +960,25 @@ export async function runEmbeddedPiAgent(
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
           });
+          const attempt = {
+            ...rawAttempt,
+            assistantTexts: rawAttempt.assistantTexts ?? [],
+            toolMetas: rawAttempt.toolMetas ?? [],
+            messagesSnapshot: rawAttempt.messagesSnapshot ?? [],
+            messagingToolSentTexts: rawAttempt.messagingToolSentTexts ?? [],
+            messagingToolSentMediaUrls: rawAttempt.messagingToolSentMediaUrls ?? [],
+            messagingToolSentTargets: rawAttempt.messagingToolSentTargets ?? [],
+            itemLifecycle: rawAttempt.itemLifecycle ?? {
+              startedCount: 0,
+              completedCount: 0,
+              activeCount: 0,
+            },
+            // Malformed or legacy harness results must not be considered safe to replay.
+            replayMetadata: rawAttempt.replayMetadata ?? {
+              hadPotentialSideEffects: true,
+              replaySafe: false,
+            },
+          };
 
           const {
             aborted,


### PR DESCRIPTION
## Summary
- Normalize agent harness attempt results before the run loop reads replay/liveness fields.
- Preserve replay metadata defaults in the shared overflow-compaction test fixture.
- Mark the clean empty-stop retry regression case as an explicitly allowed silent reply.

## Root Cause
The `checks-node-agentic-agents` shard could crash when a mocked or legacy harness result omitted fields that the PI run loop treats as required, especially `replayMetadata`. Missing replay metadata should fail closed as replay-unsafe rather than throwing or allowing duplicate-action retries.

## Validation
- `pnpm test src/cli/command-registration-policy.test.ts src/cli/program/root-help.test.ts -- --reporter=verbose`
- `pnpm check:architecture`
- `pnpm check:docs`
- `pnpm test src/agents/pi-embedded-runner/run.empty-error-retry.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -- --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-agents OPENCLAW_TEST_PROJECTS_PARALLEL=2 pnpm exec node scripts/test-projects.mjs test/vitest/vitest.agents.config.ts -- --reporter=dot`
- `pnpm check:changed`
- `git diff --check origin/main...HEAD`