### PR TITLE
fix(exec): emit "(no output)" placeholder for empty content blocks

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -78,7 +78,7 @@ export function formatNodeRunToolResult(params: {
     content: [
       {
         type: "text",
-        text: stdout || stderr || errorText || "",
+        text: stdout || stderr || errorText || "(no output)",
       },
     ],
     details: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -626,7 +626,7 @@ export async function runExecProcess(opts: {
     // signal (Layer 2) — both of which prevent this call from ever being
     // reached after the agent run has ended.
     opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
+      content: [{ type: "text", text: warningText + (tailText || "(no output)") }],
       details: {
         status: "running",
         sessionId,


### PR DESCRIPTION
Fixes #73117.

## Problem

When an exec command produces no stdout (e.g. `grep` with no matches, `mkdir`, `cp`, silent `git` commands), the runtime constructs a `tool_result` content block with `text: ""`. Anthropic's API rejects empty text content blocks, causing the session to error out after sequences of silent commands.

## Fix

Two single-character changes that fall back to a non-empty `(no output)` placeholder only when the command produced no output, mirroring the existing behavior in `buildExecForegroundResult` (`bash-tools.exec.ts:87`):

- `src/agents/bash-tools.exec-runtime.ts` — `emitUpdate()` partial-result path
- `src/agents/bash-tools.exec-host-node-phases.ts` — `formatNodeRunToolResult()` node-host path

No behavior change for any non-empty output case.