### PR TITLE
feat: Telnyx OCPlatform Embeddings Provider

### DIFF
--- a/extensions/telnyx-embeddings/embedding-provider.test.ts
+++ b/extensions/telnyx-embeddings/embedding-provider.test.ts
@@ -10,12 +10,18 @@ describe("normalizeTelnyxModel", () => {
     expect(normalizeTelnyxModel("   ")).toBe(DEFAULT_TELNYX_EMBEDDING_MODEL);
   });
 
-  it("strips telnyx/ prefix", () => {
-    expect(normalizeTelnyxModel("telnyx/gte-large")).toBe("gte-large");
+  it("passes through fully-qualified models unchanged", () => {
+    expect(normalizeTelnyxModel("thenlper/gte-large")).toBe("thenlper/gte-large");
   });
 
-  it("passes through other models unchanged", () => {
-    expect(normalizeTelnyxModel("thenlper/gte-large")).toBe("thenlper/gte-large");
+  it("passes through multilingual model unchanged", () => {
+    expect(normalizeTelnyxModel("intfloat/multilingual-e5-large")).toBe(
+      "intfloat/multilingual-e5-large",
+    );
+  });
+
+  it("passes through Qwen model unchanged", () => {
+    expect(normalizeTelnyxModel("Qwen/Qwen3-Embedding-8B")).toBe("Qwen/Qwen3-Embedding-8B");
   });
 
   it("trims whitespace", () => {

--- a/extensions/telnyx-embeddings/embedding-provider.test.ts
+++ b/extensions/telnyx-embeddings/embedding-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTelnyxModel, DEFAULT_TELNYX_EMBEDDING_MODEL } from "./embedding-provider.js";
+
+describe("normalizeTelnyxModel", () => {
+  it("returns default model for empty string", () => {
+    expect(normalizeTelnyxModel("")).toBe(DEFAULT_TELNYX_EMBEDDING_MODEL);
+  });
+
+  it("returns default model for whitespace", () => {
+    expect(normalizeTelnyxModel("   ")).toBe(DEFAULT_TELNYX_EMBEDDING_MODEL);
+  });
+
+  it("strips telnyx/ prefix", () => {
+    expect(normalizeTelnyxModel("telnyx/gte-large")).toBe("gte-large");
+  });
+
+  it("passes through other models unchanged", () => {
+    expect(normalizeTelnyxModel("thenlper/gte-large")).toBe("thenlper/gte-large");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeTelnyxModel("  thenlper/gte-large  ")).toBe("thenlper/gte-large");
+  });
+
+  it("default model is thenlper/gte-large", () => {
+    expect(DEFAULT_TELNYX_EMBEDDING_MODEL).toBe("thenlper/gte-large");
+  });
+});

--- a/extensions/telnyx-embeddings/embedding-provider.ts
+++ b/extensions/telnyx-embeddings/embedding-provider.ts
@@ -1,0 +1,82 @@
+import {
+  fetchRemoteEmbeddingVectors,
+  resolveRemoteEmbeddingClient,
+  type MemoryEmbeddingProvider,
+  type MemoryEmbeddingProviderCreateOptions,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+
+export type TelnyxEmbeddingClient = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  ssrfPolicy?: SsrFPolicy;
+  fetchImpl?: typeof fetch;
+  model: string;
+};
+
+const DEFAULT_TELNYX_BASE_URL = "https://api.telnyx.com/v2/ai/openai";
+export const DEFAULT_TELNYX_EMBEDDING_MODEL = "thenlper/gte-large";
+
+const TELNYX_MODEL_DIMENSIONS: Record<string, number> = {
+  "thenlper/gte-large": 1024,
+};
+
+export function normalizeTelnyxModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_TELNYX_EMBEDDING_MODEL;
+  }
+  return trimmed.startsWith("telnyx/") ? trimmed.slice("telnyx/".length) : trimmed;
+}
+
+export async function createTelnyxEmbeddingProvider(
+  options: MemoryEmbeddingProviderCreateOptions,
+): Promise<{ provider: MemoryEmbeddingProvider; client: TelnyxEmbeddingClient }> {
+  const client = await resolveTelnyxEmbeddingClient(options);
+  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+
+  const embed = async (input: string[]): Promise<number[][]> => {
+    if (input.length === 0) {
+      return [];
+    }
+    return await fetchRemoteEmbeddingVectors({
+      url,
+      headers: client.headers,
+      ssrfPolicy: client.ssrfPolicy,
+      fetchImpl: client.fetchImpl,
+      body: {
+        model: client.model,
+        input,
+      },
+      errorPrefix: "telnyx embeddings failed",
+    });
+  };
+
+  return {
+    provider: {
+      id: "telnyx",
+      model: client.model,
+      ...(typeof TELNYX_MODEL_DIMENSIONS[client.model] === "number"
+        ? { dimensions: TELNYX_MODEL_DIMENSIONS[client.model] }
+        : {}),
+      embedQuery: async (text) => {
+        const [vec] = await embed([text]);
+        return vec ?? [];
+      },
+      embedBatch: async (texts) => await embed(texts),
+    },
+    client,
+  };
+}
+
+export async function resolveTelnyxEmbeddingClient(
+  options: MemoryEmbeddingProviderCreateOptions,
+): Promise<TelnyxEmbeddingClient> {
+  const client = await resolveRemoteEmbeddingClient({
+    provider: "telnyx",
+    options,
+    defaultBaseUrl: DEFAULT_TELNYX_BASE_URL,
+    normalizeModel: normalizeTelnyxModel,
+  });
+  return client;
+}

--- a/extensions/telnyx-embeddings/embedding-provider.ts
+++ b/extensions/telnyx-embeddings/embedding-provider.ts
@@ -10,7 +10,6 @@ export type TelnyxEmbeddingClient = {
   baseUrl: string;
   headers: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
-  fetchImpl?: typeof fetch;
   model: string;
 };
 
@@ -19,6 +18,8 @@ export const DEFAULT_TELNYX_EMBEDDING_MODEL = "thenlper/gte-large";
 
 const TELNYX_MODEL_DIMENSIONS: Record<string, number> = {
   "thenlper/gte-large": 1024,
+  "intfloat/multilingual-e5-large": 1024,
+  "Qwen/Qwen3-Embedding-8B": 4096,
 };
 
 export function normalizeTelnyxModel(model: string): string {
@@ -26,7 +27,7 @@ export function normalizeTelnyxModel(model: string): string {
   if (!trimmed) {
     return DEFAULT_TELNYX_EMBEDDING_MODEL;
   }
-  return trimmed.startsWith("telnyx/") ? trimmed.slice("telnyx/".length) : trimmed;
+  return trimmed;
 }
 
 export async function createTelnyxEmbeddingProvider(
@@ -43,7 +44,6 @@ export async function createTelnyxEmbeddingProvider(
       url,
       headers: client.headers,
       ssrfPolicy: client.ssrfPolicy,
-      fetchImpl: client.fetchImpl,
       body: {
         model: client.model,
         input,

--- a/extensions/telnyx-embeddings/index.ts
+++ b/extensions/telnyx-embeddings/index.ts
@@ -1,0 +1,6 @@
+import { definePluginEntry } from "openclaw/plugin-sdk";
+import { telnyxMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
+
+export default definePluginEntry({
+  registerMemoryEmbeddingProvider: () => telnyxMemoryEmbeddingProviderAdapter,
+});

--- a/extensions/telnyx-embeddings/index.ts
+++ b/extensions/telnyx-embeddings/index.ts
@@ -1,6 +1,11 @@
-import { definePluginEntry } from "openclaw/plugin-sdk";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { telnyxMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 
 export default definePluginEntry({
-  registerMemoryEmbeddingProvider: () => telnyxMemoryEmbeddingProviderAdapter,
+  id: "telnyx-embeddings",
+  name: "Telnyx Embeddings",
+  description: "Bundled Telnyx memory embedding provider plugin",
+  register(api) {
+    api.registerMemoryEmbeddingProvider(telnyxMemoryEmbeddingProviderAdapter);
+  },
 });

--- a/extensions/telnyx-embeddings/memory-embedding-adapter.ts
+++ b/extensions/telnyx-embeddings/memory-embedding-adapter.ts
@@ -1,0 +1,34 @@
+import {
+  isMissingEmbeddingApiKeyError,
+  sanitizeEmbeddingCacheHeaders,
+  type MemoryEmbeddingProviderAdapter,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import {
+  createTelnyxEmbeddingProvider,
+  DEFAULT_TELNYX_EMBEDDING_MODEL,
+} from "./embedding-provider.js";
+
+export const telnyxMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "telnyx",
+  defaultModel: DEFAULT_TELNYX_EMBEDDING_MODEL,
+  transport: "remote",
+  authProviderId: "telnyx",
+  autoSelectPriority: 25,
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: isMissingEmbeddingApiKeyError,
+  create: async (options) => {
+    const { provider, client } = await createTelnyxEmbeddingProvider(options);
+    return {
+      provider,
+      runtime: {
+        id: "telnyx",
+        cacheKeyData: {
+          provider: "telnyx",
+          baseUrl: client.baseUrl,
+          model: client.model,
+          headers: sanitizeEmbeddingCacheHeaders(client.headers, ["authorization"]),
+        },
+      },
+    };
+  },
+};

--- a/extensions/telnyx-embeddings/openclaw.plugin.json
+++ b/extensions/telnyx-embeddings/openclaw.plugin.json
@@ -1,0 +1,32 @@
+{
+  "id": "telnyx-embeddings",
+  "enabledByDefault": true,
+  "providers": ["telnyx"],
+  "providerAuthEnvVars": {
+    "telnyx": ["TELNYX_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "telnyx",
+      "method": "api-key",
+      "choiceId": "telnyx-api-key",
+      "choiceLabel": "Telnyx API Key",
+      "assistantPriority": -50,
+      "groupId": "telnyx",
+      "groupLabel": "Telnyx",
+      "groupHint": "Telnyx AI API key",
+      "optionKey": "telnyxApiKey",
+      "cliFlag": "--telnyx-api-key",
+      "cliOption": "--telnyx-api-key <key>",
+      "cliDescription": "Telnyx API Key"
+    }
+  ],
+  "contracts": {
+    "memoryEmbeddingProviders": ["telnyx"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/telnyx-embeddings/package.json
+++ b/extensions/telnyx-embeddings/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "description": "Telnyx embedding provider for OpenClaw memory search",
   "type": "module",
-  "dependencies": {
-    "@mariozechner/pi-ai": "0.70.2"
-  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/extensions/telnyx-embeddings/package.json
+++ b/extensions/telnyx-embeddings/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/telnyx-embeddings",
+  "version": "2026.4.25",
+  "private": true,
+  "description": "Telnyx embedding provider for OpenClaw memory search",
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-ai": "0.70.2"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/telnyx-embeddings/tsconfig.json
+++ b/extensions/telnyx-embeddings/tsconfig.json
@@ -1,9 +1,16 @@
 {
   "extends": "../tsconfig.package-boundary.base.json",
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "dist"
+    "rootDir": "."
   },
-  "include": ["."],
-  "references": []
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
 }

--- a/extensions/telnyx-embeddings/tsconfig.json
+++ b/extensions/telnyx-embeddings/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["."],
+  "references": []
+}


### PR DESCRIPTION
## Summary

Adds a new `telnyx-embeddings` extension that registers Telnyx as a first-class memory embedding provider.

## What it does

- Registers `telnyx` as a memory embedding provider using the OpenAI-compatible Telnyx AI API
- **Provider ID:** `telnyx`
- **Default model:** `thenlper/gte-large` (1024 dimensions)
- **Base URL:** `https://api.telnyx.com/v2/ai/openai`
- **Auto-select priority:** 25 (after local=10 + openai=20, before gemini=30)
- **Auth:** `TELNYX_API_KEY` env var or provider config

## Architecture

Reuses the same `resolveRemoteEmbeddingClient` + `fetchRemoteEmbeddingVectors` infrastructure as the OpenAI provider, since Telnyx exposes an OpenAI-compatible embeddings endpoint. Minimal code, maximum compatibility.

## Files

| File | Purpose |
|------|---------|
| `index.ts` | Plugin entry point |
| `embedding-provider.ts` | Provider factory, model normalization, client resolution |
| `memory-embedding-adapter.ts` | Adapter with auto-select, cache keys |
| `openclaw.plugin.json` | Plugin manifest with contracts |
| `embedding-provider.test.ts` | Unit tests for model normalization |
| `package.json` | Package config |

## Usage

```bash
# Set API key
export TELNYX_API_KEY=KEY...

# Explicit provider
# In openclaw.json:
# { "agents": { "defaults": { "memorySearch": { "provider": "telnyx" } } } }

# Or auto-detect (priority 25)
# Just set TELNYX_API_KEY and it will be selected automatically
```

## Testing

- E2E tested locally: plugin installs, registers, and returns search results via Telnyx embeddings
- Unit tests for model normalization included

Closes AIF-124