### PR TITLE
chore(coven): enable ClawHub publishing

### DIFF
--- a/extensions/coven/package.json
+++ b/extensions/coven/package.json
@@ -5,11 +5,32 @@
   "description": "OpenClaw Coven ACP runtime bridge",
   "type": "module",
   "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*"
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.26"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
   },
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "minHostVersion": ">=2026.4.26"
+    },
+    "compat": {
+      "pluginApi": ">=2026.4.25"
+    },
+    "build": {
+      "openclawVersion": "2026.4.26"
+    },
+    "release": {
+      "publishToClawHub": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,9 @@ importers:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
 
   extensions/deepgram:
     dependencies:


### PR DESCRIPTION
## Summary
- marks `@openclaw/coven` as publishable to ClawHub
- adds OpenClaw host/plugin API compatibility metadata
- updates the pnpm lockfile importer entry for the new workspace dev dependency

## Verification
- `pnpm docs:list`
- `pnpm exec oxfmt --write --threads=1 extensions/coven/package.json`
- `pnpm install --lockfile-only --ignore-scripts`
- `pnpm check:changed`
- `git diff --check`
- `bun run --cwd /Users/buns/Documents/GitHub/OpenClaw/clawhub clawhub package publish /Users/buns/.codex/worktrees/4f2a/openclaw/extensions/coven --family code-plugin --source-repo openclaw/openclaw --source-commit 3b17229789 --source-ref meow/coven-clawhub-metadata --source-path extensions/coven --dry-run --json`
