### PR TITLE
Keep Codex same-session replies on the normal OpenClaw path

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -80,5 +80,8 @@ describe("buildDeveloperInstructions", () => {
     expect(prompt).toContain(
       "If the turn says source channel delivery is private or message-tool-only, use the messaging tool for visible output.",
     );
+    expect(prompt).not.toContain(
+      "If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply",
+    );
   });
 });

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -75,7 +75,10 @@ describe("buildDeveloperInstructions", () => {
     const prompt = buildDeveloperInstructions(createAttemptParams());
 
     expect(prompt).toContain(
-      "When replying in the current chat/session, answer normally and let OpenClaw deliver that reply automatically.",
+      "When replying in the current chat/session, answer normally and let OpenClaw handle delivery when normal final replies are enabled for that channel.",
+    );
+    expect(prompt).toContain(
+      "If the turn says source channel delivery is private or message-tool-only, use the messaging tool for visible output.",
     );
   });
 });

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,5 +1,17 @@
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
-import { resolveReasoningEffort } from "./thread-lifecycle.js";
+import { buildDeveloperInstructions, resolveReasoningEffort } from "./thread-lifecycle.js";
+
+function createAttemptParams(overrides: Partial<EmbeddedRunAttemptParams> = {}) {
+  return {
+    provider: "openai-codex",
+    modelId: "gpt-5.4",
+    config: {},
+    agentDir: "/tmp/agent",
+    workspaceDir: "/tmp/workspace",
+    ...overrides,
+  } as EmbeddedRunAttemptParams;
+}
 
 describe("resolveReasoningEffort (#71946)", () => {
   describe("modern Codex models (none/low/medium/high/xhigh enum)", () => {
@@ -55,5 +67,15 @@ describe("resolveReasoningEffort (#71946)", () => {
       expect(resolveReasoningEffort("max", "gpt-5.5")).toBeNull();
       expect(resolveReasoningEffort("max", "gpt-4o")).toBeNull();
     });
+  });
+});
+
+describe("buildDeveloperInstructions", () => {
+  it("tells same-session channel replies to answer normally", () => {
+    const prompt = buildDeveloperInstructions(createAttemptParams());
+
+    expect(prompt).toContain(
+      "When replying in the current chat/session, answer normally and let OpenClaw deliver that reply automatically.",
+    );
   });
 });

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -223,7 +223,10 @@ export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): st
   const promptOverlay = renderCodexRuntimePromptOverlay(params);
   const sections = [
     "You are running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-specific integrations such as messaging, cron, sessions, media, gateway, and nodes when available.",
-    "Preserve the user's existing channel/session context. If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply.",
+    [
+      "Preserve the user's existing channel/session context.",
+      "When replying in the current chat/session, answer normally and let OpenClaw deliver that reply automatically.",
+    ].join(" "),
     promptOverlay,
     params.extraSystemPrompt,
     params.skillsSnapshot?.prompt,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -225,7 +225,8 @@ export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): st
     "You are running inside OpenClaw. Use OpenClaw dynamic tools for OpenClaw-specific integrations such as messaging, cron, sessions, media, gateway, and nodes when available.",
     [
       "Preserve the user's existing channel/session context.",
-      "When replying in the current chat/session, answer normally and let OpenClaw deliver that reply automatically.",
+      "When replying in the current chat/session, answer normally and let OpenClaw handle delivery when normal final replies are enabled for that channel.",
+      "If the turn says source channel delivery is private or message-tool-only, use the messaging tool for visible output.",
     ].join(" "),
     promptOverlay,
     params.extraSystemPrompt,


### PR DESCRIPTION
This is the small Codex-only split from #72442.

OpenClaw already delivers a final assistant reply back to the current inbound chat session. The Codex app-server developer prompt still said that channel replies should use the OpenClaw messaging tool, which made ordinary Discord, Telegram, and similar replies look like explicit delivery work instead of the normal final-answer path.

That guidance became actively confusing when the generic messaging tool was not present. The model could still see channel-specific skills and could improvise a direct send, while OpenClaw also delivered the final assistant text automatically.

This changes the Codex runtime guidance to say that same-session replies should be written normally and delivered by OpenClaw. Proactive sends, other targets, channel actions, and explicit media-delivery cases still belong on the relevant OpenClaw tools.
