### PR TITLE
fix: allow silent local pairing for scope-upgrade

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -977,11 +977,9 @@ export function attachGatewayWsMessageHandler(params: {
               ...clientPairingMetadata,
               ...(bootstrapPairingRoles ? { roles: bootstrapPairingRoles } : {}),
               silent:
-                reason === "scope-upgrade"
-                  ? false
-                  : allowSilentLocalPairing ||
-                    allowSilentBootstrapPairing ||
-                    allowSilentTrustedCidrsNodePairing,
+                allowSilentLocalPairing ||
+                allowSilentBootstrapPairing ||
+                allowSilentTrustedCidrsNodePairing,
             });
             const context = buildRequestContext();
             let approved: Awaited<ReturnType<typeof approveDevicePairing>> | undefined;


### PR DESCRIPTION
## Summary

Fix regression from PR #22280 where scope auto-approval did not work for VPS/server lan bind (0.0.0.0) configurations. The fix removes the unconditional `silent: false` for scope-upgrade, allowing `allowSilentLocalPairing` to determine if the pairing request should be silent based on the pairing locality.

## Changes

- `src/gateway/server/ws-connection/message-handler.ts`: Remove the `reason === "scope-upgrade" ? false :` condition that was forcing `silent` to always be `false` for scope-upgrade, regardless of whether `allowSilentLocalPairing` returns `true`.

## Testing

- [x] `pnpm vitest run src/gateway/server/ws-connection/handshake-auth-helpers.test.ts` - 81 tests pass
- [x] `pnpm vitest run src/gateway/probe.test.ts` - 45 tests pass
- [x] `pnpm vitest run src/gateway/server-runtime-config.test.ts` - 28 tests pass
- [x] `pnpm check` passes with 0 errors

Fixes openclaw/openclaw#72857