### PR TITLE
fix(infra): dedupe system events by (text, contextKey)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@ Docs: https://docs.openclaw.ai
 - Slack: prefer full rich-text block content over truncated socket-mode message previews so long inbound Slack messages reach agents intact. Fixes #79027. Thanks @BobAccentWebDev.
 - Slack: include structured Slack API error details in setup, probe, streaming, and reply logs while preserving token redaction. (#53966) Thanks @deucemask.
 - Gateway/agents: keep structured reasons when active-run queueing fails and deprecate the legacy boolean queue helper, so steering and subagent wake diagnostics distinguish completed, non-streaming, and compacting runs. Fixes #80156. Thanks @markus-lassfolk.
+- System events: dedupe keyed events across the queue while preserving unkeyed, delivery-route, and trust-boundary event identity. (#73040) Thanks @statxc.
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.
 - ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.
 - Gateway/status: surface model-pricing bootstrap and refresh failures as degraded health/status warnings while keeping Gateway liveness healthy. Fixes #79599. Thanks @bzelones.

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -285,6 +285,64 @@ describe("system events (session routing)", () => {
     expect(result).toContain("Node: Mac Studio");
     expect(result).not.toContain("last input");
   });
+
+  it("returns false for non-consecutive duplicate events with the same context", () => {
+    const key = "agent:main:test-noncons-dupe";
+    const first = enqueueSystemEvent("exec approval: ps aux | grep openclaw", {
+      sessionKey: key,
+      contextKey: "exec:befadc79",
+    });
+    const interleaved = enqueueSystemEvent("Node connected", { sessionKey: key });
+    const failoverRetry = enqueueSystemEvent("exec approval: ps aux | grep openclaw", {
+      sessionKey: key,
+      contextKey: "exec:befadc79",
+    });
+
+    expect(first).toBe(true);
+    expect(interleaved).toBe(true);
+    expect(failoverRetry).toBe(false);
+    expect(peekSystemEvents(key)).toEqual([
+      "exec approval: ps aux | grep openclaw",
+      "Node connected",
+    ]);
+  });
+
+  it("allows the same text under a different context key", () => {
+    const key = "agent:main:test-context-disambiguates";
+    const reactionA = enqueueSystemEvent("Discord reaction added: ✅", {
+      sessionKey: key,
+      contextKey: "discord:reaction:msg-1",
+    });
+    const reactionB = enqueueSystemEvent("Discord reaction added: ✅", {
+      sessionKey: key,
+      contextKey: "discord:reaction:msg-2",
+    });
+
+    expect(reactionA).toBe(true);
+    expect(reactionB).toBe(true);
+    expect(peekSystemEventEntries(key)).toHaveLength(2);
+  });
+
+  it("preserves lastContextKey when a duplicate is skipped", () => {
+    const key = "agent:main:test-context-preserved";
+    enqueueSystemEvent("Node connected", { sessionKey: key, contextKey: "build:123" });
+
+    const skipped = enqueueSystemEvent("Node connected", {
+      sessionKey: key,
+      contextKey: "build:123",
+    });
+
+    expect(skipped).toBe(false);
+    expect(isSystemEventContextChanged(key, "build:123")).toBe(false);
+  });
+
+  it("does not overwrite lastContextKey when the caller omits a contextKey", () => {
+    const key = "agent:main:test-no-context-clobber";
+    enqueueSystemEvent("Node connected", { sessionKey: key, contextKey: "build:123" });
+    enqueueSystemEvent("Heartbeat tick", { sessionKey: key });
+
+    expect(isSystemEventContextChanged(key, "build:123")).toBe(false);
+  });
 });
 
 describe("isCronSystemEvent", () => {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -307,6 +307,18 @@ describe("system events (session routing)", () => {
     ]);
   });
 
+  it("allows non-consecutive unkeyed duplicate events", () => {
+    const key = "agent:main:test-unkeyed-noncons-dupe";
+    const first = enqueueSystemEvent("Node connected", { sessionKey: key });
+    const interleaved = enqueueSystemEvent("Heartbeat tick", { sessionKey: key });
+    const retry = enqueueSystemEvent("Node connected", { sessionKey: key });
+
+    expect(first).toBe(true);
+    expect(interleaved).toBe(true);
+    expect(retry).toBe(true);
+    expect(peekSystemEvents(key)).toEqual(["Node connected", "Heartbeat tick", "Node connected"]);
+  });
+
   it("allows the same text under a different context key", () => {
     const key = "agent:main:test-context-disambiguates";
     const reactionA = enqueueSystemEvent("Discord reaction added: ✅", {
@@ -320,6 +332,42 @@ describe("system events (session routing)", () => {
 
     expect(reactionA).toBe(true);
     expect(reactionB).toBe(true);
+    expect(peekSystemEventEntries(key)).toHaveLength(2);
+  });
+
+  it("allows the same text and context under a different delivery route", () => {
+    const key = "agent:main:test-context-route-disambiguates";
+    const first = enqueueSystemEvent("Build completed", {
+      sessionKey: key,
+      contextKey: "build:123",
+      deliveryContext: { channel: "telegram", to: "100" },
+    });
+    const second = enqueueSystemEvent("Build completed", {
+      sessionKey: key,
+      contextKey: "build:123",
+      deliveryContext: { channel: "telegram", to: "200" },
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(peekSystemEventEntries(key)).toHaveLength(2);
+  });
+
+  it("allows the same text and context under different trust metadata", () => {
+    const key = "agent:main:test-context-trust-disambiguates";
+    const trusted = enqueueSystemEvent("Hook finished", {
+      sessionKey: key,
+      contextKey: "hook:done",
+      trusted: true,
+    });
+    const untrusted = enqueueSystemEvent("Hook finished", {
+      sessionKey: key,
+      contextKey: "hook:done",
+      trusted: false,
+    });
+
+    expect(trusted).toBe(true);
+    expect(untrusted).toBe(true);
     expect(peekSystemEventEntries(key)).toHaveLength(2);
   });
 
@@ -342,6 +390,60 @@ describe("system events (session routing)", () => {
     enqueueSystemEvent("Heartbeat tick", { sessionKey: key });
 
     expect(isSystemEventContextChanged(key, "build:123")).toBe(false);
+  });
+
+  it("preserves lastContextKey from the newest contextful event after partial consume", () => {
+    const key = "agent:main:test-context-preserved-after-consume";
+    enqueueSystemEvent("startup", { sessionKey: key });
+    enqueueSystemEvent("contextful", { sessionKey: key, contextKey: "build:123" });
+    enqueueSystemEvent("unkeyed followup", { sessionKey: key });
+    const inspected = peekSystemEventEntries(key).slice(0, 1);
+
+    expect(consumeSystemEventEntries(key, inspected).map((entry) => entry.text)).toEqual([
+      "startup",
+    ]);
+    expect(isSystemEventContextChanged(key, "build:123")).toBe(false);
+  });
+
+  it("allows a keyed duplicate after the original is evicted", () => {
+    const key = "agent:main:test-keyed-duplicate-after-eviction";
+    enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" });
+    for (let index = 0; index < 20; index += 1) {
+      enqueueSystemEvent(`event ${index}`, { sessionKey: key, contextKey: `event:${index}` });
+    }
+
+    expect(
+      enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" }),
+    ).toBe(true);
+  });
+
+  it("allows a keyed duplicate after the original is consumed from the prefix", () => {
+    const key = "agent:main:test-keyed-duplicate-after-prefix-consume";
+    enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" });
+    const inspected = peekSystemEventEntries(key);
+
+    expect(consumeSystemEventEntries(key, inspected).map((entry) => entry.text)).toEqual([
+      "Build completed",
+    ]);
+    expect(
+      enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" }),
+    ).toBe(true);
+  });
+
+  it("allows a keyed duplicate after the original is selectively consumed", () => {
+    const key = "agent:main:test-keyed-duplicate-after-selected-consume";
+    enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" });
+    enqueueSystemEvent("Other event", { sessionKey: key, contextKey: "build:other" });
+    const selected = peekSystemEventEntries(key).filter(
+      (entry) => entry.text === "Build completed",
+    );
+
+    expect(consumeSelectedSystemEventEntries(key, selected).map((entry) => entry.text)).toEqual([
+      "Build completed",
+    ]);
+    expect(
+      enqueueSystemEvent("Build completed", { sessionKey: key, contextKey: "build:123" }),
+    ).toBe(true);
   });
 });
 

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -88,6 +88,25 @@ export function isSystemEventContextChanged(
   return normalized !== (existing?.lastContextKey ?? null);
 }
 
+function findDuplicateInQueue(
+  queue: readonly SystemEvent[],
+  text: string,
+  contextKey: string | null,
+): SystemEvent | undefined {
+  for (const event of queue) {
+    if (event.text === text && (event.contextKey ?? null) === contextKey) {
+      return event;
+    }
+  }
+  return undefined;
+}
+
+function applyContextKeyPolicy(entry: SessionQueue, incomingContextKey: string | null): void {
+  if (incomingContextKey !== null) {
+    entry.lastContextKey = incomingContextKey;
+  }
+}
+
 export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   const key = requireSessionKey(options?.sessionKey);
   const entry = getOrCreateSessionQueue(key);
@@ -97,10 +116,10 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   }
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
   const normalizedDeliveryContext = normalizeDeliveryContext(options?.deliveryContext);
-  entry.lastContextKey = normalizedContextKey;
-  if (entry.lastText === cleaned) {
+  if (findDuplicateInQueue(entry.queue, cleaned, normalizedContextKey)) {
     return false;
-  } // skip consecutive duplicates
+  }
+  applyContextKeyPolicy(entry, normalizedContextKey);
   entry.lastText = cleaned;
   entry.queue.push({
     text: cleaned,

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -26,7 +26,6 @@ const MAX_EVENTS = 20;
 
 type SessionQueue = {
   queue: SystemEvent[];
-  lastText: string | null;
   lastContextKey: string | null;
 };
 
@@ -65,7 +64,6 @@ function getOrCreateSessionQueue(sessionKey: string): SessionQueue {
   }
   const created: SessionQueue = {
     queue: [],
-    lastText: null,
     lastContextKey: null,
   };
   queues.set(key, created);
@@ -92,9 +90,17 @@ function findDuplicateInQueue(
   queue: readonly SystemEvent[],
   text: string,
   contextKey: string | null,
+  deliveryContext: DeliveryContext | undefined,
+  trusted: boolean,
 ): SystemEvent | undefined {
+  if (contextKey === null) {
+    const last = queue[queue.length - 1];
+    return last && isDuplicateSystemEvent(last, { text, contextKey, deliveryContext, trusted })
+      ? last
+      : undefined;
+  }
   for (const event of queue) {
-    if (event.text === text && (event.contextKey ?? null) === contextKey) {
+    if (isDuplicateSystemEvent(event, { text, contextKey, deliveryContext, trusted })) {
       return event;
     }
   }
@@ -116,17 +122,25 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   }
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
   const normalizedDeliveryContext = normalizeDeliveryContext(options?.deliveryContext);
-  if (findDuplicateInQueue(entry.queue, cleaned, normalizedContextKey)) {
+  const trusted = options.trusted !== false;
+  if (
+    findDuplicateInQueue(
+      entry.queue,
+      cleaned,
+      normalizedContextKey,
+      normalizedDeliveryContext,
+      trusted,
+    )
+  ) {
     return false;
   }
   applyContextKeyPolicy(entry, normalizedContextKey);
-  entry.lastText = cleaned;
   entry.queue.push({
     text: cleaned,
     ts: Date.now(),
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
-    trusted: options.trusted !== false,
+    trusted,
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -142,7 +156,6 @@ export function drainSystemEventEntries(sessionKey: string): SystemEvent[] {
   }
   const out = entry.queue.map(cloneSystemEvent);
   entry.queue.length = 0;
-  entry.lastText = null;
   entry.lastContextKey = null;
   queues.delete(key);
   return out;
@@ -158,6 +171,18 @@ function areDeliveryContextsEqual(left?: DeliveryContext, right?: DeliveryContex
   return channelRouteDedupeKey(left) === channelRouteDedupeKey(right);
 }
 
+function isDuplicateSystemEvent(
+  existing: SystemEvent,
+  incoming: Pick<SystemEvent, "text" | "contextKey" | "deliveryContext" | "trusted">,
+): boolean {
+  return (
+    existing.text === incoming.text &&
+    (existing.contextKey ?? null) === (incoming.contextKey ?? null) &&
+    (existing.trusted ?? true) === (incoming.trusted ?? true) &&
+    areDeliveryContextsEqual(existing.deliveryContext, incoming.deliveryContext)
+  );
+}
+
 function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
   return (
     left.text === right.text &&
@@ -170,14 +195,18 @@ function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
 
 function resetQueueState(key: string, entry: SessionQueue) {
   if (entry.queue.length === 0) {
-    entry.lastText = null;
     entry.lastContextKey = null;
     queues.delete(key);
     return;
   }
-  const newest = entry.queue[entry.queue.length - 1];
-  entry.lastText = newest.text;
-  entry.lastContextKey = newest.contextKey ?? null;
+  for (let index = entry.queue.length - 1; index >= 0; index -= 1) {
+    const contextKey = entry.queue[index].contextKey ?? null;
+    if (contextKey !== null) {
+      entry.lastContextKey = contextKey;
+      return;
+    }
+  }
+  entry.lastContextKey = null;
 }
 
 export function consumeSystemEventEntries(


### PR DESCRIPTION
## Summary

Fixes the queue-side system-event dedupe leak where `enqueueSystemEvent` only suppressed consecutive duplicate text and allowed older duplicate keyed events back in after interleaved events.

`enqueueSystemEvent` only suppressed identical text against the **most recent** push (`entry.lastText === cleaned`). Any interleaved unrelated event broke dedupe for keyed system events. Two adjacent issues were riding along:

1. `entry.lastContextKey` was written **before** the dedupe check, so a duplicate that was skipped still mutated `lastContextKey` and corrupted `isSystemEventContextChanged()`.
2. `entry.lastContextKey` was written unconditionally, including with `null` when the caller omitted `contextKey`, clobbering a prior session's stored context.

## What changed

- **Queue-wide dedupe** in `src/infra/system-events.ts` for keyed events, replacing the single-slot `lastText` check. The dedupe identity includes `text`, `contextKey`, trust metadata, and normalized delivery route. Unkeyed events keep consecutive-only suppression.
- Extracted two named helpers:
  - `findDuplicateInQueue(queue, text, contextKey, deliveryContext, trusted)` — does the lookup.
  - `applyContextKeyPolicy(entry, incomingContextKey)` — only writes `lastContextKey` when the caller supplies one, and only after the dedupe check has decided the event will actually be queued.

## Tests

Regression coverage in `src/infra/system-events.test.ts`:

- `returns false for non-consecutive duplicate events with the same context` — the cascade scenario from the bug report.
- `allows the same text under a different context key` — disambiguation safety.
- `preserves lastContextKey when a duplicate is skipped` — issue (1) above.
- `does not overwrite lastContextKey when the caller omits a contextKey` — issue (2) above.

All 40 tests in the file pass.

## Test plan

- [x] `pnpm test src/infra/system-events.test.ts` — 40/40 pass
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm exec oxfmt --check` on touched files — clean
- [x] `pnpm exec oxlint` on touched files — 0 warnings, 0 errors

## Notes

- Behavior change: keyed events now dedupe across the queue when text, context key, trust metadata, and delivery route match. Unkeyed events retain consecutive-only duplicate suppression.
- This patch fixes the system-events chokepoint only. A follow-up to thread a stable dedupe key through `ExecApprovalManager` / `exec-approval-forwarder.ts` (id-keyed today) is still needed for the #69478 forwarder cascade.

Refs #69478


## Real behavior proof

- **Behavior or issue addressed**: `enqueueSystemEvent` previously deduped only against the most recent `entry.lastText`, so any interleaved unrelated event let an older duplicate text re-enqueue under a fresh approval id. With the keyed-event identity check this PR uses, repeated keyed system events collapse into a single entry. Tracks openclaw/openclaw#69478. PR head: `e2cc8a7e5c15fceb59aa9b05864fd7ec7ead49c6`.
- **Real environment tested**: Local OpenClaw checkout at this PR's HEAD. `scripts/repro/issue-69478-proof.ts` drives `enqueueSystemEvent` directly through the production module `src/infra/system-events.ts` against the in-process queue (no mocked queue, no mocked module).
- **Exact steps or command run after this patch**: `node --import tsx scripts/repro/issue-69478-proof.ts`. The script enqueues five events: (a1) first emit `run-1`, (a2) immediate duplicate `run-1`, (a3) same text `run-2`, (a4) different text `run-2`, (a5) re-emit of `run-1` text+contextKey after a3+a4 interleaved. Then it peeks the queue and drains it.
- **Evidence after fix**: Copied live stdout from the repro run.

  ```text
  ENQUEUE_RETURNS
  {
    "a1": true,
    "a2": false,
    "a3": true,
    "a4": true,
    "a5": false
  }

  QUEUE_BEFORE_DRAIN
  [
    {
      "text": "Pending approval expired (run timed out)",
      "contextKey": "approval:run-1"
    },
    {
      "text": "Pending approval expired (run timed out)",
      "contextKey": "approval:run-2"
    },
    {
      "text": "Heartbeat lost; reconnecting",
      "contextKey": "approval:run-2"
    }
  ]

  DRAINED_ENTRIES
  [
    {
      "text": "Pending approval expired (run timed out)",
      "contextKey": "approval:run-1"
    },
    {
      "text": "Pending approval expired (run timed out)",
      "contextKey": "approval:run-2"
    },
    {
      "text": "Heartbeat lost; reconnecting",
      "contextKey": "approval:run-2"
    }
  ]

  ASSERTIONS
  a1 first add accepted:           true
  a2 immediate duplicate dropped:  true
  a3 fresh contextKey accepted:    true
  a4 different text accepted:      true
  a5 queue-wide dedupe blocked it: true
  drained count is 3 (no leak):    true
  no duplicate (text, contextKey): true
  ```

- **Observed result after fix**: a1 accepted, a2 dropped (immediate duplicate), a3 accepted (fresh `contextKey` is different intent), a4 accepted (different text), and a5 dropped (queue-wide `(text, contextKey)` match against a1 even though a3+a4 sat between them). The drained queue contains exactly three entries with no `(text, contextKey)` pair appearing twice. Pre-fix, a5 leaked through because the previous logic only compared against `entry.lastText`, which had been overwritten by a3/a4.
- **What was not tested**: A real Telegram approval cascade was not exercised end-to-end in this proof. The scope of #69478 reaches beyond `enqueueSystemEvent` into the approval forwarder; this PR repairs the queue-side leak that allowed the cascade and is verified at that exact seam. Forwarder-side follow-up belongs in a separate change.

