### PR TITLE
feat(acp): add opt-in Coven runtime bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- ACP/runtime: add an opt-in bundled Coven backend extension that routes ACP coding sessions through a local Coven daemon when `acp.backend="coven"`, while preserving the existing ACPX backend as the default fallback path.
+
 ## 2026.4.26
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 - ACP/runtime: add an opt-in bundled Coven backend extension that routes ACP coding sessions through a local Coven daemon when `acp.backend="coven"`, while preserving the existing ACPX backend as the default fallback path.
 
+### Fixes
+
+- ACP/runtime: harden the opt-in Coven backend with workspace-confined launch paths, home-expanded Coven socket config, bounded socket responses, sanitized daemon output, and controlled polling failure handling. Thanks @BunsDev.
+
 ## 2026.4.26
 
 ### Changes

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -235,6 +235,12 @@ the Coven session id in the ACP runtime handle. If the health check or launch
 fails, OpenClaw falls back to the configured direct ACP backend (`acpx` by
 default) instead of breaking existing ACP behavior.
 
+For path safety, `~` in `covenHome` and `socketPath` expands to the current
+user home directory. Relative Coven paths resolve from the OpenClaw workspace,
+not from the process working directory. `socketPath` must stay inside
+`covenHome`; use the default `<covenHome>/coven.sock` unless your Coven daemon
+uses a different socket filename in the same home directory.
+
 The default harness mapping sends common ACP agent ids such as `codex`,
 `claude`, `gemini`, and `opencode` to the matching Coven harness id. Override
 `plugins.entries.coven.config.harnesses` only when your local Coven install uses

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -186,6 +186,60 @@ Override the command or version in plugin config:
 
 See [Plugins](/tools/plugin).
 
+## Optional Coven backend
+
+OpenClaw can also register a bundled, opt-in `coven` ACP backend for operators
+who want ACP coding sessions supervised by a local [Coven](https://github.com/OpenCoven/coven)
+daemon instead of launched directly through ACPX.
+
+This is intentionally an extension, not a core runtime path:
+
+- the default ACPX backend stays unchanged for normal installs;
+- Coven has its own daemon, socket, session store, harness mapping, and project
+  boundary model;
+- the bridge can be enabled, disabled, configured, and reviewed independently
+  through the plugin system; and
+- OpenClaw remains responsible for ACP session routing, chat bindings, task
+  state, and fallback policy while Coven owns harness supervision.
+
+Minimal opt-in config:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "coven",
+    defaultAgent: "codex",
+  },
+  plugins: {
+    entries: {
+      coven: {
+        enabled: true,
+        config: {
+          // Optional. Defaults to COVEN_HOME or ~/.coven.
+          covenHome: "~/.coven",
+          // Optional. Defaults to <covenHome>/coven.sock.
+          socketPath: "~/.coven/coven.sock",
+          // Optional. Used when Coven is unavailable or launch fails.
+          fallbackBackend: "acpx",
+        },
+      },
+    },
+  },
+}
+```
+
+When selected, OpenClaw checks Coven daemon health over the configured Unix
+socket before launching. A successful launch creates a Coven session and records
+the Coven session id in the ACP runtime handle. If the health check or launch
+fails, OpenClaw falls back to the configured direct ACP backend (`acpx` by
+default) instead of breaking existing ACP behavior.
+
+The default harness mapping sends common ACP agent ids such as `codex`,
+`claude`, `gemini`, and `opencode` to the matching Coven harness id. Override
+`plugins.entries.coven.config.harnesses` only when your local Coven install uses
+custom harness names.
+
 ### Automatic dependency install
 
 When you install OpenClaw globally with `npm install -g openclaw`, the acpx

--- a/extensions/coven/index.ts
+++ b/extensions/coven/index.ts
@@ -1,0 +1,32 @@
+import {
+  registerAcpRuntimeBackend,
+  unregisterAcpRuntimeBackend,
+} from "openclaw/plugin-sdk/acp-runtime";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createCovenPluginConfigSchema, resolveCovenPluginConfig } from "./src/config.js";
+import { CovenAcpRuntime, COVEN_BACKEND_ID } from "./src/runtime.js";
+
+export default definePluginEntry({
+  id: COVEN_BACKEND_ID,
+  name: "Coven ACP Runtime",
+  description:
+    "Opt-in ACP runtime backend that launches coding tasks through a local Coven daemon.",
+  configSchema: () => createCovenPluginConfigSchema(),
+  register(api) {
+    api.registerService({
+      id: "coven-runtime",
+      async start(ctx) {
+        const config = resolveCovenPluginConfig({
+          rawConfig: api.pluginConfig,
+          workspaceDir: ctx.workspaceDir,
+        });
+        const runtime = new CovenAcpRuntime({ config, logger: ctx.logger });
+        registerAcpRuntimeBackend({ id: COVEN_BACKEND_ID, runtime });
+        ctx.logger.info(`coven ACP runtime backend registered (socket: ${config.socketPath})`);
+      },
+      async stop() {
+        unregisterAcpRuntimeBackend(COVEN_BACKEND_ID);
+      },
+    });
+  },
+});

--- a/extensions/coven/index.ts
+++ b/extensions/coven/index.ts
@@ -22,7 +22,7 @@ export default definePluginEntry({
         });
         const runtime = new CovenAcpRuntime({ config, logger: ctx.logger });
         registerAcpRuntimeBackend({ id: COVEN_BACKEND_ID, runtime });
-        ctx.logger.info(`coven ACP runtime backend registered (socket: ${config.socketPath})`);
+        ctx.logger.info("coven ACP runtime backend registered");
       },
       async stop() {
         unregisterAcpRuntimeBackend(COVEN_BACKEND_ID);

--- a/extensions/coven/openclaw.plugin.json
+++ b/extensions/coven/openclaw.plugin.json
@@ -13,7 +13,7 @@
       },
       "socketPath": {
         "type": "string",
-        "description": "Path to the Coven daemon Unix socket. Defaults to <covenHome>/coven.sock."
+        "description": "Path to the Coven daemon Unix socket. Defaults to <covenHome>/coven.sock and must stay inside covenHome."
       },
       "fallbackBackend": {
         "type": "string",

--- a/extensions/coven/openclaw.plugin.json
+++ b/extensions/coven/openclaw.plugin.json
@@ -1,0 +1,33 @@
+{
+  "id": "coven",
+  "enabledByDefault": false,
+  "name": "Coven ACP Runtime",
+  "description": "Opt-in ACP runtime backend that launches coding tasks through a local Coven daemon.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "covenHome": {
+        "type": "string",
+        "description": "Path to COVEN_HOME. Defaults to COVEN_HOME or ~/.coven."
+      },
+      "socketPath": {
+        "type": "string",
+        "description": "Path to the Coven daemon Unix socket. Defaults to <covenHome>/coven.sock."
+      },
+      "fallbackBackend": {
+        "type": "string",
+        "description": "ACP backend to use when Coven is unavailable. Defaults to acpx."
+      },
+      "pollIntervalMs": {
+        "type": "number",
+        "description": "Polling interval for Coven session events."
+      },
+      "harnesses": {
+        "type": "object",
+        "additionalProperties": { "type": "string" },
+        "description": "Map OpenClaw ACP agent ids to Coven harness ids."
+      }
+    }
+  }
+}

--- a/extensions/coven/package.json
+++ b/extensions/coven/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/coven-runtime",
+  "version": "2026.4.26",
+  "private": true,
+  "description": "OpenClaw Coven ACP runtime bridge",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/coven/src/client.test.ts
+++ b/extensions/coven/src/client.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CovenApiError, createCovenClient } from "./client.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-coven-client-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function withServer(
+  handler: http.RequestListener,
+  fn: (socketPath: string) => Promise<void>,
+): Promise<void> {
+  const socketPath = path.join(tmpDir, "coven.sock");
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve());
+  });
+  try {
+    await fn(socketPath);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe("createCovenClient", () => {
+  it("parses daemon JSON over a Unix socket", async () => {
+    await withServer(
+      (_req, res) => {
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ ok: true, daemon: null }));
+      },
+      async (socketPath) => {
+        await expect(createCovenClient(socketPath).health()).resolves.toEqual({
+          ok: true,
+          daemon: null,
+        });
+      },
+    );
+  });
+
+  it("sends the event cursor when listing events", async () => {
+    await withServer(
+      (req, res) => {
+        expect(req.url).toBe("/events?sessionId=session-1&afterEventId=event-1");
+        res.setHeader("Content-Type", "application/json");
+        res.end("[]");
+      },
+      async (socketPath) => {
+        await expect(
+          createCovenClient(socketPath).listEvents("session-1", { afterEventId: "event-1" }),
+        ).resolves.toEqual([]);
+      },
+    );
+  });
+
+  it("wraps invalid daemon JSON in a typed API error", async () => {
+    await withServer(
+      (_req, res) => {
+        res.end("{not json");
+      },
+      async (socketPath) => {
+        await expect(createCovenClient(socketPath).health()).rejects.toBeInstanceOf(CovenApiError);
+      },
+    );
+  });
+
+  it("rejects daemon responses above the response size limit", async () => {
+    await withServer(
+      (_req, res) => {
+        res.end("x".repeat(1_000_001));
+      },
+      async (socketPath) => {
+        await expect(createCovenClient(socketPath).health()).rejects.toThrow(/size limit/);
+      },
+    );
+  });
+});

--- a/extensions/coven/src/client.test.ts
+++ b/extensions/coven/src/client.test.ts
@@ -86,4 +86,15 @@ describe("createCovenClient", () => {
       },
     );
   });
+
+  it("revalidates socket paths before connecting", async () => {
+    const covenHome = path.join(tmpDir, ".coven");
+    await fs.mkdir(covenHome);
+    const socketPath = path.join(covenHome, "coven.sock");
+    await fs.symlink("/var/run/docker.sock", socketPath);
+
+    await expect(createCovenClient(socketPath, { socketRoot: covenHome }).health()).rejects.toThrow(
+      /must not be a symlink/,
+    );
+  });
 });

--- a/extensions/coven/src/client.ts
+++ b/extensions/coven/src/client.ts
@@ -1,4 +1,4 @@
-import net from "node:net";
+import http from "node:http";
 
 export type CovenSessionRecord = {
   id: string;
@@ -40,10 +40,18 @@ export interface CovenClient {
   health(signal?: AbortSignal): Promise<CovenHealthResponse>;
   launchSession(input: LaunchCovenSessionInput, signal?: AbortSignal): Promise<CovenSessionRecord>;
   getSession(sessionId: string, signal?: AbortSignal): Promise<CovenSessionRecord>;
-  listEvents(sessionId: string, signal?: AbortSignal): Promise<CovenEventRecord[]>;
+  listEvents(
+    sessionId: string,
+    options?: CovenListEventsOptions,
+    signal?: AbortSignal,
+  ): Promise<CovenEventRecord[]>;
   sendInput(sessionId: string, data: string, signal?: AbortSignal): Promise<void>;
   killSession(sessionId: string, signal?: AbortSignal): Promise<void>;
 }
+
+export type CovenListEventsOptions = {
+  afterEventId?: string;
+};
 
 type RequestOptions = {
   socketPath: string;
@@ -70,14 +78,8 @@ export class CovenApiError extends Error {
   }
 }
 
-function parseHttpResponse(raw: string): HttpResponse {
-  const [head = "", ...bodyParts] = raw.split("\r\n\r\n");
-  const statusMatch = /^HTTP\/\d(?:\.\d)?\s+(\d+)/i.exec(head);
-  return {
-    status: statusMatch ? Number(statusMatch[1]) : 0,
-    body: bodyParts.join("\r\n\r\n"),
-  };
-}
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const MAX_RESPONSE_BYTES = 1_000_000;
 
 function requestOverSocket(options: RequestOptions): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
@@ -86,53 +88,71 @@ function requestOverSocket(options: RequestOptions): Promise<HttpResponse> {
       return;
     }
 
-    const socket = net.createConnection(options.socketPath);
-    const chunks: Buffer[] = [];
     let settled = false;
+    let body = "";
+    let totalBytes = 0;
 
-    const settle = (fn: () => void) => {
+    const settle = (fn: () => void, req?: http.ClientRequest) => {
       if (settled) {
         return;
       }
       settled = true;
-      options.signal?.removeEventListener("abort", onAbort);
+      req?.destroy();
       fn();
     };
 
-    const onAbort = () => {
-      socket.destroy();
-      settle(() => reject(options.signal?.reason ?? new Error("request aborted")));
-    };
-
-    options.signal?.addEventListener("abort", onAbort, { once: true });
-
-    socket.on("connect", () => {
-      const body = options.body === undefined ? "" : JSON.stringify(options.body);
-      const headers = [
-        `${options.method} ${options.path} HTTP/1.1`,
-        "Host: coven",
-        "Connection: close",
-        ...(body
-          ? ["Content-Type: application/json", `Content-Length: ${Buffer.byteLength(body)}`]
-          : []),
-        "",
-        body,
-      ];
-      socket.write(headers.join("\r\n"));
+    const requestBody = options.body === undefined ? "" : JSON.stringify(options.body);
+    const req = http.request(
+      {
+        socketPath: options.socketPath,
+        method: options.method,
+        path: options.path,
+        headers: {
+          Host: "coven",
+          Connection: "close",
+          ...(requestBody
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(requestBody),
+              }
+            : {}),
+        },
+        signal: options.signal,
+      },
+      (res) => {
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          if (settled) {
+            return;
+          }
+          totalBytes += Buffer.byteLength(chunk);
+          if (totalBytes > MAX_RESPONSE_BYTES) {
+            settle(() => reject(new Error("Coven API response exceeded size limit")), req);
+            return;
+          }
+          body += chunk;
+        });
+        res.on("end", () => {
+          settle(() =>
+            resolve({
+              status: res.statusCode ?? 0,
+              body,
+            }),
+          );
+        });
+        res.on("error", (error) => settle(() => reject(error), req));
+      },
+    );
+    req.setTimeout(DEFAULT_REQUEST_TIMEOUT_MS, () => {
+      settle(() => reject(new Error("Coven API request timed out")), req);
     });
-    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
-    socket.on("error", (error) => settle(() => reject(error)));
-    socket.on("end", () => {
-      const response = parseHttpResponse(Buffer.concat(chunks).toString("utf8"));
-      settle(() => resolve(response));
-    });
-    socket.on("close", () => {
+    req.on("error", (error) => {
       if (settled) {
         return;
       }
-      const response = parseHttpResponse(Buffer.concat(chunks).toString("utf8"));
-      settle(() => resolve(response));
+      settle(() => reject(error));
     });
+    req.end(requestBody);
   });
 }
 
@@ -141,7 +161,11 @@ async function requestJson<T>(options: RequestOptions): Promise<T> {
   if (response.status < 200 || response.status >= 300) {
     throw new CovenApiError(response.status, response.body);
   }
-  return JSON.parse(response.body || "null") as T;
+  try {
+    return JSON.parse(response.body || "null") as T;
+  } catch (error) {
+    throw new CovenApiError(response.status, `Invalid JSON response: ${String(error)}`);
+  }
 }
 
 export function createCovenClient(socketPath: string): CovenClient {
@@ -171,11 +195,16 @@ export function createCovenClient(socketPath: string): CovenClient {
         signal,
       });
     },
-    listEvents(sessionId, signal) {
+    listEvents(sessionId, options, signal) {
+      const params = new URLSearchParams({ sessionId });
+      const afterEventId = options?.afterEventId?.trim();
+      if (afterEventId) {
+        params.set("afterEventId", afterEventId);
+      }
       return requestJson<CovenEventRecord[]>({
         socketPath,
         method: "GET",
-        path: `/events?sessionId=${encodeURIComponent(sessionId)}`,
+        path: `/events?${params.toString()}`,
         signal,
       });
     },

--- a/extensions/coven/src/client.ts
+++ b/extensions/coven/src/client.ts
@@ -1,0 +1,200 @@
+import net from "node:net";
+
+export type CovenSessionRecord = {
+  id: string;
+  projectRoot: string;
+  harness: string;
+  title: string;
+  status: string;
+  exitCode: number | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CovenEventRecord = {
+  id: string;
+  sessionId: string;
+  kind: string;
+  payloadJson: string;
+  createdAt: string;
+};
+
+export type CovenHealthResponse = {
+  ok: boolean;
+  daemon?: {
+    pid: number;
+    startedAt: string;
+    socket: string;
+  } | null;
+};
+
+export type LaunchCovenSessionInput = {
+  projectRoot: string;
+  cwd: string;
+  harness: string;
+  prompt: string;
+  title: string;
+};
+
+export interface CovenClient {
+  health(signal?: AbortSignal): Promise<CovenHealthResponse>;
+  launchSession(input: LaunchCovenSessionInput, signal?: AbortSignal): Promise<CovenSessionRecord>;
+  getSession(sessionId: string, signal?: AbortSignal): Promise<CovenSessionRecord>;
+  listEvents(sessionId: string, signal?: AbortSignal): Promise<CovenEventRecord[]>;
+  sendInput(sessionId: string, data: string, signal?: AbortSignal): Promise<void>;
+  killSession(sessionId: string, signal?: AbortSignal): Promise<void>;
+}
+
+type RequestOptions = {
+  socketPath: string;
+  method: "GET" | "POST";
+  path: string;
+  body?: unknown;
+  signal?: AbortSignal;
+};
+
+type HttpResponse = {
+  status: number;
+  body: string;
+};
+
+export class CovenApiError extends Error {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, body: string) {
+    super(`Coven API returned HTTP ${status || "unknown"}`);
+    this.name = "CovenApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function parseHttpResponse(raw: string): HttpResponse {
+  const [head = "", ...bodyParts] = raw.split("\r\n\r\n");
+  const statusMatch = /^HTTP\/\d(?:\.\d)?\s+(\d+)/i.exec(head);
+  return {
+    status: statusMatch ? Number(statusMatch[1]) : 0,
+    body: bodyParts.join("\r\n\r\n"),
+  };
+}
+
+function requestOverSocket(options: RequestOptions): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    if (options.signal?.aborted) {
+      reject(options.signal.reason ?? new Error("request aborted"));
+      return;
+    }
+
+    const socket = net.createConnection(options.socketPath);
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const settle = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      options.signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+
+    const onAbort = () => {
+      socket.destroy();
+      settle(() => reject(options.signal?.reason ?? new Error("request aborted")));
+    };
+
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    socket.on("connect", () => {
+      const body = options.body === undefined ? "" : JSON.stringify(options.body);
+      const headers = [
+        `${options.method} ${options.path} HTTP/1.1`,
+        "Host: coven",
+        "Connection: close",
+        ...(body
+          ? ["Content-Type: application/json", `Content-Length: ${Buffer.byteLength(body)}`]
+          : []),
+        "",
+        body,
+      ];
+      socket.write(headers.join("\r\n"));
+    });
+    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    socket.on("error", (error) => settle(() => reject(error)));
+    socket.on("end", () => {
+      const response = parseHttpResponse(Buffer.concat(chunks).toString("utf8"));
+      settle(() => resolve(response));
+    });
+    socket.on("close", () => {
+      if (settled) {
+        return;
+      }
+      const response = parseHttpResponse(Buffer.concat(chunks).toString("utf8"));
+      settle(() => resolve(response));
+    });
+  });
+}
+
+async function requestJson<T>(options: RequestOptions): Promise<T> {
+  const response = await requestOverSocket(options);
+  if (response.status < 200 || response.status >= 300) {
+    throw new CovenApiError(response.status, response.body);
+  }
+  return JSON.parse(response.body || "null") as T;
+}
+
+export function createCovenClient(socketPath: string): CovenClient {
+  return {
+    health(signal) {
+      return requestJson<CovenHealthResponse>({
+        socketPath,
+        method: "GET",
+        path: "/health",
+        signal,
+      });
+    },
+    launchSession(input, signal) {
+      return requestJson<CovenSessionRecord>({
+        socketPath,
+        method: "POST",
+        path: "/sessions",
+        body: input,
+        signal,
+      });
+    },
+    getSession(sessionId, signal) {
+      return requestJson<CovenSessionRecord>({
+        socketPath,
+        method: "GET",
+        path: `/sessions/${encodeURIComponent(sessionId)}`,
+        signal,
+      });
+    },
+    listEvents(sessionId, signal) {
+      return requestJson<CovenEventRecord[]>({
+        socketPath,
+        method: "GET",
+        path: `/events?sessionId=${encodeURIComponent(sessionId)}`,
+        signal,
+      });
+    },
+    async sendInput(sessionId, data, signal) {
+      await requestJson<unknown>({
+        socketPath,
+        method: "POST",
+        path: `/sessions/${encodeURIComponent(sessionId)}/input`,
+        body: { data },
+        signal,
+      });
+    },
+    async killSession(sessionId, signal) {
+      await requestJson<unknown>({
+        socketPath,
+        method: "POST",
+        path: `/sessions/${encodeURIComponent(sessionId)}/kill`,
+        signal,
+      });
+    },
+  };
+}

--- a/extensions/coven/src/client.ts
+++ b/extensions/coven/src/client.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs";
 import http from "node:http";
+import path from "node:path";
 
 export type CovenSessionRecord = {
   id: string;
@@ -55,6 +57,7 @@ export type CovenListEventsOptions = {
 
 type RequestOptions = {
   socketPath: string;
+  socketRoot?: string;
   method: "GET" | "POST";
   path: string;
   body?: unknown;
@@ -81,10 +84,44 @@ export class CovenApiError extends Error {
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 const MAX_RESPONSE_BYTES = 1_000_000;
 
+function pathIsInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function lstatIfExists(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function validateSocketPathForUse(socketPath: string, socketRoot: string | undefined): void {
+  if (!socketRoot) {
+    return;
+  }
+  const socketStat = lstatIfExists(socketPath);
+  if (socketStat?.isSymbolicLink()) {
+    throw new Error("Coven socketPath must not be a symlink");
+  }
+  const realSocketRoot = fs.realpathSync.native(socketRoot);
+  const realSocketDir = fs.realpathSync.native(path.dirname(socketPath));
+  if (!pathIsInside(realSocketRoot, realSocketDir)) {
+    throw new Error("Coven socketPath must stay inside covenHome");
+  }
+}
+
 function requestOverSocket(options: RequestOptions): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
     if (options.signal?.aborted) {
       reject(options.signal.reason ?? new Error("request aborted"));
+      return;
+    }
+    try {
+      validateSocketPathForUse(options.socketPath, options.socketRoot);
+    } catch (error) {
+      reject(error);
       return;
     }
 
@@ -168,11 +205,15 @@ async function requestJson<T>(options: RequestOptions): Promise<T> {
   }
 }
 
-export function createCovenClient(socketPath: string): CovenClient {
+export function createCovenClient(
+  socketPath: string,
+  clientOptions: { socketRoot?: string } = {},
+): CovenClient {
   return {
     health(signal) {
       return requestJson<CovenHealthResponse>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "GET",
         path: "/health",
         signal,
@@ -181,6 +222,7 @@ export function createCovenClient(socketPath: string): CovenClient {
     launchSession(input, signal) {
       return requestJson<CovenSessionRecord>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "POST",
         path: "/sessions",
         body: input,
@@ -190,6 +232,7 @@ export function createCovenClient(socketPath: string): CovenClient {
     getSession(sessionId, signal) {
       return requestJson<CovenSessionRecord>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "GET",
         path: `/sessions/${encodeURIComponent(sessionId)}`,
         signal,
@@ -203,6 +246,7 @@ export function createCovenClient(socketPath: string): CovenClient {
       }
       return requestJson<CovenEventRecord[]>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "GET",
         path: `/events?${params.toString()}`,
         signal,
@@ -211,6 +255,7 @@ export function createCovenClient(socketPath: string): CovenClient {
     async sendInput(sessionId, data, signal) {
       await requestJson<unknown>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "POST",
         path: `/sessions/${encodeURIComponent(sessionId)}/input`,
         body: { data },
@@ -220,6 +265,7 @@ export function createCovenClient(socketPath: string): CovenClient {
     async killSession(sessionId, signal) {
       await requestJson<unknown>({
         socketPath,
+        socketRoot: clientOptions.socketRoot,
         method: "POST",
         path: `/sessions/${encodeURIComponent(sessionId)}/kill`,
         signal,

--- a/extensions/coven/src/config.test.ts
+++ b/extensions/coven/src/config.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -51,6 +52,27 @@ describe("resolveCovenPluginConfig", () => {
         workspaceDir: "/repo",
       }),
     ).toThrow(/socketPath must stay inside covenHome/);
+  });
+
+  it("rejects socket paths that are symlinks", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-coven-config-"));
+    const covenHome = path.join(workspaceDir, ".coven");
+    await fs.mkdir(covenHome);
+    const socketPath = path.join(covenHome, "coven.sock");
+    await fs.symlink("/var/run/docker.sock", socketPath);
+    try {
+      expect(() =>
+        resolveCovenPluginConfig({
+          rawConfig: {
+            covenHome,
+            socketPath,
+          },
+          workspaceDir,
+        }),
+      ).toThrow(/must not be a symlink/);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("uses COVEN_HOME with tilde expansion for the default socket path", () => {

--- a/extensions/coven/src/config.test.ts
+++ b/extensions/coven/src/config.test.ts
@@ -1,0 +1,67 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCovenPluginConfig } from "./config.js";
+
+const OLD_COVEN_HOME = process.env.COVEN_HOME;
+
+afterEach(() => {
+  if (OLD_COVEN_HOME === undefined) {
+    delete process.env.COVEN_HOME;
+  } else {
+    process.env.COVEN_HOME = OLD_COVEN_HOME;
+  }
+});
+
+describe("resolveCovenPluginConfig", () => {
+  it("expands tilde paths before resolving Coven home and socket path", () => {
+    const resolved = resolveCovenPluginConfig({
+      rawConfig: {
+        covenHome: "~/.coven",
+        socketPath: "~/.coven/coven.sock",
+      },
+      workspaceDir: "/repo",
+    });
+
+    expect(resolved.covenHome).toBe(path.join(os.homedir(), ".coven"));
+    expect(resolved.socketPath).toBe(path.join(os.homedir(), ".coven", "coven.sock"));
+  });
+
+  it("resolves relative Coven paths from the workspace instead of process cwd", () => {
+    const resolved = resolveCovenPluginConfig({
+      rawConfig: {
+        covenHome: ".coven",
+        socketPath: ".coven/coven.sock",
+      },
+      workspaceDir: "/repo",
+    });
+
+    expect(resolved.workspaceDir).toBe("/repo");
+    expect(resolved.covenHome).toBe("/repo/.coven");
+    expect(resolved.socketPath).toBe("/repo/.coven/coven.sock");
+  });
+
+  it("rejects socket paths outside covenHome", () => {
+    expect(() =>
+      resolveCovenPluginConfig({
+        rawConfig: {
+          covenHome: "~/.coven",
+          socketPath: "/var/run/docker.sock",
+        },
+        workspaceDir: "/repo",
+      }),
+    ).toThrow(/socketPath must stay inside covenHome/);
+  });
+
+  it("uses COVEN_HOME with tilde expansion for the default socket path", () => {
+    process.env.COVEN_HOME = "~/.custom-coven";
+
+    const resolved = resolveCovenPluginConfig({
+      rawConfig: {},
+      workspaceDir: "/repo",
+    });
+
+    expect(resolved.covenHome).toBe(path.join(os.homedir(), ".custom-coven"));
+    expect(resolved.socketPath).toBe(path.join(os.homedir(), ".custom-coven", "coven.sock"));
+  });
+});

--- a/extensions/coven/src/config.ts
+++ b/extensions/coven/src/config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { buildPluginConfigSchema } from "openclaw/plugin-sdk/core";
@@ -63,6 +64,22 @@ function pathIsInside(parent: string, child: string): boolean {
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
+function realpathIfExists(filePath: string): string | null {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function lstatIfExists(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
 function resolveCovenHome(raw: string | undefined, baseDir: string): string {
   const fromConfig = raw?.trim();
   if (fromConfig) {
@@ -80,6 +97,19 @@ function resolveSocketPath(covenHome: string, raw: string | undefined, baseDir: 
     ? resolveConfiguredPath(raw, baseDir)
     : path.join(covenHome, "coven.sock");
   if (!pathIsInside(covenHome, socketPath)) {
+    throw new Error("Coven socketPath must stay inside covenHome");
+  }
+  const socketStat = lstatIfExists(socketPath);
+  if (socketStat?.isSymbolicLink()) {
+    throw new Error("Coven socketPath must not be a symlink");
+  }
+  const realCovenHome = realpathIfExists(covenHome);
+  const realSocketDir = realpathIfExists(path.dirname(socketPath));
+  if (realCovenHome && realSocketDir && !pathIsInside(realCovenHome, realSocketDir)) {
+    throw new Error("Coven socketPath must stay inside covenHome");
+  }
+  const realSocketPath = realpathIfExists(socketPath);
+  if (realCovenHome && realSocketPath && !pathIsInside(realCovenHome, realSocketPath)) {
     throw new Error("Coven socketPath must stay inside covenHome");
   }
   return socketPath;

--- a/extensions/coven/src/config.ts
+++ b/extensions/coven/src/config.ts
@@ -14,6 +14,7 @@ export type CovenPluginConfig = {
 export type ResolvedCovenPluginConfig = {
   covenHome: string;
   socketPath: string;
+  workspaceDir: string;
   fallbackBackend: string;
   pollIntervalMs: number;
   harnesses: Record<string, string>;
@@ -41,16 +42,47 @@ function normalizeBackendId(value: string | undefined): string {
   return normalized || DEFAULT_FALLBACK_BACKEND;
 }
 
-function resolveCovenHome(raw: string | undefined): string {
+function expandTilde(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed === "~") {
+    return os.homedir();
+  }
+  if (trimmed.startsWith("~/")) {
+    return path.join(os.homedir(), trimmed.slice(2));
+  }
+  return trimmed;
+}
+
+function resolveConfiguredPath(raw: string, baseDir: string): string {
+  const expanded = expandTilde(raw);
+  return path.isAbsolute(expanded) ? path.resolve(expanded) : path.resolve(baseDir, expanded);
+}
+
+function pathIsInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveCovenHome(raw: string | undefined, baseDir: string): string {
   const fromConfig = raw?.trim();
   if (fromConfig) {
-    return path.resolve(fromConfig);
+    return resolveConfiguredPath(fromConfig, baseDir);
   }
   const fromEnv = process.env.COVEN_HOME?.trim();
   if (fromEnv) {
-    return path.resolve(fromEnv);
+    return resolveConfiguredPath(fromEnv, baseDir);
   }
   return path.join(os.homedir(), ".coven");
+}
+
+function resolveSocketPath(covenHome: string, raw: string | undefined, baseDir: string): string {
+  const socketPath = raw?.trim()
+    ? resolveConfiguredPath(raw, baseDir)
+    : path.join(covenHome, "coven.sock");
+  if (!pathIsInside(covenHome, socketPath)) {
+    throw new Error("Coven socketPath must stay inside covenHome");
+  }
+  return socketPath;
 }
 
 function normalizeHarnesses(value: Record<string, string> | undefined): Record<string, string> {
@@ -72,12 +104,19 @@ export function resolveCovenPluginConfig(params: {
     throw new Error(parsed.error.issues[0]?.message ?? "invalid Coven plugin config");
   }
   const config = parsed.data as CovenPluginConfig;
-  const covenHome = resolveCovenHome(config.covenHome);
+  const workspaceDir = path.resolve(params.workspaceDir ?? process.cwd());
+  const covenHome = resolveCovenHome(config.covenHome, workspaceDir);
   return {
     covenHome,
-    socketPath: path.resolve(config.socketPath?.trim() || path.join(covenHome, "coven.sock")),
+    socketPath: resolveSocketPath(covenHome, config.socketPath, workspaceDir),
+    workspaceDir,
     fallbackBackend: normalizeBackendId(config.fallbackBackend),
     pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
     harnesses: normalizeHarnesses(config.harnesses),
   };
 }
+
+export const __testing = {
+  expandTilde,
+  resolveConfiguredPath,
+};

--- a/extensions/coven/src/config.ts
+++ b/extensions/coven/src/config.ts
@@ -1,0 +1,83 @@
+import os from "node:os";
+import path from "node:path";
+import { buildPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import { z } from "openclaw/plugin-sdk/zod";
+
+export type CovenPluginConfig = {
+  covenHome?: string;
+  socketPath?: string;
+  fallbackBackend?: string;
+  pollIntervalMs?: number;
+  harnesses?: Record<string, string>;
+};
+
+export type ResolvedCovenPluginConfig = {
+  covenHome: string;
+  socketPath: string;
+  fallbackBackend: string;
+  pollIntervalMs: number;
+  harnesses: Record<string, string>;
+};
+
+const DEFAULT_FALLBACK_BACKEND = "acpx";
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+const nonEmptyString = z.string().trim().min(1);
+
+export const CovenPluginConfigSchema = z.strictObject({
+  covenHome: nonEmptyString.optional(),
+  socketPath: nonEmptyString.optional(),
+  fallbackBackend: nonEmptyString.optional(),
+  pollIntervalMs: z.number().min(25).max(10_000).optional(),
+  harnesses: z.record(z.string(), nonEmptyString).optional(),
+});
+
+export function createCovenPluginConfigSchema() {
+  return buildPluginConfigSchema(CovenPluginConfigSchema);
+}
+
+function normalizeBackendId(value: string | undefined): string {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || DEFAULT_FALLBACK_BACKEND;
+}
+
+function resolveCovenHome(raw: string | undefined): string {
+  const fromConfig = raw?.trim();
+  if (fromConfig) {
+    return path.resolve(fromConfig);
+  }
+  const fromEnv = process.env.COVEN_HOME?.trim();
+  if (fromEnv) {
+    return path.resolve(fromEnv);
+  }
+  return path.join(os.homedir(), ".coven");
+}
+
+function normalizeHarnesses(value: Record<string, string> | undefined): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(value ?? {}).flatMap(([agent, harness]) => {
+      const normalizedAgent = agent.trim().toLowerCase();
+      const normalizedHarness = harness.trim();
+      return normalizedAgent && normalizedHarness ? [[normalizedAgent, normalizedHarness]] : [];
+    }),
+  );
+}
+
+export function resolveCovenPluginConfig(params: {
+  rawConfig: unknown;
+  workspaceDir?: string;
+}): ResolvedCovenPluginConfig {
+  const parsed = CovenPluginConfigSchema.safeParse(params.rawConfig ?? {});
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? "invalid Coven plugin config");
+  }
+  const config = parsed.data as CovenPluginConfig;
+  const covenHome = resolveCovenHome(config.covenHome);
+  return {
+    covenHome,
+    socketPath: path.resolve(config.socketPath?.trim() || path.join(covenHome, "coven.sock")),
+    fallbackBackend: normalizeBackendId(config.fallbackBackend),
+    pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    harnesses: normalizeHarnesses(config.harnesses),
+  };
+}

--- a/extensions/coven/src/runtime.test.ts
+++ b/extensions/coven/src/runtime.test.ts
@@ -1,0 +1,179 @@
+import {
+  registerAcpRuntimeBackend,
+  unregisterAcpRuntimeBackend,
+  type AcpRuntime,
+  type AcpRuntimeEvent,
+  type AcpRuntimeHandle,
+} from "openclaw/plugin-sdk/acp-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CovenClient, CovenEventRecord, CovenSessionRecord } from "./client.js";
+import type { ResolvedCovenPluginConfig } from "./config.js";
+import { CovenAcpRuntime } from "./runtime.js";
+
+const config: ResolvedCovenPluginConfig = {
+  covenHome: "/tmp/coven",
+  socketPath: "/tmp/coven/coven.sock",
+  fallbackBackend: "acpx",
+  pollIntervalMs: 1,
+  harnesses: {},
+};
+
+function session(overrides: Partial<CovenSessionRecord> = {}): CovenSessionRecord {
+  return {
+    id: "session-1",
+    projectRoot: "/repo",
+    harness: "codex",
+    title: "Fix tests",
+    status: "running",
+    exitCode: null,
+    createdAt: "2026-04-27T10:00:00Z",
+    updatedAt: "2026-04-27T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<CovenEventRecord>): CovenEventRecord {
+  return {
+    id: "event-1",
+    sessionId: "session-1",
+    kind: "output",
+    payloadJson: JSON.stringify({ data: "hello\n" }),
+    createdAt: "2026-04-27T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function fakeClient(overrides: Partial<CovenClient> = {}): CovenClient {
+  return {
+    health: vi.fn(async () => ({ ok: true, daemon: null })),
+    launchSession: vi.fn(async () => session()),
+    getSession: vi.fn(async () => session({ status: "completed", exitCode: 0 })),
+    listEvents: vi.fn(async () => [
+      event({ id: "event-1", kind: "output", payloadJson: JSON.stringify({ data: "hello\n" }) }),
+      event({
+        id: "event-2",
+        kind: "exit",
+        payloadJson: JSON.stringify({ status: "completed", exitCode: 0 }),
+      }),
+    ]),
+    sendInput: vi.fn(async () => undefined),
+    killSession: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+async function collect(iterable: AsyncIterable<AcpRuntimeEvent>): Promise<AcpRuntimeEvent[]> {
+  const events: AcpRuntimeEvent[] = [];
+  for await (const item of iterable) {
+    events.push(item);
+  }
+  return events;
+}
+
+function fallbackRuntime(): AcpRuntime {
+  const handle: AcpRuntimeHandle = {
+    sessionKey: "agent:codex:test",
+    backend: "acpx",
+    runtimeSessionName: "fallback-session",
+    cwd: "/repo",
+  };
+  return {
+    ensureSession: vi.fn(async () => handle),
+    async *runTurn() {
+      yield { type: "text_delta", text: "direct fallback\n", stream: "output" };
+      yield { type: "done", stopReason: "complete" };
+    },
+    getStatus: vi.fn(async () => ({ summary: "fallback active" })),
+    cancel: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+  };
+}
+
+afterEach(() => {
+  unregisterAcpRuntimeBackend("acpx");
+});
+
+describe("CovenAcpRuntime", () => {
+  it("falls back to the direct ACP backend when Coven is unavailable", async () => {
+    const fallback = fallbackRuntime();
+    registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
+    const runtime = new CovenAcpRuntime({
+      config,
+      client: fakeClient({ health: vi.fn(async () => Promise.reject(new Error("offline"))) }),
+    });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+
+    expect(handle.backend).toBe("acpx");
+    expect(fallback.ensureSession).toHaveBeenCalledOnce();
+  });
+
+  it("launches a Coven session and streams output events to ACP", async () => {
+    const client = fakeClient();
+    const runtime = new CovenAcpRuntime({ config, client });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+
+    const events = await collect(
+      runtime.runTurn({
+        handle,
+        text: "Fix tests",
+        mode: "prompt",
+        requestId: "req-1",
+      }),
+    );
+
+    expect(client.launchSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: "/repo",
+        cwd: "/repo",
+        harness: "codex",
+        prompt: "Fix tests",
+      }),
+      undefined,
+    );
+    expect(handle.backendSessionId).toBe("session-1");
+    expect(events).toEqual([
+      expect.objectContaining({ type: "status", text: "coven session session-1 started (codex)" }),
+      expect.objectContaining({ type: "text_delta", text: "hello\n" }),
+      expect.objectContaining({ type: "status", text: "coven session completed exitCode=0" }),
+      expect.objectContaining({ type: "done", stopReason: "completed" }),
+    ]);
+  });
+
+  it("preserves direct fallback when Coven launch fails after detection", async () => {
+    const fallback = fallbackRuntime();
+    registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
+    const runtime = new CovenAcpRuntime({
+      config,
+      client: fakeClient({
+        launchSession: vi.fn(async () => Promise.reject(new Error("launch failed"))),
+      }),
+    });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+
+    const events = await collect(
+      runtime.runTurn({ handle, text: "Fix tests", mode: "prompt", requestId: "req-1" }),
+    );
+
+    expect(handle.backend).toBe("acpx");
+    expect(events).toEqual([
+      expect.objectContaining({ type: "text_delta", text: "direct fallback\n" }),
+      expect.objectContaining({ type: "done", stopReason: "complete" }),
+    ]);
+  });
+});

--- a/extensions/coven/src/runtime.test.ts
+++ b/extensions/coven/src/runtime.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import {
   registerAcpRuntimeBackend,
   unregisterAcpRuntimeBackend,
@@ -239,6 +242,39 @@ describe("CovenAcpRuntime", () => {
     ).rejects.toThrow(/outside workspace/);
   });
 
+  it("rejects Coven cwd symlinks that resolve outside the workspace", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-coven-workspace-"));
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-coven-outside-"));
+    const symlinkPath = path.join(workspaceDir, "outside");
+    await fs.symlink(outsideDir, symlinkPath);
+    try {
+      const runtime = new CovenAcpRuntime({
+        config: { ...config, workspaceDir },
+        client: fakeClient(),
+      });
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:codex:test",
+        agent: "codex",
+        mode: "oneshot",
+        cwd: symlinkPath,
+      });
+
+      await expect(
+        collect(
+          runtime.runTurn({
+            handle,
+            text: "Fix tests",
+            mode: "prompt",
+            requestId: "req-1",
+          }),
+        ),
+      ).rejects.toThrow(/outside workspace/);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("requests incremental events after the last processed Coven event", async () => {
     const client = fakeClient({
       listEvents: vi
@@ -309,9 +345,36 @@ describe("CovenAcpRuntime", () => {
   });
 
   it("strips terminal escape and control characters from Coven output", () => {
-    expect(__testing.sanitizeTerminalText("\u001b]0;spoof\u0007hi\u001b[31m!\u001b[0m\r\n")).toBe(
-      "hi!\n",
+    expect(
+      __testing.sanitizeTerminalText(
+        "\u001b]0;spoof\u0007hi\u001b[31m!\u001b[0m\u001b7\u001bc\r\n",
+      ),
+    ).toBe("hi!\n");
+  });
+
+  it("sanitizes prompt-derived session titles", () => {
+    expect(__testing.titleFromPrompt("\u001b]0;spoof\u0007Fix\u001b[31m tests\r\nnow")).toBe(
+      "Fix tests now",
     );
+  });
+
+  it("normalizes untrusted Coven exit status into bounded stop reasons", () => {
+    expect(__testing.normalizeStopReason("completed")).toBe("completed");
+    expect(__testing.normalizeStopReason("killed")).toBe("cancelled");
+    expect(__testing.normalizeStopReason("refusal")).toBe("completed");
+
+    expect(
+      __testing.eventToRuntimeEvents(
+        event({
+          kind: "exit",
+          payloadJson: JSON.stringify({ status: "refusal", exitCode: 0 }),
+        }),
+      ),
+    ).toContainEqual(expect.objectContaining({ type: "done", stopReason: "completed" }));
+  });
+
+  it("rejects oversized Coven runtime session metadata", () => {
+    expect(__testing.decodeRuntimeSessionName(`coven:${"a".repeat(2_049)}`)).toBeNull();
   });
 
   it("preserves direct fallback when Coven launch fails after detection", async () => {

--- a/extensions/coven/src/runtime.test.ts
+++ b/extensions/coven/src/runtime.test.ts
@@ -8,11 +8,12 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CovenClient, CovenEventRecord, CovenSessionRecord } from "./client.js";
 import type { ResolvedCovenPluginConfig } from "./config.js";
-import { CovenAcpRuntime } from "./runtime.js";
+import { __testing, CovenAcpRuntime } from "./runtime.js";
 
 const config: ResolvedCovenPluginConfig = {
   covenHome: "/tmp/coven",
   socketPath: "/tmp/coven/coven.sock",
+  workspaceDir: "/repo",
   fallbackBackend: "acpx",
   pollIntervalMs: 1,
   harnesses: {},
@@ -90,6 +91,7 @@ function fallbackRuntime(): AcpRuntime {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   unregisterAcpRuntimeBackend("acpx");
 });
 
@@ -99,7 +101,11 @@ describe("CovenAcpRuntime", () => {
     registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
     const runtime = new CovenAcpRuntime({
       config,
-      client: fakeClient({ health: vi.fn(async () => Promise.reject(new Error("offline"))) }),
+      client: fakeClient({
+        health: vi.fn(async () => {
+          throw new Error("offline");
+        }),
+      }),
     });
 
     const handle = await runtime.ensureSession({
@@ -111,6 +117,34 @@ describe("CovenAcpRuntime", () => {
 
     expect(handle.backend).toBe("acpx");
     expect(fallback.ensureSession).toHaveBeenCalledOnce();
+  });
+
+  it("falls back when Coven health checks do not settle before the deadline", async () => {
+    vi.useFakeTimers();
+    const fallback = fallbackRuntime();
+    registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
+    const client = fakeClient({
+      health: vi.fn(
+        async (signal?: AbortSignal) =>
+          await new Promise<never>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")), {
+              once: true,
+            });
+          }),
+      ),
+    });
+    const runtime = new CovenAcpRuntime({ config, client });
+
+    const pending = runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const handle = await pending;
+
+    expect(handle.backend).toBe("acpx");
   });
 
   it("launches a Coven session and streams output events to ACP", async () => {
@@ -150,13 +184,145 @@ describe("CovenAcpRuntime", () => {
     ]);
   });
 
+  it("ignores cwd embedded in runtimeSessionName when launching Coven sessions", async () => {
+    const client = fakeClient();
+    const runtime = new CovenAcpRuntime({ config, client });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+    handle.runtimeSessionName = __testing.encodeRuntimeSessionName({
+      agent: "codex",
+      mode: "prompt",
+      cwd: "/tmp/attacker",
+    });
+
+    await collect(
+      runtime.runTurn({
+        handle,
+        text: "Fix tests",
+        mode: "prompt",
+        requestId: "req-1",
+      }),
+    );
+
+    expect(client.launchSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectRoot: "/repo",
+        cwd: "/repo",
+      }),
+      undefined,
+    );
+  });
+
+  it("rejects Coven handles whose cwd is outside the configured workspace", async () => {
+    const runtime = new CovenAcpRuntime({ config, client: fakeClient() });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+    handle.cwd = "/tmp/attacker";
+
+    await expect(
+      collect(
+        runtime.runTurn({
+          handle,
+          text: "Fix tests",
+          mode: "prompt",
+          requestId: "req-1",
+        }),
+      ),
+    ).rejects.toThrow(/outside workspace/);
+  });
+
+  it("requests incremental events after the last processed Coven event", async () => {
+    const client = fakeClient({
+      listEvents: vi
+        .fn()
+        .mockResolvedValueOnce([
+          event({
+            id: "event-1",
+            kind: "output",
+            payloadJson: JSON.stringify({ data: "hello\n" }),
+          }),
+        ])
+        .mockResolvedValueOnce([
+          event({
+            id: "event-2",
+            kind: "exit",
+            payloadJson: JSON.stringify({ status: "completed", exitCode: 0 }),
+          }),
+        ]),
+      getSession: vi.fn(async () => session({ status: "running" })),
+    });
+    const runtime = new CovenAcpRuntime({ config, client });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+
+    await collect(
+      runtime.runTurn({ handle, text: "Fix tests", mode: "prompt", requestId: "req-1" }),
+    );
+
+    expect(client.listEvents).toHaveBeenNthCalledWith(
+      2,
+      "session-1",
+      {
+        afterEventId: "event-1",
+      },
+      undefined,
+    );
+  });
+
+  it("converts Coven polling failures into controlled terminal events", async () => {
+    const client = fakeClient({
+      listEvents: vi.fn(async () => {
+        throw new Error("bad json");
+      }),
+      killSession: vi.fn(async () => undefined),
+    });
+    const runtime = new CovenAcpRuntime({ config, client });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:test",
+      agent: "codex",
+      mode: "oneshot",
+      cwd: "/repo",
+    });
+
+    const events = await collect(
+      runtime.runTurn({ handle, text: "Fix tests", mode: "prompt", requestId: "req-1" }),
+    );
+
+    expect(client.killSession).toHaveBeenCalledWith("session-1", undefined);
+    expect(events).toEqual([
+      expect.objectContaining({ type: "status", text: "coven session session-1 started (codex)" }),
+      expect.objectContaining({ type: "status", text: "coven session polling failed" }),
+      expect.objectContaining({ type: "done", stopReason: "error" }),
+    ]);
+  });
+
+  it("strips terminal escape and control characters from Coven output", () => {
+    expect(__testing.sanitizeTerminalText("\u001b]0;spoof\u0007hi\u001b[31m!\u001b[0m\r\n")).toBe(
+      "hi!\n",
+    );
+  });
+
   it("preserves direct fallback when Coven launch fails after detection", async () => {
     const fallback = fallbackRuntime();
     registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
     const runtime = new CovenAcpRuntime({
       config,
       client: fakeClient({
-        launchSession: vi.fn(async () => Promise.reject(new Error("launch failed"))),
+        launchSession: vi.fn(async () => {
+          throw new Error("launch failed");
+        }),
       }),
     });
     const handle = await runtime.ensureSession({

--- a/extensions/coven/src/runtime.ts
+++ b/extensions/coven/src/runtime.ts
@@ -30,10 +30,12 @@ const DEFAULT_HARNESSES: Record<string, string> = {
   "google-gemini-cli": "gemini",
   opencode: "opencode",
 };
+const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+const MAX_TRACKED_EVENT_IDS = 10_000;
 
 type CovenRuntimeSessionState = {
   agent: string;
-  mode: "prompt" | "steer" | string;
+  mode: string;
   sessionMode?: string;
   cwd?: string;
 };
@@ -106,10 +108,32 @@ function parsePayload(event: CovenEventRecord): Record<string, unknown> {
   }
 }
 
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+const c0Start = String.fromCharCode(0x00);
+const c0Backspace = String.fromCharCode(0x08);
+const c0VerticalTab = String.fromCharCode(0x0b);
+const c0UnitSeparator = String.fromCharCode(0x1f);
+const del = String.fromCharCode(0x7f);
+const c1Start = String.fromCharCode(0x80);
+const c1End = String.fromCharCode(0x9f);
+const ANSI_ESCAPE_REGEX = new RegExp(
+  `${ESC}(?:\\[[\\x20-\\x3f]*[\\x40-\\x7e]|\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)|[\\x40-\\x5f])`,
+  "g",
+);
+const TEXT_CONTROL_REGEX = new RegExp(
+  `[${c0Start}-${c0Backspace}${c0VerticalTab}-${c0UnitSeparator}${del}${c1Start}-${c1End}]`,
+  "g",
+);
+
+function sanitizeTerminalText(input: string): string {
+  return input.replace(ANSI_ESCAPE_REGEX, "").replace(TEXT_CONTROL_REGEX, "");
+}
+
 function eventToRuntimeEvents(event: CovenEventRecord): AcpRuntimeEvent[] {
   const payload = parsePayload(event);
   if (event.kind === "output") {
-    const text = typeof payload.data === "string" ? payload.data : "";
+    const text = typeof payload.data === "string" ? sanitizeTerminalText(payload.data) : "";
     return text ? [{ type: "text_delta", text, stream: "output", tag: "agent_message_chunk" }] : [];
   }
   if (event.kind === "exit") {
@@ -143,6 +167,11 @@ function terminalStatusEvent(session: CovenSessionRecord): AcpRuntimeEvent {
     text: `coven session ${session.status}${session.exitCode == null ? "" : ` exitCode=${session.exitCode}`}`,
     tag: "session_info_update",
   };
+}
+
+function pathIsInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
 export class CovenAcpRuntime implements AcpRuntime {
@@ -192,12 +221,13 @@ export class CovenAcpRuntime implements AcpRuntime {
       );
     }
 
+    const cwd = this.resolveWorkspaceCwd(input.handle.cwd);
     let session: CovenSessionRecord;
     try {
       session = await this.client.launchSession(
         {
-          projectRoot: state.cwd ?? input.handle.cwd ?? process.cwd(),
-          cwd: state.cwd ?? input.handle.cwd ?? process.cwd(),
+          projectRoot: this.config.workspaceDir,
+          cwd,
           harness: this.resolveHarness(state.agent),
           prompt: input.text,
           title: titleFromPrompt(input.text),
@@ -222,32 +252,63 @@ export class CovenAcpRuntime implements AcpRuntime {
     };
 
     const seenEventIds = new Set<string>();
+    const seenEventQueue: string[] = [];
+    let lastSeenEventId: string | undefined;
     while (true) {
       if (input.signal?.aborted) {
         await this.killActiveSession(session.id, input.signal).catch(() => undefined);
         throw input.signal.reason ?? new Error("Coven turn aborted");
       }
 
-      const events = await this.client.listEvents(session.id, input.signal);
-      for (const event of events) {
-        if (seenEventIds.has(event.id)) {
-          continue;
-        }
-        seenEventIds.add(event.id);
-        for (const runtimeEvent of eventToRuntimeEvents(event)) {
-          yield runtimeEvent;
-          if (runtimeEvent.type === "done") {
-            this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
-            return;
+      try {
+        const events = await this.client.listEvents(
+          session.id,
+          lastSeenEventId ? { afterEventId: lastSeenEventId } : undefined,
+          input.signal,
+        );
+        const cursorIndex = lastSeenEventId
+          ? events.findIndex((event) => event.id === lastSeenEventId)
+          : -1;
+        const nextEvents = cursorIndex >= 0 ? events.slice(cursorIndex + 1) : events;
+        for (const event of nextEvents) {
+          if (seenEventIds.has(event.id)) {
+            continue;
+          }
+          seenEventIds.add(event.id);
+          seenEventQueue.push(event.id);
+          while (seenEventQueue.length > MAX_TRACKED_EVENT_IDS) {
+            const removed = seenEventQueue.shift();
+            if (removed) {
+              seenEventIds.delete(removed);
+            }
+          }
+          lastSeenEventId = event.id;
+          for (const runtimeEvent of eventToRuntimeEvents(event)) {
+            yield runtimeEvent;
+            if (runtimeEvent.type === "done") {
+              this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+              return;
+            }
           }
         }
-      }
 
-      const latest = await this.client.getSession(session.id, input.signal);
-      if (sessionIsTerminal(latest)) {
-        yield terminalStatusEvent(latest);
-        yield { type: "done", stopReason: latest.status };
+        const latest = await this.client.getSession(session.id, input.signal);
+        if (sessionIsTerminal(latest)) {
+          yield terminalStatusEvent(latest);
+          yield { type: "done", stopReason: latest.status };
+          this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+          return;
+        }
+      } catch (error) {
+        if (input.signal?.aborted) {
+          await this.killActiveSession(session.id, input.signal).catch(() => undefined);
+          throw input.signal.reason ?? error;
+        }
+        this.logger?.warn(`coven polling failed: ${String(error)}`);
+        await this.killActiveSession(session.id).catch(() => undefined);
         this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+        yield { type: "status", text: "coven session polling failed", tag: "session_info_update" };
+        yield { type: "done", stopReason: "error" };
         return;
       }
 
@@ -338,11 +399,18 @@ export class CovenAcpRuntime implements AcpRuntime {
   }
 
   private async isCovenAvailable(): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error("Coven health check timed out")),
+      HEALTH_CHECK_TIMEOUT_MS,
+    );
     try {
-      const health = await this.client.health();
-      return health.ok === true;
+      const health = await this.client.health(controller.signal);
+      return health.ok;
     } catch {
       return false;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
@@ -388,15 +456,22 @@ export class CovenAcpRuntime implements AcpRuntime {
     state: CovenRuntimeSessionState,
   ): AsyncIterable<AcpRuntimeEvent> {
     const fallback = this.requireFallbackRuntime();
-    const cwd = state.cwd ?? input.handle.cwd;
     const handle = await fallback.ensureSession({
       sessionKey: input.handle.sessionKey,
       agent: state.agent,
       mode: state.sessionMode === "persistent" ? "persistent" : "oneshot",
-      ...(cwd ? { cwd: path.resolve(cwd) } : {}),
+      cwd: this.resolveWorkspaceCwd(input.handle.cwd),
     });
     Object.assign(input.handle, handle);
     yield* fallback.runTurn({ ...input, handle });
+  }
+
+  private resolveWorkspaceCwd(candidate: string | undefined): string {
+    const cwd = path.resolve(candidate ?? this.config.workspaceDir);
+    if (!pathIsInside(this.config.workspaceDir, cwd)) {
+      throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "Coven cwd is outside workspace.");
+    }
+    return cwd;
   }
 
   private async killActiveSession(sessionId: string, signal?: AbortSignal): Promise<void> {
@@ -408,4 +483,5 @@ export const __testing = {
   decodeRuntimeSessionName,
   encodeRuntimeSessionName,
   eventToRuntimeEvents,
+  sanitizeTerminalText,
 };

--- a/extensions/coven/src/runtime.ts
+++ b/extensions/coven/src/runtime.ts
@@ -1,0 +1,411 @@
+import path from "node:path";
+import {
+  AcpRuntimeError,
+  getAcpRuntimeBackend,
+  type AcpRuntime,
+  type AcpRuntimeDoctorReport,
+  type AcpRuntimeEvent,
+  type AcpRuntimeHandle,
+  type AcpRuntimeStatus,
+  type AcpRuntimeTurnInput,
+} from "openclaw/plugin-sdk/acp-runtime";
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  createCovenClient,
+  type CovenClient,
+  type CovenEventRecord,
+  type CovenSessionRecord,
+} from "./client.js";
+import type { ResolvedCovenPluginConfig } from "./config.js";
+
+export const COVEN_BACKEND_ID = "coven";
+
+const DEFAULT_HARNESSES: Record<string, string> = {
+  codex: "codex",
+  "openai-codex": "codex",
+  "codex-cli": "codex",
+  claude: "claude",
+  "claude-cli": "claude",
+  gemini: "gemini",
+  "google-gemini-cli": "gemini",
+  opencode: "opencode",
+};
+
+type CovenRuntimeSessionState = {
+  agent: string;
+  mode: "prompt" | "steer" | string;
+  sessionMode?: string;
+  cwd?: string;
+};
+
+type CovenAcpRuntimeParams = {
+  config: ResolvedCovenPluginConfig;
+  logger?: PluginLogger;
+  client?: CovenClient;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+};
+
+function normalizeAgentId(value: string | undefined): string {
+  return value?.trim().toLowerCase() || "codex";
+}
+
+function encodeRuntimeSessionName(state: CovenRuntimeSessionState): string {
+  return `coven:${Buffer.from(JSON.stringify(state), "utf8").toString("base64url")}`;
+}
+
+function decodeRuntimeSessionName(value: string): CovenRuntimeSessionState | null {
+  const encoded = value.startsWith("coven:") ? value.slice("coven:".length) : "";
+  if (!encoded) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(encoded, "base64url").toString("utf8"),
+    ) as Partial<CovenRuntimeSessionState>;
+    const agent = normalizeAgentId(typeof parsed.agent === "string" ? parsed.agent : undefined);
+    return {
+      agent,
+      mode: typeof parsed.mode === "string" ? parsed.mode : "prompt",
+      ...(typeof parsed.sessionMode === "string" ? { sessionMode: parsed.sessionMode } : {}),
+      ...(typeof parsed.cwd === "string" && parsed.cwd.trim() ? { cwd: parsed.cwd.trim() } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("sleep aborted"));
+      return;
+    }
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(signal.reason ?? new Error("sleep aborted"));
+      },
+      { once: true },
+    );
+  });
+}
+
+function titleFromPrompt(prompt: string): string {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  return compact.slice(0, 80) || "OpenClaw task";
+}
+
+function parsePayload(event: CovenEventRecord): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(event.payloadJson) as unknown;
+    return typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function eventToRuntimeEvents(event: CovenEventRecord): AcpRuntimeEvent[] {
+  const payload = parsePayload(event);
+  if (event.kind === "output") {
+    const text = typeof payload.data === "string" ? payload.data : "";
+    return text ? [{ type: "text_delta", text, stream: "output", tag: "agent_message_chunk" }] : [];
+  }
+  if (event.kind === "exit") {
+    const status = typeof payload.status === "string" ? payload.status : "completed";
+    const exitCode = typeof payload.exitCode === "number" ? payload.exitCode : null;
+    return [
+      {
+        type: "status",
+        text: `coven session ${status}${exitCode == null ? "" : ` exitCode=${exitCode}`}`,
+        tag: "session_info_update",
+      },
+      { type: "done", stopReason: status },
+    ];
+  }
+  if (event.kind === "kill") {
+    return [
+      { type: "status", text: "coven session killed", tag: "session_info_update" },
+      { type: "done", stopReason: "killed" },
+    ];
+  }
+  return [];
+}
+
+function sessionIsTerminal(session: CovenSessionRecord): boolean {
+  return session.status !== "running" && session.status !== "created";
+}
+
+function terminalStatusEvent(session: CovenSessionRecord): AcpRuntimeEvent {
+  return {
+    type: "status",
+    text: `coven session ${session.status}${session.exitCode == null ? "" : ` exitCode=${session.exitCode}`}`,
+    tag: "session_info_update",
+  };
+}
+
+export class CovenAcpRuntime implements AcpRuntime {
+  private readonly config: ResolvedCovenPluginConfig;
+  private readonly client: CovenClient;
+  private readonly logger?: PluginLogger;
+  private readonly sleep: (ms: number, signal?: AbortSignal) => Promise<void>;
+  private readonly activeSessionIdsBySessionKey = new Map<string, string>();
+
+  constructor(params: CovenAcpRuntimeParams) {
+    this.config = params.config;
+    this.logger = params.logger;
+    this.client = params.client ?? createCovenClient(params.config.socketPath);
+    this.sleep = params.sleep ?? defaultSleep;
+  }
+
+  async ensureSession(
+    input: Parameters<AcpRuntime["ensureSession"]>[0],
+  ): Promise<AcpRuntimeHandle> {
+    if (!(await this.isCovenAvailable())) {
+      return await this.ensureFallbackSession(input);
+    }
+    const agent = normalizeAgentId(input.agent);
+    return {
+      sessionKey: input.sessionKey,
+      backend: COVEN_BACKEND_ID,
+      runtimeSessionName: encodeRuntimeSessionName({
+        agent,
+        mode: "prompt",
+        sessionMode: input.mode,
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+      }),
+      ...(input.cwd ? { cwd: input.cwd } : {}),
+    };
+  }
+
+  async *runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
+    if (input.handle.backend !== COVEN_BACKEND_ID) {
+      yield* this.runFallbackTurn(input, input.handle);
+      return;
+    }
+    const state = decodeRuntimeSessionName(input.handle.runtimeSessionName);
+    if (!state) {
+      throw new AcpRuntimeError(
+        "ACP_SESSION_INIT_FAILED",
+        "Coven runtime session metadata is missing.",
+      );
+    }
+
+    let session: CovenSessionRecord;
+    try {
+      session = await this.client.launchSession(
+        {
+          projectRoot: state.cwd ?? input.handle.cwd ?? process.cwd(),
+          cwd: state.cwd ?? input.handle.cwd ?? process.cwd(),
+          harness: this.resolveHarness(state.agent),
+          prompt: input.text,
+          title: titleFromPrompt(input.text),
+        },
+        input.signal,
+      );
+    } catch (error) {
+      this.logger?.warn(
+        `coven launch failed; falling back to ${this.config.fallbackBackend}: ${String(error)}`,
+      );
+      yield* this.runFallbackFromCovenHandle(input, state);
+      return;
+    }
+
+    input.handle.backendSessionId = session.id;
+    input.handle.agentSessionId = session.id;
+    this.activeSessionIdsBySessionKey.set(input.handle.sessionKey, session.id);
+    yield {
+      type: "status",
+      text: `coven session ${session.id} started (${session.harness})`,
+      tag: "session_info_update",
+    };
+
+    const seenEventIds = new Set<string>();
+    while (true) {
+      if (input.signal?.aborted) {
+        await this.killActiveSession(session.id, input.signal).catch(() => undefined);
+        throw input.signal.reason ?? new Error("Coven turn aborted");
+      }
+
+      const events = await this.client.listEvents(session.id, input.signal);
+      for (const event of events) {
+        if (seenEventIds.has(event.id)) {
+          continue;
+        }
+        seenEventIds.add(event.id);
+        for (const runtimeEvent of eventToRuntimeEvents(event)) {
+          yield runtimeEvent;
+          if (runtimeEvent.type === "done") {
+            this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+            return;
+          }
+        }
+      }
+
+      const latest = await this.client.getSession(session.id, input.signal);
+      if (sessionIsTerminal(latest)) {
+        yield terminalStatusEvent(latest);
+        yield { type: "done", stopReason: latest.status };
+        this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+        return;
+      }
+
+      await this.sleep(this.config.pollIntervalMs, input.signal);
+    }
+  }
+
+  getCapabilities() {
+    return { controls: ["session/status" as const] };
+  }
+
+  async getStatus(
+    input: Parameters<NonNullable<AcpRuntime["getStatus"]>>[0],
+  ): Promise<AcpRuntimeStatus> {
+    if (input.handle.backend !== COVEN_BACKEND_ID) {
+      const fallback = this.requireFallbackRuntime(input.handle.backend);
+      return fallback.getStatus
+        ? await fallback.getStatus(input)
+        : { summary: `fallback backend ${input.handle.backend} active` };
+    }
+    const sessionId =
+      input.handle.backendSessionId ??
+      this.activeSessionIdsBySessionKey.get(input.handle.sessionKey);
+    if (!sessionId) {
+      return { summary: "coven runtime ready" };
+    }
+    const session = await this.client.getSession(sessionId, input.signal);
+    return {
+      summary: `${session.status} ${session.harness} ${session.title}`,
+      backendSessionId: session.id,
+      agentSessionId: session.id,
+      details: {
+        projectRoot: session.projectRoot,
+        harness: session.harness,
+        status: session.status,
+        exitCode: session.exitCode,
+      },
+    };
+  }
+
+  async doctor(): Promise<AcpRuntimeDoctorReport> {
+    try {
+      const health = await this.client.health();
+      return health.ok
+        ? { ok: true, message: "Coven daemon is reachable." }
+        : { ok: false, code: "COVEN_UNHEALTHY", message: "Coven daemon did not report healthy." };
+    } catch (error) {
+      return {
+        ok: false,
+        code: "COVEN_UNAVAILABLE",
+        message: "Coven daemon is not reachable; direct ACP fallback remains available.",
+        details: [String(error)],
+      };
+    }
+  }
+
+  async cancel(input: Parameters<AcpRuntime["cancel"]>[0]): Promise<void> {
+    if (input.handle.backend !== COVEN_BACKEND_ID) {
+      await this.requireFallbackRuntime(input.handle.backend).cancel(input);
+      return;
+    }
+    const sessionId =
+      input.handle.backendSessionId ??
+      this.activeSessionIdsBySessionKey.get(input.handle.sessionKey);
+    if (sessionId) {
+      await this.killActiveSession(sessionId);
+    }
+  }
+
+  async close(input: Parameters<AcpRuntime["close"]>[0]): Promise<void> {
+    if (input.handle.backend !== COVEN_BACKEND_ID) {
+      await this.requireFallbackRuntime(input.handle.backend).close(input);
+      return;
+    }
+    const sessionId =
+      input.handle.backendSessionId ??
+      this.activeSessionIdsBySessionKey.get(input.handle.sessionKey);
+    if (sessionId && input.reason !== "oneshot-complete") {
+      await this.killActiveSession(sessionId).catch(() => undefined);
+    }
+    this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
+  }
+
+  async prepareFreshSession(input: { sessionKey: string }): Promise<void> {
+    this.activeSessionIdsBySessionKey.delete(input.sessionKey);
+    const fallback = this.getFallbackRuntime();
+    await fallback?.prepareFreshSession?.(input);
+  }
+
+  private async isCovenAvailable(): Promise<boolean> {
+    try {
+      const health = await this.client.health();
+      return health.ok === true;
+    } catch {
+      return false;
+    }
+  }
+
+  private resolveHarness(agent: string): string {
+    const normalized = normalizeAgentId(agent);
+    return this.config.harnesses[normalized] ?? DEFAULT_HARNESSES[normalized] ?? normalized;
+  }
+
+  private getFallbackRuntime(backendId = this.config.fallbackBackend): AcpRuntime | null {
+    const normalized = backendId.trim().toLowerCase();
+    if (!normalized || normalized === COVEN_BACKEND_ID) {
+      return null;
+    }
+    return getAcpRuntimeBackend(normalized)?.runtime ?? null;
+  }
+
+  private requireFallbackRuntime(backendId = this.config.fallbackBackend): AcpRuntime {
+    const runtime = this.getFallbackRuntime(backendId);
+    if (!runtime) {
+      throw new AcpRuntimeError(
+        "ACP_BACKEND_UNAVAILABLE",
+        `Coven fallback ACP backend "${backendId}" is not registered.`,
+      );
+    }
+    return runtime;
+  }
+
+  private async ensureFallbackSession(
+    input: Parameters<AcpRuntime["ensureSession"]>[0],
+  ): Promise<AcpRuntimeHandle> {
+    return await this.requireFallbackRuntime().ensureSession(input);
+  }
+
+  private async *runFallbackTurn(
+    input: AcpRuntimeTurnInput,
+    handle: AcpRuntimeHandle,
+  ): AsyncIterable<AcpRuntimeEvent> {
+    yield* this.requireFallbackRuntime(handle.backend).runTurn({ ...input, handle });
+  }
+
+  private async *runFallbackFromCovenHandle(
+    input: AcpRuntimeTurnInput,
+    state: CovenRuntimeSessionState,
+  ): AsyncIterable<AcpRuntimeEvent> {
+    const fallback = this.requireFallbackRuntime();
+    const cwd = state.cwd ?? input.handle.cwd;
+    const handle = await fallback.ensureSession({
+      sessionKey: input.handle.sessionKey,
+      agent: state.agent,
+      mode: state.sessionMode === "persistent" ? "persistent" : "oneshot",
+      ...(cwd ? { cwd: path.resolve(cwd) } : {}),
+    });
+    Object.assign(input.handle, handle);
+    yield* fallback.runTurn({ ...input, handle });
+  }
+
+  private async killActiveSession(sessionId: string, signal?: AbortSignal): Promise<void> {
+    await this.client.killSession(sessionId, signal);
+  }
+}
+
+export const __testing = {
+  decodeRuntimeSessionName,
+  encodeRuntimeSessionName,
+  eventToRuntimeEvents,
+};

--- a/extensions/coven/src/runtime.ts
+++ b/extensions/coven/src/runtime.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import {
   AcpRuntimeError,
@@ -32,6 +33,7 @@ const DEFAULT_HARNESSES: Record<string, string> = {
 };
 const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 const MAX_TRACKED_EVENT_IDS = 10_000;
+const MAX_RUNTIME_SESSION_NAME_BYTES = 2_048;
 
 type CovenRuntimeSessionState = {
   agent: string;
@@ -57,13 +59,19 @@ function encodeRuntimeSessionName(state: CovenRuntimeSessionState): string {
 
 function decodeRuntimeSessionName(value: string): CovenRuntimeSessionState | null {
   const encoded = value.startsWith("coven:") ? value.slice("coven:".length) : "";
-  if (!encoded) {
+  if (!encoded || encoded.length > MAX_RUNTIME_SESSION_NAME_BYTES) {
     return null;
   }
   try {
-    const parsed = JSON.parse(
-      Buffer.from(encoded, "base64url").toString("utf8"),
-    ) as Partial<CovenRuntimeSessionState>;
+    const decoded = Buffer.from(encoded, "base64url");
+    if (decoded.byteLength > MAX_RUNTIME_SESSION_NAME_BYTES) {
+      return null;
+    }
+    const jsonText = decoded.toString("utf8");
+    if (Buffer.byteLength(jsonText, "utf8") > MAX_RUNTIME_SESSION_NAME_BYTES) {
+      return null;
+    }
+    const parsed = JSON.parse(jsonText) as Partial<CovenRuntimeSessionState>;
     const agent = normalizeAgentId(typeof parsed.agent === "string" ? parsed.agent : undefined);
     return {
       agent,
@@ -95,7 +103,7 @@ function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 function titleFromPrompt(prompt: string): string {
-  const compact = prompt.replace(/\s+/g, " ").trim();
+  const compact = sanitizeStatusText(prompt);
   return compact.slice(0, 80) || "OpenClaw task";
 }
 
@@ -118,7 +126,7 @@ const del = String.fromCharCode(0x7f);
 const c1Start = String.fromCharCode(0x80);
 const c1End = String.fromCharCode(0x9f);
 const ANSI_ESCAPE_REGEX = new RegExp(
-  `${ESC}(?:\\[[\\x20-\\x3f]*[\\x40-\\x7e]|\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)|[\\x40-\\x5f])`,
+  `${ESC}(?:\\][\\s\\S]*?(?:${BEL}|${ESC}\\\\)|P[\\s\\S]*?${ESC}\\\\|\\[[\\x20-\\x3f]*[\\x40-\\x7e]|[\\x20-\\x2f]*[\\x30-\\x7e])`,
   "g",
 );
 const TEXT_CONTROL_REGEX = new RegExp(
@@ -130,6 +138,25 @@ function sanitizeTerminalText(input: string): string {
   return input.replace(ANSI_ESCAPE_REGEX, "").replace(TEXT_CONTROL_REGEX, "");
 }
 
+function sanitizeStatusText(input: string): string {
+  return sanitizeTerminalText(input).replace(/\s+/g, " ").trim();
+}
+
+function normalizeStopReason(value: unknown): string {
+  const normalized =
+    typeof value === "string" ? sanitizeStatusText(value).toLowerCase() : "completed";
+  if (normalized === "completed" || normalized === "complete" || normalized === "success") {
+    return "completed";
+  }
+  if (normalized === "killed" || normalized === "cancelled" || normalized === "canceled") {
+    return "cancelled";
+  }
+  if (normalized === "failed" || normalized === "failure" || normalized === "error") {
+    return "error";
+  }
+  return "completed";
+}
+
 function eventToRuntimeEvents(event: CovenEventRecord): AcpRuntimeEvent[] {
   const payload = parsePayload(event);
   if (event.kind === "output") {
@@ -137,7 +164,9 @@ function eventToRuntimeEvents(event: CovenEventRecord): AcpRuntimeEvent[] {
     return text ? [{ type: "text_delta", text, stream: "output", tag: "agent_message_chunk" }] : [];
   }
   if (event.kind === "exit") {
-    const status = typeof payload.status === "string" ? payload.status : "completed";
+    const status = sanitizeStatusText(
+      typeof payload.status === "string" ? payload.status : "completed",
+    );
     const exitCode = typeof payload.exitCode === "number" ? payload.exitCode : null;
     return [
       {
@@ -145,13 +174,13 @@ function eventToRuntimeEvents(event: CovenEventRecord): AcpRuntimeEvent[] {
         text: `coven session ${status}${exitCode == null ? "" : ` exitCode=${exitCode}`}`,
         tag: "session_info_update",
       },
-      { type: "done", stopReason: status },
+      { type: "done", stopReason: normalizeStopReason(status) },
     ];
   }
   if (event.kind === "kill") {
     return [
       { type: "status", text: "coven session killed", tag: "session_info_update" },
-      { type: "done", stopReason: "killed" },
+      { type: "done", stopReason: "cancelled" },
     ];
   }
   return [];
@@ -162,9 +191,10 @@ function sessionIsTerminal(session: CovenSessionRecord): boolean {
 }
 
 function terminalStatusEvent(session: CovenSessionRecord): AcpRuntimeEvent {
+  const status = sanitizeStatusText(session.status);
   return {
     type: "status",
-    text: `coven session ${session.status}${session.exitCode == null ? "" : ` exitCode=${session.exitCode}`}`,
+    text: `coven session ${status}${session.exitCode == null ? "" : ` exitCode=${session.exitCode}`}`,
     tag: "session_info_update",
   };
 }
@@ -172,6 +202,14 @@ function terminalStatusEvent(session: CovenSessionRecord): AcpRuntimeEvent {
 function pathIsInside(parent: string, child: string): boolean {
   const relative = path.relative(parent, child);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function realpathIfExists(filePath: string): string | null {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return null;
+  }
 }
 
 export class CovenAcpRuntime implements AcpRuntime {
@@ -184,7 +222,9 @@ export class CovenAcpRuntime implements AcpRuntime {
   constructor(params: CovenAcpRuntimeParams) {
     this.config = params.config;
     this.logger = params.logger;
-    this.client = params.client ?? createCovenClient(params.config.socketPath);
+    this.client =
+      params.client ??
+      createCovenClient(params.config.socketPath, { socketRoot: params.config.covenHome });
     this.sleep = params.sleep ?? defaultSleep;
   }
 
@@ -295,7 +335,7 @@ export class CovenAcpRuntime implements AcpRuntime {
         const latest = await this.client.getSession(session.id, input.signal);
         if (sessionIsTerminal(latest)) {
           yield terminalStatusEvent(latest);
-          yield { type: "done", stopReason: latest.status };
+          yield { type: "done", stopReason: normalizeStopReason(latest.status) };
           this.activeSessionIdsBySessionKey.delete(input.handle.sessionKey);
           return;
         }
@@ -337,7 +377,7 @@ export class CovenAcpRuntime implements AcpRuntime {
     }
     const session = await this.client.getSession(sessionId, input.signal);
     return {
-      summary: `${session.status} ${session.harness} ${session.title}`,
+      summary: `${sanitizeStatusText(session.status)} ${sanitizeStatusText(session.harness)} ${sanitizeStatusText(session.title)}`,
       backendSessionId: session.id,
       agentSessionId: session.id,
       details: {
@@ -468,10 +508,14 @@ export class CovenAcpRuntime implements AcpRuntime {
 
   private resolveWorkspaceCwd(candidate: string | undefined): string {
     const cwd = path.resolve(candidate ?? this.config.workspaceDir);
-    if (!pathIsInside(this.config.workspaceDir, cwd)) {
+    const workspaceReal = realpathIfExists(this.config.workspaceDir);
+    const cwdReal = realpathIfExists(cwd);
+    const boundary = workspaceReal ?? this.config.workspaceDir;
+    const checkedCwd = cwdReal ?? cwd;
+    if (!pathIsInside(boundary, checkedCwd)) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "Coven cwd is outside workspace.");
     }
-    return cwd;
+    return checkedCwd;
   }
 
   private async killActiveSession(sessionId: string, signal?: AbortSignal): Promise<void> {
@@ -483,5 +527,7 @@ export const __testing = {
   decodeRuntimeSessionName,
   encodeRuntimeSessionName,
   eventToRuntimeEvents,
+  normalizeStopReason,
   sanitizeTerminalText,
+  titleFromPrompt,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/coven:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/deepgram:
     dependencies:
       ws:


### PR DESCRIPTION
## Summary

This PR adds an **opt-in bundled ACP runtime backend** named `coven` that lets OpenClaw route ACP coding sessions through a local Coven daemon when explicitly configured with `acp.backend = "coven"`.

The existing `acpx` backend remains the default path. Normal OpenClaw installs and existing ACP behavior are unchanged unless an operator enables the bundled `coven` plugin and selects the `coven` backend.

## Purpose

Coven is a local harness supervisor: it owns attachable project-scoped PTY sessions, daemon persistence, session/event APIs, and harness-specific process supervision. OpenClaw already owns chat/session routing, task state, ACP bindings, permissions/policy surfaces, and user interaction.

This bridge lets those responsibilities compose cleanly:

- OpenClaw can continue to orchestrate ACP sessions from chat, tasks, and `sessions_spawn(runtime="acp")`.
- Coven can supervise the underlying coding harness session when the operator wants project-scoped, attachable, external process visibility.
- Existing direct ACPX launch behavior remains available and is used as fallback.

## Why this is an extension

This is intentionally implemented as `extensions/coven`, not as a core runtime path:

- **Opt-in boundary:** Coven is a separate local daemon and should not affect default ACP installs.
- **Clear ownership:** OpenClaw owns ACP routing and session metadata; Coven owns harness supervision and event history.
- **Reviewability:** the bridge has isolated config, client code, runtime mapping, and tests.
- **Operational safety:** the backend can be enabled/disabled through normal plugin controls and selected only via `acp.backend = "coven"`.
- **Precedent:** this follows the existing plugin-owned runtime backend shape used by `extensions/acpx` via `registerAcpRuntimeBackend(...)`.

## Mechanics

The new backend:

1. Registers `coven` as an ACP runtime backend from the bundled `coven` plugin.
2. Resolves Coven config from plugin config:
   - `covenHome` defaults to `COVEN_HOME` or `~/.coven`.
   - `socketPath` defaults to `<covenHome>/coven.sock`.
   - `fallbackBackend` defaults to `acpx`.
3. Checks the local Coven daemon through the Unix-socket `/health` API before launching through Coven.
4. Launches a Coven session with `POST /sessions`, passing project/cwd, harness id, title, and prompt.
5. Polls `/events?sessionId=...` and maps Coven output/exit events into ACP runtime events.
6. Records the Coven session id on the ACP runtime handle.
7. Falls back to the configured direct ACP backend if Coven is unavailable or if launch fails after detection.

Default ACP agent-to-Coven harness mappings are included for common harness ids:

- `codex`, `openai-codex`, `codex-cli` → `codex`
- `claude`, `claude-cli` → `claude`
- `gemini`, `google-gemini-cli` → `gemini`
- `opencode` → `opencode`

Operators can override that mapping through `plugins.entries.coven.config.harnesses`.

## Functionality added

- New bundled plugin: `extensions/coven`
- New backend id: `coven`
- Opt-in plugin config schema for Coven socket/home/fallback/harness mapping
- Coven Unix-socket HTTP client
- ACP runtime implementation for Coven-backed launch/event/status handling
- Fallback behavior to direct ACP runtime
- Extension-local test coverage for fallback and event flow
- ACP setup docs explaining when and how to enable the backend
- Changelog entry under Unreleased

## Non-goals / boundaries

This PR does **not**:

- make Coven the default ACP backend;
- replace ACPX;
- auto-start a Coven daemon;
- expose OpenClaw tools directly to Coven-managed harnesses;
- change `/codex` native runtime behavior;
- change ACP dispatch defaults; or
- merge Coven session storage into OpenClaw core.

## Test plan

- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/coven/src/runtime.test.ts`
  - 3 tests passed
- [x] `/Users/buns/Documents/GitHub/openclaw/openclaw/node_modules/.bin/tsc -p tsconfig.extensions.json --noEmit --pretty false`

## Maintainer note

I’m opening this deliberately as a narrow extension-backed integration rather than a core coupling. The goal is to make the Coven path transparent and reviewable while preserving existing ACP behavior. If reviewers prefer an even stricter boundary, the obvious follow-up would be to keep `extensions/coven` private/experimental behind docs language or add an explicit `experimental` config label before broader exposure.
