### PR TITLE
Recover channel restarts when old lifecycles wedge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
 - Agents/compaction: keep prior context on consecutive turns against z.ai-style providers (z.ai direct, openrouter z-ai/\*, in-house GLM gateways), avoiding accidental Pi state reset after successful turns. (#76056) Thanks @openperf.
 - Doctor/plugins: run a one-time 2026.5.2 configured-plugin install repair based on `meta.lastTouchedVersion`, installing actively used downloadable OpenClaw plugins through the configured external source before marking the config touched for the release.
+- Gateway/channels: let the health monitor recover account restarts after a stop timeout by force-retiring stale lifecycle bookkeeping. Thanks @pashpashpash.
 - Sessions/transcripts: use one `session.writeLock.acquireTimeoutMs` policy for session transcript lock acquisitions and raise the default wait to 60 seconds, avoiding user-visible lock timeouts during legitimate slow prep, cleanup, compaction, and mirror work. Fixes #75894. Thanks @shandutta.
 - Control UI: contain the standalone iOS PWA viewport with safe-area-aware document locking, so Add-to-Home-Screen launches cannot scroll past the device bounds. Refs #76072. Thanks @kvncrw.
 - Agents/restart recovery: match cleaned transcript locks by exact transcript lock paths plus the canonical session fallback, so interrupted main sessions using topic-suffixed transcripts resume after gateway restart. Refs #76052. Thanks @anyech.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -131,7 +131,11 @@ async function expectRestartedChannel(
   accountId = "default",
 ) {
   const monitor = await startAndRunCheck(manager);
-  expect(manager.stopChannel).toHaveBeenCalledWith(channel, accountId);
+  expect(manager.stopChannel).toHaveBeenCalledWith(
+    channel,
+    accountId,
+    expect.objectContaining({ forceRetireOnTimeout: true }),
+  );
   expect(manager.startChannel).toHaveBeenCalledWith(channel, accountId);
   monitor.stop();
 }
@@ -267,7 +271,11 @@ describe("channel-health-monitor", () => {
       },
     );
     const monitor = await startAndRunCheck(manager);
-    expect(manager.stopChannel).toHaveBeenCalledWith("discord", "default");
+    expect(manager.stopChannel).toHaveBeenCalledWith(
+      "discord",
+      "default",
+      expect.objectContaining({ forceRetireOnTimeout: true }),
+    );
     expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
     expect(manager.stopChannel).not.toHaveBeenCalledWith("discord", "quiet");
     expect(manager.startChannel).not.toHaveBeenCalledWith("discord", "quiet");
@@ -289,7 +297,11 @@ describe("channel-health-monitor", () => {
       },
     });
     const monitor = await startAndRunCheck(manager);
-    expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default");
+    expect(manager.stopChannel).toHaveBeenCalledWith(
+      "whatsapp",
+      "default",
+      expect.objectContaining({ forceRetireOnTimeout: true }),
+    );
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
     monitor.stop();
@@ -594,7 +606,11 @@ describe("channel-health-monitor", () => {
       const monitor = await startAndRunCheck(manager, {
         staleEventThresholdMs: customThreshold,
       });
-      expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
+      expect(manager.stopChannel).toHaveBeenCalledWith(
+        "slack",
+        "default",
+        expect.objectContaining({ forceRetireOnTimeout: true }),
+      );
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
     });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -163,7 +163,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           try {
             if (status.running) {
-              await channelManager.stopChannel(channelId as ChannelId, accountId);
+              await channelManager.stopChannel(channelId as ChannelId, accountId, {
+                forceRetireOnTimeout: true,
+              });
             }
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);

--- a/src/gateway/server-channels.approval-bootstrap.test.ts
+++ b/src/gateway/server-channels.approval-bootstrap.test.ts
@@ -188,6 +188,51 @@ describe("server-channels approval bootstrap", () => {
     ).toBeUndefined();
   });
 
+  it("does not wait forever for approval cleanup when force-retiring a hung lifecycle", async () => {
+    vi.useFakeTimers();
+    try {
+      const channelRuntime = createRuntimeChannel();
+      const stopApprovalBootstrap = vi.fn(() => new Promise<void>(() => {}));
+      hoisted.startChannelApprovalHandlerBootstrap.mockResolvedValue(stopApprovalBootstrap);
+      const startAccount = vi.fn(
+        async ({
+          channelRuntime,
+        }: Parameters<NonNullable<NonNullable<ChannelPlugin["gateway"]>["startAccount"]>>[0]) => {
+          channelRuntime?.runtimeContexts.register({
+            channelId: "discord",
+            accountId: DEFAULT_ACCOUNT_ID,
+            capability: "approval.native",
+            context: { token: "tracked" },
+          });
+          await new Promise<void>(() => {});
+        },
+      );
+
+      installTestRegistry(createTestPlugin({ startAccount }));
+      const manager = createManager(createChannelManager, { channelRuntime });
+
+      await manager.startChannels();
+      await Promise.resolve();
+
+      const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+        forceRetireOnTimeout: true,
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(stopTask).resolves.toBeUndefined();
+      expect(stopApprovalBootstrap).toHaveBeenCalledTimes(1);
+      expect(
+        channelRuntime.runtimeContexts.get({
+          channelId: "discord",
+          accountId: DEFAULT_ACCOUNT_ID,
+          capability: "approval.native",
+        }),
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("continues account startup when approval bootstrap startup fails", async () => {
     const channelRuntime = createRuntimeChannel();
     const stopped = createDeferred();

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import {
+  type ChannelAccountSnapshot,
   type ChannelGatewayContext,
   type ChannelId,
   type ChannelPlugin,
@@ -327,6 +328,59 @@ describe("server-channels auto restart", () => {
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
     expect(account?.lastError).toContain("channel stop timed out");
+  });
+
+  it("force-retires a hung channel task so recovery can start a fresh lifecycle", async () => {
+    const statusSetters: Array<(next: ChannelAccountSnapshot) => void> = [];
+    const startAccount = vi.fn(async ({ setStatus }: ChannelGatewayContext<TestAccount>) => {
+      statusSetters.push(setStatus);
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    await Promise.resolve();
+
+    const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      forceRetireOnTimeout: true,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopTask;
+
+    let snapshot = manager.getRuntimeSnapshot();
+    let account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(false);
+    expect(account?.connected).toBe(false);
+    expect(account?.activeRuns).toBe(0);
+    expect(account?.lastError).toContain("stale lifecycle force-retired");
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await Promise.resolve();
+
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    statusSetters[1]?.({
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: true,
+      connected: true,
+      lastError: null,
+    });
+    statusSetters[0]?.({
+      accountId: DEFAULT_ACCOUNT_ID,
+      running: false,
+      connected: false,
+      lastError: "late stale lifecycle update",
+    });
+
+    snapshot = manager.getRuntimeSnapshot();
+    account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
+    expect(account?.connected).toBe(true);
+    expect(account?.lastError).toBeNull();
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -332,6 +332,7 @@ describe("server-channels auto restart", () => {
 
   it("force-retires a hung channel task so recovery can start a fresh lifecycle", async () => {
     const statusSetters: Array<(next: ChannelAccountSnapshot) => void> = [];
+    const runtimeContextRegistrations: Array<(context: unknown) => void> = [];
     const channelRuntime = createRuntimeChannel();
     const contextKey = {
       channelId: "discord",
@@ -342,6 +343,12 @@ describe("server-channels auto restart", () => {
       async ({ setStatus, channelRuntime }: ChannelGatewayContext<TestAccount>) => {
         const lifecycle = statusSetters.length + 1;
         statusSetters.push(setStatus);
+        runtimeContextRegistrations.push((context) => {
+          channelRuntime?.runtimeContexts.register({
+            ...contextKey,
+            context,
+          });
+        });
         channelRuntime?.runtimeContexts.register({
           ...contextKey,
           context: { lifecycle },
@@ -376,6 +383,8 @@ describe("server-channels auto restart", () => {
 
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     await Promise.resolve();
+    expect(channelRuntime.runtimeContexts.get(contextKey)).toEqual({ lifecycle: 2 });
+    runtimeContextRegistrations[0]?.({ lifecycle: "stale" });
     expect(channelRuntime.runtimeContexts.get(contextKey)).toEqual({ lifecycle: 2 });
 
     expect(startAccount).toHaveBeenCalledTimes(2);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -332,19 +332,33 @@ describe("server-channels auto restart", () => {
 
   it("force-retires a hung channel task so recovery can start a fresh lifecycle", async () => {
     const statusSetters: Array<(next: ChannelAccountSnapshot) => void> = [];
-    const startAccount = vi.fn(async ({ setStatus }: ChannelGatewayContext<TestAccount>) => {
-      statusSetters.push(setStatus);
-      await new Promise<void>(() => {});
-    });
+    const channelRuntime = createRuntimeChannel();
+    const contextKey = {
+      channelId: "discord",
+      accountId: DEFAULT_ACCOUNT_ID,
+      capability: "test-lifecycle",
+    };
+    const startAccount = vi.fn(
+      async ({ setStatus, channelRuntime }: ChannelGatewayContext<TestAccount>) => {
+        const lifecycle = statusSetters.length + 1;
+        statusSetters.push(setStatus);
+        channelRuntime?.runtimeContexts.register({
+          ...contextKey,
+          context: { lifecycle },
+        });
+        await new Promise<void>(() => {});
+      },
+    );
     installTestRegistry(
       createTestPlugin({
         startAccount,
       }),
     );
-    const manager = createManager();
+    const manager = createManager({ channelRuntime });
 
     await manager.startChannels();
     await Promise.resolve();
+    expect(channelRuntime.runtimeContexts.get(contextKey)).toEqual({ lifecycle: 1 });
 
     const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
       forceRetireOnTimeout: true,
@@ -358,9 +372,11 @@ describe("server-channels auto restart", () => {
     expect(account?.connected).toBe(false);
     expect(account?.activeRuns).toBe(0);
     expect(account?.lastError).toContain("stale lifecycle force-retired");
+    expect(channelRuntime.runtimeContexts.get(contextKey)).toBeUndefined();
 
     await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
     await Promise.resolve();
+    expect(channelRuntime.runtimeContexts.get(contextKey)).toEqual({ lifecycle: 2 });
 
     expect(startAccount).toHaveBeenCalledTimes(2);
     statusSetters[1]?.({

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -733,7 +733,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             const cleanupRetiredTask = store.taskCleanups.get(id);
             if (cleanupRetiredTask) {
               store.taskCleanups.delete(id);
-              await cleanupRetiredTask();
+              void cleanupRetiredTask().catch((error) => {
+                log.error?.(
+                  `[${id}] retired channel lifecycle cleanup failed: ${formatErrorMessage(error)}`,
+                );
+              });
             }
             setRuntime(channelId, id, {
               accountId: id,

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -188,11 +188,19 @@ type StartChannelOptions = {
   preserveManualStop?: boolean;
 };
 
+type StopChannelOptions = {
+  forceRetireOnTimeout?: boolean;
+};
+
 export type ChannelManager = {
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   startChannels: () => Promise<void>;
   startChannel: (channel: ChannelId, accountId?: string) => Promise<void>;
-  stopChannel: (channel: ChannelId, accountId?: string) => Promise<void>;
+  stopChannel: (
+    channel: ChannelId,
+    accountId?: string,
+    options?: StopChannelOptions,
+  ) => Promise<void>;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
@@ -406,6 +414,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         let scopedChannelRuntime: ReturnType<typeof createTaskScopedChannelRuntime> | null = null;
         let channelRuntimeForTask: ChannelRuntimeSurface | undefined;
         let stopApprovalBootstrap: () => Promise<void> = async () => {};
+        const isCurrentLifecycle = () => store.aborts.get(id) === abort;
+        const setRuntimeForCurrentLifecycle = (next: ChannelAccountSnapshot) => {
+          if (!isCurrentLifecycle()) {
+            log.debug?.(`[${id}] ignored stale channel status update after lifecycle retired`);
+            return;
+          }
+          setRuntime(channelId, id, next);
+        };
         const stopTaskScopedApprovalRuntime = async () => {
           const scopedRuntime = scopedChannelRuntime;
           scopedChannelRuntime = null;
@@ -517,14 +533,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 abortSignal: abort.signal,
                 log,
                 getStatus: () => getRuntime(channelId, id),
-                setStatus: (next) => setRuntime(channelId, id, next),
+                setStatus: setRuntimeForCurrentLifecycle,
                 ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
               }),
             ),
           );
           const trackedPromise = task
             .then(() => {
-              if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+              if (!isCurrentLifecycle() || abort.signal.aborted || manuallyStopped.has(rKey)) {
                 return;
               }
               const message = "channel exited without an error";
@@ -533,18 +549,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             })
             .catch((err) => {
               const message = formatErrorMessage(err);
-              setRuntime(channelId, id, { accountId: id, lastError: message });
+              if (isCurrentLifecycle()) {
+                setRuntime(channelId, id, { accountId: id, lastError: message });
+              }
               log.error?.(`[${id}] channel exited: ${message}`);
             })
             .finally(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
-              setRuntime(channelId, id, {
-                accountId: id,
-                running: false,
-                lastStopAt: Date.now(),
-              });
+              if (isCurrentLifecycle()) {
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  running: false,
+                  lastStopAt: Date.now(),
+                });
+              }
             })
             .then(async () => {
+              if (!isCurrentLifecycle()) {
+                return;
+              }
               if (manuallyStopped.has(rKey)) {
                 return;
               }
@@ -630,7 +653,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     await startChannelInternal(channelId, accountId);
   };
 
-  const stopChannel = async (channelId: ChannelId, accountId?: string) => {
+  const stopChannel = async (
+    channelId: ChannelId,
+    accountId?: string,
+    opts: StopChannelOptions = {},
+  ) => {
     const plugin = getChannelPlugin(channelId);
     const store = getStore(channelId);
     // Fast path: nothing running and no explicit plugin shutdown hook to run.
@@ -678,9 +705,31 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           CHANNEL_STOP_ABORT_TIMEOUT_MS,
         );
         if (!stoppedCleanly) {
+          const forceRetireOnTimeout = opts.forceRetireOnTimeout === true;
           log.warn?.(
-            `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
+            `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; ${
+              forceRetireOnTimeout ? "force-retiring stale lifecycle" : "continuing shutdown"
+            }`,
           );
+          if (forceRetireOnTimeout) {
+            if (store.aborts.get(id) === abort) {
+              store.aborts.delete(id);
+            }
+            if (store.tasks.get(id) === task) {
+              store.tasks.delete(id);
+            }
+            setRuntime(channelId, id, {
+              accountId: id,
+              running: false,
+              connected: false,
+              restartPending: false,
+              busy: false,
+              activeRuns: 0,
+              lastStopAt: Date.now(),
+              lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms; stale lifecycle force-retired`,
+            });
+            return;
+          }
           setRuntime(channelId, id, {
             accountId: id,
             running: true,

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -724,20 +724,32 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }`,
           );
           if (forceRetireOnTimeout) {
+            const isRetiringCurrentLifecycle =
+              store.aborts.get(id) === abort && store.tasks.get(id) === task;
             if (store.aborts.get(id) === abort) {
               store.aborts.delete(id);
             }
             if (store.tasks.get(id) === task) {
               store.tasks.delete(id);
             }
-            const cleanupRetiredTask = store.taskCleanups.get(id);
+            const cleanupRetiredTask = isRetiringCurrentLifecycle
+              ? store.taskCleanups.get(id)
+              : undefined;
             if (cleanupRetiredTask) {
               store.taskCleanups.delete(id);
+              // The cleanup synchronously disposes scoped runtime leases and disables
+              // approval bootstrap before awaiting slower native teardown.
               void cleanupRetiredTask().catch((error) => {
                 log.error?.(
                   `[${id}] retired channel lifecycle cleanup failed: ${formatErrorMessage(error)}`,
                 );
               });
+            }
+            if (!isRetiringCurrentLifecycle) {
+              log.debug?.(
+                `[${id}] ignored force-retire status update; newer lifecycle already started`,
+              );
+              return;
             }
             setRuntime(channelId, id, {
               accountId: id,

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -43,6 +43,7 @@ type ChannelRuntimeStore = {
   aborts: Map<string, AbortController>;
   starting: Map<string, Promise<void>>;
   tasks: Map<string, Promise<unknown>>;
+  taskCleanups: Map<string, () => Promise<void>>;
   runtimes: Map<string, ChannelAccountSnapshot>;
 };
 
@@ -65,6 +66,7 @@ function createRuntimeStore(): ChannelRuntimeStore {
     aborts: new Map(),
     starting: new Map(),
     tasks: new Map(),
+    taskCleanups: new Map(),
     runtimes: new Map(),
   };
 }
@@ -437,6 +439,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             log.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
           }
         };
+        const cleanupRetiredLifecycle = async () => {
+          await cleanupTaskScopedApprovalRuntime("channel lifecycle retirement cleanup failed");
+        };
+        store.taskCleanups.set(id, cleanupRetiredLifecycle);
 
         try {
           const account = plugin.config.resolveAccount(cfg, id);
@@ -556,6 +562,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             })
             .finally(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
+              if (store.taskCleanups.get(id) === cleanupRetiredLifecycle) {
+                store.taskCleanups.delete(id);
+              }
               if (isCurrentLifecycle()) {
                 setRuntime(channelId, id, {
                   accountId: id,
@@ -641,6 +650,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           if (!handedOffTask && store.aborts.get(id) === abort) {
             store.aborts.delete(id);
           }
+          if (!handedOffTask && store.taskCleanups.get(id) === cleanupRetiredLifecycle) {
+            store.taskCleanups.delete(id);
+          }
         }
       }),
     });
@@ -718,6 +730,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             if (store.tasks.get(id) === task) {
               store.tasks.delete(id);
             }
+            const cleanupRetiredTask = store.taskCleanups.get(id);
+            if (cleanupRetiredTask) {
+              store.taskCleanups.delete(id);
+              await cleanupRetiredTask();
+            }
             setRuntime(channelId, id, {
               accountId: id,
               running: false,
@@ -740,6 +757,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         }
         store.aborts.delete(id);
         store.tasks.delete(id);
+        store.taskCleanups.delete(id);
         setRuntime(channelId, id, {
           accountId: id,
           running: false,

--- a/src/infra/channel-runtime-context.test.ts
+++ b/src/infra/channel-runtime-context.test.ts
@@ -117,4 +117,27 @@ describe("channel runtime context helpers", () => {
     persistentLease?.dispose();
     unsubscribe?.();
   });
+
+  it("ignores registrations through a disposed task-scoped runtime", () => {
+    const channelRuntime = createRuntimeChannel();
+    const scoped = createTaskScopedChannelRuntime({ channelRuntime });
+
+    scoped.dispose();
+    registerChannelRuntimeContext({
+      channelRuntime: scoped.channelRuntime,
+      channelId: "slack",
+      accountId: "default",
+      capability: "approval.native",
+      context: { app: "stale" },
+    });
+
+    expect(
+      getChannelRuntimeContext({
+        channelRuntime,
+        channelId: "slack",
+        accountId: "default",
+        capability: "approval.native",
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/infra/channel-runtime-context.ts
+++ b/src/infra/channel-runtime-context.ts
@@ -99,15 +99,16 @@ export function createTaskScopedChannelRuntime(params: {
   const runtimeContexts = resolveScopedRuntimeContextRegistry({ channelRuntime: baseRuntime });
 
   const trackedLeases = new Set<{ dispose: () => void }>();
+  let disposed = false;
   const trackLease = (lease: { dispose: () => void }) => {
     trackedLeases.add(lease);
-    let disposed = false;
+    let leaseDisposed = false;
     return {
       dispose: () => {
-        if (disposed) {
+        if (leaseDisposed) {
           return;
         }
-        disposed = true;
+        leaseDisposed = true;
         trackedLeases.delete(lease);
         lease.dispose();
       },
@@ -119,6 +120,9 @@ export function createTaskScopedChannelRuntime(params: {
     runtimeContexts: {
       ...runtimeContexts,
       register: (registerParams) => {
+        if (disposed) {
+          return { dispose: NOOP_DISPOSE };
+        }
         const lease = runtimeContexts.register(registerParams);
         return trackLease(lease);
       },
@@ -128,6 +132,10 @@ export function createTaskScopedChannelRuntime(params: {
   return {
     channelRuntime: scopedRuntime,
     dispose: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
       for (const lease of Array.from(trackedLeases)) {
         lease.dispose();
       }

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -442,6 +442,35 @@ describe("createExecApprovalChannelRuntime", () => {
     );
   });
 
+  it("stops the gateway client when shutdown wins the startup handshake", async () => {
+    mockCreateOperatorApprovalsGatewayClient.mockImplementationOnce(async () => ({
+      start: mockGatewayClientStarts,
+      stop: mockGatewayClientStops,
+      request: mockGatewayClientRequests,
+    }));
+    const runtime = createExecApprovalChannelRuntime({
+      label: "test/exec-approvals",
+      clientDisplayName: "Test Exec Approvals",
+      cfg: {} as never,
+      isConfigured: () => true,
+      shouldHandle: () => true,
+      deliverRequested: async () => [],
+      finalizeResolved: async () => undefined,
+    });
+
+    const startPromise = runtime.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockGatewayClientStarts).toHaveBeenCalledTimes(1);
+
+    await expect(runtime.stop()).resolves.toBeUndefined();
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(mockGatewayClientStops).toHaveBeenCalledTimes(1);
+    await expect(runtime.request("exec.approval.resolve", { id: "abc" })).rejects.toThrow(
+      "gateway client not connected",
+    );
+  });
+
   it("logs async request handling failures from gateway events", async () => {
     const runtime = createExecApprovalChannelRuntime<
       { id: string },

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -84,10 +84,12 @@ export function createExecApprovalChannelRuntime<
   const nowMs = adapter.nowMs ?? Date.now;
   const eventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(adapter.eventKinds ?? ["exec"]);
   const pending = new Map<string, PendingApprovalEntry<TPending, TRequest, TResolved>>();
+  const stoppedGatewayClients = new WeakSet<GatewayClient>();
   let gatewayClient: GatewayClient | null = null;
   let started = false;
   let shouldRun = false;
   let startPromise: Promise<void> | null = null;
+  let cancelStartupWait: (() => void) | null = null;
   let replayPromise: Promise<void> | null = null;
 
   const shouldKeepRunning = (): boolean => shouldRun;
@@ -99,13 +101,32 @@ export function createExecApprovalChannelRuntime<
     });
   };
 
+  const stopGatewayClient = (client: GatewayClient): boolean => {
+    if (stoppedGatewayClients.has(client)) {
+      return false;
+    }
+    stoppedGatewayClients.add(client);
+    if (gatewayClient === client) {
+      gatewayClient = null;
+    }
+    client.stop();
+    return true;
+  };
+
   const stopClientIfInactive = (client: GatewayClient): boolean => {
     if (shouldKeepRunning()) {
       return false;
     }
-    gatewayClient = null;
-    client.stop();
+    stopGatewayClient(client);
     return true;
+  };
+
+  const stopActiveGatewayClient = (): boolean => {
+    const client = gatewayClient;
+    if (!client) {
+      return false;
+    }
+    return stopGatewayClient(client);
   };
 
   const clearPendingEntry = (
@@ -300,6 +321,7 @@ export function createExecApprovalChannelRuntime<
       }
 
       shouldRun = true;
+      let cancelReadyWait: (() => void) | null = null;
       startPromise = (async () => {
         if (!adapter.isConfigured()) {
           log.debug("disabled");
@@ -321,6 +343,8 @@ export function createExecApprovalChannelRuntime<
           readySettled = true;
           fn();
         };
+        cancelReadyWait = () => settleReady(resolveReady);
+        cancelStartupWait = cancelReadyWait;
 
         const client = await createOperatorApprovalsGatewayClient({
           config: adapter.cfg,
@@ -353,7 +377,7 @@ export function createExecApprovalChannelRuntime<
         });
 
         if (!shouldRun) {
-          client.stop();
+          stopGatewayClient(client);
           return;
         }
         await adapter.beforeGatewayClientStart?.();
@@ -376,10 +400,13 @@ export function createExecApprovalChannelRuntime<
         } catch (error) {
           gatewayClient = null;
           started = false;
-          client.stop();
+          stopGatewayClient(client);
           throw error;
         }
       })().finally(() => {
+        if (cancelReadyWait && cancelStartupWait === cancelReadyWait) {
+          cancelStartupWait = null;
+        }
         startPromise = null;
       });
 
@@ -388,13 +415,14 @@ export function createExecApprovalChannelRuntime<
 
     async stop(): Promise<void> {
       shouldRun = false;
+      const wasActive = started || gatewayClient !== null || replayPromise !== null;
+      stopActiveGatewayClient();
+      cancelStartupWait?.();
       if (startPromise) {
         await startPromise.catch(() => {});
       }
-      const wasActive = started || gatewayClient !== null || replayPromise !== null;
       started = false;
-      gatewayClient?.stop();
-      gatewayClient = null;
+      stopActiveGatewayClient();
       await waitForPendingApprovalReplay();
       if (!wasActive) {
         await adapter.onStopped?.();


### PR DESCRIPTION
The gateway health monitor already notices unhealthy channel lifecycles and tries to restart them, but the restart path had a blind spot: if the old channel task ignored abort and failed to settle within the stop grace window, `stopChannel` logged the timeout and left the stale task registered. The immediately-following `startChannel` then saw the existing task and no-oped, so the monitor could say it was restarting without actually creating a fresh Discord or Telegram lifecycle.

This adds an explicit forced-retirement path for health-monitor recovery. Normal manual stops keep the existing conservative behavior. Health-monitor restarts can now retire the wedged lifecycle from manager bookkeeping, clear stale busy/connected state, and start a new channel account. Runtime status updates, catch handlers, cleanup handlers, and auto-restart logic are now lifecycle-gated so a late callback from the retired task cannot mark the fresh lifecycle stopped or restart behind its back.
