### PR TITLE
Clear Codex app-server env keys case-insensitively on Windows

### DIFF
--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -112,6 +112,28 @@ describe("resolveCodexAppServerSpawnEnv", () => {
     });
   });
 
+  it("clears denied env vars case-insensitively on Windows", () => {
+    expect({
+      ...resolveCodexAppServerSpawnEnv(
+        {
+          env: {
+            OpenAI_Api_Key: "configured-openai-key",
+            Other: "configured",
+          },
+          clearEnv: ["OPENAI_API_KEY", " CODEX_API_KEY ", ""],
+        },
+        {
+          Codex_Api_Key: "parent-codex-key",
+          KEEP: "parent",
+        },
+        "win32",
+      ),
+    }).toEqual({
+      KEEP: "parent",
+      Other: "configured",
+    });
+  });
+
   it("uses a null-prototype env map and ignores prototype-polluting keys", () => {
     const overrides = Object.create(null) as Record<string, string | undefined>;
     Object.defineProperty(overrides, "__proto__", {

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -46,14 +46,36 @@ export function resolveCodexAppServerSpawnInvocation(
 export function resolveCodexAppServerSpawnEnv(
   options: Pick<CodexAppServerStartOptions, "env" | "clearEnv">,
   baseEnv: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
 ): NodeJS.ProcessEnv {
   const env = Object.create(null) as NodeJS.ProcessEnv;
   copySafeEnvironmentEntries(env, baseEnv);
   copySafeEnvironmentEntries(env, options.env ?? {});
   for (const key of options.clearEnv ?? []) {
-    delete env[key];
+    deleteEnvironmentEntry(env, key, platform);
   }
   return env;
+}
+
+function deleteEnvironmentEntry(
+  env: NodeJS.ProcessEnv,
+  rawKey: string,
+  platform: NodeJS.Platform,
+): void {
+  const key = rawKey.trim();
+  if (key.length === 0) {
+    return;
+  }
+  if (platform === "win32") {
+    const target = key.toLowerCase();
+    for (const candidate of Object.keys(env)) {
+      if (candidate.toLowerCase() === target) {
+        delete env[candidate];
+      }
+    }
+    return;
+  }
+  delete env[key];
 }
 
 function copySafeEnvironmentEntries(

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -51,31 +51,31 @@ export function resolveCodexAppServerSpawnEnv(
   const env = Object.create(null) as NodeJS.ProcessEnv;
   copySafeEnvironmentEntries(env, baseEnv);
   copySafeEnvironmentEntries(env, options.env ?? {});
-  for (const key of options.clearEnv ?? []) {
-    deleteEnvironmentEntry(env, key, platform);
+  const keysToClear = normalizedEnvironmentKeys(options.clearEnv ?? []);
+  if (platform === "win32") {
+    const lowerCaseKeysToClear = new Set(keysToClear.map((key) => key.toLowerCase()));
+    for (const candidate of Object.keys(env)) {
+      if (lowerCaseKeysToClear.has(candidate.toLowerCase())) {
+        delete env[candidate];
+      }
+    }
+  } else {
+    for (const key of keysToClear) {
+      delete env[key];
+    }
   }
   return env;
 }
 
-function deleteEnvironmentEntry(
-  env: NodeJS.ProcessEnv,
-  rawKey: string,
-  platform: NodeJS.Platform,
-): void {
-  const key = rawKey.trim();
-  if (key.length === 0) {
-    return;
-  }
-  if (platform === "win32") {
-    const target = key.toLowerCase();
-    for (const candidate of Object.keys(env)) {
-      if (candidate.toLowerCase() === target) {
-        delete env[candidate];
-      }
+function normalizedEnvironmentKeys(rawKeys: readonly string[]): string[] {
+  const keys: string[] = [];
+  for (const rawKey of rawKeys) {
+    const key = rawKey.trim();
+    if (key.length > 0) {
+      keys.push(key);
     }
-    return;
   }
-  delete env[key];
+  return keys;
 }
 
 function copySafeEnvironmentEntries(


### PR DESCRIPTION
Follow-up to #73063.

That PR fixed the main Codex subscription-auth path, but Aisle caught one Windows-specific edge after it landed. Windows treats environment variable names case-insensitively, while the new `clearEnv` handling deleted only exact key matches. A parent process with `OpenAI_Api_Key` or `Codex_Api_Key` could therefore still pass a key into the Codex app-server child even when OpenClaw asked to clear `OPENAI_API_KEY` or `CODEX_API_KEY`.

This keeps the Unix behavior straightforward, but makes the stdio spawn env cleaner platform-aware. On Windows, OpenClaw now removes every env entry whose name matches a cleared key case-insensitively. It also trims clear-list entries and ignores empty strings so direct internal callers get the same safe behavior as normalized plugin config.

The new transport test covers the exact bypass shape: mixed-case OpenAI and Codex keys from both inherited env and configured overrides are removed under `win32`, while unrelated env values survive.
