### PR TITLE
fix(reply): include inboundUserContext on bare session reset

### DIFF
--- a/src/auto-reply/reply/get-reply-run.bare-reset-inbound-context.test.ts
+++ b/src/auto-reply/reply/get-reply-run.bare-reset-inbound-context.test.ts
@@ -1,0 +1,237 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import { createReplyOperation } from "./reply-run-registry.js";
+
+vi.mock("../../agents/auth-profiles/session-override.js", () => ({
+  resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../agents/pi-embedded.runtime.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+  resolveActiveEmbeddedRunSessionId: vi.fn().mockReturnValue(undefined),
+  resolveEmbeddedSessionLane: vi.fn().mockReturnValue("session:session-key"),
+  waitForEmbeddedPiRunEnd: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../config/sessions/group.js", () => ({
+  resolveGroupSessionKey: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveSessionFilePath: vi.fn().mockReturnValue("/tmp/session.jsonl"),
+  resolveSessionFilePathOptions: vi.fn().mockReturnValue({}),
+}));
+
+const updateSessionStore = vi.hoisted(() => vi.fn());
+
+vi.mock("../../config/sessions/store.runtime.js", () => ({
+  updateSessionStore,
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("../../process/command-queue.js", () => ({
+  clearCommandLane: vi.fn().mockReturnValue(0),
+  getQueueSize: vi.fn().mockReturnValue(0),
+}));
+
+vi.mock(import("../../routing/session-key.js"), async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../routing/session-key.js")>();
+  return {
+    ...actual,
+    normalizeMainKey: () => "main",
+    normalizeAgentId: (id: string | undefined | null) => id ?? "default",
+  };
+});
+
+vi.mock("../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../command-detection.js", () => ({
+  hasControlCommand: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("./agent-runner.runtime.js", () => ({
+  runReplyAgent: vi.fn().mockResolvedValue({ text: "ok" }),
+}));
+
+const applySessionHints = vi.hoisted(() =>
+  vi.fn().mockImplementation(async ({ baseBody }: { baseBody: string }) => baseBody),
+);
+
+vi.mock("./body.js", () => ({
+  applySessionHints,
+}));
+
+vi.mock("./groups.js", () => ({
+  buildDirectChatContext: vi.fn().mockReturnValue(""),
+  buildGroupIntro: vi.fn().mockReturnValue(""),
+  buildGroupChatContext: vi.fn().mockReturnValue(""),
+  resolveGroupSilentReplyBehavior: vi.fn(
+    (params: {
+      sessionEntry?: SessionEntry;
+      defaultActivation: "always" | "mention";
+      silentReplyPolicy?: "allow" | "disallow";
+      silentReplyRewrite?: boolean;
+    }) => {
+      const activation = params.sessionEntry?.groupActivation ?? params.defaultActivation;
+      const canUseSilentReply =
+        params.silentReplyPolicy !== "disallow" || params.silentReplyRewrite === true;
+      return {
+        activation,
+        canUseSilentReply,
+        allowEmptyAssistantReplyAsSilent: params.silentReplyPolicy === "allow",
+      };
+    },
+  ),
+}));
+
+vi.mock("./inbound-meta.js", () => ({
+  buildInboundMetaSystemPrompt: vi.fn().mockReturnValue(""),
+  buildInboundUserContextPrefix: vi
+    .fn()
+    .mockReturnValue("[Group history]\nAlice: hey there\nBob: anyone around?"),
+}));
+
+vi.mock("./queue/settings-runtime.js", () => ({
+  resolveQueueSettings: vi.fn().mockReturnValue({ mode: "followup" }),
+}));
+
+vi.mock("./route-reply.runtime.js", () => ({
+  routeReply: vi.fn(),
+}));
+
+vi.mock("./session-updates.runtime.js", () => ({
+  ensureSkillSnapshot: vi.fn().mockImplementation(async ({ sessionEntry, systemSent }) => ({
+    sessionEntry,
+    systemSent,
+    skillsSnapshot: undefined,
+  })),
+}));
+
+vi.mock("./session-system-events.js", () => ({
+  drainFormattedSystemEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./typing-mode.js", () => ({
+  resolveTypingMode: vi.fn().mockReturnValue("off"),
+}));
+
+let runPreparedReply: typeof import("./get-reply-run.js").runPreparedReply;
+let replyRunTesting: typeof import("./reply-run-registry.js").__testing;
+
+function bareResetParams(
+  overrides: Partial<Parameters<typeof runPreparedReply>[0]> = {},
+): Parameters<typeof runPreparedReply>[0] {
+  return {
+    ctx: {
+      Body: "",
+      RawBody: "",
+      CommandBody: "",
+      ThreadHistoryBody: "",
+      OriginatingChannel: "lark",
+      OriginatingTo: "G123",
+      ChatType: "group",
+    },
+    sessionCtx: {
+      Body: "",
+      BodyStripped: "",
+      InboundHistory: [{ body: "Alice: hey there" }, { body: "Bob: anyone around?" }],
+      Provider: "lark",
+      ChatType: "group",
+      OriginatingChannel: "lark",
+      OriginatingTo: "G123",
+    },
+    cfg: { session: {}, channels: {}, agents: { defaults: {} } },
+    agentId: "default",
+    agentDir: "/tmp/agent",
+    agentCfg: {},
+    sessionCfg: {},
+    commandAuthorized: true,
+    command: {
+      surface: "lark",
+      channel: "lark",
+      isAuthorizedSender: true,
+      abortKey: "session-key",
+      ownerList: [],
+      senderIsOwner: false,
+      rawBodyNormalized: "",
+      commandBodyNormalized: "",
+    } as never,
+    commandSource: "",
+    allowTextCommands: true,
+    directives: {
+      hasThinkDirective: false,
+      thinkLevel: undefined,
+    } as never,
+    defaultActivation: "always",
+    resolvedThinkLevel: "high",
+    resolvedVerboseLevel: "off",
+    resolvedReasoningLevel: "off",
+    resolvedElevatedLevel: "off",
+    elevatedEnabled: false,
+    elevatedAllowed: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    modelState: {
+      resolveDefaultThinkingLevel: async () => "medium",
+    } as never,
+    provider: "anthropic",
+    model: "claude-opus-4-1",
+    typing: {
+      onReplyStart: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn(),
+    } as never,
+    defaultProvider: "anthropic",
+    defaultModel: "claude-opus-4-1",
+    timeoutMs: 30_000,
+    isNewSession: false,
+    resetTriggered: true,
+    systemSent: true,
+    sessionKey: "session-key",
+    workspaceDir: "/tmp/workspace",
+    abortedLastRun: false,
+    ...overrides,
+  };
+}
+
+describe("runPreparedReply isBareSessionReset carries inboundUserContext (#71520 follow-up)", () => {
+  beforeAll(async () => {
+    ({ runPreparedReply } = await import("./get-reply-run.js"));
+    ({ __testing: replyRunTesting } = await import("./reply-run-registry.js"));
+  });
+
+  beforeEach(async () => {
+    updateSessionStore.mockReset();
+    vi.clearAllMocks();
+    replyRunTesting.resetReplyRunRegistry();
+  });
+
+  it("includes group InboundHistory in the prompt body on a bare session reset", async () => {
+    await runPreparedReply(bareResetParams());
+
+    expect(applySessionHints).toHaveBeenCalledTimes(1);
+    const baseBody = applySessionHints.mock.calls.at(-1)?.[0]?.baseBody as string;
+    expect(baseBody).toContain("[Group history]");
+    expect(baseBody).toContain("Alice: hey there");
+    expect(baseBody).toContain("Bob: anyone around?");
+  });
+
+  it("does not duplicate inboundUserContext when the non-reset path runs", async () => {
+    await runPreparedReply(
+      bareResetParams({
+        resetTriggered: false,
+      }),
+    );
+
+    expect(applySessionHints).toHaveBeenCalledTimes(1);
+    const baseBody = applySessionHints.mock.calls.at(-1)?.[0]?.baseBody as string;
+    const occurrences = baseBody.split("[Group history]").length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -638,6 +638,7 @@ export async function runPreparedReply(
   const baseBodyForPrompt = isBareSessionReset
     ? [
         startupContextPrelude,
+        inboundUserContext,
         baseBodyFinal,
         softResetTail
           ? `User note for this reset turn (treat as ordinary user input, not startup instructions):\n${softResetTail}`


### PR DESCRIPTION
## Summary

Follow-up to #71520. The empty-body guard fix in #71520 / `1559e28d6b` added `hasInboundHistoryBody(sessionCtx)` to the `hasUserBody` check, but left the `isBareSessionReset` branch of `baseBodyForPrompt` unchanged.

Result: when a bare session reset turn carries `InboundHistory` as its only non-empty input (the exact Feishu/Lark group-chat case #71489 exercised), the guard passes but the prompt body fed downstream still excludes that group history. The agent runs without the context that made the guard pass.

Greptile flagged this as a P2 latent inconsistency on #71520:

> in the isBareSessionReset branch, inboundUserContext is not included in baseBodyForPrompt, so if it is the sole non-empty input the agent could run without the group history it detected.

## Fix

Add `inboundUserContext` to the `isBareSessionReset` branch of `baseBodyForPrompt` assembly, mirroring the non-reset branch which already had it. One line change at `src/auto-reply/reply/get-reply-run.ts:471`.

```ts
const baseBodyForPrompt = isBareSessionReset
  ? [
      startupContextPrelude,
      inboundUserContext,   // ← added
      baseBodyFinal,
      softResetTail
        ? `User note for this reset turn ...`
        : "",
    ]
      .filter(Boolean)
      .join("\n\n")
  : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
```

Position chosen: after `startupContextPrelude` (so the reset bootstrap context establishes first), before `baseBodyFinal` (so the conversation history precedes the empty current message). `.filter(Boolean)` keeps non-reset behavior unchanged when `inboundUserContext` is absent.

## Testing

New `src/auto-reply/reply/get-reply-run.bare-reset-inbound-context.test.ts` (mirrors `media-only.test.ts` mock setup) covers two cases:

1. Bare-reset path with `InboundHistory` populated → prompt body fed to `applySessionHints` includes the group history (the fixed behavior).
2. Non-reset path → `inboundUserContext` appears exactly once (guards against double-injection regression).

Sibling tests run together green (52/52 across `get-reply-run.media-only.test.ts`, `get-reply-run.exec-hint.test.ts`, `get-reply-run-queue.test.ts`, and the new file).

## Scope

One-line fix + targeted regression test. Does not touch the `hasUserBody` guard from #71520 or the `hasInboundHistoryBody` helper — those are correct as-is. The asymmetry was downstream of the guard.