### PR TITLE
fix(ci): add macOS CodeQL security shard

### DIFF
--- a/.github/codeql/codeql-macos-critical-security.yml
+++ b/.github/codeql/codeql-macos-critical-security.yml
@@ -1,0 +1,17 @@
+name: openclaw-codeql-macos-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+paths:
+  - apps/macos/Sources
+
+paths-ignore:
+  - "**/.build"
+  - "**/.build/**"
+  - "**/DerivedData"
+  - "**/DerivedData/**"
+  - "**/*.generated.swift"
+  - "**/*Tests.swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,7 @@ on:
           - security
           - quality
           - android-security
+          - macos-security
   schedule:
     - cron: "0 6 * * *"
 
@@ -117,3 +118,35 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-security/android"
+
+  macos-security:
+    name: Critical Security (macOS)
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'macos-security' }}
+    runs-on: blacksmith-6vcpu-macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.1.app
+          xcodebuild -version
+          swift --version
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: swift
+          build-mode: manual
+          config-file: ./.github/codeql/codeql-macos-critical-security.yml
+
+      - name: Build macOS for CodeQL
+        run: swift build --package-path apps/macos --product OpenClaw
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-security/macos"


### PR DESCRIPTION
## Summary

- Problem: the old broad CodeQL scan found critical Swift alerts, but Swift/macOS coverage is not part of the new fast default profile.
- Why it matters: Swift CodeQL requires a macOS/Xcode build, so it needs an isolated shard instead of being mixed back into the daily default.
- What changed: added a manual `macos-security` CodeQL profile on `blacksmith-6vcpu-macos-latest`, scoped to `apps/macos/Sources` with a dedicated macOS Swift security config.
- What did NOT change (scope boundary): default scheduled CodeQL still runs only Actions + critical JS/TS security/quality; iOS is not included in this shard.

## Change Type (select all)

- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Related #73001
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: GitHub Actions / Blacksmith macOS
- Runtime/container: CodeQL action v4, Xcode 26.1, Swift package build
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check:workflows`
2. `git diff --check`
3. Dispatch `CodeQL` with `profile=macos-security` on this branch.

### Expected

- Existing Actions/JS/Android CodeQL jobs are skipped for the macOS profile.
- macOS Swift CodeQL builds and analyzes successfully as its own shard.

### Actual

- `pnpm check:workflows` passed.
- `git diff --check` passed.
- https://github.com/openclaw/openclaw/actions/runs/25017103192 passed: macOS CodeQL completed in 16m55s.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: manual macOS CodeQL dispatch on the branch.
- Edge cases checked: confirmed non-macOS CodeQL jobs skipped for `macos-security` profile.
- What you did **not** verify: default-branch code-scanning alert refresh; that only happens after merge/default-branch run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: macOS Swift CodeQL is materially slower than Android/JS.
  - Mitigation: this shard is manual-only and scoped to macOS app source; it is not part of the scheduled default.
