### PR TITLE
feat(mattermost): add streaming.draftPreview config option

### DIFF
--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -99,6 +99,14 @@ const MattermostAccountSchemaBase = z
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
+    /** Streaming behavior configuration. */
+    streaming: z
+      .object({
+        /** Enable draft-preview streaming (create placeholder + update in place). Defaults to true. */
+        draftPreview: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     replyToMode: z.enum(["off", "first", "all", "batched"]).optional(),
     responsePrefix: z.string().optional(),
     actions: z

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -251,3 +251,18 @@ describe("buildMattermostToolStatusText", () => {
     expect(buildMattermostToolStatusText({ name: "exec" })).toBe("Running `exec`…");
   });
 });
+
+describe("createMattermostNoopDraftStream", () => {
+  it("never calls the API (draftPreview disabled)", async () => {
+    const { createMattermostNoopDraftStream } = await import("./draft-stream.js");
+    const noop = createMattermostNoopDraftStream();
+
+    noop.update("Hello");
+    await noop.flush();
+    noop.update("World");
+    await noop.flush();
+    await noop.stop();
+
+    expect(noop.postId()).toBeUndefined();
+  });
+});

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -31,6 +31,23 @@ export function normalizeMattermostDraftText(text: string, maxChars: number): st
   return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
+/**
+ * Creates a no-op draft stream that satisfies the MattermostDraftStream interface
+ * but never creates or updates any posts. Used when draftPreview is disabled.
+ */
+export function createMattermostNoopDraftStream(): MattermostDraftStream {
+  return {
+    update: () => {},
+    flush: async () => {},
+    postId: () => undefined,
+    clear: async () => {},
+    discardPending: async () => {},
+    seal: async () => {},
+    stop: async () => {},
+    forceNewMessage: () => {},
+  };
+}
+
 export function buildMattermostToolStatusText(params: { name?: string; phase?: string }): string {
   const tool = params.name?.trim() ? ` \`${params.name.trim()}\`` : " tool";
   return `Running${tool}…`;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -17,7 +17,7 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import { buildMattermostToolStatusText, createMattermostDraftStream, createMattermostNoopDraftStream } from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1632,14 +1632,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             },
           },
         });
-        const draftStream = createMattermostDraftStream({
-          client,
-          channelId,
-          rootId: effectiveReplyToId,
-          throttleMs: 1200,
-          log: logVerboseMessage,
-          warn: logVerboseMessage,
-        });
+        const draftPreviewEnabled = account.config.streaming?.draftPreview !== false;
+        const draftStream = draftPreviewEnabled
+          ? createMattermostDraftStream({
+              client,
+              channelId,
+              rootId: effectiveReplyToId,
+              throttleMs: 1200,
+              log: logVerboseMessage,
+              warn: logVerboseMessage,
+            })
+          : createMattermostNoopDraftStream();
         let lastPartialText = "";
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,


### PR DESCRIPTION
## Summary

Add a configurable `streaming.draftPreview` boolean to the Mattermost channel schema. When set to `false`, the draft-preview streaming behavior (POST placeholder + PUT updates in place) is completely skipped — only a single final POST is sent.

Defaults to `true` for backward compatibility.

### Example config

```json5
{
  channels: {
    mattermost: {
      streaming: {
        draftPreview: false
      }
    }
  }
}
```

Fixes #73211

## Changes

- `extensions/mattermost/src/config-schema-core.ts` — add `streaming.draftPreview` schema field
- `extensions/mattermost/src/mattermost/draft-stream.ts` — add `createMattermostNoopDraftStream()`
- `extensions/mattermost/src/mattermost/monitor.ts` — conditionally use noop stream when disabled
- `extensions/mattermost/src/mattermost/draft-stream.test.ts` — test noop stream