### PR TITLE
fix(doctor): do not auto-archive orphan transcripts when --fix is passed

### DIFF
--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -71,7 +71,10 @@ export function createDoctorPrompter(params: {
       );
     },
     confirmRuntimeRepair: async (p) => {
-      if (shouldAutoApproveDoctorFix(repairMode, { blockDuringUpdate: true })) {
+      // Only auto-approve when initialValue is not explicitly false.
+      // initialValue: false signals a potentially destructive action (e.g. archiving
+      // orphan transcripts) that must not be silently applied by --fix.
+      if (shouldAutoApproveDoctorFix(repairMode, { blockDuringUpdate: true }) && p.initialValue !== false) {
         return true;
       }
       if (repairMode.nonInteractive) {

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -302,6 +302,27 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(true);
   });
 
+  it("does not auto-archive orphan transcripts when --fix is passed (initialValue: false guard)", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    // Simulate --fix non-interactive prompter: auto-approve returns false for initialValue:false
+    const confirmRuntimeRepair = vi.fn(async (params: { message?: string; initialValue?: boolean }) => {
+      // This mirrors what createDoctorPrompter does when --fix is passed without a TTY:
+      // initialValue:false must NOT be auto-approved.
+      return params.initialValue !== false && Boolean(params.initialValue);
+    });
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+    expect(stateIntegrityText()).toContain(
+      "These .jsonl files are no longer referenced by sessions.json",
+    );
+    // The orphan transcript should NOT have been archived
+    const files = fs.readdirSync(sessionsDir);
+    expect(files.some((name) => name.startsWith("orphan-session.jsonl.deleted."))).toBe(false);
+    expect(files).toContain("orphan-session.jsonl");
+  });
+
   it.skipIf(process.platform === "win32")(
     "does not archive referenced transcripts when the state dir path resolves through a symlink",
     async () => {


### PR DESCRIPTION
## Problem

`openclaw doctor --fix` silently archives orphan transcript files without user confirmation. This causes session history loss after upgrades that regenerate `sessions.json`, because previously-active transcripts appear as "orphans" that don't match any index entry.

Fixes #73106

## Root Cause

In `confirmRuntimeRepair`, `shouldAutoApproveDoctorFix` returns `true` for all `--fix` runs regardless of `initialValue`. The orphan transcript archival prompt uses `initialValue: false` to signal it is potentially destructive and should not be auto-approved — but this was being ignored.

```ts
// doctor-state-integrity.ts
const archiveOrphans = await prompter.confirmRuntimeRepair({
  message: `Archive ${orphanCount}...`,
  initialValue: false,  // <-- should suppress --fix auto-approval
});
```

## Fix

Skip auto-approval in `confirmRuntimeRepair` when `p.initialValue === false`. Only prompts with `initialValue: true` or `undefined` (safe/reversible actions) are auto-approved by `--fix`.

```ts
// doctor-prompter.ts
confirmRuntimeRepair: async (p) => {
  // Only auto-approve when initialValue is not explicitly false.
  // initialValue: false signals a potentially destructive action (e.g. archiving
  // orphan transcripts) that must not be silently applied by --fix.
  if (shouldAutoApproveDoctorFix(repairMode, { blockDuringUpdate: true }) && p.initialValue !== false) {
    return true;
  }
  ...
}
```

## Test

Added a test to `doctor-state-integrity.test.ts` that verifies orphan transcripts are NOT archived when a `--fix`-style prompter (which returns `false` for `initialValue: false` prompts) is used.

## Checklist
- [x] Fix in `src/commands/doctor-prompter.ts`
- [x] Test in `src/commands/doctor-state-integrity.test.ts`
- [x] No behavior change for existing auto-approved fixes (those use `initialValue: true` or omit it)