### PR TITLE
fix(voice-call): send notify TwiML directly for Twilio

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -53,8 +53,8 @@ type TwilioApiRequest = (
   options?: { allowNotFound?: boolean },
 ) => Promise<unknown>;
 
-function createApiRequestMock() {
-  return vi.fn<TwilioApiRequest>(async () => ({}));
+function createApiRequestMock(impl?: TwilioApiRequest) {
+  return vi.fn<TwilioApiRequest>(impl ?? (async () => ({})));
 }
 
 function configureTelephonyTwiMlFallback(params: { providerCallId: string; streamSid?: string }) {
@@ -77,6 +77,61 @@ function configureTelephonyTwiMlFallback(params: { providerCallId: string; strea
 }
 
 describe("TwilioProvider", () => {
+  it("sends inline TwiML directly for notify-mode outbound calls", async () => {
+    const provider = createProvider();
+    const apiRequest = createApiRequestMock(async () => ({ sid: "CA123", status: "queued" }));
+    (
+      provider as unknown as {
+        apiRequest: TwilioApiRequest;
+      }
+    ).apiRequest = apiRequest;
+
+    const result = await provider.initiateCall({
+      callId: "call-1",
+      from: "+14155550100",
+      to: "+14155550123",
+      webhookUrl: "https://example.ngrok.app/voice/webhook",
+      inlineTwiml: "<Response><Say>Hello</Say></Response>",
+    });
+
+    expect(result).toEqual({ providerCallId: "CA123", status: "queued" });
+    expect(apiRequest).toHaveBeenCalledWith(
+      "/Calls.json",
+      expect.objectContaining({
+        To: "+14155550123",
+        From: "+14155550100",
+        Twiml: "<Response><Say>Hello</Say></Response>",
+        StatusCallback: "https://example.ngrok.app/voice/webhook?callId=call-1&type=status",
+      }),
+    );
+    expect(apiRequest.mock.calls[0]?.[1]).not.toHaveProperty("Url");
+  });
+
+  it("uses webhook URL for conversation outbound calls", async () => {
+    const provider = createProvider();
+    const apiRequest = createApiRequestMock(async () => ({ sid: "CA123", status: "queued" }));
+    (
+      provider as unknown as {
+        apiRequest: TwilioApiRequest;
+      }
+    ).apiRequest = apiRequest;
+
+    await provider.initiateCall({
+      callId: "call-1",
+      from: "+14155550100",
+      to: "+14155550123",
+      webhookUrl: "https://example.ngrok.app/voice/webhook",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      "/Calls.json",
+      expect.objectContaining({
+        Url: "https://example.ngrok.app/voice/webhook?callId=call-1",
+        StatusCallback: "https://example.ngrok.app/voice/webhook?callId=call-1&type=status",
+      }),
+    );
+    expect(apiRequest.mock.calls[0]?.[1]).not.toHaveProperty("Twiml");
+  });
   it("returns streaming TwiML for outbound conversation calls before in-progress", () => {
     const provider = createProvider();
     const ctx = createContext("CallStatus=initiated&Direction=outbound-api&CallSid=CA123", {

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -496,23 +496,21 @@ export class TwilioProvider implements VoiceCallProvider {
     statusUrl.searchParams.set("callId", input.callId);
     statusUrl.searchParams.set("type", "status"); // Differentiate from TwiML requests
 
-    // Store TwiML content if provided (for notify mode)
-    // We now serve it from the webhook endpoint instead of sending inline
-    if (input.inlineTwiml) {
-      this.twimlStorage.set(input.callId, input.inlineTwiml);
-      this.notifyCalls.add(input.callId);
-    }
-
-    // Build request params - always use URL-based TwiML.
-    // Twilio silently ignores `StatusCallback` when using the inline `Twiml` parameter.
     const params: Record<string, string | string[]> = {
       To: input.to,
       From: input.from,
-      Url: url.toString(), // TwiML serving endpoint
-      StatusCallback: statusUrl.toString(), // Separate status callback endpoint
+      StatusCallback: statusUrl.toString(),
       StatusCallbackEvent: ["initiated", "ringing", "answered", "completed"],
       Timeout: "30",
     };
+
+    if (input.inlineTwiml) {
+      // Notify-mode calls are one-shot messages. Send their TwiML directly so the
+      // initial answer path does not depend on a public webhook/tunnel roundtrip.
+      params.Twiml = input.inlineTwiml;
+    } else {
+      params.Url = url.toString();
+    }
 
     const result = await this.apiRequest<TwilioCallResponse>("/Calls.json", params);
 


### PR DESCRIPTION
## Summary

- send Twilio notify-mode inline TwiML directly via the `Twiml` call parameter
- keep webhook `Url` behavior for conversation/dynamic TwiML calls
- add provider tests for notify-mode direct TwiML and conversation-mode webhook URL behavior

## Why

Outbound notify calls are one-shot messages. The manager already generates inline TwiML for notify mode, but the Twilio provider stored that TwiML and asked Twilio to fetch it through the public webhook. That makes a simple notify call depend on webhook/tunnel/signature availability for the initial answer path, which can surface to callers as a Twilio application error.

Sending the prepared notify TwiML directly makes the documented short outbound notify smoke path more robust while leaving conversation calls on the webhook path.

## Validation

- `corepack pnpm exec vitest run --config test/vitest/vitest.extension-voice-call.config.ts extensions/voice-call/src/providers/twilio.test.ts extensions/voice-call/src/manager/outbound.test.ts`
- `corepack pnpm lint:extensions -- --quiet`
