### PR TITLE
fix(commands): stop bare /reset and /new from falling through to empty model call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/commands: stop bare `/reset` and `/new` from falling through to model execution after the reset hooks clear the body, so an empty input no longer reaches the provider (e.g. OpenAI Responses API rejecting requests with `One of "input" or "previous_response_id" or "prompt" or "conversation_id" must be provided`). The non-ACP path now acknowledges the reset in place; tails like `/new take notes` still dispatch to the model as before. Fixes #73367. Thanks @hoyanhan.
 - Gateway/device tokens: stop echoing rotated bearer tokens from shared/admin `device.token.rotate` responses while preserving the same-device token handoff needed by token-only clients before reconnect. (#66773) Thanks @MoerAI.
 - Agents/sessions_spawn: resolve configured bare model aliases for spawn model overrides using the target agent runtime default provider, carrying forward the alias-specific #69029 review fixes from #59681 without the unrelated active-session pruning path. Fixes #59681. Thanks @HowdyDooToYou.
 - Control UI/Talk: keep Google Live browser sessions on the WebSocket transport instead of falling back to WebRTC, validate browser Google Live WebSocket endpoints, cap Gateway relay sessions per browser connection, and remove stale browser-native voice buttons that did not use the configured Talk/TTS provider. Thanks @BunsDev.

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -430,4 +430,52 @@ describe("handleCommands reset hooks", () => {
     expect(triggerInternalHookMock).not.toHaveBeenCalled();
     expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
   });
+
+  it("acknowledges bare /reset without falling through to model call (#73367)", async () => {
+    const params = buildResetParams("/reset", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "✅ Session reset." },
+    });
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "reset" }),
+    );
+  });
+
+  it("acknowledges bare /new without falling through to model call (#73367)", async () => {
+    const params = buildResetParams("/new", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "✅ New session started." },
+    });
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "new" }),
+    );
+  });
+
+  it("still falls through with a tail so the model receives the user input", async () => {
+    const params = buildResetParams("/new take notes", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+
+    const result = await maybeHandleResetCommand(params);
+
+    expect(result).toBeNull();
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "command", action: "new" }),
+    );
+  });
 });

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -166,5 +166,21 @@ export async function maybeHandleResetCommand(
     previousSessionEntry: params.previousSessionEntry,
     workspaceDir: params.workspaceDir,
   });
+
+  // Bare `/reset` or `/new` (no tail) must not fall through to model execution:
+  // the reset hooks have already cleared the body, so a downstream provider
+  // call would receive empty input (e.g. OpenAI Responses API rejects this
+  // with "One of input/previous_response_id/prompt/conversation_id must be
+  // provided"). Stop command processing and emit a simple acknowledgement.
+  // See https://github.com/openclaw/openclaw/issues/73367.
+  if (!resetTail) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
+      },
+    };
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary

- Problem: a bare `/reset` (or `/new`) sent to a non-ACP session resets the session, then the command handler returns `null`, letting normal command processing continue with an empty body. With the OpenAI Responses API the resulting model call is rejected with `One of "input" or "previous_response_id" or "prompt" or "conversation_id" must be provided` instead of a reset acknowledgement.
- Why it matters: every bare `/reset` against an OpenAI Responses-backed agent surfaces a provider error to the user instead of a clean acknowledgement.
- What changed: in `src/auto-reply/reply/commands-reset.ts`, the non-ACP branch now mirrors the ACP branch — when `resetTail` is empty, return `{ shouldContinue: false, reply: { text: "✅ Session reset." | "✅ New session started." } }` after the reset hooks fire. When a tail is present (e.g. `/new take notes`), we still return `null` so the existing tail-dispatch behaviour is unchanged.
- What did NOT change (scope boundary): no changes to ACP path, soft-reset path, hook payloads, authorization checks, session-clearing logic, or session-store side effects. No new env vars/config keys.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway (auto-reply command handling)

## Linked Issue/PR

- Closes #73367
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `maybeHandleResetCommand` in `src/auto-reply/reply/commands-reset.ts` ended its non-ACP branch with `await emitResetCommandHooks(...); return null;`. The reset hooks normalize the body, so when the user sent only `/reset` the subsequent command-pipeline stages saw an empty body and forwarded it to the model.
- Missing detection: there was no guard for "reset hook ran AND tail is empty" in the non-ACP branch, even though the ACP branch already handled the same case (`resetTail` empty → reply with `✅ ACP session reset in place.`).
- Contributing context: the OpenAI Responses API surfaces the empty-input case as a hard error, making the latent bug user-visible on Responses-backed providers.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/reply/commands-reset-hooks.test.ts`
- Scenarios the test locks in:
  - `/reset` → returns `{ shouldContinue: false, reply: { text: "✅ Session reset." } }` and still emits the reset hook.
  - `/new` → returns `{ shouldContinue: false, reply: { text: "✅ New session started." } }` and still emits the new hook.
  - `/new take notes` → continues to return `null` so the tail can dispatch to the model.
- Why this is the smallest reliable guardrail: the bug is a single missing branch in `maybeHandleResetCommand`. The new tests pin both the empty-tail acknowledgement and the non-regression for the tail-dispatch path; the rest of the reset machinery is already covered by adjacent tests in the same file.

## User-visible / Behavior Changes

- Bare `/reset` now replies with `✅ Session reset.` instead of producing a provider error or empty turn.
- Bare `/new` now replies with `✅ New session started.`
- `/reset <tail>` and `/new <tail>` are unchanged — the tail still dispatches to the model.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (this PR removes an empty/erroneous provider call)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OpenAI Responses-backed agent (any provider that hits `One of "input" / "previous_response_id" / "prompt" / "conversation_id" must be provided`)

### Steps

1. Configure an agent on the OpenAI Responses API.
2. Send a bare `/reset` to that agent on a non-ACP channel (e.g. WhatsApp/Telegram/webchat).

### Expected

- Reset hook fires, then a clean acknowledgement reply is delivered. No provider call.

### Actual (before fix)

- Reset hook fires; command pipeline continues with empty body; provider rejects the request and the error surfaces to the user.

## Evidence

- Static reproduction is provided by the new unit tests in `src/auto-reply/reply/commands-reset-hooks.test.ts`. The fix mirrors the existing ACP-path behaviour at the top of `maybeHandleResetCommand`.

## Human Verification

- Verified scenarios: TypeScript clean on touched files; new tests added next to existing reset-hooks suite.
- Edge cases checked: bare `/reset`, bare `/new`, `/new <tail>` (must still fall through), ACP path (untouched), soft-reset path (untouched).
- What I did NOT verify: a live end-to-end run against a Responses-backed provider; full `pnpm check` / `pnpm test` was not exercised locally, leaving CI as the verification surface.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a downstream consumer relied on `null` being returned for bare `/reset` to trigger some additional pipeline step.
  - Mitigation: this matches the established ACP-path behaviour for the same input; bare `/reset` was already broken on the OpenAI Responses path, so the previous behaviour was not a load-bearing contract.
