### PR TITLE
fix(agents): apply subagent spawn model selection

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -42,8 +42,9 @@
           "order": 85
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao",
-          "defaultChoice": "npm"
+          "npmSpec": "openclaw-plugin-yuanbao@2.11.0",
+          "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-lYmBrU71ox3v7dzRqaltvzTXPcMjjgYrNqpBj5HIBkXgEFkXRRG8wplXg9Fub41/FjsSPn3WAbYpdTc+k+jsHg=="
         }
       }
     }

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1491,7 +1491,7 @@ describe("normalizeModelSelection", () => {
 });
 
 describe("resolveSubagentConfiguredModelSelection", () => {
-  it("prefers the agent primary model over agents.defaults.subagents.model", () => {
+  it("prefers agents.defaults.subagents.model over the agent primary model", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -1508,7 +1508,7 @@ describe("resolveSubagentConfiguredModelSelection", () => {
     } as OpenClawConfig;
 
     expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
-      "anthropic/claude-opus-4-6",
+      "openai/gpt-5.4",
     );
   });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -243,8 +243,8 @@ export function resolveSubagentConfiguredModelSelection(params: {
   const agentConfig = resolveAgentConfig(params.cfg, params.agentId);
   return (
     normalizeModelSelection(agentConfig?.subagents?.model) ??
-    normalizeModelSelection(agentConfig?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model)
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
+    normalizeModelSelection(agentConfig?.model)
   );
 }
 

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -108,6 +108,29 @@ describe("subagent spawn model + thinking plan", () => {
     });
   });
 
+  it("prefers global subagent model over target agent primary model", () => {
+    const cfg = createConfig({
+      agents: {
+        defaults: { subagents: { model: "minimax/MiniMax-M2.7" } },
+        list: [{ id: "research", model: { primary: "opencode/claude" } }],
+      },
+    });
+    const targetAgentConfig = {
+      id: "research",
+      model: { primary: "opencode/claude" },
+    };
+    const plan = resolveSubagentModelAndThinkingPlan({
+      cfg,
+      targetAgentId: "research",
+      targetAgentConfig,
+    });
+    expect(plan).toMatchObject({
+      status: "ok",
+      resolvedModel: "minimax/MiniMax-M2.7",
+      initialSessionPatch: { model: "minimax/MiniMax-M2.7" },
+    });
+  });
+
   it("prefers target agent primary model over global default", () => {
     const cfg = createConfig({
       agents: {

--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -15,7 +15,7 @@ const pruneLegacyStoreKeysMock = vi.fn();
 let resetSubagentRegistryForTests: typeof import("./subagent-registry.js").resetSubagentRegistryForTests;
 let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
 
-describe("spawnSubagentDirect runtime model persistence", () => {
+describe("spawnSubagentDirect model persistence", () => {
   beforeAll(async () => {
     ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
       callGatewayMock,
@@ -45,7 +45,7 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     );
   });
 
-  it("persists runtime model fields on the child session before starting the run", async () => {
+  it("persists selected model override fields on the child session before starting the run", async () => {
     const operations: string[] = [];
     callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
       operations.push(`gateway:${opts.method ?? "unknown"}`);
@@ -89,6 +89,12 @@ describe("spawnSubagentDirect runtime model persistence", () => {
       sessionKey: /^agent:main:subagent:/,
       provider: "openai-codex",
       model: "gpt-5.4",
+    });
+    const persistedEntry = Object.values(persistedStore ?? {})[0];
+    expect(persistedEntry).toMatchObject({
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "auto",
     });
     expect(pruneLegacyStoreKeysMock).toHaveBeenCalledTimes(3);
     expect(operations.indexOf("store:update")).toBeGreaterThan(-1);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -239,8 +239,11 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   if (typeof patch.model === "string" && patch.model.trim()) {
     const { provider, model } = splitModelRef(patch.model.trim());
     if (model) {
+      entry.modelOverride = model;
+      entry.modelOverrideSource = "auto";
       entry.model = model;
       if (provider) {
+        entry.providerOverride = provider;
         entry.modelProvider = provider;
       }
     }

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -496,7 +496,7 @@ describe("cron model formatting and precedence edge cases", () => {
       );
     });
 
-    it("prefers the agent model over agents.defaults.subagents.model", async () => {
+    it("prefers agents.defaults.subagents.model over the agent model", async () => {
       await expectSelectedModel(
         {
           cfg: {
@@ -511,7 +511,7 @@ describe("cron model formatting and precedence edge cases", () => {
             model: { primary: "anthropic/claude-opus-4-6" },
           },
         },
-        { provider: "anthropic", model: "claude-opus-4-6" },
+        { provider: "ollama", model: "llama3.2:3b" },
       );
     });
   });

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -63,8 +63,8 @@ export async function resolveCronModelSelection(
 
   const subagentModelRaw =
     normalizeModelSelection(params.agentConfigOverride?.subagents?.model) ??
-    normalizeModelSelection(params.agentConfigOverride?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
+    normalizeModelSelection(params.agentConfigOverride?.model);
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -94,8 +94,10 @@ describe("buildOfficialChannelCatalog", () => {
               label: "Yuanbao",
             }),
             install: {
-              npmSpec: "openclaw-plugin-yuanbao",
+              npmSpec: "openclaw-plugin-yuanbao@2.11.0",
               defaultChoice: "npm",
+              expectedIntegrity:
+                "sha512-lYmBrU71ox3v7dzRqaltvzTXPcMjjgYrNqpBj5HIBkXgEFkXRRG8wplXg9Fub41/FjsSPn3WAbYpdTc+k+jsHg==",
             },
           }),
         }),


### PR DESCRIPTION
## Summary

- Restore native subagent configured model precedence so `agents.defaults.subagents.model` wins over the target agent primary model when no per-agent `subagents.model` is set.
- Persist the resolved `sessions_spawn` model onto child sessions as selected model override fields (`providerOverride` / `modelOverride`, source `auto`) before the first child `agent` run.
- Align isolated cron agent-turn subagent model precedence with native subagent selection.

## Why

Native `sessions_spawn` could report `modelApplied: true` while the child run still executed on the target agent/default model. The spawn path persisted only runtime identity fields (`model` / `modelProvider`), but `agentCommand` selects from `modelOverride` / `providerOverride`, so the resolved spawn model was visible in some status surfaces without necessarily controlling the actual provider call.

This also covers the default precedence case discussed in #58822 / #58823, and adds the explicit-spawn-model application path related to #6295.

## Tests

- `corepack pnpm vitest run src/agents/model-selection.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts src/agents/subagent-spawn.model-session.test.ts src/cron/isolated-agent.model-formatting.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" corepack pnpm check:changed`
