### PR TITLE
fix(bonjour): truncate mDNS service name and hostname to 63-byte DNS label limit [AI-assisted]

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -736,7 +736,7 @@ describe("gateway bonjour advertiser", () => {
   });
 
   it("truncates service name exceeding 63-byte DNS label limit", async () => {
-    const longHostname = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf";
+    const longHostname = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf-abcdefghi";
     enableAdvertiserUnitMode(longHostname);
 
     const destroy = vi.fn().mockResolvedValue(undefined);
@@ -755,6 +755,7 @@ describe("gateway bonjour advertiser", () => {
     // Both name and hostname must be within the 63-byte DNS label limit
     expect(new TextEncoder().encode(serviceName).byteLength).toBeLessThanOrEqual(63);
     expect(new TextEncoder().encode(hostname).byteLength).toBeLessThanOrEqual(63);
+    expect(hostname).not.toMatch(/-$/);
 
     await started.stop();
   });

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -735,6 +735,54 @@ describe("gateway bonjour advertiser", () => {
     await started.stop();
   });
 
+  it("truncates service name exceeding 63-byte DNS label limit", async () => {
+    const longHostname = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf";
+    enableAdvertiserUnitMode(longHostname);
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
+    const serviceName = gatewayCall?.[0]?.name as string;
+    const hostname = gatewayCall?.[0]?.hostname as string;
+
+    // Both name and hostname must be within the 63-byte DNS label limit
+    expect(new TextEncoder().encode(serviceName).byteLength).toBeLessThanOrEqual(63);
+    expect(new TextEncoder().encode(hostname).byteLength).toBeLessThanOrEqual(63);
+
+    await started.stop();
+  });
+
+  it("truncates multi-byte hostname within DNS label byte limit", async () => {
+    // 21 CJK characters = 63 bytes in UTF-8, adding " (OpenClaw)" pushes over
+    const cjkHostname = "你".repeat(21);
+    enableAdvertiserUnitMode(cjkHostname);
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
+    const serviceName = gatewayCall?.[0]?.name as string;
+
+    expect(new TextEncoder().encode(serviceName).byteLength).toBeLessThanOrEqual(63);
+    // Should not end with a replacement character from incomplete multi-byte truncation
+    expect(serviceName).not.toMatch(/\uFFFD$/);
+
+    await started.stop();
+  });
+
   it("uses system hostname when OPENCLAW_MDNS_HOSTNAME is unset", async () => {
     // Allow advertiser to run in unit tests.
     delete process.env.VITEST;

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -183,9 +183,24 @@ function resolveSystemMdnsHostname(): string | null {
   return firstLabel;
 }
 
+const MAX_DNS_LABEL_BYTES = 63;
+
+function truncateToDnsLabel(name: string): string {
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(name);
+  if (encoded.byteLength <= MAX_DNS_LABEL_BYTES) {
+    return name;
+  }
+  // Truncate at byte boundary, then decode back (TextDecoder handles incomplete sequences)
+  const truncated = encoded.slice(0, MAX_DNS_LABEL_BYTES);
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(truncated);
+  // Strip any replacement character from incomplete multi-byte sequence at the end
+  return decoded.replace(/\uFFFD$/, "").trim() || "OpenClaw";
+}
+
 function safeServiceName(name: string) {
   const trimmed = name.trim();
-  return trimmed.length > 0 ? trimmed : "OpenClaw";
+  return trimmed.length > 0 ? truncateToDnsLabel(trimmed) : "OpenClaw";
 }
 
 function prettifyInstanceName(name: string) {
@@ -353,11 +368,12 @@ export async function startGatewayBonjourAdvertiser(
 
     const hostnameRaw =
       process.env.OPENCLAW_MDNS_HOSTNAME?.trim() || resolveSystemMdnsHostname() || "openclaw";
-    const hostname =
+    const hostname = truncateToDnsLabel(
       hostnameRaw
         .replace(/\.local$/i, "")
         .split(".")[0]
-        .trim() || "openclaw";
+        .trim() || "openclaw",
+    );
     const instanceName =
       typeof opts.instanceName === "string" && opts.instanceName.trim()
         ? opts.instanceName.trim()

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -185,7 +185,7 @@ function resolveSystemMdnsHostname(): string | null {
 
 const MAX_DNS_LABEL_BYTES = 63;
 
-function truncateToDnsLabel(name: string): string {
+function truncateToDnsLabel(name: string, fallback = "OpenClaw"): string {
   const encoder = new TextEncoder();
   const encoded = encoder.encode(name);
   if (encoded.byteLength <= MAX_DNS_LABEL_BYTES) {
@@ -195,7 +195,12 @@ function truncateToDnsLabel(name: string): string {
   const truncated = encoded.slice(0, MAX_DNS_LABEL_BYTES);
   const decoded = new TextDecoder("utf-8", { fatal: false }).decode(truncated);
   // Strip any replacement character from incomplete multi-byte sequence at the end
-  return decoded.replace(/\uFFFD$/, "").trim() || "OpenClaw";
+  return (
+    decoded
+      .replace(/\uFFFD$/, "")
+      .replace(/-+$/, "")
+      .trim() || fallback
+  );
 }
 
 function safeServiceName(name: string) {
@@ -373,6 +378,7 @@ export async function startGatewayBonjourAdvertiser(
         .replace(/\.local$/i, "")
         .split(".")[0]
         .trim() || "openclaw",
+      "openclaw",
     );
     const instanceName =
       typeof opts.instanceName === "string" && opts.instanceName.trim()


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: When the system hostname exceeds 63 bytes (common with Kubernetes pod names like `app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf`), the `@homebridge/ciao` DNS label encoder throws an `AssertionError` that crashes the gateway on startup.
- Why it matters: Prevents OpenClaw from starting at all on Kubernetes and other platforms with long auto-generated hostnames.
- What changed: Added `truncateToDnsLabel()` that safely truncates UTF-8 strings to the 63-byte DNS label limit (RFC 1035), applied to both the mDNS service instance name and hostname before passing them to ciao.
- What did NOT change (scope boundary): No changes to ciao library internals, no changes to Bonjour discovery logic, watchdog, or lifecycle management.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Plugin (bonjour)

## Linked Issue/PR
- Closes #37705
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `safeServiceName()` only checked for empty strings but did not enforce the 63-byte DNS label limit from RFC 1035. Long hostnames (e.g., Kubernetes pod names) were passed directly to `@homebridge/ciao`'s `DNSLabelCoder`, which asserts label length ≤ 63 bytes.
- Missing detection / guardrail: No input validation on hostname/service name length before passing to the mDNS library.
- Contributing context: Kubernetes generates pod hostnames that routinely exceed 63 bytes; the original code assumed short hostnames.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/bonjour/src/advertiser.test.ts`
- Scenario the test should lock in: (1) Long Kubernetes-style hostname produces service name and hostname both within 63 bytes. (2) Multi-byte CJK hostname is truncated at UTF-8 code point boundaries without producing replacement characters.
- Why this is the smallest reliable guardrail: Unit test with mock ciao service verifies the truncation contract without needing a real mDNS stack.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes
- Gateway no longer crashes on startup when the system hostname exceeds 63 bytes. The mDNS service name is silently truncated to fit within DNS label limits.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- The truncation is purely cosmetic for mDNS discovery names. No security-sensitive data is involved — hostnames are already public via mDNS broadcast.
