### PR TITLE
docs: mark 2026.4.26 as delayed in changelog (#73089)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ Docs: https://docs.openclaw.ai
 - CLI/models: move OpenAI and OpenCode Go forward-compat list rows into refreshable manifest catalogs and stop broad `models list --all` from loading runtime catalog supplement hooks. Thanks @shakkernerd.
 - CLI/models: keep broad unfiltered `models list --all` on raw registry rows instead of loading every provider runtime normalization hook, while preserving full normalization for provider-filtered and configured model paths. Thanks @shakkernerd.
 
-## 2026.4.26
+## 2026.4.26 (Delayed — not yet published to npm stable)
 
 ### Changes
 

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Maintenance update for the current OpenClaw development release.
 
-## 2026.4.26 - 2026-04-26
+## 2026.4.26 - 2026-04-26 (Delayed)
 
 Maintenance update for the current OpenClaw development release.
 


### PR DESCRIPTION
Fixes #73089.

The changelog listed 2026.4.26 as released, but the npm stable install target is missing. This PR updates the changelog headings to reflect the delayed status.

- Changed `## 2026.4.26` to `## 2026.4.26 (Delayed — not yet published to npm stable)` in `CHANGELOG.md`
- Changed `## 2026.4.26 - 2026-04-26` to `## 2026.4.26 - 2026-04-26 (Delayed)` in `apps/ios/CHANGELOG.md`