### PR TITLE
test(gateway): keep session event suite minimal

### DIFF
--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -24,11 +24,8 @@ let harness: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
 let subscribedOperatorWs:
   | Awaited<ReturnType<Awaited<ReturnType<typeof createGatewaySuiteHarness>>["openWs"]>>
   | undefined;
-let previousMinimalGateway: string | undefined;
 
 beforeAll(async () => {
-  previousMinimalGateway = process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
-  delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
   harness = await createGatewaySuiteHarness();
   subscribedOperatorWs = await harness.openWs();
   await connectOk(subscribedOperatorWs, {
@@ -42,11 +39,6 @@ afterAll(async () => {
   subscribedOperatorWs?.close();
   if (harness) {
     await harness.close();
-  }
-  if (previousMinimalGateway === undefined) {
-    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
-  } else {
-    process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = previousMinimalGateway;
   }
 });
 


### PR DESCRIPTION
## Summary
- let session-message websocket tests use the default minimal gateway harness
- avoid full gateway startup for subscription/event routing coverage

## Tests
- pnpm exec oxfmt --check --threads=1 src/gateway/session-message-events.test.ts
- Testbox tbx_01kq98y29y9kwzkpft0sr3qg2x: pnpm test:serial src/gateway/session-message-events.test.ts --reporter=verbose
- Testbox tbx_01kq98y29y9kwzkpft0sr3qg2x: pnpm check:changed

## Perf
- targeted file on Testbox: 6.78s / 1,157,516 KB before
- targeted file on Testbox: 2.76s / 919,316 KB after