### PR TITLE
fix(whatsapp): wire env HTTP proxy through HttpsProxyAgent directly

### DIFF
--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "https-proxy-agent": "^9.0.0",
     "jimp": "^1.6.1",
     "typebox": "1.1.33",
     "undici": "8.1.0"

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import type { Agent } from "node:https";
+import { HttpsProxyAgent } from "https-proxy-agent";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
-import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
+import { resolveEnvHttpProxyUrl } from "openclaw/plugin-sdk/infra-runtime";
 import { danger, success } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger, toPinoLikeLogger } from "openclaw/plugin-sdk/runtime-env";
 import { ensureDir, resolveUserPath } from "openclaw/plugin-sdk/text-runtime";
@@ -210,17 +211,32 @@ export async function createWaSocket(
 async function resolveEnvProxyAgent(
   logger: ReturnType<typeof getChildLogger>,
 ): Promise<Agent | undefined> {
-  return resolveAmbientNodeProxyAgent<Agent>({
-    onError: (err) => {
-      logger.warn(
-        { error: String(err) },
-        "Failed to initialize env proxy agent for WhatsApp WebSocket connection",
-      );
-    },
-    onUsingProxy: () => {
-      logger.info("Using ambient env proxy for WhatsApp WebSocket connection");
-    },
-  });
+  // The WhatsApp WebSocket connects to mmg.whatsapp.net via wss://; the
+  // upgrade handshake is HTTPS, so prefer the HTTPS proxy URL and fall back
+  // to HTTP_PROXY (matching undici EnvHttpProxyAgent semantics).
+  //
+  // Earlier versions wired this through `resolveAmbientNodeProxyAgent`, which
+  // dynamically imports the `proxy-agent` meta-package. That package is not a
+  // declared dependency of the whatsapp extension, so the dynamic import
+  // silently failed in bundled installs (the warn path was easy to miss) and
+  // the WebSocket fell back to a direct connection — observed as a 408
+  // Request Time-out from behind regional firewalls. See
+  // https://github.com/openclaw/openclaw/issues/72547
+  const proxyUrl = resolveEnvHttpProxyUrl("https");
+  if (!proxyUrl) {
+    return undefined;
+  }
+  try {
+    const agent = new HttpsProxyAgent(proxyUrl) as unknown as Agent;
+    logger.info({ proxyUrl }, "Using ambient env proxy for WhatsApp WebSocket connection");
+    return agent;
+  } catch (error) {
+    logger.warn(
+      { error: String(error) },
+      "Failed to initialize env proxy agent for WhatsApp WebSocket connection",
+    );
+    return undefined;
+  }
 }
 
 async function resolveEnvFetchDispatcher(


### PR DESCRIPTION
## Summary

Fixes #72547 — WhatsApp QR-code linking silently bypasses HTTP/HTTPS proxy env vars in bundled installs, causing pairing to fail with `status=408 Request Time-out` behind regional firewalls (e.g. macOS from inside China).


Also fixes #70149 — same root cause. The reporter independently traced the failure to `resolveAmbientNodeProxyAgent()` falling back to no agent (because the bundled `whatsapp` extension has no `proxy-agent` dep), and confirmed that an explicit `HttpsProxyAgent` works end-to-end against the same proxy and target — which is exactly the path this PR adopts.

## Root cause

`extensions/whatsapp/src/session.ts#resolveEnvProxyAgent` calls `resolveAmbientNodeProxyAgent` (in `plugin-sdk/extension-shared`), which performs a dynamic `import('proxy-agent')`. **`proxy-agent` is not a declared dependency of `@openclaw/whatsapp`**, so the dynamic import silently fails in bundled installs:

- The `onError` warn path logs `Failed to initialize env proxy agent…` but it's easy to miss in routine logs.
- The function returns `undefined`, so `makeWASocket({ agent: undefined })` opens a direct WebSocket connection.
- That direct `wss://mmg.whatsapp.net` request times out from inside firewalled networks → 408.

For comparison, the **discord** and **slack** extensions already use `https-proxy-agent` directly (declared as a direct dep), which is why their proxy paths work in the same environments.

## Fix

Mirror the discord/slack pattern:

1. Add `https-proxy-agent` (`^9.0.0`) as a direct dependency of `@openclaw/whatsapp`'s `package.json`.
2. Replace the dynamic-import-based `resolveAmbientNodeProxyAgent` call with `resolveEnvHttpProxyUrl('https')` (already exposed via `openclaw/plugin-sdk/infra-runtime` → re-exported from `infra/net/proxy-env`) and construct `new HttpsProxyAgent(url)` directly. The shared resolver also honors NO_PROXY / lower-vs-upper case priority semantics, matching the discord/slack behavior.

The `fetchAgent` path (undici dispatcher for media uploads) is **unchanged** — it still dynamically imports undici, which is already a direct dependency of `@openclaw/whatsapp`.

## Behavior

| Env | Before | After |
|---|---|---|
| No proxy env vars | direct connection (correct) | direct connection (correct) |
| `HTTPS_PROXY=http://…` set | **direct connection → 408** | tunneled via HttpsProxyAgent |
| `HTTP_PROXY` only set | **direct connection → 408** | tunneled via HttpsProxyAgent (fallback) |
| Malformed proxy URL | falls back to direct | falls back to direct (logged) |

## Verification

The reporter's manual diff in #72547 confirmed that constructing `new HttpsProxyAgent(process.env.HTTPS_PROXY)` directly fixes the symptom. This PR formalizes that approach with the project's shared env-proxy resolver and aligns whatsapp with the discord/slack convention.

## Refs

- Closes #72547
- Related: `extensions/slack/src/client-options.ts` (template) — same pattern
