### PR TITLE
fix #73204: release session write lock during LLM summarization to prevent message drops

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -809,11 +809,12 @@ export async function compactEmbeddedPiSessionDirect(
     };
 
     const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
-    const sessionLock = await acquireSessionWriteLock({
+    const lockMaxHoldMs = resolveSessionLockMaxHoldFromTimeout({
+      timeoutMs: compactionTimeoutMs,
+    });
+    let sessionLock: { release: () => Promise<void> } | null = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
-      maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
-        timeoutMs: compactionTimeoutMs,
-      }),
+      maxHoldMs: lockMaxHoldMs,
     });
     try {
       await repairSessionFileIfNeeded({
@@ -1062,6 +1063,12 @@ export async function compactEmbeddedPiSessionDirect(
             // the sanity check below becomes a no-op instead of crashing compaction.
           }
           const activeSession = session;
+          // Release the session write lock before the LLM summarization so
+          // incoming messages can be delivered during compaction (issue #73204).
+          // The LLM call only reads in-memory state; the session lane serializes
+          // in-process access. Re-acquire after the call for file I/O below.
+          await sessionLock.release();
+          sessionLock = null;
           const result = await compactWithSafetyTimeout(
             () => {
               setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
@@ -1075,6 +1082,12 @@ export async function compactEmbeddedPiSessionDirect(
               },
             },
           );
+          // Re-acquire the session write lock for post-compaction file I/O
+          // (manual boundary hardening, transcript rotation, checkpoint persistence).
+          sessionLock = await acquireSessionWriteLock({
+            sessionFile: params.sessionFile,
+            maxHoldMs: lockMaxHoldMs,
+          });
           let effectiveFirstKeptEntryId = result.firstKeptEntryId;
           let postCompactionLeafId =
             typeof sessionManager.getLeafId === "function"
@@ -1254,7 +1267,9 @@ export async function compactEmbeddedPiSessionDirect(
       } catch {
         /* best-effort */
       }
-      await sessionLock.release();
+      if (sessionLock) {
+        await sessionLock.release();
+      }
     }
   } catch (err) {
     const reason = resolveCompactionFailureReason({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -812,6 +812,7 @@ export async function compactEmbeddedPiSessionDirect(
     const lockMaxHoldMs = resolveSessionLockMaxHoldFromTimeout({
       timeoutMs: compactionTimeoutMs,
     });
+    const lockAcquiredAt = Date.now();
     let sessionLock: { release: () => Promise<void> } | null = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
       maxHoldMs: lockMaxHoldMs,
@@ -1067,8 +1068,9 @@ export async function compactEmbeddedPiSessionDirect(
           // incoming messages can be delivered during compaction (issue #73204).
           // The LLM call only reads in-memory state; the session lane serializes
           // in-process access. Re-acquire after the call for file I/O below.
-          await sessionLock.release();
+          const lockToRelease = sessionLock;
           sessionLock = null;
+          await lockToRelease.release();
           const result = await compactWithSafetyTimeout(
             () => {
               setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
@@ -1084,9 +1086,11 @@ export async function compactEmbeddedPiSessionDirect(
           );
           // Re-acquire the session write lock for post-compaction file I/O
           // (manual boundary hardening, transcript rotation, checkpoint persistence).
+          const elapsedMs = Date.now() - lockAcquiredAt;
+          const remainingMaxHoldMs = Math.max(30_000, lockMaxHoldMs - elapsedMs);
           sessionLock = await acquireSessionWriteLock({
             sessionFile: params.sessionFile,
-            maxHoldMs: lockMaxHoldMs,
+            maxHoldMs: remainingMaxHoldMs,
           });
           let effectiveFirstKeptEntryId = result.firstKeptEntryId;
           let postCompactionLeafId =


### PR DESCRIPTION
## Summary

Fixes #73204

### Issue
Session compaction blocks InteractionEventListener, causing silent message drops.

### Root Cause
The session write lock was held during the entire compaction process, including the LLM summarization call. This blocked InteractionEventListener and other session-level event processing, causing incoming messages to be silently dropped during the compaction window.

### Solution
Release the session write lock before the LLM summarization call so incoming messages can be delivered during compaction. The lock is re-acquired after the call for post-compaction file I/O (manual boundary hardening, transcript rotation, checkpoint persistence).

### Changes
- `src/agents/pi-embedded-runner/compact.ts`: Release `sessionLock` before `compactWithSafetyTimeout()`, re-acquire after the call completes
- Guard `sessionLock.release()` with a null check in the finally block

---

🤖 AI-assisted fix (Claude Code-generated, reviewed by maintainer).