### PR TITLE
fix(diagnostics): abort stuck sessions

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -819,6 +819,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "ms",
         description: "Age of stuck sessions",
       });
+      const sessionAbortedCounter = meter.createCounter("openclaw.session.aborted", {
+        unit: "1",
+        description: "Stuck sessions aborted by diagnostics",
+      });
+      const sessionAbortedAgeHistogram = meter.createHistogram("openclaw.session.aborted_age_ms", {
+        unit: "ms",
+        description: "Age of sessions aborted by diagnostics",
+      });
       const runAttemptCounter = meter.createCounter("openclaw.run.attempt", {
         unit: "1",
         description: "Run attempts",
@@ -1465,6 +1473,30 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         spanAttrs["openclaw.ageMs"] = evt.ageMs;
         const span = tracer.startSpan("openclaw.session.stuck", { attributes: spanAttrs });
         span.setStatus({ code: SpanStatusCode.ERROR, message: "session stuck" });
+        span.end();
+      };
+
+      const recordSessionAborted = (
+        evt: Extract<DiagnosticEventPayload, { type: "session.aborted" }>,
+      ) => {
+        const attrs: Record<string, string> = {
+          "openclaw.state": evt.state,
+          "openclaw.reason": evt.reason,
+          "openclaw.recovered": String(evt.recovered),
+        };
+        sessionAbortedCounter.add(1, attrs);
+        if (typeof evt.ageMs === "number") {
+          sessionAbortedAgeHistogram.record(evt.ageMs, attrs);
+        }
+        if (!tracesEnabled) {
+          return;
+        }
+        const spanAttrs: Record<string, string | number | boolean> = { ...attrs };
+        spanAttrs["openclaw.queueDepth"] = evt.queueDepth ?? 0;
+        spanAttrs["openclaw.ageMs"] = evt.ageMs;
+        spanAttrs["openclaw.recovered"] = evt.recovered;
+        const span = tracer.startSpan("openclaw.session.aborted", { attributes: spanAttrs });
+        span.setStatus({ code: SpanStatusCode.ERROR, message: "session aborted" });
         span.end();
       };
 
@@ -2239,6 +2271,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "session.stuck":
               recordSessionStuck(evt);
+              return;
+            case "session.aborted":
+              recordSessionAborted(evt);
               return;
             case "run.attempt":
               recordRunAttempt(evt);

--- a/src/agents/pi-embedded-runner/active-run-abort.ts
+++ b/src/agents/pi-embedded-runner/active-run-abort.ts
@@ -1,0 +1,11 @@
+import { abortReplyRunBySessionId } from "../../auto-reply/reply/reply-run-registry.js";
+import { ACTIVE_EMBEDDED_RUNS } from "./run-state.js";
+
+export function abortEmbeddedPiRunBySessionId(sessionId: string): boolean {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (!handle) {
+    return abortReplyRunBySessionId(sessionId);
+  }
+  handle.abort();
+  return true;
+}

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -151,6 +151,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
           },
+          stuckSessionAbortMs: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            maximum: 9007199254740991,
+            title: "Stuck Session Abort Threshold (ms)",
+            description:
+              "Age threshold in milliseconds for aborting a stuck processing session after warnings have fired. Set greater than diagnostics.stuckSessionWarnMs; invalid or lower values disable automatic stuck-session recovery.",
+          },
           otel: {
             type: "object",
             properties: {
@@ -24639,6 +24647,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "diagnostics.stuckSessionWarnMs": {
       label: "Session Liveness Threshold (ms)",
       help: "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
+      tags: ["observability", "storage"],
+    },
+    "diagnostics.stuckSessionAbortMs": {
+      label: "Stuck Session Abort Threshold (ms)",
+      help: "Age threshold in milliseconds for aborting a stuck processing session after warnings have fired. Set greater than diagnostics.stuckSessionWarnMs; invalid or lower values disable automatic stuck-session recovery.",
       tags: ["observability", "storage"],
     },
     "diagnostics.otel.enabled": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -588,6 +588,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Master toggle for diagnostics instrumentation output in logs and telemetry wiring paths. Defaults to enabled; set false only in tightly constrained environments.",
   "diagnostics.stuckSessionWarnMs":
     "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
+  "diagnostics.stuckSessionAbortMs":
+    "Age threshold in milliseconds for aborting a stuck processing session after warnings have fired. Set greater than diagnostics.stuckSessionWarnMs; invalid or lower values disable automatic stuck-session recovery.",
   "diagnostics.otel.enabled":
     "Enables OpenTelemetry export pipeline for traces, metrics, and logs based on configured endpoint/protocol settings. Keep disabled unless your collector endpoint and auth are fully configured.",
   "diagnostics.otel.endpoint":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -41,6 +41,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.enabled": "Diagnostics Enabled",
   "diagnostics.flags": "Diagnostics Flags",
   "diagnostics.stuckSessionWarnMs": "Session Liveness Threshold (ms)",
+  "diagnostics.stuckSessionAbortMs": "Stuck Session Abort Threshold (ms)",
   "diagnostics.otel.enabled": "OpenTelemetry Enabled",
   "diagnostics.otel.endpoint": "OpenTelemetry Endpoint",
   "diagnostics.otel.tracesEndpoint": "OpenTelemetry Traces Endpoint",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -309,6 +309,8 @@ export type DiagnosticsConfig = {
   flags?: string[];
   /** Threshold in ms before a processing session with no observed progress logs diagnostics. */
   stuckSessionWarnMs?: number;
+  /** Threshold in ms before a stuck processing session is aborted for recovery. */
+  stuckSessionAbortMs?: number;
   otel?: DiagnosticsOtelConfig;
   cacheTrace?: DiagnosticsCacheTraceConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -342,6 +342,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         flags: z.array(z.string()).optional(),
         stuckSessionWarnMs: z.number().int().positive().optional(),
+        stuckSessionAbortMs: z.number().int().positive().optional(),
         otel: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -65,6 +65,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
+  { prefix: "diagnostics.stuckSessionAbortMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -388,10 +388,14 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("secrets.providers.default.path");
   });
 
-  it("treats diagnostics.stuckSessionWarnMs as no-op for gateway restart planning", () => {
-    const plan = buildGatewayReloadPlan(["diagnostics.stuckSessionWarnMs"]);
+  it("treats stuck-session diagnostics thresholds as no-op for gateway restart planning", () => {
+    const plan = buildGatewayReloadPlan([
+      "diagnostics.stuckSessionWarnMs",
+      "diagnostics.stuckSessionAbortMs",
+    ]);
     expect(plan.restartGateway).toBe(false);
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
+    expect(plan.noopPaths).toContain("diagnostics.stuckSessionAbortMs");
   });
 
   it("restarts for gateway.auth.token changes", () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -164,6 +164,17 @@ export type DiagnosticSessionStuckEvent = DiagnosticSessionAttentionBaseEvent & 
   classification: "stale_session_state";
 };
 
+export type DiagnosticSessionAbortedEvent = DiagnosticBaseEvent & {
+  type: "session.aborted";
+  sessionKey?: string;
+  sessionId?: string;
+  state: DiagnosticSessionState;
+  ageMs: number;
+  queueDepth?: number;
+  reason: "stuck-timeout";
+  recovered: boolean;
+};
+
 export type DiagnosticLaneEnqueueEvent = DiagnosticBaseEvent & {
   type: "queue.lane.enqueue";
   lane: string;
@@ -520,6 +531,7 @@ export type DiagnosticEventPayload =
   | DiagnosticSessionLongRunningEvent
   | DiagnosticSessionStalledEvent
   | DiagnosticSessionStuckEvent
+  | DiagnosticSessionAbortedEvent
   | DiagnosticLaneEnqueueEvent
   | DiagnosticLaneDequeueEvent
   | DiagnosticRunAttemptEvent

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -8,6 +8,8 @@ export type SessionState = {
   lastLongRunningWarnAgeMs?: number;
   state: SessionStateValue;
   queueDepth: number;
+  stuckLoggedAt?: number;
+  stuckAbortRequestedAt?: number;
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -40,6 +40,7 @@ export type DiagnosticStabilityEventRecord = {
   commandLength?: number;
   exitCode?: number;
   timedOut?: boolean;
+  recovered?: boolean;
   costUsd?: number;
   count?: number;
   bytes?: number;
@@ -249,6 +250,13 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       if (event.activeToolName) {
         record.toolName = event.activeToolName;
       }
+      break;
+    case "session.aborted":
+      record.outcome = event.state;
+      record.ageMs = event.ageMs;
+      record.queueDepth = event.queueDepth;
+      record.recovered = event.recovered;
+      assignReasonCode(record, event.reason);
       break;
     case "queue.lane.enqueue":
       record.source = event.lane;

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -55,10 +55,10 @@ function formatRecoveryContext(
 
 export async function recoverStuckDiagnosticSession(
   params: StuckSessionRecoveryParams,
-): Promise<void> {
+): Promise<boolean> {
   const key = recoveryKey(params);
   if (!key || recoveriesInFlight.has(key)) {
-    return;
+    return false;
   }
 
   recoveriesInFlight.add(key);
@@ -86,7 +86,7 @@ export async function recoverStuckDiagnosticSession(
             { activeSessionId },
           )}`,
         );
-        return;
+        return false;
       }
       const result = await abortAndDrainEmbeddedPiRun({
         sessionId: activeSessionId,
@@ -106,7 +106,7 @@ export async function recoverStuckDiagnosticSession(
           { activeSessionId: activeWorkSessionId },
         )}`,
       );
-      return;
+      return false;
     }
 
     if (!activeSessionId && sessionLane) {
@@ -122,7 +122,7 @@ export async function recoverStuckDiagnosticSession(
             },
           )}`,
         );
-        return;
+        return false;
       }
     }
 
@@ -151,12 +151,14 @@ export async function recoverStuckDiagnosticSession(
         )}`,
       );
     }
+    return aborted || released > 0;
   } catch (err) {
     diag.warn(
       `stuck session recovery failed: sessionId=${params.sessionId ?? "unknown"} sessionKey=${
         params.sessionKey ?? "unknown"
       } err=${String(err)}`,
     );
+    return false;
   } finally {
     recoveriesInFlight.delete(key);
   }

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -442,7 +442,7 @@ describe("stuck session diagnostics threshold", () => {
       sessionKey: "main",
       ageMs: expect.any(Number),
       queueDepth: 0,
-      allowActiveAbort: true,
+      reason: "stuck-timeout",
     });
   });
 
@@ -562,6 +562,137 @@ describe("stuck session diagnostics threshold", () => {
       queueDepth: 1,
     });
     expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
+  it("aborts stuck sessions after diagnostics.stuckSessionAbortMs", async () => {
+    const events: Array<{ type: string; recovered?: boolean }> = [];
+    const recoverStuckSession = vi.fn(() => true);
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push({
+        type: event.type,
+        recovered: "recovered" in event ? event.recovered : undefined,
+      });
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      vi.advanceTimersByTime(91_000);
+      vi.runAllTicks();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(recoverStuckSession).toHaveBeenCalledTimes(2);
+    expect(recoverStuckSession).toHaveBeenLastCalledWith({
+      sessionId: "s1",
+      sessionKey: "main",
+      ageMs: 90_000,
+      queueDepth: 0,
+      reason: "stuck-timeout",
+    });
+    expect(events.filter((event) => event.type === "session.stuck")).toHaveLength(1);
+    expect(events).toContainEqual({ type: "session.aborted", recovered: true });
+    expect(diagnosticSessionStates.get("main")?.state).toBe("idle");
+  });
+
+  it("retries stuck session recovery after a recovery failure", async () => {
+    const recoverStuckSession = vi.fn((params: { reason?: string }) => {
+      if (params.reason !== "stuck-timeout") {
+        return false;
+      }
+      const callIndex = (recoverStuckSession.mock.calls ?? []).filter(
+        ([call]) => (call as { reason?: string } | undefined)?.reason === "stuck-timeout",
+      ).length;
+      if (callIndex === 1) {
+        return Promise.reject(new Error("temporary failure"));
+      }
+      return true;
+    });
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 30_000,
+          stuckSessionAbortMs: 60_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    vi.advanceTimersByTime(91_000);
+    vi.runAllTicks();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(diagnosticSessionStates.get("main")?.stuckAbortRequestedAt).toBeUndefined();
+    const abortCallsAfterFirstFailure = recoverStuckSession.mock.calls.filter(
+      ([call]) => (call as { reason?: string } | undefined)?.reason === "stuck-timeout",
+    ).length;
+    expect(abortCallsAfterFirstFailure).toBe(1);
+
+    vi.advanceTimersByTime(30_000);
+    vi.runAllTicks();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const abortCallsAfterRetry = recoverStuckSession.mock.calls.filter(
+      ([call]) => (call as { reason?: string } | undefined)?.reason === "stuck-timeout",
+    ).length;
+    expect(abortCallsAfterRetry).toBe(2);
+    expect(diagnosticSessionStates.get("main")?.state).toBe("idle");
+  });
+
+  it("does not let late stuck recovery clobber naturally recovered new work", async () => {
+    let resolveRecovery: ((recovered: boolean) => void) | undefined;
+    const recoverStuckSession = vi.fn((params: { reason?: string }) => {
+      if (params.reason !== "stuck-timeout") {
+        return false;
+      }
+      return new Promise<boolean>((resolve) => {
+        resolveRecovery = resolve;
+      });
+    });
+
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 30_000,
+          stuckSessionAbortMs: 60_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    vi.advanceTimersByTime(91_000);
+    vi.runAllTicks();
+    await Promise.resolve();
+
+    expect(recoverStuckSession).toHaveBeenCalledTimes(2);
+
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+
+    resolveRecovery?.(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const state = diagnosticSessionStates.get("main");
+    expect(state?.state).toBe("processing");
+    expect(state?.stuckAbortRequestedAt).toBeUndefined();
   });
 
   it("starts and stops the stability recorder with the heartbeat lifecycle", () => {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -67,6 +67,7 @@ const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
 const MIN_STALLED_EMBEDDED_RUN_ABORT_MS = 10 * 60_000;
 const STALLED_EMBEDDED_RUN_ABORT_WARN_MULTIPLIER = 5;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
+const DEFAULT_STUCK_SESSION_ABORT_MS = 15 * 60 * 1000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
 const DEFAULT_LIVENESS_CPU_CORE_RATIO_WARN = 0.9;
@@ -92,14 +93,6 @@ type DiagnosticWorkSnapshot = {
   queuedLabels: string[];
 };
 
-type RecoverStuckSession = (params: {
-  sessionId?: string;
-  sessionKey?: string;
-  ageMs: number;
-  queueDepth?: number;
-  allowActiveAbort?: boolean;
-}) => void | Promise<void>;
-
 type DiagnosticLivenessSample = {
   reasons: DiagnosticLivenessWarningReason[];
   intervalMs: number;
@@ -117,11 +110,23 @@ type SampleDiagnosticLiveness = (
   work: DiagnosticWorkSnapshot,
 ) => DiagnosticLivenessSample | null;
 
+type StuckSessionRecoveryParams = SessionRef & {
+  ageMs: number;
+  queueDepth: number;
+  reason?: "stuck-timeout";
+};
+type StuckSessionAbortParams = StuckSessionRecoveryParams & {
+  reason: "stuck-timeout";
+};
+type StuckSessionRecovery = (
+  params: StuckSessionRecoveryParams,
+) => boolean | void | Promise<boolean | void>;
+
 type StartDiagnosticHeartbeatOptions = {
   getConfig?: () => OpenClawConfig;
   emitMemorySample?: EmitDiagnosticMemorySample;
   sampleLiveness?: SampleDiagnosticLiveness;
-  recoverStuckSession?: RecoverStuckSession;
+  recoverStuckSession?: StuckSessionRecovery;
 };
 
 let diagnosticLivenessMonitor: EventLoopDelayMonitor | null = null;
@@ -136,19 +141,18 @@ function loadCommandPollBackoffRuntime() {
   return commandPollBackoffRuntimePromise;
 }
 
-function recoverStuckSession(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  ageMs: number;
-  queueDepth?: number;
-  allowActiveAbort?: boolean;
-}) {
+async function recoverStuckSession(params: StuckSessionRecoveryParams): Promise<boolean> {
   stuckSessionRecoveryRuntimePromise ??= import("./diagnostic-stuck-session-recovery.runtime.js");
-  void stuckSessionRecoveryRuntimePromise
-    .then(({ recoverStuckDiagnosticSession }) => recoverStuckDiagnosticSession(params))
-    .catch((err) => {
-      diag.warn(`stuck session recovery unavailable: ${String(err)}`);
+  try {
+    const { recoverStuckDiagnosticSession } = await stuckSessionRecoveryRuntimePromise;
+    return await recoverStuckDiagnosticSession({
+      ...params,
+      allowActiveAbort: params.reason === "stuck-timeout",
     });
+  } catch (err) {
+    diag.warn(`stuck session recovery unavailable: ${String(err)}`);
+    return false;
+  }
 }
 
 function formatDiagnosticWorkLabel(
@@ -445,6 +449,40 @@ function isStalledEmbeddedRunRecoveryEligible(params: {
   );
 }
 
+export function resolveStuckSessionAbortMs(config?: OpenClawConfig): number | undefined {
+  const warnMs = resolveStuckSessionWarnMs(config);
+  const raw = config?.diagnostics?.stuckSessionAbortMs;
+  const candidate =
+    typeof raw === "number" && Number.isFinite(raw)
+      ? Math.floor(raw)
+      : DEFAULT_STUCK_SESSION_ABORT_MS;
+  if (candidate <= warnMs || candidate > MAX_STUCK_SESSION_WARN_MS) {
+    return undefined;
+  }
+  return candidate;
+}
+
+function logSessionAbortRequested(params: StuckSessionAbortParams & { recovered: boolean }) {
+  diag.error(
+    `aborted stuck session: sessionId=${params.sessionId ?? "unknown"} sessionKey=${
+      params.sessionKey ?? "unknown"
+    } age=${Math.round(params.ageMs / 1000)}s queueDepth=${params.queueDepth} recovered=${
+      params.recovered
+    }`,
+  );
+  emitDiagnosticEvent({
+    type: "session.aborted",
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    state: "processing",
+    ageMs: params.ageMs,
+    queueDepth: params.queueDepth,
+    reason: params.reason,
+    recovered: params.recovered,
+  });
+  markActivity();
+}
+
 export function logWebhookReceived(params: {
   channel: string;
   updateType?: string;
@@ -619,6 +657,8 @@ export function logSessionStateChange(
   state.lastActivity = Date.now();
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
+  state.stuckLoggedAt = undefined;
+  state.stuckAbortRequestedAt = undefined;
   if (params.state === "idle") {
     state.queueDepth = Math.max(0, state.queueDepth - 1);
   }
@@ -924,6 +964,7 @@ export function startDiagnosticHeartbeat(
       }
     }
     const stuckSessionWarnMs = resolveStuckSessionWarnMs(heartbeatConfig);
+    const stuckSessionAbortMs = resolveStuckSessionAbortMs(heartbeatConfig);
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
     const work = getDiagnosticWorkSnapshot(now);
@@ -983,11 +1024,19 @@ export function startDiagnosticHeartbeat(
           thresholdMs: stuckSessionWarnMs,
         });
         if (classification?.recoveryEligible) {
-          void (opts?.recoverStuckSession ?? recoverStuckSession)({
-            sessionId: state.sessionId,
-            sessionKey: state.sessionKey,
-            ageMs,
-            queueDepth: state.queueDepth,
+          void Promise.resolve(
+            (opts?.recoverStuckSession ?? recoverStuckSession)({
+              sessionId: state.sessionId,
+              sessionKey: state.sessionKey,
+              ageMs,
+              queueDepth: state.queueDepth,
+            }),
+          ).catch((err) => {
+            diag.warn(
+              `stuck session recovery failed: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
+                state.sessionKey ?? "unknown"
+              } err=${String(err)}`,
+            );
           });
         } else if (
           isStalledEmbeddedRunRecoveryEligible({
@@ -996,14 +1045,66 @@ export function startDiagnosticHeartbeat(
             stuckSessionWarnMs,
           })
         ) {
-          void (opts?.recoverStuckSession ?? recoverStuckSession)({
-            sessionId: state.sessionId,
-            sessionKey: state.sessionKey,
-            ageMs,
-            queueDepth: state.queueDepth,
-            allowActiveAbort: true,
+          void Promise.resolve(
+            (opts?.recoverStuckSession ?? recoverStuckSession)({
+              sessionId: state.sessionId,
+              sessionKey: state.sessionKey,
+              ageMs,
+              queueDepth: state.queueDepth,
+              reason: "stuck-timeout",
+            }),
+          ).catch((err) => {
+            diag.warn(
+              `stuck session recovery failed: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
+                state.sessionKey ?? "unknown"
+              } err=${String(err)}`,
+            );
           });
         }
+      }
+      if (
+        state.state === "processing" &&
+        stuckSessionAbortMs !== undefined &&
+        ageMs > stuckSessionAbortMs &&
+        !state.stuckAbortRequestedAt
+      ) {
+        const abortRequestedAt = now;
+        state.stuckAbortRequestedAt = abortRequestedAt;
+        const recoveryParams: StuckSessionAbortParams = {
+          sessionId: state.sessionId,
+          sessionKey: state.sessionKey,
+          ageMs,
+          queueDepth: state.queueDepth,
+          reason: "stuck-timeout",
+        };
+        void Promise.resolve((opts?.recoverStuckSession ?? recoverStuckSession)(recoveryParams))
+          .then((recovered) => {
+            logSessionAbortRequested({ ...recoveryParams, recovered: recovered === true });
+            const latestState = getDiagnosticSessionState(recoveryParams);
+            if (
+              latestState !== state ||
+              latestState.state !== "processing" ||
+              latestState.stuckAbortRequestedAt !== abortRequestedAt
+            ) {
+              return;
+            }
+            latestState.state = "idle";
+            latestState.queueDepth = 0;
+            latestState.lastActivity = Date.now();
+            latestState.stuckLoggedAt = undefined;
+            latestState.stuckAbortRequestedAt = undefined;
+          })
+          .catch((err) => {
+            const latestState = getDiagnosticSessionState(recoveryParams);
+            if (latestState === state && latestState.stuckAbortRequestedAt === abortRequestedAt) {
+              latestState.stuckAbortRequestedAt = undefined;
+            }
+            diag.error(
+              `stuck session recovery failed: sessionId=${state.sessionId ?? "unknown"} sessionKey=${
+                state.sessionKey ?? "unknown"
+              } err=${String(err)}`,
+            );
+          });
       }
     }
   }, 30_000);


### PR DESCRIPTION
## Summary

- Problem: Stuck `processing` sessions only emitted `session.stuck` diagnostics and were never recovered.
- Why it matters: A wedged run could keep a session lane blocked indefinitely, preventing later messages from progressing.
- What changed: Added `diagnostics.stuckSessionAbortMs`; the heartbeat now aborts stuck reply/embedded runs, clears queued work, emits `session.aborted`, and marks diagnostic state idle after recovery.
- What did NOT change (scope boundary): This does not change normal run timeout behavior or message queue policy for healthy sessions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #71127
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The diagnostics heartbeat only warned when a session exceeded `stuckSessionWarnMs`; it had no recovery threshold or abort path.
- Missing detection / guardrail: Existing coverage asserted `session.stuck` emission but did not assert that stuck sessions are eventually released.
- Contributing context (if known): Session recovery already existed elsewhere (`/stop`, reply run aborts, embedded PI aborts), but diagnostics did not invoke it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/logging/diagnostic.test.ts`
- Scenario the test should lock in: A session in `processing` past `diagnostics.stuckSessionAbortMs` triggers recovery once, emits `session.aborted`, and returns diagnostic state to `idle`.
- Why this is the smallest reliable guardrail: The heartbeat threshold and recovery decision live in diagnostics, so a focused fake-timer unit test directly covers the bug.
- Existing test that already covers this (if any): Existing stuck-session warning test covered only `session.stuck`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Adds optional config `diagnostics.stuckSessionAbortMs`. By default, stuck sessions are warned after 2 minutes and recovered after 15 minutes if still processing.
