### PR TITLE
feat(codex): allow provider passthrough opt-in

### DIFF
--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -133,6 +133,10 @@
           "serviceTier": { "type": ["string", "null"], "enum": ["fast", "flex", null] },
           "defaultWorkspaceDir": {
             "type": "string"
+          },
+          "modelProviderPassthrough": {
+            "type": "boolean",
+            "default": false
           }
         }
       }
@@ -271,6 +275,11 @@
     "appServer.defaultWorkspaceDir": {
       "label": "Default Workspace",
       "help": "Workspace used by /codex bind when --cwd is omitted.",
+      "advanced": true
+    },
+    "appServer.modelProviderPassthrough": {
+      "label": "Model Provider Passthrough",
+      "help": "Pass the selected OpenClaw provider ID through to Codex app-server. Leave disabled for Codex's native provider selection.",
       "advanced": true
     }
   }

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -22,6 +22,7 @@ describe("Codex app-server config", () => {
           sandbox: "danger-full-access",
           approvalsReviewer: "guardian_subagent",
           serviceTier: "flex",
+          modelProviderPassthrough: true,
         },
       },
       env: {
@@ -36,6 +37,7 @@ describe("Codex app-server config", () => {
         sandbox: "danger-full-access",
         approvalsReviewer: "guardian_subagent",
         serviceTier: "flex",
+        modelProviderPassthrough: true,
         start: expect.objectContaining({
           transport: "websocket",
           url: "ws://127.0.0.1:39175",

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -52,6 +52,7 @@ export type CodexAppServerRuntimeOptions = {
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
+  modelProviderPassthrough?: boolean;
 };
 
 export type CodexPluginConfig = {
@@ -75,6 +76,7 @@ export type CodexPluginConfig = {
     approvalsReviewer?: CodexAppServerApprovalsReviewer;
     serviceTier?: CodexServiceTier | null;
     defaultWorkspaceDir?: string;
+    modelProviderPassthrough?: boolean;
   };
 };
 
@@ -93,6 +95,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "approvalsReviewer",
   "serviceTier",
   "defaultWorkspaceDir",
+  "modelProviderPassthrough",
 ] as const;
 
 export const CODEX_COMPUTER_USE_CONFIG_KEYS = [
@@ -163,6 +166,7 @@ const codexPluginConfigSchema = z
         approvalsReviewer: codexAppServerApprovalsReviewerSchema.optional(),
         serviceTier: codexAppServerServiceTierSchema,
         defaultWorkspaceDir: z.string().optional(),
+        modelProviderPassthrough: z.boolean().optional(),
       })
       .strict()
       .optional(),
@@ -231,6 +235,7 @@ export function resolveCodexAppServerRuntimeOptions(
       resolveApprovalsReviewer(config.approvalsReviewer) ??
       (policyMode === "guardian" ? "auto_review" : "user"),
     ...(serviceTier ? { serviceTier } : {}),
+    ...(config.modelProviderPassthrough ? { modelProviderPassthrough: true } : {}),
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1409,6 +1409,7 @@ describe("runCodexAppServerAttempt", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     const appServer = createThreadLifecycleAppServerOptions();
+    appServer.modelProviderPassthrough = true;
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-existing");
@@ -1445,12 +1446,14 @@ describe("runCodexAppServerAttempt", () => {
         "thread/start",
         expect.objectContaining({
           config,
+          modelProvider: "codex",
         }),
       ],
       [
         "thread/resume",
         expect.objectContaining({
           config,
+          modelProvider: "codex",
         }),
       ],
     ]);
@@ -1589,6 +1592,9 @@ describe("runCodexAppServerAttempt", () => {
       developerInstructions: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
       persistExtendedHistory: true,
     });
+    expect(buildThreadResumeParams(params, { threadId: "thread-1", appServer })).not.toHaveProperty(
+      "modelProvider",
+    );
     expect(
       buildTurnStartParams(params, { threadId: "thread-1", cwd: "/tmp/workspace", appServer }),
     ).toEqual(

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -66,7 +66,10 @@ export async function startOrResumeThread(params: {
           ),
         );
         const boundAuthProfileId = params.params.authProfileId ?? binding.authProfileId;
-        const fallbackModelProvider = resolveCodexAppServerModelProvider(params.params.provider);
+        const fallbackModelProvider = resolveCodexAppServerModelProvider(
+          params.params.provider,
+          params.appServer.modelProviderPassthrough,
+        );
         await writeCodexAppServerBinding(params.params.sessionFile, {
           threadId: response.thread.id,
           cwd: params.cwd,
@@ -94,7 +97,10 @@ export async function startOrResumeThread(params: {
     }
   }
 
-  const modelProvider = resolveCodexAppServerModelProvider(params.params.provider);
+  const modelProvider = resolveCodexAppServerModelProvider(
+    params.params.provider,
+    params.appServer.modelProviderPassthrough,
+  );
   const response = assertCodexThreadStartResponse(
     await params.client.request("thread/start", {
       model: params.params.modelId,
@@ -146,7 +152,10 @@ export function buildThreadResumeParams(
     config?: JsonObject;
   },
 ): CodexThreadResumeParams {
-  const modelProvider = resolveCodexAppServerModelProvider(params.provider);
+  const modelProvider = resolveCodexAppServerModelProvider(
+    params.provider,
+    options.appServer.modelProviderPassthrough,
+  );
   return {
     threadId: options.threadId,
     model: params.modelId,
@@ -274,8 +283,14 @@ function buildUserInput(
   ];
 }
 
-function resolveCodexAppServerModelProvider(provider: string): string | undefined {
+function resolveCodexAppServerModelProvider(
+  provider: string,
+  passthroughProvider = false,
+): string | undefined {
   const normalized = provider.trim();
+  if (passthroughProvider) {
+    return normalized;
+  }
   if (!normalized || normalized === "codex") {
     // `codex` is OpenClaw's virtual provider; let Codex app-server keep its
     // native provider/auth selection instead of forcing the legacy OpenAI path.


### PR DESCRIPTION
## Summary

- Add `plugins.entries.codex.config.appServer.modelProviderPassthrough` as an explicit opt-in list.
- Keep the existing default Codex app-server behavior unchanged: the virtual `codex` provider is still omitted unless configured for passthrough.
- Use the passthrough list for thread start, thread resume, and binding fallback modelProvider values.
- Update the Codex plugin schema/UI hints and generated config baselines.

## Why

OpenClaw can define custom model providers that are served by a Codex-compatible app-server or gateway. In those cases, the provider ID may need to be passed through to Codex app-server instead of using Codex native provider selection. This keeps the default native Codex path intact while allowing advanced deployments to opt in for specific provider IDs such as `codex`.

## Testing

- `pnpm exec vitest run extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm exec vitest run extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/run-attempt.test.ts src/config/doc-baseline.test.ts`
- `pnpm exec oxlint extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm exec oxfmt --check extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm config:docs:check`
- `pnpm check:bundled-channel-config-metadata`
- `pnpm check:base-config-schema`

Note: full `pnpm exec tsc --noEmit --pretty false` was run with `NODE_OPTIONS=--max-old-space-size=8192`; it still fails on existing unrelated `src/agents/pi-embedded-runner` test casts, not in the Codex files touched by this PR.