### PR TITLE
fix(channels): ignore persisted auth for auto-enable

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1020,8 +1020,10 @@ module:
 }
 ```
 
-Use it when setup, doctor, or configured-state flows need a cheap yes/no auth
-probe before the full channel plugin loads. The target export should be a small
+Use it when setup, doctor, or status-style reporting flows need a cheap yes/no
+auth probe before the full channel plugin loads. Persisted auth state is not
+treated as channel configuration by itself and must not auto-enable a channel or
+force full runtime dependency loading. The target export should be a small
 function that reads persisted state only; do not route it through the full
 channel runtime barrel.
 

--- a/src/config/channel-configured.test.ts
+++ b/src/config/channel-configured.test.ts
@@ -25,16 +25,6 @@ vi.mock("../channels/plugins/configured-state.js", () => ({
   },
 }));
 
-vi.mock("../channels/plugins/persisted-auth-state.js", () => ({
-  hasBundledChannelPersistedAuthState: ({
-    channelId,
-    env,
-  }: {
-    channelId: string;
-    env?: NodeJS.ProcessEnv;
-  }) => channelId === "matrix" && env?.OPENCLAW_STATE_DIR === "state-with-matrix-creds",
-}));
-
 vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
   getBootstrapChannelPlugin: () => undefined,
 }));
@@ -78,9 +68,9 @@ describe("isChannelConfigured", () => {
     ).toBe(true);
   });
 
-  it("detects persisted Matrix credentials through package metadata", () => {
+  it("does not treat persisted auth state as configured channel state", () => {
     expect(
       isChannelConfigured({}, "matrix", { OPENCLAW_STATE_DIR: "state-with-matrix-creds" }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/src/config/channel-configured.ts
+++ b/src/config/channel-configured.ts
@@ -1,6 +1,5 @@
 import { getBootstrapChannelPlugin } from "../channels/plugins/bootstrap-registry.js";
 import { hasBundledChannelConfiguredState } from "../channels/plugins/configured-state.js";
-import { hasBundledChannelPersistedAuthState } from "../channels/plugins/persisted-auth-state.js";
 import {
   hasMeaningfulChannelConfigShallow,
   resolveChannelConfigRecord,
@@ -16,10 +15,6 @@ export function isChannelConfigured(
     return true;
   }
   if (hasBundledChannelConfiguredState({ channelId, cfg, env })) {
-    return true;
-  }
-  const pluginPersistedAuthState = hasBundledChannelPersistedAuthState({ channelId, cfg, env });
-  if (pluginPersistedAuthState) {
     return true;
   }
   const plugin = getBootstrapChannelPlugin(channelId);

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyPluginAutoEnable,
@@ -499,6 +500,22 @@ describe("applyPluginAutoEnable core", () => {
       },
     });
     expect(result.changes).toEqual([]);
+  });
+
+  it("does not auto-enable channels from persisted auth state alone", () => {
+    const env = makeIsolatedEnv();
+    const authDir = path.join(env.OPENCLAW_STATE_DIR!, "credentials", "whatsapp", "default");
+    fs.mkdirSync(authDir, { recursive: true });
+    fs.writeFileSync(path.join(authDir, "creds.json"), "{}", "utf-8");
+
+    const result = applyPluginAutoEnable({
+      config: {},
+      env,
+    });
+
+    expect(result.config).toEqual({});
+    expect(result.changes).toEqual([]);
+    expect(result.autoEnabledReasons).toEqual({});
   });
 
   it("ignores channels.modelByChannel for plugin auto-enable", () => {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -283,7 +283,7 @@ function collectPluginIdsForConfiguredChannel(
 }
 
 function collectCandidateChannelIds(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
-  return listPotentialConfiguredChannelIds(cfg, env).map(
+  return listPotentialConfiguredChannelIds(cfg, env, { includePersistedAuthState: false }).map(
     (channelId) => normalizeChatChannelId(channelId) ?? channelId,
   );
 }
@@ -499,7 +499,7 @@ export function configMayNeedPluginAutoEnable(
   if (hasConfiguredPluginConfigEntry(cfg)) {
     return true;
   }
-  if (hasPotentialConfiguredChannels(cfg, env)) {
+  if (hasPotentialConfiguredChannels(cfg, env, { includePersistedAuthState: false })) {
     return true;
   }
   if (hasConfiguredProviderModelOrHarness(cfg, env)) {


### PR DESCRIPTION
## Summary
- stop treating persisted channel auth state as configured channel state
- exclude persisted-auth-only channels from plugin auto-enable candidate detection
- document that persisted auth probes are for setup/status-style reporting, not runtime activation

Fixes #72836.

## Verification
- CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/config/channel-configured.test.ts src/config/plugin-auto-enable.core.test.ts src/channels/config-presence.test.ts src/plugins/channel-plugin-ids.test.ts
- CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- run check

Note: an initial pre-install `test:changed`/`check` attempt failed because the workspace was missing installed deps such as `@sinclair/typebox`; after `npm exec pnpm@10.33.0 -- install`, the focused tests and `check` passed.