### PR TITLE
test(agents): align unclassified failure expectation

### DIFF
--- a/src/agents/pi-embedded-error-observation.test.ts
+++ b/src/agents/pi-embedded-error-observation.test.ts
@@ -187,7 +187,7 @@ describe("buildApiErrorObservationFields", () => {
 
     expect(observed).toMatchObject({
       httpCode: "401",
-      providerRuntimeFailureKind: "unknown",
+      providerRuntimeFailureKind: "unclassified",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Problem: CI's agent shard now classifies provider-less 401 missing-scope payloads as `unclassified`, but one observation test still expected the retired `unknown` fallback.
- Why it matters: This leaves unrelated PRs red after the newer failure-kind taxonomy landed.
- What changed: Updated the stale test expectation to `unclassified` while preserving the assertion that provider-less payloads stay out of the Codex-specific `auth_scope` lane.
- What did NOT change (scope boundary): Production classification logic and schemas are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #72778
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The provider runtime failure taxonomy changed provider-less unknown payloads to `unclassified`, but this test retained the older `unknown` expectation.
- Missing detection / guardrail: CI caught the stale expectation in `checks-node-agentic-agents`.
- Contributing context (if known): Related cron contract drift was already fixed on main; this is the remaining agent-side expectation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-error-observation.test.ts`
- Scenario the test should lock in: Provider-less missing-scope auth payloads are classified outside the `auth_scope` lane.
- Why this is the smallest reliable guardrail: The existing unit test already exercises the exact observation helper output.
- Existing test that already covers this (if any): `keeps provider-less missing-scope auth payloads out of the codex-specific scope lane`
- If no new test is added, why not: Existing coverage needed expectation alignment only.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node via `npm exec pnpm@10.33.0`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/agents/pi-embedded-error-observation.test.ts src/cron/cron-protocol-conformance.test.ts`.

### Expected

- Focused agent and cron tests pass.

### Actual

- Focused agent and cron tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Focused agent observation test and the adjacent cron protocol conformance test both pass locally.
- Edge cases checked: Confirmed the test still asserts the provider-less missing-scope payload remains outside `auth_scope`.
- What you did **not** verify: Full `pnpm test` locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
