### PR TITLE
fix(android): use absolute logcat path

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt
@@ -6,6 +6,8 @@ import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.serialization.json.JsonPrimitive
 
+private const val LOGCAT_PATH = "/system/bin/logcat"
+
 class DebugHandler(
   private val appContext: Context,
   private val identityStore: DeviceIdentityStore,
@@ -80,7 +82,7 @@ class DebugHandler(
     val logResult = try {
       val tmpFile = java.io.File(appContext.cacheDir, "debug_logs.txt")
       if (tmpFile.exists()) tmpFile.delete()
-      val pb = ProcessBuilder("logcat", "-d", "-t", "200", "--pid=$pid")
+      val pb = ProcessBuilder(LOGCAT_PATH, "-d", "-t", "200", "--pid=$pid")
       pb.redirectOutput(tmpFile)
       pb.redirectErrorStream(true)
       val proc = pb.start()


### PR DESCRIPTION
## What
- Fixes Android CodeQL alert #80 (`java/relative-path-command`) in `DebugHandler.kt`.
- Uses the absolute Android system logcat executable path instead of relying on `PATH` lookup.

## Why
Debug log collection is DEBUG-gated, but process launch should still avoid relative executable lookup. CodeQL correctly treats `ProcessBuilder("logcat", ...)` as a path-hijack shape.

## Validation
- Blacksmith Testbox: `cd apps/android && ./gradlew --no-daemon :app:compilePlayDebugKotlin`
- `git diff --check origin/main..HEAD`