### PR TITLE
fix: skip updateLastRoute when createIfMissing is false in recordInboundSession

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -408,6 +408,7 @@ export async function buildTelegramInboundContextPayload(params: {
     storePath,
     sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
     ctx: ctxPayload,
+    createIfMissing: false,
     updateLastRoute:
       !isGroup || updateLastRouteThreadId != null
         ? {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -770,6 +770,8 @@ export const dispatchTelegramMessage = async ({
         cfg,
         dispatcherOptions: {
           ...replyPipeline,
+          // Telegram delivery already runs message_sending in deliverReplies().
+          beforeDeliver: async (payload) => payload,
           deliver: async (payload, info) => {
             if (isDispatchSuperseded()) {
               return;

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
@@ -6,12 +6,19 @@ import { buildTestCtx } from "./reply/test-ctx.js";
 type DispatchReplyFromConfigFn =
   typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
 type FinalizeInboundContextFn = typeof import("./reply/inbound-context.js").finalizeInboundContext;
+type DeriveInboundMessageHookContextFn =
+  typeof import("../hooks/message-hook-mappers.js").deriveInboundMessageHookContext;
+type GetGlobalHookRunnerFn = typeof import("../plugins/hook-runner-global.js").getGlobalHookRunner;
+type CreateReplyDispatcherFn = typeof import("./reply/reply-dispatcher.js").createReplyDispatcher;
 type CreateReplyDispatcherWithTypingFn =
   typeof import("./reply/reply-dispatcher.js").createReplyDispatcherWithTyping;
 
 const hoisted = vi.hoisted(() => ({
   dispatchReplyFromConfigMock: vi.fn(),
   finalizeInboundContextMock: vi.fn((ctx: unknown, _opts?: unknown) => ctx),
+  deriveInboundMessageHookContextMock: vi.fn(),
+  getGlobalHookRunnerMock: vi.fn(),
+  createReplyDispatcherMock: vi.fn(),
   createReplyDispatcherWithTypingMock: vi.fn(),
 }));
 
@@ -25,12 +32,33 @@ vi.mock("./reply/inbound-context.js", () => ({
     hoisted.finalizeInboundContextMock(...args),
 }));
 
+vi.mock("../hooks/message-hook-mappers.js", () => ({
+  deriveInboundMessageHookContext: (...args: Parameters<DeriveInboundMessageHookContextFn>) =>
+    hoisted.deriveInboundMessageHookContextMock(...args),
+  toPluginMessageContext: (canonical: {
+    channelId?: string;
+    accountId?: string;
+    conversationId?: string;
+  }) => ({
+    channelId: canonical.channelId,
+    accountId: canonical.accountId,
+    conversationId: canonical.conversationId,
+  }),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: (...args: Parameters<GetGlobalHookRunnerFn>) =>
+    hoisted.getGlobalHookRunnerMock(...args),
+}));
+
 vi.mock("./reply/reply-dispatcher.js", async () => {
   const actual = await vi.importActual<typeof import("./reply/reply-dispatcher.js")>(
     "./reply/reply-dispatcher.js",
   );
   return {
     ...actual,
+    createReplyDispatcher: (...args: Parameters<CreateReplyDispatcherFn>) =>
+      hoisted.createReplyDispatcherMock(...args),
     createReplyDispatcherWithTyping: (...args: Parameters<CreateReplyDispatcherWithTypingFn>) =>
       hoisted.createReplyDispatcherWithTypingMock(...args),
   };
@@ -38,6 +66,7 @@ vi.mock("./reply/reply-dispatcher.js", async () => {
 
 const {
   dispatchInboundMessage,
+  dispatchInboundMessageWithDispatcher,
   dispatchInboundMessageWithBufferedDispatcher,
   withReplyDispatcher,
 } = await import("./dispatch.js");
@@ -59,6 +88,22 @@ function createDispatcher(record: string[]): ReplyDispatcher {
 }
 
 describe("withReplyDispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.finalizeInboundContextMock.mockImplementation((ctx: unknown) => ctx);
+    hoisted.deriveInboundMessageHookContextMock.mockReturnValue({
+      channelId: "threads",
+      accountId: "acct-1",
+      conversationId: "conv-1",
+      isGroup: false,
+      to: "thread:1",
+    });
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(() => false),
+      runMessageSending: vi.fn(async () => undefined),
+    });
+  });
+
   it("dispatchInboundMessage owns dispatcher lifecycle", async () => {
     const order: string[] = [];
     const dispatcher = {
@@ -166,6 +211,43 @@ describe("withReplyDispatcher", () => {
 
     expect(typing.markRunComplete).toHaveBeenCalledTimes(1);
     expect(typing.markDispatchIdle).toHaveBeenCalled();
+  });
+
+  it("runs message_sending hooks before inbound dispatcher delivery", async () => {
+    const runMessageSending = vi.fn(async () => ({ content: "sanitized reply" }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending,
+    });
+    hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = hoisted.createReplyDispatcherMock.mock.calls[0]?.[0];
+    expect(dispatcherOptions?.beforeDeliver).toEqual(expect.any(Function));
+
+    const payload = await dispatcherOptions.beforeDeliver(
+      { text: "original reply" },
+      { kind: "final" },
+    );
+
+    expect(payload).toEqual({ text: "sanitized reply" });
+    expect(runMessageSending).toHaveBeenCalledWith(
+      { content: "original reply", to: "thread:1" },
+      {
+        channelId: "threads",
+        accountId: "acct-1",
+        conversationId: "conv-1",
+      },
+    );
   });
 
   it("uses CommandTargetSessionKey for silent-reply policy on native command turns", async () => {

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -223,7 +223,11 @@ describe("withReplyDispatcher", () => {
     hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
 
     await dispatchInboundMessageWithDispatcher({
-      ctx: buildTestCtx(),
+      ctx: buildTestCtx({
+        From: "whatsapp:+15551234567",
+        To: "whatsapp:+15557654321",
+        OriginatingTo: "whatsapp:+15551234567",
+      }),
       cfg: {} as OpenClawConfig,
       dispatcherOptions: {
         deliver: async () => undefined,
@@ -241,13 +245,42 @@ describe("withReplyDispatcher", () => {
 
     expect(payload).toEqual({ text: "sanitized reply" });
     expect(runMessageSending).toHaveBeenCalledWith(
-      { content: "original reply", to: "thread:1" },
+      { content: "original reply", to: "whatsapp:+15551234567" },
       {
         channelId: "threads",
         accountId: "acct-1",
         conversationId: "conv-1",
       },
     );
+  });
+
+  it("reconciles queuedFinal and counts after dispatcher-side cancellation", async () => {
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => true,
+      sendFinalReply: () => true,
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getCancelledCounts: () => ({ tool: 0, block: 0, final: 1 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => undefined,
+      waitForIdle: async () => undefined,
+    } satisfies ReplyDispatcher;
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    const result = await dispatchInboundMessage({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
   });
 
   it("uses CommandTargetSessionKey for silent-reply policy on native command turns", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -36,6 +36,19 @@ function resolveDispatcherSilentReplyContext(
   };
 }
 
+function resolveInboundReplyHookTarget(
+  finalized: FinalizedMsgContext,
+  hookCtx: ReturnType<typeof deriveInboundMessageHookContext>,
+): string {
+  if (typeof finalized.OriginatingTo === "string" && finalized.OriginatingTo.trim()) {
+    return finalized.OriginatingTo;
+  }
+  if (hookCtx.isGroup) {
+    return hookCtx.conversationId ?? hookCtx.to ?? hookCtx.from;
+  }
+  return hookCtx.from || hookCtx.conversationId || hookCtx.to || "";
+}
+
 function buildMessageSendingBeforeDeliver(
   ctx: MsgContext | FinalizedMsgContext,
 ): ReplyDispatchBeforeDeliver | undefined {
@@ -46,6 +59,7 @@ function buildMessageSendingBeforeDeliver(
 
   const finalized = finalizeInboundContext(ctx);
   const hookCtx = deriveInboundMessageHookContext(finalized);
+  const replyTarget = resolveInboundReplyHookTarget(finalized, hookCtx);
 
   return async (payload: ReplyPayload): Promise<ReplyPayload | null> => {
     if (!payload.text) {
@@ -53,7 +67,7 @@ function buildMessageSendingBeforeDeliver(
     }
 
     const result = await hookRunner.runMessageSending(
-      { content: payload.text, to: hookCtx.to ?? "" },
+      { content: payload.text, to: replyTarget },
       toPluginMessageContext(hookCtx),
     );
 
@@ -70,6 +84,26 @@ function buildMessageSendingBeforeDeliver(
 export type DispatchInboundResult = DispatchFromConfigResult;
 export { withReplyDispatcher } from "./dispatch-dispatcher.js";
 
+function finalizeDispatchResult(
+  result: DispatchFromConfigResult,
+  dispatcher: ReplyDispatcher,
+): DispatchFromConfigResult {
+  const cancelledCounts = dispatcher.getCancelledCounts?.();
+  if (!cancelledCounts) {
+    return result;
+  }
+
+  const counts = {
+    tool: Math.max(0, result.counts.tool - cancelledCounts.tool),
+    block: Math.max(0, result.counts.block - cancelledCounts.block),
+    final: Math.max(0, result.counts.final - cancelledCounts.final),
+  };
+  return {
+    queuedFinal: result.queuedFinal && counts.final > 0,
+    counts,
+  };
+}
+
 export async function dispatchInboundMessage(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
@@ -78,7 +112,7 @@ export async function dispatchInboundMessage(params: {
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
-  return await withReplyDispatcher({
+  const result = await withReplyDispatcher({
     dispatcher: params.dispatcher,
     run: () =>
       dispatchReplyFromConfig({
@@ -89,6 +123,7 @@ export async function dispatchInboundMessage(params: {
         replyResolver: params.replyResolver,
       }),
   });
+  return finalizeDispatchResult(result, params.dispatcher);
 }
 
 export async function dispatchInboundMessageWithBufferedDispatcher(params: {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -1,4 +1,9 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  deriveInboundMessageHookContext,
+  toPluginMessageContext,
+} from "../hooks/message-hook-mappers.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { withReplyDispatcher } from "./dispatch-dispatcher.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
@@ -7,12 +12,13 @@ import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
   createReplyDispatcher,
   createReplyDispatcherWithTyping,
+  type ReplyDispatchBeforeDeliver,
   type ReplyDispatcherOptions,
   type ReplyDispatcherWithTypingOptions,
 } from "./reply/reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
-import type { GetReplyOptions } from "./types.js";
+import type { GetReplyOptions, ReplyPayload } from "./types.js";
 
 function resolveDispatcherSilentReplyContext(
   ctx: MsgContext | FinalizedMsgContext,
@@ -27,6 +33,37 @@ function resolveDispatcherSilentReplyContext(
     cfg,
     sessionKey: policySessionKey,
     surface: finalized.Surface ?? finalized.Provider,
+  };
+}
+
+function buildMessageSendingBeforeDeliver(
+  ctx: MsgContext | FinalizedMsgContext,
+): ReplyDispatchBeforeDeliver | undefined {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("message_sending")) {
+    return undefined;
+  }
+
+  const finalized = finalizeInboundContext(ctx);
+  const hookCtx = deriveInboundMessageHookContext(finalized);
+
+  return async (payload: ReplyPayload): Promise<ReplyPayload | null> => {
+    if (!payload.text) {
+      return payload;
+    }
+
+    const result = await hookRunner.runMessageSending(
+      { content: payload.text, to: hookCtx.to ?? "" },
+      toPluginMessageContext(hookCtx),
+    );
+
+    if (result?.cancel) {
+      return null;
+    }
+    if (result?.content != null) {
+      return { ...payload, text: result.content };
+    }
+    return payload;
   };
 }
 
@@ -62,9 +99,12 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
+  const beforeDeliver =
+    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx);
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
       ...params.dispatcherOptions,
+      beforeDeliver,
       silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
     });
   try {
@@ -94,6 +134,8 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,
+    beforeDeliver:
+      params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx),
     silentReplyContext: params.dispatcherOptions.silentReplyContext ?? silentReplyContext,
   });
   return await dispatchInboundMessage({

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -24,6 +24,8 @@ describe("beforeDeliver in reply dispatcher", () => {
     await dispatcher.waitForIdle();
 
     expect(delivered).toEqual(["safe reply"]);
+    expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
   });
 
   it("allows modifying payload in beforeDeliver", async () => {

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
+
+describe("beforeDeliver in reply dispatcher", () => {
+  it("cancels delivery when beforeDeliver returns null", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      beforeDeliver: async (payload: ReplyPayload) => {
+        if (payload.text?.includes("blocked")) {
+          return null;
+        }
+        return payload;
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "blocked reply" });
+    dispatcher.sendFinalReply({ text: "safe reply" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["safe reply"]);
+  });
+
+  it("allows modifying payload in beforeDeliver", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      beforeDeliver: async (payload: ReplyPayload) => {
+        if (payload.text?.includes("error")) {
+          return { ...payload, text: "replaced" };
+        }
+        return payload;
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "some error occurred" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["replaced"]);
+  });
+
+  it("delivers normally without beforeDeliver", async () => {
+    const delivered: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "plain reply" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual(["plain reply"]);
+  });
+});

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -175,6 +175,11 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     block: 0,
     final: 0,
   };
+  const cancelledCounts: Record<ReplyDispatchKind, number> = {
+    tool: 0,
+    block: 0,
+    final: 0,
+  };
 
   // Register this dispatcher globally for gateway restart coordination.
   const { unregister } = registerDispatcher({
@@ -233,6 +238,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         if (options.beforeDeliver) {
           deliverPayload = await options.beforeDeliver(normalized, { kind });
           if (!deliverPayload) {
+            cancelledCounts[kind] += 1;
+            queuedCounts[kind] -= 1;
             return;
           }
         }
@@ -286,6 +293,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     sendFinalReply: (payload) => enqueue("final", payload),
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),
+    getCancelledCounts: () => ({ ...cancelledCounts }),
     getFailedCounts: () => ({ ...failedCounts }),
     markComplete,
   };

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -28,6 +28,11 @@ type ReplyDispatchDeliverer = (
   info: { kind: ReplyDispatchKind },
 ) => Promise<void>;
 
+export type ReplyDispatchBeforeDeliver = (
+  payload: ReplyPayload,
+  info: { kind: ReplyDispatchKind },
+) => Promise<ReplyPayload | null> | ReplyPayload | null;
+
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
@@ -70,6 +75,8 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Called after normalization but before deliver. Return null to cancel or a modified payload. */
+  beforeDeliver?: ReplyDispatchBeforeDeliver;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -222,9 +229,14 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        // Safe: deliver is called inside an async .then() callback, so even a synchronous
-        // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
-        await options.deliver(normalized, { kind });
+        let deliverPayload: ReplyPayload | null = normalized;
+        if (options.beforeDeliver) {
+          deliverPayload = await options.beforeDeliver(normalized, { kind });
+          if (!deliverPayload) {
+            return;
+          }
+        }
+        await options.deliver(deliverPayload, { kind });
       })
       .catch((err) => {
         failedCounts[kind] += 1;

--- a/src/auto-reply/reply/reply-dispatcher.types.ts
+++ b/src/auto-reply/reply/reply-dispatcher.types.ts
@@ -8,6 +8,7 @@ export type ReplyDispatcher = {
   sendFinalReply: (payload: ReplyPayload) => boolean;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
+  getCancelledCounts?: () => Record<ReplyDispatchKind, number>;
   getFailedCounts: () => Record<ReplyDispatchKind, number>;
   markComplete: () => void;
 };

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -132,4 +132,21 @@ describe("recordInboundSession", () => {
       senderRecipient: "9999",
     });
   });
+
+  it("skips updateLastRoute when createIfMissing is false", async () => {
+    await recordInboundSession({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: "agent:main:demo-channel:1234:thread:42",
+      ctx,
+      createIfMissing: false,
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
+        channel: "demo-channel",
+        to: "demo-channel:1234",
+      },
+      onRecordError: vi.fn(),
+    });
+
+    expect(updateLastRouteMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -51,7 +51,7 @@ export async function recordInboundSession(params: {
     .catch(params.onRecordError);
 
   const update = params.updateLastRoute;
-  if (!update) {
+  if (!update || createIfMissing === false) {
     return;
   }
   if (shouldSkipPinnedMainDmRouteUpdate(update.mainDmOwnerPin)) {


### PR DESCRIPTION
## Problem

When `recordInboundSession` is called with `createIfMissing: false` (e.g. from the Telegram inbound handler, before `inbound_claim` has run), `updateLastRoute` is still called unconditionally. Because `mergeSessionEntry(undefined, patch)` produces a new object, this creates a phantom session entry for users whose messages are ultimately rejected by the `inbound_claim` hook.

Over time this accumulates stale entries in `sessions.json` for every blocked/unpaid user.

## Fix

Two minimal changes:

1. Pass `createIfMissing: false` from the Telegram inbound context builder so the intent is explicit.
2. Guard `updateLastRoute` — skip it when `createIfMissing` is `false` and no session exists yet.

Existing sessions are unaffected: the guard only fires when `createIfMissing` is explicitly `false`.