### PR TITLE
fix(agents): skip empty allowlist guard for modelRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/tools: skip the empty explicit tool allowlist guard for `modelRun` call shapes such as `infer model run`, so a global `tools.alsoAllow` no longer fails text-only model smokes before any provider request is made. Fixes #73024. Thanks @aa-on-ai.
 - Providers/Cloudflare AI Gateway: strip assistant prefill turns from Anthropic Messages payloads when thinking is enabled, so Claude requests through Cloudflare AI Gateway no longer fail Anthropic conversation-ending validation. Fixes #72905; carries forward #73005. Thanks @AaronFaby and @sahilsatralkar.
 - Channels/sessions: prevent guarded inbound session recording from creating route-only phantom sessions while still allowing last-route updates for sessions that already exist. Carries forward #73009. Thanks @jzakirov.
 - Cron: accept `delivery.threadId` in Gateway cron add/update schemas so scheduled announce delivery can target Telegram forum topics and other threaded channel destinations through the documented delivery path. Fixes #73017. Thanks @coachsootz.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -948,6 +948,7 @@ export async function runEmbeddedAttempt(
       callableToolNames: effectiveTools.map((tool) => tool.name),
       toolsEnabled,
       disableTools: params.disableTools,
+      modelRun: params.modelRun,
     });
     logAgentRuntimeToolDiagnostics({
       runtimePlan: params.runtimePlan,

--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -40,6 +40,18 @@ describe("tool allowlist guard", () => {
     expect(error?.message).toContain("the selected model does not support tools");
   });
 
+  it("skips the empty-allowlist guard for modelRun call shapes", () => {
+    expect(
+      buildEmptyExplicitToolAllowlistError({
+        sources: [{ label: "tools.allow", entries: ["*", "lobster", "llm-task"] }],
+        callableToolNames: [],
+        toolsEnabled: true,
+        disableTools: true,
+        modelRun: true,
+      }),
+    ).toBeNull();
+  });
+
   it("allows text-only runs without explicit allowlists", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -19,7 +19,14 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   callableToolNames: string[];
   toolsEnabled: boolean;
   disableTools?: boolean;
+  modelRun?: boolean;
 }): Error | null {
+  // `infer model run` and other modelRun call shapes intentionally zero tools, so
+  // a global `tools.alsoAllow` injected into the explicit allowlist must not fail
+  // the run before the model is even reached.
+  if (params.modelRun === true) {
+    return null;
+  }
   const callableToolNames = params.callableToolNames.map(normalizeToolName).filter(Boolean);
   if (params.sources.length === 0 || callableToolNames.length > 0) {
     return null;


### PR DESCRIPTION
## Summary

`openclaw infer model run` aborts before any provider request when `~/.openclaw/openclaw.json` has a non-empty `tools.alsoAllow`, because the empty explicit-allowlist guard still evaluates the global tool policy even though `modelRun:true` intentionally zeroes `toolsRaw`.

The fix adds a `modelRun?: boolean` parameter to `buildEmptyExplicitToolAllowlistError` and short-circuits to `null` when it is `true`. The embedded attempt path (`attempt.ts`) now passes `modelRun: params.modelRun` into the guard so model-only call shapes can run text-only without failing on a global `tools.alsoAllow`.

This keeps the existing fail-closed behavior for runtime `disableTools` conflicts and for ordinary agent runs whose explicit allowlist resolves to no callable tools (the original intent of #71292).

## Repro

1. Set in `~/.openclaw/openclaw.json`:

   ```json
   "tools": { "profile": "coding", "alsoAllow": ["lobster", "llm-task"] }
   ```

2. Run:

   ```sh
   openclaw infer model run --local --model openai-codex/gpt-5.5 --prompt 'reply exactly: ok' --json
   ```

   Before this PR, fails with `No callable tools remain after resolving explicit tool allowlist (...)`. After this PR, the model is reached.

## Test added

`src/agents/tool-allowlist-guard.test.ts` — new case `skips the empty-allowlist guard for modelRun call shapes`. Asserts `buildEmptyExplicitToolAllowlistError` returns `null` when `modelRun: true` even with non-empty `sources` and zero callable tools. The existing `disableTools: true` fail-closed test is unchanged.

## Validation

- `pnpm test src/agents/tool-allowlist-guard.test.ts` — 7/7 passing
- `pnpm check:changed --staged` — green (typecheck core/test, lint, import cycles, conflict markers, changelog attributions, etc.)
- `pnpm test:changed` — 2521 passing; one unrelated pre-existing failure on `src/agents/tools/cron-tool.schema.test.ts` (`job.delivery` keys assertion is missing the new `threadId` introduced by upstream `b6be422306 fix(cron): accept threaded delivery in gateway schema`). Reproduces on bare `upstream/main` with my changes stashed, so it is not blocking.

## Closes

Fixes #73024

## AI assistance

This PR was prepared with Claude Code (Opus 4.7). Lightly tested locally — the unit test covers the guard contract; the end-to-end `infer model run` repro was not exercised live since it requires a live model account.