### PR TITLE
fix(codeql): tune Android pinning profile

### DIFF
--- a/.github/codeql/codeql-android-critical-security.yml
+++ b/.github/codeql/codeql-android-critical-security.yml
@@ -9,6 +9,10 @@ query-filters:
   # Android canvas intentionally runs trusted A2UI JavaScript; keep this profile focused on exploitable WebView edges.
   - exclude:
       id: java/android/websettings-javascript-enabled
+  # Gateway TLS already pins verified certificate SHA-256 fingerprints. OkHttp CertificatePinner pins SPKI hashes,
+  # so this query is noisy for OpenClaw's TOFU/local-gateway trust model and does not belong in the critical profile.
+  - exclude:
+      id: java/android/missing-certificate-pinning
 
 paths:
   - apps/android/app/src/main


### PR DESCRIPTION
## What
- Removes `java/android/missing-certificate-pinning` from the Android critical-security CodeQL profile.
- Keeps the remaining Android critical profile focused on actionable exploitable findings.

## Why
The current alert #81 is a false fit for the OpenClaw gateway trust model. Gateway TLS already pins explicitly verified certificate SHA-256 fingerprints in `buildGatewayTlsConfig`; OkHttp `CertificatePinner` pins SPKI hashes and cannot represent existing stored TOFU cert fingerprints. A code-level suppression was tested in #73316 and CodeQL still reported the finding.

## Validation
- `git diff --check origin/main..HEAD`
- Pending: branch Android CodeQL should drop the profile from 3 findings to 2 camera temp-file findings.