### PR TITLE
fix(channels): skip path-install registration for bundled plugins

### DIFF
--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -629,6 +629,41 @@ describe("ensureOnboardingPluginInstalled", () => {
     });
   });
 
+  it("does not register a bundled plugin as a user path-install or load-paths entry", async () => {
+    await withTempDir({ prefix: "openclaw-onboarding-install-bundled-channel-" }, async (temp) => {
+      const workspaceDir = path.join(temp, "workspace");
+      const bundledPluginDir = path.join(temp, "bundled", "discord");
+      await fs.mkdir(path.join(workspaceDir, ".git"), { recursive: true });
+      await fs.mkdir(bundledPluginDir, { recursive: true });
+      const realBundledDir = await fs.realpath(bundledPluginDir);
+
+      findBundledPluginSourceInMap.mockReturnValueOnce({
+        pluginId: "discord",
+        localPath: realBundledDir,
+      } as never);
+
+      const result = await ensureOnboardingPluginInstalled({
+        cfg: {},
+        entry: {
+          pluginId: "discord",
+          label: "Discord",
+          install: {},
+        },
+        prompter: {
+          select: vi.fn(async () => "local"),
+        } as never,
+        runtime: {} as never,
+        workspaceDir,
+      });
+
+      expect(recordPluginInstall).not.toHaveBeenCalled();
+      expect(result.installed).toBe(true);
+      expect(result.status).toBe("installed");
+      expect(result.cfg.plugins?.load?.paths).toBeUndefined();
+      expect(result.cfg.plugins?.installs).toBeUndefined();
+    });
+  });
+
   it("rejects local install paths outside the trusted workspace roots", async () => {
     await withTempDir({ prefix: "openclaw-onboarding-install-outside-root-" }, async (temp) => {
       const workspaceDir = path.join(temp, "workspace");

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -135,6 +135,31 @@ function formatPortableLocalPath(localPath: string, workspaceDir?: string): stri
   return undefined;
 }
 
+async function applyLocalPluginInstall(params: {
+  cfg: OpenClawConfig;
+  entry: OnboardingPluginInstallEntry;
+  localPath: string;
+  bundledLocalPath: string | null;
+  npmSpec: string | null;
+  workspaceDir?: string;
+}): Promise<OpenClawConfig> {
+  // Bundled plugins are discovered automatically from the runtime's manifest
+  // scan; persisting them as user `plugins.load.paths` entries plus
+  // `source: "path"` install records produces the redundant state the loader
+  // rejects with a "remove this redundant path" warning on every config read.
+  if (params.localPath === params.bundledLocalPath) {
+    return params.cfg;
+  }
+  const withPath = addPluginLoadPath(params.cfg, params.localPath);
+  return await recordLocalPluginInstall({
+    cfg: withPath,
+    entry: params.entry,
+    localPath: params.localPath,
+    npmSpec: params.npmSpec,
+    workspaceDir: params.workspaceDir,
+  });
+}
+
 async function recordLocalPluginInstall(params: {
   cfg: OpenClawConfig;
   entry: OnboardingPluginInstallEntry;
@@ -478,8 +503,14 @@ export async function ensureOnboardingPluginInstalled(params: {
         status: "failed",
       };
     }
-    next = addPluginLoadPath(enableResult.config, localPath);
-    next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
+    next = await applyLocalPluginInstall({
+      cfg: enableResult.config,
+      entry,
+      localPath,
+      bundledLocalPath,
+      npmSpec,
+      workspaceDir,
+    });
     return {
       cfg: next,
       installed: true,
@@ -595,8 +626,14 @@ export async function ensureOnboardingPluginInstalled(params: {
           status: "failed",
         };
       }
-      next = addPluginLoadPath(enableResult.config, localPath);
-      next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
+      next = await applyLocalPluginInstall({
+        cfg: enableResult.config,
+        entry,
+        localPath,
+        bundledLocalPath,
+        npmSpec,
+        workspaceDir,
+      });
       return {
         cfg: next,
         installed: true,


### PR DESCRIPTION
## Summary

Fixes the redundant `plugins.load.paths` entry + `installs.json` `source: "path"` install record that the wizard / `channels add` writes for bundled channels (verified for Discord; same code path for any bundled channel). The loader explicitly rejects this state and emits

```
plugins: ignored plugins.load.paths entry that points at OpenClaw's
current bundled plugin directory; remove this redundant path or run
openclaw doctor --fix
```

on every config read until the user manually edits the JSON or runs `doctor --fix`.

Closes #72740 (or refs, whichever fit you prefer).

## What changed

- New `applyLocalPluginInstall` helper in `src/commands/onboarding-plugin-install.ts` that owns "what to write for a `local` choice".
- Helper short-circuits when the resolved `localPath` is the bundled directory (`localPath === bundledLocalPath`). Returns the config unchanged so the caller still records the channel config and reports `installed: true`.
- Both call sites (primary `local` branch and the `npm`-fallback-to-`local` branch) now go through the helper; behavior for genuine path-installs (workspace plugins, `pnpm openclaw` checkouts) is unchanged.

## Why this scope

The minimal change that resolves the writer/reader inconsistency without touching install record semantics. Longer-term it probably makes sense to introduce a `source: "bundled"` install record + doctor migration (option 3 in the issue), but that's a bigger blast-radius change with new install record type, schema/validation updates, uninstall behavior, etc. Happy to follow up with that as a separate PR if maintainers prefer.

I picked this option because:
- The loader already treats bundled-pointing `plugins.load.paths` entries as `ignored`; not writing them in the first place is the simplest "stop creating state the reader rejects" fix.
- `caller (channels/add.ts) requires `installed: true` to proceed with channel config writes`, so I kept that contract intact rather than routing bundled to `skip`.
- AGENTS.md "manifest-first control plane" suggests bundled plugins shouldn't appear in `installRecords` at all; this PR removes the false `source: "path"` record without inventing a new record type.

## Test plan

- [x] New test `does not register a bundled plugin as a user path-install or load-paths entry` in `src/commands/onboarding-plugin-install.test.ts` — fails on `main`, passes with the fix
- [x] All 14 existing tests in `onboarding-plugin-install.test.ts` still pass
- [x] `pnpm check:changed` (typecheck + lint + import cycles + auth/webhook guards) green
- [x] `pnpm test:changed` green
- [x] Repro from #72740 stops writing `plugins.load.paths` and stops creating the `source: "path"` install record on a fresh container; the loader warning no longer appears

Verified locally on macOS with the docker setup from #72740 plus a unit-level repro.
