### PR TITLE
feat(onboard): offer detected migration imports

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -42,7 +42,9 @@ openclaw onboard --skip-bootstrap
 openclaw onboard --mode remote --remote-url wss://gateway-host:18789
 ```
 
-`--flow import` uses plugin-owned migration providers such as Hermes. It only runs against a fresh OpenClaw setup; if existing config, credentials, sessions, or workspace memory/identity files are present, reset or choose a fresh setup before importing.
+When onboarding detects a known agent home such as Claude or Hermes, it asks whether to import before showing the normal setup modes. If no source is detected, onboarding skips the migration prompt. `--flow import` and `--import-from <provider>` force the import flow for scripted runs or custom source paths.
+
+Onboarding imports only run against a fresh OpenClaw setup. If existing config, credentials, sessions, or workspace memory/identity files are present, reset or choose a fresh setup before importing.
 
 `--modern` starts the Crestodian conversational onboarding preview. Without
 `--modern`, `openclaw onboard` keeps the classic onboarding flow.
@@ -180,7 +182,7 @@ openclaw onboard --non-interactive \
   <Accordion title="Flow types">
     - `quickstart`: minimal prompts, auto-generates a gateway token.
     - `manual`: full prompts for port, bind, and auth (alias of `advanced`).
-    - `import`: runs a detected migration provider, previews the plan, then applies after confirmation.
+    - `import`: runs a selected migration provider, previews the plan, then applies after confirmation.
   </Accordion>
   <Accordion title="Provider prefiltering">
     When an auth choice implies a preferred provider, onboarding prefilters the default-model and allowlist pickers to that provider. For Volcengine and BytePlus, this also matches the coding-plan variants (`volcengine-plan/*`, `byteplus-plan/*`).
@@ -199,7 +201,7 @@ openclaw onboard --non-interactive \
     - Local onboarding DM scope behavior: [CLI setup reference](/start/wizard-cli-reference#outputs-and-internals).
     - Fastest first chat: `openclaw dashboard` (Control UI, no channel setup).
     - Custom provider: connect any OpenAI or Anthropic compatible endpoint, including hosted providers not listed. Use Unknown to auto-detect.
-    - If Hermes state is detected, onboarding offers a migration flow. Use [Migrate](/cli/migrate) for dry-run plans, overwrite mode, reports, and exact mappings.
+    - If Claude or Hermes state is detected, onboarding offers import first, then falls back to QuickStart or Manual when you choose a fresh setup. Use [Migrate](/cli/migrate) for dry-run plans, overwrite mode, reports, and exact mappings.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/install/migrating-claude.md
+++ b/docs/install/migrating-claude.md
@@ -16,7 +16,13 @@ Onboarding imports require a fresh OpenClaw setup. If you already have local Ope
 
 <Tabs>
   <Tab title="Onboarding wizard">
-    The wizard offers Claude when it detects local Claude state.
+    Plain onboarding offers Claude first when it detects local Claude state.
+
+    ```bash
+    openclaw onboard
+    ```
+
+    To jump directly into import:
 
     ```bash
     openclaw onboard --flow import

--- a/docs/install/migrating-hermes.md
+++ b/docs/install/migrating-hermes.md
@@ -17,7 +17,13 @@ Imports require a fresh OpenClaw setup. If you already have local OpenClaw state
 
 <Tabs>
   <Tab title="Onboarding wizard">
-    The fastest path. The wizard detects Hermes at `~/.hermes` and shows a preview before applying.
+    The fastest path. Plain onboarding detects Hermes at `~/.hermes`, offers import first, and shows a preview before applying.
+
+    ```bash
+    openclaw onboard
+    ```
+
+    To jump directly into import:
 
     ```bash
     openclaw onboard --flow import

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -22,7 +22,7 @@ Use the bundled migration providers to bring instructions, MCP servers, skills, 
   </Card>
 </CardGroup>
 
-The CLI entry point is [`openclaw migrate`](/cli/migrate). Onboarding can also offer migration when it detects a known source (`openclaw onboard --flow import`).
+The CLI entry point is [`openclaw migrate`](/cli/migrate). Interactive onboarding asks whether to import when it detects a known source, then skips that prompt when nothing importable is found. Use `openclaw onboard --flow import` or `--import-from <provider>` when you want to force the import flow.
 
 ## Move OpenClaw to a new machine
 

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -520,7 +520,7 @@ describe("runSetupWizard", () => {
           found: true,
           source: "/tmp/claude-home",
           label: "Claude",
-          confidence: "high",
+          confidence: "high" as const,
         })),
       }),
     ]);

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2,10 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
+import type { MigrationProviderPlugin } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
 import { runSetupWizard } from "./setup.js";
@@ -92,6 +93,12 @@ const setupInternalHooks = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 
 const setupChannels = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
+const resolvePluginMigrationProviders = vi.hoisted(() =>
+  vi.fn((): MigrationProviderPlugin[] => []),
+);
+const resolvePluginMigrationProvider = vi.hoisted(() =>
+  vi.fn((_params: { providerId: string }) => undefined as MigrationProviderPlugin | undefined),
+);
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -255,6 +262,11 @@ vi.mock("../plugins/status.js", () => ({
   formatPluginCompatibilityNotice,
 }));
 
+vi.mock("../plugins/migration-provider-runtime.js", () => ({
+  resolvePluginMigrationProviders,
+  resolvePluginMigrationProvider,
+}));
+
 vi.mock("../channels/plugins/index.js", () => ({
   listChannelPlugins,
 }));
@@ -297,12 +309,55 @@ function createRuntime(opts?: { throwsOnExit?: boolean }): RuntimeEnv {
   };
 }
 
+function migrationProviderStub(
+  overrides: Partial<MigrationProviderPlugin> & Pick<MigrationProviderPlugin, "id" | "label">,
+): MigrationProviderPlugin {
+  return {
+    description: "migration provider",
+    detect: vi.fn(async () => ({ found: false })),
+    plan: vi.fn(async () => ({
+      providerId: overrides.id,
+      source: "/tmp/source",
+      summary: {
+        total: 0,
+        planned: 0,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [],
+    })),
+    apply: vi.fn(async () => ({
+      providerId: overrides.id,
+      source: "/tmp/source",
+      summary: {
+        total: 0,
+        planned: 0,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 0,
+      },
+      items: [],
+    })),
+    ...overrides,
+  };
+}
+
 describe("runSetupWizard", () => {
   let suiteRoot = "";
   let suiteCase = 0;
 
   beforeAll(async () => {
     suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onboard-suite-"));
+  });
+
+  beforeEach(() => {
+    resolvePluginMigrationProviders.mockReturnValue([]);
+    resolvePluginMigrationProvider.mockReturnValue(undefined);
   });
 
   afterAll(async () => {
@@ -454,6 +509,105 @@ describe("runSetupWizard", () => {
     expect(setupSkills).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
     expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("asks about detected migration sources before the normal setup mode", async () => {
+    resolvePluginMigrationProviders.mockReturnValueOnce([
+      migrationProviderStub({
+        id: "claude",
+        label: "Claude",
+        detect: vi.fn(async () => ({
+          found: true,
+          source: "/tmp/claude-home",
+          label: "Claude",
+          confidence: "high",
+        })),
+      }),
+    ]);
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Existing agent setup detected") {
+        expect(params.options.map((option) => option.value)).toEqual(["claude", "__fresh__"]);
+        expect(params.options[0]).toEqual(
+          expect.objectContaining({
+            label: "Import from Claude",
+            hint: "/tmp/claude-home",
+          }),
+        );
+        return "__fresh__";
+      }
+      if (params.message === "Setup mode") {
+        expect(params.options.map((option) => option.value)).toEqual(["quickstart", "advanced"]);
+        return "quickstart";
+      }
+      return "skip";
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        authChoice: "skip",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(select).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: "Existing agent setup detected",
+        initialValue: "claude",
+      }),
+    );
+    expect(select).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: "Setup mode",
+        initialValue: "quickstart",
+      }),
+    );
+  });
+
+  it("keeps the first setup screen unchanged when no migration source is detected", async () => {
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Setup mode") {
+        expect(params.options.map((option) => option.value)).toEqual(["quickstart", "advanced"]);
+        return "quickstart";
+      }
+      return "skip";
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        authChoice: "skip",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Setup mode",
+        initialValue: "quickstart",
+      }),
+    );
   });
 
   it("persists skipBootstrap and skips workspace bootstrap creation when requested", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -20,7 +20,11 @@ import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
-import { detectSetupMigrationSources, runSetupMigrationImport } from "./setup.migration-import.js";
+import {
+  detectSetupMigrationSources,
+  runSetupMigrationImport,
+  type SetupMigrationDetection,
+} from "./setup.migration-import.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   SECURITY_CONFIRM_MESSAGE,
@@ -30,6 +34,7 @@ import {
 import type { QuickstartGatewayDefaults, WizardFlow } from "./setup.types.js";
 
 type SetupFlowChoice = WizardFlow | "import";
+type SetupMigrationChoice = { kind: "import"; providerId: string } | { kind: "fresh" };
 
 type AuthChoiceModule = typeof import("../commands/auth-choice.js");
 type ConfigLoggingModule = typeof import("../config/logging.js");
@@ -176,6 +181,52 @@ async function requireRiskAcknowledgement(params: {
   }
 }
 
+async function promptDetectedMigrationChoice(params: {
+  detections: readonly SetupMigrationDetection[];
+  prompter: WizardPrompter;
+}): Promise<SetupMigrationChoice> {
+  const selected = await params.prompter.select({
+    message:
+      params.detections.length === 1
+        ? "Existing agent setup detected"
+        : "Existing agent setups detected",
+    options: [
+      ...params.detections.map((detection) => ({
+        value: detection.providerId,
+        label: `Import from ${detection.label}`,
+        ...(detection.source || detection.message
+          ? { hint: detection.source ?? detection.message }
+          : {}),
+      })),
+      {
+        value: "__fresh__",
+        label: "Set up fresh OpenClaw",
+        hint: "Continue to QuickStart or Manual setup",
+      },
+    ],
+    initialValue: params.detections[0]?.providerId,
+  });
+  if (selected === "__fresh__") {
+    return { kind: "fresh" };
+  }
+  return { kind: "import", providerId: selected };
+}
+
+async function promptSetupFlow(params: {
+  prompter: WizardPrompter;
+  quickstartHint: string;
+  manualHint: string;
+}): Promise<SetupFlowChoice> {
+  return await params.prompter.select({
+    message: "Setup mode",
+    options: [
+      { value: "quickstart", label: "QuickStart", hint: params.quickstartHint },
+      { value: "advanced", label: "Manual", hint: params.manualHint },
+    ],
+    initialValue: "quickstart",
+  });
+}
+
 export async function runSetupWizard(
   opts: OnboardOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -236,14 +287,6 @@ export async function runSetupWizard(
   const quickstartHint = `Configure details later via ${formatCliCommand("openclaw configure")}.`;
   const manualHint = "Configure port, network, Tailscale, and auth options.";
   const migrationDetections = await detectSetupMigrationSources({ config: baseConfig, runtime });
-  const firstMigrationDetection = migrationDetections[0];
-  const importOption = firstMigrationDetection
-    ? {
-        value: "import" as const,
-        label: `Import from ${firstMigrationDetection.label}`,
-        ...(firstMigrationDetection.source ? { hint: firstMigrationDetection.source } : {}),
-      }
-    : undefined;
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;
   if (
@@ -256,23 +299,31 @@ export async function runSetupWizard(
     runtime.exit(1);
     return;
   }
+  const hasExplicitImportProvider = Boolean(opts.importFrom?.trim());
   const explicitFlow: SetupFlowChoice | undefined =
     normalizedExplicitFlow === "quickstart" ||
     normalizedExplicitFlow === "advanced" ||
     normalizedExplicitFlow === "import"
       ? normalizedExplicitFlow
-      : undefined;
-  let flow: SetupFlowChoice =
-    explicitFlow ??
-    (await prompter.select({
-      message: "Setup mode",
-      options: [
-        { value: "quickstart", label: "QuickStart", hint: quickstartHint },
-        { value: "advanced", label: "Manual", hint: manualHint },
-        ...(importOption ? [importOption] : []),
-      ],
-      initialValue: "quickstart",
-    }));
+      : hasExplicitImportProvider
+        ? "import"
+        : undefined;
+  let migrationChoice: SetupMigrationChoice | undefined;
+  let flow: SetupFlowChoice;
+  if (explicitFlow) {
+    flow = explicitFlow;
+  } else if (migrationDetections.length > 0) {
+    migrationChoice = await promptDetectedMigrationChoice({
+      detections: migrationDetections,
+      prompter,
+    });
+    flow =
+      migrationChoice.kind === "import"
+        ? "import"
+        : await promptSetupFlow({ prompter, quickstartHint, manualHint });
+  } else {
+    flow = await promptSetupFlow({ prompter, quickstartHint, manualHint });
+  }
 
   if (opts.mode === "remote" && flow === "quickstart") {
     await prompter.note(
@@ -321,7 +372,10 @@ export async function runSetupWizard(
 
   if (opts.importFrom || flow === "import") {
     await runSetupMigrationImport({
-      opts,
+      opts:
+        migrationChoice?.kind === "import"
+          ? { ...opts, importFrom: migrationChoice.providerId }
+          : opts,
       baseConfig,
       detections: migrationDetections,
       prompter,


### PR DESCRIPTION
## Summary
- prompt first-run onboarding to import when Claude or Hermes state is detected
- keep the normal QuickStart/Manual setup screen unchanged when no importable source is found
- document the detected-source import prompt and forced import flags

## Verification
- pnpm test:serial src/wizard/setup.test.ts src/wizard/setup.migration-import.test.ts
- OPENCLAW_TESTBOX=1 pnpm check:changed via Blacksmith Testbox tbx_01kq8062mqzmccpcqzk23m4728
