### PR TITLE
fix: harden bundled plugin public surface loading

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -567,7 +567,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },
@@ -591,7 +591,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -72,9 +72,7 @@ describe("codex plugin", () => {
       registerMediaUnderstandingProvider: vi.fn(),
       registerProvider: vi.fn(),
       on: vi.fn(),
-    }) as ReturnType<typeof createTestPluginApi> & {
-      onConversationBindingResolved?: ReturnType<typeof vi.fn>;
-    };
+    });
     delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved;
 
     expect(() => plugin.register(api)).not.toThrow();

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -341,6 +341,36 @@ function canTryNodeRequireBuiltModule(modulePath: string): boolean {
   );
 }
 
+function emitBundledEntryModuleLoadProfile(params: {
+  modulePath: string;
+  loadStartMs: number;
+  getJitiEndMs: number;
+}): void {
+  const endMs = performance.now();
+  // Use shared formatter — but split timing fields ourselves so we can
+  // attribute time spent in `getJiti(...)` factory creation vs the actual
+  // graph-walking `__j(modulePath)` call. Both are emitted as extras
+  // alongside the canonical `elapsedMs=<total>` field.
+  console.error(
+    formatPluginLoadProfileLine({
+      phase: "bundled-entry-module-load",
+      pluginId: "(bundled-entry)",
+      source: params.modulePath,
+      elapsedMs: endMs - params.loadStartMs,
+      // When the built-artifact fast-path resolves the module via `nodeRequire`,
+      // `getJitiEndMs` stays `0` because the `catch` block (the only place
+      // it gets stamped) never runs. Reporting `getJitiMs` /
+      // `jitiCallMs` as `0` for that path keeps the breakdown honest:
+      // `elapsedMs=` already captures the nodeRequire time, and we don't
+      // want to mis-attribute it to jiti sub-steps.
+      extras: [
+        ["getJitiMs", params.getJitiEndMs ? params.getJitiEndMs - params.loadStartMs : 0],
+        ["jitiCallMs", params.getJitiEndMs ? endMs - params.getJitiEndMs : 0],
+      ],
+    }),
+  );
+}
+
 function loadBundledEntryModuleSync(
   importMetaUrl: string,
   specifier: string,
@@ -379,29 +409,7 @@ function loadBundledEntryModuleSync(
     loaded = jiti(toSafeImportPath(modulePath));
   }
   if (profile) {
-    const endMs = performance.now();
-    // Use shared formatter — but split timing fields ourselves so we can
-    // attribute time spent in `getJiti(...)` factory creation vs the actual
-    // graph-walking `__j(modulePath)` call. Both are emitted as extras
-    // alongside the canonical `elapsedMs=<total>` field.
-    console.error(
-      formatPluginLoadProfileLine({
-        phase: "bundled-entry-module-load",
-        pluginId: "(bundled-entry)",
-        source: modulePath,
-        elapsedMs: endMs - loadStartMs,
-        // When the built-artifact fast-path resolves the module via `nodeRequire`,
-        // `getJitiEndMs` stays `0` because the `catch` block (the only place
-        // it gets stamped) never runs. Reporting `getJitiMs` /
-        // `jitiCallMs` as `0` for that path keeps the breakdown honest:
-        // `elapsedMs=` already captures the nodeRequire time, and we don't
-        // want to mis-attribute it to jiti sub-steps.
-        extras: [
-          ["getJitiMs", getJitiEndMs ? getJitiEndMs - loadStartMs : 0],
-          ["jitiCallMs", getJitiEndMs ? endMs - getJitiEndMs : 0],
-        ],
-      }),
-    );
+    emitBundledEntryModuleLoadProfile({ modulePath, loadStartMs, getJitiEndMs });
   }
   loadedModuleExports.set(modulePath, loaded);
   return loaded;

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { execFile, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
@@ -30,10 +30,12 @@ import {
 
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
+  execFile: vi.fn(),
   spawn: vi.fn(),
   spawnSync: vi.fn(),
 }));
 
+const execFileMock = vi.mocked(execFile);
 const spawnMock = vi.mocked(spawn);
 const spawnSyncMock = vi.mocked(spawnSync);
 const tempDirs: string[] = [];
@@ -96,6 +98,7 @@ function statfsFixture(params: {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  execFileMock.mockReset();
   spawnMock.mockReset();
   spawnSyncMock.mockReset();
   bundledRuntimeDepsActivityTesting.resetBundledRuntimeDepsInstallActivity();

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -164,7 +164,11 @@ describe("bundled plugin public surface loader", () => {
     vi.doMock("node:module", async () => {
       const actual = await vi.importActual<typeof import("node:module")>("node:module");
       return Object.assign({}, actual, {
-        createRequire: vi.fn(() => requireLoader),
+        createRequire: vi.fn((modulePath: string | URL) =>
+          String(modulePath).includes("public-surface-loader")
+            ? requireLoader
+            : actual.createRequire(modulePath),
+        ),
       });
     });
     vi.resetModules();
@@ -213,9 +217,14 @@ describe("bundled plugin public surface loader", () => {
     vi.doMock("node:module", async () => {
       const actual = await vi.importActual<typeof import("node:module")>("node:module");
       return Object.assign({}, actual, {
-        createRequire: vi.fn(() => requireLoader),
+        createRequire: vi.fn((modulePath: string | URL) =>
+          String(modulePath).includes("public-surface-loader")
+            ? requireLoader
+            : actual.createRequire(modulePath),
+        ),
       });
     });
+    vi.resetModules();
 
     const publicSurfaceLoader = await importFreshModule<
       typeof import("./public-surface-loader.js")
@@ -253,9 +262,14 @@ describe("bundled plugin public surface loader", () => {
     vi.doMock("node:module", async () => {
       const actual = await vi.importActual<typeof import("node:module")>("node:module");
       return Object.assign({}, actual, {
-        createRequire: vi.fn(() => requireLoader),
+        createRequire: vi.fn((modulePath: string | URL) =>
+          String(modulePath).includes("public-surface-loader")
+            ? requireLoader
+            : actual.createRequire(modulePath),
+        ),
       });
     });
+    vi.resetModules();
 
     const publicSurfaceLoader = await importFreshModule<
       typeof import("./public-surface-loader.js")

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -190,6 +190,94 @@ describe("bundled plugin public surface loader", () => {
     expect(createJiti).not.toHaveBeenCalled();
   });
 
+  it("falls back to jiti when source require hits emitted-style js imports", async () => {
+    const jitiLoader = vi.fn(() => ({ marker: "source-jiti-ok" }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({
+      createJiti,
+    }));
+    const requireLoader = Object.assign(
+      vi.fn(() => {
+        const error = new Error(
+          "Cannot find module './config-defaults.js'",
+        ) as NodeJS.ErrnoException;
+        error.code = "ERR_MODULE_NOT_FOUND";
+        throw error;
+      }),
+      {
+        extensions: {
+          ".ts": vi.fn(),
+        },
+      },
+    );
+    vi.doMock("node:module", async () => {
+      const actual = await vi.importActual<typeof import("node:module")>("node:module");
+      return Object.assign({}, actual, {
+        createRequire: vi.fn(() => requireLoader),
+      });
+    });
+
+    const publicSurfaceLoader = await importFreshModule<
+      typeof import("./public-surface-loader.js")
+    >(import.meta.url, "./public-surface-loader.js?scope=source-require-fallback-jiti");
+    const tempRoot = createTempDir();
+    const bundledPluginsDir = path.join(tempRoot, "extensions");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+
+    const modulePath = path.join(bundledPluginsDir, "demo", "secret-contract-api.ts");
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, 'export const marker = "source-jiti-ok";\n', "utf8");
+
+    expect(
+      publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync<{ marker: string }>({
+        dirName: "demo",
+        artifactBasename: "secret-contract-api.js",
+      }).marker,
+    ).toBe("source-jiti-ok");
+    expect(requireLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
+    expect(jitiLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
+  });
+
+  it("does not mask source require syntax errors with the jiti fallback", async () => {
+    const jitiLoader = vi.fn(() => ({ marker: "jiti-should-not-run" }));
+    const createJiti = vi.fn(() => jitiLoader);
+    vi.doMock("jiti", () => ({
+      createJiti,
+    }));
+    const syntaxError = new SyntaxError("Unexpected token");
+    const requireLoader = Object.assign(vi.fn(() => { throw syntaxError; }), {
+      extensions: {
+        ".ts": vi.fn(),
+      },
+    });
+    vi.doMock("node:module", async () => {
+      const actual = await vi.importActual<typeof import("node:module")>("node:module");
+      return Object.assign({}, actual, {
+        createRequire: vi.fn(() => requireLoader),
+      });
+    });
+
+    const publicSurfaceLoader = await importFreshModule<
+      typeof import("./public-surface-loader.js")
+    >(import.meta.url, "./public-surface-loader.js?scope=source-require-syntax-error");
+    const tempRoot = createTempDir();
+    const bundledPluginsDir = path.join(tempRoot, "extensions");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledPluginsDir;
+
+    const modulePath = path.join(bundledPluginsDir, "demo", "secret-contract-api.ts");
+    fs.mkdirSync(path.dirname(modulePath), { recursive: true });
+    fs.writeFileSync(modulePath, "export const marker = ;\n", "utf8");
+
+    expect(() =>
+      publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync<{ marker: string }>({
+        dirName: "demo",
+        artifactBasename: "secret-contract-api.js",
+      }),
+    ).toThrow(syntaxError);
+    expect(requireLoader).toHaveBeenCalledWith(fs.realpathSync(modulePath));
+    expect(createJiti).not.toHaveBeenCalled();
+  });
+
   it("reuses one bundled dist jiti loader across public artifacts with the same native mode", async () => {
     const createJiti = vi.fn(() => vi.fn((modulePath: string) => ({ modulePath })));
     vi.doMock("jiti", () => ({

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -31,28 +31,6 @@ const publicSurfaceLocations = new Map<
 const jitiLoaders: PluginJitiLoaderCache = new Map();
 const sharedBundledPublicSurfaceJitiLoaders: PluginJitiLoaderCache = new Map();
 
-function isSourceArtifactPath(modulePath: string): boolean {
-  switch (path.extname(modulePath).toLowerCase()) {
-    case ".ts":
-    case ".tsx":
-    case ".mts":
-    case ".cts":
-    case ".mtsx":
-    case ".ctsx":
-      return true;
-    default:
-      return false;
-  }
-}
-
-function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
-  return (
-    !params.tryNative &&
-    isSourceArtifactPath(params.modulePath) &&
-    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
-  );
-}
-
 function createResolutionKey(params: { dirName: string; artifactBasename: string }): string {
   const bundledPluginsDir = resolveBundledPluginsDir();
   return `${params.dirName}::${params.artifactBasename}::${bundledPluginsDir ? path.resolve(bundledPluginsDir) : "<default>"}`;
@@ -110,10 +88,50 @@ function getJiti(modulePath: string) {
   return loader;
 }
 
+function isSourceArtifactPath(modulePath: string): boolean {
+  switch (path.extname(modulePath).toLowerCase()) {
+    case ".ts":
+    case ".tsx":
+    case ".mts":
+    case ".cts":
+    case ".mtsx":
+    case ".ctsx":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
+  return (
+    !params.tryNative &&
+    isSourceArtifactPath(params.modulePath) &&
+    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
+  );
+}
+
+function shouldFallbackSourceArtifactRequireToJiti(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}
+
 function loadPublicSurfaceModule(modulePath: string): unknown {
   const tryNative = resolvePluginLoaderJitiTryNative(modulePath, { preferBuiltDist: true });
   if (canUseSourceArtifactRequire({ modulePath, tryNative })) {
-    return sourceArtifactRequire(modulePath);
+    try {
+      return sourceArtifactRequire(modulePath);
+    } catch (error) {
+      // Some source public artifacts keep emitted-style `.js` relative import
+      // specifiers. Plain require() then looks for compiled sibling `.js` files
+      // that do not exist in source-tree runs, while jiti resolves the `.ts`
+      // sources correctly.
+      if (!shouldFallbackSourceArtifactRequireToJiti(error)) {
+        throw error;
+      }
+    }
   }
   return getJiti(modulePath)(modulePath);
 }

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -111,15 +111,19 @@ function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: bo
 }
 
 function shouldFallbackSourceArtifactRequireToJiti(error: unknown): boolean {
-  if (!(error instanceof Error)) {
+  if (typeof error !== "object" || error === null) {
     return false;
   }
-  const code = (error as NodeJS.ErrnoException).code;
+  const candidate = error as { code?: unknown; message?: unknown };
+  const code = candidate.code;
   if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
     return false;
   }
-  return /(?:Cannot find module|Cannot find package|imported from).+\.js(?:['"]|\b)/.test(
-    error.message,
+  return (
+    typeof candidate.message === "string" &&
+    /(?:Cannot find module|Cannot find package|imported from).+\.js(?:['"]|\b)/.test(
+      candidate.message,
+    )
   );
 }
 

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -115,7 +115,12 @@ function shouldFallbackSourceArtifactRequireToJiti(error: unknown): boolean {
     return false;
   }
   const code = (error as NodeJS.ErrnoException).code;
-  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+  return /(?:Cannot find module|Cannot find package|imported from).+\.js(?:['"]|\b)/.test(
+    error.message,
+  );
 }
 
 function loadPublicSurfaceModule(modulePath: string): unknown {


### PR DESCRIPTION
## Summary
- Harden bundled plugin public-surface/facade resolution.
- Keep channel entry contract exports explicit.
- Cover bundled runtime deps and public surface loader behavior.

Split from #71858.

## Tests
- pnpm vitest run src/plugins/bundled-runtime-deps.test.ts src/plugin-sdk/facade-loader.test.ts src/plugins/public-surface-loader.test.ts src/plugin-sdk/channel-entry-contract.test.ts