### PR TITLE
fix(gateway): limit session row enrichment

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -51,7 +51,7 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
   if (storeConfig && !isStorePathTemplate(storeConfig)) {
     const storePath = resolveStorePath(storeConfig);
     const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    const store = loadSessionStore(storePath);
+    const store = loadSessionStore(storePath, { clone: false });
     const combined: Record<string, SessionEntry> = {};
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
@@ -75,7 +75,7 @@ export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
   for (const target of targets) {
     const agentId = target.agentId;
     const storePath = target.storePath;
-    const store = loadSessionStore(storePath);
+    const store = loadSessionStore(storePath, { clone: false });
     for (const [key, entry] of Object.entries(store)) {
       const canonicalKey = resolveStoredSessionKeyForAgentStore({
         cfg,

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -32,6 +32,56 @@ describe("listSessionsFromStore subagent metadata", () => {
     agents: { list: [{ id: "main", default: true }] },
   } as OpenClawConfig;
 
+  test("applies sessions.list limit before transcript-backed row enrichment", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-limit-"));
+    const storePath = path.join(dir, "sessions.json");
+    const store: Record<string, SessionEntry> = {};
+    for (let i = 0; i < 5; i += 1) {
+      const sessionId = i === 4 ? "old-session" : `new-session-${i}`;
+      store[`agent:main:${sessionId}`] = {
+        sessionId,
+        sessionFile: `${sessionId}.jsonl`,
+        updatedAt: 10_000 - i,
+      } as SessionEntry;
+      fs.writeFileSync(
+        path.join(dir, `${sessionId}.jsonl`),
+        JSON.stringify({ message: { role: "user", content: `hello ${sessionId}` } }) + "\n",
+        "utf8",
+      );
+    }
+
+    const originalExistsSync = fs.existsSync;
+    let oldTranscriptLookups = 0;
+    Object.defineProperty(fs, "existsSync", {
+      configurable: true,
+      value: (filePath: fs.PathLike) => {
+        if (String(filePath).includes("old-session")) {
+          oldTranscriptLookups += 1;
+        }
+        return originalExistsSync(filePath);
+      },
+    });
+    try {
+      const result = listSessionsFromStore({
+        cfg,
+        storePath,
+        store,
+        opts: { limit: 2, includeLastMessage: true },
+      });
+      expect(result.sessions.map((session) => session.sessionId)).toEqual([
+        "new-session-0",
+        "new-session-1",
+      ]);
+      expect(oldTranscriptLookups).toBe(0);
+    } finally {
+      Object.defineProperty(fs, "existsSync", {
+        configurable: true,
+        value: originalExistsSync,
+      });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("includes subagent status timing and direct child session keys", () => {
     const now = Date.now();
     const store: Record<string, SessionEntry> = {

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -32,6 +32,32 @@ describe("listSessionsFromStore subagent metadata", () => {
     agents: { list: [{ id: "main", default: true }] },
   } as OpenClawConfig;
 
+  test("search matches channel-derived display names before row enrichment", () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:slack:group:general": {
+        sessionId: "sess-general",
+        channel: "slack",
+        updatedAt: 20_000,
+      } as SessionEntry,
+      "agent:main:slack:group:random": {
+        sessionId: "sess-random",
+        channel: "slack",
+        updatedAt: 10_000,
+      } as SessionEntry,
+    };
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store,
+      opts: { search: "slack:g-general" },
+    });
+
+    expect(result.sessions.map((session) => session.key)).toEqual([
+      "agent:main:slack:group:general",
+    ]);
+  });
+
   test("applies sessions.list limit before transcript-backed row enrichment", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-limit-"));
     const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1487,6 +1487,28 @@ export function buildGatewaySessionRow(params: {
   };
 }
 
+function resolveSessionListSearchDisplayName(
+  key: string,
+  entry?: SessionEntry,
+): string | undefined {
+  if (entry?.displayName) {
+    return entry.displayName;
+  }
+  const parsed = parseGroupKey(key);
+  const channel = entry?.channel ?? parsed?.channel;
+  if (!channel) {
+    return undefined;
+  }
+  return buildGroupDisplayName({
+    provider: channel,
+    subject: entry?.subject,
+    groupChannel: entry?.groupChannel,
+    space: entry?.space,
+    id: parsed?.id,
+    key,
+  });
+}
+
 export function loadGatewaySessionRow(
   sessionKey: string,
   options?: { includeDerivedTitles?: boolean; includeLastMessage?: boolean; now?: number },
@@ -1586,7 +1608,13 @@ export function listSessionsFromStore(params: {
 
   if (search) {
     entries = entries.filter(([key, entry]) => {
-      const fields = [entry?.displayName, entry?.label, entry?.subject, entry?.sessionId, key];
+      const fields = [
+        resolveSessionListSearchDisplayName(key, entry),
+        entry?.label,
+        entry?.subject,
+        entry?.sessionId,
+        key,
+      ];
       return fields.some(
         (f) => typeof f === "string" && normalizeLowercaseStringOrEmpty(f).includes(search),
       );

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1529,7 +1529,7 @@ export function listSessionsFromStore(params: {
       ? Math.max(1, Math.floor(opts.activeMinutes))
       : undefined;
 
-  let sessions = Object.entries(store)
+  let entries = Object.entries(store)
     .filter(([key]) => {
       if (isCronRunSessionKey(key)) {
         return false;
@@ -1582,24 +1582,11 @@ export function listSessionsFromStore(params: {
         return true;
       }
       return entry?.label === label;
-    })
-    .map(([key, entry]) =>
-      buildGatewaySessionRow({
-        cfg,
-        storePath,
-        store,
-        key,
-        entry,
-        now,
-        includeDerivedTitles,
-        includeLastMessage,
-      }),
-    )
-    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+    });
 
   if (search) {
-    sessions = sessions.filter((s) => {
-      const fields = [s.displayName, s.label, s.subject, s.sessionId, s.key];
+    entries = entries.filter(([key, entry]) => {
+      const fields = [entry?.displayName, entry?.label, entry?.subject, entry?.sessionId, key];
       return fields.some(
         (f) => typeof f === "string" && normalizeLowercaseStringOrEmpty(f).includes(search),
       );
@@ -1608,13 +1595,28 @@ export function listSessionsFromStore(params: {
 
   if (activeMinutes !== undefined) {
     const cutoff = now - activeMinutes * 60_000;
-    sessions = sessions.filter((s) => (s.updatedAt ?? 0) >= cutoff);
+    entries = entries.filter(([, entry]) => (entry?.updatedAt ?? 0) >= cutoff);
   }
+
+  entries = entries.toSorted(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0));
 
   if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
     const limit = Math.max(1, Math.floor(opts.limit));
-    sessions = sessions.slice(0, limit);
+    entries = entries.slice(0, limit);
   }
+
+  const sessions = entries.map(([key, entry]) =>
+    buildGatewaySessionRow({
+      cfg,
+      storePath,
+      store,
+      key,
+      entry,
+      now,
+      includeDerivedTitles,
+      includeLastMessage,
+    }),
+  );
 
   return {
     ts: now,


### PR DESCRIPTION
## Summary
- avoid building enriched session rows before sessions.list filtering/sorting/limit is applied
- avoid cloning session stores in the gateway combined-store read path
- add a regression test proving transcript-backed enrichment is not run for rows outside the requested limit

## Testing
- pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/session-utils.subagent.test.ts
- pnpm build
- pnpm ui:build
