### PR TITLE
fix(feishu): exclude @all from bot mention detection

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -249,9 +249,9 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
+  // @_all (@所有人) is NOT a direct bot mention — only explicit @bot counts.
+  // When requireMention=false the bot sees every message; treating @_all as
+  // a bot mention would force a response to broadcast pings.
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((mention) => mention.id.open_id === botOpenId);

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -190,4 +190,40 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     const ctx = parseFeishuMessageEvent(event, "ou_bot_123");
     expect(ctx.content).toBe("[Forwarded message: sc_abc123]");
   });
+
+  it("returns mentionedBot=false for @_all mention (not a direct bot mention)", () => {
+    const event = makeEvent(
+      "group",
+      [{ key: "@_all", name: "所有人", id: { open_id: "" } }],
+      "@_all hello everyone",
+    );
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false when content contains @_all but no bot mention in mentions array", () => {
+    const event = makeEvent(
+      "group",
+      [
+        { key: "@_all", name: "所有人", id: { open_id: "" } },
+        { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+      ],
+      "@_all @Alice hello",
+    );
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=true when both @_all and explicit bot mention are present", () => {
+    const event = makeEvent(
+      "group",
+      [
+        { key: "@_all", name: "所有人", id: { open_id: "" } },
+        { key: "@_bot_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+      ],
+      "@_all @Bot hello",
+    );
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- Remove the `@_all` substring check in `checkBotMentioned` that incorrectly treated every `@所有人` broadcast ping as a direct bot mention
- Only explicit `@bot` (open_id match in the mentions array) now counts as a direct mention
- Add 3 test cases covering the `@_all` scenarios

When a Feishu group message contains `@_all` (`@所有人`), the previous substring check returned `true` unconditionally, causing the bot to treat every broadcast ping as a direct mention and force a "MUST respond" reply — even when the bot was not specifically @-mentioned.

The mentions-array path already correctly ignores `@all` entries because they have no `open_id` matching the bot.

## Test plan

- [x] `pnpm test extensions/feishu/src/bot.checkBotMentioned.test.ts` — 18/18 pass
- [x] Verify `@_all` in a group no longer triggers bot response when `requireMention=false`
- [x] Verify explicit `@bot` still triggers bot response as before
- [x] Verify `@_all` + explicit `@bot` in same message still triggers bot response

Based on a fix by @zhangtong26@xiaomi.com.

Fixes #37706

🤖 Generated with [Claude Code](https://claude.com/claude-code)