### PR TITLE
fix(reply): keep consumed reset triggers empty

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -128,6 +128,7 @@ async function resolveHelloWithModelDefaults(params: {
     groupResolution: undefined,
     isGroup: false,
     triggerBodyNormalized: "hello",
+    resetTriggered: false,
     commandAuthorized: false,
     defaultProvider: "openai",
     defaultModel: "gpt-4o-mini",
@@ -301,6 +302,7 @@ describe("resolveReplyDirectives", () => {
       groupResolution: undefined,
       isGroup: false,
       triggerBodyNormalized: "hello",
+      resetTriggered: false,
       commandAuthorized: false,
       defaultProvider: "openai",
       defaultModel: "gpt-4o-mini",
@@ -392,6 +394,7 @@ describe("resolveReplyDirectives", () => {
       groupResolution: undefined,
       isGroup: false,
       triggerBodyNormalized: "/trace on",
+      resetTriggered: false,
       commandAuthorized: true,
       defaultProvider: "openai",
       defaultModel: "gpt-4o-mini",
@@ -426,6 +429,65 @@ describe("resolveReplyDirectives", () => {
       }),
     });
     expect(resolveDefaultReasoningLevel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a fully consumed reset trigger out of the agent body", async () => {
+    const sessionCtx = {
+      Body: "",
+      BodyStripped: "",
+      BodyForAgent: "",
+      BodyForCommands: "new session",
+      CommandBody: "new session",
+      Provider: "slack",
+      Surface: "slack",
+    } as TemplateContext;
+
+    const result = await resolveReplyDirectives({
+      ctx: buildTestCtx({
+        Body: "Slack envelope",
+        BodyForAgent: "new session",
+        BodyForCommands: "new session",
+        CommandBody: "new session",
+        Provider: "slack",
+        Surface: "slack",
+        CommandAuthorized: true,
+      }),
+      cfg: {},
+      agentId: "main",
+      agentDir: "/tmp/main-agent",
+      workspaceDir: "/tmp",
+      agentCfg: {},
+      sessionCtx,
+      sessionEntry: makeSessionEntry(),
+      sessionStore: {},
+      sessionKey: "agent:main:slack:direct:user",
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-sender",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "new session",
+      resetTriggered: true,
+      commandAuthorized: true,
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      aliasIndex: { byAlias: new Map(), byKey: new Map() },
+      provider: "openai",
+      model: "gpt-4o-mini",
+      hasResolvedHeartbeatModelOverride: false,
+      typing: makeTypingController(),
+      opts: undefined,
+      skillFilter: undefined,
+    });
+
+    expect(result).toEqual({
+      kind: "continue",
+      result: expect.objectContaining({
+        cleanedBody: "",
+      }),
+    });
+    expect(sessionCtx.Body).toBe("");
+    expect(sessionCtx.BodyForAgent).toBe("");
+    expect(sessionCtx.BodyStripped).toBe("");
   });
 
   it("does not re-enable model reasoning when thinking was explicitly disabled", async () => {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -156,6 +156,7 @@ export async function resolveReplyDirectives(params: {
   groupResolution: Parameters<typeof resolveGroupRequireMention>[0]["groupResolution"];
   isGroup: boolean;
   triggerBodyNormalized: string;
+  resetTriggered: boolean;
   commandAuthorized: boolean;
   defaultProvider: string;
   defaultModel: string;
@@ -183,6 +184,7 @@ export async function resolveReplyDirectives(params: {
     groupResolution,
     isGroup,
     triggerBodyNormalized,
+    resetTriggered,
     commandAuthorized,
     defaultProvider,
     defaultModel,
@@ -334,6 +336,9 @@ export async function resolveReplyDirectives(params: {
       };
   const existingBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   let cleanedBody = (() => {
+    if (resetTriggered && !existingBody) {
+      return "";
+    }
     if (!existingBody) {
       return parsedDirectives.cleaned;
     }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -469,6 +469,7 @@ export async function getReplyFromConfig(
     groupResolution,
     isGroup,
     triggerBodyNormalized,
+    resetTriggered,
     commandAuthorized,
     defaultProvider,
     defaultModel,


### PR DESCRIPTION
## Summary

- Problem: Slack text reset triggers such as `new session` can reset the session and then be restored as normal model input during directive cleanup.
- Why it matters: a consumed reset trigger should start the new session without asking the model to interpret the trigger text.
- What changed: directive cleanup now preserves an empty body when the current turn already triggered a reset, and a Slack-shaped regression test covers the consumed-trigger invariant.
- What did NOT change (scope boundary): reset trigger matching, command authorization, Slack inbound preparation, model selection, provider routing, and reset-tail handling are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73137
- Related #73137
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `initSessionState` correctly consumes a whole-message configured reset trigger by setting the stripped body to empty, but `resolveReplyDirectives` treated any empty body as a reason to fall back to parsed command text and wrote the trigger back into `Body`, `BodyForAgent`, and `BodyStripped`.
- Missing detection / guardrail: existing tests covered reset matching and bare slash reset handling, but not the handoff from reset consumption through directive cleanup for a custom text trigger.
- Contributing context (if known): Slack exposes separate command-facing and model-facing bodies, which makes the command text fallback visible after reset matching.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply-directives.target-session.test.ts`
- Scenario the test should lock in: after a Slack-shaped `new session` turn has already triggered a reset and emptied the session body, directive cleanup keeps `Body`, `BodyForAgent`, and `BodyStripped` empty.
- Why this is the smallest reliable guardrail: the bug is in the shared directive cleanup handoff, so the test exercises that function directly without requiring a live Slack gateway or model call.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Slack and other text-command channels no longer pass a fully consumed configured reset trigger, such as `new session`, to the model as ordinary user input on the reset turn.

## Diagram (if applicable)

```text
Before:
custom reset trigger -> session reset -> directive cleanup restores trigger -> model sees trigger text

After:
custom reset trigger -> session reset -> directive cleanup preserves empty body -> reset startup path runs without trigger text
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

Runtime authorization and command/reset matching controls are unchanged; the fix only prevents already-consumed reset text from being reintroduced into the model prompt.

## Repro + Verification

### Environment

- OS: macOS 25.3.0 for local source validation; original observed report was a Raspberry Pi gateway on OpenClaw 2026.4.24.
- Runtime/container: local repo checkout on Node via repo scripts.
- Model/provider: provider-independent; original symptom used Gemini after the trigger text leaked.
- Integration/channel (if any): Slack-shaped inbound context.
- Relevant config (redacted): `session.resetTriggers` includes `new session`.

### Steps

1. Configure `session.resetTriggers` with `new session`.
2. Send a Slack message whose command-facing body is exactly `new session`.
3. Observe the reset turn after directive cleanup.

### Expected

- The message starts a fresh session and the literal `new session` text is not passed to the model.

### Actual

- Before this fix, directive cleanup could restore `new session` into `Body`, `BodyForAgent`, and `BodyStripped`, allowing the model to interpret it as ordinary user input.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The new regression test fails against the old directive cleanup behavior and passes with this fix.

## Human Verification (required)

- Verified scenarios: focused directive regression test, related session/reset reply tests, formatting, whitespace, and changed gate.
- Edge cases checked: reset tails remain out of scope because they produce a non-empty body before directive cleanup; command/reset authorization and matching are unchanged.
- What you did **not** verify: live Slack gateway round trip and live model/provider behavior.

Tests run:

- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply-directives.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/get-reply-directives.target-session.test.ts`
- `pnpm test src/auto-reply/reply/get-reply-directives.target-session.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm test src/auto-reply/reply/session.test.ts src/auto-reply/reply/get-reply-directives.target-session.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts -- --reporter=verbose`
- `pnpm check:changed`

Out-of-scope follow-ups:

- No Slack-specific command parsing changes.
- No changes to configured reset trigger syntax.
- No live Slack or provider smoke in this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a reset turn with intentionally empty user text could stop falling back to command text.
  - Mitigation: the new branch only applies when reset matching has already run; non-reset directive-only messages keep the existing fallback behavior, and reset turns with tails still carry a non-empty stripped body.