### PR TITLE
fix(webchat): hide reset startup prompt from history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory-core: re-resolve the active runtime config whenever `memory_search` or `memory_get` executes, so provider changes made by `config.patch` stop leaving stale embedding backends behind in existing tool instances. Fixes #61098. Thanks @BradGroux and @Linux2010.
+- WebChat: keep bare `/new` and `/reset` startup instructions out of visible chat history while preserving `/reset <note>` as user-visible transcript text. Fixes #72369. Thanks @collynes and @haishmg.
 - Channels/setup: treat bundled channel plugins as already bundled during `channels add` and onboarding, enabling them without writing redundant `plugins.load.paths` entries or path install records. Fixes #72740. Thanks @iCodePoet.
 - WhatsApp: honor gateway `HTTPS_PROXY` / `HTTP_PROXY` env vars for QR-login WebSocket connections, while respecting `NO_PROXY`, so proxied networks no longer fall back to direct `mmg.whatsapp.net` connections that time out with 408. Fixes #72547; supersedes #72692. Thanks @mebusw and @SymbolStar.
 - Bonjour: default mDNS advertisements to the system hostname when it is DNS-safe, avoiding `openclaw.local` probing conflicts and Gateway restart loops on hosts such as `Lobster` or `ubuntu`. Fixes #72355 and #72689; supersedes #72694. Thanks @mscheuerlein-bot, @gcusms, @moyuwuhen601, @pavan987, @zml-0912, @hhq365, and @SymbolStar.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1017,6 +1017,85 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
   });
+
+  it("keeps bare reset startup instructions out of visible transcript prompt", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "/new",
+          RawBody: "/new",
+          CommandBody: "/new",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        command: {
+          surface: "webchat",
+          channel: "webchat",
+          isAuthorizedSender: true,
+          abortKey: "session-key",
+          ownerList: [],
+          senderIsOwner: true,
+          rawBodyNormalized: "/new",
+          commandBodyNormalized: "/new",
+        } as never,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.commandBody).toContain("A new session was started via /new or /reset.");
+    expect(call?.followupRun.prompt).toContain("A new session was started via /new or /reset.");
+    expect(call?.transcriptCommandBody).toBe("");
+    expect(call?.followupRun.transcriptPrompt).toBe("");
+  });
+
+  it("keeps reset user notes visible while hiding startup instructions", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "/reset summarize my workspace",
+          RawBody: "/reset summarize my workspace",
+          CommandBody: "/reset summarize my workspace",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        command: {
+          surface: "webchat",
+          channel: "webchat",
+          isAuthorizedSender: true,
+          abortKey: "session-key",
+          ownerList: [],
+          senderIsOwner: true,
+          rawBodyNormalized: "/reset summarize my workspace",
+          commandBodyNormalized: "/reset summarize my workspace",
+          softResetTriggered: true,
+          softResetTail: "summarize my workspace",
+        } as never,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.commandBody).toContain("A new session was started via /new or /reset.");
+    expect(call?.commandBody).toContain("summarize my workspace");
+    expect(call?.transcriptCommandBody).toBe("summarize my workspace");
+    expect(call?.followupRun.transcriptPrompt).toBe("summarize my workspace");
+  });
+
   it("uses inbound origin channel for run messageProvider", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -501,9 +501,11 @@ export async function runPreparedReply(
     : [inboundUserContext, "[User sent media without caption]"].filter(Boolean).join("\n\n");
   const transcriptBodyBase = isHeartbeat
     ? HEARTBEAT_TRANSCRIPT_PROMPT
-    : hasUserBody
-      ? baseBodyFinal
-      : "[User sent media without caption]";
+    : isBareSessionReset
+      ? softResetTail
+      : hasUserBody
+        ? baseBodyFinal
+        : "[User sent media without caption]";
   let prefixedBodyBase = await applySessionHints({
     baseBody: effectiveBaseBody,
     abortedLastRun,


### PR DESCRIPTION
## Summary

- Problem: bare `/new` and `/reset` WebChat turns could persist the internal startup instruction as a visible user transcript message.
- Why it matters: the Control UI could show runtime instructions as if the user typed them, creating noisy and confusing chat history.
- What changed: bare reset startup instructions stay in the runtime prompt but use an empty visible transcript prompt; `/reset` commands with a user note keep that note visible.
- What did NOT change (scope boundary): no startup behavior, config, UI rendering, or command authorization changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72369
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: bare session reset runs used the startup instruction as both the runtime prompt and `transcriptCommandBody`, so the internal instruction could be persisted/displayed as user-authored chat text.
- Missing detection / guardrail: no regression test asserted that runtime-only reset startup prompts stay out of the visible transcript.
- Contributing context (if known): heartbeat turns already use a separate transcript prompt; reset startup turns did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply-run.media-only.test.ts`
- Scenario the test should lock in: bare `/new` keeps the startup instruction in the runtime command body but sets the visible transcript prompt to empty.
- Why this is the smallest reliable guardrail: `runPreparedReply` owns the split between runtime prompt and transcript prompt.
- Existing test that already covers this (if any): heartbeat transcript prompt coverage existed, but not reset startup prompts.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bare `/new` and `/reset` startup instructions no longer appear as visible user messages in chat history. `/reset <note>` still records `<note>` as the visible user text.

## Diagram (if applicable)

```text
Before:
/new -> startup instruction used as runtime prompt + visible transcript message

After:
/new -> startup instruction used as runtime-only prompt context -> no visible transcript message
/reset note -> startup instruction hidden, note remains visible
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS/Darwin local checkout
- Runtime/container: Node 22-compatible repo scripts via `npm exec pnpm@10.33.0`
- Model/provider: N/A
- Integration/channel (if any): WebChat / auto-reply reset flow
- Relevant config (redacted): default test config

### Steps

1. Trigger a bare `/new` or `/reset` run.
2. Inspect the transcript-visible prompt passed to the runner.
3. Trigger `/reset summarize my workspace` and inspect the visible prompt.

### Expected

- Bare reset startup instruction is runtime-only and not visible in transcript history.
- Reset user note remains visible.

### Actual

- Before this fix, the bare reset startup instruction was used as the visible transcript prompt.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/auto-reply/reply/get-reply-run.media-only.test.ts`
  - `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- tsgo:core`
  - `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- lint:core`
- Edge cases checked: `/reset <note>` keeps the user note visible while hiding the startup instruction.
- What you did **not** verify: live browser WebChat rendering.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: hiding too much user-authored reset text.
  - Mitigation: regression test verifies `/reset <note>` keeps the note as the transcript prompt.
