### PR TITLE
fix(gateway): accept heartbeat/cron/webhook channel hints in agent params (#73237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Channels/Telegram: keep Bot API network fallbacks sticky after failed attempts and retry timed-out startup control calls once on the fallback route, so `deleteWebhook` IPv6 stalls no longer trigger slow multi-account retry storms. Fixes #73255. Thanks @ttomiczek and @sktbrd.
+- Gateway/agents: accept heartbeat, cron, and webhook as internal channel hints for agent runs so `sessions_spawn` works from non-delivery parent sessions while unknown channel hints still fail closed. Fixes #73237. Thanks @KeWang0622.
 - Gateway/models: merge explicit `models.providers.*.models` rows into the Gateway model catalog with normalized provider/model dedupe, and use normalized image-capability lookup so custom vision models keep native image attachments even when Pi discovery omits them or model ID casing differs. Fixes #64213 and #65165. Thanks @billonese and @202233a.
 - Gateway/reload: publish canonical post-write source config to in-process reloaders so simple config saves no longer create phantom plugin diffs or trigger unnecessary Gateway restarts. (#73267) Thanks @szsip239.
 - Gateway/Docker: keep config-triggered restarts in-process inside containers instead of spawning a detached child and exiting PID 1 cleanly, so Docker Swarm and other on-failure supervisors do not leave the service stuck at 0/1 replicas. Fixes #73178. Thanks @du-nguyen-IT007.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -966,35 +966,36 @@ describe("gateway agent handler", () => {
     );
   });
 
-  it.each(["heartbeat", "cron", "webhook"] as const)(
-    "accepts internal non-delivery channel hint %s",
-    async (channel) => {
-      primeMainAgentRun();
-      mocks.agentCommand.mockClear();
-      const respond = vi.fn();
+  it.each(
+    (["channel", "replyChannel"] as const).flatMap((field) =>
+      (["heartbeat", "cron", "webhook"] as const).map((channel) => [field, channel] as const),
+    ),
+  )("accepts internal non-delivery %s hint %s", async (field, channel) => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    const respond = vi.fn();
 
-      await invokeAgent(
-        {
-          message: "spawn from internal source",
-          agentId: "main",
-          sessionKey: "agent:main:main",
-          channel,
-          idempotencyKey: `internal-channel-${channel}`,
-        } as AgentParams,
-        { reqId: `internal-channel-${channel}-1`, respond },
-      );
+    await invokeAgent(
+      {
+        message: "spawn from internal source",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        [field]: channel,
+        idempotencyKey: `internal-channel-${field}-${channel}`,
+      } as AgentParams,
+      { reqId: `internal-channel-${field}-${channel}-1`, respond },
+    );
 
-      const rejection = respond.mock.calls.find(
-        (call: unknown[]) =>
-          call[0] === false &&
-          typeof (call[2] as { message?: string } | undefined)?.message === "string" &&
-          (call[2] as { message: string }).message.includes("unknown channel"),
-      );
-      expect(rejection).toBeUndefined();
-    },
-  );
+    const rejection = respond.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] === false &&
+        typeof (call[2] as { message?: string } | undefined)?.message === "string" &&
+        (call[2] as { message: string }).message.includes("unknown channel"),
+    );
+    expect(rejection).toBeUndefined();
+  });
 
-  it("rejects unknown channel hints", async () => {
+  it.each(["channel", "replyChannel"] as const)("rejects unknown %s hints", async (field) => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();
     const respond = vi.fn();
@@ -1004,10 +1005,10 @@ describe("gateway agent handler", () => {
         message: "bogus channel",
         agentId: "main",
         sessionKey: "agent:main:main",
-        channel: "not-a-real-channel",
-        idempotencyKey: "unknown-channel",
+        [field]: "not-a-real-channel",
+        idempotencyKey: `unknown-${field}`,
       } as AgentParams,
-      { reqId: "unknown-channel-1", respond },
+      { reqId: `unknown-${field}-1`, respond },
     );
 
     expect(respond).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -966,6 +966,59 @@ describe("gateway agent handler", () => {
     );
   });
 
+  it.each(["heartbeat", "cron", "webhook"] as const)(
+    "accepts internal non-delivery channel hint %s",
+    async (channel) => {
+      primeMainAgentRun();
+      mocks.agentCommand.mockClear();
+      const respond = vi.fn();
+
+      await invokeAgent(
+        {
+          message: "spawn from internal source",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          channel,
+          idempotencyKey: `internal-channel-${channel}`,
+        } as AgentParams,
+        { reqId: `internal-channel-${channel}-1`, respond },
+      );
+
+      const rejection = respond.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === false &&
+          typeof (call[2] as { message?: string } | undefined)?.message === "string" &&
+          (call[2] as { message: string }).message.includes("unknown channel"),
+      );
+      expect(rejection).toBeUndefined();
+    },
+  );
+
+  it("rejects unknown channel hints", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    const respond = vi.fn();
+
+    await invokeAgent(
+      {
+        message: "bogus channel",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        channel: "not-a-real-channel",
+        idempotencyKey: "unknown-channel",
+      } as AgentParams,
+      { reqId: "unknown-channel-1", respond },
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("unknown channel: not-a-real-channel"),
+      }),
+    );
+  });
+
   it("accepts music generation internal events", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -75,6 +75,7 @@ import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
   isGatewayMessageChannel,
+  isInternalNonDeliveryChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
@@ -540,7 +541,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const isKnownGatewayChannel = (value: string): boolean => isGatewayMessageChannel(value);
+    // Accept internal non-delivery sources (heartbeat, cron, webhook) as valid
+    // channel hints so subagent spawns from those parent runs are not rejected.
+    const isKnownGatewayChannel = (value: string): boolean =>
+      isGatewayMessageChannel(value) || isInternalNonDeliveryChannel(value);
     const channelHints = [request.channel, request.replyChannel]
       .filter((value): value is string => typeof value === "string")
       .map((value) => value.trim())

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -15,7 +15,6 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
   { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
-  { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
 ];
 
 export const expectedAugmentedOpenaiCodexCatalogEntriesWithGpt55 = [

--- a/src/plugins/provider-runtime.test-support.ts
+++ b/src/plugins/provider-runtime.test-support.ts
@@ -15,6 +15,7 @@ export const expectedAugmentedOpenaiCodexCatalogEntries = [
   { provider: "openai", id: "gpt-5.4-nano", name: "gpt-5.4-nano" },
   { provider: "openai-codex", id: "gpt-5.4", name: "gpt-5.4" },
   { provider: "openai-codex", id: "gpt-5.4-pro", name: "gpt-5.4-pro" },
+  { provider: "openai-codex", id: "gpt-5.4-mini", name: "gpt-5.4-mini" },
 ];
 
 export const expectedAugmentedOpenaiCodexCatalogEntriesWithGpt55 = [

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -1,2 +1,15 @@
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
 export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
+
+// Internal, non-delivery sources that may surface as a `channel` hint when an
+// agent run is triggered by something other than a chat message — heartbeat
+// ticks, cron jobs, or webhook receivers. They are not deliverable on their
+// own, but they should still pass agent-param channel validation so internal
+// callers (e.g. sessions_spawn from a heartbeat-driven parent run) are not
+// rejected as "unknown channel".
+export const INTERNAL_NON_DELIVERY_CHANNELS = ["heartbeat", "cron", "webhook"] as const;
+export type InternalNonDeliveryChannel = (typeof INTERNAL_NON_DELIVERY_CHANNELS)[number];
+
+export function isInternalNonDeliveryChannel(value: string): value is InternalNonDeliveryChannel {
+  return (INTERNAL_NON_DELIVERY_CHANNELS as readonly string[]).includes(value);
+}

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -3,6 +3,8 @@ import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
+  INTERNAL_NON_DELIVERY_CHANNELS,
+  isInternalNonDeliveryChannel,
   isMarkdownCapableMessageChannel,
   resolveGatewayMessageChannel,
 } from "./message-channel.js";
@@ -56,6 +58,16 @@ describe("message-channel", () => {
       ]),
     );
     expect(resolveGatewayMessageChannel("workspace-chat")).toBe("demo-alias-channel");
+  });
+
+  it("recognises internal non-delivery channel sources", () => {
+    for (const channel of INTERNAL_NON_DELIVERY_CHANNELS) {
+      expect(isInternalNonDeliveryChannel(channel)).toBe(true);
+    }
+    expect(isInternalNonDeliveryChannel("telegram")).toBe(false);
+    expect(isInternalNonDeliveryChannel("webchat")).toBe(false);
+    expect(isInternalNonDeliveryChannel("")).toBe(false);
+    expect(isInternalNonDeliveryChannel("HEARTBEAT")).toBe(false);
   });
 
   it("reads markdown capability from channel metadata", () => {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -24,7 +24,10 @@ export {
 } from "./message-channel-normalize.js";
 export {
   INTERNAL_MESSAGE_CHANNEL,
+  INTERNAL_NON_DELIVERY_CHANNELS,
+  isInternalNonDeliveryChannel,
   type InternalMessageChannel,
+  type InternalNonDeliveryChannel,
 } from "./message-channel-constants.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,


### PR DESCRIPTION
## Summary

Fixes #73237. `agentHandlers.agent` rejected `request.channel` / `request.replyChannel` values like `heartbeat`, `cron`, and `webhook` with `invalid agent params: unknown channel: ...`, blocking `sessions_spawn` calls from agent runs triggered by non-delivery sources. The validation only accepted `isGatewayMessageChannel(value)` (deliverable channels + plugins + `webchat`).

This PR adds an explicit `INTERNAL_NON_DELIVERY_CHANNELS` set (`heartbeat`, `cron`, `webhook`) and a typed `isInternalNonDeliveryChannel` predicate, then composes it into the channel-hint check in `src/gateway/server-methods/agent.ts` so internal-source parent runs can spawn subagents without hitting validation.

## Changes

| File | What |
|------|------|
| `src/utils/message-channel-constants.ts` | new: `INTERNAL_NON_DELIVERY_CHANNELS`, `InternalNonDeliveryChannel`, `isInternalNonDeliveryChannel` |
| `src/utils/message-channel.ts` | re-export the new symbols from the constants module |
| `src/utils/message-channel.test.ts` | unit test for `isInternalNonDeliveryChannel` (members accepted, others rejected, no implicit case-folding) |
| `src/gateway/server-methods/agent.ts` | broaden `isKnownGatewayChannel` to also accept `isInternalNonDeliveryChannel` |
| `src/gateway/server-methods/agent.test.ts` | parameterised acceptance test for `heartbeat`/`cron`/`webhook` + a regression test that genuine unknown channels still 400 |

```
 5 files changed, 86 insertions(+), 1 deletion(-)
```

## Tests

- `pnpm test src/utils/message-channel.test.ts` — 4 pass (1 new)
- `pnpm test src/gateway/server-methods/agent.test.ts` — 64 pass (4 new)
- `pnpm exec oxfmt --check` — clean
- `pnpm exec oxlint` — 0 warnings, 0 errors
- `pnpm tsgo` — clean

## Context

Closes #73237.

Subagent spawning is intentionally channel-agnostic — the parent channel identity isn't relevant to child session creation. The reporter offered two fix options; this implements the second (expand the accepted-channel set with an explicit, named constant) because it keeps the existing validation a single boolean predicate and makes the new accepted values searchable / testable as a typed union, rather than scattering "skip validation for these strings" branches.

`isGatewayMessageChannel` is intentionally unchanged: the new constants are a separate, narrower category (non-delivery sources), not deliverable channels — anything that calls `isGatewayMessageChannel` to decide where to *send* output keeps the same behavior.