### PR TITLE
fix(signal): keep idle SSE monitor open [AI-assisted]

### DIFF
--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -230,6 +230,24 @@ describe("streamSignalEvents", () => {
     ).rejects.toThrow("Signal SSE connection timed out after 25ms");
   });
 
+  it("allows idle event streams to wait for abort when the deadline is disabled", async () => {
+    const baseUrl = await withSignalServer(() => {
+      // Leave the request open without response headers, matching idle signal-cli behavior.
+    });
+    const abortController = new AbortController();
+    const abortTimer = setTimeout(() => abortController.abort(), 25);
+    abortTimer.unref?.();
+
+    await expect(
+      streamSignalEvents({
+        baseUrl,
+        timeoutMs: 0,
+        abortSignal: abortController.signal,
+        onEvent: () => {},
+      }),
+    ).rejects.toMatchObject({ name: "AbortError", message: "Signal SSE aborted" });
+  });
+
   it("rejects oversized SSE line buffers by byte size", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "text/event-stream" });

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -45,6 +45,13 @@ function createSignalSseAbortError(): Error {
   return error;
 }
 
+function normalizeSignalSseTimeoutMs(timeoutMs: number): number | null {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return null;
+  }
+  return timeoutMs;
+}
+
 function normalizeBaseUrl(url: string): string {
   const trimmed = url.trim();
   if (!trimmed) {
@@ -248,15 +255,23 @@ function openSignalEventStream(
     let response: IncomingMessage | undefined;
     let onAbort: () => void = () => {};
     let request: ClientRequest;
-    const headerDeadline = setTimeout(() => {
-      const error = new Error(`Signal SSE connection timed out after ${timeoutMs}ms`);
-      response?.destroy(error);
-      request.destroy(error);
-      rejectOnce(error);
-    }, timeoutMs);
-    headerDeadline.unref?.();
+    const effectiveTimeoutMs = normalizeSignalSseTimeoutMs(timeoutMs);
+    const headerDeadline =
+      effectiveTimeoutMs === null
+        ? undefined
+        : setTimeout(() => {
+            const error = new Error(
+              `Signal SSE connection timed out after ${effectiveTimeoutMs}ms`,
+            );
+            response?.destroy(error);
+            request.destroy(error);
+            rejectOnce(error);
+          }, effectiveTimeoutMs);
+    headerDeadline?.unref?.();
     const cleanup = () => {
-      clearTimeout(headerDeadline);
+      if (headerDeadline) {
+        clearTimeout(headerDeadline);
+      }
       abortSignal?.removeEventListener("abort", onAbort);
     };
     const rejectOnce = (error: unknown) => {
@@ -284,7 +299,9 @@ function openSignalEventStream(
           res.destroy();
           return;
         }
-        clearTimeout(headerDeadline);
+        if (headerDeadline) {
+          clearTimeout(headerDeadline);
+        }
         settled = true;
         response = res;
         resolve({ response: res, cleanup });

--- a/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
+++ b/extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
@@ -109,6 +109,8 @@ describe("monitorSignalProvider tool results", () => {
       await monitorPromise;
 
       expect(streamMock).toHaveBeenCalledTimes(2);
+      expect(streamMock.mock.calls[0]?.[0]).toMatchObject({ timeoutMs: 0 });
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject({ timeoutMs: 0 });
     } finally {
       randomSpy.mockRestore();
       vi.useRealTimers();

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -489,6 +489,8 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       account,
       abortSignal: daemonLifecycle.abortSignal,
       runtime,
+      // signal-cli can keep the SSE event endpoint idle until the next inbound event.
+      timeoutMs: 0,
       policy: opts.reconnectPolicy,
       onEvent: (event) => {
         void handleEvent(event).catch((err) => {

--- a/extensions/signal/src/sse-reconnect.ts
+++ b/extensions/signal/src/sse-reconnect.ts
@@ -21,6 +21,7 @@ type RunSignalSseLoopParams = {
   abortSignal?: AbortSignal;
   runtime: RuntimeEnv;
   onEvent: (event: SignalSseEvent) => void;
+  timeoutMs?: number;
   policy?: Partial<BackoffPolicy>;
 };
 
@@ -30,6 +31,7 @@ export async function runSignalSseLoop({
   abortSignal,
   runtime,
   onEvent,
+  timeoutMs,
   policy,
 }: RunSignalSseLoopParams) {
   const reconnectPolicy = {
@@ -54,6 +56,7 @@ export async function runSignalSseLoop({
         baseUrl,
         account,
         abortSignal,
+        timeoutMs,
         onEvent: (event) => {
           reconnectAttempts = 0;
           onEvent(event);


### PR DESCRIPTION
## Summary

AI-assisted patch, human-reviewed and locally validated on the targeted Signal lanes.

- Problem: the native Signal `signal-cli` SSE event stream can remain healthy while idle, but OpenClaw applied the generic 10s HTTP response deadline to the long-lived `/api/v1/events` stream.
- Why it matters: a healthy but quiet Signal daemon could produce repeated `Signal SSE connection timed out after 10000ms` errors and reconnect churn instead of waiting for the next inbound event.
- What changed: `streamSignalEvents` now accepts an optional timeout, the low-level SSE opener treats `timeoutMs <= 0` as "no header deadline", and the monitor opens the long-lived event stream with `timeoutMs: 0`.
- What did NOT change (scope boundary): Signal send/RPC deadlines, health-check deadlines, reconnect/backoff behavior, access-control logic, and non-Signal integrations are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related #16085
- [x] This PR fixes a bug or regression

Duplicate check: I searched open PRs for the exact Signal SSE timeout text, `openSignalEventStream`, `keep idle SSE`, and `Signal SSE connection lost`. I did not find an existing open PR for this idle native SSE timeout. #16085 is adjacent Signal transport work, but does not address the native idle `/api/v1/events` timeout.

## Root Cause (if applicable)

- Root cause: the native Signal event stream is a long-lived SSE connection, but the client reused the generic `SIGNAL_HTTP_TIMEOUT_MS` deadline that is appropriate for bounded RPC/check requests.
- Missing detection / guardrail: Signal client tests covered SSE event parsing and header timeout failures, but not the valid case where headers arrive and then the stream remains idle until abort.
- Contributing context (if known): this was observed on a live native Signal setup where OpenClaw repeatedly logged the 10s SSE timeout even though the Signal daemon was still reachable.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/signal/src/client.test.ts`
- Scenario the test should lock in: an SSE stream that sends headers and then stays idle should remain open when the caller disables the deadline, and should close only when the abort signal fires.
- Why this is the smallest reliable guardrail: it exercises the HTTP/SSE client behavior directly without requiring a live `signal-cli` daemon or external Signal account.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Signal channel monitors no longer reconnect every 10 seconds solely because the native SSE event stream is idle. Quiet-but-healthy Signal event streams remain open until an event, transport error, or abort.

## Diagram (if applicable)

```text
Before:
signal-cli /api/v1/events idle stream -> 10s response deadline -> timeout -> reconnect loop

After:
signal-cli /api/v1/events idle stream -> timeoutMs=0 for monitor SSE -> wait for event/error/abort
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local clean upstream worktree for tests; Linux native Signal deployment for the original runtime symptom
- Runtime/container: Node.js 25.9.0 locally; native `signal-cli` HTTP/SSE deployment for the observed issue
- Model/provider: N/A
- Integration/channel (if any): Signal
- Relevant config (redacted): native Signal HTTP/SSE URL; no secrets included

### Steps

1. Start a Signal SSE endpoint that accepts `/api/v1/events`, sends response headers, and then remains idle without sending event frames.
2. Open the Signal monitor event stream.
3. Wait longer than 10 seconds.
4. Abort the monitor stream.

### Expected

- The idle stream remains open past 10 seconds when the monitor disables the SSE header/body deadline.
- The stream exits on abort, stream error, or explicit connection close.

### Actual

- Before this patch, the monitor treated the healthy idle stream as `Signal SSE connection timed out after 10000ms` and entered reconnect churn.
- After this patch, the new unit test verifies that an idle SSE stream waits for abort when the deadline is disabled.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Relevant pre-fix runtime log observed on the native deployment:

```text
Signal SSE stream error: Error: Signal SSE connection timed out after 10000ms
```

Local validation from this clean branch:

```text
pnpm test extensions/signal/src/client.test.ts extensions/signal/src/monitor.tool-result.pairs-uuid-only-senders-uuid-allowlist-entry.test.ts
# passed: 2 test files, 16 tests

pnpm test:extension signal
# passed: 22 test files, 185 tests

pnpm check:changed
# passed: extension typecheck, extension test typecheck, extension lint, import-cycle guard, conflict-marker guard

pnpm check
# passed

pnpm build
# passed after allowing the runtime-postbuild nested install path to complete
```

Full-suite note:

```text
pnpm test
# targeted Signal shard passed during the full run, but the complete high-parallel local suite failed after one Vitest worker hit ERR_WORKER_OUT_OF_MEMORY.

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test
# attempted using the documented low-memory setting; the local run was stopped after no-output watchdog timeouts on broad runtime/agentic shards.
```

I also reran the likely OOM shard in isolation:

```text
pnpm test test/vitest/vitest.wizard.config.ts
# passed: 6 test files, 52 tests
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: the Signal SSE client keeps an idle response stream open when `timeoutMs: 0`; timeout behavior still rejects streams that do not send headers before the default deadline; the monitor passes `timeoutMs: 0` only for the long-lived Signal event stream.
- Edge cases checked: malformed RPC JSON, oversized RPC responses, Signal check failures, SSE HTTP status failures, missing headers, idle stream abort, oversized SSE buffers/events, monitor sender allowlist handling.
- What you did **not** verify: a complete local full-suite pass; the broad suite hit local resource/no-output limits as noted above. I did not verify a maintainer CI environment or a live external Signal account in this upstream worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: disabling the monitor SSE deadline could keep a broken-but-not-closed TCP connection around longer than before.
  - Mitigation: this applies only to the long-lived monitor event stream; bounded Signal RPC/check operations keep their deadlines, and the existing reconnect/backoff path still handles stream errors, closes, and aborts.
