### PR TITLE
fix(cli): bare parent commands print help with exit 0 (#73077)

### DIFF
--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import {
+  attachBareCommandHelp,
   formatDocsLink,
   formatHelpExamples,
   theme,
@@ -112,6 +113,7 @@ export function registerMemoryCli(program: Command) {
           ["openclaw memory status --json", "Output machine-readable JSON (good for scripts)."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );
+  attachBareCommandHelp(memory);
 
   memory
     .command("status")

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -9,6 +9,7 @@ import { formatCliChannelOptions } from "./channel-options.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
 import { hasExplicitOptions } from "./command-options.js";
 import { formatHelpExamples } from "./help-format.js";
+import { attachBareCommandHelp } from "./program/bare-command-help.js";
 
 type ChannelsCommandsModule = typeof import("../commands/channels.js");
 
@@ -82,6 +83,7 @@ export function registerChannelsCli(program: Command) {
           "docs.openclaw.ai/cli/channels",
         )}\n`,
     );
+  attachBareCommandHelp(channels);
 
   channels
     .command("list")

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
+import { attachBareCommandHelp } from "../program/bare-command-help.js";
 import {
   registerCronAddCommand,
   registerCronListCommand,
@@ -18,6 +19,7 @@ export function registerCronCli(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/cron", "docs.openclaw.ai/cli/cron")}\n${theme.muted("Upgrade tip:")} run \`openclaw doctor --fix\` to normalize legacy cron job storage.\n`,
     );
+  attachBareCommandHelp(cron);
 
   registerCronStatusCommand(cron);
   registerCronListCommand(cron);

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -25,6 +25,7 @@ import {
 import { sanitizeForLog } from "../terminal/ansi.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
+import { attachBareCommandHelp } from "./program/bare-command-help.js";
 import { withProgress } from "./progress.js";
 
 type DevicesRpcOpts = {
@@ -346,6 +347,7 @@ function resolveRequiredDeviceRole(
 
 export function registerDevicesCli(program: Command) {
   const devices = program.command("devices").description("Device pairing and auth tokens");
+  attachBareCommandHelp(devices);
 
   devicesCallOpts(
     devices

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -23,6 +23,7 @@ import { isRich, theme } from "../terminal/theme.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
 import { nodesCallOpts, resolveNodeId } from "./nodes-cli/rpc.js";
 import type { NodesRpcOpts } from "./nodes-cli/types.js";
+import { attachBareCommandHelp } from "./program/bare-command-help.js";
 
 type ExecApprovalsSnapshot = {
   path: string;
@@ -484,6 +485,7 @@ export function registerExecApprovalsCli(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/approvals", "docs.openclaw.ai/cli/approvals")}\n`,
     );
+  attachBareCommandHelp(approvals);
 
   const getCmd = approvals
     .command("get")

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -12,6 +12,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "../shared/string-coerce.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
+import { attachBareCommandHelp } from "./program/bare-command-help.js";
 
 function fail(message: string): never {
   defaultRuntime.error(message);
@@ -25,6 +26,7 @@ function printJson(value: unknown): void {
 
 export function registerMcpCli(program: Command) {
   const mcp = program.command("mcp").description("Manage OpenClaw MCP config and channel bridge");
+  attachBareCommandHelp(mcp);
 
   mcp
     .command("serve")

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -13,6 +13,7 @@ import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
 import { formatPluginLine } from "./plugins-list-format.js";
+import { attachBareCommandHelp } from "./program/bare-command-help.js";
 
 export type PluginsListOptions = {
   json?: boolean;
@@ -138,6 +139,7 @@ export function registerPluginsCli(program: Command) {
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/plugins", "docs.openclaw.ai/cli/plugins")}\n`,
     );
+  attachBareCommandHelp(plugins);
 
   plugins
     .command("list")

--- a/src/cli/program/bare-command-help.test.ts
+++ b/src/cli/program/bare-command-help.test.ts
@@ -1,0 +1,101 @@
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { attachBareCommandHelp } from "./bare-command-help.js";
+
+function buildParentWithSubcommand(): { program: Command; parent: Command } {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  const parent = program.command("widget").description("manage widgets");
+  parent.exitOverride();
+  parent.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  parent
+    .command("list")
+    .description("list widgets")
+    .action(() => {});
+  return { program, parent };
+}
+
+describe("attachBareCommandHelp", () => {
+  it("makes bare parent invocation print help and exit cleanly", () => {
+    const { program, parent } = buildParentWithSubcommand();
+    const writeOut = vi.fn<(str: string) => void>();
+    parent.configureOutput({ writeOut, writeErr: () => {} });
+    attachBareCommandHelp(parent);
+
+    // commander invokes process.exit(0) via exitOverride after .help() — must not throw a usage error
+    expect(() => program.parse(["node", "prog", "widget"])).toThrow(
+      expect.objectContaining({ code: "commander.help" }),
+    );
+
+    expect(writeOut).toHaveBeenCalled();
+    const output = writeOut.mock.calls.map((call) => call[0]).join("");
+    expect(output).toContain("widget");
+    expect(output).toContain("list");
+  });
+
+  it("does not interfere with subcommand invocation", () => {
+    const { program, parent } = buildParentWithSubcommand();
+    attachBareCommandHelp(parent);
+    const listAction = vi.fn();
+    parent.command("show").description("show widget").action(listAction);
+
+    program.parse(["node", "prog", "widget", "show"]);
+    expect(listAction).toHaveBeenCalled();
+  });
+
+  it("returns the same command for chaining", () => {
+    const cmd = new Command("widget");
+    cmd
+      .command("noop")
+      .description("noop")
+      .action(() => {});
+    expect(attachBareCommandHelp(cmd)).toBe(cmd);
+  });
+});
+
+describe("attachBareCommandHelp regression: bare parent must exit 0", () => {
+  // commander's default behavior for a parent command with subcommands but
+  // no own action is to print help to stderr and exit with code 1. This
+  // breaks `openclaw <parent> && next-command` shell chains. The helper
+  // installs an explicit action that calls .help({ error: false }) so the
+  // process exits 0 with help on stdout.
+  it("uses error:false (exit code 0) instead of commander default (exit 1)", () => {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeOut: () => {}, writeErr: () => {} });
+    const cmd = program.command("widget").description("manage widgets");
+    cmd.exitOverride();
+    const writeOut = vi.fn<(str: string) => void>();
+    const writeErr = vi.fn<(str: string) => void>();
+    cmd.configureOutput({ writeOut, writeErr });
+    cmd
+      .command("list")
+      .description("list")
+      .action(() => {});
+    attachBareCommandHelp(cmd);
+
+    let caught: { code?: string; exitCode?: number } | null = null;
+    const previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    try {
+      program.parse(["node", "prog", "widget"]);
+    } catch (err) {
+      caught = err as { code?: string; exitCode?: number };
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(caught?.code).toBe("commander.help");
+    expect(caught?.exitCode).toBe(0);
+    expect(writeOut).toHaveBeenCalled();
+    expect(writeErr).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/program/bare-command-help.ts
+++ b/src/cli/program/bare-command-help.ts
@@ -1,0 +1,23 @@
+import type { Command } from "commander";
+
+/**
+ * Attach a default action to a parent command so that invoking it bare
+ * (`openclaw <name>` with no subcommand) prints the help and exits 0,
+ * matching the behavior of `openclaw <name> --help`.
+ *
+ * Without this, commander's default behavior on a parent command with
+ * subcommands but no own action is to print help and exit with code 1
+ * (treated as a usage error). That breaks shell `&&` chains and is
+ * inconsistent with sibling parents like `agents` and `sessions` that
+ * already define a bare default action.
+ *
+ * Use this only on parent commands whose bare invocation should be a
+ * no-op + help (purely informational). Commands that intentionally treat
+ * a missing subcommand as a usage error should keep `cmd.help({ error: true })`.
+ */
+export function attachBareCommandHelp(cmd: Command): Command {
+  cmd.action(() => {
+    cmd.help({ error: false });
+  });
+  return cmd;
+}

--- a/src/memory-host-sdk/runtime-cli.ts
+++ b/src/memory-host-sdk/runtime-cli.ts
@@ -1,5 +1,6 @@
 // Focused runtime contract for memory CLI/UI helpers.
 
+export { attachBareCommandHelp } from "../cli/program/bare-command-help.js";
 export { formatErrorMessage, withManager } from "../cli/cli-utils.js";
 export { formatHelpExamples } from "../cli/help-format.js";
 export { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";


### PR DESCRIPTION
Fixes #73077

## Problem

Parent CLI commands like `openclaw memory`, `openclaw mcp`, `openclaw channels`, `openclaw plugins`, `openclaw approvals`, `openclaw devices`, and `openclaw cron` exit with code **1** when invoked without a subcommand, treating it as a usage error. This breaks shell chains:

```bash
openclaw memory && echo ok   # never prints "ok" today
```

Meanwhile `openclaw agents` and `openclaw sessions` already exit 0 with a useful default action — so behavior is inconsistent.

Repro on 2026.4.23:
```
$ openclaw mcp >/dev/null; echo $?
1
$ openclaw agents >/dev/null; echo $?
0
```

## Fix

Introduce `attachBareCommandHelp(cmd)` in `src/cli/program/bare-command-help.ts`. It installs a default `.action()` on the parent that calls `cmd.help({ error: false })` — prints help to stdout and exits with code 0, matching the user-friendly pattern.

Apply it to the seven affected parents:
- `memory` (extensions/memory-core)
- `mcp`
- `channels`
- `plugins`
- `approvals` (exec-approvals)
- `devices`
- `cron`

The helper is also re-exported from `src/memory-host-sdk/runtime-cli.ts` (`openclaw/plugin-sdk/memory-core-host-runtime-cli`) so the bundled memory-core extension can use it without reaching into internal paths.

Note: `openclaw message` exhibits the same bug but explicitly opts into `{ error: true }`. Left as-is in this PR — issue only enumerates the seven parents above. Happy to fold it in if maintainers prefer.

## Tests

New file `src/cli/program/bare-command-help.test.ts` covers:
- bare invocation prints help and exits cleanly
- subcommand invocation is unaffected
- **regression test**: explicit `expect(caught.exitCode).toBe(0)` (would fail without the helper, since commander defaults to 1 for parents-with-subcommands invoked bare)

```
✓ src/cli/program/bare-command-help.test.ts (4 tests) 105ms
```

Existing `mcp-cli.test.ts`, `devices-cli.test.ts`, `exec-approvals-cli.test.ts`, `plugins-cli.install.test.ts` (44), `cron-cli/shared.test.ts` (21) all still pass.

## Notes

- 10-line helper, ~2 lines per callsite — minimal surface
- No behavior change for subcommand invocations
- No public API change (helper is internal to the program directory)
