### PR TITLE
fix(ci): add android CodeQL security shard

### DIFF
--- a/.github/codeql/codeql-android-critical-security.yml
+++ b/.github/codeql/codeql-android-critical-security.yml
@@ -1,0 +1,21 @@
+name: openclaw-codeql-android-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+paths:
+  - apps/android/app/src/main
+
+paths-ignore:
+  - "**/.gradle"
+  - "**/build"
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.*"
+  - "**/*Test.kt"
+  - "**/*Test.java"
+  - "**/*Benchmark.kt"
+  - apps/android/app/src/test
+  - apps/android/benchmark

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
           - all
           - security
           - quality
+          - android-security
   schedule:
     - cron: "0 6 * * *"
 
@@ -83,3 +84,36 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/javascript-typescript"
+
+  android-security:
+    name: Critical Security (android)
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'android-security' }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          config-file: ./.github/codeql/codeql-android-critical-security.yml
+
+      - name: Build Android for CodeQL
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:assemblePlayDebug
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-security/android"


### PR DESCRIPTION
## Summary

- Problem: the default CodeQL profile is now fast, but Android security coverage is still only visible through stale full-scan alerts.
- Why it matters: Kotlin CodeQL needs a real Android build, so it should be isolated from the daily lightweight default instead of making the core CodeQL lane slow again.
- What changed: added a manual `android-security` CodeQL profile on `blacksmith-8vcpu-ubuntu-2404`, scoped to `apps/android/app/src/main` and backed by a dedicated Android security config.
- What did NOT change (scope boundary): the scheduled/default CodeQL run still only covers Actions + critical JS/TS security/quality.

## Change Type (select all)

- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Related #70079
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: GitHub Actions / Blacksmith Ubuntu 24.04
- Runtime/container: CodeQL action v4, Java 21, Android Gradle build
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check:workflows`
2. `git diff --check`
3. Dispatch `CodeQL` with `profile=android-security` on this branch.

### Expected

- Existing critical JS/TS jobs are skipped for the Android profile.
- Android CodeQL builds and analyzes successfully as its own shard.

### Actual

- `pnpm check:workflows` passed.
- `git diff --check` passed.
- https://github.com/openclaw/openclaw/actions/runs/25015043640 passed: Android CodeQL completed in 4m22s.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: manual Android CodeQL dispatch on the branch.
- Edge cases checked: confirmed non-Android CodeQL jobs skipped for `android-security` profile.
- What you did **not** verify: default-branch code-scanning alert refresh; that only happens after merge/default-branch run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: Android CodeQL can grow slower than the lean default.
  - Mitigation: this shard is manual-only for now and not part of the scheduled default.
