### PR TITLE
fix(memory-core): retry dreaming cron registration after startup deferral [AI-assisted]

### DIFF
--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1824,6 +1824,113 @@ describe("gateway startup reconciliation", () => {
       clearInternalHooks();
     }
   });
+
+  it("schedules a deferred retry when cron is unavailable at startup (regression #72841)", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config as OpenClawConfig,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      expect(harness.addCalls).toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("cron service not yet available at gateway_start"),
+      );
+
+      cronAvailable = true;
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(harness.addCalls).toHaveLength(1);
+      expect(harness.addCalls[0]).toMatchObject({
+        schedule: {
+          kind: "cron",
+          expr: "15 4 * * *",
+          tz: "UTC",
+        },
+      });
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("created managed dreaming cron job"),
+      );
+    } finally {
+      vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("emits runtime warning when deferred retry still cannot resolve cron (regression #72841)", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, {
+        config: api.config as OpenClawConfig,
+        getCron: () => undefined,
+      });
+
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
+    } finally {
+      vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
 });
 
 describe("short-term dreaming trigger", () => {

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -873,6 +873,15 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
         `memory-core: dreaming startup reconciliation failed: ${formatErrorMessage(err)}`,
       );
     }
+    if (!resolveStartupCron?.()) {
+      setTimeout(() => {
+        void reconcileManagedDreamingCron({ reason: "runtime" }).catch((err) => {
+          api.logger.error(
+            `memory-core: deferred dreaming cron retry failed: ${formatErrorMessage(err)}`,
+          );
+        });
+      }, STARTUP_CRON_RETRY_DELAY_MS);
+    }
   });
 
   api.on("gateway_stop", () => {


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: The memory-core dreaming cron job fails to register at gateway startup due to a timing race — the `gateway_start` hook fires before the cron service is available. The runtime reconciliation path only triggers on heartbeat/cron events, creating a deadlock when the cron was never registered.
- Why it matters: The Memory Dreaming Promotion task never executes, breaking the dreaming feature entirely for affected users.
- What changed: Added a deferred retry (5-second `setTimeout`) after the startup deferral so the managed dreaming cron job registers once sidecars have settled.
- What did NOT change (scope boundary): No changes to core gateway code, no changes to the cron service lifecycle, no changes to the runtime reconciliation logic.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Plugin / extension

## Linked Issue/PR
- Closes #72841
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The `gateway_start` hook fires via `void hookRunner.runGatewayStart()` (fire-and-forget) before sidecars fully start, so `getCron()` returns null. The existing runtime retry path in `before_agent_reply` only fires on heartbeat/cron triggers — if the dreaming cron never registered and no heartbeat fires, the reconciliation never runs, creating a deadlock.
- Missing detection / guardrail: No fallback mechanism to retry cron registration independent of incoming heartbeat/cron events.
- Contributing context: The fix for #67362 added runtime retry via `gatewayContext.getCron()` in `before_agent_reply`, but this path depends on heartbeat/cron triggers that may not fire if dreaming cron never registered.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`
- Scenario the test should lock in: When cron service is unavailable at startup but becomes available during the deferred retry window, the managed dreaming cron job is successfully registered.
- Why this is the smallest reliable guardrail: The unit test mocks the cron service availability timing and verifies the deferred retry path fires and succeeds.
- Existing test that already covers this (if any): N/A — existing tests only covered the startup success and runtime heartbeat-triggered reconciliation paths.

## User-visible / Behavior Changes
- The Memory Dreaming Promotion cron job now registers successfully even when the cron service is briefly unavailable at gateway startup.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix adds a deferred retry timer within the existing memory-core plugin scope. No new permissions, no security surface changes, no credential handling.
