### PR TITLE
Fix cron payload model allowlist failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/providers: return an explicit error when a cron `payload.model` is not allowed instead of silently falling back to the agent default model before the configured provider/proxy can run. Fixes #73146. Thanks @oneandrewwang.
 - Cron/providers: preflight local Ollama and OpenAI-compatible provider endpoints before isolated cron agent turns, record unreachable local providers as skipped runs, and cache dead-endpoint probes so many jobs do not hammer the same stopped local server. Fixes #58584. Thanks @jpeghead.
 - Gateway/config: let config reload continue in degraded mode when invalidity is scoped to plugin entries, so incompatible plugin configs can be skipped and the Gateway restart can still pick up the rest of the config after rollbacks. Fixes #73131. Thanks @Adam-Researchh.
 - Doctor/channels: suppress disabled bundled-plugin blocker warnings when a trusted external plugin owns the configured channel, so Lark/Feishu installs no longer get Feishu repair noise after switching to `openclaw-lark`. Fixes #56794. Thanks @wuji-tech-dev.

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -35,7 +35,6 @@ export type ResolveCronModelSelectionResult =
       ok: true;
       provider: string;
       model: string;
-      warning?: string;
     }
   | {
       ok: false;
@@ -114,10 +113,8 @@ export async function resolveCronModelSelection(
     if ("error" in resolvedOverride) {
       if (resolvedOverride.error.startsWith("model not allowed:")) {
         return {
-          ok: true,
-          provider,
-          model,
-          warning: `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
+          ok: false,
+          error: `cron: payload.model '${modelOverride}' rejected by agents.defaults.models allowlist: ${resolvedOverride.error}`,
         };
       }
       return { ok: false, error: resolvedOverride.error };

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -211,30 +211,36 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
-    it("falls back to agent defaults when payload.model is not allowed", async () => {
+    it("returns an explicit error when payload.model is not allowed", async () => {
       resolveAllowedModelRefMock.mockReturnValueOnce({
         error: "model not allowed: anthropic/claude-sonnet-4-6",
       });
 
-      await runSkillFilterCase({
-        cfg: {
-          agents: {
-            defaults: {
-              model: { primary: "openai-codex/gpt-5.4", fallbacks: defaultFallbacks },
+      const result = await runCronIsolatedAgentTurn(
+        makeSkillParams({
+          cfg: {
+            agents: {
+              defaults: {
+                model: { primary: "openai-codex/gpt-5.4", fallbacks: defaultFallbacks },
+              },
             },
           },
-        },
-        job: makeSkillJob({
-          payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
+          job: makeSkillJob({
+            payload: {
+              kind: "agentTurn",
+              message: "test",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          }),
         }),
-      });
-      expect(logWarnMock).toHaveBeenCalledWith(
-        "cron: payload.model 'anthropic/claude-sonnet-4-6' not allowed, falling back to agent defaults",
       );
-      expectDefaultModelCall({
-        primary: "openai-codex/gpt-5.4",
-        fallbacks: defaultFallbacks,
-      });
+
+      expect(result.status).toBe("error");
+      expect(result.error).toBe(
+        "cron: payload.model 'anthropic/claude-sonnet-4-6' rejected by agents.defaults.models allowlist: model not allowed: anthropic/claude-sonnet-4-6",
+      );
+      expect(logWarnMock).not.toHaveBeenCalled();
+      expect(runWithModelFallbackMock).not.toHaveBeenCalled();
     });
 
     it("returns an error when payload.model is invalid", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -575,9 +575,6 @@ async function prepareCronRunContext(params: {
   }
   let provider = resolvedModelSelection.provider;
   let model = resolvedModelSelection.model;
-  if (resolvedModelSelection.warning) {
-    logWarn(resolvedModelSelection.warning);
-  }
 
   const preflight = await (
     await loadCronModelPreflightRuntime()


### PR DESCRIPTION
## Summary
- Fixes #73146.
- Cron `payload.model` allowlist failures now stop the isolated cron run with an explicit `payload.model` / `agents.defaults.models` validation error instead of falling back to the agent default model.
- Updated the focused cron regression test and changelog entry for the new behavior.

## Root Cause
Cron model selection treated `model not allowed` from payload model resolution as a warning path. That returned the previously selected provider/model, which could be the agent default, so provider/proxy routes configured in `payload.model` were bypassed without a hard validation failure.

## Why This Is Safe
The change only affects cron `payload.model` values that already fail the runtime allowlist check. Valid configured models still resolve and run through the existing provider/model forwarding path, and invalid model syntax still returns the existing invalid-model error.

## Security And Runtime Controls
No allowlist, provider catalog, auth profile, preflight, fallback, or execution policy is loosened. The existing runtime model allowlist remains authoritative; this PR changes the rejected cron payload path from silent fallback to explicit failure.

## Tests
- `git diff --check origin/main...HEAD`
- `pnpm test src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts src/cron/isolated-agent/run.skill-filter.test.ts -- --reporter=verbose`
- `pnpm check:changed`

## Out Of Scope
- No changes to model catalog resolution or provider/proxy configuration.
- No changes to normal model fallback behavior after a valid cron model has been selected.
- No changes to non-cron session model override behavior.

Made with [Cursor](https://cursor.com)