### PR TITLE
fix(agents/anthropic-transport): suppress default beta headers on custom Anthropic-compatible providers

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -40,6 +40,8 @@ function makeAnthropicTransportModel(
   params: {
     id?: string;
     name?: string;
+    provider?: string;
+    baseUrl?: string;
     reasoning?: boolean;
     maxTokens?: number;
     headers?: Record<string, string>;
@@ -51,8 +53,8 @@ function makeAnthropicTransportModel(
       id: params.id ?? "claude-sonnet-4-6",
       name: params.name ?? "Claude Sonnet 4.6",
       api: "anthropic-messages",
-      provider: "anthropic",
-      baseUrl: "https://api.anthropic.com",
+      provider: params.provider ?? "anthropic",
+      baseUrl: params.baseUrl ?? "https://api.anthropic.com",
       reasoning: params.reasoning ?? true,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -133,6 +135,94 @@ describe("anthropic transport stream", () => {
       model: "claude-sonnet-4-6",
       stream: true,
     });
+    const headers = new Headers(latestAnthropicRequest().init?.headers);
+    expect(headers.get("anthropic-beta")).toBe("fine-grained-tool-streaming-2025-05-14");
+  });
+
+  it("does not add Anthropic beta headers for custom anthropic-compatible providers by default", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "custom-anthropic-compat",
+      baseUrl: "https://custom-proxy.example",
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(guardedFetchMock).toHaveBeenCalledWith(
+      "https://custom-proxy.example/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    const headers = new Headers(latestAnthropicRequest().init?.headers);
+    expect(headers.get("anthropic-beta")).toBeNull();
+  });
+
+  it("treats schemeless api.anthropic.com baseUrls as direct Anthropic (beta header added)", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "anthropic",
+      baseUrl: "api.anthropic.com",
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const headers = new Headers(latestAnthropicRequest().init?.headers);
+    expect(headers.get("anthropic-beta")).toBe("fine-grained-tool-streaming-2025-05-14");
+  });
+
+  it("does not add Anthropic beta headers when api.anthropic.com appears only in the path of a foreign host", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "anthropic",
+      baseUrl: "https://attacker.example/api.anthropic.com",
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const headers = new Headers(latestAnthropicRequest().init?.headers);
+    expect(headers.get("anthropic-beta")).toBeNull();
+  });
+
+  it("does not add Anthropic beta headers when baseUrl is malformed", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "anthropic",
+      baseUrl: "not a url at all",
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const headers = new Headers(latestAnthropicRequest().init?.headers);
+    expect(headers.get("anthropic-beta")).toBeNull();
   });
 
   it("ignores non-positive runtime maxTokens overrides and falls back to the model limit", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -15,6 +15,7 @@ import {
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
+import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -189,6 +190,31 @@ function adjustMaxTokensForThinking(params: {
 
 function isAnthropicOAuthToken(apiKey: string): boolean {
   return apiKey.includes("sk-ant-oat");
+}
+
+// Gates the implicit `anthropic-beta` header on the API-key transport
+// path. The OAuth-token branch retains the beta bundle unconditionally;
+// see the OAuth-branch comment in createAnthropicTransportClient for the
+// trade-off behind that scope.
+function isDirectAnthropicModel(
+  model: Pick<AnthropicTransportModel, "provider" | "baseUrl">,
+): boolean {
+  const provider = normalizeLowercaseStringOrEmpty(model.provider);
+  if (provider !== "anthropic") {
+    return false;
+  }
+  // No explicit baseUrl → SDK default lands on api.anthropic.com.
+  if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {
+    return true;
+  }
+  // Reuse the canonical endpoint classifier from provider-attribution
+  // instead of inlining URL parsing or substring matching. Handles
+  // schemeless candidates, manifest-driven hostname matches, and avoids
+  // false positives where "api.anthropic.com" appears in a path or query
+  // of an unrelated host. Malformed baseUrls resolve to
+  // `endpointClass: "invalid"` and are NOT treated as direct Anthropic —
+  // the beta header is suppressed defensively.
+  return resolveProviderEndpoint(model.baseUrl).endpointClass === "anthropic-public";
 }
 
 function toClaudeCodeName(name: string): string {
@@ -577,6 +603,12 @@ function createAnthropicTransportClient(params: {
     betaFeatures.push("interleaved-thinking-2025-05-14");
   }
   if (isAnthropicOAuthToken(apiKey)) {
+    // OAuth-token transport keeps the default beta bundle even when
+    // `model.baseUrl` is custom: `sk-ant-oat-…` tokens are Anthropic-issued,
+    // so deployments routing them through a foreign backend are uncommon
+    // enough that we leave the existing behaviour rather than silently
+    // suppressing headers. Gate this branch with `isDirectAnthropicModel(model)`
+    // too if maintainers prefer parity with the API-key path below.
     return {
       client: createAnthropicMessagesClient({
         apiKey: null,
@@ -598,6 +630,7 @@ function createAnthropicTransportClient(params: {
       isOAuthToken: true,
     };
   }
+  const defaultBetaHeader = isDirectAnthropicModel(model) ? betaFeatures.join(",") : undefined;
   return {
     client: createAnthropicMessagesClient({
       apiKey,
@@ -606,7 +639,7 @@ function createAnthropicTransportClient(params: {
         {
           accept: "application/json",
           "anthropic-dangerous-direct-browser-access": "true",
-          "anthropic-beta": betaFeatures.join(","),
+          ...(defaultBetaHeader ? { "anthropic-beta": defaultBetaHeader } : {}),
         },
         model.headers,
         options?.headers,


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw's `anthropic-messages` transport unconditionally injects the `anthropic-beta: fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14` header on every request, regardless of whether the target endpoint actually understands those beta features. Custom Anthropic-compatible providers (proxies that translate to non-Anthropic backends, OpenAI-style relays advertising the `anthropic-messages` API surface, vendor-specific compat layers) routinely choke on the header — the model stops at the thinking block with `stop_reason=max_tokens` instead of producing a final answer.
- **Why it matters:** any operator routing `anthropic-messages` through a non-direct-Anthropic backend sees silently degraded responses by default. Direct replay of the same payload without the beta header succeeds, confirming the header is the offending input.
- **What changed:** new `isDirectAnthropicModel()` guard gates beta-header injection on the **API-key path** to direct Anthropic endpoints only. Uses the canonical `resolveProviderEndpoint()` classifier from `provider-attribution.ts` — `provider === "anthropic"` AND either no `baseUrl`, or a baseUrl whose `endpointClass` is `anthropic-public`. Custom Anthropic-compat providers no longer receive the beta header by default.
- **What did NOT change:** native Anthropic endpoint behaviour is unchanged — same headers, same defaults, same beta opt-ins. The OAuth-token branch (entered when `apiKey` matches `sk-ant-oat-…`) is intentionally **left as-is** pending maintainer direction; documented inline. Backward-compatible for all direct Anthropic users.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `src/agents/anthropic-transport-stream.ts` builds the default headers for every `anthropic-messages` API-key call by unconditionally including `anthropic-beta: fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14`. The function was written when only direct Anthropic was a realistic target for that API; the assumption that all `anthropic-messages` traffic ends up on a beta-aware backend silently broke once custom-baseUrl proxies became common.
- **Missing detection / guardrail:** the existing transport had no concept of "direct vs proxied Anthropic endpoint" at the header-emission layer. Provider-attribution machinery elsewhere in the codebase already understood the distinction via `resolveProviderEndpoint()`, but the transport-stream module did not consult it.
- **Contributing context:** the failure mode looks identical to a model running out of token budget (`stop_reason=max_tokens`), so operators typically misdiagnose it as model-side or quota-related instead of header-related, and may not even notice it on simple prompts.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/anthropic-transport-stream.test.ts` (extended).
- **Scenario the test should lock in:** the constructed default headers contain `anthropic-beta` only when the model points at a direct Anthropic endpoint per the canonical classifier; foreign / malformed / substring-poisoning baseUrls suppress it.
- **Why this is the smallest reliable guardrail:** the bug is at header-construction time, not request-dispatch time. A unit test that asserts on the constructed header dictionary is faster, more deterministic, and more localised than a network/integration test.
- **Existing test that already covers this:** none — prior tests assumed direct Anthropic only.
- **If no new test is added, why not:** N/A (4 new tests added; 17/17 total in the file).

## User-visible / Behavior Changes

None for direct Anthropic users (header injection unchanged when `provider === "anthropic"` and baseUrl is missing or resolves via `resolveProviderEndpoint()` to `endpointClass: anthropic-public`). For operators routing `anthropic-messages` through custom proxies on the API-key path, the beta header is now omitted by default — typically resolves the silent `stop_reason=max_tokens` regression those operators were seeing. The OAuth-token path is unchanged in either direction; see the inline comment near the OAuth branch for the maintainer-direction trade-off.

## Diagram (if applicable)

```text
Before (API-key + custom baseUrl):
[any anthropic-messages request] -> [beta header always injected]
  -> direct Anthropic: works
  -> custom proxy: degraded response (stop_reason=max_tokens)

After (API-key + custom baseUrl):
[anthropic-messages, provider=anthropic + endpointClass anthropic-public] -> [beta header injected] -> works
[anthropic-messages, provider!=anthropic OR endpointClass != anthropic-public] -> [no beta header] -> works

OAuth-token path: unchanged in this PR (intentional; documented inline).
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: WSL2 Ubuntu (Windows host)
- Runtime/container: openclaw runtime (Node 22+, dist-bundled)
- Model/provider: any custom Anthropic-compat target (e.g., a relay translating `anthropic-messages` to a non-Anthropic backend)
- Integration/channel: gateway-mode `openclaw agent`
- Relevant config: provider configured with `baseUrl` pointing at the custom proxy, NOT `https://api.anthropic.com`

### Steps

1. Configure an `anthropic-messages` provider whose `baseUrl` is a custom proxy (any non-Anthropic host).
2. Run an agent turn requiring a non-trivial response: `openclaw agent --agent <name> -m "<prompt>"`.
3. Observe behavior before/after.

### Expected (after fix)

- Agent returns a normal final response.

### Actual (before fix)

- Agent stops at the thinking block with `stop_reason=max_tokens`; no final answer text emitted.
- Direct replay of the SAME payload via `curl` against the SAME proxy WITHOUT the `anthropic-beta` header returns a normal final response — confirming the header is the offending input.

## Evidence

- [x] Failing test/log before + passing after — `pnpm test src/agents/anthropic-transport-stream.test.ts` → **17/17 pass**. New scenarios in this PR: custom anthropic-compat provider (header absent), schemeless `api.anthropic.com` baseUrl (header present), substring poisoning `https://attacker.example/api.anthropic.com` (header absent), malformed `"not a url at all"` baseUrl (header absent — `endpointClass: invalid`).

## Human Verification (required)

- **Verified scenarios:**
  - Default + explicit `https://api.anthropic.com` baseUrl, `provider === "anthropic"` → beta header present (unchanged behaviour).
  - Custom anthropic-compat provider with foreign-host baseUrl, `provider !== "anthropic"` → beta header absent (the fix).
  - Schemeless `api.anthropic.com` baseUrl → recognised by `resolveProviderEndpoint`'s schemeless candidate path → beta header present.
  - Substring-poisoning baseUrl `https://attacker.example/api.anthropic.com` → classifier resolves host to `attacker.example` → beta header absent. The OLD inline `baseUrl.includes("api.anthropic.com")` fallback would have mishandled this; the new classifier-based check does not.
  - Malformed baseUrl `"not a url at all"` → `resolveProviderEndpoint` returns `endpointClass: "invalid"` → beta header absent (suppressed defensively, NOT falling through to direct-Anthropic).
- **Edge cases checked:** classifier handles schemeless candidates (via `tryParseHostname` + `isSchemelessHostnameCandidate` chain); embedded `api.anthropic.com` substring in path/query has no effect; truly malformed URLs are rejected as `invalid` and produce header suppression.
- **What I did NOT verify:** live integration against a real custom Anthropic-compat backend in CI. Was verified locally against a custom proxy that previously reproduced the `stop_reason=max_tokens` regression; the unit test now covers the header-construction guarantee that the fix relies on.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment (OAuth-scope question — see inline code comment near the OAuth branch + previous PR comment for the symmetry argument).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an operator routing `anthropic-messages` API-key requests through a custom proxy that DID accept the beta headers and DID benefit from the beta features would silently lose those features.
  - Mitigation: the fix is conservative — only suppresses headers on confirmed non-direct endpoints per the canonical classifier. Such operators can still opt back in via explicit per-provider header config (existing OpenClaw provider-options machinery already accepts custom headers). Worth a follow-up changelog note if maintainers want to make the opt-in path more discoverable.
- Risk: OAuth-token path is intentionally not gated in this PR; operators sending `sk-ant-oat-…` tokens through a custom proxy would still receive the beta bundle.
  - Mitigation: documented inline in the OAuth branch (`anthropic-transport-stream.ts` near the `isAnthropicOAuthToken(apiKey)` check). One-line follow-up to gate that branch with `isDirectAnthropicModel(model)` if maintainers prefer parity.

---

🤖 _AI-assisted: this PR was authored with assistance from Claude Code (Anthropic). All code, tests, and verification have been reviewed by the human contributor before submission._
