### PR TITLE
fix(slack): honor configured ACP bindings

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -20,7 +20,10 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/text-runtime";
 import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
@@ -234,6 +237,46 @@ function parseSlackExplicitTarget(raw: string) {
   };
 }
 
+function normalizeSlackAcpConversationId(raw: string | undefined | null) {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = parseSlackTarget(trimmed, { defaultKind: "channel" });
+  const candidate =
+    parsed?.id ?? trimmed.replace(/^slack:/i, "").replace(/^(?:channel|group|direct|user):/i, "");
+  const conversationId = normalizeLowercaseStringOrEmpty(candidate);
+  return conversationId ? { conversationId } : null;
+}
+
+function matchSlackAcpConversation(params: {
+  bindingConversationId: string;
+  conversationId: string;
+  parentConversationId?: string;
+}) {
+  const bindingConversationId = normalizeSlackAcpConversationId(
+    params.bindingConversationId,
+  )?.conversationId;
+  const conversationId = normalizeSlackAcpConversationId(params.conversationId)?.conversationId;
+  const parentConversationId = normalizeSlackAcpConversationId(
+    params.parentConversationId,
+  )?.conversationId;
+  if (!bindingConversationId || !conversationId) {
+    return null;
+  }
+  if (bindingConversationId === conversationId) {
+    return { conversationId, matchPriority: 2 };
+  }
+  if (
+    parentConversationId &&
+    parentConversationId !== conversationId &&
+    bindingConversationId === parentConversationId
+  ) {
+    return { conversationId: parentConversationId, matchPriority: 1 };
+  }
+  return null;
+}
+
 function buildSlackBaseSessionKey(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -381,6 +424,16 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
     groups: {
       resolveRequireMention: resolveSlackGroupRequireMention,
       resolveToolPolicy: resolveSlackGroupToolPolicy,
+    },
+    bindings: {
+      compileConfiguredBinding: ({ conversationId }) =>
+        normalizeSlackAcpConversationId(conversationId),
+      matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) =>
+        matchSlackAcpConversation({
+          bindingConversationId: compiledBinding.conversationId,
+          conversationId,
+          parentConversationId,
+        }),
     },
     messaging: {
       normalizeTarget: normalizeSlackMessagingTarget,

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import {
+  resolveConfiguredBindingRoute,
   resolveRuntimeConversationBindingRoute,
+  type ConfiguredBindingRouteResult,
   type RuntimeConversationBindingRouteResult,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -21,6 +23,8 @@ export type SlackRoutingContext = {
   route: ReturnType<typeof resolveAgentRoute>;
   runtimeBinding: RuntimeConversationBindingRouteResult["bindingRecord"];
   runtimeBoundSessionKey: string | undefined;
+  configuredBinding: ConfiguredBindingRouteResult["bindingResolution"];
+  configuredBindingSessionKey: string;
   chatType: "direct" | "group" | "channel";
   replyToMode: ReturnType<typeof resolveSlackReplyToMode>;
   threadContext: ReturnType<typeof resolveSlackThreadContext>;
@@ -140,14 +144,33 @@ export function resolveSlackRoutingContext(params: {
             conversationId: baseConversationId,
           },
         });
-  route = runtimeRoute.route;
-  const threadKeys = runtimeRoute.boundSessionKey
-    ? { sessionKey: route.sessionKey, parentSessionKey: undefined }
-    : resolveThreadSessionKeys({
-        baseSessionKey: route.sessionKey,
-        threadId: routedThreadId,
-        parentSessionKey: routedThreadId && ctx.threadInheritParent ? route.sessionKey : undefined,
-      });
+  let configuredBinding: ConfiguredBindingRouteResult["bindingResolution"] = null;
+  let configuredBindingSessionKey = "";
+  if (runtimeRoute.boundSessionKey || runtimeRoute.bindingRecord) {
+    route = runtimeRoute.route;
+  } else {
+    const configuredRoute = resolveConfiguredBindingRoute({
+      cfg: ctx.cfg,
+      route,
+      conversation: {
+        channel: "slack",
+        accountId: account.accountId,
+        conversationId: baseConversationId,
+      },
+    });
+    configuredBinding = configuredRoute.bindingResolution;
+    configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
+    route = configuredRoute.route;
+  }
+  const threadKeys =
+    runtimeRoute.boundSessionKey || configuredBindingSessionKey
+      ? { sessionKey: route.sessionKey, parentSessionKey: undefined }
+      : resolveThreadSessionKeys({
+          baseSessionKey: route.sessionKey,
+          threadId: routedThreadId,
+          parentSessionKey:
+            routedThreadId && ctx.threadInheritParent ? route.sessionKey : undefined,
+        });
   const sessionKey = threadKeys.sessionKey;
   const historyKey =
     isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
@@ -156,6 +179,8 @@ export function resolveSlackRoutingContext(params: {
     route,
     runtimeBinding: runtimeRoute.bindingRecord,
     runtimeBoundSessionKey: runtimeRoute.boundSessionKey,
+    configuredBinding,
+    configuredBindingSessionKey,
     chatType,
     replyToMode,
     threadContext,

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -1,5 +1,18 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveConfiguredBindingRouteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/conversation-runtime")>(
+    "openclaw/plugin-sdk/conversation-runtime",
+  );
+  return {
+    ...actual,
+    resolveConfiguredBindingRoute: (...args: unknown[]) =>
+      resolveConfiguredBindingRouteMock(...args),
+  };
+});
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { resolveSlackRoutingContext, type SlackRoutingContextDeps } from "./prepare-routing.js";
@@ -42,6 +55,131 @@ function buildChannelMessage(overrides?: Partial<SlackMessageEvent>): SlackMessa
 }
 
 describe("thread-level session keys", () => {
+  beforeEach(() => {
+    resolveConfiguredBindingRouteMock.mockReset();
+    resolveConfiguredBindingRouteMock.mockImplementation(({ route }) => ({
+      bindingResolution: null,
+      route,
+    }));
+  });
+
+  it("routes configured ACP bindings for top-level Slack channels", () => {
+    const ctx = buildCtx({ replyToMode: "off" });
+    const account = buildAccount("off");
+    const targetSessionKey = "agent:codex:acp:binding:slack:default:c123";
+    resolveConfiguredBindingRouteMock.mockImplementation(({ route, conversation }) => ({
+      bindingResolution: {
+        conversation,
+        record: {
+          bindingId: "config:acp:slack:default:c123",
+          targetSessionKey,
+          targetKind: "session",
+          conversation: {
+            channel: "slack",
+            accountId: "default",
+            conversationId: "c123",
+          },
+          status: "active",
+          boundAt: 0,
+          metadata: {
+            source: "config",
+            mode: "persistent",
+            agentId: "codex",
+          },
+        },
+      },
+      boundSessionKey: targetSessionKey,
+      boundAgentId: "codex",
+      route: {
+        ...route,
+        agentId: "codex",
+        sessionKey: targetSessionKey,
+        mainSessionKey: "agent:codex:main",
+        matchedBy: "binding.channel",
+        lastRoutePolicy: "bound",
+      },
+    }));
+
+    const routing = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: buildChannelMessage({ channel: "C123" }),
+      isDirectMessage: false,
+      isGroupDm: false,
+      isRoom: true,
+      isRoomish: true,
+    });
+
+    expect(resolveConfiguredBindingRouteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation: {
+          channel: "slack",
+          accountId: "default",
+          conversationId: "C123",
+        },
+      }),
+    );
+    expect(routing.route.agentId).toBe("codex");
+    expect(routing.sessionKey).toBe(targetSessionKey);
+    expect(routing.configuredBindingSessionKey).toBe(targetSessionKey);
+    expect(routing.runtimeBinding).toBeNull();
+  });
+
+  it("does not append Slack thread suffixes to configured ACP binding sessions", () => {
+    const ctx = buildCtx({ replyToMode: "all" });
+    const account = buildAccount("all");
+    const targetSessionKey = "agent:codex:acp:binding:slack:default:c123";
+    resolveConfiguredBindingRouteMock.mockImplementation(({ route, conversation }) => ({
+      bindingResolution: {
+        conversation,
+        record: {
+          bindingId: "config:acp:slack:default:c123",
+          targetSessionKey,
+          targetKind: "session",
+          conversation: {
+            channel: "slack",
+            accountId: "default",
+            conversationId: "c123",
+          },
+          status: "active",
+          boundAt: 0,
+          metadata: {
+            source: "config",
+            mode: "persistent",
+            agentId: "codex",
+          },
+        },
+      },
+      boundSessionKey: targetSessionKey,
+      boundAgentId: "codex",
+      route: {
+        ...route,
+        agentId: "codex",
+        sessionKey: targetSessionKey,
+        mainSessionKey: "agent:codex:main",
+        matchedBy: "binding.channel",
+        lastRoutePolicy: "bound",
+      },
+    }));
+
+    const routing = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: buildChannelMessage({
+        channel: "C123",
+        ts: "1770408522.168859",
+        thread_ts: "1770408518.451689",
+      }),
+      isDirectMessage: false,
+      isGroupDm: false,
+      isRoom: true,
+      isRoomish: true,
+    });
+
+    expect(routing.sessionKey).toBe(targetSessionKey);
+    expect(routing.sessionKey).not.toContain(":thread:");
+  });
+
   it("keeps top-level channel turns in one session when replyToMode=off", () => {
     const ctx = buildCtx({ replyToMode: "off" });
     const account = buildAccount("off");

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -15,6 +15,7 @@ import {
 import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-gating";
 import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-surface";
+import { ensureConfiguredBindingRouteReady } from "openclaw/plugin-sdk/conversation-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import {
@@ -339,6 +340,8 @@ export async function prepareSlackMessage(params: {
   const {
     route,
     runtimeBinding,
+    configuredBinding,
+    configuredBindingSessionKey,
     replyToMode,
     threadContext,
     threadTs,
@@ -351,6 +354,30 @@ export async function prepareSlackMessage(params: {
     logVerbose(
       `slack: routed via bound conversation ${runtimeBinding.conversation.conversationId} -> ${runtimeBinding.targetSessionKey}`,
     );
+  }
+  if (configuredBinding) {
+    const ensured = await ensureConfiguredBindingRouteReady({
+      cfg,
+      bindingResolution: configuredBinding,
+    });
+    if (ensured.ok) {
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `slack: using configured ACP binding for ${configuredBinding.record.conversation.conversationId} -> ${configuredBindingSessionKey}`,
+        );
+      }
+    } else {
+      logVerbose(
+        `slack: configured ACP binding unavailable for ${configuredBinding.record.conversation.conversationId}: ${ensured.error}`,
+      );
+      logInboundDrop({
+        log: logVerbose,
+        channel: "slack",
+        reason: "configured ACP binding unavailable",
+        target: configuredBinding.record.conversation.conversationId,
+      });
+      return null;
+    }
   }
   const implicitMentionKinds =
     isDirectMessage || !ctx.botUserId || !message.thread_ts


### PR DESCRIPTION
## Summary
- register Slack as a configured binding provider so `bindings[].type = "acp"` can match Slack conversations
- route Slack inbound messages through configured ACP bindings when no runtime conversation binding is active
- ensure configured ACP targets are ready before dispatching, and drop instead of silently falling back to `main` when unavailable
- keep configured ACP sessions unsuffixed by Slack thread ids so persistent channel bindings stay pinned to the ACP session

## Testing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts`
- `pnpm lint:extensions -- --quiet`

## Notes
- `pnpm check:test-types` currently fails on pre-existing non-Slack `RuntimeEnv` / `OutputRuntimeEnv` constraint errors in Discord/Feishu tests.
