### PR TITLE
fix(telegram): preserve replies during polling restart

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -179,13 +179,24 @@ export function createTelegramBotCore(
     : undefined;
 
   // Wrap fetch so polling requests cannot hang indefinitely on a wedged network path,
-  // and so shutdown still aborts in-flight Telegram API requests immediately.
+  // and so shutdown still aborts in-flight Telegram API requests immediately unless the
+  // caller narrows aborts to specific Bot API methods (polling restarts use this to avoid
+  // killing in-flight sendMessage replies while aborting a stuck getUpdates request).
   let finalFetch: TelegramCompatFetch | undefined = shouldProvideFetch ? fetchForClient : undefined;
   if (finalFetch || opts.fetchAbortSignal) {
     const baseFetch = finalFetch ?? asTelegramCompatFetch(asTelegramClientFetch(globalThis.fetch));
     // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
     // they are runtime-compatible (the codebase already casts at every fetch boundary).
     const callFetch = baseFetch;
+    const abortMethodAllowList = opts.fetchAbortMethods
+      ? new Set(
+          opts.fetchAbortMethods
+            .map((method) => normalizeOptionalLowercaseString(method))
+            .filter((method): method is string => Boolean(method)),
+        )
+      : null;
+    const shouldHonorFetchAbortSignal = (method: string | null) =>
+      abortMethodAllowList === null || (method !== null && abortMethodAllowList.has(method));
     // Use manual event forwarding instead of AbortSignal.any() to avoid the cross-realm
     // AbortSignal issue in Node.js (grammY's signal may come from a different module context,
     // causing "signals[0] must be an instance of AbortSignal" errors).
@@ -196,19 +207,20 @@ export function createTelegramBotCore(
       const shutdownSignal = isTelegramAbortSignalLike(opts.fetchAbortSignal)
         ? opts.fetchAbortSignal
         : undefined;
+      const method = extractTelegramApiMethod(input);
+      const honorShutdownAbort = shouldHonorFetchAbortSignal(method);
       const onShutdown = () => {
         if (shutdownSignal) {
           abortWith(shutdownSignal);
         }
       };
-      const method = extractTelegramApiMethod(input);
       const requestTimeoutMs = resolveTelegramRequestTimeoutMs(method);
       let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
       const requestSignal = isTelegramAbortSignalLike(init?.signal) ? init.signal : undefined;
-      if (shutdownSignal?.aborted) {
+      if (honorShutdownAbort && shutdownSignal?.aborted) {
         abortWith(shutdownSignal);
-      } else if (shutdownSignal) {
+      } else if (honorShutdownAbort && shutdownSignal) {
         shutdownSignal.addEventListener("abort", onShutdown, { once: true });
       }
       if (requestSignal) {
@@ -232,7 +244,9 @@ export function createTelegramBotCore(
         if (requestTimeout) {
           clearTimeout(requestTimeout);
         }
-        shutdownSignal?.removeEventListener("abort", onShutdown);
+        if (honorShutdownAbort) {
+          shutdownSignal?.removeEventListener("abort", onShutdown);
+        }
         if (requestSignal && onRequestAbort) {
           requestSignal.removeEventListener("abort", onRequestAbort);
         }

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -14,13 +14,17 @@ const createTelegramBot = (opts: import("./bot.types.js").TelegramBotOptions) =>
     telegramDeps: telegramBotDepsForTest,
   });
 
-function createWrappedTelegramClientFetch(proxyFetch: typeof fetch) {
+function createWrappedTelegramClientFetch(
+  proxyFetch: typeof fetch,
+  opts?: Pick<import("./bot.types.js").TelegramBotOptions, "fetchAbortMethods">,
+) {
   const shutdown = new AbortController();
   botCtorSpy.mockClear();
   createTelegramBot({
     token: "tok",
     fetchAbortSignal: shutdown.signal,
     proxyFetch,
+    ...opts,
   });
   const clientFetch = (botCtorSpy.mock.calls.at(-1)?.[1] as { client?: { fetch?: unknown } })
     ?.client?.fetch as (input: RequestInfo | URL, init?: RequestInit) => Promise<unknown>;
@@ -47,6 +51,34 @@ describe("createTelegramBot fetch abort", () => {
 
     expect(observedSignal).toBeInstanceOf(AbortSignal);
     expect(observedSignal.aborted).toBe(true);
+  });
+
+  it("can scope fetchAbortSignal to getUpdates without aborting overlapping sends", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<string | AbortSignal>((resolve) => {
+          const signal = init?.signal as AbortSignal;
+          signal.addEventListener("abort", () => resolve(signal), { once: true });
+          setTimeout(() => resolve("completed"), 1_000);
+        }),
+    );
+    const { clientFetch, shutdown } = createWrappedTelegramClientFetch(
+      fetchSpy as unknown as typeof fetch,
+      { fetchAbortMethods: ["getupdates"] },
+    );
+
+    const getUpdatesPromise = clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates");
+    const sendMessagePromise = clientFetch("https://api.telegram.org/bot123456:ABC/sendMessage");
+    shutdown.abort(new Error("polling restart"));
+
+    const getUpdatesSignal = (await getUpdatesPromise) as AbortSignal;
+    expect(getUpdatesSignal).toBeInstanceOf(AbortSignal);
+    expect(getUpdatesSignal.aborted).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(sendMessagePromise).resolves.toBe("completed");
+    vi.useRealTimers();
   });
 
   it("tags wrapped Telegram fetch failures with the Bot API method", async () => {

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -16,6 +16,11 @@ export type TelegramBotOptions = {
   config?: OpenClawConfig;
   /** Signal to abort in-flight Telegram API fetch requests (e.g. getUpdates) on shutdown. */
   fetchAbortSignal?: AbortSignal;
+  /**
+   * Optional lowercase Telegram Bot API method allow-list for fetchAbortSignal.
+   * When omitted, fetchAbortSignal aborts all wrapped API requests.
+   */
+  fetchAbortMethods?: string[];
   updateOffset?: {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -184,6 +184,10 @@ export class TelegramPollingSession {
         config: this.opts.config,
         accountId: this.opts.accountId,
         fetchAbortSignal: fetchAbortController.signal,
+        // Polling-cycle restarts use this controller to break a wedged long-poll.
+        // Keep it scoped to getUpdates so an overlapping user reply/sendMessage is
+        // not aborted during transport recovery.
+        fetchAbortMethods: ["getupdates"],
         updateOffset: {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,


### PR DESCRIPTION
## Summary
- scope polling-restart fetch aborts to `getUpdates` so watchdog restarts do not abort overlapping `sendMessage` replies
- keep default bot fetch-abort behavior unchanged for normal shutdown callers
- add regression coverage for scoped abort behavior

## Tests
- `npx pnpm@10.33.0 exec vitest run extensions/telegram/src/bot.fetch-abort.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/polling-transport-state.test.ts`
- `npx pnpm@10.33.0 check:changed`