### PR TITLE
fix(agents): emit fallback terminal lifecycle on subscription teardown

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -192,12 +192,11 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
     return undefined;
   };
 
-  let lifecycleTerminalEmitted = false;
   const emitLifecycleTerminalOnce = (): void | Promise<void> => {
-    if (lifecycleTerminalEmitted) {
+    if (ctx.state.lifecycleTerminalEmitted) {
       return;
     }
-    lifecycleTerminalEmitted = true;
+    ctx.state.lifecycleTerminalEmitted = true;
     let beforeLifecycleTerminal: void | Promise<void> = undefined;
     try {
       beforeLifecycleTerminal = ctx.params.onBeforeLifecycleTerminal?.();
@@ -248,4 +247,88 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
   }
 
   return emitLifecycleTerminalOnce();
+}
+
+/**
+ * Emit a synthetic terminal lifecycle event during teardown when the underlying
+ * pi-agent never delivered `agent_end` to this subscription. Without this, the
+ * fire-and-forget `activeSession.abort()` in the embedded runner can race past
+ * the subscription's listener removal, leaving Control UI runs stuck on Stop.
+ * Idempotent with `handleAgentEnd` via the shared `lifecycleTerminalEmitted` flag.
+ */
+export function emitFallbackTerminalLifecycle(ctx: EmbeddedPiSubscribeContext): void {
+  if (ctx.state.lifecycleTerminalEmitted) {
+    return;
+  }
+  ctx.state.lifecycleTerminalEmitted = true;
+
+  const lastAssistant = ctx.state.lastAssistant;
+  const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
+  const replayInvalid = true;
+  const livenessState =
+    ctx.state.livenessState && ctx.state.livenessState !== "working"
+      ? ctx.state.livenessState
+      : isError
+        ? "blocked"
+        : "abandoned";
+
+  let errorText: string | undefined;
+  if (isError && lastAssistant) {
+    const friendlyError = formatAssistantErrorText(lastAssistant, {
+      cfg: ctx.params.config,
+      sessionKey: ctx.params.sessionKey,
+      provider: lastAssistant.provider,
+      model: lastAssistant.model,
+    });
+    errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+  }
+
+  try {
+    const beforeResult = ctx.params.onBeforeLifecycleTerminal?.();
+    if (isPromiseLike<void>(beforeResult)) {
+      void Promise.resolve(beforeResult).catch((err) => {
+        ctx.log.debug(`fallback before lifecycle terminal failed: ${String(err)}`);
+      });
+    }
+  } catch (err) {
+    ctx.log.debug(`fallback before lifecycle terminal failed: ${String(err)}`);
+  }
+
+  const phase = isError ? "error" : "end";
+  const data = {
+    phase,
+    ...(errorText ? { error: errorText } : {}),
+    livenessState,
+    replayInvalid,
+    endedAt: Date.now(),
+  };
+
+  try {
+    emitAgentEvent({
+      runId: ctx.params.runId,
+      stream: "lifecycle",
+      data,
+    });
+  } catch (err) {
+    ctx.log.warn(`fallback lifecycle terminal emit failed: ${String(err)}`);
+  }
+
+  try {
+    const onAgentEventResult = ctx.params.onAgentEvent?.({
+      stream: "lifecycle",
+      data: {
+        phase,
+        ...(errorText ? { error: errorText } : {}),
+        livenessState,
+        replayInvalid,
+      },
+    });
+    if (isPromiseLike<void>(onAgentEventResult)) {
+      void Promise.resolve(onAgentEventResult).catch((err) => {
+        ctx.log.warn(`fallback onAgentEvent rejected: ${String(err)}`);
+      });
+    }
+  } catch (err) {
+    ctx.log.warn(`fallback onAgentEvent threw: ${String(err)}`);
+  }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -256,7 +256,9 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
  * the subscription's listener removal, leaving Control UI runs stuck on Stop.
  * Idempotent with `handleAgentEnd` via the shared `lifecycleTerminalEmitted` flag.
  */
-export function emitFallbackTerminalLifecycle(ctx: EmbeddedPiSubscribeContext): void {
+export function emitFallbackTerminalLifecycle(
+  ctx: EmbeddedPiSubscribeContext,
+): void | Promise<void> {
   if (ctx.state.lifecycleTerminalEmitted) {
     return;
   }
@@ -287,52 +289,62 @@ export function emitFallbackTerminalLifecycle(ctx: EmbeddedPiSubscribeContext): 
       "LLM request failed.";
   }
 
-  try {
-    const beforeResult = ctx.params.onBeforeLifecycleTerminal?.();
-    if (isPromiseLike<void>(beforeResult)) {
-      void Promise.resolve(beforeResult).catch((err) => {
-        ctx.log.debug(`fallback before lifecycle terminal failed: ${String(err)}`);
+  const emitLifecycleTerminal = () => {
+    const phase = isError ? "error" : "end";
+    const data = {
+      phase,
+      ...(errorText ? { error: errorText } : {}),
+      livenessState,
+      replayInvalid,
+      endedAt: Date.now(),
+    };
+
+    try {
+      emitAgentEvent({
+        runId: ctx.params.runId,
+        stream: "lifecycle",
+        data,
       });
+    } catch (err) {
+      ctx.log.warn(`fallback lifecycle terminal emit failed: ${String(err)}`);
     }
+
+    try {
+      const onAgentEventResult = ctx.params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase,
+          ...(errorText ? { error: errorText } : {}),
+          livenessState,
+          replayInvalid,
+        },
+      });
+      if (isPromiseLike<void>(onAgentEventResult)) {
+        void Promise.resolve(onAgentEventResult).catch((err) => {
+          ctx.log.warn(`fallback onAgentEvent rejected: ${String(err)}`);
+        });
+      }
+    } catch (err) {
+      ctx.log.warn(`fallback onAgentEvent threw: ${String(err)}`);
+    }
+  };
+
+  let beforeResult: void | Promise<void> = undefined;
+  try {
+    beforeResult = ctx.params.onBeforeLifecycleTerminal?.();
   } catch (err) {
     ctx.log.debug(`fallback before lifecycle terminal failed: ${String(err)}`);
   }
 
-  const phase = isError ? "error" : "end";
-  const data = {
-    phase,
-    ...(errorText ? { error: errorText } : {}),
-    livenessState,
-    replayInvalid,
-    endedAt: Date.now(),
-  };
-
-  try {
-    emitAgentEvent({
-      runId: ctx.params.runId,
-      stream: "lifecycle",
-      data,
-    });
-  } catch (err) {
-    ctx.log.warn(`fallback lifecycle terminal emit failed: ${String(err)}`);
-  }
-
-  try {
-    const onAgentEventResult = ctx.params.onAgentEvent?.({
-      stream: "lifecycle",
-      data: {
-        phase,
-        ...(errorText ? { error: errorText } : {}),
-        livenessState,
-        replayInvalid,
-      },
-    });
-    if (isPromiseLike<void>(onAgentEventResult)) {
-      void Promise.resolve(onAgentEventResult).catch((err) => {
-        ctx.log.warn(`fallback onAgentEvent rejected: ${String(err)}`);
+  if (isPromiseLike<void>(beforeResult)) {
+    return Promise.resolve(beforeResult)
+      .catch((err) => {
+        ctx.log.debug(`fallback before lifecycle terminal failed: ${String(err)}`);
+      })
+      .then(() => {
+        emitLifecycleTerminal();
       });
-    }
-  } catch (err) {
-    ctx.log.warn(`fallback onAgentEvent threw: ${String(err)}`);
   }
+
+  emitLifecycleTerminal();
 }

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -280,7 +280,11 @@ export function emitFallbackTerminalLifecycle(ctx: EmbeddedPiSubscribeContext): 
       provider: lastAssistant.provider,
       model: lastAssistant.model,
     });
-    errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+    const rawText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+    // Redact via buildTextObservationFields to match handleAgentEnd's emit safety.
+    errorText =
+      buildTextObservationFields(rawText, { provider: lastAssistant.provider }).textPreview ??
+      "LLM request failed.";
   }
 
   try {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -69,6 +69,7 @@ export type EmbeddedPiSubscribeState = {
   compactionRetryReject?: (reason?: unknown) => void;
   compactionRetryPromise: Promise<void> | null;
   unsubscribed: boolean;
+  lifecycleTerminalEmitted: boolean;
   replayState: EmbeddedRunReplayState;
   livenessState?: EmbeddedRunLivenessState;
   hadDeterministicSideEffect?: boolean;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -833,7 +833,14 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // fire-and-forget `activeSession.abort()` path can leave Control UI stuck
     // on Stop because the gateway only finalizes the chat run on phase=end/error.
     // Idempotent with handleAgentEnd via state.lifecycleTerminalEmitted.
-    emitFallbackTerminalLifecycle(ctx);
+    const fallbackLifecycleResult = emitFallbackTerminalLifecycle(ctx);
+    if (isPromiseLike<void>(fallbackLifecycleResult)) {
+      void Promise.resolve(fallbackLifecycleResult).catch((err) => {
+        log.warn(
+          `unsubscribe: fallback lifecycle emit failed runId=${params.runId} err=${String(err)}`,
+        );
+      });
+    }
     // Reject pending compaction wait to unblock awaiting code.
     // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
     if (state.compactionRetryPromise) {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -21,6 +21,7 @@ import {
 } from "./pi-embedded-runner/replay-state.js";
 import type { EmbeddedRunLivenessState } from "./pi-embedded-runner/types.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
+import { emitFallbackTerminalLifecycle } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import {
   consumePendingAssistantReplyDirectivesIntoReply,
   consumePendingToolMediaIntoReply,
@@ -123,6 +124,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     compactionRetryReject: undefined,
     compactionRetryPromise: null,
     unsubscribed: false,
+    lifecycleTerminalEmitted: false,
     replayState: createEmbeddedRunReplayState(params.initialReplayState),
     livenessState: "working",
     hadDeterministicSideEffect: false,
@@ -826,6 +828,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Mark as unsubscribed FIRST to prevent waitForCompactionRetry from creating
     // new un-resolvable promises during teardown.
     state.unsubscribed = true;
+    // Synthesize a terminal lifecycle event when the underlying pi-agent never
+    // delivered `agent_end` — otherwise an embedded run aborted via the
+    // fire-and-forget `activeSession.abort()` path can leave Control UI stuck
+    // on Stop because the gateway only finalizes the chat run on phase=end/error.
+    // Idempotent with handleAgentEnd via state.lifecycleTerminalEmitted.
+    emitFallbackTerminalLifecycle(ctx);
     // Reject pending compaction wait to unblock awaiting code.
     // Don't resolve, as that would incorrectly signal "compaction complete" when it's still in-flight.
     if (state.compactionRetryPromise) {

--- a/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
+++ b/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { createStubSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+}));
+
+const emitAgentEventMock = vi.mocked(emitAgentEvent);
+
+type LifecycleEvent = {
+  stream?: string;
+  runId?: string;
+  data?: { phase?: string; error?: unknown; livenessState?: string; replayInvalid?: boolean };
+};
+
+function emitAgentEventLifecycleCalls(): LifecycleEvent[] {
+  return emitAgentEventMock.mock.calls
+    .map((args) => args[0] as LifecycleEvent)
+    .filter((evt) => evt.stream === "lifecycle");
+}
+
+function onAgentEventLifecycleCalls(fn: ReturnType<typeof vi.fn>): LifecycleEvent[] {
+  return fn.mock.calls
+    .map((args) => args[0] as LifecycleEvent)
+    .filter((evt) => evt.stream === "lifecycle");
+}
+
+describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", () => {
+  beforeEach(() => {
+    emitAgentEventMock.mockClear();
+  });
+
+  it("emits a synthetic phase:end lifecycle event when unsubscribe runs without a prior agent_end", () => {
+    const onAgentEvent = vi.fn();
+    const { session } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-stuck",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    subscription.unsubscribe();
+
+    const lifecycleCalls = emitAgentEventLifecycleCalls();
+    expect(lifecycleCalls).toHaveLength(1);
+    expect(lifecycleCalls[0]).toMatchObject({
+      runId: "run-stuck",
+      stream: "lifecycle",
+      data: { phase: "end", livenessState: "abandoned", replayInvalid: true },
+    });
+
+    const observerCalls = onAgentEventLifecycleCalls(onAgentEvent);
+    expect(observerCalls).toHaveLength(1);
+    expect(observerCalls[0]).toMatchObject({
+      stream: "lifecycle",
+      data: { phase: "end", livenessState: "abandoned", replayInvalid: true },
+    });
+  });
+
+  it("does not emit a fallback when handleAgentEnd already emitted the terminal lifecycle", async () => {
+    const onAgentEvent = vi.fn();
+    const { session, emit } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-clean",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    emit({ type: "agent_start" });
+    emit({ type: "agent_end" });
+    // agent_end handler returns a Promise; let microtasks flush.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    onAgentEvent.mockClear();
+    emitAgentEventMock.mockClear();
+
+    subscription.unsubscribe();
+
+    expect(emitAgentEventLifecycleCalls()).toHaveLength(0);
+    expect(onAgentEventLifecycleCalls(onAgentEvent)).toHaveLength(0);
+  });
+
+  it("calls unsubscribe twice without double-emitting the fallback", () => {
+    const onAgentEvent = vi.fn();
+    const { session } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-double",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    subscription.unsubscribe();
+    subscription.unsubscribe();
+
+    expect(emitAgentEventLifecycleCalls()).toHaveLength(1);
+    expect(onAgentEventLifecycleCalls(onAgentEvent)).toHaveLength(1);
+  });
+
+  it("invokes onBeforeLifecycleTerminal exactly once before the fallback emit", () => {
+    const events: string[] = [];
+    const onBeforeLifecycleTerminal = vi.fn(() => {
+      events.push("before");
+    });
+    const onAgentEvent = vi.fn(() => {
+      events.push("onAgentEvent");
+    });
+    emitAgentEventMock.mockImplementation((evt) => {
+      if (evt.stream === "lifecycle") {
+        events.push("emitAgentEvent");
+      }
+    });
+
+    const { session } = createStubSessionHarness();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-before",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+      onBeforeLifecycleTerminal,
+    });
+
+    subscription.unsubscribe();
+
+    expect(onBeforeLifecycleTerminal).toHaveBeenCalledTimes(1);
+    expect(events.indexOf("before")).toBeLessThan(events.indexOf("emitAgentEvent"));
+    expect(events.indexOf("before")).toBeLessThan(events.indexOf("onAgentEvent"));
+  });
+
+  it("emits phase:error with the recorded error message when lastAssistant.stopReason is error", () => {
+    const onAgentEvent = vi.fn();
+    const { session, emit } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-err",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    // Simulate the underlying session producing an assistant error message
+    // whose terminal `agent_end` event never reaches the subscription.
+    const errorMessage = {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "connection refused",
+      content: [{ type: "text", text: "" }],
+      provider: "openai",
+      model: "gpt-test",
+    };
+    emit({ type: "message_start", message: errorMessage });
+    emit({ type: "message_end", message: errorMessage });
+
+    emitAgentEventMock.mockClear();
+    onAgentEvent.mockClear();
+
+    subscription.unsubscribe();
+
+    const lifecycleCalls = emitAgentEventLifecycleCalls();
+    expect(lifecycleCalls).toHaveLength(1);
+    expect(lifecycleCalls[0]).toMatchObject({
+      runId: "run-err",
+      stream: "lifecycle",
+      data: { phase: "error", livenessState: "blocked" },
+    });
+    expect(typeof lifecycleCalls[0]?.data?.error).toBe("string");
+    expect((lifecycleCalls[0]?.data?.error as string).length).toBeGreaterThan(0);
+  });
+
+  it("respects replayInvalid set via setTerminalLifecycleMeta before unsubscribe", () => {
+    const onAgentEvent = vi.fn();
+    const { session } = createStubSessionHarness();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-meta",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    subscription.setTerminalLifecycleMeta({
+      replayInvalid: true,
+      livenessState: "blocked",
+    });
+
+    subscription.unsubscribe();
+
+    const lifecycleCalls = emitAgentEventLifecycleCalls();
+    expect(lifecycleCalls).toHaveLength(1);
+    expect(lifecycleCalls[0]).toMatchObject({
+      runId: "run-meta",
+      stream: "lifecycle",
+      data: { phase: "end", livenessState: "blocked", replayInvalid: true },
+    });
+  });
+
+  it("rejects pending compaction wait after fallback emit so callers unblock", async () => {
+    const onAgentEvent = vi.fn();
+    const { session, emit } = createStubSessionHarness();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-compact",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+    });
+
+    emit({ type: "compaction_start" });
+    const waitPromise = subscription.waitForCompactionRetry();
+
+    subscription.unsubscribe();
+
+    const rejection = await waitPromise.then(
+      () => undefined,
+      (err: Error) => err,
+    );
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection?.name).toBe("AbortError");
+
+    const lifecycleCalls = emitAgentEventLifecycleCalls();
+    expect(lifecycleCalls).toHaveLength(1);
+    expect(lifecycleCalls[0]?.data?.phase).toBe("end");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
+++ b/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
@@ -137,6 +137,48 @@ describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", (
     expect(events.indexOf("before")).toBeLessThan(events.indexOf("onAgentEvent"));
   });
 
+  it("waits for an async onBeforeLifecycleTerminal before emitting the fallback lifecycle", async () => {
+    const events: string[] = [];
+    let resolveBefore: (() => void) | undefined;
+    const onBeforeLifecycleTerminal = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveBefore = () => {
+            events.push("before");
+            resolve();
+          };
+        }),
+    );
+    const onAgentEvent = vi.fn(() => {
+      events.push("onAgentEvent");
+    });
+    emitAgentEventMock.mockImplementation((evt) => {
+      if (evt.stream === "lifecycle") {
+        events.push("emitAgentEvent");
+      }
+    });
+
+    const { session } = createStubSessionHarness();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run-before-async",
+      sessionKey: "agent:main:main",
+      onAgentEvent,
+      onBeforeLifecycleTerminal,
+    });
+
+    subscription.unsubscribe();
+
+    expect(onBeforeLifecycleTerminal).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([]);
+
+    resolveBefore?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual(["before", "emitAgentEvent", "onAgentEvent"]);
+  });
+
   it("emits phase:error with the recorded error message when lastAssistant.stopReason is error", () => {
     const onAgentEvent = vi.fn();
     const { session, emit } = createStubSessionHarness();
@@ -185,7 +227,7 @@ describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", (
     expect(typeof observerCalls[0]?.data?.error).toBe("string");
   });
 
-  it("respects replayInvalid set via setTerminalLifecycleMeta before unsubscribe", () => {
+  it("applies setTerminalLifecycleMeta livenessState while fallback replayInvalid stays true", () => {
     const onAgentEvent = vi.fn();
     const { session } = createStubSessionHarness();
     const subscription = subscribeEmbeddedPiSession({
@@ -196,7 +238,7 @@ describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", (
     });
 
     subscription.setTerminalLifecycleMeta({
-      replayInvalid: true,
+      replayInvalid: false,
       livenessState: "blocked",
     });
 

--- a/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
+++ b/src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts
@@ -29,7 +29,9 @@ function onAgentEventLifecycleCalls(fn: ReturnType<typeof vi.fn>): LifecycleEven
 
 describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", () => {
   beforeEach(() => {
-    emitAgentEventMock.mockClear();
+    // mockReset clears both calls and any per-test mockImplementation so tests
+    // that customize emit behavior (e.g. ordering) don't leak into later cases.
+    emitAgentEventMock.mockReset();
   });
 
   it("emits a synthetic phase:end lifecycle event when unsubscribe runs without a prior agent_end", () => {
@@ -173,6 +175,14 @@ describe("subscribeEmbeddedPiSession unsubscribe terminal lifecycle fallback", (
     });
     expect(typeof lifecycleCalls[0]?.data?.error).toBe("string");
     expect((lifecycleCalls[0]?.data?.error as string).length).toBeGreaterThan(0);
+
+    const observerCalls = onAgentEventLifecycleCalls(onAgentEvent);
+    expect(observerCalls).toHaveLength(1);
+    expect(observerCalls[0]).toMatchObject({
+      stream: "lifecycle",
+      data: { phase: "error", livenessState: "blocked" },
+    });
+    expect(typeof observerCalls[0]?.data?.error).toBe("string");
   });
 
   it("respects replayInvalid set via setTerminalLifecycleMeta before unsubscribe", () => {


### PR DESCRIPTION
## Summary

Closes #42011

- Problem: Control UI / Gateway Dashboard chats can stay stuck on `Stop` after a long-running embedded run times out — `Stop` does nothing, the gateway looks healthy, and the run is zombied in the UI until the page is refreshed.
- Why it matters: Crash-class UX bug on a primary surface (Control UI). Reaches any user whose model takes longer than the embedded-run timeout (the reporter saw this with `timeoutMs=600000` per the issue logs).
- What changed: `subscribeEmbeddedPiSession.unsubscribe()` now synthesizes a terminal lifecycle event when the underlying pi-agent never delivered `agent_end` to this subscription, so the gateway's `finalizeLifecycleEvent` always fires and the webchat clears its `Stop` state. Idempotent with `handleAgentEnd` via a shared `lifecycleTerminalEmitted` flag on the subscription state.
- What did NOT change (scope boundary): no changes to `runEmbeddedAttempt`/`runEmbeddedPiAgent` timeout paths, no UI-side defensive timer, no `pi-agent-core` patching, no gateway broadcast logic. The fix sits at the contract seam where the bug actually lives.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #42011
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The embedded runner aborts the active pi-agent session via fire-and-forget `void activeSession.abort()` and then runs its inner-finally `unsubscribe()` synchronously. pi-agent-core's `runWithLifecycle` emits `agent_end` only after `await handleRunFailure → processEvents("agent_end")` completes — which lives in a separate task chain. When the runner's `unsubscribe()` removes the listener first, `agent_end` lands on zero subscribers, `handleAgentEnd` never runs, no `phase:"end"|"error"` is emitted on the agent-events bus, the gateway's `finalizeLifecycleEvent` never calls `emitChatFinal`, and the webchat client never receives `state:"final"|"error"` to clear `chatRunId`.
- Missing detection / guardrail: `subscribeEmbeddedPiSession` did not enforce the contract "exactly one terminal lifecycle event before teardown" — `handleAgentEnd` was the only emitter and it depends on an `agent_end` race that can be lost.
- Contributing context: Reporter's logs show the timeout triggered at `timeoutMs=600000`; the same race is platform-agnostic (it lives in async task scheduling) but was surfaced on Windows in the report — could plausibly hit other platforms with enough latency on the abort/teardown path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.unsubscribe-fallback.test.ts`
- Scenario the test should lock in: `subscribeEmbeddedPiSession.unsubscribe()` always emits exactly one terminal lifecycle event (`phase:"end"` or `phase:"error"`) via both `emitAgentEvent` and `params.onAgentEvent`, regardless of whether the underlying session ever delivered `agent_end`. Idempotent with `handleAgentEnd`. Respects `setTerminalLifecycleMeta` overrides.
- Why this is the smallest reliable guardrail: Pinning the contract at the subscription seam directly prevents the race; covers every caller of `subscribeEmbeddedPiSession`, not just the timeout path.
- Existing test that already covers this (if any): None. `pi-embedded-subscribe.handlers.lifecycle.test.ts` covers `handleAgentEnd` only.
- If no new test is added, why not: N/A — new test added.

## User-visible / Behavior Changes

- Control UI / Gateway Dashboard chats no longer get stuck on `Stop` after embedded run timeouts or aborts that race past `agent_end`. Stuck runs now finalize as `state:"final"` (or `state:"error"` if the last assistant message recorded an error stopReason) with `livenessState:"abandoned"` and `replayInvalid:true` so observability/replay paths can distinguish a synthesized terminal from a clean one. No config or default changes.

## Diagram (if applicable)

```text
Before:
[timeout] → abortRun(true) → void activeSession.abort()
   ↓ (sync)
finally: unsubscribe() removes listener
   ↓ (later, lost race)
pi-agent: handleRunFailure → processEvents("agent_end") → no listeners → ∅
   ↓
gateway never sees phase:end/error → UI stuck on Stop

After:
[timeout] → abortRun(true) → void activeSession.abort()
   ↓ (sync)
finally: unsubscribe()
   → emitFallbackTerminalLifecycle(ctx)   ← synthesizes phase:end (or error)
   → sessionUnsubscribe()
   ↓
gateway finalizeLifecycleEvent → emitChatFinal → state:"final"
   ↓
UI clears chatRunId → Stop button gone
