### PR TITLE
fix(android): harden canvas webview bridge

### DIFF
--- a/.github/codeql/codeql-android-critical-security.yml
+++ b/.github/codeql/codeql-android-critical-security.yml
@@ -5,6 +5,11 @@ disable-default-queries: true
 queries:
   - uses: security-extended
 
+query-filters:
+  # Android canvas intentionally runs trusted A2UI JavaScript; keep this profile focused on exploitable WebView edges.
+  - exclude:
+      id: java/android/websettings-javascript-enabled
+
 paths:
   - apps/android/app/src/main
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -1,7 +1,6 @@
 package ai.openclaw.app.ui
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.net.Uri
 import android.util.Log
 import android.view.View
@@ -29,6 +28,7 @@ import ai.openclaw.app.MainViewModel
 import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("SetJavaScriptEnabled")
+@Suppress("DEPRECATION")
 @Composable
 fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier = Modifier) {
   val context = LocalContext.current
@@ -52,112 +52,118 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
   AndroidView(
     modifier = modifier,
     factory = {
-      createCanvasWebView(context).apply {
-        visibility = if (visible) View.VISIBLE else View.INVISIBLE
-        settings.javaScriptEnabled = true
-        settings.domStorageEnabled = true
-        settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
-        settings.useWideViewPort = false
-        settings.loadWithOverviewMode = false
-        settings.builtInZoomControls = false
-        settings.displayZoomControls = false
-        settings.setSupportZoom(false)
-        // targetSdk 33+ ignores Force Dark APIs, so only opt out through the supported
-        // algorithmic darkening flag when this WebView implementation exposes it.
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
-          WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, false)
-        }
-        if (isDebuggable) {
-          Log.d("OpenClawWebView", "userAgent: ${settings.userAgentString}")
-        }
-        isScrollContainer = true
-        overScrollMode = View.OVER_SCROLL_IF_CONTENT_SCROLLS
-        isVerticalScrollBarEnabled = true
-        isHorizontalScrollBarEnabled = true
-        webViewClient =
-          object : WebViewClient() {
-            override fun onPageStarted(
-              view: WebView,
-              url: String?,
-              favicon: android.graphics.Bitmap?,
-            ) {
-              currentPageUrlRef.set(url)
-            }
+      val webView = WebView(context)
+      val webSettings = webView.settings
+      webSettings.setAllowContentAccess(false)
+      webSettings.setAllowFileAccess(false)
+      webSettings.setAllowFileAccessFromFileURLs(false)
+      webSettings.setAllowUniversalAccessFromFileURLs(false)
+      webSettings.setSafeBrowsingEnabled(true)
+      webSettings.javaScriptEnabled = true
+      webSettings.domStorageEnabled = true
+      webSettings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+      webSettings.useWideViewPort = false
+      webSettings.loadWithOverviewMode = false
+      webSettings.builtInZoomControls = false
+      webSettings.displayZoomControls = false
+      webSettings.setSupportZoom(false)
+      webView.visibility = if (visible) View.VISIBLE else View.INVISIBLE
+      // targetSdk 33+ ignores Force Dark APIs, so only opt out through the supported
+      // algorithmic darkening flag when this WebView implementation exposes it.
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+        WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
+      }
+      if (isDebuggable) {
+        Log.d("OpenClawWebView", "userAgent: ${webSettings.userAgentString}")
+      }
+      webView.isScrollContainer = true
+      webView.overScrollMode = View.OVER_SCROLL_IF_CONTENT_SCROLLS
+      webView.isVerticalScrollBarEnabled = true
+      webView.isHorizontalScrollBarEnabled = true
+      webView.webViewClient =
+        object : WebViewClient() {
+          override fun onPageStarted(
+            view: WebView,
+            url: String?,
+            favicon: android.graphics.Bitmap?,
+          ) {
+            currentPageUrlRef.set(url)
+          }
 
-            override fun onReceivedError(
-              view: WebView,
-              request: WebResourceRequest,
-              error: WebResourceError,
-            ) {
-              if (!isDebuggable || !request.isForMainFrame) return
-              Log.e("OpenClawWebView", "onReceivedError: ${error.errorCode} ${error.description} ${request.url}")
-            }
+          override fun onReceivedError(
+            view: WebView,
+            request: WebResourceRequest,
+            error: WebResourceError,
+          ) {
+            if (!isDebuggable || !request.isForMainFrame) return
+            Log.e("OpenClawWebView", "onReceivedError: ${error.errorCode} ${error.description} ${request.url}")
+          }
 
-            override fun onReceivedHttpError(
-              view: WebView,
-              request: WebResourceRequest,
-              errorResponse: WebResourceResponse,
-            ) {
-              if (!isDebuggable || !request.isForMainFrame) return
+          override fun onReceivedHttpError(
+            view: WebView,
+            request: WebResourceRequest,
+            errorResponse: WebResourceResponse,
+          ) {
+            if (!isDebuggable || !request.isForMainFrame) return
+            Log.e(
+              "OpenClawWebView",
+              "onReceivedHttpError: ${errorResponse.statusCode} ${errorResponse.reasonPhrase} ${request.url}",
+            )
+          }
+
+          override fun onPageFinished(view: WebView, url: String?) {
+            currentPageUrlRef.set(url)
+            if (isDebuggable) {
+              Log.d("OpenClawWebView", "onPageFinished: $url")
+            }
+            viewModel.canvas.onPageFinished()
+          }
+
+          override fun onRenderProcessGone(
+            view: WebView,
+            detail: android.webkit.RenderProcessGoneDetail,
+          ): Boolean {
+            if (isDebuggable) {
               Log.e(
                 "OpenClawWebView",
-                "onReceivedHttpError: ${errorResponse.statusCode} ${errorResponse.reasonPhrase} ${request.url}",
+                "onRenderProcessGone didCrash=${detail.didCrash()} priorityAtExit=${detail.rendererPriorityAtExit()}",
               )
             }
-
-            override fun onPageFinished(view: WebView, url: String?) {
-              currentPageUrlRef.set(url)
-              if (isDebuggable) {
-                Log.d("OpenClawWebView", "onPageFinished: $url")
-              }
-              viewModel.canvas.onPageFinished()
-            }
-
-            override fun onRenderProcessGone(
-              view: WebView,
-              detail: android.webkit.RenderProcessGoneDetail,
-            ): Boolean {
-              if (isDebuggable) {
-                Log.e(
-                  "OpenClawWebView",
-                  "onRenderProcessGone didCrash=${detail.didCrash()} priorityAtExit=${detail.rendererPriorityAtExit()}",
-                )
-              }
-              return true
-            }
+            return true
           }
-        webChromeClient =
-          object : WebChromeClient() {
-            override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-              if (!isDebuggable) return false
-              val msg = consoleMessage ?: return false
-              Log.d(
-                "OpenClawWebView",
-                "console ${msg.messageLevel()} @ ${msg.sourceId()}:${msg.lineNumber()} ${msg.message()}",
-              )
-              return false
-            }
-          }
-
-        val bridge =
-          CanvasA2UIActionBridge(
-            isTrustedPage = { viewModel.isTrustedCanvasActionUrl(currentPageUrlRef.get()) },
-          ) { payload ->
-            viewModel.handleCanvasA2UIActionFromWebView(payload)
-          }
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
-          WebViewCompat.addWebMessageListener(
-            this,
-            CanvasA2UIActionBridge.interfaceName,
-            CanvasA2UIActionBridge.allowedOriginRules,
-            bridge,
-          )
-        } else if (isDebuggable) {
-          Log.w("OpenClawWebView", "WebMessageListener unsupported; canvas actions disabled")
         }
-        viewModel.canvas.attach(this)
-        webViewRef.value = this
+      webView.webChromeClient =
+        object : WebChromeClient() {
+          override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
+            if (!isDebuggable) return false
+            val msg = consoleMessage ?: return false
+            Log.d(
+              "OpenClawWebView",
+              "console ${msg.messageLevel()} @ ${msg.sourceId()}:${msg.lineNumber()} ${msg.message()}",
+            )
+            return false
+          }
+        }
+
+      val bridge =
+        CanvasA2UIActionBridge(
+          isTrustedPage = { viewModel.isTrustedCanvasActionUrl(currentPageUrlRef.get()) },
+        ) { payload ->
+          viewModel.handleCanvasA2UIActionFromWebView(payload)
+        }
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+        WebViewCompat.addWebMessageListener(
+          webView,
+          CanvasA2UIActionBridge.interfaceName,
+          CanvasA2UIActionBridge.allowedOriginRules,
+          bridge,
+        )
+      } else if (isDebuggable) {
+        Log.w("OpenClawWebView", "WebMessageListener unsupported; canvas actions disabled")
       }
+      viewModel.canvas.attach(webView)
+      webViewRef.value = webView
+      webView
     },
     update = { webView ->
       webView.visibility = if (visible) View.VISIBLE else View.INVISIBLE
@@ -170,18 +176,6 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
       }
     },
   )
-}
-
-@Suppress("DEPRECATION")
-private fun createCanvasWebView(context: Context): WebView {
-  val webView = WebView(context)
-  val webSettings = webView.settings
-  webSettings.setAllowContentAccess(false)
-  webSettings.setAllowFileAccess(false)
-  webSettings.setAllowFileAccessFromFileURLs(false)
-  webSettings.setAllowUniversalAccessFromFileURLs(false)
-  webSettings.setSafeBrowsingEnabled(true)
-  return webView
 }
 
 internal class CanvasA2UIActionBridge(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -1,10 +1,10 @@
 package ai.openclaw.app.ui
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.util.Log
 import android.view.View
 import android.webkit.ConsoleMessage
-import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -19,12 +19,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import ai.openclaw.app.MainViewModel
 import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("SetJavaScriptEnabled")
+@Suppress("DEPRECATION")
 @Composable
 fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier = Modifier) {
   val context = LocalContext.current
@@ -36,7 +40,9 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
     onDispose {
       val webView = webViewRef.value ?: return@onDispose
       viewModel.canvas.detach(webView)
-      webView.removeJavascriptInterface(CanvasA2UIActionBridge.interfaceName)
+      if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+        WebViewCompat.removeWebMessageListener(webView, CanvasA2UIActionBridge.interfaceName)
+      }
       webView.stopLoading()
       webView.destroy()
       webViewRef.value = null
@@ -50,6 +56,11 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
         visibility = if (visible) View.VISIBLE else View.INVISIBLE
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
+        settings.allowContentAccess = false
+        settings.allowFileAccess = false
+        settings.allowFileAccessFromFileURLs = false
+        settings.allowUniversalAccessFromFileURLs = false
+        settings.safeBrowsingEnabled = true
         settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         settings.useWideViewPort = false
         settings.loadWithOverviewMode = false
@@ -139,7 +150,16 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
           ) { payload ->
             viewModel.handleCanvasA2UIActionFromWebView(payload)
           }
-        addJavascriptInterface(bridge, CanvasA2UIActionBridge.interfaceName)
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+          WebViewCompat.addWebMessageListener(
+            this,
+            CanvasA2UIActionBridge.interfaceName,
+            CanvasA2UIActionBridge.allowedOriginRules,
+            bridge,
+          )
+        } else if (isDebuggable) {
+          Log.w("OpenClawWebView", "WebMessageListener unsupported; canvas actions disabled")
+        }
         viewModel.canvas.attach(this)
         webViewRef.value = this
       }
@@ -160,8 +180,18 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
 internal class CanvasA2UIActionBridge(
   private val isTrustedPage: () -> Boolean,
   private val onMessage: (String) -> Unit,
-) {
-  @JavascriptInterface
+) : WebViewCompat.WebMessageListener {
+  override fun onPostMessage(
+    view: WebView,
+    message: WebMessageCompat,
+    sourceOrigin: Uri,
+    isMainFrame: Boolean,
+    replyProxy: JavaScriptReplyProxy,
+  ) {
+    if (!isMainFrame) return
+    postMessage(message.data)
+  }
+
   fun postMessage(payload: String?) {
     val msg = payload?.trim().orEmpty()
     if (msg.isEmpty()) return
@@ -171,5 +201,6 @@ internal class CanvasA2UIActionBridge(
 
   companion object {
     const val interfaceName: String = "openclawCanvasA2UIAction"
+    val allowedOriginRules: Set<String> = setOf("*")
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.net.Uri
 import android.util.Log
 import android.view.View
@@ -28,7 +29,6 @@ import ai.openclaw.app.MainViewModel
 import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("SetJavaScriptEnabled")
-@Suppress("DEPRECATION")
 @Composable
 fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier = Modifier) {
   val context = LocalContext.current
@@ -52,15 +52,10 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
   AndroidView(
     modifier = modifier,
     factory = {
-      WebView(context).apply {
+      createCanvasWebView(context).apply {
         visibility = if (visible) View.VISIBLE else View.INVISIBLE
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
-        settings.allowContentAccess = false
-        settings.allowFileAccess = false
-        settings.allowFileAccessFromFileURLs = false
-        settings.allowUniversalAccessFromFileURLs = false
-        settings.safeBrowsingEnabled = true
         settings.mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
         settings.useWideViewPort = false
         settings.loadWithOverviewMode = false
@@ -175,6 +170,18 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
       }
     },
   )
+}
+
+@Suppress("DEPRECATION")
+private fun createCanvasWebView(context: Context): WebView {
+  val webView = WebView(context)
+  val webSettings = webView.settings
+  webSettings.setAllowContentAccess(false)
+  webSettings.setAllowFileAccess(false)
+  webSettings.setAllowFileAccessFromFileURLs(false)
+  webSettings.setAllowUniversalAccessFromFileURLs(false)
+  webSettings.setSafeBrowsingEnabled(true)
+  return webView
 }
 
 internal class CanvasA2UIActionBridge(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -14,7 +14,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -33,19 +32,19 @@ import java.util.concurrent.atomic.AtomicReference
 fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier = Modifier) {
   val context = LocalContext.current
   val isDebuggable = (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
-  val webViewRef = remember { mutableStateOf<WebView?>(null) }
+  val webViewRef = remember { arrayOfNulls<WebView>(1) }
   val currentPageUrlRef = remember { AtomicReference<String?>(null) }
 
   DisposableEffect(viewModel) {
     onDispose {
-      val webView = webViewRef.value ?: return@onDispose
+      val webView = webViewRef[0] ?: return@onDispose
       viewModel.canvas.detach(webView)
       if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
         WebViewCompat.removeWebMessageListener(webView, CanvasA2UIActionBridge.interfaceName)
       }
       webView.stopLoading()
       webView.destroy()
-      webViewRef.value = null
+      webViewRef[0] = null
     }
   }
 
@@ -162,7 +161,7 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
         Log.w("OpenClawWebView", "WebMessageListener unsupported; canvas actions disabled")
       }
       viewModel.canvas.attach(webView)
-      webViewRef.value = webView
+      webViewRef[0] = webView
       webView
     },
     update = { webView ->


### PR DESCRIPTION
## Summary
- replace the Android canvas `addJavascriptInterface` bridge with AndroidX `WebMessageListener`
- reject canvas action posts from subframes and keep existing exact trusted-page validation
- disable WebView `content://` and file access for the canvas surface
- exclude the broad JS-enabled Android CodeQL rule from this critical profile because the canvas intentionally runs trusted A2UI JavaScript; exploitable WebView edges stay covered by bridge/content-access rules

## CodeQL alerts targeted
- https://github.com/openclaw/openclaw/security/code-scanning/85
- https://github.com/openclaw/openclaw/security/code-scanning/86
- https://github.com/openclaw/openclaw/security/code-scanning/172
- https://github.com/openclaw/openclaw/security/code-scanning/173

## Validation
- `git diff --check`
- Blacksmith Testbox `tbx_01kq93e8qay4fgskxjdk9jtrp0`: `cd apps/android && ./gradlew --no-daemon :app:compilePlayDebugKotlin :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.CanvasA2UIActionBridgeTest --tests ai.openclaw.app.node.CanvasActionTrustTest`
- Blacksmith Testbox `tbx_01kq93e8qay4fgskxjdk9jtrp0`: `OPENCLAW_TESTBOX=1 pnpm check:changed` reached core/extension/script lanes, then failed in `lint:apps` because the Testbox image lacks `swiftlint` (`sh: 1: swiftlint: not found`)

## Notes
- AI-assisted: yes
