### PR TITLE
fix(agents): enforce explicit subagent allowlist self-spawns

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -76,6 +76,45 @@ describe("spawnSubagentDirect seam flow", () => {
     );
   });
 
+  it("rejects an explicit same-agent spawn when allowAgents does not include the requester (#72827)", async () => {
+    hoisted.configOverride = createConfigOverride({
+      agents: {
+        defaults: {
+          workspace: os.tmpdir(),
+          subagents: {
+            allowAgents: ["coder"],
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/workspace-main",
+          },
+          {
+            id: "coder",
+            workspace: "/tmp/workspace-coder",
+          },
+        ],
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "spawn another main worker",
+        agentId: "main",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "forbidden",
+      error: "agentId is not allowed for sessions_spawn (allowed: coder)",
+    });
+    expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("accepts a spawned run across session patching, runtime-model persistence, registry registration, and lifecycle emission", async () => {
     const operations: string[] = [];
     let persistedStore: Record<string, Record<string, unknown>> | undefined;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -744,7 +744,7 @@ export async function spawnSubagentDirect(
     requesterGroupSpace: ctx.agentGroupSpace,
     requesterMemberRoleIds: ctx.agentMemberRoleIds,
   });
-  if (targetAgentId !== requesterAgentId) {
+  if (requestedAgentId) {
     const allowAgents =
       resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
       cfg?.agents?.defaults?.subagents?.allowAgents ??


### PR DESCRIPTION
## Summary
- enforce `subagents.allowAgents` whenever `sessions_spawn` receives an explicit `agentId`, including explicit same-agent spawns
- keep implicit same-agent spawns working without requiring the requester to list itself
- add regression coverage for explicit self-spawn denial

Fixes #72827.

## Tests
- `pnpm test src/agents/subagent-spawn.test.ts`
- `pnpm check:changed`

## Notes
- Local commands warn that this shell is on Node v20.19.2 while the repo wants Node >=22.14.0; the targeted test and changed gate still passed.
