### PR TITLE
fix(cron): clarify local timezone cron expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/nodes: allow Windows companion nodes to use safe declared commands such as canvas, camera list, location, device info, and screen snapshot by default while keeping dangerous media commands opt-in. (#71884) Thanks @shanselman.
+- Agents/cron: clarify agent-tool and CLI cron timezone guidance so supplied `tz` values use local wall-clock cron fields and omitted cron `tz` falls back to the Gateway host local timezone. Fixes #53669; carries forward #46177. (#73372) Thanks @chen-zhang-cs-code and @maranello-o.
 
 ## 2026.4.27
 

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -70,6 +70,32 @@ describe("cron tool flat-params", () => {
     });
   });
 
+  it("passes local cron wall-clock expression and timezone through add", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-local-cron-add", {
+      action: "add",
+      name: "shanghai reminder",
+      cron: "0 18 * * *",
+      tz: "Asia/Shanghai",
+      message: "send reminder",
+    });
+
+    const [method, _gatewayOpts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      {
+        schedule?: unknown;
+      },
+    ];
+    expect(method).toBe("cron.add");
+    expect(params.schedule).toEqual({
+      kind: "cron",
+      expr: "0 18 * * *",
+      tz: "Asia/Shanghai",
+    });
+  });
+
   it("recovers flat cron schedule shorthand for update", async () => {
     const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
 

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -82,6 +82,24 @@ describe("CronToolSchema", () => {
     expect(patchStagger?.description).toBe("Random jitter in ms (kind=cron)");
   });
 
+  it("describes cron expressions as local wall-clock time in the supplied timezone", () => {
+    const jobExpr = propertyAt(schemaRecord, "job.schedule.expr");
+    const patchExpr = propertyAt(schemaRecord, "patch.schedule.expr");
+    const jobTz = propertyAt(schemaRecord, "job.schedule.tz");
+    const patchTz = propertyAt(schemaRecord, "patch.schedule.tz");
+
+    for (const prop of [jobExpr, patchExpr]) {
+      expect(prop?.description).toMatch(/wall-clock time/i);
+      expect(prop?.description).toMatch(/do not convert/i);
+      expect(prop?.description).toContain("0 18 * * *");
+      expect(prop?.description).toContain("Asia/Shanghai");
+    }
+    for (const prop of [jobTz, patchTz]) {
+      expect(prop?.description).toMatch(/wall-clock fields/i);
+      expect(prop?.description).toContain("Asia/Shanghai");
+    }
+  });
+
   it("job.delivery exposes mode, channel, to, threadId, bestEffort, accountId, failureDestination", () => {
     expect(keysAt(schemaRecord, "job.delivery")).toEqual(
       [

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -91,11 +91,13 @@ describe("CronToolSchema", () => {
     for (const prop of [jobExpr, patchExpr]) {
       expect(prop?.description).toMatch(/wall-clock time/i);
       expect(prop?.description).toMatch(/do not convert/i);
+      expect(prop?.description).toContain("Gateway host local timezone");
       expect(prop?.description).toContain("0 18 * * *");
       expect(prop?.description).toContain("Asia/Shanghai");
     }
     for (const prop of [jobTz, patchTz]) {
       expect(prop?.description).toMatch(/wall-clock fields/i);
+      expect(prop?.description).toContain("Gateway host local timezone");
       expect(prop?.description).toContain("Asia/Shanghai");
     }
   });

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -58,6 +58,15 @@ describe("cron tool", () => {
     return call.params;
   }
 
+  it("tells models to keep cron expressions in local wall-clock time for tz", () => {
+    const tool = createTestCronTool();
+
+    expect(tool.description).toContain("local wall-clock time");
+    expect(tool.description).toContain("do not convert the requested local time to UTC first");
+    expect(tool.description).toContain('"expr": "0 18 * * *"');
+    expect(tool.description).toContain('"tz": "Asia/Shanghai"');
+  });
+
   function buildReminderAgentTurnJob(overrides: Record<string, unknown> = {}): {
     name: string;
     schedule: { at: string };

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -63,6 +63,10 @@ describe("cron tool", () => {
 
     expect(tool.description).toContain("local wall-clock time");
     expect(tool.description).toContain("do not convert the requested local time to UTC first");
+    expect(tool.description).toContain("Gateway host local timezone");
+    expect(tool.description).toContain(
+      'For schedule.kind="at", ISO timestamps without an explicit timezone are treated as UTC.',
+    );
     expect(tool.description).toContain('"expr": "0 18 * * *"');
     expect(tool.description).toContain('"tz": "Asia/Shanghai"');
   });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -166,13 +166,13 @@ const CronScheduleSchema = Type.Optional(
       expr: Type.Optional(
         Type.String({
           description:
-            'Cron expression (kind=cron) written in the supplied tz/local wall-clock time; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is "0 18 * * *" with tz "Asia/Shanghai".',
+            'Cron expression (kind=cron) written in the supplied tz\'s local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is "0 18 * * *" with tz "Asia/Shanghai".',
         }),
       ),
       tz: Type.Optional(
         Type.String({
           description:
-            'IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. "Asia/Shanghai".',
+            'IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. "Asia/Shanghai"; if omitted, cron uses the Gateway host local timezone.',
         }),
       ),
       staggerMs: Type.Optional(Type.Number({ description: "Random jitter in ms (kind=cron)" })),
@@ -579,12 +579,13 @@ SCHEDULE TYPES (schedule.kind):
   { "kind": "at", "at": "<ISO-8601 timestamp>" }
 - "every": Recurring interval
   { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
-- "cron": Cron expression evaluated in the supplied timezone
-  { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-timezone>" }
+- "cron": Cron expression evaluated in the supplied timezone, or the Gateway host local timezone when tz is omitted
+  { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-IANA-timezone>" }
   Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.
+  If tz is omitted, do not assume UTC; the Gateway host local timezone is used.
   Example: "Remind me every day at 6pm Shanghai time" -> { "kind": "cron", "expr": "0 18 * * *", "tz": "Asia/Shanghai" }
 
-ISO timestamps without an explicit timezone are treated as UTC.
+For schedule.kind="at", ISO timestamps without an explicit timezone are treated as UTC.
 
 PAYLOAD TYPES (payload.kind):
 - "systemEvent": Injects text as system event into session

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -163,8 +163,18 @@ const CronScheduleSchema = Type.Optional(
       anchorMs: Type.Optional(
         Type.Number({ description: "Optional start anchor in milliseconds (kind=every)" }),
       ),
-      expr: Type.Optional(Type.String({ description: "Cron expression (kind=cron)" })),
-      tz: Type.Optional(Type.String({ description: "IANA timezone (kind=cron)" })),
+      expr: Type.Optional(
+        Type.String({
+          description:
+            'Cron expression (kind=cron) written in the supplied tz/local wall-clock time; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is "0 18 * * *" with tz "Asia/Shanghai".',
+        }),
+      ),
+      tz: Type.Optional(
+        Type.String({
+          description:
+            'IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. "Asia/Shanghai".',
+        }),
+      ),
       staggerMs: Type.Optional(Type.Number({ description: "Random jitter in ms (kind=cron)" })),
     },
     { additionalProperties: true },
@@ -569,8 +579,10 @@ SCHEDULE TYPES (schedule.kind):
   { "kind": "at", "at": "<ISO-8601 timestamp>" }
 - "every": Recurring interval
   { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
-- "cron": Cron expression
+- "cron": Cron expression evaluated in the supplied timezone
   { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-timezone>" }
+  Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.
+  Example: "Remind me every day at 6pm Shanghai time" -> { "kind": "cron", "expr": "0 18 * * *", "tz": "Asia/Shanghai" }
 
 ISO timestamps without an explicit timezone are treated as UTC.
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -247,6 +247,16 @@ async function runCronRunAndCaptureExit(params: {
 }
 
 describe("cron cli", () => {
+  it("documents the gateway-host timezone default for cron --tz help", () => {
+    const program = buildProgram();
+    const cronCommand = program.commands.find((command) => command.name() === "cron");
+    const addCommand = cronCommand?.commands.find((command) => command.name() === "add");
+    const editCommand = cronCommand?.commands.find((command) => command.name() === "edit");
+
+    expect(addCommand?.helpInformation()).toContain("Gateway host local timezone");
+    expect(editCommand?.helpInformation()).toContain("Gateway host local timezone");
+  });
+
   it.each([
     {
       name: "exits 0 for cron run when job executes successfully",

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -85,7 +85,11 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)", "")
+      .option(
+        "--tz <iana>",
+        "Timezone for cron expressions (IANA; cron default: Gateway host local timezone)",
+        "",
+      )
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)", false)
       .option("--system-event <text>", "System event payload (main session)")

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -81,7 +81,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)")
+      .option(
+        "--tz <iana>",
+        "Timezone for cron expressions (IANA; cron default: Gateway host local timezone)",
+      )
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)")
       .option("--system-event <text>", "Set systemEvent payload")


### PR DESCRIPTION
## Problem

CronCreate can choose a UTC-converted hour while keeping a local `tz`. For example, "6pm Shanghai" can become `expr: "0 10 * * *", tz: "Asia/Shanghai"`, which fires at 10:00 in Shanghai instead of 18:00.

## Root cause

The cron runtime already evaluates `expr` in the supplied timezone, but the model-facing cron tool schema and description only said "Cron expression" and "IANA timezone". They did not tell the model that cron fields must be written in the selected timezone's local wall-clock time, and they did not include a concrete Shanghai example.

## Complete fix boundary

- Updated `CronToolSchema` `expr` and `tz` descriptions to state local wall-clock semantics and forbid pre-converting local time to UTC.
- Updated the cron tool description's `schedule.kind="cron"` guidance with the 6pm Shanghai example.
- Added schema regression coverage for `job.schedule` and `patch.schedule`.
- Added tool description regression coverage for the model-facing instruction.
- Added downstream flat-param coverage proving `0 18 * * *` plus `Asia/Shanghai` is passed through to `cron.add` unchanged.

## What intentionally did not change

- No runtime heuristic in `src/cron/schedule.ts`; changing already-correct `expr + tz` schedules would risk shifting valid user jobs.
- No CLI `cron add --tz` behavior; that human command path already handles `--tz` for `--at` and forwards cron expressions as supplied.
- No Gateway/UI/plugin-hook changes; those paths validate, forward, or store cron payloads rather than choosing model arguments.

## Tests run

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/cron-tool.flat-params.test.ts --reporter verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.flat-params.test.ts src/agents/tools/cron-tool.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/cron-tool.schema.test.ts src/agents/tools/cron-tool.test.ts --reporter dot`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/tools/cron-tool.schema.test.ts --reporter verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/schedule.test.ts`
- `pnpm check:changed`
- `node scripts/test-projects.mjs --changed upstream/main`
- `git diff --check`

## Linked issue

Fixes #53669

## CI red analysis

Greptile Review passed with confidence 5/5 and marked the PR safe to merge.

Remote red checks currently visible on PR #73372:

- `Run the OpenAI / Opus 4.6 parity gate against the qa-lab mock`: unrelated to this diff. The uploaded report shows 11/12 scenarios passed and the only failure was `thread-memory-isolation`, which timed out after 45000ms while answering a memory-backed fact inside a thread. This PR does not touch memory, thread isolation, gateway routing, or QA scenario code.
- `checks-node-auto-reply-reply-commands-state-routing`: unrelated to this diff. The only failing test is `src/auto-reply/reply/commands-status.thinking-default.test.ts > buildStatusReply > keeps default fallback config when the agent has no explicit fallback override`, expecting `Fallbacks: anthropic/claude-sonnet-4-6` in the status text. This PR does not touch auto-reply, status rendering, model fallback config, or routing.
- `checks-node-core-fast-support`: unrelated to this diff. The failures are three assertions in `src/video-generation/provider-registry.test.ts` about provider registry resolution (`expected ... to deeply equal []`, `expected undefined to be 'custom-video'`, and provider IDs expected to equal `['safe-video']`). This PR does not touch video-generation, provider registry, plugins, or capability provider loading.
- `checks-node-core`: aggregate failure caused by the non-dist shard failure above; no separate cron-specific failure is reported.

I attempted to rerun the failed remote workflows with `gh run rerun --failed`, but GitHub rejected it because rerunning upstream workflows requires repository admin rights.

Local red diagnostic:

- `pnpm test:changed` failed 27 of 7317 tests because it defaults to `origin/main` in this fork/worktree. That compared against the fork base instead of `upstream/main` and ran a broad unrelated unit-fast set. The failures were Windows path separator expectations and Windows symlink permission errors in unrelated files such as `src/daemon/restart-logs.test.ts`, `src/trajectory/export.test.ts`, `src/memory-host-sdk/host/backend-config.test.ts`, and `src/terminal/table.test.ts`. These files are not touched by this diff, so the reds are not related.
- The same changed test flow against the actual PR base, `node scripts/test-projects.mjs --changed upstream/main`, passed 2 Vitest shards, 3 files, 77 tests.
