### PR TITLE
fix(cli): surface respawn child exit signal/code so launcher no longer hangs silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/respawn: surface the underlying signal or non-zero exit code when the CLI respawn shim's child process dies (for example when killed by OOM on low-memory hosts), and always exit the parent on signal so the launcher no longer hangs silently with no output. Includes an `OPENCLAW_NO_RESPAWN=1` hint in the diagnostic so users can bypass the shim. Fixes #72720. Thanks @sign-2025.
 - Channels/setup: treat bundled channel plugins as already bundled during `channels add` and onboarding, enabling them without writing redundant `plugins.load.paths` entries or path install records. Fixes #72740. Thanks @iCodePoet.
 - Agents/OpenAI-compatible: retry replay-safe empty `stop` turns once for `openai-completions` endpoints, so transient empty local backend responses no longer surface as “Agent couldn't generate a response” when a continuation succeeds. Fixes #72751. Thanks @moooV252.
 - Git hooks: skip ignored staged paths when formatting and restaging pre-commit files, so merge commits no longer abort when `.gitignore` newly ignores staged merged content. Fixes #72744. Thanks @100yenadmin.

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildCliRespawnPlan,
   EXPERIMENTAL_WARNING_FLAG,
+  formatRespawnedChildExitDiagnostic,
   OPENCLAW_NODE_EXTRA_CA_CERTS_READY,
   OPENCLAW_NODE_OPTIONS_READY,
   resolveCliRespawnCommand,
@@ -120,5 +121,35 @@ describe("resolveCliRespawnCommand", () => {
         platform: "linux",
       }),
     ).toBe("node");
+  });
+});
+
+describe("formatRespawnedChildExitDiagnostic", () => {
+  it("returns null on clean exit (code 0, no signal)", () => {
+    expect(formatRespawnedChildExitDiagnostic({ code: 0, signal: null })).toBeNull();
+  });
+
+  it("returns null when both code and signal are missing", () => {
+    expect(formatRespawnedChildExitDiagnostic({ code: null, signal: null })).toBeNull();
+  });
+
+  it("describes the signal and points at OPENCLAW_NO_RESPAWN when killed", () => {
+    const message = formatRespawnedChildExitDiagnostic({ code: null, signal: "SIGKILL" });
+    expect(message).not.toBeNull();
+    expect(message).toContain("SIGKILL");
+    expect(message).toContain("OPENCLAW_NO_RESPAWN=1");
+  });
+
+  it("describes the exit code and points at OPENCLAW_NO_RESPAWN when non-zero", () => {
+    const message = formatRespawnedChildExitDiagnostic({ code: 1, signal: null });
+    expect(message).not.toBeNull();
+    expect(message).toContain("code 1");
+    expect(message).toContain("OPENCLAW_NO_RESPAWN=1");
+  });
+
+  it("prefers the signal description when both code and signal are present", () => {
+    const message = formatRespawnedChildExitDiagnostic({ code: 137, signal: "SIGKILL" });
+    expect(message).toContain("SIGKILL");
+    expect(message).not.toContain("code 137");
   });
 });

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -108,3 +108,37 @@ export function buildCliRespawnPlan(
     env: childEnv,
   };
 }
+
+/**
+ * Build a stderr diagnostic line for a respawned-child abnormal exit, or
+ * `null` when the child exited cleanly.
+ *
+ * Surfaces the underlying signal/code and points users at
+ * `OPENCLAW_NO_RESPAWN=1` so they can bypass the respawn shim if startup
+ * fails silently (for example when the child is OOM-killed on a low-RAM
+ * host or fails very early in module loading before producing output).
+ *
+ * Reported in https://github.com/openclaw/openclaw/issues/72720.
+ */
+export function formatRespawnedChildExitDiagnostic(params: {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}): string | null {
+  const { code, signal } = params;
+  if (signal) {
+    return (
+      `[openclaw] respawned CLI process was terminated by signal ${signal}.\n` +
+      "If this happens repeatedly (for example on low-memory hosts), set " +
+      "OPENCLAW_NO_RESPAWN=1 to bypass the respawn shim and run the CLI " +
+      "directly.\n"
+    );
+  }
+  if (code != null && code !== 0) {
+    return (
+      `[openclaw] respawned CLI process exited with code ${code}.\n` +
+      "If this happens with no other output, set OPENCLAW_NO_RESPAWN=1 to " +
+      "bypass the respawn shim so the underlying error is visible.\n"
+    );
+  }
+  return null;
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -7,7 +7,7 @@ import { isRootHelpInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
-import { buildCliRespawnPlan } from "./entry.respawn.js";
+import { buildCliRespawnPlan, formatRespawnedChildExitDiagnostic } from "./entry.respawn.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
@@ -78,8 +78,14 @@ if (
     attachChildProcessBridge(child);
 
     child.once("exit", (code, signal) => {
+      const diagnostic = formatRespawnedChildExitDiagnostic({ code, signal });
+      if (diagnostic) {
+        process.stderr.write(diagnostic);
+      }
       if (signal) {
-        process.exitCode = 1;
+        // Always exit explicitly so the parent does not hang waiting on a
+        // drained event loop after the child was killed (e.g. OOM SIGKILL).
+        process.exit(1);
         return;
       }
       process.exit(code ?? 1);


### PR DESCRIPTION
## Summary

- Problem: `openclaw gateway run` on Node.js v24 (reported on Alibaba Cloud Linux 3, 1.8GB RAM) hangs indefinitely with zero stdout/stderr because the `openclaw.mjs` respawn shim's child Node process is killed during module loading (consistent with OOM SIGKILL — `strace` in the report shows the child loading modules and then being killed) and the parent never reports it.
- Why it matters: from the user's perspective the CLI looks broken (no port listening, no error). The only way to discover what is happening today is `strace` or running `dist/index.js` directly to bypass the shim.
- What changed: the respawn `exit` handler in `src/entry.ts` now writes a one-line stderr diagnostic naming the signal or non-zero exit code and pointing at `OPENCLAW_NO_RESPAWN=1` as a bypass, and on signal it always calls `process.exit(1)` so the parent cannot hang waiting on a drained event loop after `child.kill`. The diagnostic builder is a new pure helper `formatRespawnedChildExitDiagnostic` in `src/entry.respawn.ts` with unit tests.
- What did NOT change (scope boundary): no respawn policy changes, no new env vars, no argv parsing changes, no behavior for clean child exits (code 0). Windows already short-circuits respawn earlier and is unaffected.

## Change Type

- [x] Bug fix

## Scope

- [x] CI/CD / infra (CLI launcher path)

## Linked Issue/PR

- Closes #72720
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `child.once("exit", ...)` set `process.exitCode = 1` on signal exits but did not call `process.exit`, so if anything kept the parent's event loop alive the launcher could appear to hang silently. On non-zero `code` exits the parent propagated the code without any user-visible explanation, so OOM-style child failures (the reporter's case) presented as a silent hang with no log output.
- Missing detection / guardrail: no diagnostic line on abnormal child termination; no documented escape hatch surfaced to the user at the moment of failure.
- Contributing context: low-RAM hosts (1.8GB) and slow module loading (~30s reported) make SIGKILL during respawn child startup realistic.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/entry.respawn.test.ts`
- Scenario the test should lock in: `formatRespawnedChildExitDiagnostic` returns `null` for clean exits and a message that names the signal / exit code and includes `OPENCLAW_NO_RESPAWN=1` for abnormal exits, and prefers the signal description when both are present.
- Why this is the smallest reliable guardrail: the actual fix is two pieces — (a) the formatter pure function (covered by unit tests) and (b) the one-line wiring in `src/entry.ts` that calls `process.stderr.write` and `process.exit(1)` on signal. The wiring is essentially a single call site; a unit test on the formatter is the smallest assertion that locks the diagnostic shape.

## User-visible / Behavior Changes

- When the respawned CLI child terminates abnormally, the parent now writes a single diagnostic line to stderr (signal name or exit code, plus an `OPENCLAW_NO_RESPAWN=1` hint).
- On signal exits the parent now exits with code 1 immediately instead of relying on the event loop to drain.
- No change for clean (code 0) exits.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (same `spawn` call, same args)
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Alibaba Cloud Linux 3 (kernel 5.10.x), reported by issue author
- Runtime: Node.js v24.14.0
- openclaw: 2026.4.24 (cbcfdf6)

### Steps

1. Install openclaw on a small (≈1.8GB RAM) Linux host with Node 24.
2. Run `openclaw gateway run --bind loopback --port 14720`.
3. Observe the command hang with no output and no listening port.

### Expected

- A stderr line such as: `[openclaw] respawned CLI process was terminated by signal SIGKILL.` with the `OPENCLAW_NO_RESPAWN=1` bypass hint, and the parent exits.

### Actual (before fix)

- Silent hang, no stderr line, no exit.

## Evidence

- Static reproduction is provided by the unit tests in `src/entry.respawn.test.ts`. A live host with constrained RAM is required to reproduce the original SIGKILL path; the existing `entry.ts` `child.once("error", ...)` path was the only one already producing stderr output, while the `exit` path now matches that behaviour.

## Human Verification

- Verified scenarios: type-check passes locally on the touched files; new pure-function tests added next to existing `entry.respawn.test.ts` suite.
- Edge cases checked: signal-only exit, code-only exit, signal+code exit (signal preferred), clean code 0 exit (no diagnostic), null/null exit (no diagnostic).
- What I did NOT verify: a live OOM repro on a small Linux host; full `pnpm check` / `pnpm test` was not run locally, leaving CI as the verification surface for the broader test matrix.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (existing `OPENCLAW_NO_RESPAWN=1` is only mentioned in the new diagnostic; behavior unchanged)
- Migration needed? No

## Risks and Mitigations

- Risk: the new stderr line could be considered noisy by tooling that scrapes stderr for known patterns.
  - Mitigation: the line is only emitted on abnormal child termination (signal or non-zero code). Clean exits remain silent.
