### PR TITLE
fix(github): action manual Barnacle triage labels

### DIFF
--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -2,6 +2,9 @@
 
 export const activePrLimit = 10;
 
+const thirdPartyExtensionMessage =
+  "Please publish this as a third-party plugin on [ClawHub](https://clawhub.ai) instead of adding it to the core repo. Docs: https://docs.openclaw.ai/plugin and https://docs.openclaw.ai/tools/clawhub";
+
 export const rules = [
   {
     label: "r: skill",
@@ -39,8 +42,7 @@ export const rules = [
   {
     label: "r: third-party-extension",
     close: true,
-    message:
-      "Please publish this as a third-party plugin on [ClawHub](https://clawhub.ai) instead of adding it to the core repo. Docs: https://docs.openclaw.ai/plugin and https://docs.openclaw.ai/tools/clawhub",
+    message: thirdPartyExtensionMessage,
   },
   {
     label: "r: moltbook",
@@ -184,6 +186,55 @@ const maintainerAuthorLabel = "maintainer";
 const candidateLabelValues = Object.values(candidateLabels);
 const noisyPrMessage =
   "Closing this PR because it looks dirty (too many unrelated or unexpected changes). This usually happens when a branch picks up unrelated commits or a merge went sideways. Please recreate the PR from a clean branch.";
+
+const candidateActionRules = [
+  {
+    label: candidateLabels.dirtyCandidate,
+    close: true,
+    message: noisyPrMessage,
+  },
+  {
+    label: candidateLabels.externalPluginCandidate,
+    close: true,
+    message: thirdPartyExtensionMessage,
+  },
+  {
+    label: candidateLabels.riskyInfra,
+    close: true,
+    message:
+      "Closing this PR because it changes infra/CI/release/ops plumbing without maintainer context and validation. That surface is high-blast-radius; open an issue/RFC or get owner approval before sending a patch.",
+  },
+  {
+    label: candidateLabels.docsDiscoverability,
+    close: true,
+    message:
+      "Closing this PR because docs discoverability and community-plugin listing changes should go through ClawHub or a maintainer-owned docs plan, not drive-by core churn.",
+  },
+  {
+    label: candidateLabels.lowSignalDocs,
+    close: true,
+    message:
+      "Closing this PR because the docs-only change is too low-signal for the core repo. Please reopen or resubmit with a concrete OpenClaw docs gap and linked context.",
+  },
+  {
+    label: candidateLabels.testOnlyNoBug,
+    close: true,
+    message:
+      "Closing this PR because it only changes tests without a linked bug, owner request, or behavior change. Test-only PRs need a concrete regression or maintainer-requested gap.",
+  },
+  {
+    label: candidateLabels.refactorOnly,
+    close: true,
+    message:
+      "Closing this PR because it is refactor/cleanup-only without maintainer context. We avoid churn in core unless it unlocks a concrete fix, architecture change, or owned cleanup.",
+  },
+  {
+    label: candidateLabels.blankTemplate,
+    close: true,
+    message:
+      "Closing this PR because the template is mostly blank and does not describe a concrete OpenClaw problem, fix, or test plan. Please reopen or resubmit with the missing context filled in.",
+  },
+];
 
 const normalizeLogin = (login) => login.toLowerCase();
 
@@ -643,6 +694,67 @@ async function applyPullRequestCandidateLabels(github, context, core, pullReques
   );
 }
 
+function isAutomationActor(context) {
+  const sender = context.payload.sender;
+  const login = sender?.login ?? context.actor ?? "";
+  return sender?.type === "Bot" || /\[bot\]$/i.test(login);
+}
+
+function candidateActionRuleForLabelSet(labelSet, preferredLabel = "") {
+  const preferredRule = candidateActionRules.find(
+    (rule) => rule.label === preferredLabel && labelSet.has(rule.label),
+  );
+  if (preferredRule) {
+    return preferredRule;
+  }
+  return candidateActionRules.find((rule) => labelSet.has(rule.label));
+}
+
+async function applyPullRequestCandidateAction({
+  github,
+  context,
+  pullRequest,
+  labelSet,
+  hasTriggerLabel,
+  isLabelEvent,
+}) {
+  if (isAutomationActor(context)) {
+    return false;
+  }
+
+  const eventLabel = context.payload.label?.name ?? "";
+  const isCandidateLabelEvent = isLabelEvent && candidateLabelValues.includes(eventLabel);
+  if (!hasTriggerLabel && !isCandidateLabelEvent) {
+    return false;
+  }
+
+  const rule = candidateActionRuleForLabelSet(
+    labelSet,
+    isCandidateLabelEvent ? eventLabel : undefined,
+  );
+  if (!rule) {
+    return false;
+  }
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequest.number,
+    body: rule.message,
+  });
+
+  if (rule.close) {
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullRequest.number,
+      state: "closed",
+    });
+  }
+
+  return true;
+}
+
 async function removeLabels(github, context, issueNumber, labels, labelSet) {
   for (const label of labels) {
     if (!labelSet.has(label)) {
@@ -867,6 +979,18 @@ export async function runBarnacleAutoResponse({ github, context, core = console 
         issue_number: pullRequest.number,
         state: "closed",
       });
+      return;
+    }
+
+    const handledCandidateAction = await applyPullRequestCandidateAction({
+      github,
+      context,
+      pullRequest,
+      labelSet,
+      hasTriggerLabel,
+      isLabelEvent,
+    });
+    if (handledCandidateAction) {
       return;
     }
   }

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -44,14 +44,20 @@ function file(filename: string, status = "modified") {
   };
 }
 
-function barnacleContext(pullRequest: Record<string, unknown>, labels: string[] = []) {
+function barnacleContext(
+  pullRequest: Record<string, unknown>,
+  labels: string[] = [],
+  options: Record<string, unknown> = {},
+) {
   return {
     repo: {
       owner: "openclaw",
       repo: "openclaw",
     },
     payload: {
-      action: "opened",
+      action: options.action ?? "opened",
+      label: options.label,
+      sender: options.sender,
       pull_request: {
         number: 123,
         title: "Cleanup plugin docs",
@@ -70,7 +76,10 @@ function barnacleContext(pullRequest: Record<string, unknown>, labels: string[] 
 function barnacleGithub(files: ReturnType<typeof file>[]) {
   const calls = {
     addLabels: [] as Array<{ issue_number: number; labels: string[] }>,
+    createComment: [] as Array<{ issue_number: number; body: string }>,
+    lock: [] as Array<{ issue_number: number; lock_reason?: string }>,
     removeLabel: [] as Array<{ issue_number: number; name: string }>,
+    update: [] as Array<{ issue_number: number; state?: string }>,
   };
   const github = {
     paginate: async () => files,
@@ -79,7 +88,9 @@ function barnacleGithub(files: ReturnType<typeof file>[]) {
         addLabels: async (params: { issue_number: number; labels: string[] }) => {
           calls.addLabels.push(params);
         },
-        createComment: async () => undefined,
+        createComment: async (params: { issue_number: number; body: string }) => {
+          calls.createComment.push(params);
+        },
         createLabel: async () => undefined,
         getLabel: async (params: { name: string }) => ({
           data: {
@@ -89,11 +100,15 @@ function barnacleGithub(files: ReturnType<typeof file>[]) {
               managedLabelSpecs[params.name as keyof typeof managedLabelSpecs]?.description ?? "",
           },
         }),
-        lock: async () => undefined,
+        lock: async (params: { issue_number: number; lock_reason?: string }) => {
+          calls.lock.push(params);
+        },
         removeLabel: async (params: { issue_number: number; name: string }) => {
           calls.removeLabel.push(params);
         },
-        update: async () => undefined,
+        update: async (params: { issue_number: number; state?: string }) => {
+          calls.update.push(params);
+        },
         updateLabel: async () => undefined,
       },
       pulls: {
@@ -195,6 +210,30 @@ describe("barnacle-auto-response", () => {
     expect(labels).not.toContain(candidateLabels.dirtyCandidate);
   });
 
+  it("does not classify a linked core plugin auto-enable fix as an external plugin candidate", () => {
+    const labels = classifyPullRequestCandidateLabels(
+      pr(
+        "Fix duplicate plugin auto-enable entries",
+        [
+          "- Problem: openclaw doctor --fix adds duplicate installed plugin entries",
+          "- Why it matters: users get noisy config churn",
+          "- What changed: respect manifest-provided channel auto-loads",
+          "",
+          "Fixes #37548",
+          "",
+          "This touches external plugin install state but fixes core config repair behavior.",
+        ].join("\n"),
+      ),
+      [
+        file("src/config/plugin-auto-enable.shared.ts"),
+        file("src/config/plugin-auto-enable.channels.test.ts"),
+        file("src/config/plugin-auto-enable.test-helpers.ts"),
+      ],
+    );
+
+    expect(labels).not.toContain(candidateLabels.externalPluginCandidate);
+  });
+
   it("does not add candidate labels to maintainer-authored PRs", async () => {
     const { calls, github } = barnacleGithub([
       file("ui/src/app.ts"),
@@ -272,5 +311,73 @@ describe("barnacle-auto-response", () => {
         labels: expect.arrayContaining([candidateLabels.dirtyCandidate]),
       }),
     );
+    expect(calls.createComment).toEqual([]);
+    expect(calls.update).toEqual([]);
+  });
+
+  it("actions manually applied candidate labels", async () => {
+    const { calls, github } = barnacleGithub([file("extensions/example/openclaw.plugin.json")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, [candidateLabels.externalPluginCandidate], {
+        action: "labeled",
+        label: { name: candidateLabels.externalPluginCandidate },
+        sender: { login: "maintainer", type: "User" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.createComment).toContainEqual(
+      expect.objectContaining({
+        body: expect.stringContaining("ClawHub"),
+      }),
+    );
+    expect(calls.update).toContainEqual(expect.objectContaining({ state: "closed" }));
+  });
+
+  it("keeps bot-applied candidate labels passive", async () => {
+    const { calls, github } = barnacleGithub([file("extensions/example/openclaw.plugin.json")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, [candidateLabels.externalPluginCandidate], {
+        action: "labeled",
+        label: { name: candidateLabels.externalPluginCandidate },
+        sender: { login: "openclaw-bot[bot]", type: "Bot" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.createComment).toEqual([]);
+    expect(calls.update).toEqual([]);
+  });
+
+  it("actions existing candidate labels when a maintainer adds trigger-response", async () => {
+    const { calls, github } = barnacleGithub([file("src/gateway/foo.test.ts")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, [candidateLabels.testOnlyNoBug, "trigger-response"], {
+        action: "labeled",
+        label: { name: "trigger-response" },
+        sender: { login: "maintainer", type: "User" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).toContainEqual(expect.objectContaining({ name: "trigger-response" }));
+    expect(calls.createComment).toContainEqual(
+      expect.objectContaining({
+        body: expect.stringContaining("only changes tests"),
+      }),
+    );
+    expect(calls.update).toContainEqual(expect.objectContaining({ state: "closed" }));
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Barnacle synced the newer `triage:*` candidate labels, but human-applied candidate labels did not trigger any comment/close action.
- Why it matters: maintainers could tag low-signal PRs and still have to manually close/comment, while bot-applied heuristic labels needed to stay passive.
- What changed: added explicit candidate-action rules for the newer triage labels, gated to human label events or human `trigger-response` events.
- What did NOT change (scope boundary): auto-applied candidate labels remain passive; `r:*`, `dirty`, `invalid`, and spam behavior stays unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/69292
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Barnacle only had active response rules for `r:*` labels plus a few legacy close labels; the newer candidate triage labels were only classified/synced.
- Missing detection / guardrail: no test covered a human applying a `triage:*` candidate label or `trigger-response` to an existing candidate label.
- Contributing context (if known): candidate labels were intentionally passive when auto-applied, but the manual maintainer action path was missing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/barnacle-auto-response.test.ts`
- Scenario the test should lock in: human candidate-label events close/comment, bot-applied candidate labels stay passive, and human `trigger-response` actions existing candidate labels.
- Why this is the smallest reliable guardrail: Barnacle behavior is deterministic script logic with mocked GitHub API calls.
- Existing test that already covers this (if any): existing candidate-label tests covered auto-labeling only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Human-applied Barnacle `triage:*` PR labels now trigger the intended auto-response. Bot-applied heuristic candidate labels remain passive.

## Diagram (if applicable)

```text
Before:
maintainer adds triage label -> Barnacle syncs labels -> no PR action

After:
maintainer adds triage label -> Barnacle comments -> closes PR
bot adds triage label -> Barnacle leaves it as review signal only
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local + Blacksmith Testbox Ubuntu runner
- Runtime/container: Node 22 / repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions Barnacle auto-response
- Relevant config (redacted): N/A

### Steps

1. Run the focused Barnacle test file.
2. Run changed-gate validation through Blacksmith Testbox.

### Expected

- Manual candidate labels and `trigger-response` produce the configured response.
- Bot-applied candidate labels remain passive.
- Changed gate passes.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test:serial test/scripts/barnacle-auto-response.test.ts` passed with 13 tests.
- Edge cases checked: human-applied candidate label closes/comments; bot-applied candidate label stays passive; `trigger-response` actions an existing candidate label; linked core plugin auto-enable fix does not classify as external plugin candidate.
- What you did **not** verify: live GitHub Actions execution on a real PR label event.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Barnacle could accidentally close PRs from its own heuristic labels.
  - Mitigation: candidate actions are gated to non-bot label events or non-bot `trigger-response`; tests cover the bot-applied passive path.
