### PR TITLE
test(memory): allow packed index suite timeout

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -18,6 +18,14 @@ import {
   registerBuiltInMemoryEmbeddingProviders,
 } from "./provider-adapters.js";
 
+// This suite performs real sqlite/media indexing and can exceed the global
+// timeout when it shares a packed CI extension shard.
+vi.setConfig({ testTimeout: 240_000 });
+
+afterAll(() => {
+  vi.resetConfig();
+});
+
 let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];


### PR DESCRIPTION
## Summary
- rebase onto current main; the trusted-proxy password fallback changes are already present upstream
- give the memory index suite a scoped 240s timeout and reset Vitest config after the file
- keep the packed extension shard from failing just over the global 120s cap

## Validation
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/index.test.ts`
- `pnpm test:serial extensions/memory-core/src/memory/index.test.ts`
- Blacksmith Testbox `tbx_01kq8fxzd9x6ne3j3as9mxnzas`: exact shard-2 batch via `pnpm test:extensions:batch -- amazon-bedrock-mantle,firecrawl,fireworks,google-meet,kimi-coding,memory-core,memory-lancedb,migrate-claude,msteams,nextcloud-talk,ollama,opencode,openshell,qianfan,synology-chat,telegram,together,webhooks`
- Blacksmith Testbox `tbx_01kq8fxzd9x6ne3j3as9mxnzas`: `OPENCLAW_TESTBOX=1 pnpm check:changed`
