### PR TITLE
fix(build): write runtime-postbuild stamp during build

### DIFF
--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -51,6 +51,10 @@ function withBuildCacheFixture(
   }
 }
 
+function readPackageScripts() {
+  return JSON.parse(fs.readFileSync("package.json", "utf8")).scripts as Record<string, string>;
+}
+
 describe("resolveBuildAllStep", () => {
   it("routes pnpm steps through the npm_execpath pnpm runner on Windows", () => {
     const step = BUILD_ALL_STEPS.find((entry) => entry.label === "canvas:a2ui:bundle");
@@ -182,6 +186,18 @@ describe("resolveBuildAllSteps", () => {
   it("rejects unknown build profiles", () => {
     expect(() => resolveBuildAllSteps("wat")).toThrow("Unknown build profile: wat");
   });
+});
+
+describe("package build scripts", () => {
+  it.each(["build:docker", "build:strict-smoke"])(
+    "writes the runtime postbuild stamp after the build stamp in %s",
+    (scriptName) => {
+      const script = readPackageScripts()[scriptName];
+      expect(script).toContain(
+        "node scripts/runtime-postbuild.mjs && node scripts/build-stamp.mjs && node scripts/runtime-postbuild-stamp.mjs",
+      );
+    },
+  );
 });
 
 describe("resolveBuildAllStepCacheState", () => {


### PR DESCRIPTION
## Summary

- Problem: `pnpm build` runs `[build-all] runtime-postbuild` but did not create `dist/.runtime-postbuildstamp`, so the first later `pnpm openclaw` invocation re-synced runtime artifacts.
- Why it matters: The first CLI command after a successful build paid redundant runtime-postbuild work and printed a misleading `missing_runtime_postbuild_stamp` message.
- What changed: Added a shared runtime-postbuild stamp writer, added a `runtime-postbuild-stamp` build step after `build-stamp`, and kept `run-node` on the same stamp writer.
- What did NOT change (scope boundary): No runtime artifact contents, provider behavior, channel behavior, or changelog updates.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #73151
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `scripts/run-node.mjs` owned the only `.runtime-postbuildstamp` writer, while `scripts/build-all.mjs` ran `scripts/runtime-postbuild.mjs` without writing that stamp.
- Missing detection / guardrail: Build-step tests asserted the runtime-postbuild step existed, but not that the build pipeline produced the runtime-postbuild freshness stamp.
- Contributing context (if known): The runtime freshness check treats a missing stamp as `missing_runtime_postbuild_stamp`, which is correct for ad hoc CLI launches but incorrect immediately after a successful build-side runtime-postbuild.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/build-all.test.ts`, `test/scripts/runtime-postbuild-stamp.test.ts`, `src/infra/run-node.test.ts`.
- Scenario the test should lock in: `build-all` runs `runtime-postbuild-stamp` after `build-stamp`, and the shared writer produces `dist/.runtime-postbuildstamp` with the current git head.
- Why this is the smallest reliable guardrail: The regression is in script orchestration and stamp production, so script-level tests cover the failing path without a full build.
- Existing test that already covers this (if any): `src/infra/run-node.test.ts` already covers runtime stamp freshness consumption.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

After a successful `pnpm build`, the next `pnpm openclaw <cmd>` no longer performs an avoidable runtime artifact sync solely because `dist/.runtime-postbuildstamp` is missing.

## Diagram (if applicable)

```text
Before:
pnpm build -> runtime-postbuild -> build-stamp -> no runtime-postbuild stamp -> first CLI re-syncs

After:
pnpm build -> runtime-postbuild -> build-stamp -> runtime-postbuild-stamp -> first CLI uses current artifacts
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS
- Runtime/container: Node v22.22.1, pnpm 10.33.0, source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `rm -f dist/.runtime-postbuildstamp`.
2. Run `pnpm build`.
3. Run `pnpm openclaw --version`.

### Expected

- `dist/.runtime-postbuildstamp` exists after `pnpm build`.
- `pnpm openclaw --version` does not print `Syncing runtime artifacts` because the runtime-postbuild stamp is missing.

### Actual

- Before this fix, the stamp was missing after `pnpm build` and the next CLI invocation printed `missing_runtime_postbuild_stamp`.
- With this fix, the stamp exists after build and the next CLI invocation does not print the sync log.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

After fix direct repro:

```text
stamp_after_build=present
sync_log_after_build=absent
build_steps=[build-all] runtime-postbuild;[build-all] build-stamp;[build-all] runtime-postbuild-stamp;
version_output=OpenClaw 2026.4.26 (df6554e)
```

Test commands run:

```text
pnpm test test/scripts/build-all.test.ts test/scripts/runtime-postbuild-stamp.test.ts src/infra/run-node.test.ts
pnpm check:changed
```

## Human Verification (required)

- Verified scenarios: Targeted script/runtime tests; changed gate; direct repro from deleted stamp through `pnpm build` and first `pnpm openclaw --version`.
- Edge cases checked: Runtime stamp ordering is after `build-stamp`; `run-node` and build-side script share one writer.
- What you did **not** verify: Packaged npm install/update flow and cross-platform Windows/macOS build execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The build pipeline now has one extra lightweight Node step.
  - Mitigation: The step only writes a small JSON stamp and is covered by script tests.
