### PR TITLE
fix(webchat): hide startup trigger transcript prompt

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agents/pi-embedded-runner/runs.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { createReplyOperation } from "./reply-run-registry.js";
+import { BARE_SESSION_RESET_PROMPT } from "./session-reset-prompt.js";
 
 vi.mock("../../agents/auth-profiles/session-override.js", () => ({
   resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
@@ -1017,6 +1018,75 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
   });
+
+  it("keeps bare session reset startup prompts out of visible transcript prompt", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "/new",
+          RawBody: "/new",
+          CommandBody: "/new",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "/new",
+          BodyStripped: "/new",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        command: {
+          ...(baseParams().command as unknown as Record<string, unknown>),
+          rawBodyNormalized: "/new",
+          commandBodyNormalized: "/new",
+        } as never,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.commandBody).toContain(BARE_SESSION_RESET_PROMPT);
+    expect(call?.followupRun.prompt).toContain(BARE_SESSION_RESET_PROMPT);
+    expect(call?.transcriptCommandBody).toBe("");
+    expect(call?.followupRun.transcriptPrompt).toBe("");
+  });
+
+  it("keeps reset user notes visible while hiding startup instructions", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "/reset keep this note",
+          RawBody: "/reset keep this note",
+          CommandBody: "/reset keep this note",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "/reset keep this note",
+          BodyStripped: "/reset keep this note",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        command: {
+          ...(baseParams().command as unknown as Record<string, unknown>),
+          rawBodyNormalized: "/reset keep this note",
+          commandBodyNormalized: "/reset keep this note",
+          softResetTriggered: true,
+          softResetTail: "keep this note",
+        } as never,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.commandBody).toContain(BARE_SESSION_RESET_PROMPT);
+    expect(call?.commandBody).toContain("User note for this reset turn");
+    expect(call?.transcriptCommandBody).toBe("keep this note");
+    expect(call?.followupRun.transcriptPrompt).toBe("keep this note");
+  });
+
   it("uses inbound origin channel for run messageProvider", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -501,9 +501,11 @@ export async function runPreparedReply(
     : [inboundUserContext, "[User sent media without caption]"].filter(Boolean).join("\n\n");
   const transcriptBodyBase = isHeartbeat
     ? HEARTBEAT_TRANSCRIPT_PROMPT
-    : hasUserBody
-      ? baseBodyFinal
-      : "[User sent media without caption]";
+    : isBareSessionReset
+      ? softResetTail
+      : hasUserBody
+        ? baseBodyFinal
+        : "[User sent media without caption]";
   let prefixedBodyBase = await applySessionHints({
     baseBody: effectiveBaseBody,
     abortedLastRun,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -471,6 +471,18 @@ describe("projectRecentChatDisplayMessages", () => {
 
     expect(result).toEqual([{ role: "assistant", content: "older answer", timestamp: 2 }]);
   });
+
+  it("drops empty user transcript placeholders before applying history limits", () => {
+    const result = projectRecentChatDisplayMessages(
+      [
+        { role: "user", content: [{ type: "text", text: "   " }], timestamp: 1 },
+        { role: "assistant", content: "Startup complete.", timestamp: 2 },
+      ],
+      { maxMessages: 1 },
+    );
+
+    expect(result).toEqual([{ role: "assistant", content: "Startup complete.", timestamp: 2 }]);
+  });
 });
 
 describe("resolveEffectiveChatHistoryMaxChars", () => {

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -47,6 +47,26 @@ describe("buildChatItems", () => {
     expect(groups.map((group) => group.senderLabel)).toEqual(["Iris", "Joaquin De Rojas"]);
   });
 
+  it("drops empty user transcript placeholders before grouping", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "   " }],
+          timestamp: 999,
+        },
+        {
+          role: "assistant",
+          content: "Ready.",
+          timestamp: 1000,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.role).toBe("assistant");
+  });
+
   it("attaches lifted canvas previews to the nearest assistant turn", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -148,6 +148,14 @@ function findNearestAssistantMessageIndex(
   return assistantEntries[assistantEntries.length - 1]?.index ?? null;
 }
 
+function isEmptyUserTextMessage(message: unknown): boolean {
+  const normalized = normalizeMessage(message);
+  if (normalized.role.toLowerCase() !== "user") {
+    return false;
+  }
+  return normalized.content.every((item) => item.type === "text" && !item.text?.trim());
+}
+
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -230,6 +238,10 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
 
     if (!props.showToolCalls && normalized.role.toLowerCase() === "toolresult") {
+      continue;
+    }
+
+    if (isEmptyUserTextMessage(msg)) {
       continue;
     }
 


### PR DESCRIPTION
## Problem

Bare `/new` and `/reset` turns in WebChat need to run the Session Startup sequence, but the internal startup instruction was also persisted as the visible transcript prompt. `chat.history` then projected it like a normal user message, so the Control UI showed the startup trigger text in the conversation.

## Root cause

`runPreparedReply` used `bareResetPromptState.prompt` for both the runtime prompt and `transcriptBodyBase`. The embedded runner already supports a split where an empty `transcriptPrompt` moves runtime-only context into system context, but the bare reset path never used that split.

## Complete fix boundary

- Keep the startup prompt in the runtime prompt sent to the agent.
- Use an empty visible transcript prompt for bare `/new` and `/reset` startup-only turns.
- Preserve the user-authored soft reset tail as the visible transcript prompt when `/reset` includes a note.
- Keep downstream display filtering aligned by ensuring WebChat item building drops empty user transcript placeholders, matching the existing gateway `chat.history` and Control UI controller behavior.

## What intentionally did not change

- Did not change the startup prompt text or `startupContext` behavior.
- Did not add a new config option or new transcript marker shape.
- Did not change heartbeat transcript prompts or media-only transcript prompts.
- Did not change `runtime-context-prompt.ts`; its existing runtime-only behavior is the mechanism this path now uses.

## Tests run

- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts src/gateway/server-methods/server-methods.test.ts`
- `pnpm --dir ui test src/ui/chat/build-chat-items.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply-run.media-only.test.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts src/gateway/server-methods/server-methods.test.ts`
- `git diff --check`
- `pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/gateway/server-methods/server-methods.test.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts`
- `pnpm check:changed --base upstream/main`

Note: `pnpm lint:core` is blocked in this Windows worktree before linting by the repo script invoking a `C:\Program Files` Node path through shell parsing (`'C:\Program' is not recognized...`). Touched-file `oxlint` passed cleanly.

## CI status note

GitHub CI is currently red on `checks-node-core-fast-support`, with `checks-node-core-support-boundary` and `checks-node-core` failing as downstream aggregate jobs. I inspected the failed job logs; the root failure is in `test/vitest-projects-config.test.ts`, where the root `ui` lane and `unit-ui` shard assertions expect `config.test.isolate` to be `true` but receive `false`. This PR does not modify Vitest config, test project definitions, or those assertions, and the touched auto-reply/gateway/UI tests passed, so the red CI is unrelated to this diff.

## Linked issue

Fixes #72369
