### PR TITLE
fix: inject pluginConfig into hook handler event context

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3310,6 +3310,66 @@ module.exports = { id: "throws-after-import", register() {} };`,
     clearInternalHooks();
   });
 
+  it("injects plugin config into internal hook event context", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "hook-config-context",
+      filename: "hook-config-context.cjs",
+      body: `module.exports = {
+        id: "hook-config-context",
+        register(api) {
+          api.registerHook(
+            "gateway:startup",
+            (event) => {
+              event.messages.push(event.context.pluginConfig?.marker);
+            },
+            { name: "hook-config-context" },
+          );
+        },
+      };`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "hook-config-context",
+          configSchema: { type: "object" },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    clearInternalHooks();
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["hook-config-context"],
+          entries: {
+            "hook-config-context": {
+              config: {
+                marker: "plugin-config-visible",
+              },
+            },
+          },
+        },
+      },
+      onlyPluginIds: ["hook-config-context"],
+    });
+
+    const event = createInternalHookEvent("gateway", "startup", "gateway:startup");
+    await triggerInternalHook(event);
+    expect(event.messages).toEqual(["plugin-config-visible"]);
+    expect(event.context).toEqual({});
+
+    clearInternalHooks();
+  });
+
   it("rolls back global side effects when registration fails", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -500,13 +500,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       handler: Parameters<typeof registerInternalHook>[1];
     }> = [];
     for (const event of normalizedEvents) {
-      // Wrap handler to inject pluginConfig into event context
-      // so plugins can access their configured pluginConfig at invocation time
       const wrappedHandler: typeof handler = async (evt) => {
-        if (evt.context && typeof evt.context === "object") {
-          (evt.context as Record<string, unknown>).pluginConfig = pluginConfig;
-        }
-        return handler(evt);
+        // Shallow-copy to avoid mutating the shared event object
+        // passed to all handlers sequentially by triggerInternalHook
+        return handler({ ...evt, context: { ...evt.context, pluginConfig } });
       };
       registerInternalHook(event, wrappedHandler);
       nextRegistrations.push({ event, handler: wrappedHandler });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -422,6 +422,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     handler: Parameters<typeof registerInternalHook>[1],
     opts: OpenClawPluginHookOptions | undefined,
     config: OpenClawPluginApi["config"],
+    pluginConfig: unknown,
   ) => {
     const eventList = Array.isArray(events) ? events : [events];
     const normalizedEvents = eventList.map((event) => event.trim()).filter(Boolean);
@@ -499,8 +500,16 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       handler: Parameters<typeof registerInternalHook>[1];
     }> = [];
     for (const event of normalizedEvents) {
-      registerInternalHook(event, handler);
-      nextRegistrations.push({ event, handler });
+      // Wrap handler to inject pluginConfig into event context
+      // so plugins can access their configured pluginConfig at invocation time
+      const wrappedHandler: typeof handler = async (evt) => {
+        if (evt.context && typeof evt.context === "object") {
+          (evt.context as Record<string, unknown>).pluginConfig = pluginConfig;
+        }
+        return handler(evt);
+      };
+      registerInternalHook(event, wrappedHandler);
+      nextRegistrations.push({ event, handler: wrappedHandler });
     }
     activePluginHookRegistrations.set(hookName, nextRegistrations);
     const rollbackEntries = pluginHookRollback.get(record.id) ?? [];
@@ -1466,7 +1475,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           ? {
               registerTool: (tool, opts) => registerTool(record, tool, opts),
               registerHook: (events, handler, opts) =>
-                registerHook(record, events, handler, opts, params.config),
+                registerHook(record, events, handler, opts, params.config, params.pluginConfig),
               registerHttpRoute: (routeParams) => registerHttpRoute(record, routeParams),
               registerProvider: (provider) => registerProvider(record, provider),
               registerAgentHarness: (harness) => registerAgentHarness(record, harness),


### PR DESCRIPTION
## Problem

When plugins register hooks via `api.registerHook()`, the `pluginConfig` from `openclaw.json` is **not** injected into the hook event context. Any plugin that accesses `event.context.pluginConfig` inside a hook handler receives `undefined`.

## Root Cause

In `src/plugins/registry.ts`:
- `registerHook()` (line 419) passes the handler directly to `registerInternalHook(event, handler)` without wrapping — no `pluginConfig` is added to the event context
- `createApi()` (line 1469) passes `params.config` but not `params.pluginConfig` to `registerHook`

## Impact

- Plugins that access `ctx.pluginConfig` in hook handlers silently get `undefined`
- Plugins that fall back to defaults (`ctx.pluginConfig ?? {}`) ignore user configuration
- `api.pluginConfig` is available at registration time but NOT at hook invocation time

## Fix

1. Add `pluginConfig` parameter to `registerHook()`
2. Wrap the handler to inject `pluginConfig` into `event.context` before each invocation
3. Pass `params.pluginConfig` through from `createApi()`

## Testing

Verified locally on v2026.4.22 with a custom plugin (`ava-bootstrap-inject`) that reads `pluginConfig.files` from the hook context. Before patch: `undefined` → plugin was a silent no-op. After patch: config resolves correctly and files are injected.

Debug log confirming fix:
```
[ava-bootstrap-inject] hook fired. sessionKey=agent:main:main 
pluginConfig={"files":["memory/alive.md","memory/daily_focus.md","memory/session_primer.md"]} 
filesResolved=["memory/alive.md","memory/daily_focus.md","memory/session_primer.md"]
```

Fixes #72880