### PR TITLE
fix(cli): reject empty/whitespace-only --prompt for infer model run

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -437,6 +437,31 @@ describe("capability cli", () => {
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
   });
 
+  it("rejects empty / whitespace-only --prompt before any provider dispatch", async () => {
+    for (const blank of ["", "   ", "\n", "\t \n  \t"]) {
+      mocks.runtime.error.mockClear();
+      mocks.runtime.writeJson.mockClear();
+      mocks.prepareSimpleCompletionModelForAgent.mockClear();
+      mocks.completeWithPreparedSimpleCompletionModel.mockClear();
+      mocks.callGateway.mockClear();
+
+      await expect(
+        runRegisteredCli({
+          register: registerCapabilityCli as (program: Command) => void,
+          argv: ["capability", "model", "run", "--prompt", blank, "--json"],
+        }),
+      ).rejects.toThrow("exit 1");
+
+      expect(mocks.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("--prompt cannot be empty or whitespace-only"),
+      );
+      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+      expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+    }
+  });
+
   it("runs gateway model probes without chat-agent prompt policy or tools", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1487,6 +1487,16 @@ export function registerCapabilityCli(program: Command) {
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const promptText =
+          typeof opts.prompt === "string" ? opts.prompt : String(opts.prompt ?? "");
+        // Reject empty / whitespace-only prompts before any provider dispatch.
+        // The --gateway transport already enforces this server-side via a
+        // JSON-schema minLength on /message; --local had no equivalent guard,
+        // so empty input either surfaced as a misleading "No text output
+        // returned" error (Anthropic) or a billed completion (DeepSeek). #73185.
+        if (promptText.trim().length === 0) {
+          throw new Error("--prompt cannot be empty or whitespace-only");
+        }
         const transport = resolveTransport({
           local: Boolean(opts.local),
           gateway: Boolean(opts.gateway),
@@ -1494,7 +1504,7 @@ export function registerCapabilityCli(program: Command) {
           defaultTransport: "local",
         });
         const result = await runModelRun({
-          prompt: String(opts.prompt),
+          prompt: promptText,
           model: opts.model as string | undefined,
           transport,
         });


### PR DESCRIPTION
Fixes #73185

## Summary

`openclaw infer model run --local --prompt ""` (and `"   "`, `"\n"`) sent the empty user turn straight to the provider with no client-side validation. Anthropic surfaced a misleading `Error: No text output returned` after a real round-trip; DeepSeek silently billed for ~3.5 KB of unrelated content. The `--gateway` transport already enforces a `minLength: 1` JSON-schema check on `/message`; this PR adds the equivalent guard on the `--local` path. In the `model run` action of `src/cli/capability-cli.ts`, trim the resolved `--prompt` and throw `--prompt cannot be empty or whitespace-only` before dispatch. No production transport / provider code touched.

## Test plan

- [x] `pnpm test src/cli/capability-cli.test.ts`
- [x] `pnpm check:changed`
- [x] End-to-end on the real CLI for all 3 repro inputs from the issue + the existing in-tree baseline (missing `--prompt`).

### Evidence

Unit test:

```
 Test Files  1 passed (1)
      Tests  39 passed (39)
```

(38 existing + 1 new test covering `""`, `"   "`, `"\n"`, mixed whitespace; the new test asserts `prepareSimpleCompletionModelForAgent`, `completeWithPreparedSimpleCompletionModel`, and `callGateway` are never invoked.)

`pnpm check:changed` → `EXIT=0`.

End-to-end on the real CLI (OpenClaw 2026.4.26, Node 22.14, Linux):

```shell
$ pnpm openclaw infer model run --prompt ""
Error: --prompt cannot be empty or whitespace-only
 ELIFECYCLE  Command failed with exit code 1.

$ pnpm openclaw infer model run --prompt "   "
Error: --prompt cannot be empty or whitespace-only
 ELIFECYCLE  Command failed with exit code 1.

$ pnpm openclaw infer model run --prompt $'\n'
Error: --prompt cannot be empty or whitespace-only
 ELIFECYCLE  Command failed with exit code 1.

# Baseline (already worked before this PR; the in-tree reference Commander check):
$ pnpm openclaw infer model run
error: required option '--prompt <text>' not specified
 ELIFECYCLE  Command failed with exit code 1.
```

In all three blank-input cases the process exited before any provider dispatch — no auth prompt, no network round-trip, no billing.

## Risks

None. The new branch fires only on inputs that previously produced misleading errors or billed degenerate completions, and only on the `model run` subcommand. Other `--prompt` callers (image describe, etc. at lines 1593/1632/1734/1981) are out of scope and unchanged. Error message matches the reporter's suggested wording for consistency with the gateway-side schema rejection.
