### PR TITLE
Add Discord response watchdog

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -712,6 +712,13 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.deliver).toBe(true);
     expect(agentCall?.params?.lane).toBe("subagent");
     expect(agentCall?.params?.acpTurnSource).toBe("manual_spawn");
+    expect(hoisted.createRunningTaskRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "acp",
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+      }),
+    );
     expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: expect.stringMatching(/^agent:codex:acp:/),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1479,6 +1479,7 @@ export async function spawnAcpDirect(
       task: params.task,
       preferMetadata: true,
       deliveryStatus: requesterInternalKey ? "pending" : "parent_missing",
+      notifyPolicy: requesterInternalKey ? "state_changes" : undefined,
       startedAt: Date.now(),
     });
   } catch (error) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -373,6 +373,8 @@ export function createSubagentRunManager(params: {
         task: registerParams.task,
         deliveryStatus:
           registerParams.expectsCompletionMessage === false ? "not_applicable" : "pending",
+        notifyPolicy:
+          registerParams.expectsCompletionMessage === false ? "silent" : "state_changes",
         startedAt: now,
         lastEventAt: now,
       });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -725,7 +725,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("records delivery failure and queues a session fallback when direct delivery misses", async () => {
+  it("marks terminal delivery as session queued when direct delivery falls back cleanly", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -760,7 +760,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expect(findTaskByRunId("run-delivery-fail")).toMatchObject({
           status: "failed",
-          deliveryStatus: "failed",
+          deliveryStatus: "session_queued",
           error: "Permission denied by ACP runtime",
         }),
       );
@@ -798,7 +798,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expect(findTaskByRunId("run-delivery-blocked")).toMatchObject({
           status: "succeeded",
-          deliveryStatus: "failed",
+          deliveryStatus: "session_queued",
           terminalOutcome: "blocked",
         }),
       );
@@ -1951,6 +1951,48 @@ describe("task-registry", () => {
           inconsistent_timestamps: 0,
         },
       });
+    });
+  });
+
+  it("emits an immediate start update for newly-created running state-change tasks", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      resetSystemEventsForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "guildchat",
+        to: "guildchat:123",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "guildchat",
+          to: "guildchat:123",
+        },
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-create-start",
+        task: "Investigate issue",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "guildchat",
+            to: "guildchat:123",
+            content: "Background task started: ACP background task.",
+          }),
+        ),
+      );
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1187,17 +1187,21 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
         if (latest.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(latest);
         }
+        return updateTask(taskId, {
+          deliveryStatus: "session_queued",
+          lastEventAt: Date.now(),
+        });
       } catch (fallbackError) {
         log.warn("Failed to queue background task fallback event", {
           taskId,
           ownerKey: latest.ownerKey,
           error: fallbackError,
         });
+        return updateTask(taskId, {
+          deliveryStatus: "failed",
+          lastEventAt: Date.now(),
+        });
       }
-      return updateTask(taskId, {
-        deliveryStatus: "failed",
-        lastEventAt: Date.now(),
-      });
     }
   } finally {
     tasksWithPendingDelivery.delete(taskId);
@@ -1589,6 +1593,12 @@ export function createTaskRecord(params: {
   }));
   if (isTerminalTaskStatus(record.status)) {
     void maybeDeliverTaskTerminalUpdate(taskId);
+  } else if (record.status === "running") {
+    void maybeDeliverTaskStateChangeUpdate(taskId, {
+      at: record.lastEventAt ?? record.startedAt ?? record.createdAt,
+      kind: "running",
+      summary: "Started.",
+    });
   }
   return cloneTaskRecord(record);
 }


### PR DESCRIPTION
## Summary
- emit an immediate state-change notice when long-running task records are created
- preserve `session_queued` delivery status when terminal delivery falls back to queued session recovery
- default completion-visible subagent/ACP runs to `state_changes` notifications while leaving silent/streaming paths unchanged

## Verification
- `corepack pnpm test src/tasks/task-registry.test.ts src/agents/acp-spawn.test.ts` → 105 passed
- `git diff --check origin/main..HEAD` → passed

## Notes
- Rebased/cherry-picked onto current `origin/main` to avoid unrelated stale-branch diff.
- Draft PR only; no deploy, gateway restart, merge, or live Discord smoke performed.
- Supabase task: `22d72cfc-73b9-4d8b-b56f-4edbaf7f5561`.
