### PR TITLE
fix(acpx): tolerate fs.chmod EPERM on remote/special filesystems (#73333)

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { prepareAcpxCodexAuthConfig } from "./codex-auth-bridge.js";
 import { resolveAcpxPluginConfig } from "./config.js";
 
@@ -418,5 +418,74 @@ describe("prepareAcpxCodexAuthConfig", () => {
     });
 
     expect(resolved.agents.claude).toBe(command);
+  });
+
+  // Regression for #73333: filesystems that reject chmod (some NFS/SMB mounts,
+  // hardened cloud storage) used to abort acpx plugin startup with EPERM even
+  // though the wrapper file itself was written successfully. The executable
+  // bit is cosmetic — wrappers run via `node <path>` — so chmod failure must
+  // be best-effort.
+  it.each(["EPERM", "EACCES", "EROFS", "ENOSYS", "ENOTSUP"] as const)(
+    "tolerates fs.chmod failing with %s on the wrapper script (regression #73333)",
+    async (code) => {
+      const root = await makeTempDir();
+      const stateDir = path.join(root, "state");
+      const generated = generatedCodexPaths(stateDir);
+      const generatedClaude = generatedClaudePaths(stateDir);
+
+      const chmodSpy = vi.spyOn(fs, "chmod").mockImplementation(async () => {
+        const error = new Error(`mock ${code} on remote filesystem`) as NodeJS.ErrnoException;
+        error.code = code;
+        throw error;
+      });
+
+      try {
+        const pluginConfig = resolveAcpxPluginConfig({
+          rawConfig: {},
+          workspaceDir: root,
+        });
+        const resolved = await prepareAcpxCodexAuthConfig({
+          pluginConfig,
+          stateDir,
+        });
+
+        expectCodexWrapperCommand(resolved.agents.codex, generated.wrapperPath);
+        expectClaudeWrapperCommand(resolved.agents.claude, generatedClaude.wrapperPath);
+        // Wrapper file content is still written even though chmod is rejected.
+        await expect(fs.access(generated.wrapperPath)).resolves.toBeUndefined();
+        await expect(fs.access(generatedClaude.wrapperPath)).resolves.toBeUndefined();
+        // Both wrappers were chmod-attempted and both swallowed the error.
+        expect(chmodSpy).toHaveBeenCalledWith(generated.wrapperPath, 0o755);
+        expect(chmodSpy).toHaveBeenCalledWith(generatedClaude.wrapperPath, 0o755);
+      } finally {
+        chmodSpy.mockRestore();
+      }
+    },
+  );
+
+  it("still surfaces unexpected fs.chmod errors so real bugs are not hidden (regression #73333)", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+
+    const chmodSpy = vi.spyOn(fs, "chmod").mockImplementation(async () => {
+      const error = new Error("mock ENOSPC out of disk") as NodeJS.ErrnoException;
+      error.code = "ENOSPC";
+      throw error;
+    });
+
+    try {
+      const pluginConfig = resolveAcpxPluginConfig({
+        rawConfig: {},
+        workspaceDir: root,
+      });
+      await expect(
+        prepareAcpxCodexAuthConfig({
+          pluginConfig,
+          stateDir,
+        }),
+      ).rejects.toMatchObject({ code: "ENOSPC" });
+    } finally {
+      chmodSpy.mockRestore();
+    }
   });
 });

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -240,13 +240,44 @@ async function prepareIsolatedCodexHome(baseDir: string): Promise<string> {
   return codexHome;
 }
 
+/**
+ * Best-effort chmod for ACP wrapper scripts.
+ *
+ * Wrappers are always invoked via `node /path/to/wrapper.mjs`, so the executable
+ * bit is purely cosmetic. On filesystems that reject chmod (some NFS/SMB mounts,
+ * hardened cloud storage, read-only-perms volumes), the previous hard failure
+ * here aborted acpx plugin startup with EPERM even though the wrapper itself
+ * was already written successfully (issue #73333). Treat permission-related
+ * failures as non-fatal and keep going; surface other unexpected errors so we
+ * still notice real bugs.
+ */
+async function chmodWrapperBestEffort(wrapperPath: string): Promise<void> {
+  try {
+    await fs.chmod(wrapperPath, 0o755);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (
+      code === "EPERM" ||
+      code === "EACCES" ||
+      code === "EROFS" ||
+      code === "ENOSYS" ||
+      code === "ENOTSUP"
+    ) {
+      // Filesystem refuses chmod (remote/special FS). Wrapper is invoked via
+      // `node <path>`, so the missing executable bit is harmless.
+      return;
+    }
+    throw error;
+  }
+}
+
 async function writeCodexAcpWrapper(baseDir: string, installedBinPath?: string): Promise<string> {
   await fs.mkdir(baseDir, { recursive: true });
   const wrapperPath = path.join(baseDir, "codex-acp-wrapper.mjs");
   await fs.writeFile(wrapperPath, buildCodexAcpWrapperScript(installedBinPath), {
     encoding: "utf8",
   });
-  await fs.chmod(wrapperPath, 0o755);
+  await chmodWrapperBestEffort(wrapperPath);
   return wrapperPath;
 }
 
@@ -256,7 +287,7 @@ async function writeClaudeAcpWrapper(baseDir: string, installedBinPath?: string)
   await fs.writeFile(wrapperPath, buildClaudeAcpWrapperScript(installedBinPath), {
     encoding: "utf8",
   });
-  await fs.chmod(wrapperPath, 0o755);
+  await chmodWrapperBestEffort(wrapperPath);
   return wrapperPath;
 }
 


### PR DESCRIPTION
## Summary

- Problem: `acpx` plugin startup aborts with `EPERM: operation not permitted, chmod '…/codex-acp-wrapper.mjs'` when `OPENCLAW_STATE_DIR` (or `~/.openclaw`) lives on a filesystem that rejects `chmod` — common on some NFS/SMB mounts, hardened cloud storage, and read-only-perms volumes (issue #73333). The wrapper file itself is already written successfully when the chmod failure throws.
- Why it matters: ACP wrappers are always invoked via `node /path/to/wrapper.mjs`, so the executable bit is purely cosmetic. The plugin had no reason to die here, but it did, taking the entire `acpx-runtime` plugin service with it.
- What changed: Wrap both `fs.chmod` calls in `extensions/acpx/src/codex-auth-bridge.ts` (`writeCodexAcpWrapper`, `writeClaudeAcpWrapper`) in a small `chmodWrapperBestEffort` helper that swallows `EPERM` / `EACCES` / `EROFS` / `ENOSYS` / `ENOTSUP` and rethrows everything else.
- What did NOT change (scope boundary): No change to wrapper script content, `prepareAcpxCodexAuthConfig` API, ACP launch command building, codex-auth handling, or any other plugin. No new config knob.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Skills / tool execution  <!-- acpx plugin runtime -->
- [ ] Gateway / orchestration
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73333
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `writeCodexAcpWrapper` and `writeClaudeAcpWrapper` always called `await fs.chmod(wrapperPath, 0o755)` after writing the file. On filesystems that disallow `chmod` on regular files, `fs.chmod` rejects with `EPERM` (or `EACCES`, depending on the FS), which propagates up through `prepareAcpxCodexAuthConfig` and aborts `acpx-runtime.start()` — even though the wrapper file is on disk and would launch correctly via `node`.
- Missing detection / guardrail: The wrapper-write path treated `chmod` as required for execution, but the wrapper is never executed directly — only via `process.execPath` (Node) — so the executable bit is decorative.
- Contributing context (if known): Reported on Ubuntu 24.04 with the OpenClaw state dir on a remote/cloud-mounted volume (`/home/node/.openclaw`). The same pattern reproduces on read-only-perms NFS / SMB mounts. Surfaces in self-compiled deployments where state dir placement is more flexible than the canonical `~/.openclaw` on local disk.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/acpx/src/codex-auth-bridge.test.ts`.
- Scenario the test should lock in: `prepareAcpxCodexAuthConfig` must succeed (and produce wrapper files) even when `fs.chmod` rejects with `EPERM` / `EACCES` / `EROFS` / `ENOSYS` / `ENOTSUP`; unexpected errnos (e.g. `ENOSPC`) must still propagate.
- Why this is the smallest reliable guardrail: The bug is isolated to one helper that runs once per plugin start; mocking `fs.chmod` with `vi.spyOn` catches both the Codex and the Claude wrapper paths and asserts the file is still on disk afterward.
- Existing test that already covers this (if any): None — existing tests only assert the happy path on a writable temp dir.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`acpx` plugin no longer fails to start on filesystems that reject `chmod`. No config / API change. On every other filesystem, behavior is byte-identical.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — the wrapper is still spawned via `node <path>`; not having `+x` on it does not introduce any new surface.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.5 (Apple Silicon) for unit tests; original report on Ubuntu 24.04.1 LTS.
- Runtime/container: local pnpm workspace, Node 25.9, vitest.
- Model/provider: N/A.
- Integration/channel (if any): `acpx-runtime` plugin.
- Relevant config (redacted): N/A — bug is in plugin startup, not user config.

### Steps

1. On `origin/main`: `pnpm vitest run extensions/acpx/src/codex-auth-bridge.test.ts` → 12 tests, 10 pass, 2 unrelated pre-existing failures (the bundled-dep tests).
2. Apply this PR: `pnpm vitest run extensions/acpx/src/codex-auth-bridge.test.ts` → 18 tests, 16 pass, same 2 unrelated pre-existing failures.

### Expected

- `prepareAcpxCodexAuthConfig` returns a resolved config and writes both wrapper files when `fs.chmod` rejects with any of `EPERM` / `EACCES` / `EROFS` / `ENOSYS` / `ENOTSUP`.
- `prepareAcpxCodexAuthConfig` propagates unexpected errnos (e.g. `ENOSPC`) so genuine bugs stay visible.

### Actual

- Before: `EPERM` from `fs.chmod` aborts `prepareAcpxCodexAuthConfig` → `acpx-runtime` plugin fails to start.
- After: `EPERM` is swallowed at the chmod site only; everything else continues normally.

## Evidence

- [x] Failing test/log before + passing after

```
$ pnpm vitest run extensions/acpx/src/codex-auth-bridge.test.ts
…
 ✓ tolerates fs.chmod failing with EPERM on the wrapper script (regression #73333)
 ✓ tolerates fs.chmod failing with EACCES on the wrapper script (regression #73333)
 ✓ tolerates fs.chmod failing with EROFS on the wrapper script (regression #73333)
 ✓ tolerates fs.chmod failing with ENOSYS on the wrapper script (regression #73333)
 ✓ tolerates fs.chmod failing with ENOTSUP on the wrapper script (regression #73333)
 ✓ still surfaces unexpected fs.chmod errors so real bugs are not hidden (regression #73333)
…
Test Files  1 failed (1)   <-- 2 unrelated pre-existing failures, also present on origin/main
     Tests  2 failed | 16 passed (18)
```

## Human Verification (required)

- Verified scenarios:
  - Targeted vitest run on `extensions/acpx/src/codex-auth-bridge.test.ts` before and after the change, confirming the 2 pre-existing failures (`uses the bundled Codex/Claude ACP dependency by default when it is installed`) exist on `origin/main` and are unrelated to this fix.
  - Wrapper file content unchanged — `fs.readFile(wrapperPath, "utf8")` still passes the same wrapper-content assertions.
  - Both Codex and Claude wrapper paths exercised by the new tests.
- Edge cases checked: each of the 5 ignored errnos individually; one rethrown errno (`ENOSPC`).
- What I did **not** verify: Live reproduction on an actual NFS/SMB mount — the unit test mocks `fs.chmod` directly because that is the only seam where the kernel would have raised the error.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: A future change makes the wrapper file actually-executable-required (e.g., shebang launch). Then a missing `+x` would silently fail.
  - Mitigation: The helper only swallows the 5 documented errnos; any real launch failure surfaces at spawn time (`spawn ENOENT` / `EACCES`) with a clear stack. Today the wrapper is invoked via `process.execPath` (Node), enforced by tests.
