### PR TITLE
fix(ci): preserve mixed macOS CodeQL SARIF findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -177,7 +177,8 @@ jobs:
           for file in "${files[@]}"; do
             jq '
               def in_dependency_build:
-                ((.locations[0].physicalLocation.artifactLocation.uri? // "") | test("^apps/macos/\\.build/"));
+                ((.locations // []) | length > 0)
+                and all(.locations[]; (.physicalLocation.artifactLocation.uri? // "") | test("^apps/macos/\\.build/"));
 
               .runs |= map(.results = ((.results // []) | map(select(in_dependency_build | not))))
             ' "$file" > "sarif-results-filtered/$(basename "$file")"


### PR DESCRIPTION
## Summary
- tighten the macOS CodeQL dependency-output SARIF filter again
- drop only results where every SARIF location is under `apps/macos/.build/`
- keep app-source findings visible when any location points at first-party source

## Why
The previous hardening used primary location only. That was safer than the original broad `any(.locations[])` filter, but still unnecessarily dependent on SARIF location ordering. This version only suppresses pure SwiftPM build-output findings.

## Verification
- `pnpm check:workflows`
- `git diff --check origin/main...HEAD`
- local `jq` sample confirms dependency-only findings are removed, while mixed app/dependency and app-only findings remain
