### PR TITLE
fix(bundled-runtime-deps): collapse nested cache pluginRoot to enclosing key (Fixes #72956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: normalize accidental full `/bot<TOKEN>` Telegram `apiRoot` values at runtime and teach `openclaw doctor --fix` to remove the suffix, so startup control calls no longer 404 when direct Bot API curl commands work. Fixes #55387. Thanks @brendanmatthewjones-cmyk, @techfindubai-ux, and @Sivlerback-Chris.
 - Zalo Personal: persist refreshed `zca-js` session cookies after QR login, session restore, and successful API calls so gateway restarts restore the freshest local session. (#73277) Thanks @darkamenosa.
 - Logging/security: redact sensitive tokens (sk-\* keys, Bearer/Authorization values, etc.) at the subsystem console sink so `createSubsystemLogger().info/warn/error` output that bypasses the patched console-capture handler still applies the same redaction the file transport already does. Fixes #73284; refs #67953 and #64046. Thanks @edwin-rivera-dev.
+- Plugins/runtime deps: reuse enclosing versioned cache roots when bundled plugins resolve from nested staged paths, so plugin-runtime-deps no longer mints `openclaw-unknown-*` directories or loops on `ENOTEMPTY`. Fixes #72956. (#73205) Thanks @SymbolStar.
 
 ## 2026.4.27
 

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1696,7 +1696,7 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     ).toEqual({ installedSpecs: [], retainSpecs: [] });
   });
 
-  it("resolves nested cache pluginRoot to enclosing versioned cache (regression for #72956)", () => {
+  it("resolves nested cache pluginRoot to enclosing versioned cache", () => {
     const packageRoot = makeTempDir();
     const stageDir = makeTempDir();
     fs.writeFileSync(
@@ -1712,11 +1712,6 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     const env = { OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
     const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env });
 
-    // Simulate a deeply-nested pluginRoot inside the existing cache directory
-    // (e.g. plugin-sdk loaded as a transitive dep). The path no longer matches
-    // `<root>/dist/extensions/<plugin>`, so resolveBundledPluginPackageRoot()
-    // returns null and the caller previously fell back to the raw pluginRoot,
-    // generating a self-referential `openclaw-unknown-*` cache directory.
     const nestedPluginRoot = path.join(
       installRoot,
       "dist",

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1696,6 +1696,42 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     ).toEqual({ installedSpecs: [], retainSpecs: [] });
   });
 
+  it("resolves nested cache pluginRoot to enclosing versioned cache (regression for #72956)", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+    const pluginRoot = path.join(packageRoot, "dist", "extensions", "telegram");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({ dependencies: { grammy: "^1.42.0" } }),
+    );
+    const env = { OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env });
+
+    // Simulate a deeply-nested pluginRoot inside the existing cache directory
+    // (e.g. plugin-sdk loaded as a transitive dep). The path no longer matches
+    // `<root>/dist/extensions/<plugin>`, so resolveBundledPluginPackageRoot()
+    // returns null and the caller previously fell back to the raw pluginRoot,
+    // generating a self-referential `openclaw-unknown-*` cache directory.
+    const nestedPluginRoot = path.join(
+      installRoot,
+      "dist",
+      "extensions",
+      "node_modules",
+      "openclaw",
+      "plugin-sdk",
+    );
+    fs.mkdirSync(nestedPluginRoot, { recursive: true });
+
+    const resolved = resolveBundledRuntimeDependencyInstallRoot(nestedPluginRoot, { env });
+    expect(resolved).toBe(installRoot);
+    expect(path.basename(resolved).startsWith("openclaw-unknown-")).toBe(false);
+  });
+
   it("links source-checkout runtime deps from the cache instead of copying them", () => {
     const packageRoot = makeTempDir();
     fs.writeFileSync(

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -980,12 +980,6 @@ function resolveExistingExternalBundledRuntimeDepsRoots(params: {
     if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
       continue;
     }
-    // Accept both `<base>/<key>` and any descendant such as
-    // `<base>/<key>/dist/extensions/node_modules/openclaw/plugin-sdk`.
-    // Without this, when a bundled package re-enters resolution via a nested
-    // `pluginRoot` (e.g. plugin-sdk loaded as a dependency), the caller falls
-    // back to `params.pluginRoot`, which lacks a `package.json`, producing a
-    // self-referential `openclaw-unknown-*` cache directory (#72956).
     const packageKey = relative.split(path.sep)[0];
     if (!packageKey || !packageKey.startsWith("openclaw-")) {
       continue;

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -977,18 +977,20 @@ function resolveExistingExternalBundledRuntimeDepsRoots(params: {
   const externalBaseDirs = resolveBundledRuntimeDepsExternalBaseDirs(params.env);
   for (const externalBaseDir of externalBaseDirs) {
     const relative = path.relative(path.resolve(externalBaseDir), packageRoot);
-    if (
-      relative === "" ||
-      relative.startsWith("..") ||
-      path.isAbsolute(relative) ||
-      relative.includes(path.sep)
-    ) {
+    if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
       continue;
     }
-    const packageKey = path.basename(packageRoot);
-    return packageKey.startsWith("openclaw-")
-      ? externalBaseDirs.map((baseDir) => path.join(baseDir, packageKey))
-      : null;
+    // Accept both `<base>/<key>` and any descendant such as
+    // `<base>/<key>/dist/extensions/node_modules/openclaw/plugin-sdk`.
+    // Without this, when a bundled package re-enters resolution via a nested
+    // `pluginRoot` (e.g. plugin-sdk loaded as a dependency), the caller falls
+    // back to `params.pluginRoot`, which lacks a `package.json`, producing a
+    // self-referential `openclaw-unknown-*` cache directory (#72956).
+    const packageKey = relative.split(path.sep)[0];
+    if (!packageKey || !packageKey.startsWith("openclaw-")) {
+      continue;
+    }
+    return externalBaseDirs.map((baseDir) => path.join(baseDir, packageKey));
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Eliminates the `openclaw-unknown-<hash>` zombie cache that appeared next to the legitimate versioned `openclaw-<version>-<hash>` directory under `~/.openclaw/plugin-runtime-deps/`, and the `ENOTEMPTY` crash loops that followed when bundled channels raced `replaceNodeModulesDir()`.

## Root cause

`resolveBundledPluginPackageRoot()` walks `pluginRoot → ../.. → packageRoot` expecting `dist/extensions/<plugin>`. When the gateway later resolves a plugin whose `pluginRoot` already lives inside the cache (e.g. `plugin-sdk` loaded transitively at `<cache>/openclaw-2026.4.24-.../dist/extensions/node_modules/openclaw/plugin-sdk`), that walk does not match and the function returns `null`. The caller then falls back to the raw `pluginRoot`.

`resolveExistingExternalBundledRuntimeDepsRoots()` rejected that fallback because the relative path from the stage base contained directory separators, so the resolver minted a brand new `openclaw-unknown-<pathhash>` directory key. The two caches then duplicated each other and clashed on rename.

## Fix

When `pluginRoot` resolves to any descendant of `<stageBase>/openclaw-*`, treat the first segment (the existing versioned cache key) as the install root instead of inventing a new one. The new path is unit-tested as a regression guard for #72956.

## Test plan

- New unit test `resolves nested cache pluginRoot to enclosing versioned cache (regression for #72956)` in `bundled-runtime-deps.test.ts`.
- Existing `mirroredPluginRoot` test still passes (single-segment cache key path remains valid).

Fixes #72956
