### PR TITLE
fix(telegram): avoid webhook probe in polling status checks

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -769,6 +769,7 @@ export const telegramPlugin = createChatChannelPlugin({
           proxyUrl: account.config.proxy,
           network: account.config.network,
           apiRoot: account.config.apiRoot,
+          includeWebhookInfo: Boolean(account.config.webhookUrl),
         }),
       formatCapabilitiesProbe: ({ probe }) => {
         const lines = [];
@@ -885,6 +886,7 @@ export const telegramPlugin = createChatChannelPlugin({
             proxyUrl: account.config.proxy,
             network: account.config.network,
             apiRoot: account.config.apiRoot,
+            includeWebhookInfo: false,
           });
           const username = probe.ok ? probe.bot?.username?.trim() : null;
           if (username) {

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -57,6 +57,18 @@ describe("probeTelegram retry logic", () => {
     expect(result.bot?.username).toBe("test_bot");
   }
 
+  it("skips webhook info when disabled", async () => {
+    const fetchMock = installFetchMock();
+    mockGetMeSuccess(fetchMock);
+
+    const result = await probeTelegram(token, timeoutMs, { includeWebhookInfo: false });
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.telegram.org/bottest-token/getMe");
+    expect(result.webhook).toBeUndefined();
+  });
+
   afterEach(() => {
     resetTelegramProbeFetcherCacheForTests();
     resolveTelegramFetch.mockReset();

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -23,6 +23,7 @@ export type TelegramProbeOptions = {
   network?: TelegramNetworkConfig;
   accountId?: string;
   apiRoot?: string;
+  includeWebhookInfo?: boolean;
 };
 
 const probeFetcherCache = new Map<string, typeof fetch>();
@@ -105,6 +106,7 @@ export async function probeTelegram(
   const fetcher = resolveProbeFetcher(token, options);
   const apiBase = resolveTelegramApiBase(options?.apiRoot);
   const base = `${apiBase}/bot${token}`;
+  const includeWebhookInfo = options?.includeWebhookInfo !== false;
   const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
   const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
 
@@ -184,29 +186,31 @@ export async function probeTelegram(
           : null,
     };
 
-    // Try to fetch webhook info, but don't fail health if it errors.
-    try {
-      const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
-      if (webhookRemainingBudgetMs > 0) {
-        const webhookRes = await fetchWithTimeout(
-          `${base}/getWebhookInfo`,
-          {},
-          Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
-          fetcher,
-        );
-        const webhookJson = (await webhookRes.json()) as {
-          ok?: boolean;
-          result?: { url?: string; has_custom_certificate?: boolean };
-        };
-        if (webhookRes.ok && webhookJson?.ok) {
-          result.webhook = {
-            url: webhookJson.result?.url ?? null,
-            hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+    // Try to fetch webhook info when requested, but don't fail health if it errors.
+    if (includeWebhookInfo) {
+      try {
+        const webhookRemainingBudgetMs = resolveRemainingBudgetMs();
+        if (webhookRemainingBudgetMs > 0) {
+          const webhookRes = await fetchWithTimeout(
+            `${base}/getWebhookInfo`,
+            {},
+            Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+            fetcher,
+          );
+          const webhookJson = (await webhookRes.json()) as {
+            ok?: boolean;
+            result?: { url?: string; has_custom_certificate?: boolean };
           };
+          if (webhookRes.ok && webhookJson?.ok) {
+            result.webhook = {
+              url: webhookJson.result?.url ?? null,
+              hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+            };
+          }
         }
+      } catch {
+        // ignore webhook errors for probe
       }
-    } catch {
-      // ignore webhook errors for probe
     }
 
     result.ok = true;


### PR DESCRIPTION
## Summary

- Problem: Telegram health/status probes always called both `getMe` and `getWebhookInfo`, even in polling mode.
- Why it matters: The extra Telegram API round trip can make status checks look slow; observed locally as ~1173ms.
- What changed: Added `includeWebhookInfo` and disabled webhook info fetching for polling-mode status/startup probes.
- What did NOT change: Webhook-mode probes still fetch webhook info when a webhook URL is configured.

First PR here — would appreciate a quick review when you have a moment :)

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Telegram polling-mode health checks were doing unnecessary webhook-status work.
- Missing detection / guardrail: No unit test asserted that webhook info can be skipped.
- Contributing context: `getWebhookInfo` is useful for webhook mode but unnecessary for polling status checks.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
 - [x] Unit test
- Target test or file: `extensions/telegram/src/probe.test.ts`
- Scenario the test should lock in: `probeTelegram(..., { includeWebhookInfo: false })` only calls `getMe`.
- Why this is the smallest reliable guardrail: It directly verifies the probe behavior without live Telegram calls.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram polling-mode status checks avoid an extra network call and should report faster probe latency.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any Yes, explain risk + mitigation: Reduces network calls in polling mode; webhook info is still fetched when webhook mode is configured.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw dev clone
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram polling mode

### Steps

1. Run Telegram status/deep health check in polling mode.
2. Observe Telegram probe latency.
3. Apply patch and rerun focused unit tests.

### Expected

- Polling-mode health probes call `getMe` only.
- Webhook-mode/status probes can still include webhook info.

### Actual

- Before: polling-mode probes also called `getWebhookInfo`.
- After: polling-mode probes skip `getWebhookInfo`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Perf numbers (if relevant)

Local observed Telegram status latency improved from ~1173ms to ~316ms after the hotfix.

## Human Verification (required)

- Verified scenarios: Focused Telegram probe unit test suite.
- Edge cases checked: `includeWebhookInfo: false` skips webhook request; existing webhook behavior remains default.
- What you did not verify: Live webhook-mode Telegram deployment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Webhook status detail could be omitted where expected.
 - Mitigation: Webhook info remains enabled when a webhook URL is configured.