### PR TITLE
Fix web_fetch legacy charset decoding

### DIFF
--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -94,6 +94,64 @@ export type ReadResponseTextResult = {
   bytesRead: number;
 };
 
+const HTML_META_CHARSET_SCAN_BYTES = 4096;
+
+function normalizeCharset(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/^['"]|['"]$/g, "");
+  return trimmed || undefined;
+}
+
+function charsetFromContentType(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const match = /(?:^|;)\s*charset\s*=\s*([^;]+)/i.exec(value);
+  return normalizeCharset(match?.[1]);
+}
+
+function charsetFromHtmlMeta(bytes: Uint8Array): string | undefined {
+  const head = bytes.subarray(0, Math.min(bytes.byteLength, HTML_META_CHARSET_SCAN_BYTES));
+  // HTML declarations are ASCII-compatible even when the document body uses a
+  // legacy charset, so this bounded latin1 pass is only for sniffing metadata.
+  const sample = new TextDecoder("latin1").decode(head);
+  return (
+    normalizeCharset(/<meta\s+[^>]*charset\s*=\s*['"]?\s*([^\s'"/>;]+)/i.exec(sample)?.[1]) ??
+    normalizeCharset(
+      /<meta\s+[^>]*http-equiv\s*=\s*['"]?content-type['"]?[^>]*content\s*=\s*['"][^'"]*charset\s*=\s*([^\s'"/>;]+)/i.exec(
+        sample,
+      )?.[1],
+    ) ??
+    normalizeCharset(
+      /<meta\s+[^>]*content\s*=\s*['"][^'"]*charset\s*=\s*([^\s'"/>;]+)[^'"]*['"][^>]*http-equiv\s*=\s*['"]?content-type['"]?/i.exec(
+        sample,
+      )?.[1],
+    )
+  );
+}
+
+function decodeResponseBytes(res: Response, bytes: Uint8Array): string {
+  const charset =
+    charsetFromContentType(res.headers.get("content-type")) ?? charsetFromHtmlMeta(bytes);
+  try {
+    return new TextDecoder(charset ?? "utf-8").decode(bytes);
+  } catch {
+    return new TextDecoder("utf-8").decode(bytes);
+  }
+}
+
+function concatBytes(parts: Uint8Array[], totalBytes: number): Uint8Array {
+  if (parts.length === 1 && parts[0]?.byteLength === totalBytes) {
+    return parts[0];
+  }
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const part of parts) {
+    bytes.set(part, offset);
+    offset += part.byteLength;
+  }
+  return bytes;
+}
+
 export async function readResponseText(
   res: Response,
   options?: { maxBytes?: number },
@@ -113,10 +171,9 @@ export async function readResponseText(
     typeof (body as { getReader: () => unknown }).getReader === "function"
   ) {
     const reader = (body as ReadableStream<Uint8Array>).getReader();
-    const decoder = new TextDecoder();
     let bytesRead = 0;
     let truncated = false;
-    const parts: string[] = [];
+    const parts: Uint8Array[] = [];
 
     try {
       while (true) {
@@ -140,7 +197,7 @@ export async function readResponseText(
         }
 
         bytesRead += chunk.byteLength;
-        parts.push(decoder.decode(chunk, { stream: true }));
+        parts.push(chunk);
 
         if (truncated || bytesRead >= maxBytes) {
           truncated = true;
@@ -148,7 +205,7 @@ export async function readResponseText(
         }
       }
     } catch {
-      // Best-effort: return whatever we decoded so far.
+      // Best-effort: return whatever we read so far.
     } finally {
       if (truncated) {
         // Some mocked or non-compliant streams never settle cancel(); do not
@@ -157,14 +214,20 @@ export async function readResponseText(
       }
     }
 
-    parts.push(decoder.decode());
-    return { text: parts.join(""), truncated, bytesRead };
+    const bytes = concatBytes(parts, bytesRead);
+    return { text: decodeResponseBytes(res, bytes), truncated, bytesRead };
   }
 
   try {
-    const text = await res.text();
-    return { text, truncated: false, bytesRead: text.length };
+    const arrayBuffer = await res.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+    return { text: decodeResponseBytes(res, bytes), truncated: false, bytesRead: bytes.byteLength };
   } catch {
-    return { text: "", truncated: false, bytesRead: 0 };
+    try {
+      const text = await res.text();
+      return { text, truncated: false, bytesRead: text.length };
+    } catch {
+      return { text: "", truncated: false, bytesRead: 0 };
+    }
   }
 }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -115,6 +115,8 @@ function charsetFromHtmlMeta(bytes: Uint8Array): string | undefined {
   // legacy charset, so this bounded latin1 pass is only for sniffing metadata.
   const sample = new TextDecoder("latin1").decode(head);
   return (
+    // Regex sniffing is intentionally heuristic: this mirrors browser-style
+    // early metadata detection without attempting full HTML parsing.
     normalizeCharset(/<meta\s+[^>]*charset\s*=\s*['"]?\s*([^\s'"/>;]+)/i.exec(sample)?.[1]) ??
     normalizeCharset(
       /<meta\s+[^>]*http-equiv\s*=\s*['"]?content-type['"]?[^>]*content\s*=\s*['"][^'"]*charset\s*=\s*([^\s'"/>;]+)/i.exec(
@@ -130,8 +132,10 @@ function charsetFromHtmlMeta(bytes: Uint8Array): string | undefined {
 }
 
 function decodeResponseBytes(res: Response, bytes: Uint8Array): string {
+  const contentType = res.headers.get("content-type") ?? "";
   const charset =
-    charsetFromContentType(res.headers.get("content-type")) ?? charsetFromHtmlMeta(bytes);
+    charsetFromContentType(contentType) ??
+    (/\btext\/html\b/i.test(contentType) ? charsetFromHtmlMeta(bytes) : undefined);
   try {
     return new TextDecoder(charset ?? "utf-8").decode(bytes);
   } catch {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -231,6 +231,64 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details.truncated).toBe(true);
   });
 
+  it("decodes response bytes with a charset declared in Content-Type", async () => {
+    const bytes = new Uint8Array([0x63, 0x61, 0x66, 0xe9]);
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        new Response(bytes, {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=iso-8859-1" },
+        }),
+      ).then((response) => {
+        Object.defineProperty(response, "url", { value: resolveRequestUrl(input) });
+        return response;
+      }),
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await executeFetch(tool, {
+      url: "https://example.com/latin1",
+      extractMode: "text",
+    });
+    const details = result?.details as { text?: string };
+
+    expect(details.text).toContain("café");
+    expect(details.text).not.toContain("caf�");
+  });
+
+  it("sniffs a bounded HTML meta charset before decoding", async () => {
+    const htmlBytes = new Uint8Array([
+      ...new TextEncoder().encode(
+        '<!doctype html><html><head><meta charset="iso-8859-1"><title>Caf',
+      ),
+      0xe9,
+      ...new TextEncoder().encode("</title></head><body><p>Caf"),
+      0xe9,
+      ...new TextEncoder().encode(" body</p></body></html>"),
+    ]);
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        new Response(htmlBytes, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+      ).then((response) => {
+        Object.defineProperty(response, "url", { value: resolveRequestUrl(input) });
+        return response;
+      }),
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await executeFetch(tool, {
+      url: "https://example.com/meta-latin1",
+      extractMode: "text",
+    });
+    const details = result?.details as { text?: string; title?: string };
+
+    expect(`${details.title ?? ""}\n${details.text ?? ""}`).toContain("Café");
+    expect(`${details.title ?? ""}\n${details.text ?? ""}`).not.toContain("Caf�");
+  });
+
   it("caps response bytes and does not hang on endless streams", async () => {
     const chunk = new TextEncoder().encode("<html><body><div>hi</div></body></html>");
     const stream = new ReadableStream<Uint8Array>({


### PR DESCRIPTION
## Summary
- Decode `web_fetch` responses from raw bytes with charset detection from `Content-Type`
- Sniff a bounded first 4KB HTML meta charset before falling back to UTF-8
- Keep bounded response reads by accumulating capped bytes before decoding
- Add regressions for ISO-8859-1 via `Content-Type` and HTML `<meta charset>`

Fixes #72916.

## Validation
- `pnpm exec oxfmt --write --threads=1 src/agents/tools/web-shared.ts src/agents/tools/web-tools.fetch.test.ts`
- `pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/tools/web-tools.fetch.test.ts` (16 tests passed)
- `pnpm exec tsgo --ignoreConfig --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck src/agents/tools/web-shared.ts`

Note: full `pnpm exec tsgo -p tsconfig.core.test.json --noEmit --pretty false` currently fails on upstream `src/plugins/contracts/host-hooks.contract.test.ts` missing `../../../test/helpers/plugins/contracts-testkit.js` plus implicit-any errors; unrelated to this scoped change.
