### PR TITLE
fix: fail fast on completion announce delivery

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -47,6 +47,7 @@ import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 export { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
 
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
+const DEFAULT_SUBAGENT_COMPLETION_ANNOUNCE_TIMEOUT_MS = 30_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 type SubagentAnnounceDeliveryDeps = {
@@ -157,12 +158,31 @@ function resolveDirectAnnounceTransientRetryDelaysMs() {
     : ([5_000, 10_000, 20_000] as const);
 }
 
-export function resolveSubagentAnnounceTimeoutMs(cfg: OpenClawConfig): number {
-  const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
-  if (typeof configured !== "number" || !Number.isFinite(configured)) {
-    return DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS;
+function coercePositiveTimerMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
   }
-  return Math.min(Math.max(1, Math.floor(configured)), MAX_TIMER_SAFE_TIMEOUT_MS);
+  return Math.min(Math.max(1, Math.floor(value)), MAX_TIMER_SAFE_TIMEOUT_MS);
+}
+
+export function resolveSubagentAnnounceTimeoutMs(cfg: OpenClawConfig): number {
+  return (
+    coercePositiveTimerMs(cfg.agents?.defaults?.subagents?.announceTimeoutMs) ??
+    DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS
+  );
+}
+
+export function resolveSubagentCompletionAnnounceTimeoutMs(cfg: OpenClawConfig): number {
+  const configuredCompletionTimeout = coercePositiveTimerMs(
+    cfg.agents?.defaults?.subagents?.completionAnnounceTimeoutMs,
+  );
+  if (configuredCompletionTimeout !== undefined) {
+    return configuredCompletionTimeout;
+  }
+  return Math.min(
+    resolveSubagentAnnounceTimeoutMs(cfg),
+    DEFAULT_SUBAGENT_COMPLETION_ANNOUNCE_TIMEOUT_MS,
+  );
 }
 
 export function isInternalAnnounceRequesterSession(sessionKey: string | undefined): boolean {
@@ -256,8 +276,9 @@ export async function runAnnounceDeliveryWithRetry<T>(params: {
   operation: string;
   signal?: AbortSignal;
   run: () => Promise<T>;
+  retryDelaysMs?: readonly number[];
 }): Promise<T> {
-  const retryDelaysMs = resolveDirectAnnounceTransientRetryDelaysMs();
+  const retryDelaysMs = params.retryDelaysMs ?? resolveDirectAnnounceTransientRetryDelaysMs();
   let retryIndex = 0;
   for (;;) {
     if (params.signal?.aborted) {
@@ -647,7 +668,9 @@ async function sendSubagentAnnounceDirectly(params: {
     };
   }
   const cfg = subagentAnnounceDeliveryDeps.loadConfig();
-  const announceTimeoutMs = resolveSubagentAnnounceTimeoutMs(cfg);
+  const announceTimeoutMs = params.expectsCompletionMessage
+    ? resolveSubagentCompletionAnnounceTimeoutMs(cfg)
+    : resolveSubagentAnnounceTimeoutMs(cfg);
   const canonicalRequesterSessionKey = resolveRequesterStoreKey(
     cfg,
     params.targetRequesterSessionKey,
@@ -753,6 +776,9 @@ async function sendSubagentAnnounceDirectly(params: {
           ? "completion direct announce agent call"
           : "direct announce agent call",
         signal: params.signal,
+        retryDelaysMs: params.expectsCompletionMessage
+          ? []
+          : resolveDirectAnnounceTransientRetryDelaysMs(),
         run: async () =>
           await subagentAnnounceDeliveryDeps.callGateway({
             method: "agent",

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -96,6 +96,7 @@ vi.mock("./subagent-announce-delivery.js", () => ({
     targetRequesterSessionKey: string;
     triggerMessage: string;
     requesterIsSubagent?: boolean;
+    expectsCompletionMessage?: boolean;
     requesterOrigin?: { channel?: string; to?: string; accountId?: string; threadId?: string };
     requesterSessionOrigin?: { provider?: string; channel?: string };
     bestEffortDeliver?: boolean;
@@ -122,16 +123,24 @@ vi.mock("./subagent-announce-delivery.js", () => ({
             }),
       },
     });
-    const timeoutMs =
-      typeof configOverride.agents?.defaults?.subagents?.announceTimeoutMs === "number" &&
-      Number.isFinite(configOverride.agents.defaults.subagents.announceTimeoutMs)
-        ? Math.min(
-            Math.max(1, Math.floor(configOverride.agents.defaults.subagents.announceTimeoutMs)),
-            2_147_000_000,
-          )
-        : 120_000;
+    const coercePositiveTimerMs = (value: unknown) =>
+      typeof value === "number" && Number.isFinite(value)
+        ? Math.min(Math.max(1, Math.floor(value)), 2_147_000_000)
+        : undefined;
+    const announceTimeoutMs =
+      coercePositiveTimerMs(configOverride.agents?.defaults?.subagents?.announceTimeoutMs) ??
+      120_000;
+    const timeoutMs = params.expectsCompletionMessage
+      ? (coercePositiveTimerMs(
+          configOverride.agents?.defaults?.subagents?.completionAnnounceTimeoutMs,
+        ) ?? Math.min(announceTimeoutMs, 30_000))
+      : announceTimeoutMs;
     const retryDelaysMs =
-      process.env.OPENCLAW_TEST_FAST === "1" ? [8, 16, 32] : [5_000, 10_000, 20_000];
+      params.expectsCompletionMessage === true
+        ? []
+        : process.env.OPENCLAW_TEST_FAST === "1"
+          ? [8, 16, 32]
+          : [5_000, 10_000, 20_000];
     let retryIndex = 0;
     for (;;) {
       const request = buildRequest();
@@ -165,6 +174,18 @@ vi.mock("./subagent-announce-delivery.js", () => ({
       return 120_000;
     }
     return Math.min(Math.max(1, Math.floor(configured)), 2_147_000_000);
+  },
+  resolveSubagentCompletionAnnounceTimeoutMs: (cfg: typeof configOverride) => {
+    const configured = cfg.agents?.defaults?.subagents?.completionAnnounceTimeoutMs;
+    if (typeof configured === "number" && Number.isFinite(configured)) {
+      return Math.min(Math.max(1, Math.floor(configured)), 2_147_000_000);
+    }
+    const announceConfigured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
+    const announceTimeoutMs =
+      typeof announceConfigured === "number" && Number.isFinite(announceConfigured)
+        ? Math.min(Math.max(1, Math.floor(announceConfigured)), 2_147_000_000)
+        : 120_000;
+    return Math.min(announceTimeoutMs, 30_000);
   },
   runAnnounceDeliveryWithRetry: async <T>(params: { run: () => Promise<T> }) => await params.run(),
 }));
@@ -219,6 +240,19 @@ function setConfiguredAnnounceTimeout(timeoutMs: number): void {
       defaults: {
         subagents: {
           announceTimeoutMs: timeoutMs,
+        },
+      },
+    },
+  };
+}
+
+function setConfiguredCompletionAnnounceTimeout(timeoutMs: number): void {
+  configOverride = {
+    session: defaultSessionConfig,
+    agents: {
+      defaults: {
+        subagents: {
+          completionAnnounceTimeoutMs: timeoutMs,
         },
       },
     },
@@ -297,7 +331,7 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.timeoutMs).toBe(120_000);
   });
 
-  it("honors configured announce timeout for completion direct agent call", async () => {
+  it("caps completion direct agent call to 30s by default even when announce timeout is longer", async () => {
     setConfiguredAnnounceTimeout(120_000);
     await runAnnounceFlowForTest("run-config-timeout-send", {
       requesterOrigin: {
@@ -310,10 +344,26 @@ describe("subagent announce timeout config", () => {
     const completionDirectAgentCall = findGatewayCall(
       (call) => call.method === "agent" && call.expectFinal === true,
     );
-    expect(completionDirectAgentCall?.timeoutMs).toBe(120_000);
+    expect(completionDirectAgentCall?.timeoutMs).toBe(30_000);
   });
 
-  it("retries gateway timeout for externally delivered completion announces before giving up", async () => {
+  it("honors configured completion announce timeout for completion direct agent call", async () => {
+    setConfiguredCompletionAnnounceTimeout(12_000);
+    await runAnnounceFlowForTest("run-config-completion-timeout", {
+      requesterOrigin: {
+        channel: "discord",
+        to: "12345",
+      },
+      expectsCompletionMessage: true,
+    });
+
+    const completionDirectAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(completionDirectAgentCall?.timeoutMs).toBe(12_000);
+  });
+
+  it("does not retry gateway timeout inside a completion direct announce attempt", async () => {
     try {
       vi.stubEnv("OPENCLAW_TEST_FAST", "1");
       callGatewayImpl = async (request) => {
@@ -335,7 +385,8 @@ describe("subagent announce timeout config", () => {
       const directAgentCalls = gatewayCalls.filter(
         (call) => call.method === "agent" && call.expectFinal === true,
       );
-      expect(directAgentCalls).toHaveLength(4);
+      expect(directAgentCalls).toHaveLength(1);
+      expect(directAgentCalls[0]?.timeoutMs).toBe(30_000);
     } finally {
       vi.unstubAllEnvs();
     }

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5498,6 +5498,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
                   },
+                  completionAnnounceTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   requireAgentId: {
                     type: "boolean",
                   },

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -408,8 +408,10 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
-    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
     announceTimeoutMs?: number;
+    /** Gateway timeout in ms for direct sub-agent completion announce attempts (default: min(announceTimeoutMs, 30000)). */
+    completionAnnounceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -280,6 +280,7 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        completionAnnounceTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
       })
       .strict()


### PR DESCRIPTION
## Summary
- add a separate configurable timeout for direct subagent completion announce attempts (`agents.defaults.subagents.completionAnnounceTimeoutMs`)
- keep general announce delivery timeout behavior unchanged for non-completion paths
- disable inner transient retries for completion direct announce calls so registry retry/backoff remains the durable retry path

## Validation
- `corepack pnpm exec vitest run src/agents/subagent-announce.timeout.test.ts src/agents/subagent-registry-lifecycle.test.ts`
- `corepack pnpm tsgo:test:src`
- `corepack pnpm config:schema:check`
- `git diff --check`
