### PR TITLE
fix(skills): isolate skill env from gateway process

### DIFF
--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -128,7 +128,9 @@ Use one of:
 - `agents.defaults.sandbox.docker.env` for the Docker backend (or per-agent `agents.list[].sandbox.docker.env`)
 - bake the env into your custom sandbox image or remote sandbox environment
 
-Global `env` and `skills.entries.<skill>.env/apiKey` apply to **host** runs only.
+Global `env` and `skills.entries.<skill>.env/apiKey` apply to **host** runs only,
+as request-scoped child-process env overlays. They are not written into the
+Gateway process environment.
 
 ## Related
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -142,7 +142,7 @@ Prefer sandboxed runs for untrusted inputs and risky tools. See
 - Workspace and extra-dir skill discovery only accepts skill roots and `SKILL.md` files whose resolved realpath stays inside the configured root.
 - Gateway-backed skill dependency installs (`skills.install`, onboarding, and the Skills settings UI) run the built-in dangerous-code scanner before executing installer metadata. `critical` findings block by default unless the caller explicitly sets the dangerous override; suspicious findings still warn only.
 - `openclaw skills install <slug>` is different — it downloads a ClawHub skill folder into the workspace and does not use the installer-metadata path above.
-- `skills.entries.*.env` and `skills.entries.*.apiKey` inject secrets into the **host** process for that agent turn (not the sandbox). Keep secrets out of prompts and logs.
+- `skills.entries.*.env` and `skills.entries.*.apiKey` provide secrets as request-scoped child-process env overlays for host runs (not the sandbox). They are not written into the Gateway process environment. Keep secrets out of prompts and logs.
 
 For a broader threat model and checklists, see [Security](/gateway/security).
 
@@ -355,9 +355,10 @@ auth/API key too.
 When an agent run starts, OpenClaw:
 
 1. Reads skill metadata.
-2. Applies `skills.entries.<key>.env` and `skills.entries.<key>.apiKey` to `process.env`.
-3. Builds the system prompt with **eligible** skills.
-4. Restores the original environment after the run ends.
+2. Resolves `skills.entries.<key>.env` and `skills.entries.<key>.apiKey` into a run-scoped overlay.
+3. Passes that overlay to eligible host child processes without mutating the Gateway `process.env`.
+4. Builds the system prompt with **eligible** skills.
+5. Clears the overlay after the run ends.
 
 Environment injection is **scoped to the agent run**, not a global shell
 environment.

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -58,6 +58,7 @@ import {
   resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
+import { getActiveSkillEnvValues } from "./skills/env-overrides.js";
 import { EXEC_TOOL_DISPLAY_SUMMARY } from "./tool-description-presets.js";
 import { type AgentToolWithMeta, failedTextResult, textResult } from "./tools/common.js";
 
@@ -1533,7 +1534,8 @@ export function createExecTool(
       }
       rejectExecApprovalShellCommand(params.command);
 
-      const inheritedBaseEnv = coerceEnv(process.env);
+      const skillEnv = getActiveSkillEnvValues();
+      const inheritedBaseEnv = coerceEnv({ ...process.env, ...skillEnv });
       const hostEnvResult =
         host === "sandbox"
           ? null

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./bash-process-registry.js";
 import { createExecTool, createProcessTool } from "./bash-tools.js";
 import { resolveShellFromPath, sanitizeBinaryOutput } from "./shell-utils.js";
+import { applySkillEnvOverrides } from "./skills/env-overrides.js";
 
 vi.mock("../infra/channel-summary.js", () => ({
   buildChannelSummary: vi.fn(async () => []),
@@ -115,6 +116,14 @@ vi.mock("../process/supervisor/index.js", () => {
     if (segment === "echo $PATH" || segment === "Write-Output $env:PATH") {
       return `${readEnvPath(env)}\n`;
     }
+    const bashEnvMatch = /^echo \$([A-Z_][A-Z0-9_]*)$/u.exec(segment);
+    if (bashEnvMatch?.[1]) {
+      return `${env?.[bashEnvMatch[1]] ?? ""}\n`;
+    }
+    const powershellEnvMatch = /^Write-Output \$env:([A-Z_][A-Z0-9_]*)$/iu.exec(segment);
+    if (powershellEnvMatch?.[1]) {
+      return `${env?.[powershellEnvMatch[1]] ?? ""}\n`;
+    }
     if (segment.startsWith("echo ")) {
       return `${segment.slice("echo ".length)}\n`;
     }
@@ -204,6 +213,9 @@ const shellEcho = (message: string) => (isWin ? `Write-Output ${message}` : `ech
 const COMMAND_NOOP = isWin ? "$null" : ":";
 const COMMAND_ECHO_HELLO = shellEcho("hello");
 const COMMAND_PRINT_PATH = isWin ? "Write-Output $env:PATH" : "echo $PATH";
+const COMMAND_PRINT_SKILL_TOKEN = isWin
+  ? "Write-Output $env:SKILL_TEST_TOKEN"
+  : "echo $SKILL_TEST_TOKEN";
 const COMMAND_EXIT_WITH_ERROR = "exit 1";
 const SCOPE_KEY_ALPHA = "agent:alpha";
 const SCOPE_KEY_BETA = "agent:beta";
@@ -657,6 +669,55 @@ beforeEach(() => {
   callIdCounter = 0;
   resetProcessRegistryForTests();
   resetSystemEventsForTest();
+});
+
+describe("exec skill env", () => {
+  it("passes active skill env to child processes without mutating host env", async () => {
+    const envSnapshot = captureEnv(["SKILL_TEST_TOKEN"]);
+    delete process.env.SKILL_TEST_TOKEN;
+    const restoreSkillEnv = applySkillEnvOverrides({
+      skills: [
+        {
+          skill: {
+            name: "token-skill",
+            description: "Uses a token",
+            filePath: "/virtual/token-skill/SKILL.md",
+            baseDir: "/virtual/token-skill",
+            source: "test",
+            sourceInfo: {
+              path: "/virtual/token-skill/SKILL.md",
+              source: "test",
+              scope: "temporary",
+              origin: "top-level",
+            },
+            disableModelInvocation: false,
+          },
+          frontmatter: {},
+          metadata: {
+            primaryEnv: "SKILL_TEST_TOKEN",
+            requires: { env: ["SKILL_TEST_TOKEN"] },
+          },
+        },
+      ],
+      config: {
+        skills: {
+          entries: {
+            "token-skill": { apiKey: "skill-child-secret" }, // pragma: allowlist secret
+          },
+        },
+      },
+    });
+
+    try {
+      expect(process.env.SKILL_TEST_TOKEN).toBeUndefined();
+      const result = await executeExecCommand(execTool, COMMAND_PRINT_SKILL_TOKEN);
+      expect(readNormalizedTextContent(result.content)).toBe("skill-child-secret");
+      expect(process.env.SKILL_TEST_TOKEN).toBeUndefined();
+    } finally {
+      restoreSkillEnv();
+      envSnapshot.restore();
+    }
+  });
 });
 
 describe("exec tool backgrounding", () => {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -279,8 +279,9 @@ export async function executePreparedCliRun(
           isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]) ||
           isTruthyEnvValue(process.env[LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV]);
         const env = (() => {
+          const skillEnv = restoreSkillEnv?.env ?? {};
           const next = sanitizeHostExecEnv({
-            baseEnv: process.env,
+            baseEnv: { ...process.env, ...skillEnv },
             blockPathOverrides: true,
           });
           const preservedEnv = parseCliBackendPreserveEnv(process.env[CLI_BACKEND_PRESERVE_ENV]);

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -564,6 +564,52 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
+  it("snapshots only the current handle's env values", async () => {
+    const firstEntries = envSkillEntries("first-env-skill", {
+      primaryEnv: "FIRST_ENV_KEY",
+      requires: { env: ["FIRST_ENV_KEY"] },
+    });
+    const secondEntries = envSkillEntries("second-env-skill", {
+      primaryEnv: "SECOND_ENV_KEY",
+      requires: { env: ["SECOND_ENV_KEY"] },
+    });
+
+    withClearedEnv(["FIRST_ENV_KEY", "SECOND_ENV_KEY"], () => {
+      const firstRestore = applySkillEnvOverrides({
+        skills: firstEntries,
+        config: {
+          skills: {
+            entries: {
+              "first-env-skill": { apiKey: "first-secret" }, // pragma: allowlist secret
+            },
+          },
+        },
+      });
+      const secondRestore = applySkillEnvOverrides({
+        skills: secondEntries,
+        config: {
+          skills: {
+            entries: {
+              "second-env-skill": { apiKey: "second-secret" }, // pragma: allowlist secret
+            },
+          },
+        },
+      });
+
+      try {
+        expect(firstRestore.env).toEqual({ FIRST_ENV_KEY: "first-secret" });
+        expect(secondRestore.env).toEqual({ SECOND_ENV_KEY: "second-secret" });
+        expect(getActiveSkillEnvValues()).toMatchObject({
+          FIRST_ENV_KEY: "first-secret",
+          SECOND_ENV_KEY: "second-secret",
+        });
+      } finally {
+        firstRestore();
+        secondRestore();
+      }
+    });
+  });
+
   it("applies env overrides from snapshots", async () => {
     const snapshot = envSkillSnapshot("env-skill", {
       primaryEnv: "ENV_KEY",

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -17,6 +17,7 @@ import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
   getActiveSkillEnvKeys,
+  getActiveSkillEnvValues,
 } from "./skills/env-overrides.js";
 import {
   restoreMockSkillsHomeEnv,
@@ -509,7 +510,7 @@ describe("buildWorkspaceSkillsPrompt", () => {
 });
 
 describe("applySkillEnvOverrides", () => {
-  it("sets and restores env vars", async () => {
+  it("tracks skill env overrides without mutating host env", async () => {
     const entries = envSkillEntries("env-skill", {
       primaryEnv: "ENV_KEY",
       requires: { env: ["ENV_KEY"] },
@@ -522,7 +523,9 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.ENV_KEY).toBe("injected");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(restore.env.ENV_KEY).toBe("injected");
+        expect(getActiveSkillEnvValues().ENV_KEY).toBe("injected");
         expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(true);
       } finally {
         restore();
@@ -544,11 +547,14 @@ describe("applySkillEnvOverrides", () => {
       const restoreSecond = applySkillEnvOverrides({ skills: entries, config });
 
       try {
-        expect(process.env.ENV_KEY).toBe("injected");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(restoreFirst.env.ENV_KEY).toBe("injected");
+        expect(restoreSecond.env.ENV_KEY).toBe("injected");
         expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(true);
 
         restoreFirst();
-        expect(process.env.ENV_KEY).toBe("injected");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(getActiveSkillEnvValues().ENV_KEY).toBe("injected");
         expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(true);
       } finally {
         restoreSecond();
@@ -571,7 +577,8 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.ENV_KEY).toBe("snap-key");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(restore.env.ENV_KEY).toBe("snap-key");
       } finally {
         restore();
         expect(process.env.ENV_KEY).toBeUndefined();
@@ -596,7 +603,8 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.ENV_KEY).toBe("resolved-key");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(restore.env.ENV_KEY).toBe("resolved-key");
       } finally {
         restore();
         expect(process.env.ENV_KEY).toBeUndefined();
@@ -621,7 +629,8 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.ENV_KEY).toBe("resolved-key");
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(restore.env.ENV_KEY).toBe("resolved-key");
       } finally {
         restore();
         expect(process.env.ENV_KEY).toBeUndefined();
@@ -656,6 +665,7 @@ describe("applySkillEnvOverrides", () => {
 
       try {
         expect(process.env.ENV_KEY).toBe("host-key");
+        expect(restore.env.ENV_KEY).toBeUndefined();
       } finally {
         restore();
         expect(process.env.ENV_KEY).toBe("host-key");
@@ -688,8 +698,10 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.OPENAI_API_KEY).toBe("sk-test");
+        expect(process.env.OPENAI_API_KEY).toBeUndefined();
+        expect(restore.env.OPENAI_API_KEY).toBe("sk-test");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
+        expect(restore.env.NODE_OPTIONS).toBeUndefined();
       } finally {
         restore();
         expect(process.env.OPENAI_API_KEY).toBeUndefined();
@@ -791,7 +803,8 @@ describe("applySkillEnvOverrides", () => {
       });
 
       try {
-        expect(process.env.OPENAI_API_KEY).toBe("snap-secret");
+        expect(process.env.OPENAI_API_KEY).toBeUndefined();
+        expect(restore.env.OPENAI_API_KEY).toBe("snap-secret");
       } finally {
         restore();
         expect(process.env.OPENAI_API_KEY).toBeUndefined();

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -14,9 +14,11 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 const log = createSubsystemLogger("env-overrides");
 
 type EnvUpdate = { key: string };
+export type SkillEnvOverrideHandle = (() => void) & {
+  readonly env: Readonly<Record<string, string>>;
+};
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
 type ActiveSkillEnvEntry = {
-  baseline: string | undefined;
   value: string;
   count: number;
 };
@@ -34,20 +36,23 @@ export function getActiveSkillEnvKeys(): ReadonlySet<string> {
   return new Set(activeSkillEnvEntries.keys());
 }
 
+/** Returns request-scoped skill env values for child processes. */
+export function getActiveSkillEnvValues(): Readonly<Record<string, string>> {
+  return Object.fromEntries(
+    [...activeSkillEnvEntries.entries()].map(([key, entry]) => [key, entry.value]),
+  );
+}
+
 function acquireActiveSkillEnvKey(key: string, value: string): boolean {
   const active = activeSkillEnvEntries.get(key);
   if (active) {
     active.count += 1;
-    if (process.env[key] === undefined) {
-      process.env[key] = active.value;
-    }
     return true;
   }
   if (process.env[key] !== undefined) {
     return false;
   }
   activeSkillEnvEntries.set(key, {
-    baseline: process.env[key],
     value,
     count: 1,
   });
@@ -61,17 +66,9 @@ function releaseActiveSkillEnvKey(key: string) {
   }
   active.count -= 1;
   if (active.count > 0) {
-    if (process.env[key] === undefined) {
-      process.env[key] = active.value;
-    }
     return;
   }
   activeSkillEnvEntries.delete(key);
-  if (active.baseline === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = active.baseline;
-  }
 }
 
 type SanitizedSkillEnvOverrides = {
@@ -204,16 +201,21 @@ function applySkillConfigEnvOverrides(params: {
       continue;
     }
     updates.push({ key: envKey });
-    process.env[envKey] = activeSkillEnvEntries.get(envKey)?.value ?? envValue;
   }
 }
 
-function createEnvReverter(updates: EnvUpdate[]) {
-  return () => {
+function createEnvReverter(updates: EnvUpdate[]): SkillEnvOverrideHandle {
+  const env = Object.freeze(getActiveSkillEnvValues());
+  const restore = (() => {
     for (const update of updates) {
       releaseActiveSkillEnvKey(update.key);
     }
-  };
+  }) as SkillEnvOverrideHandle;
+  Object.defineProperty(restore, "env", {
+    enumerable: true,
+    value: env,
+  });
+  return restore;
 }
 
 export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
@@ -247,7 +249,7 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const { snapshot } = params;
   const config = resolveSkillRuntimeConfig(params.config);
   if (!snapshot) {
-    return () => {};
+    return createEnvReverter([]);
   }
   const updates: EnvUpdate[] = [];
 

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import {
@@ -13,14 +14,16 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 
 const log = createSubsystemLogger("env-overrides");
 
-type EnvUpdate = { key: string };
+type EnvUpdate = { key: string; value: string };
 export type SkillEnvOverrideHandle = (() => void) & {
   readonly env: Readonly<Record<string, string>>;
 };
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
 type ActiveSkillEnvEntry = {
-  value: string;
   count: number;
+};
+type SkillEnvOverlayStore = {
+  overrides: ReadonlyMap<symbol, Readonly<Record<string, string>>>;
 };
 
 /**
@@ -30,20 +33,23 @@ type ActiveSkillEnvEntry = {
  * @see https://github.com/openclaw/openclaw/issues/36280
  */
 const activeSkillEnvEntries = new Map<string, ActiveSkillEnvEntry>();
+const skillEnvOverlayStorage = new AsyncLocalStorage<SkillEnvOverlayStore>();
 
 /** Returns a snapshot of env var keys currently injected by skill overrides. */
 export function getActiveSkillEnvKeys(): ReadonlySet<string> {
   return new Set(activeSkillEnvEntries.keys());
 }
 
-/** Returns request-scoped skill env values for child processes. */
+/** Returns the current async run's request-scoped skill env values for child processes. */
 export function getActiveSkillEnvValues(): Readonly<Record<string, string>> {
-  return Object.fromEntries(
-    [...activeSkillEnvEntries.entries()].map(([key, entry]) => [key, entry.value]),
-  );
+  const store = skillEnvOverlayStorage.getStore();
+  if (!store) {
+    return {};
+  }
+  return Object.freeze(Object.assign({}, ...store.overrides.values()));
 }
 
-function acquireActiveSkillEnvKey(key: string, value: string): boolean {
+function acquireActiveSkillEnvKey(key: string): boolean {
   const active = activeSkillEnvEntries.get(key);
   if (active) {
     active.count += 1;
@@ -53,7 +59,6 @@ function acquireActiveSkillEnvKey(key: string, value: string): boolean {
     return false;
   }
   activeSkillEnvEntries.set(key, {
-    value,
     count: 1,
   });
   return true;
@@ -197,19 +202,33 @@ function applySkillConfigEnvOverrides(params: {
   }
 
   for (const [envKey, envValue] of Object.entries(sanitized.allowed)) {
-    if (!acquireActiveSkillEnvKey(envKey, envValue)) {
+    if (!acquireActiveSkillEnvKey(envKey)) {
       continue;
     }
-    updates.push({ key: envKey });
+    updates.push({ key: envKey, value: envValue });
   }
 }
 
 function createEnvReverter(updates: EnvUpdate[]): SkillEnvOverrideHandle {
-  const env = Object.freeze(getActiveSkillEnvValues());
+  const env = Object.freeze(
+    Object.fromEntries(updates.map((update) => [update.key, update.value])),
+  );
+  const overlayId = Symbol("skill-env-overlay");
+  const currentStore = skillEnvOverlayStorage.getStore();
+  const overrides = new Map(currentStore?.overrides);
+  overrides.set(overlayId, env);
+  skillEnvOverlayStorage.enterWith({ overrides });
   const restore = (() => {
     for (const update of updates) {
       releaseActiveSkillEnvKey(update.key);
     }
+    const activeStore = skillEnvOverlayStorage.getStore();
+    if (!activeStore?.overrides.has(overlayId)) {
+      return;
+    }
+    const remainingOverrides = new Map(activeStore.overrides);
+    remainingOverrides.delete(overlayId);
+    skillEnvOverlayStorage.enterWith({ overrides: remainingOverrides });
   }) as SkillEnvOverrideHandle;
   Object.defineProperty(restore, "env", {
     enumerable: true,


### PR DESCRIPTION
## Summary
- stop skill env/apiKey overrides from mutating the Gateway process environment
- pass skill env as a request-scoped overlay to CLI and shell child processes
- update docs and regression tests for host-env isolation

Fixes #12539.

## Tests
- corepack pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/skills.test.ts src/agents/cli-runner.spawn.test.ts src/agents/bash-tools.test.ts
- corepack pnpm exec tsc --noEmit -p tsconfig.core.test.agents.json
- corepack pnpm docs:list
- git diff --check