### PR TITLE
fix(ci): run CodeQL on small Blacksmith runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
       matrix:
         include:
           - language: javascript-typescript
-            runs_on: ubuntu-24.04
+            runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-javascript-typescript-critical-security.yml
           - language: actions
-            runs_on: ubuntu-24.04
+            runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 10
             config_file: ./.github/codeql/codeql-actions-critical-security.yml
     steps:
@@ -65,7 +65,7 @@ jobs:
   critical-quality:
     name: Critical Quality (javascript-typescript)
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'quality' }}
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Move the narrowed CodeQL critical security and critical quality jobs back onto Blacksmith.
- Use the smaller `blacksmith-8vcpu-ubuntu-2404` runner because the new critical surface is small enough that 16 vCPU is unnecessary.

## Validation

- `pnpm check:workflows`
- `git diff --check`
- Parsed `.github/workflows/codeql.yml` with the repo `yaml` package
- CodeQL workflow dispatch succeeded on `fix/codeql-blacksmith`: https://github.com/openclaw/openclaw/actions/runs/25013484586
  - `Critical Security (actions)`: 47s
  - `Critical Security (javascript-typescript)`: 65s
  - `Critical Quality (javascript-typescript)`: 164s

AI-assisted: yes. I understand the workflow change.
