### PR TITLE
test(gateway): reduce server shard memory pressure

### DIFF
--- a/test/vitest/vitest.gateway-server.config.ts
+++ b/test/vitest/vitest.gateway-server.config.ts
@@ -21,6 +21,7 @@ export function createGatewayServerVitestConfig(env?: Record<string, string | un
         "src/gateway/sessions-history-http.test.ts",
       ],
       name: "gateway-server",
+      pool: "forks",
     },
   );
 }


### PR DESCRIPTION
## Summary
- Run the `gateway-server` Vitest project in the fork pool to reduce retained worker/module-graph memory.
- Keeps the full gateway suite below the previous RSS peak without the 3x slowdown from `isolate: true`.

## Evidence
- Baseline after #73302: `pnpm test:gateway` passed 257 files / 3003 tests, elapsed 57.92s, max RSS 4,429,864 KB.
- With this patch: `pnpm test:gateway` passed 257 files / 3003 tests, elapsed 56.78s, max RSS 3,711,392 KB.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed.
- `pnpm exec oxfmt --check --threads=1 test/vitest/vitest.gateway-server.config.ts` passed after rebase.
- `git diff --check origin/main...HEAD` passed after rebase.

## Notes
- No changelog: test configuration only.
- AI-assisted: yes; I understand the one-line Vitest config change and verified the touched surface above.
