### PR TITLE
Plugins: list Kudosity SMS in community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -61,6 +61,19 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### Kudosity SMS
+
+Cloud SMS channel powered by the Kudosity v2 API. Send SMS to any phone with
+a real sender number, no app required. Includes interactive setup wizard with
+live API-key validation, env-var fallback, and webhook payload utilities.
+
+- **npm:** `kudosity-openclaw-sms`
+- **repo:** [github.com/kudosity/openclaw-sms](https://github.com/kudosity/openclaw-sms)
+
+```bash
+openclaw plugins install kudosity-openclaw-sms
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation


### PR DESCRIPTION
## Summary

Adds an entry for **Kudosity SMS** to [docs/plugins/community.md](docs/plugins/community.md), alphabetical placement between **DingTalk** and **Lossless Claw (LCM)**.

- **npm:** `kudosity-openclaw-sms` (https://www.npmjs.com/package/kudosity-openclaw-sms)
- **ClawHub:** `kudosity-openclaw-sms` (id `rd7df0vtcet2xkcv99z593a0vh85p0mx`)
- **Repo:** [github.com/kudosity/openclaw-sms](https://github.com/kudosity/openclaw-sms)
- **Install:** `openclaw plugins install kudosity-openclaw-sms`

## Context

This listing follows the redirect from [openclaw/openclaw#55396](https://github.com/openclaw/openclaw/pull/55396), where @steipete closed the bundled-extension version as "better suited for ClawHub/community plugin work":

> "the Kudosity SMS work is a useful plugin, but current OpenClaw scope and docs point vendor-specific channel integrations toward external plugin distribution rather than bundling them into `openclaw/openclaw`."

The plugin is now published as [`kudosity-openclaw-sms@1.0.0`](https://clawhub.ai/plugins/kudosity-openclaw-sms) on ClawHub and npm. This PR adds the matching entry to `community.md` so users browsing third-party plugins can discover it.

## Quality bar checklist (per docs/plugins/community.md)

- ✅ Published on ClawHub and npm
- ✅ Public GitHub repo with README, LICENSE (MIT), CHANGELOG, issue tracker
- ✅ Setup and usage docs in the README
- ✅ 74 unit tests pass; lean GitHub Actions CI green on main

## Test plan

- [x] Verify alphabetical position (D < K < L) in the rendered docs site
- [x] `openclaw plugins install kudosity-openclaw-sms` end-to-end on a fresh openclaw install (resolved via ClawHub-first → npm fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
