### PR TITLE
fix(plugins): discover symlinked plugin directories

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -302,6 +302,29 @@ describe("discoverOpenClawPlugins", () => {
     expectCandidateIds(candidates, { includes: ["alpha", "beta"] });
   });
 
+  it("discovers symlinked plugin directories in scanned roots", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions");
+    mkdirSafe(globalExt);
+
+    const linkedPluginDir = path.join(stateDir, "linked-plugin-src");
+    createPackagePluginWithEntry({
+      packageDir: linkedPluginDir,
+      packageName: "@openclaw/linked-plugin",
+      pluginId: "linked-plugin",
+    });
+
+    const symlinkPath = path.join(globalExt, "linked-plugin");
+    fs.symlinkSync(linkedPluginDir, symlinkPath, process.platform === "win32" ? "junction" : "dir");
+
+    const { candidates, diagnostics } = await discoverWithStateDir(stateDir, {});
+    expectCandidateIds(candidates, { includes: ["linked-plugin"] });
+    expect(findCandidateById(candidates, "linked-plugin")?.rootDir).toBe(
+      fs.realpathSync(linkedPluginDir),
+    );
+    expect(diagnostics).toEqual([]);
+  });
+
   it("does not recurse arbitrary workspace directories for plugin auto-discovery", () => {
     const stateDir = makeTempDir();
     const workspaceDir = path.join(stateDir, "workspace");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -348,6 +348,29 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
+function resolveScannedEntryType(entry: fs.Dirent, fullPath: string): "file" | "directory" | null {
+  if (entry.isFile()) {
+    return "file";
+  }
+  if (entry.isDirectory()) {
+    return "directory";
+  }
+  if (!entry.isSymbolicLink()) {
+    return null;
+  }
+  const stat = safeStatSync(fullPath);
+  if (!stat) {
+    return null;
+  }
+  if (stat.isFile()) {
+    return "file";
+  }
+  if (stat.isDirectory()) {
+    return "directory";
+  }
+  return null;
+}
+
 function resolvesToSameDirectory(left?: string, right?: string): boolean {
   if (!left || !right) {
     return false;
@@ -594,7 +617,8 @@ function discoverInDirectory(params: {
 
   for (const entry of entries) {
     const fullPath = path.join(params.dir, entry.name);
-    if (entry.isFile()) {
+    const entryType = resolveScannedEntryType(entry, fullPath);
+    if (entryType === "file") {
       if (!isExtensionFile(fullPath)) {
         continue;
       }
@@ -609,8 +633,9 @@ function discoverInDirectory(params: {
         ownershipUid: params.ownershipUid,
         workspaceDir: params.workspaceDir,
       });
+      continue;
     }
-    if (!entry.isDirectory()) {
+    if (entryType !== "directory") {
       continue;
     }
     if (params.skipDirectories?.has(entry.name)) {


### PR DESCRIPTION
## Summary
- follow explicitly linked plugin entries in scanned plugin roots when the symlink target is a file or directory
- keep broken/non-file/non-directory symlinks ignored
- add a regression test for discovering a symlinked plugin directory

## Test
- `node scripts/test-projects.mjs src/plugins/discovery.test.ts`
