### PR TITLE
fix(memory-core): mark plugin enabledByDefault so chokidar runtime dep installs (Fixes #72882)

### DIFF
--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,6 +1,7 @@
 {
   "id": "memory-core",
   "kind": "memory",
+  "enabledByDefault": true,
   "contracts": {
     "memoryEmbeddingProviders": ["local"]
   },


### PR DESCRIPTION
## Summary

Fixes `openclaw memory status` crashing with `ERR_MODULE_NOT_FOUND: Cannot find package 'chokidar'` after upgrading to 2026.4.25, even after running `openclaw doctor --fix`.

## Root cause

`extensions/memory-core/package.json` declares `chokidar ^5.0.0` (used by `manager-sync-ops.ts`) as a runtime dependency. The bundled-runtime-deps installer (`scanBundledPluginRuntimeDeps` → `isBundledPluginConfiguredForRuntimeDeps`) only includes a plugin's deps when:

- `openclaw.plugin.json` has `enabledByDefault: true`, **or**
- the user explicitly enables the plugin in `plugins.entries`, **or**
- a configured channel routes through the plugin.

`memory-core/openclaw.plugin.json` lacked `enabledByDefault: true`, so on a fresh install the runtime-deps collector silently skipped its dependencies. `openclaw memory status` is, however, a built-in CLI surface that always loads memory-core — leaving users with a missing `chokidar` package and a `doctor --fix` that reports no problems.

The manual workaround the reporter used (`npm install chokidar` inside the cache) just papered over the missing manifest entry.

## Fix

Add `"enabledByDefault": true` to `extensions/memory-core/openclaw.plugin.json`. memory-core is a core plugin shipped in every install and exercised by `openclaw memory ...` regardless of user config, so it should sit in the same default-enabled bucket as the other core extensions (`anthropic`, `bonjour`, `browser`, etc.).

After this change, `doctor --fix` (and the initial post-install runtime-deps stage) will include `chokidar` in the plugin-runtime-deps bundle and `openclaw memory status` will work out of the box.

## Test plan

- Inspect other `extensions/*/openclaw.plugin.json` core plugins for the existing `enabledByDefault: true` convention (matched).
- No code-path change; the behavior is exclusively driven by `readBundledPluginRuntimeDepsManifest` reading the new field.

Fixes #72882
