### PR TITLE
fix(cli): skills install/update respect current agent workspace context

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -110,7 +110,8 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: () => mocks.resolveDefaultAgentIdMock(),
-  resolveAgentWorkspaceDir: () => mocks.resolveAgentWorkspaceDirMock(),
+  resolveAgentWorkspaceDir: (...args: unknown[]) => mocks.resolveAgentWorkspaceDirMock(...args),
+  resolveAgentIdByWorkspacePath: () => undefined,
 }));
 
 vi.mock("../agents/skills-clawhub.js", () => ({
@@ -208,6 +209,27 @@ describe("skills cli commands", () => {
         line.includes("Installed calendar@1.2.3 -> /tmp/workspace/skills/calendar"),
       ),
     ).toBe(true);
+  });
+
+  it("installs a skill into agent-specific workspace when --agent is provided", async () => {
+    resolveAgentWorkspaceDirMock.mockImplementation(
+      (_cfg: unknown, agentId: string) => `/tmp/workspace-${agentId}`,
+    );
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      version: "1.0.0",
+      targetDir: "/tmp/workspace-writer/skills/calendar",
+    });
+
+    await runCommand(["skills", "install", "calendar", "--agent", "writer"]);
+
+    expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith(expect.anything(), "writer");
+    expect(installSkillFromClawHubMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/workspace-writer",
+      }),
+    );
   });
 
   it("updates all tracked ClawHub skills", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentIdByWorkspacePath,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import {
   installSkillFromClawHub,
   readTrackedClawHubSkillSlugs,
@@ -41,9 +45,13 @@ async function runSkillsAction(render: (report: SkillStatusReport) => string): P
   }
 }
 
-function resolveActiveWorkspaceDir(): string {
+function resolveActiveWorkspaceDir(agentId?: string): string {
   const config = loadConfig();
-  return resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const effectiveAgentId =
+    agentId?.trim() ||
+    resolveAgentIdByWorkspacePath(config, process.cwd()) ||
+    resolveDefaultAgentId(config);
+  return resolveAgentWorkspaceDir(config, effectiveAgentId);
 }
 
 /**
@@ -96,9 +104,10 @@ export function registerSkillsCli(program: Command) {
     .argument("<slug>", "ClawHub skill slug")
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
-    .action(async (slug: string, opts: { version?: string; force?: boolean }) => {
+    .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred or default agent)")
+    .action(async (slug: string, opts: { version?: string; force?: boolean; agent?: string }) => {
       try {
-        const workspaceDir = resolveActiveWorkspaceDir();
+        const workspaceDir = resolveActiveWorkspaceDir(opts.agent);
         const result = await installSkillFromClawHub({
           workspaceDir,
           slug,
@@ -125,7 +134,8 @@ export function registerSkillsCli(program: Command) {
     .description("Update ClawHub-installed skills in the active workspace")
     .argument("[slug]", "Single skill slug")
     .option("--all", "Update all tracked ClawHub skills", false)
-    .action(async (slug: string | undefined, opts: { all?: boolean }) => {
+    .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred or default agent)")
+    .action(async (slug: string | undefined, opts: { all?: boolean; agent?: string }) => {
       try {
         if (!slug && !opts.all) {
           defaultRuntime.error("Provide a skill slug or use --all.");
@@ -137,7 +147,7 @@ export function registerSkillsCli(program: Command) {
           defaultRuntime.exit(1);
           return;
         }
-        const workspaceDir = resolveActiveWorkspaceDir();
+        const workspaceDir = resolveActiveWorkspaceDir(opts.agent);
         const tracked = await readTrackedClawHubSkillSlugs(workspaceDir);
         if (opts.all && tracked.length === 0) {
           defaultRuntime.log("No tracked ClawHub skills to update.");


### PR DESCRIPTION
## Fixes #56161

`openclaw skills install` always installs to the default agent workspace, ignoring the current agent context. This breaks skill isolation in multi-agent setups.

### Root Cause

`resolveActiveWorkspaceDir()` in `src/cli/skills-cli.ts` hardcoded `resolveDefaultAgentId(config)`, always returning the main workspace path regardless of context.

### Fix

Updated `resolveActiveWorkspaceDir()` to resolve the agent workspace using a priority chain:

1. `--agent <id>` flag (explicit override)
2. `resolveAgentIdByWorkspacePath(config, cwd)` (infer from current directory)
3. `resolveDefaultAgentId(config)` (fallback to default)

Added `--agent <id>` option to both `skills install` and `skills update` commands, consistent with other CLI commands.

### Testing

- Added regression test verifying `--agent` flag is passed through to workspace resolution
- All existing tests pass
- Format check passes

### Reproduction

```shell
cd ~/.openclaw/workspace-writer
openclaw skills install content-writer
# Before: installs to ~/.openclaw/workspace/skills/content-writer (wrong)
# After:  installs to ~/.openclaw/workspace-writer/skills/content-writer (correct)
```