### PR TITLE
feat: add issue triage hook

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -21400,6 +21400,56 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Gmail push integration settings used for Pub/Sub notifications and optional local callback serving. Keep this scoped to dedicated Gmail automation accounts where possible.",
           },
+          issueTriage: {
+            type: "object",
+            properties: {
+              enabled: {
+                type: "boolean",
+              },
+              githubTokenEnv: {
+                type: "string",
+                minLength: 1,
+              },
+              agentId: {
+                type: "string",
+                minLength: 1,
+              },
+              model: {
+                type: "string",
+                minLength: 1,
+              },
+              thinking: {
+                anyOf: [
+                  {
+                    type: "string",
+                    const: "off",
+                  },
+                  {
+                    type: "string",
+                    const: "minimal",
+                  },
+                  {
+                    type: "string",
+                    const: "low",
+                  },
+                  {
+                    type: "string",
+                    const: "medium",
+                  },
+                  {
+                    type: "string",
+                    const: "high",
+                  },
+                ],
+              },
+              timeoutSeconds: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
+            },
+            additionalProperties: false,
+          },
           internal: {
             type: "object",
             properties: {
@@ -28738,6 +28788,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "messages.tts.personas.*.providers.*.apiKey": {
       sensitive: true,
       tags: ["security", "auth", "media"],
+    },
+    "hooks.issueTriage.githubTokenEnv": {
+      sensitive: true,
+      tags: ["security", "auth"],
     },
     "mcp.servers.*.headers.*": {
       sensitive: true,

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -66,6 +66,21 @@ export type HooksGmailConfig = {
   thinking?: "off" | "minimal" | "low" | "medium" | "high";
 };
 
+export type HooksIssueTriageConfig = {
+  /** Enable the dedicated `/hooks/issue-triage` GitHub issue triage handler. */
+  enabled?: boolean;
+  /** Environment variable containing the GitHub PAT/installation token. Default: OPENCLAW_ISSUE_TRIAGE_GITHUB_TOKEN, then GITHUB_TOKEN. */
+  githubTokenEnv?: string;
+  /** Route classifier runs to a specific OpenClaw agent id. */
+  agentId?: string;
+  /** Optional classifier model override (provider/model or alias). */
+  model?: string;
+  /** Optional classifier thinking override. */
+  thinking?: "off" | "minimal" | "low" | "medium" | "high";
+  /** Classifier timeout in seconds. */
+  timeoutSeconds?: number;
+};
+
 export type HookConfig = {
   enabled?: boolean;
   env?: Record<string, string>;
@@ -119,6 +134,7 @@ export type HooksConfig = {
   transformsDir?: string;
   mappings?: HookMappingConfig[];
   gmail?: HooksGmailConfig;
+  issueTriage?: HooksIssueTriageConfig;
   /** Internal agent event hooks */
   internal?: InternalHooksConfig;
 };

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -150,3 +150,23 @@ export const HooksGmailSchema = z
   })
   .strict()
   .optional();
+
+export const HooksIssueTriageSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    githubTokenEnv: z.string().trim().min(1).optional().register(sensitive),
+    agentId: z.string().trim().min(1).optional(),
+    model: z.string().trim().min(1).optional(),
+    thinking: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+      ])
+      .optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -18,7 +18,12 @@ import {
   SecretInputSchema,
   SecretsConfigSchema,
 } from "./zod-schema.core.js";
-import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
+import {
+  HookMappingSchema,
+  HooksGmailSchema,
+  HooksIssueTriageSchema,
+  InternalHooksSchema,
+} from "./zod-schema.hooks.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
 import { ProxyConfigSchema } from "./zod-schema.proxy.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -660,6 +665,7 @@ export const OpenClawSchema = z
         transformsDir: z.string().optional(),
         mappings: z.array(HookMappingSchema).optional(),
         gmail: HooksGmailSchema,
+        issueTriage: HooksIssueTriageSchema,
         internal: InternalHooksSchema,
       })
       .strict()

--- a/src/gateway/issue-triage-service.ts
+++ b/src/gateway/issue-triage-service.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+import type { CliDeps } from "../cli/deps.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CronJob } from "../cron/types.js";
+import {
+  ISSUE_TRIAGE_COMMENT_MARKER,
+  type IssueTriageIssue,
+  type IssueTriageService,
+} from "./issue-triage.js";
+
+const GITHUB_API = "https://api.github.com";
+const DEFAULT_TRIAGE_TIMEOUT_SECONDS = 120;
+
+function splitRepo(repo: string): { owner: string; name: string } {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) {
+    throw new Error("invalid repo");
+  }
+  return { owner, name };
+}
+
+function resolveGithubToken(config: OpenClawConfig): string | undefined {
+  const envName = config.hooks?.issueTriage?.githubTokenEnv?.trim();
+  if (envName) {
+    return process.env[envName]?.trim() || undefined;
+  }
+  return (
+    process.env.OPENCLAW_ISSUE_TRIAGE_GITHUB_TOKEN?.trim() ||
+    process.env.GITHUB_TOKEN?.trim() ||
+    undefined
+  );
+}
+
+function normalizeGithubLabels(labels: unknown): string[] {
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+  return labels
+    .map((label) => {
+      if (typeof label === "string") {
+        return label.trim();
+      }
+      if (label && typeof label === "object") {
+        const name = (label as { name?: unknown }).name;
+        return typeof name === "string" ? name.trim() : "";
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+async function githubJson<T>(params: {
+  token: string;
+  path: string;
+  method?: string;
+  body?: unknown;
+}): Promise<T> {
+  const response = await fetch(`${GITHUB_API}${params.path}`, {
+    method: params.method ?? "GET",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${params.token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "OpenClaw-Issue-Triage",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: params.body === undefined ? undefined : JSON.stringify(params.body),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}`);
+  }
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+function buildClassifierPrompt(issue: IssueTriageIssue): string {
+  return `You are OpenClaw's GitHub issue triage classifier.
+
+Decide whether this issue should be delegated to an automatic code-changing PR workflow or declined.
+
+Return ONLY a JSON object with this exact shape:
+{"decision":"delegate"|"close","reason":"one-line reason","details":"2-4 sentences for maintainers"}
+
+Decision guidance:
+- delegate: actionable bug/feature/change request with enough reproduction, scope, or implementation clue for an agent to attempt a PR.
+- close: duplicate, support question, vague/insufficient info, won't-fix, policy/product decision, not code-changing, spam, or unsafe.
+- If uncertain or missing key information, choose close.
+
+Issue:
+repo: ${issue.repo}
+number: ${issue.number}
+title: ${issue.title}
+url: ${issue.html_url ?? ""}
+labels: ${issue.labels.join(", ") || "(none)"}
+state: ${issue.state ?? "unknown"}
+locked: ${issue.locked === true ? "true" : "false"}
+body_preview:
+${issue.body_preview ?? ""}`;
+}
+
+async function classifyWithOpenClawAgent(params: {
+  cfg: OpenClawConfig;
+  deps: CliDeps;
+  issue: IssueTriageIssue;
+}): Promise<string> {
+  const triageConfig = params.cfg.hooks?.issueTriage;
+  const jobId = randomUUID();
+  const now = Date.now();
+  const message = buildClassifierPrompt(params.issue);
+  const job: CronJob = {
+    id: jobId,
+    agentId: triageConfig?.agentId,
+    name: `Issue triage ${params.issue.repo}#${params.issue.number}`,
+    enabled: true,
+    createdAtMs: now,
+    updatedAtMs: now,
+    schedule: { kind: "at", at: new Date(now).toISOString() },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      message,
+      model: triageConfig?.model,
+      thinking: triageConfig?.thinking,
+      timeoutSeconds: triageConfig?.timeoutSeconds ?? DEFAULT_TRIAGE_TIMEOUT_SECONDS,
+      externalContentSource: "webhook",
+    },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: now },
+  };
+  const { runCronIsolatedAgentTurn } = await import("../cron/isolated-agent.js");
+  const result = await runCronIsolatedAgentTurn({
+    cfg: params.cfg,
+    deps: params.deps,
+    job,
+    message,
+    sessionKey: `hook:issue-triage:${params.issue.repo}#${params.issue.number}`,
+    lane: "hook:issue-triage",
+  });
+  if (result.status !== "ok") {
+    throw new Error(result.error ?? result.summary ?? "classifier failed");
+  }
+  return result.outputText ?? result.summary ?? "";
+}
+
+export function createIssueTriageService(params: {
+  cfg: OpenClawConfig;
+  deps: CliDeps;
+}): IssueTriageService | undefined {
+  if (params.cfg.hooks?.issueTriage?.enabled !== true) {
+    return undefined;
+  }
+  const token = resolveGithubToken(params.cfg);
+  if (!token) {
+    return undefined;
+  }
+
+  return {
+    async getIssue(repo, issueNumber) {
+      const { owner, name } = splitRepo(repo);
+      const issue = await githubJson<Record<string, unknown>>({
+        token,
+        path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${issueNumber}`,
+      });
+      return {
+        repo,
+        number: issueNumber,
+        title: typeof issue.title === "string" ? issue.title : "(untitled)",
+        html_url: typeof issue.html_url === "string" ? issue.html_url : undefined,
+        labels: normalizeGithubLabels(issue.labels),
+        body_preview: typeof issue.body === "string" ? issue.body.slice(0, 4_000) : undefined,
+        state: typeof issue.state === "string" ? issue.state.toLowerCase() : undefined,
+        locked: issue.locked === true,
+      };
+    },
+    async classifyIssue(issue) {
+      return await classifyWithOpenClawAgent({ cfg: params.cfg, deps: params.deps, issue });
+    },
+    async addLabels(repo, issueNumber, labels) {
+      const { owner, name } = splitRepo(repo);
+      await githubJson({
+        token,
+        method: "POST",
+        path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${issueNumber}/labels`,
+        body: { labels },
+      });
+    },
+    async createComment(repo, issueNumber, body) {
+      const { owner, name } = splitRepo(repo);
+      await githubJson({
+        token,
+        method: "POST",
+        path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${issueNumber}/comments`,
+        body: { body },
+      });
+    },
+    async hasExistingTriageComment(repo, issueNumber) {
+      const { owner, name } = splitRepo(repo);
+      const comments = await githubJson<Array<Record<string, unknown>>>({
+        token,
+        path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${issueNumber}/comments?per_page=100`,
+      });
+      return comments.some(
+        (comment) =>
+          typeof comment.body === "string" && comment.body.includes(ISSUE_TRIAGE_COMMENT_MARKER),
+      );
+    },
+  };
+}

--- a/src/gateway/issue-triage.test.ts
+++ b/src/gateway/issue-triage.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  ISSUE_TRIAGE_AUTO_FIX_LABEL,
+  ISSUE_TRIAGE_DECLINED_LABEL,
+  ISSUE_TRIAGE_COMMENT_MARKER,
+  parseIssueTriageText,
+  triageIssue,
+  type IssueTriageService,
+} from "./issue-triage.js";
+
+function clawhipText(payload: Record<string, unknown>) {
+  return `[clawhip:github.issue-opened] new issue\n\nPayload: ${JSON.stringify(payload, null, 2)}`;
+}
+
+function service(overrides: Partial<IssueTriageService> = {}): IssueTriageService {
+  return {
+    classifyIssue: vi.fn(async () => "delegate"),
+    addLabels: vi.fn(async () => {}),
+    createComment: vi.fn(async () => {}),
+    hasExistingTriageComment: vi.fn(async () => false),
+    ...overrides,
+  };
+}
+
+describe("issue triage helpers", () => {
+  test("parses clawhip Payload JSON", () => {
+    const parsed = parseIssueTriageText(
+      clawhipText({
+        repo: "openclaw/openclaw",
+        number: 123,
+        title: "Bug",
+        html_url: "https://github.com/openclaw/openclaw/issues/123",
+        labels: [{ name: "bug" }, "needs-triage"],
+        body_preview: "broken",
+      }),
+    );
+
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.issue).toMatchObject({
+        repo: "openclaw/openclaw",
+        number: 123,
+        title: "Bug",
+        labels: ["bug", "needs-triage"],
+      });
+    }
+  });
+
+  test.each([
+    { labels: [ISSUE_TRIAGE_AUTO_FIX_LABEL], reason: "already-triaged" },
+    { labels: [ISSUE_TRIAGE_DECLINED_LABEL], reason: "already-triaged" },
+    { labels: [], state: "closed", reason: "closed" },
+    { labels: [], locked: true, reason: "locked" },
+  ])("noops for idempotent issue states %#", async (input) => {
+    const svc = service();
+    const result = await triageIssue(
+      {
+        repo: "openclaw/openclaw",
+        number: 1,
+        title: "Bug",
+        labels: input.labels,
+        state: input.state,
+        locked: input.locked,
+      },
+      svc,
+    );
+
+    expect(result).toEqual({ ok: true, status: "noop", reason: input.reason });
+    expect(svc.classifyIssue).not.toHaveBeenCalled();
+    expect(svc.addLabels).not.toHaveBeenCalled();
+  });
+
+  test("delegate classification adds only auto-fix label", async () => {
+    const svc = service({ classifyIssue: vi.fn(async () => ({ decision: "delegate" })) });
+    const result = await triageIssue(
+      { repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] },
+      svc,
+    );
+
+    expect(result).toEqual({ ok: true, status: "labeled", decision: "delegate" });
+    expect(svc.addLabels).toHaveBeenCalledWith("openclaw/openclaw", 1, [
+      ISSUE_TRIAGE_AUTO_FIX_LABEL,
+    ]);
+    expect(svc.createComment).not.toHaveBeenCalled();
+  });
+
+  test("close classification comments before adding declined label", async () => {
+    const calls: string[] = [];
+    const svc = service({
+      classifyIssue: vi.fn(async () => "close"),
+      createComment: vi.fn(async (_repo, _number, body) => {
+        expect(body).toContain(ISSUE_TRIAGE_COMMENT_MARKER);
+        calls.push("comment");
+      }),
+      addLabels: vi.fn(async () => {
+        calls.push("label");
+      }),
+    });
+
+    const result = await triageIssue(
+      { repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] },
+      svc,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "labeled",
+      decision: "close",
+      commentCreated: true,
+    });
+    expect(calls).toEqual(["comment", "label"]);
+    expect(svc.addLabels).toHaveBeenCalledWith("openclaw/openclaw", 1, [
+      ISSUE_TRIAGE_DECLINED_LABEL,
+    ]);
+  });
+
+  test("does not duplicate existing close comment", async () => {
+    const svc = service({
+      classifyIssue: vi.fn(async () => "close"),
+      hasExistingTriageComment: vi.fn(async () => true),
+    });
+    const result = await triageIssue(
+      { repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] },
+      svc,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "labeled",
+      decision: "close",
+      commentCreated: false,
+    });
+    expect(svc.createComment).not.toHaveBeenCalled();
+    expect(svc.addLabels).toHaveBeenCalledWith("openclaw/openclaw", 1, [
+      ISSUE_TRIAGE_DECLINED_LABEL,
+    ]);
+  });
+
+  test("classifier failures do not label", async () => {
+    const svc = service({
+      classifyIssue: vi.fn(async () => {
+        throw new Error("llm down");
+      }),
+    });
+    const result = await triageIssue(
+      { repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] },
+      svc,
+    );
+
+    expect(result).toEqual({ ok: false, httpStatus: 503, error: "issue triage classifier failed" });
+    expect(svc.addLabels).not.toHaveBeenCalled();
+  });
+
+  test("unknown classifier result and GitHub failures map to 502 without unsafe follow-up", async () => {
+    const unknownSvc = service({ classifyIssue: vi.fn(async () => "maybe") });
+    await expect(
+      triageIssue({ repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] }, unknownSvc),
+    ).resolves.toEqual({
+      ok: false,
+      httpStatus: 502,
+      error: "issue triage classifier returned an unknown decision",
+    });
+    expect(unknownSvc.addLabels).not.toHaveBeenCalled();
+
+    const commentFailsSvc = service({
+      classifyIssue: vi.fn(async () => "close"),
+      createComment: vi.fn(async () => {
+        throw new Error("comment failed");
+      }),
+    });
+    await expect(
+      triageIssue(
+        { repo: "openclaw/openclaw", number: 1, title: "Bug", labels: [] },
+        commentFailsSvc,
+      ),
+    ).resolves.toEqual({ ok: false, httpStatus: 502, error: "GitHub comment API failed" });
+    expect(commentFailsSvc.addLabels).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/issue-triage.ts
+++ b/src/gateway/issue-triage.ts
@@ -1,0 +1,291 @@
+export const ISSUE_TRIAGE_AUTO_FIX_LABEL = "iyen:auto-fix";
+export const ISSUE_TRIAGE_DECLINED_LABEL = "iyen:declined";
+export const ISSUE_TRIAGE_COMMENT_MARKER = "<!-- openclaw:issue-triage:declined -->";
+
+export type IssueTriageDecision = "delegate" | "close";
+
+export type IssueTriageClassification = {
+  decision: IssueTriageDecision;
+  reason?: string;
+  details?: string;
+  commentBody?: string;
+};
+
+export type IssueTriageIssue = {
+  repo: string;
+  number: number;
+  title: string;
+  html_url?: string;
+  labels: string[];
+  body_preview?: string;
+  state?: string;
+  locked?: boolean;
+};
+
+export type IssueTriageService = {
+  getIssue?: (repo: string, issueNumber: number) => Promise<IssueTriageIssue>;
+  classifyIssue: (issue: IssueTriageIssue) => Promise<unknown>;
+  addLabels: (repo: string, issueNumber: number, labels: string[]) => Promise<void>;
+  createComment: (repo: string, issueNumber: number, body: string) => Promise<void>;
+  hasExistingTriageComment?: (repo: string, issueNumber: number) => Promise<boolean>;
+};
+
+export type IssueTriageResult =
+  | { ok: true; status: "noop"; reason: "already-triaged" | "closed" | "locked" }
+  | { ok: true; status: "labeled"; decision: "delegate" | "close"; commentCreated?: boolean }
+  | { ok: false; httpStatus: 400 | 502 | 503; error: string };
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeLabels(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const labels: string[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      const label = entry.trim();
+      if (label) {
+        labels.push(label);
+      }
+      continue;
+    }
+    if (
+      entry &&
+      typeof entry === "object" &&
+      typeof (entry as { name?: unknown }).name === "string"
+    ) {
+      const label = (entry as { name: string }).name.trim();
+      if (label) {
+        labels.push(label);
+      }
+    }
+  }
+  return labels;
+}
+
+export function extractIssueTriagePayloadJson(text: string): string | undefined {
+  const marker = "Payload:";
+  const markerIndex = text.lastIndexOf(marker);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+  const afterMarker = text.slice(markerIndex + marker.length).trim();
+  if (!afterMarker.startsWith("{")) {
+    return undefined;
+  }
+  return afterMarker;
+}
+
+export function parseIssueTriageText(
+  text: unknown,
+): { ok: true; issue: IssueTriageIssue } | { ok: false; error: string } {
+  const normalizedText = normalizeString(text);
+  if (!normalizedText) {
+    return { ok: false, error: "text required" };
+  }
+  const jsonText = extractIssueTriagePayloadJson(normalizedText);
+  if (!jsonText) {
+    return { ok: false, error: "Payload JSON required" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return { ok: false, error: "Payload JSON is invalid" };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "Payload JSON must be an object" };
+  }
+  const payload = parsed as Record<string, unknown>;
+  const repo = normalizeString(payload.repo);
+  if (!repo || !/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+    return { ok: false, error: "Payload repo must be owner/name" };
+  }
+  const number = payload.number;
+  if (!Number.isInteger(number) || (number as number) <= 0) {
+    return { ok: false, error: "Payload number must be a positive integer" };
+  }
+  const title = normalizeString(payload.title);
+  if (!title) {
+    return { ok: false, error: "Payload title required" };
+  }
+  return {
+    ok: true,
+    issue: {
+      repo,
+      number: number as number,
+      title,
+      html_url: normalizeString(payload.html_url),
+      labels: normalizeLabels(payload.labels),
+      body_preview: normalizeString(payload.body_preview),
+      state: normalizeString(payload.state)?.toLowerCase(),
+      locked: payload.locked === true,
+    },
+  };
+}
+
+export function resolveIssueTriageNoopReason(
+  issue: IssueTriageIssue,
+): "already-triaged" | "closed" | "locked" | undefined {
+  const labelSet = new Set(issue.labels.map((label) => label.toLowerCase()));
+  if (
+    labelSet.has(ISSUE_TRIAGE_AUTO_FIX_LABEL.toLowerCase()) ||
+    labelSet.has(ISSUE_TRIAGE_DECLINED_LABEL.toLowerCase())
+  ) {
+    return "already-triaged";
+  }
+  if (issue.state?.toLowerCase() === "closed") {
+    return "closed";
+  }
+  if (issue.locked === true) {
+    return "locked";
+  }
+  return undefined;
+}
+
+function tryParseJsonObject(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    const match = value.match(/\{[\s\S]*\}/);
+    if (!match) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export function normalizeIssueTriageClassification(
+  value: unknown,
+): IssueTriageClassification | undefined {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "delegate" || normalized === "close") {
+      return { decision: normalized };
+    }
+    const parsed = tryParseJsonObject(value.trim());
+    if (parsed !== undefined) {
+      return normalizeIssueTriageClassification(parsed);
+    }
+    return undefined;
+  }
+  if (value && typeof value === "object") {
+    const record = value as {
+      decision?: unknown;
+      reason?: unknown;
+      details?: unknown;
+      comment_body?: unknown;
+      commentBody?: unknown;
+    };
+    const decisionValue = normalizeIssueTriageClassification(record.decision)?.decision;
+    if (!decisionValue) {
+      return undefined;
+    }
+    return {
+      decision: decisionValue,
+      reason: normalizeString(record.reason),
+      details: normalizeString(record.details),
+      commentBody: normalizeString(record.commentBody) ?? normalizeString(record.comment_body),
+    };
+  }
+  return undefined;
+}
+
+export function normalizeIssueTriageDecision(value: unknown): IssueTriageDecision | undefined {
+  return normalizeIssueTriageClassification(value)?.decision;
+}
+
+export function buildIssueTriageDeclineComment(
+  issue: IssueTriageIssue,
+  classification?: Pick<IssueTriageClassification, "reason" | "details" | "commentBody">,
+): string {
+  const custom = normalizeString(classification?.commentBody);
+  if (custom && !custom.includes("iyensystem:context-report")) {
+    return custom.includes(ISSUE_TRIAGE_COMMENT_MARKER)
+      ? custom
+      : `${ISSUE_TRIAGE_COMMENT_MARKER}\n${custom}`;
+  }
+  const reason = classification?.reason ?? "Not suitable for an automatic fix PR";
+  const details =
+    classification?.details ??
+    `OpenClaw reviewed ${issue.html_url ?? `${issue.repo}#${issue.number}`} and will not delegate it to the auto-fix workflow.`;
+  return `${ISSUE_TRIAGE_COMMENT_MARKER}\n🤖 OpenClaw triage\n\nThis issue was reviewed automatically and won't be picked up for an\nauto-fix PR.\n\n**Reason**: ${reason}\n**Details**: ${details}\n\nIf you disagree, remove the \`${ISSUE_TRIAGE_DECLINED_LABEL}\` label and reopen — a human\nmaintainer can re-triage.\n\n<sub>agent: openclaw-triage</sub>`;
+}
+
+export async function triageIssue(
+  inputIssue: IssueTriageIssue,
+  service: IssueTriageService,
+): Promise<IssueTriageResult> {
+  let issue = inputIssue;
+  if (service.getIssue) {
+    try {
+      issue = await service.getIssue(inputIssue.repo, inputIssue.number);
+    } catch {
+      return { ok: false, httpStatus: 502, error: "GitHub issue API failed" };
+    }
+  }
+  const noopReason = resolveIssueTriageNoopReason(issue);
+  if (noopReason) {
+    return { ok: true, status: "noop", reason: noopReason };
+  }
+
+  let rawDecision: unknown;
+  try {
+    rawDecision = await service.classifyIssue(issue);
+  } catch {
+    return { ok: false, httpStatus: 503, error: "issue triage classifier failed" };
+  }
+  const classification = normalizeIssueTriageClassification(rawDecision);
+  if (!classification) {
+    return {
+      ok: false,
+      httpStatus: 502,
+      error: "issue triage classifier returned an unknown decision",
+    };
+  }
+  const decision = classification.decision;
+
+  if (decision === "delegate") {
+    try {
+      await service.addLabels(issue.repo, issue.number, [ISSUE_TRIAGE_AUTO_FIX_LABEL]);
+    } catch {
+      return { ok: false, httpStatus: 502, error: "GitHub label API failed" };
+    }
+    return { ok: true, status: "labeled", decision };
+  }
+
+  let commentCreated = false;
+  try {
+    const hasExisting =
+      (await service.hasExistingTriageComment?.(issue.repo, issue.number)) === true;
+    if (!hasExisting) {
+      await service.createComment(
+        issue.repo,
+        issue.number,
+        buildIssueTriageDeclineComment(issue, classification),
+      );
+      commentCreated = true;
+    }
+  } catch {
+    return { ok: false, httpStatus: 502, error: "GitHub comment API failed" };
+  }
+
+  try {
+    await service.addLabels(issue.repo, issue.number, [ISSUE_TRIAGE_DECLINED_LABEL]);
+  } catch {
+    return { ok: false, httpStatus: 502, error: "GitHub label API failed" };
+  }
+  return { ok: true, status: "labeled", decision, commentCreated };
+}

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -200,6 +200,7 @@ export function createHooksHandler(
     | {
         dispatchWakeHook?: HooksHandlerDeps["dispatchWakeHook"];
         dispatchAgentHook?: HooksHandlerDeps["dispatchAgentHook"];
+        issueTriageService?: HooksHandlerDeps["issueTriageService"];
         bindHost?: string;
         getClientIpConfig?: HooksHandlerDeps["getClientIpConfig"];
       },
@@ -218,6 +219,7 @@ export function createHooksHandler(
     getClientIpConfig: options.getClientIpConfig,
     dispatchWakeHook: options.dispatchWakeHook ?? (() => {}),
     dispatchAgentHook: options.dispatchAgentHook ?? (() => "run-1"),
+    issueTriageService: options.issueTriageService,
   });
 }
 

--- a/src/gateway/server.issue-triage-hook.test.ts
+++ b/src/gateway/server.issue-triage-hook.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createHookRequest,
+  createHooksHandler,
+  createResponse,
+} from "./server-http.test-harness.js";
+
+const { readJsonBodyMock } = vi.hoisted(() => ({
+  readJsonBodyMock: vi.fn(),
+}));
+
+vi.mock("./hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("./hooks.js")>("./hooks.js");
+  return {
+    ...actual,
+    readJsonBody: readJsonBodyMock,
+  };
+});
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    text: `[clawhip:github.issue-opened] opened\n\nPayload: ${JSON.stringify({
+      repo: "openclaw/openclaw",
+      number: 7,
+      title: "Bug",
+      labels: [],
+      ...overrides,
+    })}`,
+    mode: "now",
+  };
+}
+
+describe("issue triage hook endpoint", () => {
+  beforeEach(() => {
+    readJsonBodyMock.mockReset();
+  });
+
+  test("POST /hooks/issue-triage invokes service and returns result", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: true, value: payload() });
+    const issueTriageService = {
+      classifyIssue: vi.fn(async () => "delegate"),
+      addLabels: vi.fn(async () => {}),
+      createComment: vi.fn(async () => {}),
+    };
+    const handler = createHooksHandler({ issueTriageService });
+    const { res, getBody } = createResponse();
+
+    const handled = await handler(createHookRequest({ url: "/hooks/issue-triage" }), res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(getBody())).toMatchObject({
+      ok: true,
+      status: "labeled",
+      decision: "delegate",
+    });
+    expect(issueTriageService.classifyIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: "openclaw/openclaw", number: 7, title: "Bug" }),
+    );
+    expect(issueTriageService.addLabels).toHaveBeenCalledWith("openclaw/openclaw", 7, [
+      "iyen:auto-fix",
+    ]);
+  });
+
+  test("returns 503 when issue triage service is not configured", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: true, value: payload() });
+    const handler = createHooksHandler({});
+    const { res, getBody } = createResponse();
+
+    const handled = await handler(createHookRequest({ url: "/hooks/issue-triage" }), res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(getBody())).toEqual({
+      ok: false,
+      error: "issue triage service is not configured",
+    });
+  });
+
+  test("maps malformed clawhip payload to 400", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: true, value: { text: "no payload", mode: "now" } });
+    const handler = createHooksHandler({
+      issueTriageService: {
+        classifyIssue: vi.fn(async () => "delegate"),
+        addLabels: vi.fn(async () => {}),
+        createComment: vi.fn(async () => {}),
+      },
+    });
+    const { res, getBody } = createResponse();
+
+    const handled = await handler(createHookRequest({ url: "/hooks/issue-triage" }), res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(getBody())).toEqual({ ok: false, error: "Payload JSON required" });
+  });
+});

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -29,6 +29,7 @@ import {
   resolveHookSessionKey,
   resolveHookTargetAgentId,
 } from "../hooks.js";
+import { parseIssueTriageText, triageIssue, type IssueTriageService } from "../issue-triage.js";
 import { resolveRequestClientIp } from "../net.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "../server-constants.js";
 
@@ -47,6 +48,7 @@ export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) =>
 type HookDispatchers = {
   dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
   dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
+  issueTriageService?: IssueTriageService;
 };
 
 type HookReplayEntry = {
@@ -89,7 +91,14 @@ export function createHooksRequestHandler(
     getClientIpConfig?: () => HookClientIpConfig;
   } & HookDispatchers,
 ): HooksRequestHandler {
-  const { getHooksConfig, logHooks, dispatchAgentHook, dispatchWakeHook, getClientIpConfig } = opts;
+  const {
+    getHooksConfig,
+    logHooks,
+    dispatchAgentHook,
+    dispatchWakeHook,
+    getClientIpConfig,
+    issueTriageService,
+  } = opts;
   const hookReplayCache = new Map<string, HookReplayEntry>();
   const hookAuthLimiter = createAuthRateLimiter({
     maxAttempts: HOOK_AUTH_FAILURE_LIMIT,
@@ -249,6 +258,25 @@ export function createHooksRequestHandler(
       headers,
     });
     const now = Date.now();
+
+    if (subPath === "issue-triage") {
+      if (!issueTriageService) {
+        sendJson(res, 503, { ok: false, error: "issue triage service is not configured" });
+        return true;
+      }
+      const parsed = parseIssueTriageText((payload as Record<string, unknown>).text);
+      if (!parsed.ok) {
+        sendJson(res, 400, { ok: false, error: parsed.error });
+        return true;
+      }
+      const result = await triageIssue(parsed.issue, issueTriageService);
+      if (!result.ok) {
+        sendJson(res, result.httpStatus, { ok: false, error: result.error });
+        return true;
+      }
+      sendJson(res, 200, result);
+      return true;
+    }
 
     if (subPath === "wake") {
       const normalized = normalizeWakePayload(payload as Record<string, unknown>);

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -14,6 +14,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { type HookAgentDispatchPayload, type HooksConfigResolved } from "../hooks.js";
+import { createIssueTriageService } from "../issue-triage-service.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-request-handler.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -132,6 +133,7 @@ export function createGatewayHooksRequestHandler(params: {
     port,
     logHooks,
     getClientIpConfig,
+    issueTriageService: createIssueTriageService({ cfg: getRuntimeConfig(), deps }),
     dispatchAgentHook,
     dispatchWakeHook,
   });


### PR DESCRIPTION
## Summary
- add dedicated POST /hooks/issue-triage handler for clawhip GitHub issue-opened events
- add GitHub-backed triage service that noops terminal issues, runs an OpenClaw classifier, and applies iyen:auto-fix or iyen:declined
- add hooks.issueTriage config schema and targeted tests

## Tests
- pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/issue-triage.test.ts src/gateway/server.issue-triage-hook.test.ts
- pnpm tsgo:core:test
- pnpm config:schema:check