### PR TITLE
fix(tui): dedupe ASCII backspace events

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -210,6 +210,14 @@ describe("createBackspaceDeduper", () => {
     expect(dedupe("\x7f")).toBe("\x7f");
   });
 
+  it("treats ASCII BS as backspace when it is the first event", () => {
+    const { dedupe, advance } = createTimedDedupe();
+
+    expect(dedupe("\x08")).toBe("\x08");
+    advance(1);
+    expect(dedupe("\x7f")).toBe("");
+  });
+
   it("never suppresses non-backspace keys", () => {
     const dedupe = createBackspaceDeduper();
     expect(dedupe("a")).toBe("a");

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -209,7 +209,7 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
   let lastBackspaceAt = -1;
 
   return (data: string): string => {
-    if (!matchesKey(data, Key.backspace)) {
+    if (data !== "\x08" && !matchesKey(data, Key.backspace)) {
       return data;
     }
     const ts = now();


### PR DESCRIPTION
## Summary

- Problem: The TUI backspace deduper handled DEL (`\x7f`) via `pi-tui`'s `Key.backspace` matching, but ASCII BS (`\x08`) no longer matched and slipped through as a second backspace inside the dedupe window.
- Why it matters: Terminals can emit either DEL or BS for backspace depending on terminal/app mode, so the TUI should keep deduping both encodings instead of double-deleting input in one environment.
- What changed: Treat ASCII BS (`\x08`) as a backspace input in `createBackspaceDeduper` and add the reverse-direction regression test.
- What did NOT change (scope boundary): No changes to general key handling, non-backspace input, terminal startup, or TUI command routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related #71884
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `createBackspaceDeduper` relied only on `matchesKey(data, Key.backspace)`. With the current `@mariozechner/pi-tui`, DEL (`\x7f`) matches `Key.backspace`, but ASCII BS (`\x08`) does not.
- Missing detection / guardrail: Existing coverage checked DEL followed by BS, but the implementation delegated all recognition to `pi-tui` and missed the explicit BS encoding when dependency behavior changed.
- Contributing context (if known): This failure reproduced on latest `origin/main` while preparing #71884.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tui/tui.test.ts`
- Scenario the test should lock in: `createBackspaceDeduper` treats both DEL (`\x7f`) and ASCII BS (`\x08`) as backspace encodings regardless of which arrives first.
- Why this is the smallest reliable guardrail: The bug is isolated to pure input normalization/deduping with injectable time.
- Existing test that already covers this (if any): The previous DEL-then-BS test caught the current failure; this PR adds BS-then-DEL coverage too.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The TUI backspace deduper again handles ASCII BS (`\x08`) as backspace, avoiding duplicate deletion when terminals emit mixed BS/DEL encodings.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/WSL terminal environment
- Runtime/container: Node 22+ local worktree
- Model/provider: N/A
- Integration/channel (if any): TUI
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/tui/tui.test.ts` on latest `origin/main`.
2. Observe the `createBackspaceDeduper` duplicate-backspace test failing because `\x08` is returned instead of suppressed.
3. Apply this fix and rerun `pnpm test src/tui/tui.test.ts`.

### Expected

- Both DEL and ASCII BS are treated as backspace inputs by the deduper.

### Actual

- Before: ASCII BS did not match `Key.backspace` through `pi-tui` and was not deduped.
- After: ASCII BS is recognized explicitly and the TUI test file passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/tui/tui.test.ts` passed with 39 tests.
- Edge cases checked: DEL then BS, BS then DEL, outside-window backspaces, and non-backspace input.
- What I did not verify: Manual interactive TUI input on every terminal emulator.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Treating ASCII BS as backspace could affect non-terminal input if it intentionally sends raw `\x08`.
  - Mitigation: `\x08` is the standard ASCII Backspace control character; other non-backspace keys are still returned unchanged and covered by tests.
