### PR TITLE
Add Discord stuck-session circuit breaker

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -65,6 +65,8 @@ import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import {
   enqueueFollowupRun,
   refreshQueuedFollowupSession,
+  scheduleDiscordStuckSessionCircuitBreaker,
+  scheduleFollowupDrain,
   type FollowupRun,
   type QueueSettings,
 } from "./queue.js";
@@ -825,6 +827,9 @@ export async function runReplyAgent(params: {
   shouldFollowup: boolean;
   isActive: boolean;
   isRunActive?: () => boolean;
+  isRunStreaming?: () => boolean;
+  resolveActiveRunSessionId?: () => string | undefined;
+  abortActiveRun?: (activeSessionId: string) => boolean;
   isStreaming: boolean;
   opts?: GetReplyOptions;
   typing: TypingController;
@@ -862,6 +867,9 @@ export async function runReplyAgent(params: {
     shouldFollowup,
     isActive,
     isRunActive,
+    isRunStreaming,
+    resolveActiveRunSessionId,
+    abortActiveRun,
     isStreaming,
     opts,
     typing,
@@ -974,6 +982,17 @@ export async function runReplyAgent(params: {
     // the followup queue idle if the original run already finished.
     if (!isRunActive?.()) {
       finalizeWithFollowup(undefined, queueKey, queuedRunFollowupTurn);
+    } else if (isRunStreaming?.() !== true && resolveActiveRunSessionId && abortActiveRun) {
+      scheduleDiscordStuckSessionCircuitBreaker({
+        queueKey,
+        followupRun,
+        runFollowup: queuedRunFollowupTurn,
+        resolveActiveRunSessionId,
+        isRunActive,
+        isRunStreaming: () => isRunStreaming?.() === true,
+        abortActiveRun,
+        scheduleDrain: scheduleFollowupDrain,
+      });
     }
     await touchActiveSessionEntry();
     typing.cleanup();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -892,6 +892,20 @@ export async function runPreparedReply(
         piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ?? latestSessionState.sessionId;
       return piRuntime?.isEmbeddedPiRunActive(latestActiveSessionId) ?? false;
     },
+    isRunStreaming: () => {
+      const latestSessionState = resolvePreparedSessionState();
+      const latestActiveSessionId =
+        piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ?? latestSessionState.sessionId;
+      return piRuntime?.isEmbeddedPiRunStreaming(latestActiveSessionId) ?? false;
+    },
+    resolveActiveRunSessionId: () => {
+      const latestSessionState = resolvePreparedSessionState();
+      return (
+        piRuntime?.resolveActiveEmbeddedRunSessionId(sessionKey) ?? latestSessionState.sessionId
+      );
+    },
+    abortActiveRun: (activeRunSessionId) =>
+      piRuntime?.abortEmbeddedPiRun(activeRunSessionId) ?? false,
     isStreaming,
     opts,
     typing,

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -8,6 +8,10 @@ export {
   resetRecentQueuedMessageIdDedupe,
 } from "./queue/enqueue.js";
 export { resolveQueueSettings } from "./queue/settings-runtime.js";
+export {
+  DISCORD_STUCK_SESSION_BREAKER_THRESHOLD_MS,
+  scheduleDiscordStuckSessionCircuitBreaker,
+} from "./queue/circuit-breaker.js";
 export { clearFollowupQueue, refreshQueuedFollowupSession } from "./queue/state.js";
 export type {
   FollowupRun,

--- a/src/auto-reply/reply/queue/circuit-breaker.test.ts
+++ b/src/auto-reply/reply/queue/circuit-breaker.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetDiscordStuckSessionCircuitBreakerForTest,
+  scheduleDiscordStuckSessionCircuitBreaker,
+} from "./circuit-breaker.js";
+import { enqueueFollowupRun } from "./enqueue.js";
+import { clearFollowupQueue, getExistingFollowupQueue } from "./state.js";
+import type { FollowupRun, QueueSettings } from "./types.js";
+
+const settings: QueueSettings = {
+  mode: "followup",
+  debounceMs: 0,
+  cap: 20,
+  dropPolicy: "summarize",
+};
+
+function makeRun(overrides: Partial<FollowupRun> = {}): FollowupRun {
+  return {
+    prompt: "queued user message",
+    enqueuedAt: Date.now(),
+    originatingChannel: "discord",
+    originatingTo: "channel:123",
+    run: {
+      agentId: "rex",
+      agentDir: "/tmp/agent",
+      sessionId: "session-1",
+      sessionKey: "agent:rex:discord:channel:123",
+      messageProvider: "discord",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      timeoutMs: 1000,
+      blockReplyBreak: "message_end",
+    },
+    ...overrides,
+  };
+}
+
+describe("scheduleDiscordStuckSessionCircuitBreaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetDiscordStuckSessionCircuitBreakerForTest();
+    clearFollowupQueue("agent:rex:discord:channel:123");
+    clearFollowupQueue("agent:rex:telegram:channel:123");
+    vi.useRealTimers();
+  });
+
+  it("aborts a non-streaming stuck Discord run and drains a recovery notice before queued messages", async () => {
+    const queueKey = "agent:rex:discord:channel:123";
+    const run = makeRun({ enqueuedAt: Date.now() - 10_000 });
+    const calls: string[] = [];
+    const runFollowup = vi.fn(async (item: FollowupRun) => {
+      calls.push(item.prompt);
+      clearFollowupQueue(queueKey);
+    });
+    const abortActiveRun = vi.fn(() => true);
+
+    expect(enqueueFollowupRun(queueKey, run, settings, "none", runFollowup, false)).toBe(true);
+    scheduleDiscordStuckSessionCircuitBreaker({
+      queueKey,
+      followupRun: run,
+      runFollowup,
+      resolveActiveRunSessionId: () => "active-session",
+      isRunActive: () => true,
+      isRunStreaming: () => false,
+      abortActiveRun,
+      scheduleDrain: (key, cb) => cb(getExistingFollowupQueue(key)!.items.shift()!),
+      thresholdMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(abortActiveRun).toHaveBeenCalledWith("active-session");
+    expect(calls[0]).toContain("previous Discord turn appears stuck");
+  });
+
+  it("does not abort active streaming Discord runs", async () => {
+    const queueKey = "agent:rex:discord:channel:123";
+    const run = makeRun({ enqueuedAt: Date.now() - 10_000 });
+    const abortActiveRun = vi.fn(() => true);
+
+    enqueueFollowupRun(queueKey, run, settings, "none", async () => undefined, false);
+    scheduleDiscordStuckSessionCircuitBreaker({
+      queueKey,
+      followupRun: run,
+      runFollowup: async () => undefined,
+      resolveActiveRunSessionId: () => "active-session",
+      isRunActive: () => true,
+      isRunStreaming: () => true,
+      abortActiveRun,
+      scheduleDrain: vi.fn(),
+      thresholdMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(abortActiveRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-Discord queues", async () => {
+    const queueKey = "agent:rex:telegram:channel:123";
+    const run = makeRun({
+      originatingChannel: "telegram",
+      run: { ...makeRun().run, messageProvider: "telegram" },
+    });
+    const abortActiveRun = vi.fn(() => true);
+
+    enqueueFollowupRun(queueKey, run, settings, "none", async () => undefined, false);
+    scheduleDiscordStuckSessionCircuitBreaker({
+      queueKey,
+      followupRun: run,
+      runFollowup: async () => undefined,
+      resolveActiveRunSessionId: () => "active-session",
+      isRunActive: () => true,
+      isRunStreaming: () => false,
+      abortActiveRun,
+      scheduleDrain: vi.fn(),
+      thresholdMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(abortActiveRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/queue/circuit-breaker.ts
+++ b/src/auto-reply/reply/queue/circuit-breaker.ts
@@ -1,0 +1,127 @@
+import { defaultRuntime } from "../../../runtime.js";
+import { resolveGlobalMap } from "../../../shared/global-singleton.js";
+import { getExistingFollowupQueue } from "./state.js";
+import type { FollowupRun } from "./types.js";
+
+const DISCORD_STUCK_SESSION_BREAKER_TIMERS_KEY = Symbol.for(
+  "openclaw.discordStuckSessionCircuitBreakerTimers",
+);
+
+const DISCORD_STUCK_SESSION_BREAKER_TIMERS = resolveGlobalMap<
+  string,
+  ReturnType<typeof setTimeout>
+>(DISCORD_STUCK_SESSION_BREAKER_TIMERS_KEY);
+
+export const DISCORD_STUCK_SESSION_BREAKER_THRESHOLD_MS = 5 * 60 * 1000;
+
+const RECOVERY_NOTICE_PROMPT = [
+  "The previous Discord turn appears stuck and queued messages are waiting.",
+  "First, briefly acknowledge that recovery kicked in, then handle the queued user message normally.",
+].join("\n");
+
+function isDiscordOrigin(run: FollowupRun): boolean {
+  return run.originatingChannel === "discord" || run.run.messageProvider === "discord";
+}
+
+function clearDiscordStuckSessionCircuitBreaker(queueKey: string): void {
+  const existing = DISCORD_STUCK_SESSION_BREAKER_TIMERS.get(queueKey);
+  if (!existing) {
+    return;
+  }
+  clearTimeout(existing);
+  DISCORD_STUCK_SESSION_BREAKER_TIMERS.delete(queueKey);
+}
+
+function buildRecoveryNoticeRun(item: FollowupRun): FollowupRun {
+  return {
+    ...item,
+    prompt: RECOVERY_NOTICE_PROMPT,
+    transcriptPrompt: RECOVERY_NOTICE_PROMPT,
+    messageId: undefined,
+    summaryLine: "Discord stuck-session recovery notice",
+    enqueuedAt: Date.now(),
+    images: undefined,
+    imageOrder: undefined,
+  };
+}
+
+export function scheduleDiscordStuckSessionCircuitBreaker(params: {
+  queueKey: string;
+  followupRun: FollowupRun;
+  runFollowup: (run: FollowupRun) => Promise<void>;
+  resolveActiveRunSessionId: () => string | undefined;
+  isRunActive: () => boolean;
+  isRunStreaming: () => boolean;
+  abortActiveRun: (activeSessionId: string) => boolean;
+  scheduleDrain: (key: string, runFollowup: (run: FollowupRun) => Promise<void>) => void;
+  thresholdMs?: number;
+}): void {
+  const { queueKey, followupRun } = params;
+  if (!queueKey.trim() || !isDiscordOrigin(followupRun)) {
+    return;
+  }
+
+  const queue = getExistingFollowupQueue(queueKey);
+  if (!queue || queue.items.length === 0) {
+    clearDiscordStuckSessionCircuitBreaker(queueKey);
+    return;
+  }
+
+  // One breaker timer per queue key. A fresh enqueue updates lastEnqueuedAt on
+  // the queue; the existing timer will reschedule until the threshold is met.
+  if (DISCORD_STUCK_SESSION_BREAKER_TIMERS.has(queueKey)) {
+    return;
+  }
+
+  const thresholdMs = Math.max(1, params.thresholdMs ?? DISCORD_STUCK_SESSION_BREAKER_THRESHOLD_MS);
+  const arm = (delayMs: number) => {
+    const timer = setTimeout(() => {
+      DISCORD_STUCK_SESSION_BREAKER_TIMERS.delete(queueKey);
+      const latest = getExistingFollowupQueue(queueKey);
+      if (!latest || latest.items.length === 0) {
+        return;
+      }
+
+      const oldestQueuedAt = Math.min(...latest.items.map((item) => item.enqueuedAt));
+      const ageMs = Date.now() - Math.min(oldestQueuedAt, latest.lastEnqueuedAt || oldestQueuedAt);
+      if (ageMs < thresholdMs) {
+        arm(thresholdMs - ageMs);
+        return;
+      }
+
+      if (!params.isRunActive() || params.isRunStreaming()) {
+        return;
+      }
+
+      const activeSessionId = params.resolveActiveRunSessionId();
+      if (!activeSessionId) {
+        return;
+      }
+
+      const aborted = params.abortActiveRun(activeSessionId);
+      defaultRuntime.log?.(
+        `discord stuck-session circuit breaker fired for ${queueKey}: queueDepth=${latest.items.length}, activeSessionId=${activeSessionId}, aborted=${aborted}`,
+      );
+      if (!aborted) {
+        return;
+      }
+
+      latest.items.unshift(buildRecoveryNoticeRun(latest.items[0]));
+      latest.lastEnqueuedAt = Date.now();
+      latest.draining = false;
+      params.scheduleDrain(queueKey, params.runFollowup);
+    }, delayMs);
+    DISCORD_STUCK_SESSION_BREAKER_TIMERS.set(queueKey, timer);
+  };
+
+  const oldestQueuedAt = Math.min(...queue.items.map((item) => item.enqueuedAt));
+  const ageMs = Date.now() - Math.min(oldestQueuedAt, queue.lastEnqueuedAt || oldestQueuedAt);
+  arm(Math.max(1, thresholdMs - ageMs));
+}
+
+export function resetDiscordStuckSessionCircuitBreakerForTest(): void {
+  for (const timer of DISCORD_STUCK_SESSION_BREAKER_TIMERS.values()) {
+    clearTimeout(timer);
+  }
+  DISCORD_STUCK_SESSION_BREAKER_TIMERS.clear();
+}


### PR DESCRIPTION
## Summary
- add a Discord stuck-session circuit breaker for queued follow-ups behind stale non-streaming active runs
- emit a recovery notice before abort/requeue handling
- cover circuit-breaker and queue behavior with focused tests

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/queue/circuit-breaker.test.ts src/auto-reply/reply/get-reply-run-queue.test.ts --reporter=dot` → 2 files / 6 tests passed
- `git diff --check origin/main..HEAD` → passed
- `corepack pnpm tsgo:core:test` → blocked by existing baseline fixture type error in `src/gateway/server-startup-config.recovery.test.ts` (`ModelDefinitionConfig` mock missing reasoning/input/cost/contextWindow/maxTokens), unrelated to this 5-file change

## Notes
- Rebased/cherry-picked onto current `origin/main` to avoid unrelated stale-branch diff.
- Draft PR only; no deploy, gateway restart, merge, runtime patch, destructive action, or live Discord smoke performed.
- Supabase task: `59131098-6e62-4b41-9bb7-8c317ecd6d41`.
