### PR TITLE
fix(acpx): ignore Codex ACP timeout config

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -353,6 +353,37 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
   });
 
+  it("ignores unsupported Codex ACP timeout config controls", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:codex:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:test",
+      acpxRecordId: "agent:codex:acp:test",
+    };
+
+    await runtime.setConfigOption({
+      handle,
+      key: "timeout",
+      value: "60000",
+    });
+    await runtime.setConfigOption({
+      handle,
+      key: "timeout_seconds",
+      value: "60",
+    });
+
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
+
   it("keeps stale persistent loads hidden until a fresh record is saved", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => ({ acpxRecordId: "stale" }) as never),

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -510,36 +510,40 @@ export class AcpxRuntime implements AcpRuntime {
   ): Promise<void> {
     const delegate = await this.resolveDelegateForHandle(input.handle);
     const command = await this.resolveCommandForHandle(input.handle);
-    if (
-      (input.key === "model" ||
-        input.key === "thinking" ||
-        input.key === "thought_level" ||
-        input.key === "reasoning_effort") &&
-      isCodexAcpCommand(command)
-    ) {
-      const override =
-        input.key === "model"
-          ? normalizeCodexAcpModelOverride(input.value)
-          : normalizeCodexAcpModelOverride(undefined, input.value);
-      if (!override && input.key !== "model") {
+    if (isCodexAcpCommand(command)) {
+      if (input.key === "timeout" || input.key === "timeout_seconds") {
         return;
       }
-      if (override) {
-        if (override.model) {
-          await delegate.setConfigOption({
-            ...input,
-            key: "model",
-            value: override.model,
-          });
+      if (
+        input.key === "model" ||
+        input.key === "thinking" ||
+        input.key === "thought_level" ||
+        input.key === "reasoning_effort"
+      ) {
+        const override =
+          input.key === "model"
+            ? normalizeCodexAcpModelOverride(input.value)
+            : normalizeCodexAcpModelOverride(undefined, input.value);
+        if (!override && input.key !== "model") {
+          return;
         }
-        if (override.reasoningEffort) {
-          await delegate.setConfigOption({
-            ...input,
-            key: "reasoning_effort",
-            value: override.reasoningEffort,
-          });
+        if (override) {
+          if (override.model) {
+            await delegate.setConfigOption({
+              ...input,
+              key: "model",
+              value: override.model,
+            });
+          }
+          if (override.reasoningEffort) {
+            await delegate.setConfigOption({
+              ...input,
+              key: "reasoning_effort",
+              value: override.reasoningEffort,
+            });
+          }
+          return;
         }
-        return;
       }
     }
     await delegate.setConfigOption(input);


### PR DESCRIPTION
## Summary
- Ignore unsupported `timeout` / `timeout_seconds` ACP config pushes for Codex ACP sessions
- Keep existing Codex model/thinking normalization behavior intact
- Add regression coverage for the Codex ACP timeout config path

Fixes #73052

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-acpx.config.ts extensions/acpx/src/runtime.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts`