### PR TITLE
fix(android): document gateway TLS pinning

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -278,6 +278,9 @@ class GatewaySession(
 
     val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
 
+    // Gateway TLS uses certificate SHA-256 pinning in buildGatewayTlsConfig.
+    // OkHttp CertificatePinner pins SPKI hashes, so it cannot represent existing TOFU cert pins.
+    @SuppressWarnings("java/android/missing-certificate-pinning")
     suspend fun connect() {
       val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
       val request = Request.Builder().url(url).build()


### PR DESCRIPTION
## What
- Addresses Android CodeQL alert #81 (`java/android/missing-certificate-pinning`) at the gateway WebSocket call site.
- Documents and suppresses the alert where the connection is already protected by custom certificate SHA-256 pinning in `buildGatewayTlsConfig`.

## Why
OpenClaw gateway TLS pins the peer certificate fingerprint after explicit user verification. OkHttp `CertificatePinner` pins SPKI hashes, not certificate DER fingerprints, so wiring it here would not represent existing stored TOFU cert pins and would risk breaking trusted gateways.

## Validation
- Blacksmith Testbox: `cd apps/android && ./gradlew --no-daemon :app:compilePlayDebugKotlin`
- `git diff --check origin/main..HEAD`
- Pending: branch Android CodeQL to verify suppression is honored.