### PR TITLE
fix(cli): skip compile cache for source-checkout installs

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import module from "node:module";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const MIN_NODE_MAJOR = 22;
@@ -38,8 +39,23 @@ const ensureSupportedNodeVersion = () => {
 
 ensureSupportedNodeVersion();
 
+// Skip compile cache for source-checkout installs (a `.git` entry sitting next
+// to this script). Live `pnpm build` rebuilds dist/ in place, and a stale cache
+// hit can mask freshly built CLI changes — see openclaw#73037.
+const isSourceCheckoutInstall = () => {
+  try {
+    return existsSync(path.join(path.dirname(fileURLToPath(import.meta.url)), ".git"));
+  } catch {
+    return false;
+  }
+};
+
 // https://nodejs.org/api/module.html#module-compile-cache
-if (module.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+if (
+  module.enableCompileCache &&
+  !process.env.NODE_DISABLE_COMPILE_CACHE &&
+  !isSourceCheckoutInstall()
+) {
   try {
     module.enableCompileCache();
   } catch {


### PR DESCRIPTION
## Summary
- Problem: bootstrap unconditionally calls `module.enableCompileCache()` when the env opt-out is unset. Source-checkout installs rebuild `dist/` in place, so a stale cache hit can mask freshly built CLI changes.
- Why it matters: `openclaw gateway status --json` reports `rpc.ok: false / "timeout"` after a `pnpm build`, even though the rebuilt source path succeeds. Workaround so far has been `NODE_DISABLE_COMPILE_CACHE=1`.
- What changed: detect a `.git` entry sitting next to `openclaw.mjs` and skip `enableCompileCache` in that case.
- What did NOT change: packaged installs (no `.git` sibling) keep compile-cache behavior; the existing `NODE_DISABLE_COMPILE_CACHE` env opt-out is unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] CI/CD / infra (CLI bootstrap)

## Linked Issue
- Closes #73037

## Root Cause
- Root cause: `openclaw.mjs:42` enabled compile cache unconditionally; no source-checkout gate.
- Missing detection / guardrail: bootstrap script has no test coverage in this repo.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (single sync `existsSync` check on bootstrap path)
- Data access scope changed? No

## Compatibility / Migration
- Backward compatible? Yes (packaged installs unaffected; existing env opt-out preserved).
- Config/env changes? No
- Migration needed? No
