### PR TITLE
fix: preserve NVIDIA model id prefixes for direct runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/model probes: prefer current bundled model-id normalization metadata over stale persisted bundled entries, so NVIDIA NIM requests keep the required `nvidia/` model prefix during direct model runs. Fixes #73014. Thanks @bautrey.
 - Memory/Ollama: resolve `memorySearch.provider` custom provider ids through their configured `models.providers.<id>.api` owner, so multi-GPU Ollama setups can dedicate embeddings to providers such as `ollama-5080` without losing the Ollama adapter or local auth semantics. Fixes #73150. Thanks @oneandrewwang.
 - CLI/memory: skip eager context-window warmup for `openclaw memory` commands so memory search does not race unrelated model metadata discovery. Fixes #73123. Thanks @oalansilva and @neeravmakwana.
 - CLI/Telegram: route Telegram `message send` and poll actions through the running Gateway when available, so packaged installs use the staged `grammy` runtime deps and CLI sends return instead of hanging after the Telegram channel is active. Fixes #73140. Thanks @oalansilva.

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -1,15 +1,77 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearManifestModelIdNormalizationCacheForTest } from "../plugins/manifest-model-id-normalization.js";
 import { normalizeStaticProviderModelId } from "./model-ref-shared.js";
+
+const tempDirs: string[] = [];
+
+function writePluginManifest(root: string, id: string, manifest: Record<string, unknown>) {
+  const pluginDir = path.join(root, id);
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(path.join(pluginDir, "openclaw.plugin.json"), JSON.stringify(manifest), "utf8");
+}
+
+function useBundledPluginManifestFixture(manifest: Record<string, unknown>) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-ref-"));
+  tempDirs.push(root);
+  const bundledRoot = path.join(root, "bundled");
+  writePluginManifest(bundledRoot, "nvidia", manifest);
+  vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledRoot);
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+  clearManifestModelIdNormalizationCacheForTest();
+  return root;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  clearManifestModelIdNormalizationCacheForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("normalizeStaticProviderModelId", () => {
   it("re-adds the nvidia prefix for bare model ids", () => {
+    useBundledPluginManifestFixture({
+      id: "nvidia",
+      modelIdNormalization: { providers: { nvidia: { prefixWhenBare: "nvidia" } } },
+    });
+
     expect(normalizeStaticProviderModelId("nvidia", "nemotron-3-super-120b-a12b")).toBe(
       "nvidia/nemotron-3-super-120b-a12b",
     );
   });
 
   it("does not double-prefix already prefixed models", () => {
+    useBundledPluginManifestFixture({
+      id: "nvidia",
+      modelIdNormalization: { providers: { nvidia: { prefixWhenBare: "nvidia" } } },
+    });
+
     expect(normalizeStaticProviderModelId("nvidia", "nvidia/nemotron-3-super-120b-a12b")).toBe(
+      "nvidia/nemotron-3-super-120b-a12b",
+    );
+  });
+
+  it("prefers current bundled model normalization over stale persisted bundled metadata", () => {
+    const root = useBundledPluginManifestFixture({
+      id: "nvidia",
+      modelIdNormalization: { providers: { nvidia: { prefixWhenBare: "nvidia" } } },
+    });
+    const staleRoot = path.join(root, "stale");
+    writePluginManifest(staleRoot, "nvidia", { id: "nvidia" });
+    const installsPath = path.join(root, "state", "plugins", "installs.json");
+    fs.mkdirSync(path.dirname(installsPath), { recursive: true });
+    fs.writeFileSync(
+      installsPath,
+      JSON.stringify({ plugins: [{ rootDir: path.join(staleRoot, "nvidia"), origin: "bundled" }] }),
+      "utf8",
+    );
+    clearManifestModelIdNormalizationCacheForTest();
+
+    expect(normalizeStaticProviderModelId("nvidia", "nemotron-3-super-120b-a12b")).toBe(
       "nvidia/nemotron-3-super-120b-a12b",
     );
   });

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -124,7 +124,7 @@ function listPersistedIndexPluginDirs(env: NodeJS.ProcessEnv, startOrder: number
     }
     dirs.push({
       pluginDir: resolveUserPath(rootDir, env),
-      rank: rawPlugin.origin === "bundled" ? 2 : 1,
+      rank: rawPlugin.origin === "bundled" ? 3 : 1,
       order: order++,
       origin: normalizeTrimmedString(rawPlugin.origin),
     });


### PR DESCRIPTION
## Summary
- Prefer the current bundled plugin metadata over stale persisted bundled index entries when scanning manifests.
- Keep NVIDIA model-id normalization active for direct model runs so bare `nemotron-...` ids are restored to the wire-safe `nvidia/nemotron-...` form.
- Add regression coverage for the stale persisted bundled metadata case and record the user-facing fix in the changelog.

## Root Cause
The direct model-run parser already delegates static model ids through manifest-backed normalization, but manifest discovery could read an older persisted bundled plugin record before the current bundled plugin metadata. When that stale NVIDIA manifest lacked `modelIdNormalization.prefixWhenBare`, `parseStaticModelRef` returned the bare suffix and OpenAI-compatible NVIDIA NIM requests sent the wrong model id.

Fixes #73014.

## Why This Is Safe
Persisted third-party plugin installs still keep the highest priority. This only lowers persisted entries marked `origin: "bundled"` below the current bundled plugin root, so bundled plugin metadata follows the currently running OpenClaw package instead of a stale package path. The normalization remains provider-declared through plugin metadata and does not add hard-coded NVIDIA behavior to the parser.

Security and runtime controls are unchanged: provider auth lookup, API-key handling, model execution, transport selection, and provider runtime hooks are not changed. This only changes which manifest metadata snapshot supplies existing model-id normalization policy.

## Tests
- `pnpm docs:list`
- `pnpm test src/agents/model-ref-shared.test.ts src/agents/simple-completion-runtime.selection.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

## Out Of Scope
- Live NVIDIA NIM credentialed request testing.
- Broader redesign of model-reference parsing or provider-owned normalization policy.
- Persisted plugin-index repair or migration flows beyond precedence for bundled entries.

## Notes
- AI-assisted: yes.

Made with [Cursor](https://cursor.com)