### PR TITLE
fix(android): disable app data backup

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -41,9 +41,7 @@
 
     <application
         android:name=".NodeApp"
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"

--- a/apps/android/app/src/main/res/xml/backup_rules.xml
+++ b/apps/android/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<full-backup-content>
-  <include domain="file" path="." />
-</full-backup-content>

--- a/apps/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/apps/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<data-extraction-rules>
-  <cloud-backup>
-    <include domain="file" path="." />
-  </cloud-backup>
-  <device-transfer>
-    <include domain="file" path="." />
-  </device-transfer>
-</data-extraction-rules>


### PR DESCRIPTION
## Summary
- disable Android OS backup for the node app
- remove include-all backup and data extraction rules so local app files are not cloud/device-transfer backed up

## Validation
- Blacksmith Testbox: `cd apps/android && ./gradlew --no-daemon :app:processPlayDebugMainManifest :app:mergePlayDebugResources :app:compilePlayDebugKotlin`
- CodeQL Android critical security: https://github.com/openclaw/openclaw/actions/runs/25034694023
- CodeQL analysis `1192811969`: `/codeql-critical-security/android`, `results_count: 5`