### PR TITLE
fix(gateway): include connecting client in presence snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/tools: scope tool-loop detection history to the active run when available, so scheduled heartbeat cycles no longer inherit stale repeated-call counts from previous runs. Fixes #40144. Thanks @mattbrown319.
+- Gateway/presence: include the newly authenticated client in the initial hello-ok presence snapshot, keeping first-connect presence state consistent with follow-up presence reads. Thanks @haishmg.
 - Agents/reasoning: recover fully wrapped unclosed `<think>` replies that would otherwise sanitize to empty text while keeping strict stripping for closed reasoning blocks and unclosed tails after visible text. Fixes #37696; supersedes #51915. Thanks @druide67 and @okuyam2y.
 - Control UI/Gateway: bind WebChat handshakes to their active socket and reject post-close server registrations, so aborted connects no longer leave zombie clients or misleading duplicate WebSocket connection logs. Fixes #72753. Thanks @LumenFromTheFuture.
 - Plugins/Windows: normalize Windows absolute paths before handing bundled plugin modules to Jiti, so Feishu/Lark message sending no longer fails with unsupported `c:` ESM loader URLs. Fixes #72783. Thanks @jackychen-png.

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -36,7 +36,7 @@ import {
   updatePairedNodeMetadata,
 } from "../../../infra/node-pairing.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../infra/skills-remote.js";
-import { upsertPresence } from "../../../infra/system-presence.js";
+import { listSystemPresence, upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeRoutingConfig } from "../../../infra/voicewake-routing.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
@@ -1380,7 +1380,9 @@ export function attachGatewayWsMessageHandler(params: {
             instanceId: device?.id ?? instanceId,
             reason: "connect",
           });
-          incrementPresenceVersion();
+          const presenceVersion = incrementPresenceVersion();
+          snapshot.presence = listSystemPresence();
+          snapshot.stateVersion.presence = presenceVersion;
         }
         if (role === "node") {
           const context = buildRequestContext();


### PR DESCRIPTION
## Summary

- Problem: the `hello-ok` snapshot was built before the authenticated WebSocket was inserted into gateway presence.
- Why it matters: first-connect clients could receive a stale presence snapshot, and `src/gateway/server.auth.default-token.test.ts` failed deterministically on current main because the just-authenticated device was missing from `snapshot.presence`.
- What changed: after presence is upserted on connect, the initial `hello-ok` snapshot refreshes `presence` and its state version before the response is sent.
- What did NOT change (scope boundary): no auth policy, scope grant, pairing, or presence storage semantics changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #72778
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `buildGatewaySnapshot()` ran before `upsertPresence()` during successful connect handling, so the first `hello-ok` payload could not include the client that had just authenticated.
- Missing detection / guardrail: existing coverage was sufficient, but the code path regressed and the test now catches it deterministically.
- Contributing context (if known): this surfaced as a repeated #72778 CI failure in `checks-node-agentic-control-plane`, but the failure is independent of the OpenCode changes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/gateway/server.auth.default-token.test.ts`
- Scenario the test should lock in: a device-authenticated token connect with omitted scopes appears in the initial `hello-ok.snapshot.presence` and does not gain admin scope.
- Why this is the smallest reliable guardrail: it exercises the real gateway WebSocket connect path and presence snapshot payload.
- Existing test that already covers this (if any): `does not grant admin when scopes are omitted`
- If no new test is added, why not: the existing test failed before this patch and passed after it.

## User-visible / Behavior Changes

Newly authenticated gateway clients are included in their initial `hello-ok` presence snapshot instead of only appearing in later presence reads/events.

## Diagram (if applicable)

```text
Before:
connect -> build snapshot -> upsert presence -> send hello-ok without this client

After:
connect -> build snapshot -> upsert presence -> refresh snapshot presence -> send hello-ok with this client
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22 / pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket auth/connect
- Relevant config (redacted): default token auth test harness

### Steps

1. Run `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/gateway/server.auth.default-token.test.ts` on current main.
2. Observe `does not grant admin when scopes are omitted` fail because `mine` is undefined.
3. Apply this patch and rerun the focused gateway tests.

### Expected

- The authenticated device appears in the initial hello-ok presence snapshot with no admin scope.

### Actual

- Before this patch, the initial snapshot omitted the just-authenticated device.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Before patch: `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/gateway/server.auth.default-token.test.ts` failed at `src/gateway/server.auth.default-token.suite.ts:363`.
  - After patch: `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/gateway/server.auth.default-token.test.ts src/gateway/server.health.test.ts` passed (`25` tests).
- Edge cases checked: scope list remains empty for the omitted-scopes device; health/presence tests still pass.
- What you did **not** verify: full `pnpm check:changed`, because this fork checkout's changed-lanes output is currently comparing a very broad base and is not useful for the two-file patch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: refreshing the snapshot presence could produce a presence list slightly newer than the rest of the snapshot.
  - Mitigation: only `presence` and its `stateVersion.presence` are refreshed after the presence mutation; the rest of the connect snapshot remains unchanged.
