### PR TITLE
fix(gateway): omit rotated bearer token from device.token.rotate response (#66773)

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -294,12 +294,14 @@ describe("deviceHandlers", () => {
       {
         deviceId: " device-1 ",
         role: "operator",
-        token: "new-token",
         scopes: ["operator.pairing"],
         rotatedAtMs: 789,
       },
       undefined,
     );
+    // SECURITY: rotate response MUST NOT leak the freshly rotated bearer token (#66773)
+    const rotatePayload = (opts.respond as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
+    expect(rotatePayload).not.toHaveProperty("token");
   });
 
   it("treats normalized device ids as self-owned for token rotation", async () => {
@@ -328,12 +330,14 @@ describe("deviceHandlers", () => {
       {
         deviceId: " device-1 ",
         role: "operator",
-        token: "new-token",
         scopes: ["operator.pairing"],
         rotatedAtMs: 789,
       },
       undefined,
     );
+    // SECURITY: rotate response MUST NOT leak the freshly rotated bearer token (#66773)
+    const rotatePayload = (opts.respond as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
+    expect(rotatePayload).not.toHaveProperty("token");
   });
 
   it("rejects rotating a token for a role that was never approved", async () => {

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -362,12 +362,15 @@ export const deviceHandlers: GatewayRequestHandlers = {
     context.logGateway.info(
       `device token rotated device=${deviceId} role=${entry.role} scopes=${entry.scopes.join(",")}`,
     );
+    // SECURITY: Do NOT include the rotated bearer token in the RPC response payload.
+    // The freshly generated credential is persisted server-side; callers that need it
+    // should retrieve it through the documented bootstrap/provisioning path. Returning
+    // it here exposes the token to RPC trace logs, browser devtools, and proxies.
     respond(
       true,
       {
         deviceId,
         role: entry.role,
-        token: entry.token,
         scopes: entry.scopes,
         rotatedAtMs: entry.rotatedAtMs ?? entry.createdAtMs,
       },

--- a/src/gateway/server.device-token-rotate-authz.test.ts
+++ b/src/gateway/server.device-token-rotate-authz.test.ts
@@ -176,13 +176,23 @@ describe("gateway device.token.rotate/revoke ownership guard (IDOR)", () => {
     try {
       await connectOk(started.ws);
 
-      const rotate = await rpcReq<{ token?: string }>(started.ws, "device.token.rotate", {
-        deviceId: device.deviceId,
-        role: "operator",
-        scopes: ["operator.pairing"],
-      });
+      const rotate = await rpcReq<{ rotatedAtMs?: number; token?: string }>(
+        started.ws,
+        "device.token.rotate",
+        {
+          deviceId: device.deviceId,
+          role: "operator",
+          scopes: ["operator.pairing"],
+        },
+      );
       expect(rotate.ok).toBe(true);
-      expect(rotate.payload?.token).toBeTruthy();
+      // Successful rotation reports the rotation timestamp; the freshly generated
+      // bearer token is intentionally NOT echoed back over the RPC channel (#66773).
+      expect(rotate.payload?.rotatedAtMs).toBeTypeOf("number");
+      expect(rotate.payload?.token).toBeUndefined();
+      // Verify the new token actually persisted server-side via the pairing store.
+      const pairedAfterRotate = await getPairedDevice(device.deviceId);
+      expect(pairedAfterRotate?.tokens?.operator?.token).toBeTruthy();
 
       const revoke = await rpcReq<{ revokedAtMs?: number }>(started.ws, "device.token.revoke", {
         deviceId: device.deviceId,


### PR DESCRIPTION
## Summary
The `device.token.rotate` gateway RPC currently returns the freshly rotated bearer token in the success payload. This exposes the credential to RPC trace logs, browser devtools, transcripts, and any proxy that observes the response. This PR removes the `token` field from the rotate response so the secret stays inside the persisted device-pairing store.

## Root Cause
In `src/gateway/server-methods/devices.ts`, the rotate handler serialized `entry.token` directly into the success payload alongside metadata. The fresh credential is already persisted server-side by `rotateDeviceToken`, so echoing it back over the RPC response is a redundant secret-exposure sink in the control plane.

## Changes
- `src/gateway/server-methods/devices.ts`: drop `token: entry.token` from the rotate success payload; keep `deviceId`, `role`, `scopes`, `rotatedAtMs`. Add a comment explaining why the token is intentionally omitted.
- `src/gateway/server-methods/devices.test.ts`: update the two rotate-success cases to assert the redacted shape and add explicit `not.toHaveProperty("token")` regression assertions.
- `src/gateway/server.device-token-rotate-authz.test.ts`: update the admin-rotate IDOR test to verify the response no longer leaks the bearer token but that the rotation still persists a new token server-side via the pairing store.

## Reproduction (before fix)
With `entry.token` still in the payload, the existing unit test at `src/gateway/server-methods/devices.test.ts:292-303` and the IDOR integration test at `src/gateway/server.device-token-rotate-authz.test.ts:185` both encoded the leak as expected behavior. Any RPC client observing a successful rotate response could capture the new bearer token, exactly as reported in the issue.

## Verification (after fix)
~~~
$ pnpm test src/gateway/server-methods/devices.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
~~~

The IDOR integration suite (`src/gateway/server.device-token-rotate-authz.test.ts`) reports 6/7 pass. The single failing case (`rejects a device-token caller rotating or revoking another device's token`) times out on the WebSocket helper on this Windows host BEFORE this change too — it is a pre-existing local flake unrelated to the redaction. The admin-rotate case I touched passes and now also asserts the persisted pairing store contains a fresh token after rotation.

`pnpm tsgo`, `pnpm check:test-types`, and `pnpm lint:core` all exit `0`.

## Test
- Regression test: `src/gateway/server-methods/devices.test.ts` — both rotate cases now assert the response shape lacks `token` (`expect(rotatePayload).not.toHaveProperty("token")`).
- Integration coverage: `src/gateway/server.device-token-rotate-authz.test.ts` — admin rotate path verifies redacted response + persisted pairing-store update.
- `pnpm test src/gateway/server-methods/devices.test.ts` — 20/20 pass.

## Notes
- This is a behavioral contract change: any operator workflow that read the rotated token straight out of the RPC response will no longer receive it. The credential is still generated and persisted server-side; consumers that need the fresh secret should use the documented bootstrap/provisioning path (e.g. the device-pairing store) rather than the rotate response. The `device.token.rotate` CLI subcommand still works — it now prints the rotation metadata (`deviceId`, `role`, `scopes`, `rotatedAtMs`) without echoing the bearer token.
- Aligns with the conservative direction in `clawsweeper`'s review on #66773 and supersedes the closed unmerged attempt in #66794 (which broke its own tests).

Closes #66773
