### PR TITLE
fix(ollama): add supportsUsageInStreaming compat flag for token counting

### DIFF
--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -225,6 +225,7 @@ export function buildOllamaModelDefinition(
     cost: OLLAMA_DEFAULT_COST,
     contextWindow: contextWindow ?? OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
+    compat: { supportsUsageInStreaming: true },
   };
 }
 


### PR DESCRIPTION
## Problem

Local Ollama models always show `0/64k (0%)` token count in `/status`.

## Root Cause

Ollama natively supports streaming usage data (`prompt_tokens`/`completion_tokens`) when `stream_options: { include_usage: true }` is sent. However, `buildOllamaModelDefinition` in the Ollama extension did not set `compat: { supportsUsageInStreaming: true }`, causing OpenClaw to skip requesting usage data.

This resulted in:
- Token count showing `0/64k (0%)` in `/status`
- Session entry `totalTokens` not updating
- Transcript entries showing empty `usage: {}`

## Fix

Add `compat: { supportsUsageInStreaming: true }` to `buildOllamaModelDefinition`, matching the behavior of the LM Studio provider (`extensions/lmstudio/index.ts`).

## Testing

- Verified Ollama returns standard OpenAI usage fields (`prompt_tokens`, `completion_tokens`) when `stream_options: { include_usage: true }` is sent
- Tested via `curl` against local Ollama instance — usage data returned correctly
- Lint and import cycle checks pass

## Changes

- `extensions/ollama/src/provider-models.ts`: Added `compat: { supportsUsageInStreaming: true }` to `buildOllamaModelDefinition` (1 line)