### PR TITLE
fix: cancel in-flight Anthropic SSE read when abort signal fires (#72…

### DIFF
--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1817,7 +1817,7 @@ async function maybeResolveActiveRecall(params: {
     if (raceResult === TIMEOUT_SENTINEL) {
       const result: ActiveRecallResult = {
         status: "timeout",
-        elapsedMs: Date.now() - startedAt,
+        elapsedMs: params.config.timeoutMs,
         summary: null,
       };
       if (params.config.logging) {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -561,4 +561,44 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("terminates the SSE read loop immediately when the abort signal fires mid-stream", async () => {
+    const controller = new AbortController();
+    const encoder = new TextEncoder();
+    const firstChunk = encoder.encode(
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}\n\n',
+    );
+    let firstSent = false;
+    const body = new ReadableStream<Uint8Array>({
+      async pull(ctrl) {
+        if (!firstSent) {
+          firstSent = true;
+          ctrl.enqueue(firstChunk);
+          return;
+        }
+        await new Promise<void>((resolve) => {
+          controller.signal.addEventListener("abort", () => resolve(), { once: true });
+          setTimeout(resolve, 5_000);
+        });
+        ctrl.close();
+      },
+    });
+    guardedFetchMock.mockResolvedValue(
+      new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    );
+
+    setTimeout(() => controller.abort(), 50);
+
+    const startedAt = Date.now();
+    try {
+      await runTransportStream(
+        makeAnthropicTransportModel(),
+        { messages: [{ role: "user", content: "hello" }] } as AnthropicStreamContext,
+        { apiKey: "sk-ant-api", signal: controller.signal } as AnthropicStreamOptions,
+      );
+    } catch {
+      // ignored
+    }
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -452,15 +452,64 @@ function resolveAnthropicMessagesUrl(baseUrl?: string): string {
   return normalized.endsWith("/v1") ? `${normalized}/messages` : `${normalized}/v1/messages`;
 }
 
+function readChunkOrAbort(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal: AbortSignal,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const onAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reader.cancel().catch(() => {});
+      const reason = signal.reason;
+      const err =
+        reason instanceof Error
+          ? reason
+          : Object.assign(new Error("AbortError"), { name: "AbortError" });
+      reject(err);
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    reader.read().then(
+      (result) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        resolve(result);
+      },
+      (err: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
 async function* parseAnthropicSseBody(
   body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      if (signal?.aborted) {
+        break;
+      }
+      const { done, value } = signal ? await readChunkOrAbort(reader, signal) : await reader.read();
       if (done) {
         break;
       }
@@ -531,7 +580,7 @@ function createAnthropicMessagesClient(params: {
         if (!response.body) {
           return;
         }
-        yield* parseAnthropicSseBody(response.body);
+        yield* parseAnthropicSseBody(response.body, options?.signal);
       },
     },
   };


### PR DESCRIPTION
## Summary

- Problem: `active-memory` timeout fired after 30 s, but startup blocked for 97+ seconds. The `parseAnthropicSseBody` SSE reader called `reader.read()` with no abort awareness, so the in-flight HTTP connection was never cancelled.
- Why it matters: The orphaned subagent kept its embedded-runner concurrency queue slot until the provider's own timeout fired (~65 s), stalling anything queued behind it during startup.
- What changed: Added `readChunkOrAbort` helper that races `reader.read()` against the abort signal; on abort it calls `reader.cancel()` and rejects immediately. Passed `options?.signal` into `parseAnthropicSseBody`. Fixed `elapsedMs` in the timeout result to use `params.config.timeoutMs` directly.
- What did NOT change (scope boundary): Queue logic, retry/failover, timeout scheduling, and all other transport providers are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72965
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `parseAnthropicSseBody` iterated `response.body` via a bare `reader.read()` loop. The `AbortSignal` was passed to `fetch()` and `client.messages.stream()`, but nothing raced `reader.read()` against it. Once the body stream started, `reader.read()` blocked until the next chunk regardless of abort state.
- Missing detection / guardrail: Existing active-memory abort tests mocked `runEmbeddedPiAgent` at a higher level, bypassing the actual SSE read path entirely.
- Contributing context (if known): `Promise.race` in `maybeResolveActiveRecall` correctly returned the timeout sentinel at 30 s, but the orphaned subagent kept its queue slot until `reader.read()` eventually unblocked.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`
- Scenario the test should lock in: A `ReadableStream` sends one SSE event then stalls 5 s; abort fires at 50 ms; asserts wall-clock time is under 1 s.
- Why this is the smallest reliable guardrail: Directly exercises the `readChunkOrAbort` seam without a live provider or embedded runner.
- Existing test that already covers this (if any): None at the transport layer.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`active-memory` recall subagents that hit the timeout now release their queue slot immediately. Startup latency is bounded to `timeoutMs`, not `timeoutMs + provider-response-time`. Timeout log lines now report `elapsedMs` equal to the configured value.

## Diagram (if applicable)

```text
Before:
[abort at T=30s] -> [Promise.race unblocks] -> [reader.read() blocks until T=65s+] -> [queue slot held]

After:
[abort at T=30s] -> [Promise.race unblocks] -> [readChunkOrAbort rejects] -> [reader.cancel(); queue slot released]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: Any Anthropic-compatible provider
- Integration/channel (if any): `active-memory` plugin enabled
- Relevant config (redacted): `active-memory.timeoutMs = 30000`

### Steps

1. Enable `active-memory` with `timeoutMs: 30000`
2. Trigger a session where the provider response takes > 30 s
3. Observe startup time

### Expected

- Unblocks within ~30 s

### Actual

- Blocked for 97+ s

## Evidence

- [x] Failing test/log before + passing after — new transport test fails on `main`, passes with this change; 72 tests pass across both touched files

## Human Verification (required)

- Verified scenarios: `pnpm check` exits 0; `pnpm test src/agents/anthropic-transport-stream.test.ts extensions/active-memory/index.test.ts` — 10 transport + 62 active-memory tests pass
- Edge cases checked: signal already aborted before `readChunkOrAbort` is called; `reader.read()` errors independently; both branches racing to settle
- What you did **not** verify: live provider round-trip with a real slow Anthropic response

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `reader.cancel()` while `reader.read()` is in-flight may behave differently across Node.js versions.
  - Mitigation: `settled` flag ensures only one branch resolves the promise; `reader.cancel()` errors are swallowed so they cannot surface as unhandled rejections.
