### PR TITLE
fix(sanitizer): strip new runtime-context preface headers from outbound text

### DIFF
--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -47,6 +47,108 @@ describe("internal runtime context codec", () => {
     ).toBe(false);
   });
 
+  it("strips a standalone next-turn runtime-context preface echoed by the model", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe("");
+  });
+
+  it("strips next-turn preface and preserves visible reply that follows", () => {
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "Hey Jim, how can I help?",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe("Hey Jim, how can I help?");
+  });
+
+  it("strips a runtime-event preface echoed by the model", () => {
+    const input = [
+      "Some preceding output.",
+      "",
+      "OpenClaw runtime event.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "Tail content.",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe(
+      ["Some preceding output.", "", "Tail content."].join("\n"),
+    );
+  });
+
+  it("strips multiple preface occurrences in the same text", () => {
+    const input = [
+      "First reply.",
+      "",
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "Middle.",
+      "",
+      "OpenClaw runtime event.",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+      "",
+      "End.",
+    ].join("\n");
+
+    expect(stripInternalRuntimeContext(input)).toBe(
+      ["First reply.", "", "Middle.", "", "End."].join("\n"),
+    );
+  });
+
+  it("does not strip prose that merely mentions the preface phrasing inline", () => {
+    const input =
+      "I see the OpenClaw runtime context for the immediately preceding user message. came up earlier — should we look at that?";
+    expect(stripInternalRuntimeContext(input)).toBe(input);
+  });
+
+  it("does not strip when only the privacy notice line appears without a header above it", () => {
+    const input = [
+      "Reply to user.",
+      "",
+      "This context is runtime-generated, not user-authored. Keep internal details private.",
+    ].join("\n");
+    expect(stripInternalRuntimeContext(input)).toBe(input);
+  });
+
+  it("hasInternalRuntimeContext detects new preface headers when paired with the privacy notice", () => {
+    expect(
+      hasInternalRuntimeContext(
+        [
+          "OpenClaw runtime context for the immediately preceding user message.",
+          "This context is runtime-generated, not user-authored. Keep internal details private.",
+        ].join("\n"),
+      ),
+    ).toBe(true);
+
+    expect(
+      hasInternalRuntimeContext(
+        [
+          "OpenClaw runtime event.",
+          "This context is runtime-generated, not user-authored. Keep internal details private.",
+        ].join("\n"),
+      ),
+    ).toBe(true);
+
+    expect(
+      hasInternalRuntimeContext(
+        "OpenClaw runtime context for the immediately preceding user message.",
+      ),
+    ).toBe(false);
+
+    expect(
+      hasInternalRuntimeContext(
+        "Inline mention of OpenClaw runtime event. should not count as a block.",
+      ),
+    ).toBe(false);
+  });
+
   it("fuzzes delimiter injection and nested marker handling deterministically", () => {
     const rng = createDeterministicRng(0xc0ff_ee42);
     const tokenPool = [

--- a/src/agents/internal-runtime-context.test.ts
+++ b/src/agents/internal-runtime-context.test.ts
@@ -108,6 +108,19 @@ describe("internal runtime context codec", () => {
     expect(stripInternalRuntimeContext(input)).toBe(input);
   });
 
+  it("does not strip when extra characters follow the privacy notice on the same line", () => {
+    // Model echo where the privacy-notice line is continued with additional
+    // text on the same line. Without an end-of-line boundary check the strip
+    // would land in the middle of the line and leak the trailing fragment.
+    const input = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored. Keep internal details private. [ack]",
+      "",
+      "Visible reply.",
+    ].join("\n");
+    expect(stripInternalRuntimeContext(input)).toBe(input);
+  });
+
   it("does not strip when only the privacy notice line appears without a header above it", () => {
     const input = [
       "Reply to user.",

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -191,8 +191,11 @@ function findLineStartIndex(text: string, header: string, from: number): number 
 
 // Returns the byte offset just past the privacy-notice line that follows
 // `headerIdx`, or null if the header isn't immediately followed by a newline
-// + the exact privacy-notice line. Tolerates an optional `\r` before the
-// newline that joins header → notice.
+// + the exact privacy-notice line + an end-of-line boundary. Tolerates an
+// optional `\r` before the newline that joins header → notice. Rejects
+// matches where extra characters follow the notice on the same line, so
+// model echoes like `"...Keep internal details private. [ack]"` are left
+// alone instead of being half-stripped.
 function findRuntimeContextPrefaceEnd(text: string, headerIdx: number, header: string): number | null {
   let cursor = headerIdx + header.length;
   if (text.charCodeAt(cursor) === 0x0d /* \r */) {
@@ -206,7 +209,14 @@ function findRuntimeContextPrefaceEnd(text: string, headerIdx: number, header: s
       RUNTIME_CONTEXT_PREFACE_NOTICE_LINE) {
     return null;
   }
-  return cursor + RUNTIME_CONTEXT_PREFACE_NOTICE_LINE.length;
+  const endOfNotice = cursor + RUNTIME_CONTEXT_PREFACE_NOTICE_LINE.length;
+  if (endOfNotice < text.length) {
+    const charAfter = text.charCodeAt(endOfNotice);
+    if (charAfter !== 0x0a /* \n */ && charAfter !== 0x0d /* \r */) {
+      return null;
+    }
+  }
+  return endOfNotice;
 }
 
 function hasRuntimeContextPreface(text: string): boolean {
@@ -240,8 +250,8 @@ function stripRuntimeContextPreface(text: string): string {
         searchFrom = headerIdx + header.length;
         continue;
       }
-      const before = next.slice(0, headerIdx).replace(/[ \t]*\r?\n+$/g, "");
-      const after = next.slice(blockEnd).replace(/^\r?\n+[ \t]*/g, "");
+      const before = next.slice(0, headerIdx).replace(/[ \t]*\r?\n+$/, "");
+      const after = next.slice(blockEnd).replace(/^\r?\n+[ \t]*/, "");
       const joiner = before && after ? "\n\n" : "";
       next = `${before}${joiner}${after}`;
       searchFrom = before.length;

--- a/src/agents/internal-runtime-context.ts
+++ b/src/agents/internal-runtime-context.ts
@@ -16,6 +16,23 @@ const LEGACY_INTERNAL_EVENT_SEPARATOR = "\n\n---\n\n";
 const LEGACY_UNTRUSTED_RESULT_BEGIN = "<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>";
 const LEGACY_UNTRUSTED_RESULT_END = "<<<END_UNTRUSTED_CHILD_RESULT>>>";
 
+// Headers used by `buildRuntimeContextMessageContent` in
+// src/agents/pi-embedded-runner/run/runtime-context-prompt.ts. The Pi runtime
+// converts the resulting custom-message into a user-role LLM turn, so any
+// model that ignores the privacy notice can echo these lines verbatim into
+// its visible reply. Strip them on outbound the same way we strip the
+// legacy `OpenClaw runtime context (internal):` header.
+const RUNTIME_CONTEXT_NEXT_TURN_PREFACE_HEADER =
+  "OpenClaw runtime context for the immediately preceding user message.";
+const RUNTIME_CONTEXT_RUNTIME_EVENT_PREFACE_HEADER = "OpenClaw runtime event.";
+const RUNTIME_CONTEXT_PREFACE_NOTICE_LINE =
+  "This context is runtime-generated, not user-authored. Keep internal details private.";
+
+const RUNTIME_CONTEXT_PREFACE_HEADERS: readonly string[] = [
+  RUNTIME_CONTEXT_NEXT_TURN_PREFACE_HEADER,
+  RUNTIME_CONTEXT_RUNTIME_EVENT_PREFACE_HEADER,
+];
+
 export function escapeInternalRuntimeContextDelimiters(value: string): string {
   return value
     .replaceAll(INTERNAL_RUNTIME_CONTEXT_BEGIN, ESCAPED_INTERNAL_RUNTIME_CONTEXT_BEGIN)
@@ -154,6 +171,85 @@ function stripLegacyInternalRuntimeContext(text: string): string {
   }
 }
 
+// Returns the index of the first line-start occurrence of `header` at or
+// after `from`, where "line-start" means either the very beginning of the
+// string or immediately after a newline. Returns -1 if no such occurrence
+// exists.
+function findLineStartIndex(text: string, header: string, from: number): number {
+  let cursor = Math.max(0, from);
+  for (;;) {
+    const idx = text.indexOf(header, cursor);
+    if (idx === -1) {
+      return -1;
+    }
+    if (idx === 0 || text.charCodeAt(idx - 1) === 0x0a /* \n */) {
+      return idx;
+    }
+    cursor = idx + 1;
+  }
+}
+
+// Returns the byte offset just past the privacy-notice line that follows
+// `headerIdx`, or null if the header isn't immediately followed by a newline
+// + the exact privacy-notice line. Tolerates an optional `\r` before the
+// newline that joins header → notice.
+function findRuntimeContextPrefaceEnd(text: string, headerIdx: number, header: string): number | null {
+  let cursor = headerIdx + header.length;
+  if (text.charCodeAt(cursor) === 0x0d /* \r */) {
+    cursor += 1;
+  }
+  if (text.charCodeAt(cursor) !== 0x0a /* \n */) {
+    return null;
+  }
+  cursor += 1;
+  if (text.slice(cursor, cursor + RUNTIME_CONTEXT_PREFACE_NOTICE_LINE.length) !==
+      RUNTIME_CONTEXT_PREFACE_NOTICE_LINE) {
+    return null;
+  }
+  return cursor + RUNTIME_CONTEXT_PREFACE_NOTICE_LINE.length;
+}
+
+function hasRuntimeContextPreface(text: string): boolean {
+  for (const header of RUNTIME_CONTEXT_PREFACE_HEADERS) {
+    let cursor = 0;
+    for (;;) {
+      const headerIdx = findLineStartIndex(text, header, cursor);
+      if (headerIdx === -1) {
+        break;
+      }
+      if (findRuntimeContextPrefaceEnd(text, headerIdx, header) !== null) {
+        return true;
+      }
+      cursor = headerIdx + header.length;
+    }
+  }
+  return false;
+}
+
+function stripRuntimeContextPreface(text: string): string {
+  let next = text;
+  for (const header of RUNTIME_CONTEXT_PREFACE_HEADERS) {
+    let searchFrom = 0;
+    for (;;) {
+      const headerIdx = findLineStartIndex(next, header, searchFrom);
+      if (headerIdx === -1) {
+        break;
+      }
+      const blockEnd = findRuntimeContextPrefaceEnd(next, headerIdx, header);
+      if (blockEnd === null) {
+        searchFrom = headerIdx + header.length;
+        continue;
+      }
+      const before = next.slice(0, headerIdx).replace(/[ \t]*\r?\n+$/g, "");
+      const after = next.slice(blockEnd).replace(/^\r?\n+[ \t]*/g, "");
+      const joiner = before && after ? "\n\n" : "";
+      next = `${before}${joiner}${after}`;
+      searchFrom = before.length;
+    }
+  }
+  return next;
+}
+
 export function stripInternalRuntimeContext(text: string): string {
   if (!text) {
     return text;
@@ -163,7 +259,8 @@ export function stripInternalRuntimeContext(text: string): string {
     INTERNAL_RUNTIME_CONTEXT_BEGIN,
     INTERNAL_RUNTIME_CONTEXT_END,
   );
-  return stripLegacyInternalRuntimeContext(withoutDelimitedBlocks);
+  const withoutLegacyHeader = stripLegacyInternalRuntimeContext(withoutDelimitedBlocks);
+  return stripRuntimeContextPreface(withoutLegacyHeader);
 }
 
 export function hasInternalRuntimeContext(text: string): boolean {
@@ -172,6 +269,7 @@ export function hasInternalRuntimeContext(text: string): boolean {
   }
   return (
     findDelimitedTokenIndex(text, INTERNAL_RUNTIME_CONTEXT_BEGIN, 0) !== -1 ||
-    text.includes(LEGACY_INTERNAL_CONTEXT_HEADER)
+    text.includes(LEGACY_INTERNAL_CONTEXT_HEADER) ||
+    hasRuntimeContextPreface(text)
   );
 }


### PR DESCRIPTION
## Summary

Outbound sanitizer extension that catches the new runtime-context preface headers introduced by the v2026.4.24 / #71761 redesign, so models that ignore the privacy-notice line cannot leak the preface into user-visible replies.

Closes the **visible** half of #72386 (Telegram + Qwen-class vLLM model echoing the preface verbatim). The structural fix — making the Pi conversion path treat `openclaw.runtime-context` custom messages as non-user-role context — remains a separate, larger change and is tracked in that issue.

## What's leaking

`buildRuntimeContextMessageContent` in `src/agents/pi-embedded-runner/run/runtime-context-prompt.ts` builds custom-message bodies that begin with one of two human-readable headers, followed by a privacy-notice line:

```
OpenClaw runtime context for the immediately preceding user message.
This context is runtime-generated, not user-authored. Keep internal details private.

…runtime context payload…
```

or:

```
OpenClaw runtime event.
This context is runtime-generated, not user-authored. Keep internal details private.

…runtime context payload…
```

`queueRuntimeContextForNextTurn` queues that body as `customType: "openclaw.runtime-context"`, `display: false`, `deliverAs: "nextTurn"`. The pinned Pi runtime (`@mariozechner/pi-coding-agent@0.70.2`) converts those custom messages into `role: "user"` LLM turns, so the model reads the entire body — including the human-readable preface.

Smaller open-weight models do not reliably honor the *Keep internal details private* line and echo the preface back into their visible reply. Reproduced on v2026.4.24 and confirmed still present in v2026.4.25 (clawsweeper bot review on #72386 walks through the same source path with file:line citations).

## Why a sanitizer (and not a structural fix) here

The bot's review on #72386 explicitly recommends the structural fix as the right long-term answer. That requires either:

- a new Pi capability for non-user-role runtime context (cross-repo work in `@mariozechner/pi-coding-agent`), or
- routing runtime-context through the system-prompt assembly path instead of `sendCustomMessage`, which has wider behavioral implications.

In the meantime, the existing `stripInternalRuntimeContext` already handles two prior runtime-context shapes (the delimited `<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>` block and the legacy `OpenClaw runtime context (internal):` header). Extending it with the two new headers is the same pattern, single-file, low-risk, and addresses the user-visible regression today. #71847 just shipped a similar outbound-strip for inbound metadata envelopes.

## Implementation

`src/agents/internal-runtime-context.ts`:

- New constants for the two new preface headers and the privacy-notice line.
- `findLineStartIndex`, `findRuntimeContextPrefaceEnd` helpers — explicit substring matching (not regex) so the strip is precise. Line-anchored: the header must start at the beginning of the string or immediately after a newline. The privacy notice must follow on the next line. Tolerates an optional `\r` before the header→notice newline.
- `stripRuntimeContextPreface` walks each header in turn, removes matched preface blocks, and trims the surrounding whitespace so the remaining text re-flows as a clean two-newline paragraph break.
- `hasRuntimeContextPreface` parallel detection, exposed via `hasInternalRuntimeContext`.
- `stripInternalRuntimeContext` now calls the new strip after `stripLegacyInternalRuntimeContext`, preserving order/precedence with the existing block + legacy strips.

The strip is conservative: an inline prose mention of either header phrase (e.g. *"the OpenClaw runtime event. came up earlier"*) is preserved because the immediately-following line is not the exact privacy notice. Tests cover this case explicitly.

## Tests

`src/agents/internal-runtime-context.test.ts` adds 7 new cases:

1. Standalone next-turn preface stripped to empty
2. Next-turn preface + visible reply → reply preserved alone
3. Runtime-event preface in the middle of text → surrounding text preserved
4. Multiple prefaces in same text (mixed kinds) → all stripped, blank-line spacing preserved
5. Inline prose mentioning the preface phrasing → preserved
6. Privacy-notice line alone (no header above) → preserved
7. `hasInternalRuntimeContext` detects both headers when paired with the notice; rejects header-only and inline mentions

All 10 tests in the file pass (3 pre-existing + 7 new).

## Test plan

- [x] `vitest run src/agents/internal-runtime-context.test.ts` — 10 / 10 pass
- [x] Manual code review of the strip path against the original `buildRuntimeContextMessageContent` shape
- [ ] Reviewers: please verify in CI / on a real model. I do not have access to run the full test suite locally with all OpenClaw deps installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>