### PR TITLE
fix(qqbot): route gateway websocket through ambient proxy agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- QQBot: route gateway WebSocket connections through the ambient proxy agent so deployments with `https_proxy`, `HTTPS_PROXY`, or `HTTP_PROXY` can reach the QQ gateway. (#72961) Thanks @xialonglee.
 - Memory/QMD: warn with a manual stale collection removal hint when QMD reports a path/pattern conflict but `collection list` lacks verifiable metadata, avoiding unsafe stderr-only rebinds. Refs #71783. (#72297) Thanks @MonkeyLeeT.
 - Models/auth: make `openclaw models status --check` and dashboard auth health honor effective auth profile order while keeping stale profiles visible. (#79685) Thanks @nimbleenigma.
 - Agents/failover: classify bare `stream_read_error` streaming failures as transient timeouts so configured model fallback runs instead of surfacing the raw transport error. Fixes #79689. (#79692) Thanks @hekunwang.

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -28,6 +28,7 @@ import { dispatchEvent } from "./event-dispatcher.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
 import { ReconnectState } from "./reconnect.js";
 import type { GatewayAccount, EngineLogger, GatewayPluginRuntime, WSPayload } from "./types.js";
+import { createQQWSClient } from "./ws-client.js";
 
 // ============ Connection context ============
 
@@ -188,9 +189,9 @@ export class GatewayConnection {
       log?.info(`✅ Access token obtained successfully`);
       const gatewayUrl = await getGatewayUrl(accessToken, account.appId);
       log?.info(`Connecting to ${gatewayUrl}`);
-
-      const ws = new WebSocket(gatewayUrl, {
-        headers: { "User-Agent": getPluginUserAgent() },
+      const ws = await createQQWSClient({
+        gatewayUrl,
+        userAgent: getPluginUserAgent(),
       });
       this.currentWs = ws;
 

--- a/extensions/qqbot/src/engine/gateway/ws-client.test.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+const webSocketCtorMock = vi.hoisted(() =>
+  vi.fn(function webSocketCtorMockImpl(_url: string, _options?: Record<string, unknown>) {
+    return { readyState: 0 };
+  }),
+);
+const proxyAgentCtorMock = vi.hoisted(() =>
+  vi.fn(function proxyAgentCtorMockImpl() {
+    return { proxied: true };
+  }),
+);
+const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
+type ProxyEnvKey = (typeof proxyEnvKeys)[number];
+
+vi.mock("ws", () => ({
+  default: webSocketCtorMock,
+}));
+
+type CreateQQWSClient = typeof import("./ws-client.js").createQQWSClient;
+let createQQWSClient: CreateQQWSClient;
+let priorProxyEnv: Partial<Record<ProxyEnvKey, string | undefined>> = {};
+
+beforeAll(async () => {
+  vi.doMock("proxy-agent", () => ({
+    ProxyAgent: proxyAgentCtorMock,
+  }));
+  ({ createQQWSClient } = await import("./ws-client.js"));
+});
+
+describe("createQQWSClient", () => {
+  beforeEach(() => {
+    priorProxyEnv = {};
+    for (const key of proxyEnvKeys) {
+      priorProxyEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const key of proxyEnvKeys) {
+      const value = priorProxyEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("does not set a ws proxy agent when proxy env is absent", async () => {
+    await createQQWSClient({
+      gatewayUrl: "wss://qq.example.test/ws",
+      userAgent: "openclaw-qqbot-test",
+    });
+
+    expect(webSocketCtorMock).toHaveBeenCalledTimes(1);
+    expect(proxyAgentCtorMock).not.toHaveBeenCalled();
+    const [, options] = webSocketCtorMock.mock.calls[0] ?? [];
+    expect(options).toMatchObject({
+      headers: { "User-Agent": "openclaw-qqbot-test" },
+    });
+    expect(options).not.toHaveProperty("agent");
+  });
+
+  it("creates a ws proxy agent when lowercase https_proxy is set", async () => {
+    process.env.https_proxy = "http://lower-https:8001";
+
+    await createQQWSClient({
+      gatewayUrl: "wss://qq.example.test/ws",
+      userAgent: "openclaw-qqbot-test",
+    });
+
+    expect(webSocketCtorMock).toHaveBeenCalledTimes(1);
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    const [, options] = webSocketCtorMock.mock.calls[0] ?? [];
+    expect(options).toMatchObject({
+      headers: { "User-Agent": "openclaw-qqbot-test" },
+      agent: { proxied: true },
+    });
+  });
+
+  it("creates a ws proxy agent when uppercase HTTPS_PROXY is set", async () => {
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+
+    await createQQWSClient({
+      gatewayUrl: "wss://qq.example.test/ws",
+      userAgent: "openclaw-qqbot-test",
+    });
+
+    expect(webSocketCtorMock).toHaveBeenCalledTimes(1);
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    const [, options] = webSocketCtorMock.mock.calls[0] ?? [];
+    expect(options).toMatchObject({
+      headers: { "User-Agent": "openclaw-qqbot-test" },
+      agent: { proxied: true },
+    });
+  });
+
+  it("falls back to HTTP_PROXY for ws proxy agent creation", async () => {
+    process.env.HTTP_PROXY = "http://upper-http:8999";
+
+    await createQQWSClient({
+      gatewayUrl: "wss://qq.example.test/ws",
+      userAgent: "openclaw-qqbot-test",
+    });
+
+    expect(webSocketCtorMock).toHaveBeenCalledTimes(1);
+    expect(proxyAgentCtorMock).toHaveBeenCalledTimes(1);
+    const [, options] = webSocketCtorMock.mock.calls[0] ?? [];
+    expect(options).toMatchObject({
+      headers: { "User-Agent": "openclaw-qqbot-test" },
+      agent: { proxied: true },
+    });
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/ws-client.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.ts
@@ -1,0 +1,16 @@
+import type { Agent } from "node:http";
+import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
+import WebSocket from "ws";
+
+export interface QQWSClientOptions {
+  gatewayUrl: string;
+  userAgent: string;
+}
+
+export async function createQQWSClient(options: QQWSClientOptions): Promise<WebSocket> {
+  const wsAgent = await resolveAmbientNodeProxyAgent<Agent>();
+  return new WebSocket(options.gatewayUrl, {
+    headers: { "User-Agent": options.userAgent },
+    ...(wsAgent ? { agent: wsAgent } : {}),
+  });
+}


### PR DESCRIPTION
## Summary
- Route qqbot gateway websocket creation through a dedicated helper that uses `resolveAmbientNodeProxyAgent` from `openclaw/plugin-sdk/extension-shared`.
- Ensure qqbot websocket connections follow system proxy env behavior (`https_proxy` / `HTTPS_PROXY` / `HTTP_PROXY`) in private network environments where direct egress cannot reach QQ gateway.
- Align qqbot behavior with Feishu's proxy-aware connection behavior and add focused regression tests for proxy/no-proxy wiring.

## Evidence
In a private environment, direct websocket connection repeatedly failed without proxy routing:

```text
00:33:12 [qqbot] [default] [qqbot:api] <<< Status: 200 OK | TraceId: **********
00:33:12 [qqbot] [default] Connecting to wss://api.sgroup.qq.com/websocket
00:33:12 [ws] ⇄ res ✓ node.list 90ms conn=ebd26fa2…b049 id=c964130f…d391
00:33:12 [ws] ⇄ res ✓ config.get 19780ms conn=ebd26fa2…b049 id=b818e75d…c2af
00:33:44 [qqbot] [default] WebSocket error:
00:33:44 [qqbot] [qqbot:default] Gateway error:
00:33:44 [qqbot] [default] WebSocket closed: 1006
00:33:45 [qqbot] [default] ✅ Access token obtained successfully
00:33:45 [qqbot] [default] [qqbot:api] <<< Status: 200 OK | TraceId: **********
00:33:45 [qqbot] [default] Connecting to wss://api.sgroup.qq.com/websocket
```

## Test plan
- [x] `pnpm docs:list`
- [x] `pnpm test extensions/qqbot/src/engine/gateway/ws-client.test.ts`

## AI-assisted
- [x] AI-assisted and manually reviewed

Made with [Cursor](https://cursor.com)