### PR TITLE
fix(logging): redact secrets at subsystem console sink (#73284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/inbound files: recover CJK filenames from plain `Content-Disposition: filename=` download headers when Feishu exposes UTF-8 bytes through Latin-1 header decoding, while leaving valid Latin-1 and JSON-derived names unchanged. (#48578, #50435, #59431) Thanks @alex-xuweilong, @lishuaigit, and @DoChaoing.
 - Channels/Telegram: normalize accidental full `/bot<TOKEN>` Telegram `apiRoot` values at runtime and teach `openclaw doctor --fix` to remove the suffix, so startup control calls no longer 404 when direct Bot API curl commands work. Fixes #55387. Thanks @brendanmatthewjones-cmyk, @techfindubai-ux, and @Sivlerback-Chris.
 - Zalo Personal: persist refreshed `zca-js` session cookies after QR login, session restore, and successful API calls so gateway restarts restore the freshest local session. (#73277) Thanks @darkamenosa.
+- Logging/security: redact sensitive tokens (sk-\* keys, Bearer/Authorization values, etc.) at the subsystem console sink so `createSubsystemLogger().info/warn/error` output that bypasses the patched console-capture handler still applies the same redaction the file transport already does. Fixes #73284; refs #67953 and #64046. Thanks @edwin-rivera-dev.
 
 ## 2026.4.27
 

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -9,10 +9,10 @@ import { createSubsystemLogger } from "./subsystem.js";
 
 const logPathTracker = createSuiteLogPathTracker("openclaw-subsystem-log-");
 
-function installConsoleMethodSpy(method: "warn" | "error") {
+function installConsoleMethodSpy(method: "log" | "warn" | "error") {
   const spy = vi.fn();
   loggingState.rawConsole = {
-    log: vi.fn(),
+    log: method === "log" ? spy : vi.fn(),
     info: vi.fn(),
     warn: method === "warn" ? spy : vi.fn(),
     error: method === "error" ? spy : vi.fn(),
@@ -29,6 +29,7 @@ afterEach(() => {
   setLoggerOverride(null);
   loggingState.rawConsole = null;
   resetLogger();
+  vi.unstubAllEnvs();
   vi.useRealTimers();
 });
 
@@ -231,6 +232,36 @@ describe("createSubsystemLogger().isEnabled", () => {
     const written = String(error.mock.calls[0]?.[0] ?? "");
     expect(written).not.toContain("abcdefghijklmnopqrstuvwxyz");
     expect(written).toContain("Bearer ");
+  });
+
+  it("redacts before colorizing subsystem console messages so ANSI reset codes survive", () => {
+    vi.stubEnv("FORCE_COLOR", "1");
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const logSpy = installConsoleMethodSpy("log");
+    const log = createSubsystemLogger("gateway/auth");
+    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+
+    log.info(`provider API_KEY=${secret}`);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const written = String(logSpy.mock.calls[0]?.[0] ?? "");
+    expect(written).not.toContain(secret);
+    expect(written).toContain("API_KEY=***");
+    expect(written.endsWith("\u001B[39m")).toBe(true);
+  });
+
+  it("redacts sensitive tokens from raw subsystem console output", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const logSpy = installConsoleMethodSpy("log");
+    const log = createSubsystemLogger("gateway/auth");
+    const secret = "sk-rawtokenabcdefghijklmnopqrstuvwxyz123456";
+
+    log.raw(`raw token ${secret}`);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const written = String(logSpy.mock.calls[0]?.[0] ?? "");
+    expect(written).not.toContain(secret);
+    expect(written).toContain("sk-raw…3456");
   });
 
   it("keeps long-lived subsystem loggers on the current-day rolling file", () => {

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -205,6 +205,34 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
+  it("redacts sensitive tokens at the console sink so subsystem writes do not leak secrets (#73284)", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warn = installConsoleMethodSpy("warn");
+    const log = createSubsystemLogger("gateway");
+    const secret = "sk-supersecretvaluefortest12345";
+
+    log.warn(`token=${secret}`);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const written = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(written).not.toContain(secret);
+    expect(written).toMatch(/sk-sup…2345|\*\*\*/);
+  });
+
+  it("redacts Bearer tokens on subsystem error console writes", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "error" });
+    const error = installConsoleMethodSpy("error");
+    const log = createSubsystemLogger("gateway").child("auth");
+    const bearer = "Bearer abcdefghijklmnopqrstuvwxyz";
+
+    log.error(`Authorization failed: ${bearer}`);
+
+    expect(error).toHaveBeenCalledTimes(1);
+    const written = String(error.mock.calls[0]?.[0] ?? "");
+    expect(written).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(written).toContain("Bearer ");
+  });
+
   it("keeps long-lived subsystem loggers on the current-day rolling file", () => {
     const logDir = path.dirname(logPathTracker.nextPath());
     const firstDay = path.join(logDir, "openclaw-2026-01-01.log");

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -216,13 +216,15 @@ function formatConsoleLine(opts: {
   const displaySubsystem =
     opts.style === "json" ? opts.subsystem : formatSubsystemForConsole(opts.subsystem);
   if (opts.style === "json") {
-    return JSON.stringify({
-      time: formatConsoleTimestamp("json"),
-      level: opts.level,
-      subsystem: displaySubsystem,
-      message: opts.message,
-      ...opts.meta,
-    });
+    return redactSensitiveText(
+      JSON.stringify({
+        time: formatConsoleTimestamp("json"),
+        level: opts.level,
+        subsystem: displaySubsystem,
+        message: opts.message,
+        ...opts.meta,
+      }),
+    );
   }
   const color = getColorForConsole();
   const prefix = `[${displaySubsystem}]`;
@@ -235,7 +237,8 @@ function formatConsoleLine(opts: {
         : opts.level === "debug" || opts.level === "trace"
           ? color.gray
           : color.cyan;
-  const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
+  const redactedMessage = redactSensitiveText(opts.message);
+  const displayMessage = stripRedundantSubsystemPrefixForConsole(redactedMessage, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
       return color.gray(formatConsoleTimestamp("pretty"));
@@ -250,18 +253,17 @@ function formatConsoleLine(opts: {
   return `${head} ${levelColor(displayMessage)}`;
 }
 
-function writeConsoleLine(level: LogLevel, line: string) {
+function writeConsoleLine(level: LogLevel, line: string, opts: { redacted?: boolean } = {}) {
   clearActiveProgressLine();
   const sanitized =
     process.platform === "win32" && process.env.GITHUB_ACTIONS === "true"
       ? line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?").replace(/[\uD800-\uDFFF]/g, "?")
       : line;
   // Subsystem console output bypasses the patched console.* capture handler in
-  // ./console.ts to avoid recursion, so the sink-boundary redaction applied
-  // there does not run for these writes (#73284). Redact at this exit instead
-  // so secrets reaching subsystem loggers as message strings or formatted meta
-  // do not appear verbatim on the terminal.
-  const redacted = redactSensitiveText(sanitized);
+  // ./console.ts to avoid recursion. Normal formatted messages are redacted
+  // before colorization; keep this exit guard for raw writes and structured
+  // lines that reach the sink already serialized (#73284).
+  const redacted = opts.redacted ? sanitized : redactSensitiveText(sanitized);
   const sink = loggingState.rawConsole ?? console;
   if (loggingState.forceConsoleToStderr || level === "error" || level === "fatal") {
     (sink.error ?? console.error)(redacted);
@@ -378,6 +380,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
         style: consoleSettings.style,
         meta: fileMeta,
       }),
+      { redacted: true },
     );
   };
 

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -12,6 +12,7 @@ import {
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -255,13 +256,19 @@ function writeConsoleLine(level: LogLevel, line: string) {
     process.platform === "win32" && process.env.GITHUB_ACTIONS === "true"
       ? line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?").replace(/[\uD800-\uDFFF]/g, "?")
       : line;
+  // Subsystem console output bypasses the patched console.* capture handler in
+  // ./console.ts to avoid recursion, so the sink-boundary redaction applied
+  // there does not run for these writes (#73284). Redact at this exit instead
+  // so secrets reaching subsystem loggers as message strings or formatted meta
+  // do not appear verbatim on the terminal.
+  const redacted = redactSensitiveText(sanitized);
   const sink = loggingState.rawConsole ?? console;
   if (loggingState.forceConsoleToStderr || level === "error" || level === "fatal") {
-    (sink.error ?? console.error)(sanitized);
+    (sink.error ?? console.error)(redacted);
   } else if (level === "warn") {
-    (sink.warn ?? console.warn)(sanitized);
+    (sink.warn ?? console.warn)(redacted);
   } else {
-    (sink.log ?? console.log)(sanitized);
+    (sink.log ?? console.log)(redacted);
   }
 }
 


### PR DESCRIPTION
## What

`createSubsystemLogger()` writes console output via `writeConsoleLine()` in [src/logging/subsystem.ts](src/logging/subsystem.ts), which deliberately bypasses the patched `console.*` capture handler in [src/logging/console.ts](src/logging/console.ts) to avoid recursion and preserve subsystem formatting. That bypass also skips the sink-boundary `redactSensitiveText()` gate that protects every other console exit, so any secret reaching a subsystem logger as a message string or formatted meta — `sk-*` keys, `Bearer`/`Authorization` values, PEM blocks — appears verbatim on the terminal.

This is a sub-issue of the umbrella tracked in #64046 and a direct follow-up to #67953, which fixed the same leak for the file transport.

Closes #73284.

## Why this fix

Apply `redactSensitiveText()` at the `writeConsoleLine()` exit, immediately after the existing Windows surrogate sanitization and before dispatching to `loggingState.rawConsole`. This is the redact-at-sink-boundary pattern already used in:

- `console.ts:266` and `console.ts:277` (patched stdout/stderr capture)
- The file transport (#67953)

All subsystem console paths — `trace`/`debug`/`info`/`warn`/`error`/`fatal` and `.raw()` — share `writeConsoleLine()`, so this single change covers every level on every subsystem logger created by `createSubsystemLogger()` (and the children produced by `.child()`).

The fix is intentionally narrow:

- One imported helper (`redactSensitiveText` from `./redact.js`).
- One redaction call between sanitization and sink dispatch.
- A short comment explaining *why* the sink-boundary redaction has to live here, anchored to #73284 so it does not get refactored away.

Out-of-scope per the issue: raw JSONL sinks (`raw-stream`, `config-audit`, cron run logs, session transcript JSONL) are tracked separately under #64046 and are not touched here.

## Tests

Added two cases in [src/logging/subsystem.test.ts](src/logging/subsystem.test.ts) that reuse the existing `installConsoleMethodSpy()` helper:

- A subsystem `warn` containing an `sk-` token: the secret is not present in the captured console arg, and the masked form (`sk-sup…2345` or `***`) is.
- A subsystem `error` containing a `Bearer <token>`: the token body is not present in the captured console arg, while the literal `"Bearer "` prefix is preserved.

The existing `installConsoleMethodSpy()` already routes through `loggingState.rawConsole`, which is exactly the sink path the fix touches, so the assertions exercise the production code path end-to-end.

## Notes

- Single-area diff: `src/logging/subsystem.ts`, its test, and a one-line CHANGELOG entry under `## Unreleased` `### Fixes` with `Thanks @edwin-rivera-dev`.
- No Plugin SDK or other-extension files touched. Pure core logging fix.
- AI-assisted (Claude). Reviewed locally; please flag any oversight.

## Validation

I have not run the full `pnpm test`/`pnpm check:changed` lanes locally for environment reasons, so I am relying on CI for the canonical proof. I have:

- Mirrored the redact-at-sink-boundary pattern from `src/logging/console.ts` exactly, only adapting variable names to the subsystem path.
- Confirmed the new tests use the same `installConsoleMethodSpy()` + `setLoggerOverride()` patterns as the surrounding suite, so the test isolation contract is unchanged.
- Confirmed the CHANGELOG entry is single-line, anchored to a contributor (`@edwin-rivera-dev`), and references both the issue and the prior file-transport fix.

Happy to address any Greptile/Codex review feedback or extend coverage to additional patterns if reviewers want them.