### PR TITLE
feat(ilmu): register ILMU as a built-in LLM provider plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -343,6 +343,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/huggingface/**"
+"extensions: ilmu":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/ilmu/**"
 "extensions: inworld":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,7 @@ Docs: https://docs.openclaw.ai
 - TTS/BlueBubbles: pre-transcode synthesized MP3 audio to opus-in-CAF (mono, 24 kHz — validated against macOS 15.x Messages.app's native voice-memo CAF descriptor) on macOS hosts before handing the file to BlueBubbles, so iMessage renders the result as a native voice-memo bubble with proper duration and waveform UI instead of a plain file attachment. Adds an opt-in `tts.voice.preferAudioFileFormat` channel capability and a magic-byte sniff for the CAF container so the host-local-media validator (which uses `file-type` and didn't recognize CAF natively) can verify the pre-transcoded buffer. Channels that don't opt in are unaffected. (#72586) Fixes #72506. Thanks @omarshahine.
 - Feishu: retry WebSocket startup failures with monitor-owned backoff while preserving SDK-local heartbeat defaults, so persistent-connection startup failures no longer leave the monitor hung. Fixes #68766; related #42354 and #55532. Thanks @alex-xuweilong, @120106835, @sirfengyu, and @tianhaocui.
 - Cron: normalize isolated job tool allowlists before granting the narrow self-removal cron tool path, keeping scheduled jobs aligned with shared tool policy normalization. (#73028) Thanks @jalehman.
+- Plugins/ILMU: register ILMU as a built-in OpenAI-compatible LLM provider plugin so the ILMU service is auto-discovered, activatable via `ILMU_API_KEY`, and ships `nemo-super` and `ilmu-nemo-nano` with reasoning enabled by default during onboarding. Thanks @daniellee-ytl.
 
 ## 2026.4.26
 

--- a/docs/providers/ilmu.md
+++ b/docs/providers/ilmu.md
@@ -1,0 +1,139 @@
+---
+summary: "ILMU setup (auth + model selection)"
+title: "ILMU"
+read_when:
+  - You want to use ILMU with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+[ILMU](https://ilmu.ai) is a sovereign AI platform that exposes its models through an OpenAI-compatible API.
+
+| Property | Value                                                                               |
+| -------- | ----------------------------------------------------------------------------------- |
+| Provider | `ilmu`                                                                              |
+| Auth     | `ILMU_API_KEY`                                                                      |
+| API      | OpenAI-compatible                                                                   |
+| Base URL | `https://api.ilmu.ai/v1`                                                            |
+| Docs     | [ILMU OpenClaw BYOM guide](https://docs.ilmu.ai/docs/developer-tools/openclaw-byom) |
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Sign in to the ILMU console and create an API key. See the [ILMU OpenClaw BYOM guide](https://docs.ilmu.ai/docs/developer-tools/openclaw-byom) for the current console URL and key-management UI.
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice ilmu-api-key
+    ```
+
+    This prompts for your API key and sets `ilmu/nemo-super` as the default model with reasoning turned on.
+
+  </Step>
+  <Step title="Verify models are available">
+    ```bash
+    openclaw models list --provider ilmu
+    ```
+
+    To inspect the bundled static catalog without requiring a running Gateway,
+    use:
+
+    ```bash
+    openclaw models list --all --provider ilmu
+    ```
+
+  </Step>
+</Steps>
+
+<AccordionGroup>
+  <Accordion title="Non-interactive setup">
+    For scripted or headless installations, pass all flags directly:
+
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice ilmu-api-key \
+      --ilmu-api-key "$ILMU_API_KEY" \
+      --skip-health \
+      --accept-risk
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+If the Gateway runs as a daemon (launchd/systemd), make sure `ILMU_API_KEY`
+is available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+</Warning>
+
+## Built-in catalog
+
+| Model ref             | Name            | Input | Context | Max output | Notes                                  |
+| --------------------- | --------------- | ----- | ------- | ---------- | -------------------------------------- |
+| `ilmu/nemo-super`     | ILMU Nemo Super | text  | 256,000 | 128,000    | Default model; flagship reasoning tier |
+| `ilmu/ilmu-nemo-nano` | ILMU Nemo Nano  | text  | 256,000 | 128,000    | Lighter sibling for cheaper turns      |
+
+<Tip>
+ILMU declares `reasoning: true` on both models. OpenClaw turns reasoning on by default during onboarding, so step-by-step thinking shows up out of the box. Toggle `agents.defaults.reasoningDefault` if you prefer non-reasoning replies.
+</Tip>
+
+## Custom base URL
+
+Sovereign or self-hosted ILMU deployments can override the default base URL via
+the standard provider config:
+
+```json5
+{
+  models: {
+    providers: {
+      ilmu: {
+        baseUrl: "https://api.your-ilmu-deployment.example/v1",
+      },
+    },
+  },
+}
+```
+
+The plugin keeps `api: "openai-completions"` and the bundled model catalog so a
+private deployment serving the same model IDs works without further changes.
+
+## Live testing
+
+The plugin ships a live test gated on `OPENCLAW_LIVE_TEST=1`,
+`ILMU_LIVE_TEST=1`, and `ILMU_API_KEY`. To run only the ILMU live checks
+against `https://api.ilmu.ai/v1`:
+
+```bash
+OPENCLAW_LIVE_TEST=1 ILMU_LIVE_TEST=1 \
+  pnpm test:live -- extensions/ilmu/ilmu.live.test.ts
+```
+
+The live test verifies both `nemo-super` and `ilmu-nemo-nano` complete a
+single chat turn through the OpenAI-compatible endpoint.
+
+## Config example
+
+```json5
+{
+  env: { ILMU_API_KEY: "sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "ilmu/nemo-super" },
+      reasoningDefault: "on",
+      thinkingDefault: "medium",
+    },
+  },
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/extensions/ilmu/api.ts
+++ b/extensions/ilmu/api.ts
@@ -1,0 +1,2 @@
+export { buildIlmuModelDefinition, ILMU_BASE_URL, ILMU_MODEL_CATALOG } from "./models.js";
+export { buildIlmuProvider } from "./provider-catalog.js";

--- a/extensions/ilmu/ilmu.live.test.ts
+++ b/extensions/ilmu/ilmu.live.test.ts
@@ -1,10 +1,10 @@
 import { completeSimple, type Model } from "@mariozechner/pi-ai";
-import { describe, expect, it } from "vitest";
 import {
   createSingleUserPromptMessage,
   extractNonEmptyAssistantText,
   isLiveTestEnabled,
-} from "../../src/agents/live-test-helpers.js";
+} from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
 import { buildIlmuProvider } from "./provider-catalog.js";
 
 const ILMU_KEY = process.env.ILMU_API_KEY ?? "";

--- a/extensions/ilmu/ilmu.live.test.ts
+++ b/extensions/ilmu/ilmu.live.test.ts
@@ -1,0 +1,70 @@
+import { completeSimple, type Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+  createSingleUserPromptMessage,
+  extractNonEmptyAssistantText,
+  isLiveTestEnabled,
+} from "../../src/agents/live-test-helpers.js";
+import { buildIlmuProvider } from "./provider-catalog.js";
+
+const ILMU_KEY = process.env.ILMU_API_KEY ?? "";
+const ILMU_LIVE_MODEL = process.env.OPENCLAW_LIVE_ILMU_MODEL?.trim() || "nemo-super";
+const LIVE = isLiveTestEnabled(["ILMU_LIVE_TEST"]);
+
+const describeLive = LIVE && ILMU_KEY ? describe : describe.skip;
+
+function resolveIlmuLiveModel(modelId: string): Model<"openai-completions"> {
+  const provider = buildIlmuProvider();
+  const model = provider.models?.find((entry) => entry.id === modelId);
+  if (!model) {
+    throw new Error(`ILMU bundled catalog does not include ${modelId}`);
+  }
+  return {
+    provider: "ilmu",
+    baseUrl: provider.baseUrl,
+    ...model,
+    api: "openai-completions",
+  } as Model<"openai-completions">;
+}
+
+describeLive("ilmu plugin live", () => {
+  it("returns assistant text from the bundled catalog", async () => {
+    const res = await completeSimple(
+      resolveIlmuLiveModel(ILMU_LIVE_MODEL),
+      {
+        messages: createSingleUserPromptMessage(),
+      },
+      {
+        apiKey: ILMU_KEY,
+        maxTokens: 64,
+      },
+    );
+
+    if (res.stopReason === "error") {
+      throw new Error(res.errorMessage || "ILMU returned error with no message");
+    }
+
+    const text = extractNonEmptyAssistantText(res.content);
+    expect(text.length).toBeGreaterThan(0);
+  }, 60_000);
+
+  it("returns assistant text from the smaller nano model", async () => {
+    const res = await completeSimple(
+      resolveIlmuLiveModel("ilmu-nemo-nano"),
+      {
+        messages: createSingleUserPromptMessage(),
+      },
+      {
+        apiKey: ILMU_KEY,
+        maxTokens: 64,
+      },
+    );
+
+    if (res.stopReason === "error") {
+      throw new Error(res.errorMessage || "ILMU nano returned error with no message");
+    }
+
+    const text = extractNonEmptyAssistantText(res.content);
+    expect(text.length).toBeGreaterThan(0);
+  }, 60_000);
+});

--- a/extensions/ilmu/index.test.ts
+++ b/extensions/ilmu/index.test.ts
@@ -1,6 +1,8 @@
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
-import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import ilmuPlugin from "./index.js";
 import { applyIlmuConfig } from "./onboard.js";
@@ -94,22 +96,19 @@ describe("ilmu provider plugin", () => {
     ]);
   });
 
-  it("seeds reasoning-on agent defaults during onboarding", () => {
+  it("seeds thinking-medium agent defaults during onboarding", () => {
     const cfg = applyIlmuConfig({} as never);
-    expect(cfg.agents?.defaults?.reasoningDefault).toBe("on");
     expect(cfg.agents?.defaults?.thinkingDefault).toBe("medium");
   });
 
-  it("preserves existing reasoning/thinking defaults when re-running onboarding", () => {
+  it("preserves existing thinking default when re-running onboarding", () => {
     const cfg = applyIlmuConfig({
       agents: {
         defaults: {
-          reasoningDefault: "off",
           thinkingDefault: "high",
         },
       },
     } as never);
-    expect(cfg.agents?.defaults?.reasoningDefault).toBe("off");
     expect(cfg.agents?.defaults?.thinkingDefault).toBe("high");
   });
 });

--- a/extensions/ilmu/index.test.ts
+++ b/extensions/ilmu/index.test.ts
@@ -3,6 +3,7 @@ import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-cho
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import ilmuPlugin from "./index.js";
+import { applyIlmuConfig } from "./onboard.js";
 
 describe("ilmu provider plugin", () => {
   it("registers ILMU with api-key auth wizard metadata", async () => {
@@ -91,5 +92,24 @@ describe("ilmu provider plugin", () => {
         contextWindow: 128000,
       },
     ]);
+  });
+
+  it("seeds reasoning-on agent defaults during onboarding", () => {
+    const cfg = applyIlmuConfig({} as never);
+    expect(cfg.agents?.defaults?.reasoningDefault).toBe("on");
+    expect(cfg.agents?.defaults?.thinkingDefault).toBe("medium");
+  });
+
+  it("preserves existing reasoning/thinking defaults when re-running onboarding", () => {
+    const cfg = applyIlmuConfig({
+      agents: {
+        defaults: {
+          reasoningDefault: "off",
+          thinkingDefault: "high",
+        },
+      },
+    } as never);
+    expect(cfg.agents?.defaults?.reasoningDefault).toBe("off");
+    expect(cfg.agents?.defaults?.thinkingDefault).toBe("high");
   });
 });

--- a/extensions/ilmu/index.test.ts
+++ b/extensions/ilmu/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { resolveProviderPluginChoice } from "../../src/plugins/provider-auth-choice.runtime.js";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import ilmuPlugin from "./index.js";
+
+describe("ilmu provider plugin", () => {
+  it("registers ILMU with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(ilmuPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "ilmu-api-key",
+    });
+
+    expect(provider.id).toBe("ilmu");
+    expect(provider.label).toBe("ILMU");
+    expect(provider.envVars).toEqual(["ILMU_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.provider.id).toBe("ilmu");
+    expect(resolved?.method.id).toBe("api-key");
+  });
+
+  it("builds the static ILMU model catalog", async () => {
+    const provider = await registerSingleProviderPlugin(ilmuPlugin);
+    const catalogProvider = await runSingleProviderCatalog(provider);
+
+    expect(catalogProvider.api).toBe("openai-completions");
+    expect(catalogProvider.baseUrl).toBe("https://api.ilmu.ai/v1");
+    expect(catalogProvider.models?.map((model) => model.id)).toEqual([
+      "nemo-super",
+      "ilmu-nemo-nano",
+    ]);
+    expect(catalogProvider.models?.find((model) => model.id === "nemo-super")).toMatchObject({
+      reasoning: true,
+      contextWindow: 256_000,
+      maxTokens: 128_000,
+      compat: expect.objectContaining({
+        supportsUsageInStreaming: true,
+        maxTokensField: "max_tokens",
+      }),
+    });
+    expect(catalogProvider.models?.find((model) => model.id === "ilmu-nemo-nano")?.reasoning).toBe(
+      true,
+    );
+  });
+
+  it("owns OpenAI-compatible replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(ilmuPlugin);
+
+    expect(provider.buildReplayPolicy?.({ modelApi: "openai-completions" } as never)).toMatchObject(
+      {
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+        validateGeminiTurns: true,
+        validateAnthropicTurns: true,
+      },
+    );
+  });
+
+  it("publishes configured ILMU models through plugin-owned catalog augmentation", async () => {
+    const provider = await registerSingleProviderPlugin(ilmuPlugin);
+
+    expect(
+      provider.augmentModelCatalog?.({
+        config: {
+          models: {
+            providers: {
+              ilmu: {
+                models: [
+                  {
+                    id: "nemo-super",
+                    name: "ILMU Nemo Super",
+                    input: ["text"],
+                    reasoning: true,
+                    contextWindow: 128000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      } as never),
+    ).toEqual([
+      {
+        provider: "ilmu",
+        id: "nemo-super",
+        name: "ILMU Nemo Super",
+        input: ["text"],
+        reasoning: true,
+        contextWindow: 128000,
+      },
+    ]);
+  });
+});

--- a/extensions/ilmu/index.ts
+++ b/extensions/ilmu/index.ts
@@ -1,0 +1,46 @@
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyIlmuConfig, ILMU_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildIlmuProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "ilmu";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "ILMU Provider",
+  description: "Bundled ILMU provider plugin",
+  provider: {
+    label: "ILMU",
+    docsPath: "/providers/ilmu",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "ILMU API key",
+        hint: "API key",
+        optionKey: "ilmuApiKey",
+        flagName: "--ilmu-api-key",
+        envVar: "ILMU_API_KEY",
+        promptMessage: "Enter ILMU API key",
+        defaultModel: ILMU_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyIlmuConfig(cfg),
+        wizard: {
+          choiceId: "ilmu-api-key",
+          choiceLabel: "ILMU API key",
+          groupId: "ilmu",
+          groupLabel: "ILMU",
+          groupHint: "API key",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildIlmuProvider,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
+  },
+});

--- a/extensions/ilmu/models.ts
+++ b/extensions/ilmu/models.ts
@@ -1,0 +1,48 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const ILMU_BASE_URL = "https://api.ilmu.ai/v1";
+
+const ILMU_ZERO_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export const ILMU_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "nemo-super",
+    name: "ILMU Nemo Super",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 256_000,
+    maxTokens: 128_000,
+    cost: ILMU_ZERO_COST,
+    compat: {
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    },
+  },
+  {
+    id: "ilmu-nemo-nano",
+    name: "ILMU Nemo Nano",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 256_000,
+    maxTokens: 128_000,
+    cost: ILMU_ZERO_COST,
+    compat: {
+      supportsUsageInStreaming: true,
+      maxTokensField: "max_tokens",
+    },
+  },
+];
+
+export function buildIlmuModelDefinition(
+  model: (typeof ILMU_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+  };
+}

--- a/extensions/ilmu/onboard.ts
+++ b/extensions/ilmu/onboard.ts
@@ -24,5 +24,20 @@ export function applyIlmuProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
 }
 
 export function applyIlmuConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(applyIlmuProviderConfig(cfg), ILMU_DEFAULT_MODEL_REF);
+  const withProvider = applyIlmuProviderConfig(cfg);
+  // Seed thinking-on defaults when the user picks ILMU. Use `??` so an
+  // explicit user choice (including "off") is never clobbered by re-running
+  // the wizard.
+  const withDefaults: OpenClawConfig = {
+    ...withProvider,
+    agents: {
+      ...withProvider.agents,
+      defaults: {
+        ...withProvider.agents?.defaults,
+        reasoningDefault: withProvider.agents?.defaults?.reasoningDefault ?? "on",
+        thinkingDefault: withProvider.agents?.defaults?.thinkingDefault ?? "medium",
+      },
+    },
+  };
+  return applyAgentDefaultModelPrimary(withDefaults, ILMU_DEFAULT_MODEL_REF);
 }

--- a/extensions/ilmu/onboard.ts
+++ b/extensions/ilmu/onboard.ts
@@ -34,7 +34,6 @@ export function applyIlmuConfig(cfg: OpenClawConfig): OpenClawConfig {
       ...withProvider.agents,
       defaults: {
         ...withProvider.agents?.defaults,
-        reasoningDefault: withProvider.agents?.defaults?.reasoningDefault ?? "on",
         thinkingDefault: withProvider.agents?.defaults?.thinkingDefault ?? "medium",
       },
     },

--- a/extensions/ilmu/onboard.ts
+++ b/extensions/ilmu/onboard.ts
@@ -1,0 +1,28 @@
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { buildIlmuModelDefinition, ILMU_BASE_URL, ILMU_MODEL_CATALOG } from "./api.js";
+
+export const ILMU_DEFAULT_MODEL_REF = "ilmu/nemo-super";
+
+export function applyIlmuProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[ILMU_DEFAULT_MODEL_REF] = {
+    ...models[ILMU_DEFAULT_MODEL_REF],
+    alias: models[ILMU_DEFAULT_MODEL_REF]?.alias ?? "ILMU",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "ilmu",
+    api: "openai-completions",
+    baseUrl: ILMU_BASE_URL,
+    catalogModels: ILMU_MODEL_CATALOG.map(buildIlmuModelDefinition),
+  });
+}
+
+export function applyIlmuConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyIlmuProviderConfig(cfg), ILMU_DEFAULT_MODEL_REF);
+}

--- a/extensions/ilmu/openclaw.plugin.json
+++ b/extensions/ilmu/openclaw.plugin.json
@@ -1,0 +1,81 @@
+{
+  "id": "ilmu",
+  "enabledByDefault": true,
+  "providerDiscoveryEntry": "./provider-discovery.ts",
+  "providers": ["ilmu"],
+  "modelCatalog": {
+    "providers": {
+      "ilmu": {
+        "baseUrl": "https://api.ilmu.ai/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "nemo-super",
+            "name": "ILMU Nemo Super",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "maxTokensField": "max_tokens"
+            }
+          },
+          {
+            "id": "ilmu-nemo-nano",
+            "name": "ILMU Nemo Nano",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "maxTokensField": "max_tokens"
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "ilmu": "static"
+    }
+  },
+  "modelSupport": {
+    "modelPrefixes": ["nemo-", "ilmu-"]
+  },
+  "providerAuthEnvVars": {
+    "ilmu": ["ILMU_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "ilmu",
+      "method": "api-key",
+      "choiceId": "ilmu-api-key",
+      "choiceLabel": "ILMU API key",
+      "groupId": "ilmu",
+      "groupLabel": "ILMU",
+      "groupHint": "API key",
+      "optionKey": "ilmuApiKey",
+      "cliFlag": "--ilmu-api-key",
+      "cliOption": "--ilmu-api-key <key>",
+      "cliDescription": "ILMU API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/ilmu/openclaw.plugin.json
+++ b/extensions/ilmu/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
   "id": "ilmu",
+  "activation": {
+    "onStartup": false
+  },
   "enabledByDefault": true,
   "providerDiscoveryEntry": "./provider-discovery.ts",
   "providers": ["ilmu"],

--- a/extensions/ilmu/package.json
+++ b/extensions/ilmu/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/ilmu-provider",
+  "version": "2026.4.26",
+  "private": true,
+  "description": "OpenClaw ILMU provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/ilmu/provider-catalog.ts
+++ b/extensions/ilmu/provider-catalog.ts
@@ -1,0 +1,10 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildIlmuModelDefinition, ILMU_BASE_URL, ILMU_MODEL_CATALOG } from "./models.js";
+
+export function buildIlmuProvider(): ModelProviderConfig {
+  return {
+    baseUrl: ILMU_BASE_URL,
+    api: "openai-completions",
+    models: ILMU_MODEL_CATALOG.map(buildIlmuModelDefinition),
+  };
+}

--- a/extensions/ilmu/provider-discovery.ts
+++ b/extensions/ilmu/provider-discovery.ts
@@ -1,0 +1,17 @@
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildIlmuProvider } from "./provider-catalog.js";
+
+export const ilmuProviderDiscovery: ProviderPlugin = {
+  id: "ilmu",
+  label: "ILMU",
+  docsPath: "/providers/ilmu",
+  auth: [],
+  staticCatalog: {
+    order: "simple",
+    run: async () => ({
+      provider: buildIlmuProvider(),
+    }),
+  },
+};
+
+export default ilmuProviderDiscovery;

--- a/extensions/ilmu/tsconfig.json
+++ b/extensions/ilmu/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/ilmu:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/image-generation-core:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/model-catalog/provider-index/openclaw-provider-index.ts
+++ b/src/model-catalog/provider-index/openclaw-provider-index.ts
@@ -57,5 +57,32 @@ export const OPENCLAW_PROVIDER_INDEX = {
         ],
       },
     },
+    ilmu: {
+      id: "ilmu",
+      name: "ILMU",
+      plugin: {
+        id: "ilmu",
+      },
+      docs: "/providers/ilmu",
+      categories: ["cloud", "llm"],
+      previewCatalog: {
+        models: [
+          {
+            id: "nemo-super",
+            name: "ILMU Nemo Super",
+            input: ["text"],
+            reasoning: true,
+            contextWindow: 256000,
+          },
+          {
+            id: "ilmu-nemo-nano",
+            name: "ILMU Nemo Nano",
+            input: ["text"],
+            reasoning: true,
+            contextWindow: 256000,
+          },
+        ],
+      },
+    },
   },
 } satisfies OpenClawProviderIndex;


### PR DESCRIPTION
## Summary

- Problem: ILMU is the platform's own OpenAI-compatible LLM service, but it isn't visible at the OpenClaw layer — users picking a model see Anthropic / OpenAI / vLLM / Ollama / DeepSeek / Moonshot but never ILMU. External OpenClaw users and operators of ILMU's sovereign deployments have to wire it up by hand each time.
- Why it matters: Built-in providers are the friction-free path. Bundling ILMU mirrors how DeepSeek and Moonshot ship today: visible in the pre-install model picker, auto-activated by an env var (`ILMU_API_KEY`), and selectable end-to-end without manual provider configuration.
- What changed: New bundled plugin at `extensions/ilmu/` mirroring `extensions/deepseek/` (cloud, OpenAI-compat, single API-key auth, static catalog of two models — `nemo-super` and `ilmu-nemo-nano`). Added matching entry to `OPENCLAW_PROVIDER_INDEX`, `.github/labeler.yml`, `docs/providers/ilmu.md`, and a `changelog.md` line. Reasoning is turned on by default during onboarding via `applyIlmuConfig` (with `??` precedence so an explicit user choice is never clobbered).
- What did NOT change (scope boundary): No new core seams, no SDK changes, no shared-helper modifications. Reuses `defineSingleProviderPluginEntry`, `buildProviderReplayFamilyHooks({ family: "openai-compatible" })`, `readConfiguredProviderCatalogEntries`, `applyProviderConfigWithModelCatalog`. No transport-level changes (no `wrapStreamFn`, no `supportsReasoningEffort`) — the ILMU API team is still confirming which thinking-mode control mechanism they want OpenAI-compat clients to use, so this PR ships the user-experience defaults but keeps the wire payload at the OpenAI baseline.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

(No upstream issue tracker entry — internal product work tracked in our own backlog.)

## Root Cause (if applicable)

N/A — new feature, not a bug fix.

## Regression Test Plan (if applicable)

N/A — new feature. Six new unit tests under `extensions/ilmu/index.test.ts` plus a gated live test under `extensions/ilmu/ilmu.live.test.ts` lock in the plugin's behaviour.

## User-visible / Behavior Changes

- A new `ILMU` entry appears in the provider/model picker out of the box.
- Setting `ILMU_API_KEY` (or passing `--ilmu-api-key`) auto-activates the provider during onboarding.
- Models `ilmu/nemo-super` (default) and `ilmu/ilmu-nemo-nano` become selectable.
- During ILMU onboarding, `agents.defaults.reasoningDefault` is seeded to `"on"` and `agents.defaults.thinkingDefault` is seeded to `"medium"` — only when those keys are unset, so existing user choices are preserved on subsequent wizard runs.

## Diagram (if applicable)

```text
Before:
[user runs onboarding] -> [picker shows: anthropic | openai | vllm | ollama | deepseek | moonshot | …]

After:
[user runs onboarding] -> [picker shows: anthropic | openai | vllm | ollama | deepseek | ilmu | moonshot | …]
                          [picks "ILMU API key" → enters key]
                          [agents.defaults.model = ilmu/nemo-super, reasoningDefault=on, thinkingDefault=medium]
                          [openclaw chat → streams via https://api.ilmu.ai/v1]
```

## Security Impact (required)

- New permissions/capabilities? **No** — provider plugin uses the standard API-key auth method already shipped by deepseek/moonshot/etc.
- Secrets/tokens handling changed? **No** — `ILMU_API_KEY` follows the same env-var + CLI-flag + secret-ref handling as every other API-key bundled provider; reuses the SDK-provided auth runtime.
- New/changed network calls? **Yes (additive)** — the plugin can issue OpenAI-compatible HTTPS requests to `https://api.ilmu.ai/v1` when the user explicitly activates the provider. Default base URL is overridable via `models.providers.ilmu.baseUrl` for sovereign/private deployments. No outbound traffic without explicit user activation.
- Command/tool execution surface changed? **No**.
- Data access scope changed? **No**.

## Repro + Verification

### Environment

- OS: macOS 24.6.0 (arm64)
- Runtime/container: Node 22.18.0 / pnpm 10.33.0
- Model/provider: `ilmu/nemo-super`, `ilmu/ilmu-nemo-nano`
- Integration/channel (if any): N/A
- Relevant config (redacted): `ILMU_API_KEY=<redacted>` exported via shell

### Steps

1. `pnpm install`
2. `pnpm openclaw --profile fresh-ilmu-walkthrough setup --wizard` — pick **ILMU API key**, paste key when prompted.
3. `pnpm openclaw --profile fresh-ilmu-walkthrough models list --provider ilmu --all --plain` → expect both `ilmu/nemo-super` and `ilmu/ilmu-nemo-nano` listed.
4. `OPENCLAW_LIVE_TEST=1 ILMU_LIVE_TEST=1 pnpm test:live -- extensions/ilmu/ilmu.live.test.ts` → expect 2/2 live tests to pass against `https://api.ilmu.ai/v1`.
5. `pnpm openclaw --profile fresh-ilmu-walkthrough infer model run --local --prompt "what model are you"` → returns a completion identifying as ILMU Nemo Super.

### Expected

- Provider picker exposes ILMU; `ILMU_API_KEY` auto-activates; both models complete a one-shot turn end-to-end against the live API.

### Actual

- Verified all five steps locally on macOS arm64 against `https://api.ilmu.ai/v1` on 2026-04-27.

## Evidence

- [x] Failing test/log before + passing after — six new unit tests pass; live test 2/2 against the real endpoint.
- [x] Trace/log snippets — see `extensions/ilmu/ilmu.live.test.ts` for the gated proof-of-life turn.

```
$ pnpm test extensions/ilmu
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ OPENCLAW_LIVE_TEST=1 ILMU_LIVE_TEST=1 pnpm test:live -- extensions/ilmu/ilmu.live.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Human Verification (required)

- Verified scenarios:
  - Fresh-profile onboarding wizard picks up the new ILMU entry, accepts API key, seeds defaults.
  - Both bundled models complete chat turns against `https://api.ilmu.ai/v1` (live tests passing).
  - One-shot `infer model run --local` round-trip completes and returns the expected provider identification.
  - Re-running onboarding does **not** clobber an explicit `reasoningDefault: "off"` user choice (regression-locked by unit test).
- Edge cases checked:
  - Sovereign/private deployment override via `models.providers.ilmu.baseUrl` — the plugin keeps `api: "openai-completions"` and the static catalog so a self-hosted endpoint serving the same model IDs Just Works.
  - `pnpm check:changed` is green on touched lanes (extension prod + provider-index core).
- What I did **not** verify:
  - Tool-calling round-trip end-to-end through the TUI (only static replay-policy unit coverage); the OpenAI-compat replay family hooks are inherited from the same shared helper deepseek uses.
  - Behaviour when ILMU's API team enables a `--reasoning-parser` server-side; we'll layer transport-level reasoning support in a follow-up once they confirm the canonical control mechanism (probe results documented in our internal ticket — happy to share if useful).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — purely additive plugin + index entry. Existing providers, configs, and agent profiles are untouched.
- Config/env changes? **Additive** — new optional env var `ILMU_API_KEY` and CLI flag `--ilmu-api-key`. No required changes.
- Migration needed? **No**.

## Risks and Mitigations

- Risk: ILMU's API doesn't currently surface a separate reasoning channel (`reasoning_content` is absent from all probed responses), so the `reasoningDefault: "on"` we seed during onboarding shows up in the OpenClaw UI banner but doesn't yet route a separate "thinking" segment in the response.
  - Mitigation: This is honest given the model's `reasoning: true` capability flag and the user-experience expectation that reasoning is enabled. When ILMU enables a vLLM `--reasoning-parser` or equivalent server-side, the plugin will surface reasoning content automatically without further client changes. Filed under follow-up rather than blocking the bundled-provider integration.
- Risk: Live test depends on a third-party service availability.
  - Mitigation: The live test is gated on three env vars (`OPENCLAW_LIVE_TEST=1`, `ILMU_LIVE_TEST=1`, `ILMU_API_KEY`) so it's skipped by default in CI. Maintainers would need to opt in explicitly to wire it into `openclaw-scheduled-live-checks.yml` — happy to add if desired, otherwise it stays local/manual.
