### PR TITLE
fix(exec): avoid empty running output blocks

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -14,6 +14,7 @@ vi.mock("../infra/system-events.js", () => ({
 let buildExecExitOutcome: typeof import("./bash-tools.exec-runtime.js").buildExecExitOutcome;
 let detectCursorKeyMode: typeof import("./bash-tools.exec-runtime.js").detectCursorKeyMode;
 let emitExecSystemEvent: typeof import("./bash-tools.exec-runtime.js").emitExecSystemEvent;
+let formatExecRunningUpdateText: typeof import("./bash-tools.exec-runtime.js").formatExecRunningUpdateText;
 let formatExecFailureReason: typeof import("./bash-tools.exec-runtime.js").formatExecFailureReason;
 let resolveExecTarget: typeof import("./bash-tools.exec-runtime.js").resolveExecTarget;
 
@@ -22,6 +23,7 @@ beforeAll(async () => {
     buildExecExitOutcome,
     detectCursorKeyMode,
     emitExecSystemEvent,
+    formatExecRunningUpdateText,
     formatExecFailureReason,
     resolveExecTarget,
   } = await import("./bash-tools.exec-runtime.js"));
@@ -356,6 +358,24 @@ describe("emitExecSystemEvent", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatExecRunningUpdateText", () => {
+  it("uses a non-empty placeholder when running exec output is empty", () => {
+    expect(formatExecRunningUpdateText({ warnings: [], tailText: "" })).toBe("(no output)");
+  });
+
+  it("preserves warnings before the no-output placeholder", () => {
+    expect(formatExecRunningUpdateText({ warnings: ["Careful."], tailText: "" })).toBe(
+      "Careful.\n\n(no output)",
+    );
+  });
+
+  it("preserves non-empty output text", () => {
+    expect(formatExecRunningUpdateText({ warnings: ["Careful."], tailText: "done" })).toBe(
+      "Careful.\n\ndone",
+    );
   });
 });
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -389,6 +389,14 @@ function joinExecFailureOutput(aggregated: string, reason: string) {
   return aggregated ? `${aggregated}\n\n${reason}` : reason;
 }
 
+export function formatExecRunningUpdateText(params: {
+  warnings: readonly string[];
+  tailText: string;
+}) {
+  const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
+  return warningText + (params.tailText || "(no output)");
+}
+
 function classifyExecFailureKind(params: {
   exitReason: TerminationReason;
   exitCode: number;
@@ -573,7 +581,6 @@ export async function runExecProcess(opts: {
       return;
     }
     const tailText = session.tail || session.aggregated;
-    const warningText = opts.warnings.length ? `${opts.warnings.join("\n")}\n\n` : "";
     // Note: opts.onUpdate() is provided by pi-agent-core's agent-loop and
     // internally pushes Promise.resolve(emit(event)) into an updateEvents
     // array.  Because emit → processEvents is async, any failure (e.g.
@@ -584,7 +591,9 @@ export async function runExecProcess(opts: {
     // signal (Layer 2) — both of which prevent this call from ever being
     // reached after the agent run has ended.
     opts.onUpdate({
-      content: [{ type: "text", text: warningText + (tailText || "") }],
+      content: [
+        { type: "text", text: formatExecRunningUpdateText({ warnings: opts.warnings, tailText }) },
+      ],
       details: {
         status: "running",
         sessionId,


### PR DESCRIPTION
## Summary
- ensure exec running updates emit `(no output)` instead of an empty text block
- cover empty output, warnings-only, and normal output formatting

Fixes #73117

## Tests
- `npm exec pnpm@10.33.0 -- test src/agents/bash-tools.exec-runtime.test.ts`
- `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- run test:changed`