### PR TITLE
fix(cron): add missing threadId to delivery schema

### DIFF
--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -186,7 +186,6 @@ const CronDeliverySharedProperties = {
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
-  // Fixed: Added threadId to bridge drift between TypeScript types and runtime schema
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
 };
 
@@ -383,3 +382,4 @@ export const CronRunLogEntrySchema = Type.Object(
   },
   { additionalProperties: false },
 );
+

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -187,13 +187,13 @@ const CronDeliverySharedProperties = {
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  to: Type.Optional(Type.String()),
 };
 
 const CronDeliveryNoopSchema = Type.Object(
   {
     mode: Type.Literal("none"),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -202,7 +202,6 @@ const CronDeliveryAnnounceSchema = Type.Object(
   {
     mode: Type.Literal("announce"),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -211,6 +210,7 @@ const CronDeliveryWebhookSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
     ...CronDeliverySharedProperties,
+    // Required 'to' override for webhooks
     to: NonEmptyString,
   },
   { additionalProperties: false },
@@ -228,7 +228,6 @@ export const CronDeliveryPatchSchema = Type.Object(
       Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
     ),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -187,13 +187,13 @@ const CronDeliverySharedProperties = {
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+  to: Type.Optional(Type.String()),
 };
 
 const CronDeliveryNoopSchema = Type.Object(
   {
     mode: Type.Literal("none"),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -202,7 +202,6 @@ const CronDeliveryAnnounceSchema = Type.Object(
   {
     mode: Type.Literal("announce"),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -211,6 +210,7 @@ const CronDeliveryWebhookSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
     ...CronDeliverySharedProperties,
+    // Webhook specifically requires 'to' to be a NonEmptyString
     to: NonEmptyString,
   },
   { additionalProperties: false },
@@ -228,7 +228,6 @@ export const CronDeliveryPatchSchema = Type.Object(
       Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
     ),
     ...CronDeliverySharedProperties,
-    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -382,4 +381,5 @@ export const CronRunLogEntrySchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -210,7 +210,6 @@ const CronDeliveryWebhookSchema = Type.Object(
   {
     mode: Type.Literal("webhook"),
     ...CronDeliverySharedProperties,
-    // Webhook specifically requires 'to' to be a NonEmptyString
     to: NonEmptyString,
   },
   { additionalProperties: false },
@@ -381,5 +380,6 @@ export const CronRunLogEntrySchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
 
 

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -186,6 +186,8 @@ const CronDeliverySharedProperties = {
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
+  // Fixed: Added threadId to bridge drift between TypeScript types and runtime schema
+  threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
 };
 
 const CronDeliveryNoopSchema = Type.Object(

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -187,13 +187,13 @@ const CronDeliverySharedProperties = {
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
   threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-  to: Type.Optional(Type.String()),
 };
 
 const CronDeliveryNoopSchema = Type.Object(
   {
     mode: Type.Literal("none"),
     ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -202,6 +202,7 @@ const CronDeliveryAnnounceSchema = Type.Object(
   {
     mode: Type.Literal("announce"),
     ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -227,6 +228,7 @@ export const CronDeliveryPatchSchema = Type.Object(
       Type.Union([Type.Literal("none"), Type.Literal("announce"), Type.Literal("webhook")]),
     ),
     ...CronDeliverySharedProperties,
+    to: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );
@@ -380,6 +382,4 @@ export const CronRunLogEntrySchema = Type.Object(
   },
   { additionalProperties: false },
 );
-
-
 


### PR DESCRIPTION
## Title
`fix(cron): add missing threadId to CronDelivery schemas`

---

## Description
This PR resolves a schema validation regression where passing a `threadId` in a cron job's delivery object would cause the API to reject the request. 

While `threadId` was correctly defined in the TypeScript types (`types.d.ts`) and the general `ConfigDeliveryContextSchema`, it was missing from the `CronDeliverySharedProperties` in the runtime validation logic. Because these schemas use `additionalProperties: false`, valid Telegram forum topic configurations were being blocked.

### Changes
* Added `threadId: Type.Optional(Type.Union([Type.String(), Type.Number()]))` to `CronDeliverySharedProperties`.
* This change propagates to `CronDeliveryNoopSchema`, `CronDeliveryAnnounceSchema`, and `CronDeliveryWebhookSchema`.

---

## Related Issues
Fixes: #73025

Reported by: `coachsootz`

---

## Motivation and Context
Without this fix, users cannot route cron-generated announcements to specific Telegram forum topics using the standard delivery abstraction. The only existing workaround was bypassing the delivery layer entirely, which breaks built-in logging and retry logic.

---

## How Has This Been Tested?
- [x] **Manual Validation:** Verified that `cron.add` now accepts a `delivery` object containing a `threadId` without throwing a schema validation error.
- [x] **Build Check:** Ran `pnpm build` to ensure TypeBox definitions remain consistent with the project's internal protocols.
- [x] **Regression Testing:** Confirmed that other delivery modes (webhook/none) still validate correctly with and without the new field.

---

## Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] **AI-assisted:** This fix was developed with AI assistance to identify the specific schema drift in `src/gateway/protocol/schema/cron.ts`.


