### PR TITLE
fix(image-generation): add configurable timeout with higher default (180s)

### DIFF
--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -122,6 +122,68 @@ describe("image-generation runtime", () => {
     expect(seenTimeoutMs).toBe(180_000);
   });
 
+  it("falls back to DEFAULT_IMAGE_GENERATION_TIMEOUT_MS (180s) when no timeout is configured", async () => {
+    let seenTimeoutMs: number | undefined;
+    mocks.resolveAgentModelPrimaryValue.mockReturnValue("image-plugin/img-v1");
+    mocks.getImageGenerationProvider.mockReturnValue({
+      id: "image-plugin",
+      capabilities: { generate: {}, edit: { enabled: false } },
+      async generateImage(req: { timeoutMs?: number }) {
+        seenTimeoutMs = req.timeoutMs;
+        return {
+          images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          model: "img-v1",
+        };
+      },
+    });
+
+    await generateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: { primary: "image-plugin/img-v1" },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+    });
+
+    expect(seenTimeoutMs).toBe(180_000);
+  });
+
+  it("per-request timeoutMs takes priority over config and default", async () => {
+    let seenTimeoutMs: number | undefined;
+    mocks.resolveAgentModelPrimaryValue.mockReturnValue("image-plugin/img-v1");
+    mocks.getImageGenerationProvider.mockReturnValue({
+      id: "image-plugin",
+      capabilities: { generate: {}, edit: { enabled: false } },
+      async generateImage(req: { timeoutMs?: number }) {
+        seenTimeoutMs = req.timeoutMs;
+        return {
+          images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          model: "img-v1",
+        };
+      },
+    });
+
+    await generateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "image-plugin/img-v1",
+              timeoutMs: 120_000,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "draw a cat",
+      timeoutMs: 30_000,
+    });
+
+    expect(seenTimeoutMs).toBe(30_000);
+  });
+
   it("auto-detects and falls through to another configured image-generation provider by default", async () => {
     mocks.getImageGenerationProvider.mockImplementation((providerId: string) => {
       if (providerId === "openai") {

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -18,6 +18,14 @@ import type { ImageGenerationResult } from "./types.js";
 
 const log = createSubsystemLogger("image-generation");
 
+/**
+ * Default timeout for image generation HTTP requests.
+ * Image generation models (e.g. gpt-image-2) can take 60-90s for complex prompts,
+ * which exceeds the global DEFAULT_GUARDED_HTTP_TIMEOUT_MS (60s).
+ * Using a higher default avoids premature AbortController timeouts.
+ */
+const DEFAULT_IMAGE_GENERATION_TIMEOUT_MS = 180_000;
+
 export type { GenerateImageParams, GenerateImageRuntimeResult } from "./runtime-types.js";
 
 function buildNoImageGenerationModelConfiguredMessage(cfg: OpenClawConfig): string {
@@ -35,9 +43,11 @@ export function listRuntimeImageGenerationProviders(params?: { config?: OpenClaw
 export async function generateImage(
   params: GenerateImageParams,
 ): Promise<GenerateImageRuntimeResult> {
-  const timeoutMs =
+  // Priority: per-request tool param > config-level timeoutMs > built-in default (180s)
+  const effectiveTimeoutMs =
     params.timeoutMs ??
-    resolveAgentModelTimeoutMsValue(params.cfg.agents?.defaults?.imageGenerationModel);
+    resolveAgentModelTimeoutMsValue(params.cfg.agents?.defaults?.imageGenerationModel) ??
+    DEFAULT_IMAGE_GENERATION_TIMEOUT_MS;
   const candidates = resolveCapabilityModelCandidates({
     cfg: params.cfg,
     modelConfig: params.cfg.agents?.defaults?.imageGenerationModel,
@@ -95,7 +105,7 @@ export async function generateImage(
         outputFormat: sanitized.outputFormat,
         background: sanitized.background,
         inputImages: params.inputImages,
-        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        timeoutMs: effectiveTimeoutMs,
         providerOptions: params.providerOptions,
       });
       if (!Array.isArray(result.images) || result.images.length === 0) {


### PR DESCRIPTION
## Problem

Image generation models like `gpt-image-2` routinely take 60–90s for complex prompts. When neither the tool call nor config provides a `timeoutMs`, the request falls through to `DEFAULT_GUARDED_HTTP_TIMEOUT_MS` (60s), causing the `AbortController` to fire and the generation to fail with *"This operation was aborted"*.

Simple prompts complete in ~25s and succeed, but moderately detailed prompts consistently time out.

## Fix

Add `DEFAULT_IMAGE_GENERATION_TIMEOUT_MS = 180_000` (3 minutes) as a capability-specific default fallback, consistent with `DEFAULT_VIDEO_GENERATION_TIMEOUT_MS = 120_000`.

### Timeout resolution priority
1. Per-request `timeoutMs` from tool call (LLM-provided)
2. Config-level `imageGenerationModel.timeoutMs` (already supported on main)
3. **`DEFAULT_IMAGE_GENERATION_TIMEOUT_MS` (180s)** ← new fallback

Previously step 3 fell through to the global 60s default, which is too short for image generation.

## Changes (2 files, +75 -3)
| File | Change |
|------|--------|
| `src/image-generation/runtime.ts` | Add `DEFAULT_IMAGE_GENERATION_TIMEOUT_MS`, always pass effective timeout to provider |
| `src/image-generation/runtime.test.ts` | 2 new tests: default 180s fallback, tool param priority over config+default |