### PR TITLE
docs(channel-target): clarify Discord DM requires user:<id> prefix

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -7,7 +7,7 @@ import { MESSAGE_ACTION_TARGET_MODE } from "./message-action-spec.js";
 export const hasNonEmptyString = sharedHasNonEmptyString;
 
 export const CHANNEL_TARGET_DESCRIPTION =
-  "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack channel/user, or iMessage handle/chat_id";
+  "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord channel/user (use 'user:<id>' for DMs), Slack channel/user, or iMessage handle/chat_id";
 
 export const CHANNEL_TARGETS_DESCRIPTION =
   "Recipient/channel targets (same format as --target); accepts ids or names when the directory is available.";


### PR DESCRIPTION
## Summary

Fixes #72401

Models struggle to use Discord tool/skill for sending Discord DMs because the target parameter description does not mention that DMs require the `user:<id>` prefix format.

## Changes

- Updated `CHANNEL_TARGET_DESCRIPTION` in `src/infra/outbound/channel-target.ts`
- Added explicit guidance: `Discord channel/user (use user:<id> for DMs)`
- Separated Discord and Slack in the description for clarity

## Before

```
Discord/Slack channel/user
```

## After

```
Discord channel/user (use user:<id> for DMs), Slack channel/user
```

## Test Plan

- N/A (documentation change only)
- Existing tests should pass unchanged

## Security

- No security implications (documentation change only)