### PR TITLE
fix(media): surface image optimization failure cause

### DIFF
--- a/src/media/web-media.optimize.test.ts
+++ b/src/media/web-media.optimize.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resizeToJpegMock = vi.fn();
+
+vi.mock("./image-ops.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./image-ops.js")>();
+  return {
+    ...actual,
+    resizeToJpeg: resizeToJpegMock,
+  };
+});
+
+describe("optimizeImageToJpeg", () => {
+  beforeEach(() => {
+    resizeToJpegMock.mockReset();
+  });
+
+  it("surfaces the underlying resize failure when all optimization attempts fail", async () => {
+    const cause = new Error("Cannot find package 'sharp'");
+    resizeToJpegMock.mockRejectedValue(cause);
+    const { optimizeImageToJpeg } = await import("./web-media.js");
+
+    await expect(optimizeImageToJpeg(Buffer.from("not-an-image"), 1024)).rejects.toThrow(
+      "Failed to optimize image: Cannot find package 'sharp'",
+    );
+    await expect(optimizeImageToJpeg(Buffer.from("not-an-image"), 1024)).rejects.toMatchObject({
+      cause,
+    });
+  });
+});

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveCanvasHttpPathToLocalPath } from "../gateway/canvas-documents.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { SafeOpenError, readLocalFileSafely } from "../infra/fs-safe.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
 import type { PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
@@ -616,6 +617,7 @@ export async function optimizeImageToJpeg(
     resizeSide: number;
     quality: number;
   } | null = null;
+  let lastError: unknown;
 
   for (const side of sides) {
     for (const quality of qualities) {
@@ -638,7 +640,8 @@ export async function optimizeImageToJpeg(
             quality,
           };
         }
-      } catch {
+      } catch (err) {
+        lastError = err;
         // Continue trying other size/quality combinations
       }
     }
@@ -653,7 +656,8 @@ export async function optimizeImageToJpeg(
     };
   }
 
-  throw new Error("Failed to optimize image");
+  const detail = lastError ? `: ${formatErrorMessage(lastError)}` : "";
+  throw new Error(`Failed to optimize image${detail}`, { cause: lastError });
 }
 
 export { optimizeImageToPng };


### PR DESCRIPTION
## Summary
- preserve the last resize/optimization error when image optimization exhausts all size/quality attempts
- include the underlying failure message and cause in the final `Failed to optimize image` error
- add coverage for missing-sharp style failures so operators see the real cause

Fixes #73148

## Test plan
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.media.config.ts src/media/web-media.test.ts src/media/web-media.optimize.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/media/web-media.ts src/media/web-media.optimize.test.ts`