### PR TITLE
fix(logging): redact subsystem console output

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -9,10 +9,10 @@ import { createSubsystemLogger } from "./subsystem.js";
 
 const logPathTracker = createSuiteLogPathTracker("openclaw-subsystem-log-");
 
-function installConsoleMethodSpy(method: "warn" | "error") {
+function installConsoleMethodSpy(method: "log" | "warn" | "error") {
   const spy = vi.fn();
   loggingState.rawConsole = {
-    log: vi.fn(),
+    log: method === "log" ? spy : vi.fn(),
     info: vi.fn(),
     warn: method === "warn" ? spy : vi.fn(),
     error: method === "error" ? spy : vi.fn(),
@@ -203,6 +203,50 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("redacts sensitive tokens from info console output", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const logSpy = installConsoleMethodSpy("log");
+    const log = createSubsystemLogger("gateway/auth");
+    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+
+    log.info(`provider api key API_KEY=${secret}`);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const message = String(logSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("API_KEY=");
+    expect(message).not.toContain(secret);
+    expect(message).toContain("API_KEY=***");
+  });
+
+  it("redacts bearer tokens from error console output", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "error" });
+    const error = installConsoleMethodSpy("error");
+    const log = createSubsystemLogger("gateway/auth");
+    const token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.secret";
+
+    log.error(`Authorization: Bearer ${token}`);
+
+    expect(error).toHaveBeenCalledTimes(1);
+    const message = String(error.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("Authorization: Bearer");
+    expect(message).not.toContain(token);
+    expect(message).toContain("eyJhbG…cret");
+  });
+
+  it("redacts sensitive tokens from raw console output", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const logSpy = installConsoleMethodSpy("log");
+    const log = createSubsystemLogger("gateway/auth");
+    const secret = "sk-rawtokenabcdefghijklmnopqrstuvwxyz123456";
+
+    log.raw(`raw token ${secret}`);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const message = String(logSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).not.toContain(secret);
+    expect(message).toContain("sk-raw…3456");
   });
 
   it("keeps long-lived subsystem loggers on the current-day rolling file", () => {

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -12,6 +12,7 @@ import {
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
 import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -255,13 +256,14 @@ function writeConsoleLine(level: LogLevel, line: string) {
     process.platform === "win32" && process.env.GITHUB_ACTIONS === "true"
       ? line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "?").replace(/[\uD800-\uDFFF]/g, "?")
       : line;
+  const redacted = redactSensitiveText(sanitized);
   const sink = loggingState.rawConsole ?? console;
   if (loggingState.forceConsoleToStderr || level === "error" || level === "fatal") {
-    (sink.error ?? console.error)(sanitized);
+    (sink.error ?? console.error)(redacted);
   } else if (level === "warn") {
-    (sink.warn ?? console.warn)(sanitized);
+    (sink.warn ?? console.warn)(redacted);
   } else {
-    (sink.log ?? console.log)(sanitized);
+    (sink.log ?? console.log)(redacted);
   }
 }
 


### PR DESCRIPTION
## Summary

- redact subsystem direct console output at the shared `writeConsoleLine()` sink exit
- keep the existing Windows surrogate sanitization, then apply `redactSensitiveText()` before calling `rawConsole` / `console`
- add regression coverage for `.info()`, `.error()`, and `.raw()` subsystem console paths

Fixes #73284
Follow-up to #67953
Part of #64046

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts src/logging/subsystem.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts`
- `pnpm check`

## AI assistance

AI-assisted. I reviewed the changes and ran the targeted logging test suite plus `pnpm check`.
