### PR TITLE
fix(bonjour): use system hostname for mDNS announcements instead of hardcoded 'openclaw'

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -661,10 +661,61 @@ describe("gateway bonjour advertiser", () => {
     });
 
     const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
-    expect(gatewayCall?.[0]?.name).toBe("openclaw (OpenClaw)");
+    expect(gatewayCall?.[0]?.name).toBe("Mac (OpenClaw)");
     expect(gatewayCall?.[0]?.domain).toBe("local");
+    expect(gatewayCall?.[0]?.hostname).toBe("Mac");
+    expect((gatewayCall?.[0]?.txt as Record<string, string>)?.lanHost).toBe("Mac.local");
+
+    await started.stop();
+  });
+
+  it("falls back to 'openclaw' when system hostname is invalid for DNS", async () => {
+    // Allow advertiser to run in unit tests.
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    delete process.env.OPENCLAW_MDNS_HOSTNAME;
+
+    // Hostnames containing characters disallowed in RFC 1123 LDH labels
+    // (underscores, spaces, etc.) must not leak into ciao or it will reject
+    // them during PROBING. See https://github.com/openclaw/openclaw/issues/72355
+    vi.spyOn(os, "hostname").mockReturnValue("My_Lobster Host");
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
     expect(gatewayCall?.[0]?.hostname).toBe("openclaw");
     expect((gatewayCall?.[0]?.txt as Record<string, string>)?.lanHost).toBe("openclaw.local");
+
+    await started.stop();
+  });
+
+  it("uses system hostname when OPENCLAW_MDNS_HOSTNAME is unset", async () => {
+    // Allow advertiser to run in unit tests.
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    delete process.env.OPENCLAW_MDNS_HOSTNAME;
+
+    vi.spyOn(os, "hostname").mockReturnValue("Lobster");
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
+    expect(gatewayCall?.[0]?.hostname).toBe("Lobster");
+    expect((gatewayCall?.[0]?.txt as Record<string, string>)?.lanHost).toBe("Lobster.local");
 
     await started.stop();
   });

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { classifyCiaoProcessError, type CiaoProcessErrorClassification } from "./ciao.js";
@@ -148,6 +149,45 @@ function isDisabledByEnv() {
   return false;
 }
 
+function resolveSystemMdnsHostname(): string | null {
+  // Use the system hostname (os.hostname()) so the mDNS announcement matches
+  // what the host actually resolves to on the LAN. Strip a single trailing
+  // ".local" suffix and take the first label so we always pass a bare label
+  // to ciao (matching the `${hostname}.local.` FQDN it builds).
+  //
+  // Falls back to null when:
+  //   - os.hostname() throws (rare, sandboxed environments)
+  //   - the hostname is empty or whitespace
+  //   - the hostname contains characters disallowed in DNS labels (RFC 1123
+  //     LDH); we let the caller fall through to "openclaw" rather than
+  //     advertise an invalid label that ciao would reject during PROBING.
+  // See https://github.com/openclaw/openclaw/issues/72355
+  let raw: string;
+  try {
+    raw = os.hostname();
+  } catch {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const firstLabel = trimmed.replace(/\.local$/i, "").split(".")[0]?.trim() ?? "";
+  if (!firstLabel) {
+    return null;
+  }
+  // RFC 1123 label: letters/digits/hyphens, 1-63 chars, no leading/trailing
+  // hyphen. ciao itself is stricter than `bonjour-service` was, so reject
+  // anything that wouldn't survive its own validation up-front.
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(firstLabel)) {
+    return null;
+  }
+  return firstLabel;
+}
+
 function safeServiceName(name: string) {
   const trimmed = name.trim();
   return trimmed.length > 0 ? trimmed : "OpenClaw";
@@ -256,7 +296,8 @@ export async function startGatewayBonjourAdvertiser(
   cleanupUncaughtException = deps.registerUncaughtExceptionHandler?.(handleCiaoProcessError);
 
   try {
-    const hostnameRaw = process.env.OPENCLAW_MDNS_HOSTNAME?.trim() || "openclaw";
+    const hostnameRaw =
+      process.env.OPENCLAW_MDNS_HOSTNAME?.trim() || resolveSystemMdnsHostname() || "openclaw";
     const hostname =
       hostnameRaw
         .replace(/\.local$/i, "")


### PR DESCRIPTION
## Summary

Fixes #72355 (and the regression #72689 reports the same way) — the Bonjour advertiser hardcoded the announced hostname to `openclaw.local` whenever `OPENCLAW_MDNS_HOSTNAME` was unset. On any host whose system hostname is something else (e.g. `Lobster` on Debian, `ubuntu` on a fresh VPS), the advertised host record collides with no real host on the LAN and ciao gets stuck cycling through PROBING:

```
[plugins] bonjour: watchdog detected non-announced service;
  attempting re-advertise (host=openclaw.local. state=probing)
[plugins] bonjour: restarting advertiser (service stuck in probing for 34568ms)
[openclaw] Unhandled promise rejection: CIAO PROBING CANCELLED
```

The watchdog tears the responder down every ~45 seconds and the gateway enters a crash loop until the user manually disables mDNS via `discovery.mdns.mode = "off"`.

## Fix

Introduce `resolveSystemMdnsHostname()` and use it as the new default. The function:

- calls `os.hostname()` and tolerates the rare throw / non-string return, returning `null` for the caller to fall through;
- strips a trailing `.local` suffix and uses the first label so we pass a bare label to ciao (matching the `${hostname}.local.` FQDN it builds);
- rejects labels that violate **RFC 1123 LDH** (letters/digits/hyphens, 1–63 chars, no leading/trailing hyphen) so we never advertise a name ciao would refuse during PROBING. Hostnames containing underscores or whitespace fall back to the legacy `openclaw` default rather than guaranteeing a probe failure.

### New resolution order

`OPENCLAW_MDNS_HOSTNAME` (explicit override) → system hostname (validated) → `openclaw` (last-resort fallback)

This is fully backwards compatible:

| Scenario | Before | After |
|---|---|---|
| `OPENCLAW_MDNS_HOSTNAME` set | uses env | uses env (unchanged) |
| Hostname is `Lobster` | advertises `openclaw.local` (probe loop) | advertises `Lobster.local` ✅ |
| Hostname is `Mac.localdomain` | advertises `openclaw.local` (probe loop) | advertises `Mac.local` ✅ |
| Hostname is `ubuntu` (#72689) | advertises `openclaw.local` (probe loop) | advertises `ubuntu.local` ✅ |
| Hostname has `_` / spaces | advertises `openclaw.local` | advertises `openclaw.local` (legacy fallback) |
| `os.hostname()` throws / returns empty | advertises `openclaw.local` | advertises `openclaw.local` |

## Tests

`extensions/bonjour/src/advertiser.test.ts`:

- updates the existing **"normalizes hostnames with domains for service names"** case to reflect the new system-hostname default (`Mac.localdomain` → `Mac`).
- adds **"falls back to 'openclaw' when system hostname is invalid for DNS"** — asserts the legacy fallback when `os.hostname()` returns `My_Lobster Host` (underscores + space).
- adds **"uses system hostname when OPENCLAW_MDNS_HOSTNAME is unset"** — asserts `Lobster` → `Lobster.local`.

## Refs

- Closes #72355
- Also fixes the regression report in #72689 (same root cause, hostname `ubuntu`)