### PR TITLE
fix(cron): set nested lane concurrency to match maxConcurrentRuns

### DIFF
--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { CommandLane } from "../process/lanes.js";
+
+const setConcurrency = vi.fn();
+
+vi.mock("../process/command-queue.js", () => ({
+  setCommandLaneConcurrency: (...args: unknown[]) => setConcurrency(...args),
+}));
+
+vi.mock("../config/agent-limits.js", () => ({
+  resolveAgentMaxConcurrent: (cfg: OpenClawConfig) => cfg.agents?.maxConcurrent ?? 1,
+  resolveSubagentMaxConcurrent: (cfg: OpenClawConfig) => cfg.agents?.subagentMaxConcurrent ?? 1,
+}));
+
+const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+describe("applyGatewayLaneConcurrency", () => {
+  beforeEach(() => {
+    setConcurrency.mockClear();
+  });
+
+  it("sets Nested lane concurrency from cron.maxConcurrentRuns", () => {
+    const cfg = { cron: { maxConcurrentRuns: 4 } } as OpenClawConfig;
+    applyGatewayLaneConcurrency(cfg);
+
+    const nestedCall = setConcurrency.mock.calls.find(
+      ([lane]: [string]) => lane === CommandLane.Nested,
+    );
+    expect(nestedCall).toBeDefined();
+    expect(nestedCall![1]).toBe(4);
+  });
+
+  it("defaults Nested lane concurrency to 1 when maxConcurrentRuns is unset", () => {
+    const cfg = {} as OpenClawConfig;
+    applyGatewayLaneConcurrency(cfg);
+
+    const nestedCall = setConcurrency.mock.calls.find(
+      ([lane]: [string]) => lane === CommandLane.Nested,
+    );
+    expect(nestedCall).toBeDefined();
+    expect(nestedCall![1]).toBe(1);
+  });
+
+  it("sets all four lanes", () => {
+    const cfg = { cron: { maxConcurrentRuns: 2 } } as OpenClawConfig;
+    applyGatewayLaneConcurrency(cfg);
+
+    const lanes = setConcurrency.mock.calls.map(([lane]: [string]) => lane);
+    expect(lanes).toContain(CommandLane.Cron);
+    expect(lanes).toContain(CommandLane.Main);
+    expect(lanes).toContain(CommandLane.Subagent);
+    expect(lanes).toContain(CommandLane.Nested);
+  });
+
+  it("Nested and Cron lanes share the same concurrency value", () => {
+    const cfg = { cron: { maxConcurrentRuns: 3 } } as OpenClawConfig;
+    applyGatewayLaneConcurrency(cfg);
+
+    const cronCall = setConcurrency.mock.calls.find(
+      ([lane]: [string]) => lane === CommandLane.Cron,
+    );
+    const nestedCall = setConcurrency.mock.calls.find(
+      ([lane]: [string]) => lane === CommandLane.Nested,
+    );
+    expect(cronCall![1]).toBe(nestedCall![1]);
+  });
+});

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -7,4 +7,5 @@ export function applyGatewayLaneConcurrency(cfg: OpenClawConfig) {
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, cfg.cron?.maxConcurrentRuns ?? 1);
 }


### PR DESCRIPTION
Fixes #72707

## Problem

`applyGatewayLaneConcurrency()` configures concurrency for `Cron`, `Main`, and `Subagent` lanes but not `Nested`. Since cron job LLM execution is routed from the `cron` lane to the `nested` lane (to avoid deadlocks), the missing configuration means `nested` defaults to `maxConcurrent: 1`, serializing all cron LLM executions regardless of `cron.maxConcurrentRuns`.

## Fix

Add `setCommandLaneConcurrency(CommandLane.Nested, cfg.cron?.maxConcurrentRuns ?? 1)` to `applyGatewayLaneConcurrency()` so the nested lane respects the user's configured concurrency.

## Changes

- `src/gateway/server-lanes.ts`: Add nested lane concurrency configuration
- `src/gateway/server-lanes.test.ts`: 4 new tests covering nested lane behavior

## Testing

All new tests pass. The fix is a single additional `setCommandLaneConcurrency` call using the same config value that already controls the cron scheduling lane.