### PR TITLE
fix(cli): skip memory eager context warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/memory: skip eager context-window warmup for `openclaw memory` commands so memory search does not race unrelated model metadata discovery. Fixes #73123. Thanks @oalansilva.
+- CLI/memory: skip eager context-window warmup for `openclaw memory` commands so memory search does not race unrelated model metadata discovery. Fixes #73123. Thanks @oalansilva and @neeravmakwana.
 - Cron/providers: preflight local Ollama and OpenAI-compatible provider endpoints before isolated cron agent turns, record unreachable local providers as skipped runs, and cache dead-endpoint probes so many jobs do not hammer the same stopped local server. Fixes #58584. Thanks @jpeghead.
 - Gateway/config: let config reload continue in degraded mode when invalidity is scoped to plugin entries, so incompatible plugin configs can be skipped and the Gateway restart can still pick up the rest of the config after rollbacks. Fixes #73131. Thanks @Adam-Researchh.
 - Doctor/channels: suppress disabled bundled-plugin blocker warnings when a trusted external plugin owns the configured channel, so Lark/Feishu installs no longer get Feishu repair noise after switching to `openclaw-lark`. Fixes #56794. Thanks @wuji-tech-dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/memory: skip eager context-window warmup for `openclaw memory` commands so memory search does not race unrelated model metadata discovery. Fixes #73123. Thanks @oalansilva.
 - Cron/providers: preflight local Ollama and OpenAI-compatible provider endpoints before isolated cron agent turns, record unreachable local providers as skipped runs, and cache dead-endpoint probes so many jobs do not hammer the same stopped local server. Fixes #58584. Thanks @jpeghead.
 - Gateway/config: let config reload continue in degraded mode when invalidity is scoped to plugin entries, so incompatible plugin configs can be skipped and the Gateway restart can still pick up the rest of the config after rollbacks. Fixes #73131. Thanks @Adam-Researchh.
 - Doctor/channels: suppress disabled bundled-plugin blocker warnings when a trusted external plugin owns the configured channel, so Lark/Feishu installs no longer get Feishu repair noise after switching to `openclaw-lark`. Fixes #56794. Thanks @wuji-tech-dev.

--- a/src/agents/context.eager-warmup.test.ts
+++ b/src/agents/context.eager-warmup.test.ts
@@ -19,6 +19,7 @@ describe("agents/context eager warmup", () => {
   it.each([
     ["models", ["node", "openclaw", "models", "set", "openai/gpt-5.4"]],
     ["agent", ["node", "openclaw", "agent", "--message", "ok"]],
+    ["memory", ["node", "openclaw", "memory", "search", "--json"]],
   ])("does not eager-load config for %s commands on import", async (_label, argv) => {
     process.argv = argv;
     await importFreshModule(import.meta.url, `./context.js?scope=${_label}`);

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -222,6 +222,9 @@ describe("lookupContextTokens", () => {
     expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "logs", "--limit", "5"])).toBe(
       false,
     );
+    expect(
+      shouldEagerWarmContextWindowCache(["node", "openclaw", "memory", "search", "--json"]),
+    ).toBe(false);
     expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "status", "--json"])).toBe(false);
     expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "sessions", "--json"])).toBe(
       false,

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -151,6 +151,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "health",
   "hooks",
   "logs",
+  "memory",
   "models",
   "pairing",
   "plugins",


### PR DESCRIPTION
## Summary
- Add `memory` to the CLI commands that skip eager context-window cache warmup.
- Cover both the command-classification helper and import-time side effect so `openclaw memory search` does not start unrelated model metadata discovery.
- Add an unreleased changelog entry for #73123.

## Root Cause
`src/agents/context.ts` eagerly warms context-window metadata on import for real OpenClaw CLI invocations unless the primary command is in `SKIP_EAGER_WARMUP_PRIMARY_COMMANDS`. `memory` was missing from that skip list, so `openclaw memory search` could start context-window/model metadata discovery concurrently with the memory embedding search path.

## Linked Issue
Fixes #73123.

## Why This Is Safe
`openclaw memory` commands do not need context-window metadata during CLI startup; memory search manages its own memory manager, index, and embedding provider lifecycle. The change matches existing skipped read-only or maintenance commands such as `logs`, `status`, and `sessions`, and only disables import-time warmup for the `memory` primary command.

## Security And Runtime Controls
No auth, secret resolution, proxy behavior, embedding provider policy, prompt text, or runtime security control changes. Memory command secret resolution and memory manager behavior remain unchanged; this only prevents unrelated background context-window warmup from starting on `memory` CLI imports.

## Tests
- `git diff --check origin/main...HEAD`
- `pnpm test src/agents/context.lookup.test.ts src/agents/context.eager-warmup.test.ts`
- `pnpm check:changed`

## Out Of Scope
- Changes to memory embedding provider timeout behavior.
- Changes to context-window warmup for chat or other model-running startup commands.
- Broader refactors of CLI command registration or memory runtime lifecycle.

## Contributor Notes
- AI-assisted: yes.
- Testing: focused tests plus changed gate passed.

Made with [Cursor](https://cursor.com)