### PR TITLE
fix(memory-lancedb): add encoding_format=float to embedding requests

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -177,9 +177,10 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number } = {
+    const params: { model: string; input: string; dimensions?: number; encoding_format: string } = {
       model: this.model,
       input: text,
+      encoding_format: "float",
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;


### PR DESCRIPTION
## Problem

OpenAI SDK v6.34+ defaults to `encoding_format=base64` for embedding requests. Local embedding providers (LM Studio, Ollama) may not handle this correctly, returning truncated vectors.

### Observed behavior

With LM Studio serving `nomic-embed-text-v1.5`:
- Raw HTTP request → **768-dim** float array ✅
- OpenAI SDK request (default base64) → LM Studio returns **192-dim** ❌
- OpenAI SDK request with `encoding_format: 'float'` → **768-dim** ✅

This causes `memory-lancedb` recall to fail with:
```
No vector column found to match with the query vector dimension: 192
```

## Fix

Explicitly set `encoding_format: 'float'` in the embedding request params to ensure consistent behavior regardless of OpenAI SDK version defaults.

Fixes #72839