### PR TITLE
fix: keep local assistant avatar overrides authoritative

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -567,7 +567,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },
@@ -591,7 +591,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -72,9 +72,7 @@ describe("codex plugin", () => {
       registerMediaUnderstandingProvider: vi.fn(),
       registerProvider: vi.fn(),
       on: vi.fn(),
-    }) as ReturnType<typeof createTestPluginApi> & {
-      onConversationBindingResolved?: ReturnType<typeof vi.fn>;
-    };
+    });
     delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved;
 
     expect(() => plugin.register(api)).not.toThrow();

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import type { ChatHost } from "./app-chat.ts";
 import {
   getChatAttachmentDataUrl,
@@ -8,6 +9,7 @@ import {
   registerChatAttachmentPayload,
   resetChatAttachmentPayloadStoreForTest,
 } from "./chat/attachment-payload-store.ts";
+import { saveLocalAssistantIdentity } from "./storage.ts";
 import type { GatewaySessionRow, SessionsListResult } from "./types.ts";
 
 const { setLastActiveSessionKeyMock } = vi.hoisted(() => ({
@@ -23,6 +25,8 @@ let steerQueuedChatMessage: typeof import("./app-chat.ts").steerQueuedChatMessag
 let navigateChatInputHistory: typeof import("./app-chat.ts").navigateChatInputHistory;
 let handleAbortChat: typeof import("./app-chat.ts").handleAbortChat;
 let refreshChatAvatar: typeof import("./app-chat.ts").refreshChatAvatar;
+let setChatAvatarUrl: typeof import("./app-chat.ts").setChatAvatarUrl;
+let clearChatAvatarUrl: typeof import("./app-chat.ts").clearChatAvatarUrl;
 let clearPendingQueueItemsForRun: typeof import("./app-chat.ts").clearPendingQueueItemsForRun;
 let removeQueuedMessage: typeof import("./app-chat.ts").removeQueuedMessage;
 
@@ -33,6 +37,8 @@ async function loadChatHelpers(): Promise<void> {
     navigateChatInputHistory,
     handleAbortChat,
     refreshChatAvatar,
+    setChatAvatarUrl,
+    clearChatAvatarUrl,
     clearPendingQueueItemsForRun,
     removeQueuedMessage,
   } = await import("./app-chat.ts"));
@@ -124,8 +130,13 @@ describe("refreshChatAvatar", () => {
     await loadChatHelpers();
   });
 
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
   afterEach(() => {
     resetChatAttachmentPayloadStoreForTest();
+    window.localStorage.clear();
     vi.unstubAllGlobals();
   });
 
@@ -285,6 +296,85 @@ describe("refreshChatAvatar", () => {
     expect(createObjectURL).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).not.toHaveBeenCalled();
     expect(host.chatAvatarUrl).toBe("blob:session-avatar");
+  });
+
+  it("does not let fetched server avatars override a local assistant avatar override", async () => {
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bG9jYWw=" });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ avatarUrl: "/avatar/main" }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    await refreshChatAvatar(host);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(host.chatAvatarUrl).toBeNull();
+    expect(host.chatAvatarSource).toBe("data:image/png;base64,bG9jYWw=");
+    expect(host.chatAvatarStatus).toBe("data");
+    expect(host.chatAvatarReason).toBeNull();
+  });
+
+  it("revokes fetched avatar blob URLs when the chat avatar URL is cleared", async () => {
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static createObjectURL = vi.fn(() => "blob:server-avatar");
+        static revokeObjectURL = revokeObjectURL;
+      },
+    );
+
+    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    setChatAvatarUrl(host, "blob:server-avatar");
+    clearChatAvatarUrl(host);
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:server-avatar");
+    expect(host.chatAvatarUrl).toBeNull();
+  });
+
+  it("ignores an in-flight server avatar when a local assistant avatar override appears", async () => {
+    const createObjectURL = vi.fn(() => "blob:server-avatar");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static createObjectURL = createObjectURL;
+        static revokeObjectURL = revokeObjectURL;
+      },
+    );
+    const metaRequest = createDeferred<{ avatarUrl?: string }>();
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = requestUrl(input);
+      if (url === "/avatar/main?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => metaRequest.promise,
+        });
+      }
+      if (url === "/avatar/main") {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["server-avatar"]),
+        });
+      }
+      throw new Error(`Unexpected avatar URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    const refresh = refreshChatAvatar(host);
+    saveLocalAssistantIdentity({ avatar: "data:image/png;base64,bG9jYWw=" });
+    metaRequest.resolve({ avatarUrl: "/avatar/main" });
+    await refresh;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    expect(host.chatAvatarUrl).toBeNull();
+    expect(host.chatAvatarSource).toBe("data:image/png;base64,bG9jYWw=");
+    expect(host.chatAvatarStatus).toBe("data");
   });
 
   it("keeps mounted dashboard avatar endpoints under the normalized base path", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -34,6 +34,7 @@ import { loadSessions, type SessionsState } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
 import { parseAgentSessionKey } from "./session-key.ts";
+import { loadLocalAssistantIdentity } from "./storage.ts";
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -683,6 +684,10 @@ type SessionDefaultsSnapshot = {
 
 const chatAvatarObjectUrls = new WeakMap<object, string>();
 
+export type ChatAvatarUrlState = {
+  chatAvatarUrl?: string | null;
+};
+
 function beginChatAvatarRequest(host: ChatHost): number {
   const key = host as object;
   const nextVersion = (chatAvatarRequestVersions.get(key) ?? 0) + 1;
@@ -714,7 +719,7 @@ function buildAvatarMetaUrl(basePath: string, agentId: string): string {
   return base ? `${base}/avatar/${encoded}?meta=1` : `/avatar/${encoded}?meta=1`;
 }
 
-function clearChatAvatarUrl(host: ChatHost) {
+export function clearChatAvatarUrl(host: ChatAvatarUrlState) {
   const key = host as object;
   const previousBlobUrl = chatAvatarObjectUrls.get(key);
   if (previousBlobUrl) {
@@ -731,7 +736,7 @@ function clearChatAvatarState(host: ChatHost) {
   host.chatAvatarReason = null;
 }
 
-function setChatAvatarUrl(host: ChatHost, nextUrl: string | null) {
+export function setChatAvatarUrl(host: ChatAvatarUrlState, nextUrl: string | null) {
   const key = host as object;
   const previousBlobUrl = chatAvatarObjectUrls.get(key);
   if (previousBlobUrl && previousBlobUrl !== nextUrl) {
@@ -778,6 +783,18 @@ function isLocalControlUiAvatarUrl(avatarUrl: string): boolean {
   return avatarUrl.startsWith("/");
 }
 
+function applyLocalAssistantAvatarOverride(host: ChatHost): boolean {
+  const localAvatar = loadLocalAssistantIdentity().avatar;
+  if (!localAvatar) {
+    return false;
+  }
+  clearChatAvatarUrl(host);
+  host.chatAvatarSource = localAvatar;
+  host.chatAvatarStatus = "data";
+  host.chatAvatarReason = null;
+  return true;
+}
+
 export async function refreshChatAvatar(host: ChatHost) {
   if (!host.connected) {
     clearChatAvatarState(host);
@@ -785,6 +802,9 @@ export async function refreshChatAvatar(host: ChatHost) {
   }
   const sessionKey = host.sessionKey;
   const requestVersion = beginChatAvatarRequest(host);
+  if (applyLocalAssistantAvatarOverride(host)) {
+    return;
+  }
   const agentId = resolveAgentIdForSession(host);
   if (!agentId) {
     if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
@@ -814,6 +834,9 @@ export async function refreshChatAvatar(host: ChatHost) {
     if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
       return;
     }
+    if (applyLocalAssistantAvatarOverride(host)) {
+      return;
+    }
     setChatAvatarMeta(host, data);
     const avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
     if (!avatarUrl || !isRenderableControlUiAvatarUrl(avatarUrl)) {
@@ -836,6 +859,10 @@ export async function refreshChatAvatar(host: ChatHost) {
     }
     const blobUrl = URL.createObjectURL(await avatarRes.blob());
     if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      URL.revokeObjectURL(blobUrl);
+      return;
+    }
+    if (applyLocalAssistantAvatarOverride(host)) {
       URL.revokeObjectURL(blobUrl);
       return;
     }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1064,7 +1064,6 @@ export function renderApp(state: AppViewState) {
                 .loadAssistantIdentity()
                 .then(() => refreshChatAvatar(state))
                 .finally(() => requestHostUpdate?.());
-              requestHostUpdate?.();
             },
             basePath: state.basePath ?? "",
             configObject: configObj,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
-import { refreshChat } from "./app-chat.ts";
+import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { DEFAULT_CRON_FORM } from "./app-defaults.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
@@ -1054,20 +1054,16 @@ export function renderApp(state: AppViewState) {
             assistantAvatarUploadError: state.assistantAvatarUploadError,
             onAssistantAvatarOverrideChange: (dataUrl) => {
               setAssistantAvatarOverride(state, dataUrl);
-              state.chatAvatarUrl = dataUrl;
-              state.chatAvatarSource = dataUrl;
-              state.chatAvatarStatus = "data";
-              state.chatAvatarReason = null;
               state.assistantAvatarUploadError = null;
               requestHostUpdate?.();
             },
             onAssistantAvatarClearOverride: () => {
               setAssistantAvatarOverride(state, null);
-              state.chatAvatarUrl = null;
-              state.chatAvatarSource = null;
-              state.chatAvatarStatus = null;
-              state.chatAvatarReason = null;
               state.assistantAvatarUploadError = null;
+              void state
+                .loadAssistantIdentity()
+                .then(() => refreshChatAvatar(state))
+                .finally(() => requestHostUpdate?.());
               requestHostUpdate?.();
             },
             basePath: state.basePath ?? "",

--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { setChatAvatarUrl } from "../app-chat.ts";
 import { loadLocalAssistantIdentity } from "../storage.ts";
 import { loadAssistantIdentity, setAssistantAvatarOverride } from "./assistant-identity.ts";
 
@@ -74,6 +75,10 @@ describe("setAssistantAvatarOverride", () => {
     expect(state.assistantAvatarSource).toBe("data:image/png;base64,YXZhdGFy");
     expect(state.assistantAvatarStatus).toBe("data");
     expect(state.assistantAvatarReason).toBeNull();
+    expect(state.chatAvatarUrl).toBe("data:image/png;base64,YXZhdGFy");
+    expect(state.chatAvatarSource).toBe("data:image/png;base64,YXZhdGFy");
+    expect(state.chatAvatarStatus).toBe("data");
+    expect(state.chatAvatarReason).toBeNull();
     expect(loadLocalAssistantIdentity().avatar).toBe("data:image/png;base64,YXZhdGFy");
   });
 
@@ -82,14 +87,43 @@ describe("setAssistantAvatarOverride", () => {
       assistantAvatar: "data:image/png;base64,YXZhdGFy",
       assistantAvatarSource: "data:image/png;base64,YXZhdGFy",
       assistantAvatarStatus: "data",
+      chatAvatarUrl: "blob:server-avatar",
+      chatAvatarSource: "server-avatar.png",
+      chatAvatarStatus: "local",
     };
     setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
 
     setAssistantAvatarOverride(state, null);
 
+    expect(state.assistantAvatar).toBeNull();
     expect(state.assistantAvatarSource).toBeNull();
     expect(state.assistantAvatarStatus).toBeNull();
     expect(state.assistantAvatarReason).toBeNull();
+    expect(state.chatAvatarUrl).toBeNull();
+    expect(state.chatAvatarSource).toBeNull();
+    expect(state.chatAvatarStatus).toBeNull();
+    expect(state.chatAvatarReason).toBeNull();
     expect(loadLocalAssistantIdentity().avatar).toBeNull();
+  });
+
+  it("revokes managed blob URLs when changing or clearing the override", () => {
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal(
+      "URL",
+      class extends URL {
+        static revokeObjectURL = revokeObjectURL;
+      },
+    );
+    const state: Parameters<typeof setAssistantAvatarOverride>[0] = {};
+
+    setChatAvatarUrl(state, "blob:server-avatar");
+    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:server-avatar");
+
+    setChatAvatarUrl(state, "blob:next-server-avatar");
+    setAssistantAvatarOverride(state, null);
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:next-server-avatar");
   });
 });

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -1,3 +1,4 @@
+import { clearChatAvatarUrl, setChatAvatarUrl } from "../app-chat.ts";
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import { loadLocalAssistantIdentity, saveLocalAssistantIdentity } from "../storage.ts";
@@ -19,6 +20,10 @@ export type AssistantAvatarOverrideState = {
   assistantAvatarSource?: string | null;
   assistantAvatarStatus?: "none" | "local" | "remote" | "data" | null;
   assistantAvatarReason?: string | null;
+  chatAvatarUrl?: string | null;
+  chatAvatarSource?: string | null;
+  chatAvatarStatus?: "none" | "local" | "remote" | "data" | null;
+  chatAvatarReason?: string | null;
 };
 
 const assistantIdentityRequestVersions = new WeakMap<object, number>();
@@ -89,9 +94,18 @@ export function setAssistantAvatarOverride(
     state.assistantAvatarSource = avatar;
     state.assistantAvatarStatus = "data";
     state.assistantAvatarReason = null;
+    setChatAvatarUrl(state, avatar);
+    state.chatAvatarSource = avatar;
+    state.chatAvatarStatus = "data";
+    state.chatAvatarReason = null;
   } else {
+    state.assistantAvatar = null;
     state.assistantAvatarSource = null;
     state.assistantAvatarStatus = null;
     state.assistantAvatarReason = null;
+    clearChatAvatarUrl(state);
+    state.chatAvatarSource = null;
+    state.chatAvatarStatus = null;
+    state.chatAvatarReason = null;
   }
 }

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -177,6 +177,17 @@ describe("resolveChatAvatarRenderUrl", () => {
     ).toBe("blob:http://localhost/uuid-123");
   });
 
+  it("lets a local assistant image override stale fetched avatar candidates", () => {
+    expect(
+      resolveChatAvatarRenderUrl("blob:http://localhost/server-avatar", {
+        identity: {
+          avatar: "data:image/png;base64,bG9jYWw=",
+          avatarUrl: "/avatar/main",
+        },
+      }),
+    ).toBe("data:image/png;base64,bG9jYWw=");
+  });
+
   it("falls back to the config-sanitized avatar when no blob candidate is present", () => {
     expect(
       resolveChatAvatarRenderUrl(null, {

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -200,9 +200,14 @@ export function normalizeAgentLabel(agent: {
 }
 
 const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/(?!\/))/i;
+const LOCAL_ASSISTANT_IMAGE_AVATAR_RE = /^(?:data:image\/|blob:)/i;
 
 export function isRenderableControlUiAvatarUrl(value: string): boolean {
   return CONTROL_UI_AVATAR_URL_RE.test(value);
+}
+
+function isLocalAssistantImageAvatar(value: string): boolean {
+  return LOCAL_ASSISTANT_IMAGE_AVATAR_RE.test(value.trim());
 }
 
 export function resolveAgentAvatarUrl(
@@ -234,6 +239,10 @@ export function resolveChatAvatarRenderUrl(
   agent: { identity?: { avatar?: string; avatarUrl?: string } },
   agentIdentity?: AgentIdentityResult | null,
 ): string | null {
+  const identityAvatar = normalizeOptionalString(agent.identity?.avatar);
+  if (identityAvatar && isLocalAssistantImageAvatar(identityAvatar)) {
+    return identityAvatar;
+  }
   const trimmed = normalizeOptionalString(candidate);
   if (trimmed?.startsWith("blob:")) {
     return trimmed;

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -200,7 +200,7 @@ export function normalizeAgentLabel(agent: {
 }
 
 const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/(?!\/))/i;
-const LOCAL_ASSISTANT_IMAGE_AVATAR_RE = /^(?:data:image\/|blob:)/i;
+const LOCAL_ASSISTANT_IMAGE_AVATAR_RE = /^data:image\//i;
 
 export function isRenderableControlUiAvatarUrl(value: string): boolean {
   return CONTROL_UI_AVATAR_URL_RE.test(value);


### PR DESCRIPTION
## Summary
- Preserve local assistant avatar overrides when delayed server identity refreshes arrive.
- Centralize assistant identity/avatar resolution helpers.
- Cover chat/render and agents view behavior.

Split from #71858.

## Tests
- pnpm vitest run ui/src/ui/app-chat.test.ts ui/src/ui/controllers/assistant-identity.test.ts ui/src/ui/views/agents-utils.test.ts