### PR TITLE
fix: stabilize isolated heartbeat routing

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -567,7 +567,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },
@@ -591,7 +591,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -72,9 +72,7 @@ describe("codex plugin", () => {
       registerMediaUnderstandingProvider: vi.fn(),
       registerProvider: vi.fn(),
       on: vi.fn(),
-    }) as ReturnType<typeof createTestPluginApi> & {
-      onConversationBindingResolved?: ReturnType<typeof vi.fn>;
-    };
+    });
     delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved;
 
     expect(() => plugin.register(api)).not.toThrow();

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -201,6 +201,73 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
     });
   });
 
+  it("uses the configured isolated heartbeat base when a forced live session has no pending work", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "main");
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const liveSessionKey = "agent:main:cloud-codex";
+      await seedSessionStore(storePath, liveSessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "telegram:170703438",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: liveSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(store["agent:main:cloud-codex:heartbeat"]).toBeUndefined();
+    });
+  });
+
+  it("consumes forced-session cron events from the forced base session while running on its isolated sibling", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "main");
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "Relay the forced-session cron update now" });
+
+      const liveSessionKey = "agent:main:cloud-codex";
+      await seedSessionStore(storePath, liveSessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "telegram:170703438",
+      });
+      enqueueSystemEvent("Cron: forced live-session update", {
+        sessionKey: liveSessionKey,
+        contextKey: "cron:forced-live-session-update",
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: liveSessionKey,
+        reason: "cron:forced-live-session-update",
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      expect(peekSystemEventEntries(liveSessionKey)).toEqual([]);
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+        SessionKey: "agent:main:cloud-codex:heartbeat",
+        Provider: "cron-event",
+      });
+    });
+  });
+
   it("consumes base-session cron events when isolated heartbeat runs on a :heartbeat session", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
@@ -334,6 +401,7 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       expect(calledCtx.SessionKey).toBe(isolatedSessionKey);
       expect(calledCtx.Provider).toBe("exec-event");
       expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
+      expect(peekSystemEventEntries(isolatedSessionKey)).toEqual([]);
     });
   });
 

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -35,11 +35,11 @@ beforeEach(() => {
   resetSystemEventsForTest();
 });
 
-function createHeartbeatTelegramConfig(): OpenClawConfig {
+function createHeartbeatTelegramConfig(isolatedSession = false): OpenClawConfig {
   return {
     agents: {
       defaults: {
-        heartbeat: { every: "30m" },
+        heartbeat: { every: "30m", ...(isolatedSession ? { isolatedSession: true } : {}) },
         model: { primary: "test/model" },
       },
     },
@@ -122,6 +122,107 @@ describe("heartbeat runner skips when target session lane is busy", () => {
 
       expect(replySpy).toHaveBeenCalled();
       expect(result.status).toBe("ran");
+    });
+  });
+
+  it("skips isolated heartbeat when the configured base lane is busy", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${baseSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${baseSessionKey}`);
+      expect(getQueueSize).not.toHaveBeenCalledWith(`session:${baseSessionKey}:heartbeat`);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("skips isolated heartbeat when a forced live session lane is busy", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const forcedLiveSessionKey = "agent:main:cloud-codex";
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${forcedLiveSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        sessionKey: forcedLiveSessionKey,
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${baseSessionKey}`);
+      expect(getQueueSize).toHaveBeenCalledWith(`session:${forcedLiveSessionKey}`);
+      expect(getQueueSize).not.toHaveBeenCalledWith(`session:${forcedLiveSessionKey}:heartbeat`);
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("checks the isolated heartbeat lane when wake re-enters on an active :heartbeat session", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(true);
+      const baseSessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+
+      enqueueSystemEvent("exec finished: deploy succeeded", {
+        sessionKey: isolatedSessionKey,
+      });
+
+      const getQueueSize = vi.fn((lane?: string) => {
+        if (!lane || lane === "main") {
+          return 0;
+        }
+        return lane === `session:${isolatedSessionKey}` ? 1 : 0;
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedSessionKey,
+        reason: "hook:wake",
+        deps: {
+          getQueueSize,
+          nowMs: () => Date.now(),
+          getReplyFromConfig: replySpy,
+        } as HeartbeatDeps,
+      });
+
+      expect(result.status).toBe("skipped");
+      if (result.status === "skipped") {
+        expect(result.reason).toBe("requests-in-flight");
+      }
+      expect(replySpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/infra/heartbeat-runner.subagent-session-guard.test.ts
+++ b/src/infra/heartbeat-runner.subagent-session-guard.test.ts
@@ -9,74 +9,91 @@ import { withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
 installHeartbeatRunnerTestRuntime();
 
 describe("runHeartbeatOnce", () => {
-  it("falls back to the main session when a subagent session key is forced", async () => {
-    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
-      const cfg: OpenClawConfig = {
-        agents: {
-          defaults: {
-            workspace: tmpDir,
-            heartbeat: {
-              every: "5m",
-              target: "whatsapp",
+  it.each([
+    {
+      name: "when a subagent session key is forced",
+      heartbeat: undefined,
+      sessionKey: "agent:main:subagent:demo",
+      expectedRunSessionKey: "agent:main:main",
+    },
+    {
+      name: "when isolatedSession is enabled and a subagent session key is forced",
+      heartbeat: { isolatedSession: true },
+      sessionKey: "agent:main:subagent:demo",
+      expectedRunSessionKey: "agent:main:main:heartbeat",
+    },
+  ])(
+    "falls back to the main session %s",
+    async ({ heartbeat, sessionKey, expectedRunSessionKey }) => {
+      await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "whatsapp",
+                ...heartbeat,
+              },
             },
           },
-        },
-        channels: {
-          whatsapp: {
-            allowFrom: ["*"],
+          channels: {
+            whatsapp: {
+              allowFrom: ["*"],
+            },
           },
-        },
-        session: { store: storePath },
-      };
+          session: { store: storePath },
+        };
 
-      const mainSessionKey = resolveMainSessionKey(cfg);
-      await fs.writeFile(
-        storePath,
-        JSON.stringify({
-          [mainSessionKey]: {
-            sessionId: "sid-main",
-            updatedAt: Date.now(),
-            lastChannel: "whatsapp",
-            lastProvider: "whatsapp",
-            lastTo: "120363401234567890@g.us",
-          },
-          "agent:main:subagent:demo": {
-            sessionId: "sid-subagent",
-            updatedAt: Date.now(),
-            lastChannel: "whatsapp",
-            lastProvider: "whatsapp",
-            lastTo: "120363409999999999@g.us",
-          },
-        }),
-      );
+        const mainSessionKey = resolveMainSessionKey(cfg);
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [mainSessionKey]: {
+              sessionId: "sid-main",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "120363401234567890@g.us",
+            },
+            "agent:main:subagent:demo": {
+              sessionId: "sid-subagent",
+              updatedAt: Date.now(),
+              lastChannel: "whatsapp",
+              lastProvider: "whatsapp",
+              lastTo: "120363409999999999@g.us",
+            },
+          }),
+        );
 
-      replySpy.mockResolvedValue({ text: "Final alert" });
-      const sendWhatsApp = vi.fn().mockResolvedValue({
-        messageId: "m1",
-        toJid: "jid",
+        replySpy.mockResolvedValue({ text: "Final alert" });
+        const sendWhatsApp = vi.fn().mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+        await runHeartbeatOnce({
+          cfg,
+          sessionKey,
+          deps: {
+            getReplyFromConfig: replySpy,
+            whatsapp: sendWhatsApp,
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        expect(replySpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            SessionKey: expectedRunSessionKey,
+            OriginatingChannel: undefined,
+            OriginatingTo: undefined,
+          }),
+          expect.anything(),
+          cfg,
+        );
       });
-
-      await runHeartbeatOnce({
-        cfg,
-        sessionKey: "agent:main:subagent:demo",
-        deps: {
-          getReplyFromConfig: replySpy,
-          whatsapp: sendWhatsApp,
-          getQueueSize: () => 0,
-          nowMs: () => 0,
-        },
-      });
-
-      expect(replySpy).toHaveBeenCalledTimes(1);
-      expect(replySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          SessionKey: mainSessionKey,
-          OriginatingChannel: undefined,
-          OriginatingTo: undefined,
-        }),
-        expect.anything(),
-        cfg,
-      );
-    });
-  });
+    },
+  );
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -373,6 +373,14 @@ function resolveHeartbeatSession(
   };
 }
 
+function isHeartbeatSuffixChain(value: string) {
+  return /^(:heartbeat)+$/i.test(value);
+}
+
+function hasHeartbeatSuffixChain(value: string) {
+  return /:heartbeat(?::heartbeat)*$/i.test(value);
+}
+
 function resolveIsolatedHeartbeatSessionKey(params: {
   sessionKey: string;
   configuredSessionKey: string;
@@ -384,7 +392,7 @@ function resolveIsolatedHeartbeatSessionKey(params: {
     if (
       params.sessionKey.startsWith(storedBaseSessionKey) &&
       suffix.length > 0 &&
-      /^(:heartbeat)+$/.test(suffix)
+      isHeartbeatSuffixChain(suffix)
     ) {
       return {
         isolatedSessionKey: `${storedBaseSessionKey}:heartbeat`,
@@ -402,8 +410,8 @@ function resolveIsolatedHeartbeatSessionKey(params: {
   const configuredSuffix = params.sessionKey.slice(params.configuredSessionKey.length);
   if (
     params.sessionKey.startsWith(params.configuredSessionKey) &&
-    /^(:heartbeat)+$/.test(configuredSuffix) &&
-    !params.configuredSessionKey.endsWith(":heartbeat")
+    isHeartbeatSuffixChain(configuredSuffix) &&
+    !params.configuredSessionKey.toLowerCase().endsWith(":heartbeat")
   ) {
     return {
       isolatedSessionKey: `${params.configuredSessionKey}:heartbeat`,
@@ -428,7 +436,7 @@ function resolveStaleHeartbeatIsolatedSessionKey(params: {
   if (
     params.sessionKey.startsWith(params.isolatedBaseSessionKey) &&
     suffix.length > 0 &&
-    /^(:heartbeat)+$/.test(suffix)
+    isHeartbeatSuffixChain(suffix)
   ) {
     return params.sessionKey;
   }
@@ -530,6 +538,9 @@ type HeartbeatSkipReason = "empty-heartbeat-file";
 
 type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
+  inspectionSessionKey: string;
+  inspectionSessionEntry?: ReturnType<typeof resolveHeartbeatSession>["entry"];
+  busySessionKeys: string[];
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   turnSourceDeliveryContext: ReturnType<typeof resolveSystemEventDeliveryContext>;
   hasTaggedCronEvents: boolean;
@@ -556,13 +567,62 @@ async function resolveHeartbeatPreflight(params: {
   reason?: string;
 }): Promise<HeartbeatPreflight> {
   const reasonFlags = resolveHeartbeatReasonFlags(params.reason);
-  const session = resolveHeartbeatSession(
-    params.cfg,
-    params.agentId,
-    params.heartbeat,
-    params.forcedSessionKey,
+  const configuredSession = resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat);
+  const forcedSession = params.forcedSessionKey
+    ? resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat, params.forcedSessionKey)
+    : undefined;
+  const forcedIsConfiguredIsolatedLane =
+    params.heartbeat?.isolatedSession === true &&
+    forcedSession !== undefined &&
+    forcedSession.sessionKey.startsWith(configuredSession.sessionKey) &&
+    isHeartbeatSuffixChain(forcedSession.sessionKey.slice(configuredSession.sessionKey.length));
+  const forcedIsRealHeartbeatSession =
+    params.heartbeat?.isolatedSession === true &&
+    forcedSession !== undefined &&
+    hasHeartbeatSuffixChain(forcedSession.sessionKey) &&
+    !forcedIsConfiguredIsolatedLane;
+  const forcedTargetsDistinctSession =
+    forcedSession !== undefined && forcedSession.sessionKey !== configuredSession.sessionKey;
+  const forcedPendingEventEntries = forcedSession
+    ? peekSystemEventEntries(forcedSession.sessionKey)
+    : [];
+  const forcedHasPendingEvents = forcedPendingEventEntries.length > 0;
+  const shouldUseForcedDistinctSession =
+    forcedTargetsDistinctSession &&
+    (forcedIsConfiguredIsolatedLane || forcedIsRealHeartbeatSession || forcedHasPendingEvents);
+  const session =
+    params.heartbeat?.isolatedSession === true
+      ? shouldUseForcedDistinctSession
+        ? {
+            ...forcedSession,
+            suppressOriginatingContext:
+              forcedSession.suppressOriginatingContext ||
+              configuredSession.suppressOriginatingContext,
+          }
+        : {
+            ...configuredSession,
+            suppressOriginatingContext:
+              configuredSession.suppressOriginatingContext ||
+              forcedSession?.suppressOriginatingContext === true,
+          }
+      : (forcedSession ?? configuredSession);
+  const inspectionSession =
+    params.heartbeat?.isolatedSession === true && shouldUseForcedDistinctSession
+      ? (forcedSession ?? session)
+      : session;
+  const inspectionSessionKey = inspectionSession.sessionKey;
+  const inspectionSessionEntry = inspectionSession.entry;
+  const busySessionKeys = Array.from(
+    new Set([
+      session.sessionKey,
+      ...(params.heartbeat?.isolatedSession === true &&
+      forcedSession !== undefined &&
+      forcedSession.sessionKey !== session.sessionKey
+        ? [forcedSession.sessionKey]
+        : []),
+    ]),
   );
-  const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const pendingEventEntries = peekSystemEventEntries(inspectionSessionKey);
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
@@ -576,13 +636,12 @@ async function resolveHeartbeatPreflight(params: {
     if (params.heartbeat?.isolatedSession !== true) {
       return true;
     }
-    const configuredSession = resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat);
     const { isolatedSessionKey } = resolveIsolatedHeartbeatSessionKey({
-      sessionKey: session.sessionKey,
+      sessionKey: inspectionSessionKey,
       configuredSessionKey: configuredSession.sessionKey,
-      sessionEntry: session.entry,
+      sessionEntry: inspectionSessionEntry,
     });
-    return isolatedSessionKey === session.sessionKey;
+    return isolatedSessionKey === inspectionSessionKey;
   })();
   const shouldInspectPendingEvents =
     reasonFlags.isExecEventReason ||
@@ -597,6 +656,9 @@ async function resolveHeartbeatPreflight(params: {
   const basePreflight = {
     ...reasonFlags,
     session,
+    inspectionSessionKey,
+    inspectionSessionEntry,
+    busySessionKeys,
     pendingEventEntries,
     turnSourceDeliveryContext,
     hasTaggedCronEvents,
@@ -777,13 +839,30 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: preflight.skipReason };
   }
   const { entry, sessionKey, storePath, suppressOriginatingContext } = preflight.session;
+  const useIsolatedSession = heartbeat?.isolatedSession === true;
+  const isolatedSessionResolution = useIsolatedSession
+    ? (() => {
+        const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
+        return {
+          configuredSession,
+          ...resolveIsolatedHeartbeatSessionKey({
+            sessionKey: preflight.inspectionSessionKey,
+            configuredSessionKey: configuredSession.sessionKey,
+            sessionEntry: preflight.inspectionSessionEntry,
+          }),
+        };
+      })()
+    : undefined;
 
-  // Check the resolved session lane — if it is busy, skip to avoid interrupting
-  // an active streaming turn.  The wake-layer retry (heartbeat-wake.ts) will
-  // re-schedule this wake automatically.  See #14396 (closed without merge).
-  const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey);
-  const sessionLaneSize = (opts.deps?.getQueueSize ?? getQueueSize)(sessionLaneKey);
-  if (sessionLaneSize > 0) {
+  // Check the pre-isolation session lanes — if any are busy, skip to avoid
+  // interrupting an active streaming turn that shares the same delivery context.
+  // The wake-layer retry (heartbeat-wake.ts) will re-schedule this wake automatically.
+  // See #14396 (closed without merge).
+  const resolveQueueSize = opts.deps?.getQueueSize ?? getQueueSize;
+  const busySessionLaneKey = preflight.busySessionKeys
+    .map((busySessionKey) => resolveEmbeddedSessionLane(busySessionKey))
+    .find((laneKey) => resolveQueueSize(laneKey) > 0);
+  if (busySessionLaneKey) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: "requests-in-flight",
@@ -799,7 +878,6 @@ export async function runHeartbeatOnce(opts: {
   // a new session ID (empty transcript) each run, avoiding the cost of
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
-  const useIsolatedSession = heartbeat?.isolatedSession === true;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
@@ -858,22 +936,14 @@ export async function runHeartbeatOnce(opts: {
     const shouldConsumeInspectedEvents =
       !preflight.isWakeReason && preflight.shouldInspectPendingEvents;
     if (shouldConsumeInspectedEvents && preflight.pendingEventEntries.length > 0) {
-      consumeSystemEventEntries(sessionKey, preflight.pendingEventEntries);
+      consumeSystemEventEntries(preflight.inspectionSessionKey, preflight.pendingEventEntries);
     }
     return { status: "skipped", reason: "no-tasks-due" };
   }
 
   let runSessionKey = sessionKey;
-  if (useIsolatedSession) {
-    const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
-    // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
-    // re-entry for heartbeat-created isolated sessions. Real session keys that
-    // happen to end with `:heartbeat` still get a distinct isolated sibling.
-    const { isolatedSessionKey, isolatedBaseSessionKey } = resolveIsolatedHeartbeatSessionKey({
-      sessionKey,
-      configuredSessionKey: configuredSession.sessionKey,
-      sessionEntry: entry,
-    });
+  if (useIsolatedSession && isolatedSessionResolution) {
+    const { isolatedSessionKey, isolatedBaseSessionKey } = isolatedSessionResolution;
     const cronSession = resolveCronSession({
       cfg,
       sessionKey: isolatedSessionKey,
@@ -882,7 +952,7 @@ export async function runHeartbeatOnce(opts: {
       forceNew: true,
     });
     const staleIsolatedSessionKey = resolveStaleHeartbeatIsolatedSessionKey({
-      sessionKey,
+      sessionKey: preflight.inspectionSessionKey,
       isolatedSessionKey,
       isolatedBaseSessionKey,
     });
@@ -966,7 +1036,7 @@ export async function runHeartbeatOnce(opts: {
     if (!preflight.shouldInspectPendingEvents || preflight.pendingEventEntries.length === 0) {
       return;
     }
-    consumeSystemEventEntries(sessionKey, preflight.pendingEventEntries);
+    consumeSystemEventEntries(preflight.inspectionSessionKey, preflight.pendingEventEntries);
   };
 
   const ctx = {


### PR DESCRIPTION
## Summary
- Keep forced/idle heartbeat event runs on stable isolated lane keys.
- Check the active base session lane when deciding whether to skip busy sessions.
- Guard subagent session key routing from accidental main-lane materialization.

Split from #71858.

## Tests
- pnpm vitest run src/infra/heartbeat-runner.isolated-key-stability.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts src/infra/heartbeat-runner.subagent-session-guard.test.ts