### PR TITLE
fix(macos): parse model catalog without JavaScriptCore

### DIFF
--- a/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
+++ b/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
@@ -5,6 +5,7 @@ enum ModelCatalogLoader {
         self.resolveDefaultPath()
     }
 
+    private static let maxCatalogBytes: UInt64 = 2 * 1024 * 1024
     private static let logger = Logger(subsystem: "ai.openclaw", category: "models")
     private nonisolated static let appSupportDir: URL = {
         let base = FileManager().urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -25,7 +26,7 @@ enum ModelCatalogLoader {
                 userInfo: [NSLocalizedDescriptionKey: "Model catalog file not found"])
         }
         self.logger.debug("model catalog load start file=\(URL(fileURLWithPath: resolved.path).lastPathComponent)")
-        let source = try String(contentsOfFile: resolved.path, encoding: .utf8)
+        let source = try self.readCatalogSource(path: resolved.path)
         let rawModels = try self.parseModels(source: source)
 
         var choices: [ModelChoice] = []
@@ -122,18 +123,137 @@ enum ModelCatalogLoader {
         }
     }
 
+    private static func readCatalogSource(path: String) throws -> String {
+        let attrs = try FileManager().attributesOfItem(atPath: path)
+        if let size = attrs[.size] as? NSNumber,
+           size.uint64Value > self.maxCatalogBytes
+        {
+            throw NSError(
+                domain: "ModelCatalogLoader",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Model catalog file is too large"])
+        }
+        return try String(contentsOfFile: path, encoding: .utf8)
+    }
+
     private static func parseModels(source: String) throws -> [String: Any] {
-        guard let exportRange = source.range(
-            of: #"export\s+const\s+MODELS\s*="#,
-            options: .regularExpression)
-        else {
-            return [:]
+        guard let assignmentEnd = self.findModelsAssignmentEnd(in: source) else {
+            throw ModelCatalogParseError.missingModelsExport
         }
-        guard let firstBrace = source[exportRange.upperBound...].firstIndex(of: "{") else {
-            throw ModelCatalogParseError.expectedObject
-        }
-        var parser = ModelCatalogObjectParser(source: String(source[firstBrace...]))
+        var parser = ModelCatalogObjectParser(source: String(source[assignmentEnd...]))
         return try parser.parseObject()
+    }
+
+    private static func findModelsAssignmentEnd(in source: String) -> String.Index? {
+        var index = source.startIndex
+        while index < source.endIndex {
+            if self.consumeIf("//", in: source, at: &index) {
+                self.skipLineComment(in: source, from: &index)
+                continue
+            }
+            if self.consumeIf("/*", in: source, at: &index) {
+                self.skipBlockComment(in: source, from: &index)
+                continue
+            }
+            if source[index] == "\"" || source[index] == "'" || source[index] == "`" {
+                self.skipString(in: source, quote: source[index], from: &index)
+                continue
+            }
+
+            var cursor = index
+            if self.consumeKeyword("export", in: source, at: &cursor) {
+                self.skipWhitespaceAndComments(in: source, from: &cursor)
+                if self.consumeKeyword("const", in: source, at: &cursor) {
+                    self.skipWhitespaceAndComments(in: source, from: &cursor)
+                    if self.consumeKeyword("MODELS", in: source, at: &cursor) {
+                        self.skipWhitespaceAndComments(in: source, from: &cursor)
+                        if self.consumeIf("=", in: source, at: &cursor) {
+                            return cursor
+                        }
+                    }
+                }
+            }
+
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func skipWhitespaceAndComments(in source: String, from index: inout String.Index) {
+        while index < source.endIndex {
+            if source[index].isWhitespace {
+                index = source.index(after: index)
+                continue
+            }
+            if self.consumeIf("//", in: source, at: &index) {
+                self.skipLineComment(in: source, from: &index)
+                continue
+            }
+            if self.consumeIf("/*", in: source, at: &index) {
+                self.skipBlockComment(in: source, from: &index)
+                continue
+            }
+            return
+        }
+    }
+
+    private static func skipLineComment(in source: String, from index: inout String.Index) {
+        while index < source.endIndex, source[index] != "\n" {
+            index = source.index(after: index)
+        }
+    }
+
+    private static func skipBlockComment(in source: String, from index: inout String.Index) {
+        while index < source.endIndex, !self.consumeIf("*/", in: source, at: &index) {
+            index = source.index(after: index)
+        }
+    }
+
+    private static func skipString(in source: String, quote: Character, from index: inout String.Index) {
+        index = source.index(after: index)
+        while index < source.endIndex {
+            let char = source[index]
+            index = source.index(after: index)
+            if char == "\\" {
+                if index < source.endIndex {
+                    index = source.index(after: index)
+                }
+                continue
+            }
+            if char == quote {
+                return
+            }
+        }
+    }
+
+    private static func consumeKeyword(_ keyword: String, in source: String, at index: inout String.Index) -> Bool {
+        guard source[index...].hasPrefix(keyword) else {
+            return false
+        }
+        let end = source.index(index, offsetBy: keyword.count)
+        if index > source.startIndex {
+            let previous = source[source.index(before: index)]
+            if self.isIdentifierCharacter(previous) {
+                return false
+            }
+        }
+        if end < source.endIndex, self.isIdentifierCharacter(source[end]) {
+            return false
+        }
+        index = end
+        return true
+    }
+
+    private static func consumeIf(_ token: String, in source: String, at index: inout String.Index) -> Bool {
+        guard source[index...].hasPrefix(token) else {
+            return false
+        }
+        index = source.index(index, offsetBy: token.count)
+        return true
+    }
+
+    private static func isIdentifierCharacter(_ char: Character) -> Bool {
+        char.isLetter || char.isNumber || char == "_" || char == "$"
     }
 }
 
@@ -142,21 +262,28 @@ private enum ModelCatalogParseError: Error {
     case expectedKey
     case expectedColon
     case expectedValue
+    case maxDepthExceeded
+    case missingModelsExport
     case unterminatedString
     case invalidNumber
     case unexpectedToken
 }
 
 private struct ModelCatalogObjectParser {
+    private let maxDepth: Int
     private let source: String
     private var index: String.Index
 
-    init(source: String) {
+    init(source: String, maxDepth: Int = 80) {
+        self.maxDepth = maxDepth
         self.source = source
         self.index = source.startIndex
     }
 
-    mutating func parseObject() throws -> [String: Any] {
+    mutating func parseObject(depth: Int = 0) throws -> [String: Any] {
+        guard depth <= self.maxDepth else {
+            throw ModelCatalogParseError.maxDepthExceeded
+        }
         try self.consume("{", or: .expectedObject)
         var result: [String: Any] = [:]
 
@@ -169,7 +296,7 @@ private struct ModelCatalogObjectParser {
             let key = try self.parseKey()
             self.skipWhitespaceAndComments()
             try self.consume(":", or: .expectedColon)
-            let value = try self.parseValue()
+            let value = try self.parseValue(depth: depth)
             self.skipTypeAssertion()
             result[key] = value
 
@@ -184,7 +311,10 @@ private struct ModelCatalogObjectParser {
         }
     }
 
-    private mutating func parseArray() throws -> [Any] {
+    private mutating func parseArray(depth: Int) throws -> [Any] {
+        guard depth <= self.maxDepth else {
+            throw ModelCatalogParseError.maxDepthExceeded
+        }
         try self.consume("[", or: .expectedValue)
         var result: [Any] = []
 
@@ -194,7 +324,7 @@ private struct ModelCatalogObjectParser {
                 return result
             }
 
-            result.append(try self.parseValue())
+            try result.append(self.parseValue(depth: depth))
             self.skipTypeAssertion()
             self.skipWhitespaceAndComments()
             if self.consumeIf(",") {
@@ -207,7 +337,7 @@ private struct ModelCatalogObjectParser {
         }
     }
 
-    private mutating func parseValue() throws -> Any {
+    private mutating func parseValue(depth: Int) throws -> Any {
         self.skipWhitespaceAndComments()
         guard let char = self.current else {
             throw ModelCatalogParseError.expectedValue
@@ -215,9 +345,9 @@ private struct ModelCatalogObjectParser {
 
         switch char {
         case "{":
-            return try self.parseObject()
+            return try self.parseObject(depth: depth + 1)
         case "[":
-            return try self.parseArray()
+            return try self.parseArray(depth: depth + 1)
         case "\"", "'":
             return try self.parseString()
         case "-", "0"..."9":
@@ -232,7 +362,7 @@ private struct ModelCatalogObjectParser {
             case "null", "undefined":
                 return NSNull()
             default:
-                return identifier
+                throw ModelCatalogParseError.unexpectedToken
             }
         }
     }
@@ -273,7 +403,7 @@ private struct ModelCatalogObjectParser {
                 return result
             }
             if char == "\\" {
-                result.append(try self.parseEscapedCharacter())
+                try result.append(self.parseEscapedCharacter())
             } else {
                 result.append(char)
             }
@@ -373,8 +503,19 @@ private struct ModelCatalogObjectParser {
     }
 
     private mutating func skipTypeExpression() {
+        var angleDepth = 0
         while let char = self.current {
-            if char == "," || char == "}" || char == "]" {
+            if char == "<" {
+                angleDepth += 1
+                self.advance()
+                continue
+            }
+            if char == ">", angleDepth > 0 {
+                angleDepth -= 1
+                self.advance()
+                continue
+            }
+            if angleDepth == 0, char == "," || char == "}" || char == "]" {
                 return
             }
             self.advance()
@@ -410,7 +551,7 @@ private struct ModelCatalogObjectParser {
     }
 
     private mutating func consumeIf(_ token: String) -> Bool {
-        guard self.source[index...].hasPrefix(token) else {
+        guard self.source[self.index...].hasPrefix(token) else {
             return false
         }
         self.index = self.source.index(self.index, offsetBy: token.count)
@@ -418,7 +559,7 @@ private struct ModelCatalogObjectParser {
     }
 
     private mutating func consumeKeyword(_ keyword: String) -> Bool {
-        guard self.source[index...].hasPrefix(keyword) else {
+        guard self.source[self.index...].hasPrefix(keyword) else {
             return false
         }
         let end = self.source.index(self.index, offsetBy: keyword.count)

--- a/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
+++ b/apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import JavaScriptCore
 
 enum ModelCatalogLoader {
     static var defaultPath: String {
@@ -27,22 +26,7 @@ enum ModelCatalogLoader {
         }
         self.logger.debug("model catalog load start file=\(URL(fileURLWithPath: resolved.path).lastPathComponent)")
         let source = try String(contentsOfFile: resolved.path, encoding: .utf8)
-        let sanitized = self.sanitize(source: source)
-
-        let ctx = JSContext()
-        ctx?.exceptionHandler = { _, exception in
-            if let exception {
-                self.logger.warning("model catalog JS exception: \(exception)")
-            }
-        }
-        ctx?.evaluateScript(sanitized)
-        guard let rawModels = ctx?.objectForKeyedSubscript("MODELS")?.toDictionary() as? [String: Any] else {
-            self.logger.error("model catalog parse failed: MODELS missing")
-            throw NSError(
-                domain: "ModelCatalogLoader",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Failed to parse models.generated.ts"])
-        }
+        let rawModels = try self.parseModels(source: source)
 
         var choices: [ModelChoice] = []
         for (provider, value) in rawModels {
@@ -138,22 +122,325 @@ enum ModelCatalogLoader {
         }
     }
 
-    private static func sanitize(source: String) -> String {
-        guard let exportRange = source.range(of: "export const MODELS"),
-              let firstBrace = source[exportRange.upperBound...].firstIndex(of: "{"),
-              let lastBrace = source.lastIndex(of: "}")
+    private static func parseModels(source: String) throws -> [String: Any] {
+        guard let exportRange = source.range(
+            of: #"export\s+const\s+MODELS\s*="#,
+            options: .regularExpression)
         else {
-            return "var MODELS = {}"
+            return [:]
         }
-        var body = String(source[firstBrace...lastBrace])
-        body = body.replacingOccurrences(
-            of: #"(?m)\bsatisfies\s+[^,}\n]+"#,
-            with: "",
-            options: .regularExpression)
-        body = body.replacingOccurrences(
-            of: #"(?m)\bas\s+[^;,\n]+"#,
-            with: "",
-            options: .regularExpression)
-        return "var MODELS = \(body);"
+        guard let firstBrace = source[exportRange.upperBound...].firstIndex(of: "{") else {
+            throw ModelCatalogParseError.expectedObject
+        }
+        var parser = ModelCatalogObjectParser(source: String(source[firstBrace...]))
+        return try parser.parseObject()
+    }
+}
+
+private enum ModelCatalogParseError: Error {
+    case expectedObject
+    case expectedKey
+    case expectedColon
+    case expectedValue
+    case unterminatedString
+    case invalidNumber
+    case unexpectedToken
+}
+
+private struct ModelCatalogObjectParser {
+    private let source: String
+    private var index: String.Index
+
+    init(source: String) {
+        self.source = source
+        self.index = source.startIndex
+    }
+
+    mutating func parseObject() throws -> [String: Any] {
+        try self.consume("{", or: .expectedObject)
+        var result: [String: Any] = [:]
+
+        while true {
+            self.skipWhitespaceAndComments()
+            if self.consumeIf("}") {
+                return result
+            }
+
+            let key = try self.parseKey()
+            self.skipWhitespaceAndComments()
+            try self.consume(":", or: .expectedColon)
+            let value = try self.parseValue()
+            self.skipTypeAssertion()
+            result[key] = value
+
+            self.skipWhitespaceAndComments()
+            if self.consumeIf(",") {
+                continue
+            }
+            if self.consumeIf("}") {
+                return result
+            }
+            throw ModelCatalogParseError.unexpectedToken
+        }
+    }
+
+    private mutating func parseArray() throws -> [Any] {
+        try self.consume("[", or: .expectedValue)
+        var result: [Any] = []
+
+        while true {
+            self.skipWhitespaceAndComments()
+            if self.consumeIf("]") {
+                return result
+            }
+
+            result.append(try self.parseValue())
+            self.skipTypeAssertion()
+            self.skipWhitespaceAndComments()
+            if self.consumeIf(",") {
+                continue
+            }
+            if self.consumeIf("]") {
+                return result
+            }
+            throw ModelCatalogParseError.unexpectedToken
+        }
+    }
+
+    private mutating func parseValue() throws -> Any {
+        self.skipWhitespaceAndComments()
+        guard let char = self.current else {
+            throw ModelCatalogParseError.expectedValue
+        }
+
+        switch char {
+        case "{":
+            return try self.parseObject()
+        case "[":
+            return try self.parseArray()
+        case "\"", "'":
+            return try self.parseString()
+        case "-", "0"..."9":
+            return try self.parseNumber()
+        default:
+            let identifier = try self.parseIdentifier()
+            switch identifier {
+            case "true":
+                return true
+            case "false":
+                return false
+            case "null", "undefined":
+                return NSNull()
+            default:
+                return identifier
+            }
+        }
+    }
+
+    private mutating func parseKey() throws -> String {
+        self.skipWhitespaceAndComments()
+        guard let char = self.current else {
+            throw ModelCatalogParseError.expectedKey
+        }
+        if char == "\"" || char == "'" {
+            return try self.parseString()
+        }
+        return try self.parseIdentifier()
+    }
+
+    private mutating func parseIdentifier() throws -> String {
+        self.skipWhitespaceAndComments()
+        let start = self.index
+        while let char = self.current, self.isIdentifierCharacter(char) {
+            self.advance()
+        }
+        guard start != self.index else {
+            throw ModelCatalogParseError.expectedKey
+        }
+        return String(self.source[start..<self.index])
+    }
+
+    private mutating func parseString() throws -> String {
+        guard let quote = self.current, quote == "\"" || quote == "'" else {
+            throw ModelCatalogParseError.expectedValue
+        }
+        self.advance()
+
+        var result = ""
+        while let char = self.current {
+            self.advance()
+            if char == quote {
+                return result
+            }
+            if char == "\\" {
+                result.append(try self.parseEscapedCharacter())
+            } else {
+                result.append(char)
+            }
+        }
+        throw ModelCatalogParseError.unterminatedString
+    }
+
+    private mutating func parseEscapedCharacter() throws -> Character {
+        guard let char = self.current else {
+            throw ModelCatalogParseError.unterminatedString
+        }
+        self.advance()
+
+        switch char {
+        case "\"", "'", "\\", "/":
+            return char
+        case "b":
+            return "\u{08}"
+        case "f":
+            return "\u{0c}"
+        case "n":
+            return "\n"
+        case "r":
+            return "\r"
+        case "t":
+            return "\t"
+        case "u":
+            return try self.parseUnicodeEscape()
+        default:
+            return char
+        }
+    }
+
+    private mutating func parseUnicodeEscape() throws -> Character {
+        var hex = ""
+        for _ in 0..<4 {
+            guard let char = self.current else {
+                throw ModelCatalogParseError.unterminatedString
+            }
+            hex.append(char)
+            self.advance()
+        }
+        guard let value = UInt32(hex, radix: 16),
+              let scalar = UnicodeScalar(value)
+        else {
+            throw ModelCatalogParseError.unterminatedString
+        }
+        return Character(scalar)
+    }
+
+    private mutating func parseNumber() throws -> Any {
+        let start = self.index
+        if self.current == "-" {
+            self.advance()
+        }
+        while let char = self.current, ("0"..."9").contains(char) {
+            self.advance()
+        }
+        var isFloatingPoint = false
+        if self.current == "." {
+            isFloatingPoint = true
+            self.advance()
+            while let char = self.current, ("0"..."9").contains(char) {
+                self.advance()
+            }
+        }
+        if self.current == "e" || self.current == "E" {
+            isFloatingPoint = true
+            self.advance()
+            if self.current == "-" || self.current == "+" {
+                self.advance()
+            }
+            while let char = self.current, ("0"..."9").contains(char) {
+                self.advance()
+            }
+        }
+
+        let raw = String(self.source[start..<self.index])
+        if !isFloatingPoint, let int = Int(raw) {
+            return int
+        }
+        if let double = Double(raw) {
+            return double
+        }
+        throw ModelCatalogParseError.invalidNumber
+    }
+
+    private mutating func skipTypeAssertion() {
+        while true {
+            self.skipWhitespaceAndComments()
+            if self.consumeKeyword("satisfies") || self.consumeKeyword("as") {
+                self.skipTypeExpression()
+            } else {
+                return
+            }
+        }
+    }
+
+    private mutating func skipTypeExpression() {
+        while let char = self.current {
+            if char == "," || char == "}" || char == "]" {
+                return
+            }
+            self.advance()
+        }
+    }
+
+    private mutating func skipWhitespaceAndComments() {
+        while true {
+            while let char = self.current, char.isWhitespace {
+                self.advance()
+            }
+            if self.consumeIf("//") {
+                while let char = self.current, char != "\n" {
+                    self.advance()
+                }
+                continue
+            }
+            if self.consumeIf("/*") {
+                while self.index < self.source.endIndex, !self.consumeIf("*/") {
+                    self.advance()
+                }
+                continue
+            }
+            return
+        }
+    }
+
+    private mutating func consume(_ token: String, or error: ModelCatalogParseError) throws {
+        self.skipWhitespaceAndComments()
+        guard self.consumeIf(token) else {
+            throw error
+        }
+    }
+
+    private mutating func consumeIf(_ token: String) -> Bool {
+        guard self.source[index...].hasPrefix(token) else {
+            return false
+        }
+        self.index = self.source.index(self.index, offsetBy: token.count)
+        return true
+    }
+
+    private mutating func consumeKeyword(_ keyword: String) -> Bool {
+        guard self.source[index...].hasPrefix(keyword) else {
+            return false
+        }
+        let end = self.source.index(self.index, offsetBy: keyword.count)
+        if end < self.source.endIndex, self.isIdentifierCharacter(self.source[end]) {
+            return false
+        }
+        self.index = end
+        return true
+    }
+
+    private var current: Character? {
+        guard self.index < self.source.endIndex else {
+            return nil
+        }
+        return self.source[self.index]
+    }
+
+    private mutating func advance() {
+        self.index = self.source.index(after: self.index)
+    }
+
+    private func isIdentifierCharacter(_ char: Character) -> Bool {
+        char.isLetter || char.isNumber || char == "_" || char == "$"
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift
@@ -49,4 +49,27 @@ struct ModelCatalogLoaderTests {
         let choices = try await ModelCatalogLoader.load(from: tmp.path)
         #expect(choices.isEmpty)
     }
+
+    @Test
+    func `load rejects executable catalog expressions`() async throws {
+        let src = """
+        export const MODELS = {
+          openai: {
+            "gpt-4o": { name: (() => { throw new Error("nope") })(), contextWindow: 128000 },
+          },
+        };
+        """
+
+        let tmp = FileManager().temporaryDirectory
+            .appendingPathComponent("models-\(UUID().uuidString).ts")
+        defer { try? FileManager().removeItem(at: tmp) }
+        try src.write(to: tmp, atomically: true, encoding: .utf8)
+
+        do {
+            _ = try await ModelCatalogLoader.load(from: tmp.path)
+            Issue.record("expected executable catalog expression rejection")
+        } catch {
+            #expect(String(describing: error).isEmpty == false)
+        }
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift
@@ -39,15 +39,42 @@ struct ModelCatalogLoaderTests {
     }
 
     @Test
-    func `load with no export returns empty choices`() async throws {
+    func `load with no export rejects catalog`() async throws {
         let src = "const NOPE = 1;"
         let tmp = FileManager().temporaryDirectory
             .appendingPathComponent("models-\(UUID().uuidString).ts")
         defer { try? FileManager().removeItem(at: tmp) }
         try src.write(to: tmp, atomically: true, encoding: .utf8)
 
+        do {
+            _ = try await ModelCatalogLoader.load(from: tmp.path)
+            Issue.record("expected missing MODELS export rejection")
+        } catch {
+            #expect(String(describing: error).isEmpty == false)
+        }
+    }
+
+    @Test
+    func `load ignores fake exports in comments and strings`() async throws {
+        let src = #"""
+        // export const MODELS = { bad: { "bad": { name: "Bad", contextWindow: 1 } } };
+        const text = "export const MODELS = { alsoBad: {} }";
+        export const MODELS = {
+          openai: {
+            "gpt-4o": { name: "GPT-4o", contextWindow: 128000 } satisfies ModelConfig<string, number>,
+          },
+        };
+        """#
+
+        let tmp = FileManager().temporaryDirectory
+            .appendingPathComponent("models-\(UUID().uuidString).ts")
+        defer { try? FileManager().removeItem(at: tmp) }
+        try src.write(to: tmp, atomically: true, encoding: .utf8)
+
         let choices = try await ModelCatalogLoader.load(from: tmp.path)
-        #expect(choices.isEmpty)
+        #expect(choices.count == 1)
+        #expect(choices.first?.id == "gpt-4o")
+        #expect(choices.first?.provider == "openai")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Problem: macOS CodeQL reports `swift/unsafe-js-eval` in `ModelCatalogLoader` because model catalog parsing runs generated catalog source through `JavaScriptCore`.
- Why it matters: this is app-source code scanning alert #187 and the catalog path can resolve from cache, bundle, or `node_modules`.
- What changed: replaced JavaScript execution with a deterministic object-literal parser for the generated `MODELS` catalog, added fail-closed parser behavior, and added coverage that rejects executable expressions.
- Hardening added after review: missing `MODELS` exports now fail, fake exports in comments/strings are ignored, unknown identifiers throw, catalog size is capped, parser depth is capped, and generic type assertions with commas are handled.
- What did NOT change (scope boundary): no model catalog schema changes, no provider/model sorting changes, no cache path changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: https://github.com/openclaw/openclaw/security/code-scanning/187
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `ModelCatalogLoader` treated the generated TypeScript/JavaScript model catalog as executable JavaScript and evaluated it with `JSContext` to recover the `MODELS` object.
- Missing detection / guardrail: existing tests covered parsing output but not the no-script-execution security invariant.
- Contributing context: the macOS CodeQL shard added during the current CodeQL rollout exposed this as app-source `swift/unsafe-js-eval`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift`
- Scenario the test should lock in: generated catalog object literals parse, TypeScript `satisfies` / `as` assertions are tolerated, fake exports are ignored, unsupported identifiers fail closed, and executable expressions are rejected.
- Why this is the smallest reliable guardrail: it exercises the loader directly without requiring the full app or network catalog generation.
- Existing test that already covers this (if any): existing parse/sort coverage remains and now runs through the non-executing parser.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None for valid generated catalogs. Invalid or unsupported catalog files now fail closed instead of returning empty choices or executing JavaScript.

## Diagram (if applicable)

```text
Before:
models.generated.js -> JSContext.evaluateScript -> MODELS dictionary

After:
models.generated.js -> bounded object-literal parser -> MODELS dictionary
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree + Blacksmith Testbox
- Runtime/container: Swift CLI, Blacksmith `ci-check-testbox.yml`
- Model/provider: N/A
- Integration/channel (if any): macOS app model catalog loader
- Relevant config (redacted): N/A

### Steps

1. Inspect CodeQL alert https://github.com/openclaw/openclaw/security/code-scanning/187.
2. Remove `JavaScriptCore`/`JSContext.evaluateScript` from model catalog parsing.
3. Parse generated object-literal catalog directly with bounded fail-closed parsing.
4. Validate parser behavior and repo changed gate.

### Expected

- Model catalog choices still load and sort.
- Executable catalog expressions are rejected instead of evaluated.
- CodeQL sink strings are absent from `ModelCatalogLoader`.

### Actual

- Local harness parsed the real generated catalog: `generated catalog ok 884`.
- `rg` found no `JavaScriptCore`, `JSContext`, `evaluateScript`, or `evaluateJavaScript` in the touched loader/test files.
- Blacksmith `pnpm check:changed` reached the app lane but failed because the Linux Testbox image does not have `swiftlint` installed: `sh: 1: swiftlint: not found`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `swiftc -parse apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift`; compiled local Swift harness against `ModelCatalogLoader.swift`; parsed the real generated model catalog (`884` choices); executable expression fixture rejected; missing export rejected; unknown identifier rejected; fake exports in comments/strings ignored; generic type assertion with comma parsed; `git diff --check` passed; `swiftformat --lint apps/macos/Sources/OpenClaw/ModelCatalogLoader.swift apps/macos/Tests/OpenClawIPCTests/ModelCatalogLoaderTests.swift` passed.
- Edge cases checked: quoted and unquoted keys, nested objects, arrays, booleans, numbers, trailing commas, comments, `satisfies any`, `satisfies ModelConfig<string, number>`, `as any`, missing export, fake export text, unknown identifier values, executable IIFE values.
- What you did **not** verify: full `swift test --package-path apps/macos --filter ModelCatalogLoaderTests`; local SwiftPM dependency fetch wedged while cloning Peekaboo. PR macOS CI should provide the package-level proof.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes for valid generated catalogs
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: generated catalog syntax could grow beyond the supported object-literal subset.
  - Mitigation: parser supports the current generated catalog shape and the test/harness parses the real `models.generated.js`; unsupported executable expressions fail closed instead of executing.
