### PR TITLE
fix(ci): filter macOS CodeQL dependency SARIF

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -147,6 +147,42 @@ jobs:
         run: swift build --package-path apps/macos --product OpenClaw
 
       - name: Analyze
+        id: analyze
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
+          output: sarif-results
+          upload: failure-only
+          category: "/codeql-critical-security/macos"
+
+      - name: Remove dependency build results
+        env:
+          SARIF_OUTPUT: ${{ steps.analyze.outputs.sarif-output }}
+        run: |
+          set -euo pipefail
+          mkdir -p sarif-results-filtered
+
+          found=0
+          for file in "$SARIF_OUTPUT"/*.sarif; do
+            if [ ! -e "$file" ]; then
+              continue
+            fi
+
+            found=1
+            jq '
+              def in_dependency_build:
+                any(.locations[]?; (.physicalLocation.artifactLocation.uri? // "") | test("(^|/)\\.build/"));
+
+              .runs |= map(.results = ((.results // []) | map(select(in_dependency_build | not))))
+            ' "$file" > "sarif-results-filtered/$(basename "$file")"
+          done
+
+          if [ "$found" -eq 0 ]; then
+            echo "No SARIF files found in $SARIF_OUTPUT" >&2
+            exit 1
+          fi
+
+      - name: Upload filtered SARIF
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: sarif-results-filtered
           category: "/codeql-critical-security/macos"


### PR DESCRIPTION
## Summary
- keep the manual macOS CodeQL security shard app-focused after SwiftPM builds
- generate CodeQL SARIF without uploading on success
- remove results whose primary location is under `apps/macos/.build/**`, then upload the filtered SARIF under the same category

## Why
The first main run of the macOS shard passed, but it still surfaced a SwiftPM dependency alert from `apps/macos/.build/checkouts/textual/...`. That is third-party build output noise and should not be part of the default remediation queue.

## Verification
- `pnpm check:workflows`
- `git diff --check origin/main...HEAD`
- local `jq` sample confirms `.build` result is removed while `apps/macos/Sources` result remains
