### PR TITLE
chore: remove coven changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,11 @@ Docs: https://docs.openclaw.ai
 - Channels/QQBot: add full group chat support (history tracking, @-mention gating, activation modes, per-group config, FIFO message queue with deliver debounce), C2C `stream_messages` streaming with a `StreamingController` lifecycle manager, unified `sendMedia` with chunked upload for large files, and refactor the engine into pipeline stages, focused outbound submodules, builtin slash-command modules, and explicit DI ports via `createEngineAdapters()`. (#70624) Thanks @cxyhhhhh.
 - Gateway/runtime: reuse the current plugin metadata snapshot for provider discovery so repeated model-provider discovery avoids rebuilding plugin manifest metadata. Thanks @shakkernerd.
 - Gateway/startup: pass the plugin metadata snapshot from config validation into plugin bootstrap so startup reuses one manifest product instead of rebuilding plugin metadata. Thanks @shakkernerd.
-- ACP/runtime: add an opt-in bundled Coven backend extension that routes ACP coding sessions through a local Coven daemon when `acp.backend="coven"`, while preserving the existing ACPX backend as the default fallback path. Thanks @BunsDev.
 - Matrix: attach versioned structured approval metadata to pending approval messages so capable Matrix clients can render richer approval UI while body text and reaction fallback keep working. (#72432) Thanks @kakahu2015.
 
 ### Fixes
 
 - Gateway/startup: keep hot Gateway boot paths on leaf config imports and add max-RSS reporting to the gateway startup bench so low-memory startup regressions are visible before release. Thanks @vincentkoc.
-- ACP/runtime: harden the opt-in Coven backend with workspace-confined launch paths, home-expanded Coven socket config, bounded socket responses, sanitized daemon output, and controlled polling failure handling. Thanks @BunsDev.
 - Agents/LSP: terminate bundled stdio LSP process trees during runtime disposal and Gateway shutdown, so nested children such as `tsserver` do not survive stop or restart. Fixes #72357. Thanks @ai-hpc and @bittoby.
 
 ## 2026.4.26


### PR DESCRIPTION
## Summary

- Problem: Coven release-note entries were reintroduced after the extension removal.
- Why it matters: the changelog should not advertise removed functionality.
- What changed: removed the two Coven ACP/runtime bullets from Unreleased.
- What did NOT change (scope boundary): no runtime, docs, package, or extension behavior changed.

## Change Type (select all)

- [x] Docs
- [x] Chore/infra

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #72988
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

The Unreleased changelog no longer includes Coven entries.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Search changelog files for Coven references.
2. Check whitespace errors in the branch diff.

### Expected

- No Coven references remain in changelog files.
- Diff has no whitespace errors.

### Actual

- `rg -n -i "coven" CHANGELOG.md Swabble/CHANGELOG.md extensions/matrix/CHANGELOG.md apps/ios/CHANGELOG.md` returned no matches.
- `git diff --check origin/main..HEAD` passed.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: no Coven references remain in changelog files; branch diff is only `CHANGELOG.md` with two deleted bullets.
- Edge cases checked: checked root, Swabble, Matrix, and iOS changelog files.
- What you did **not** verify: full test suite, because this is a changelog-only removal.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.
