### PR TITLE
fix(gateway): allow internal agent channel hints

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -114,6 +114,15 @@ import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
 const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
+const INTERNAL_AGENT_CHANNEL_HINTS = new Set(["cron", "heartbeat", "webhook"]);
+
+function normalizeAgentChannelHint(raw?: string): string | undefined {
+  const normalized = normalizeMessageChannel(raw);
+  if (!normalized || normalized === "last") {
+    return normalized;
+  }
+  return INTERNAL_AGENT_CHANNEL_HINTS.has(normalized) ? undefined : normalized;
+}
 
 function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
@@ -532,7 +541,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    const isKnownGatewayChannel = (value: string): boolean =>
+      isGatewayMessageChannel(value) || INTERNAL_AGENT_CHANNEL_HINTS.has(value);
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())
@@ -551,6 +561,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    const requestChannelHint = normalizeAgentChannelHint(request.channel);
+    const requestReplyChannelHint = normalizeAgentChannelHint(request.replyChannel);
 
     const knownAgents = listAgentIds(cfg);
     const agentIdRaw = normalizeOptionalString(request.agentId) ?? "";
@@ -774,7 +786,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         resetType: resolveSessionResetType({ sessionKey: canonicalKey }),
         resetOverride: resolveChannelResetConfig({
           sessionCfg: cfg.session,
-          channel: entry?.lastChannel ?? entry?.channel ?? request.channel,
+          channel: entry?.lastChannel ?? entry?.channel ?? requestChannelHint,
         }),
       });
       const freshness = entry
@@ -837,7 +849,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       // and no `to`/`threadId`, which causes announce delivery to either target the
       // wrong channel (when the parent's lastTo drifts) or fail entirely.
       const requestDeliveryHint = normalizeDeliveryContext({
-        channel: request.channel?.trim(),
+        channel: requestChannelHint,
         to: request.to?.trim(),
         accountId: request.accountId?.trim(),
         // Pass threadId directly — normalizeDeliveryContext handles both
@@ -882,7 +894,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         spawnedBy: spawnedByValue,
         spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
         spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
+        channel: entry?.channel ?? requestChannelHint,
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,
@@ -959,12 +971,12 @@ export const agentHandlers: GatewayRequestHandlers = {
     const explicitTo =
       normalizeOptionalString(request.replyTo) ?? normalizeOptionalString(request.to);
     const explicitThreadId = normalizeOptionalString(request.threadId);
-    const turnSourceChannel = normalizeOptionalString(request.channel);
+    const turnSourceChannel = requestChannelHint;
     const turnSourceTo = normalizeOptionalString(request.to);
     const turnSourceAccountId = normalizeOptionalString(request.accountId);
     const deliveryPlan = resolveAgentDeliveryPlan({
       sessionEntry,
-      requestedChannel: request.replyChannel ?? request.channel,
+      requestedChannel: requestReplyChannelHint ?? requestChannelHint,
       explicitTo,
       explicitThreadId,
       accountId: request.replyAccountId ?? request.accountId,

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -341,6 +341,19 @@ describe("gateway server agent", () => {
     });
   });
 
+  test("agent accepts internal non-delivery channel hints", async () => {
+    for (const channel of ["heartbeat", "cron", "webhook"]) {
+      const res = await rpcReq(ws, "agent", {
+        message: "hi",
+        sessionKey: "main",
+        channel,
+        deliver: false,
+        idempotencyKey: `idem-agent-internal-${channel}`,
+      });
+      expect(res.ok).toBe(true);
+    }
+  });
+
   test("agent rejects unknown channel", async () => {
     const res = await rpcReq(ws, "agent", {
       message: "hi",


### PR DESCRIPTION
## Summary
- Accept internal non-delivery channel hints (`cron`, `heartbeat`, `webhook`) during `agent` request validation.
- Normalize those internal hints out of delivery/session routing so they do not behave like deliverable channels.
- Keep unknown external channel rejection unchanged.
- Add a gateway-server regression test for those internal hints.

Closes #73237

## Testing
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/agent.ts src/gateway/server.agent.gateway-server-agent-b.test.ts`
- `pnpm test src/gateway/server.agent.gateway-server-agent-b.test.ts -t 'agent accepts internal non-delivery channel hints'`
- `pnpm lint:core`

## AI-assisted disclosure
AI-assisted: yes. I understand the change; internal source channels are accepted as provenance but intentionally ignored for delivery routing.
