### PR TITLE
fix(telegram): show full provider/model label for nested OpenRouter ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - MCP/tools: prefix bundle MCP server/tool fragments that would start with digits, keeping generated tool names valid for Moonshot/Kimi and other strict providers. Fixes #79179.
 - Models/OpenRouter: treat `403 API key budget limit exceeded` as billing so model fallback advances instead of retrying the exhausted primary. Fixes #60191. Thanks @omgitsgela.
 - Models/OpenRouter: repair stale session overrides that lost the outer `openrouter/` provider wrapper, so sessions return to the configured OpenRouter model instead of failing as an unknown direct-provider model. Fixes #78161. Thanks @hjamal7-bit.
+- Telegram: show full provider/model labels for nested OpenRouter model ids in the model picker, so `openrouter/openai/gpt-5.4-mini` no longer displays as `openai/gpt-5.4-mini`. Fixes #67792. (#72752) Thanks @iot2edge.
 - Kimi Code: use Kimi's stable `kimi-for-coding` API model id in bundled catalog, onboarding, and docs while normalizing legacy `kimi-code` and `k2p5` refs. Fixes #79965.
 - Volcengine/Kimi: strip provider-unsupported tool schema length and item constraint keywords for direct and coding-plan models so hosted Kimi runs do not reject message tools with `minLength`. Fixes #38817.
 - DeepSeek: backfill V4 `reasoning_content` replay fields for unowned OpenAI-compatible proxy providers, preventing follow-up request failures outside the bundled DeepSeek and OpenRouter routes. Fixes #79608.

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -264,6 +264,27 @@ describe("buildModelsKeyboard", () => {
     expect(result[1]?.[0]?.text).toBe("unknown-id");
   });
 
+  it("prefixes provider in fallback label for nested provider-local ids (OpenRouter)", () => {
+    const result = buildModelsKeyboard({
+      provider: "openrouter",
+      models: ["openai/gpt-5.4-mini"],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("openrouter/openai/gpt-5.4-mini");
+  });
+
+  it("marks nested provider-local id as current when full ref matches", () => {
+    const result = buildModelsKeyboard({
+      provider: "openrouter",
+      models: ["openai/gpt-5.4-mini"],
+      currentModel: "openrouter/openai/gpt-5.4-mini",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("openrouter/openai/gpt-5.4-mini ✓");
+  });
+
   it("uses provider-scoped modelNames keys to avoid cross-provider collisions", () => {
     const modelNames = new Map([
       ["openai/shared-id", "OpenAI Shared"],

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -217,7 +217,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     }
 
     const isCurrentModel = isCurrentModelSelection({ currentModel, provider, model });
-    const displayLabel = modelNames?.get(`${provider}/${model}`) ?? model;
+    const fallbackLabel = model.includes("/") ? `${provider}/${model}` : model;
+    const displayLabel = modelNames?.get(`${provider}/${model}`) ?? fallbackLabel;
     const displayText = truncateModelId(displayLabel, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
"Fixes #67792\r\n\r\n## Summary\r\n\r\n- Problem: Telegram model selection menu drops the provider prefix for OpenRouter-configured refs. A model configured as `openrouter/openai/gpt-5.4-mini` renders as `openai/gpt-5.4-mini` in the inline keyboard.\r\n- Why it matters: The visible label no longer matches the user's configured model ref, which is confusing on its own and ambiguous when multiple providers expose similarly-named ids.\r\n- What changed: In `buildModelsKeyboard`, the fallback display label now prepends the provider when the resolved `model` id itself contains `/` (i.e. it carries an embedded provider, as with OpenRouter). When `modelNames` already supplies a display name, that still wins.\r\n- What did NOT change (scope boundary): callback data, selection resolution, dedupe keys, the `modelNames` lookup key, pagination, the ✓ \"current\" marker logic, or labels for non-nested ids like `gpt-5.4` / `claude-opus-4`.\r\n\r\n## Change Type (select all)\r\n\r\n- [x] Bug fix\r\n- [ ] Feature\r\n- [ ] Refactor required for the fix\r\n- [ ] Docs\r\n- [ ] Security hardening\r\n- [ ] Chore/infra\r\n\r\n## Scope (select all touched areas)\r\n\r\n- [ ] Gateway / orchestration\r\n- [ ] Skills / tool execution\r\n- [ ] Auth / tokens\r\n- [ ] Memory / storage\r\n- [x] Integrations\r\n- [ ] API / contracts\r\n- [x] UI / DX\r\n- [ ] CI/CD / infra\r\n\r\n## Linked Issue/PR\r\n\r\n- Closes #67792\r\n- Related #\r\n- [x] This PR fixes a bug or regression\r\n\r\n## Root Cause\r\n\r\n- Root cause: `parseModelRef(\"openrouter/openai/gpt-5.4-mini\")` splits on the first `/`, producing `provider = \"openrouter\"` and `model = \"openai/gpt-5.4-mini\"`. `buildModelsKeyboard` then displayed `model` directly when no `modelNames` entry was present, dropping the `openrouter/` prefix from the visible label even though the dedupe and callback data were correct.\r\n- Missing detection / guardrail: existing tests asserted the bare-id fallback (`unknown-id` → `unknown-id`) but no test covered nested provider-local ids where the model already contains a `/`.\r\n- Contributing context (if known): OpenRouter is one of the few providers that routes through nested provider-local ids; the menu code was written before that pattern was widely configured, so the assumption \"model never contains `/`\" was implicit.\r\n\r\n## Regression Test Plan\r\n\r\n- Coverage level that should have caught this:\r\n  - [x] Unit test\r\n  - [ ] Seam / integration test\r\n  - [ ] End-to-end test\r\n  - [ ] Existing coverage already sufficient\r\n- Target test or file: `extensions/telegram/src/model-buttons.test.ts`\r\n- Scenario the test should lock in: with `provider = \"openrouter\"`, `models = [\"openai/gpt-5.4-mini\"]`, no `modelNames`, the visible button label must be `openrouter/openai/gpt-5.4-mini` (and `openrouter/openai/gpt-5.4-mini ✓` when that ref is the current model).\r\n- Why this is the smallest reliable guardrail: the bug lives entirely in label construction in a pure function with no I/O. A unit test against `buildModelsKeyboard` is deterministic, fast, and pinpoints any regression to the exact line.\r\n- Existing test that already covers this (if any): none — the closest existing test (`falls back to model ID when modelNames does not contain an entry`) only covers non-nested ids.\r\n- If no new test is added, why not: N/A — two new tests added.\r\n\r\n## User-visible / Behavior Changes\r\n\r\n- Telegram inline model menu: nested provider-local ids now show the full `provider/model` label instead of the bare model id. Example: `openrouter/openai/gpt-5.4-mini` (was: `openai/gpt-5.4-mini`).\r\n- Non-nested ids (e.g. `gpt-5.4`, `claude-opus-4`) are unchanged.\r\n- The ✓ marker on the currently-selected model is unchanged.\r\n\r\n## Diagram\r\n\r\n```text\r\nConfigured ref: openrouter/openai/gpt-5.4-mini\r\n\r\nBefore:\r\n[user opens /model menu]\r\n  -> parseModelRef -> provider=openrouter, model=openai/gpt-5.4-mini\r\n  -> button label = \"openai/gpt-5.4-mini\"        <- prefix dropped\r\n\r\nAfter:\r\n[user opens /model menu]\r\n  -> parseModelRef -> provider=openrouter, model=openai/gpt-5.4-mini\r\n  -> model contains \"/\", fallback = `${provider}/${model}`\r\n  -> button label = \"openrouter/openai/gpt-5.4-mini\"\r\n```\r\n\r\n## Security Impact (required)\r\n\r\n- New permissions/capabilities?  No\r\n- Secrets/tokens handling changed?  No\r\n- New/changed network calls?  No\r\n- Command/tool execution surface changed? No\r\n- Data access scope changed? No\r\n- If any `Yes`, explain risk + mitigation:\r\n\r\n## Repro + Verification\r\n\r\n### Environment\r\n\r\n- OS: Ubuntu 24.04 \r\n- Runtime/container: Node 22+ via pnpm 10.33\r\n- Model/provider: OpenRouter (openrouter/openai/gpt-5.4-mini)\r\n- Integration/channel (if any): Telegram\r\n- Relevant config (redacted):\r\n          \"agents\": {\r\n            \"defaults\": {\r\n              \"models\": {\r\n                \"openrouter/openai/gpt-5.4-mini\": {}\r\n              }\r\n            }\r\n          }\r\n\r\n\r\n### Steps\r\n\r\n1. Configure agents.defaults.models with an OpenRouter model id of the form openrouter/<provider>/<model>.\r\n2. Open the model selection menu in Telegram via /model.\r\n3. Inspect the visible button label for that model.\r\n\r\n### Expected\r\n\r\n- Button label reads openrouter/openai/gpt-5.4-mini (the full configured ref).\r\n\r\n### Actual\r\n\r\n- Button label read openai/gpt-5.4-mini, dropping the openrouter/ provider prefix.\r\n\r\n## Evidence\r\n\r\nAttach at least one:\r\n\r\n- [x] Failing test/log before + passing after\r\n- [ ] Trace/log snippets\r\n- [ ] Screenshot/recording\r\n- [ ] Perf numbers (if relevant)\r\n\r\n      $ pnpm test extensions/telegram/src/model-buttons.test.ts\r\n       Test Files  1 passed (1)\r\n            Tests  26 passed (26)   # 24 existing + 2 new regression tests\r\n      pnpm check:changed is green: typecheck extensions, typecheck extension tests, lint extensions, and runtime import cycles all pass.\r\n\r\n## Human Verification (required)\r\n\r\nWhat you personally verified (not just CI), and how:\r\n\r\n- Verified scenarios:\r\n    -Targeted vitest run for extensions/telegram/src/model-buttons.test.ts (26/26).\r\n    -Full pnpm check:changed gate (extensions + extension-tests + lint + import-cycles, all green).\r\n- Edge cases checked:\r\n    -Non-nested ids (gpt-5.4, claude-opus-4, unknown-id) — labels unchanged (existing tests pass).\r\n    -✓ marker on currently-selected model with the nested ref — works (new test).\r\n    -modelNames overrides still take precedence when present (existing test still passes).\r\n- What you did **not** verify:\r\n    -behavior with truncated long display labels for OpenRouter ids over 38 chars\r\n\r\n## Review Conversations\r\n\r\n- [ ] I replied to or resolved every bot review conversation I addressed in this PR.\r\n- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.\r\n\r\nIf a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.\r\n\r\n## Compatibility / Migration\r\n\r\n- Backward compatible? Yes\r\n- Config/env changes? No\r\n- Migration needed? No\r\n- If yes, exact upgrade steps:\r\n\r\n## Risks and Mitigations\r\n\r\nList only real risks for this PR. Add/remove entries as needed. If none, write `None`.\r\n\r\n- Risk: a non-OpenRouter provider that happens to register a model id containing / will now show a provider/model prefix where it previously showed the bare id.\r\n  - Mitigation: the new label is more accurate, not less, and matches how the configured ref reads. The dedupe key already used provider/model so there is no behavioral drift in selection. If a particular provider needs a different display, modelNames already overrides this fallback.\r\n"

## Real behavior proof

Maintainer proof after rebasing the PR branch onto current `main`:

```text
$ pnpm test extensions/telegram/src/model-buttons.test.ts
Test Files  1 passed (1)
Tests  26 passed (26)
```

```text
$ OPENCLAW_TESTBOX=0 pnpm check:changed
[check:changed] lanes=extensions, extensionTests
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
```

The regression tests exercise the real Telegram keyboard builder: `provider="openrouter"`, `models=["openai/gpt-5.4-mini"]` now renders `openrouter/openai/gpt-5.4-mini`, and the current-model marker renders `openrouter/openai/gpt-5.4-mini ✓`.
