### PR TITLE
test(reset): cover bare reset startup prompts

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1056,6 +1056,45 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw session new]");
   });
 
+  it("uses a non-empty transcript marker for bare reset startup turns", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "/reset",
+          RawBody: "/reset",
+          CommandBody: "/reset",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+          Surface: "webchat",
+          ChatType: "direct",
+        },
+        command: {
+          surface: "webchat",
+          channel: "webchat",
+          isAuthorizedSender: true,
+          abortKey: "session-key",
+          ownerList: [],
+          senderIsOwner: true,
+          rawBodyNormalized: "/reset",
+          commandBodyNormalized: "/reset",
+        } as never,
+        resetTriggered: true,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.commandBody).toContain("A new session was started via /new or /reset.");
+    expect(call?.followupRun.prompt).toContain("A new session was started via /new or /reset.");
+    expect(call?.transcriptCommandBody).toBe("[OpenClaw session reset]");
+    expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw session reset]");
+  });
+
   it("keeps reset user notes visible while hiding startup instructions", async () => {
     await runPreparedReply(
       baseParams({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1975,6 +1975,34 @@ describe("gateway agent handler", () => {
     expect(call?.sessionId).toBe("reset-session-id");
   });
 
+  it("handles bare /reset by resetting the same session and sending reset greeting prompt", async () => {
+    mockSessionResetSuccess({ reason: "reset" });
+    mocks.performGatewaySessionReset.mockClear();
+    mocks.agentCommand.mockClear();
+
+    primeMainAgentRun({ sessionId: "reset-session-id" });
+
+    await invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem-reset-bare",
+      },
+      {
+        reqId: "4-reset-bare",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(mocks.performGatewaySessionReset).toHaveBeenCalledTimes(1);
+    const call = readLastAgentCommandCall();
+    expect(call?.message).toContain("Execute your Session Startup sequence now");
+    expect(call?.message).toContain("Current time:");
+    expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
+    expect(call?.sessionId).toBe("reset-session-id");
+  });
+
   it("prepends runtime-loaded startup memory to bare /new agent runs", async () => {
     await withTempDir({ prefix: "openclaw-gateway-reset-startup-" }, async (workspaceDir) => {
       await fs.mkdir(`${workspaceDir}/memory`, { recursive: true });


### PR DESCRIPTION
## Problem
Bare `/new` already had coverage for the intentional reset-then-startup-prompt behavior, but bare `/reset` did not. That gap made it easy to add provider-boundary fallbacks instead of verifying the reset ingress paths.

## Changes
- Add gateway RPC coverage for bare `/reset` resetting the same session and sending the reset/startup prompt.
- Add chat auto-reply coverage that bare `/reset` uses a non-empty transcript marker (`[OpenClaw session reset]`) while keeping startup instructions out of the visible transcript prompt.

## Validation
- `pnpm test src/gateway/server-methods/agent.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/agent.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts && git diff --check`
- `pnpm test:changed`
