### PR TITLE
fix(signal): detect generic voice-note attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Signal/TTS: infer voice-note audio from generic Signal attachment MIME types when the saved filename is audio, so `messages.tts.auto: "inbound"` can produce voice replies for Signal DMs that arrive as `application/octet-stream`. Fixes #73091. Thanks @ScientificProgrammer.
 - Cron/providers: preflight local Ollama and OpenAI-compatible provider endpoints before isolated cron agent turns, record unreachable local providers as skipped runs, and cache dead-endpoint probes so many jobs do not hammer the same stopped local server. Fixes #58584. Thanks @jpeghead.
 - Gateway/config: let config reload continue in degraded mode when invalidity is scoped to plugin entries, so incompatible plugin configs can be skipped and the Gateway restart can still pick up the rest of the config after rollbacks. Fixes #73131. Thanks @Adam-Researchh.
 - Doctor/channels: suppress disabled bundled-plugin blocker warnings when a trusted external plugin owns the configured channel, so Lark/Feishu installs no longer get Feishu repair noise after switching to `openclaw-lark`. Fixes #56794. Thanks @wuji-tech-dev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Signal/TTS: infer voice-note audio from generic Signal attachment MIME types when the saved filename is audio, so `messages.tts.auto: "inbound"` can produce voice replies for Signal DMs that arrive as `application/octet-stream`. Fixes #73091. Thanks @ScientificProgrammer.
+- Signal/TTS: preserve sniffed audio MIME types for generic Signal voice-note downloads, so `messages.tts.auto: "inbound"` can produce voice replies without trusting attachment filenames. Fixes #73091. Thanks @ScientificProgrammer.
 - Cron/providers: preflight local Ollama and OpenAI-compatible provider endpoints before isolated cron agent turns, record unreachable local providers as skipped runs, and cache dead-endpoint probes so many jobs do not hammer the same stopped local server. Fixes #58584. Thanks @jpeghead.
 - Gateway/config: let config reload continue in degraded mode when invalidity is scoped to plugin entries, so incompatible plugin configs can be skipped and the Gateway restart can still pick up the rest of the config after rollbacks. Fixes #73131. Thanks @Adam-Researchh.
 - Doctor/channels: suppress disabled bundled-plugin blocker warnings when a trusted external plugin owns the configured channel, so Lark/Feishu installs no longer get Feishu repair noise after switching to `openclaw-lark`. Fixes #56794. Thanks @wuji-tech-dev.

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -299,9 +299,10 @@ async function fetchAttachment(params: {
   }
   const buffer = Buffer.from(result.data, "base64");
   const originalFilename = normalizeOptionalString(attachment.filename ?? undefined);
-  const contentType =
-    normalizeOptionalString(attachment.contentType ?? undefined) ??
-    (await detectMime({ buffer, filePath: originalFilename }));
+  const contentType = await detectMime({
+    buffer,
+    headerMime: attachment.contentType ?? undefined,
+  });
   const saved = await saveMediaBuffer(
     buffer,
     contentType,

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -301,7 +301,41 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.MediaTypes).toEqual(["image/jpeg", "application/octet-stream"]);
   });
 
-  it("infers Signal voice attachment audio from filename when MIME is generic", async () => {
+  it("threads sniffed audio contentType for generic Signal voice attachments", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        },
+        ignoreAttachments: false,
+        fetchAttachment: async ({ attachment }) => ({
+          path: `/tmp/${String(attachment.id)}.dat`,
+          contentType: "audio/aac",
+        }),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "",
+          attachments: [
+            { id: "voice1", contentType: "application/octet-stream", filename: "voice.aac" },
+          ],
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.MediaPath).toBe("/tmp/voice1.dat");
+    expect(capture.ctx?.MediaType).toBe("audio/aac");
+    expect(capture.ctx?.MediaTypes).toEqual(["audio/aac"]);
+    expect(capture.ctx?.BodyForAgent).toBe("<media:audio>");
+  });
+
+  it("does not infer audio from an unverified Signal attachment filename", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
@@ -329,10 +363,9 @@ describe("signal createSignalEventHandler inbound context", () => {
     );
 
     expect(capture.ctx).toBeTruthy();
-    expect(capture.ctx?.MediaPath).toBe("/tmp/voice1.aac");
-    expect(capture.ctx?.MediaType).toBe("audio/aac");
-    expect(capture.ctx?.MediaTypes).toEqual(["audio/aac"]);
-    expect(capture.ctx?.BodyForAgent).toBe("<media:audio>");
+    expect(capture.ctx?.MediaType).toBe("application/octet-stream");
+    expect(capture.ctx?.MediaTypes).toEqual(["application/octet-stream"]);
+    expect(capture.ctx?.BodyForAgent).toBe("<media:document>");
   });
 
   it("drops own UUID inbound messages when only accountUuid is configured", async () => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -301,7 +301,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.MediaTypes).toEqual(["image/jpeg", "application/octet-stream"]);
   });
 
-  it("threads resolved audio contentType for Signal voice attachments", async () => {
+  it("infers Signal voice attachment audio from filename when MIME is generic", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
         cfg: {
@@ -311,7 +311,7 @@ describe("signal createSignalEventHandler inbound context", () => {
         ignoreAttachments: false,
         fetchAttachment: async ({ attachment }) => ({
           path: `/tmp/${String(attachment.id)}.aac`,
-          contentType: "audio/aac",
+          contentType: "application/octet-stream",
         }),
         historyLimit: 0,
       }),
@@ -321,7 +321,9 @@ describe("signal createSignalEventHandler inbound context", () => {
       createSignalReceiveEvent({
         dataMessage: {
           message: "",
-          attachments: [{ id: "voice1", contentType: undefined, filename: "voice.aac" }],
+          attachments: [
+            { id: "voice1", contentType: "application/octet-stream", filename: "voice.aac" },
+          ],
         },
       }),
     );
@@ -330,6 +332,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.MediaPath).toBe("/tmp/voice1.aac");
     expect(capture.ctx?.MediaType).toBe("audio/aac");
     expect(capture.ctx?.MediaTypes).toEqual(["audio/aac"]);
+    expect(capture.ctx?.BodyForAgent).toBe("<media:audio>");
   });
 
   it("drops own UUID inbound messages when only accountUuid is configured", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -25,7 +25,7 @@ import {
   toInternalMessageReceivedContext,
   triggerInternalHook,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { kindFromMime, mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-runtime";
+import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -83,26 +83,6 @@ function formatAttachmentSummaryPlaceholder(contentTypes: Array<string | undefin
     formatAttachmentKindCount(kind, count),
   );
   return `[${parts.join(" + ")} attached]`;
-}
-
-function resolveSignalAttachmentMediaType(params: {
-  attachmentContentType?: string | null;
-  attachmentFilename?: string | null;
-  fetchedContentType?: string;
-  fetchedPath: string;
-}): string | undefined {
-  const contentType =
-    normalizeOptionalString(params.fetchedContentType) ??
-    normalizeOptionalString(params.attachmentContentType);
-  const normalized = contentType?.split(";")[0]?.trim().toLowerCase();
-  if (normalized && normalized !== "application/octet-stream") {
-    return contentType;
-  }
-  return (
-    mimeTypeFromFilePath(
-      normalizeOptionalString(params.attachmentFilename) ?? params.fetchedPath,
-    ) ?? contentType
-  );
 }
 
 function resolveSignalInboundRoute(params: {
@@ -814,17 +794,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             maxBytes: deps.mediaMaxBytes,
           });
           if (fetched) {
-            const resolvedMediaType = resolveSignalAttachmentMediaType({
-              attachmentContentType: attachment.contentType,
-              attachmentFilename: attachment.filename,
-              fetchedContentType: fetched.contentType,
-              fetchedPath: fetched.path,
-            });
             mediaPaths.push(fetched.path);
-            mediaTypes.push(resolvedMediaType ?? "application/octet-stream");
+            mediaTypes.push(
+              fetched.contentType ?? attachment.contentType ?? "application/octet-stream",
+            );
             if (!mediaPath) {
               mediaPath = fetched.path;
-              mediaType = resolvedMediaType;
+              mediaType = fetched.contentType ?? attachment.contentType ?? undefined;
             }
           }
         } catch (err) {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -25,7 +25,7 @@ import {
   toInternalMessageReceivedContext,
   triggerInternalHook,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
+import { kindFromMime, mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -83,6 +83,26 @@ function formatAttachmentSummaryPlaceholder(contentTypes: Array<string | undefin
     formatAttachmentKindCount(kind, count),
   );
   return `[${parts.join(" + ")} attached]`;
+}
+
+function resolveSignalAttachmentMediaType(params: {
+  attachmentContentType?: string | null;
+  attachmentFilename?: string | null;
+  fetchedContentType?: string;
+  fetchedPath: string;
+}): string | undefined {
+  const contentType =
+    normalizeOptionalString(params.fetchedContentType) ??
+    normalizeOptionalString(params.attachmentContentType);
+  const normalized = contentType?.split(";")[0]?.trim().toLowerCase();
+  if (normalized && normalized !== "application/octet-stream") {
+    return contentType;
+  }
+  return (
+    mimeTypeFromFilePath(
+      normalizeOptionalString(params.attachmentFilename) ?? params.fetchedPath,
+    ) ?? contentType
+  );
 }
 
 function resolveSignalInboundRoute(params: {
@@ -794,13 +814,17 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             maxBytes: deps.mediaMaxBytes,
           });
           if (fetched) {
+            const resolvedMediaType = resolveSignalAttachmentMediaType({
+              attachmentContentType: attachment.contentType,
+              attachmentFilename: attachment.filename,
+              fetchedContentType: fetched.contentType,
+              fetchedPath: fetched.path,
+            });
             mediaPaths.push(fetched.path);
-            mediaTypes.push(
-              fetched.contentType ?? attachment.contentType ?? "application/octet-stream",
-            );
+            mediaTypes.push(resolvedMediaType ?? "application/octet-stream");
             if (!mediaPath) {
               mediaPath = fetched.path;
-              mediaType = fetched.contentType ?? attachment.contentType ?? undefined;
+              mediaType = resolvedMediaType;
             }
           }
         } catch (err) {


### PR DESCRIPTION
## Summary
- Fixes #73091 by preserving byte-sniffed audio MIME types when Signal downloads voice-note attachments that were declared as `application/octet-stream`.
- Keeps verified Signal voice notes marked as `audio/*` so `messages.tts.auto: "inbound"` reaches the existing inbound-audio TTS gate.
- Adds Signal regression coverage for both sniffed generic voice attachments and audio-looking filenames that remain unverified.

## Root cause
Signal attachments can arrive with `application/octet-stream`. The previous Signal download path preserved that generic declared MIME even after fetching the attachment bytes, so the reply dispatcher later computed `inboundAudio = false` before media understanding could transcribe the audio.

## Why this is safe
The fix uses the existing shared `detectMime` helper on the downloaded bytes and declared header MIME, then passes that verified content type through the existing Signal inbound context. Non-generic MIME values continue through the same shared detector path, and audio-looking filenames no longer upgrade generic attachments to `audio/*` by themselves.

Security/runtime controls are unchanged: Signal allowlist/DM policy, mention gating, attachment fetch limits, media storage, media understanding, and the TTS `auto: "inbound"` runtime gate all remain enforced by the existing runtime paths.

## Tests
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/signal/src/monitor.ts extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts`
- `pnpm test extensions/signal/src/monitor/event-handler.inbound-context.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm check:changed`

## Out of scope
- No changes to TTS provider selection, TTS auto-mode policy, or outbound audio generation.
- No changes to Signal attachment download limits or Signal access policy.
- No broad media MIME policy changes outside the Signal inbound download path.