### PR TITLE
fix(cli): reject empty or whitespace-only --prompt in model run

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -437,6 +437,29 @@ describe("capability cli", () => {
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
   });
 
+  it("rejects empty or whitespace-only --prompt before dispatching to provider", async () => {
+    for (const argv of [
+      ["capability", "model", "run", "--prompt", "", "--json"],
+      ["capability", "model", "run", "--prompt", "   ", "--json"],
+      ["capability", "model", "run", "--prompt", "\n", "--json"],
+    ]) {
+      await expect(
+        runRegisteredCli({
+          register: registerCapabilityCli as (program: Command) => void,
+          argv,
+        }),
+      ).rejects.toThrow("exit 1");
+
+      expect(mocks.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("--prompt cannot be empty or whitespace-only"),
+      );
+      // Provider seams must never be called for empty prompts
+      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+    }
+  });
+
   it("runs gateway model probes without chat-agent prompt policy or tools", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1487,6 +1487,10 @@ export function registerCapabilityCli(program: Command) {
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const promptText = String(opts.prompt);
+        if (promptText.trim().length === 0) {
+          throw new Error("--prompt cannot be empty or whitespace-only");
+        }
         const transport = resolveTransport({
           local: Boolean(opts.local),
           gateway: Boolean(opts.gateway),
@@ -1494,7 +1498,7 @@ export function registerCapabilityCli(program: Command) {
           defaultTransport: "local",
         });
         const result = await runModelRun({
-          prompt: String(opts.prompt),
+          prompt: promptText,
           model: opts.model as string | undefined,
           transport,
         });


### PR DESCRIPTION
## Summary

`openclaw infer model run --local --prompt ""` sends empty/whitespace input to the provider with no client-side validation. This causes:

- **Claude**: misleading "No text output returned" error after a real provider round-trip
- **DeepSeek (and similar providers)**: silently billed ~3.5 KB unrelated response

Adding a `trim().length === 0` guard before dispatching to the provider, so empty strings, whitespace-only, and newline-only prompts fail fast with a clear error message and **zero provider calls**.

## Root Cause

`--prompt` uses Commander's `requiredOption()` which only checks argument *presence*, not *content*. The `--gateway` transport path already rejects empty input via gateway-side JSON-schema validation (`must NOT have fewer than 1 characters`); the `--local` path had no equivalent guard.

## Changes

| File | Change |
|------|--------|
| `src/cli/capability-cli.ts` | +4 lines: `prompt.trim()` guard in `model run` action |
| `src/cli/capability-cli.test.ts` | +23 lines: regression test covering `""`, `"   "`, `"\n"` |

## Testing

- [x] 39/39 tests pass in `src/cli/capability-cli.test.ts`
- [x] Typecheck clean (`tsgo:core` + `tsgo:core:test`)
- [x] Formatting clean (`oxfmt`)
- [x] Provider seams verified **never called** for empty prompts

## Expected Behavior After Fix

```
$ openclaw capability model run --prompt ""
error: --prompt cannot be empty or whitespace-only
(exit 1, no provider call)
```

Closes #73185
