### PR TITLE
fix(tui): include approve command in pairing-required hint

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -169,6 +169,7 @@ describe("resolveGatewayDisconnectState", () => {
     expect(state.connectionStatus).toContain("pairing required");
     expect(state.activityStatus).toBe("pairing required: run openclaw devices list");
     expect(state.pairingHint).toContain("openclaw devices list");
+    expect(state.pairingHint).toContain("openclaw devices approve <requestId>");
   });
 
   it("falls back to idle for generic disconnect reasons", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -194,7 +194,7 @@ export function resolveGatewayDisconnectState(reason?: string): {
       connectionStatus: `gateway disconnected: ${reasonLabel}`,
       activityStatus: "pairing required: run openclaw devices list",
       pairingHint:
-        "Pairing required. Run `openclaw devices list`, approve your request ID, then reconnect.",
+        "Pairing required. Run `openclaw devices list`, then `openclaw devices approve <requestId>`, then reconnect.",
     };
   }
   return {


### PR DESCRIPTION
## Summary
- update TUI pairing-required hint to include the exact approval command
- keep existing `openclaw devices list` guidance and add `openclaw devices approve <requestId>`
- extend TUI test coverage to assert both commands are present

## Testing
- pnpm vitest src/tui/tui.test.ts

Fixes #67618
