### PR TITLE
feat(android): add authenticated presence alive beacons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
+- Android: publish authenticated `node.presence.alive` events after node connect and background transitions so paired Android nodes retain durable last-seen metadata after disconnects. Carries forward #63123. Thanks @ngutman.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.
 - Security/networking: add opt-in operator-managed outbound proxy routing (proxy.enabled + proxy.proxyUrl/OPENCLAW_PROXY_URL) with strict http:// forward-proxy validation, loopback-only Gateway bypass, and cleanup of proxy env/dispatcher state on exit. (#70044) Thanks @jesse-merhi and @joshavant.
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -15,6 +15,7 @@ Status: **extremely alpha**. The app is actively being rebuilt from the ground u
 - [x] Request camera/location and other permissions in onboarding/settings flow
 - [x] Push notifications for gateway/chat status updates
 - [x] Security hardening (biometric lock, token handling, safer defaults)
+- [x] Authenticated background presence beacons
 - [x] Voice tab full functionality
 - [x] Screen tab full functionality
 - [ ] Full end-to-end QA and release hardening

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -247,7 +247,7 @@ class NodeRuntime(
   private var gatewayAgents: List<GatewayAgentSummary> = emptyList()
   private var didAutoRequestCanvasRehydrate = false
   private val canvasRehydrateSeq = AtomicLong(0)
-  private var nodePresenceAliveLastSuccessAtMs: Long? = null
+  @Volatile private var nodePresenceAliveLastSuccessAtMs: Long? = null
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
@@ -673,7 +673,6 @@ class NodeRuntime(
     if (
       throttleRecentSuccess &&
         NodePresenceAliveBeacon.shouldSkipRecentSuccess(
-          isGatewayConnected = true,
           nowMs = nowMs,
           lastSuccessAtMs = nodePresenceAliveLastSuccessAtMs,
         )
@@ -704,7 +703,7 @@ class NodeRuntime(
     } else {
       Log.d(
         "OpenClawNode",
-        "node.presence.alive not handled: ${response?.reason ?: "unsupported"}",
+        "node.presence.alive not handled: ${NodePresenceAliveBeacon.sanitizeReasonForLog(response?.reason)}",
       )
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -247,6 +247,7 @@ class NodeRuntime(
   private var gatewayAgents: List<GatewayAgentSummary> = emptyList()
   private var didAutoRequestCanvasRehydrate = false
   private val canvasRehydrateSeq = AtomicLong(0)
+  private var nodePresenceAliveLastSuccessAtMs: Long? = null
   private var operatorConnected = false
   private var operatorStatusText: String = "Offline"
   private var nodeStatusText: String = "Offline"
@@ -302,6 +303,7 @@ class NodeRuntime(
         _canvasRehydrateErrorText.value = null
         updateStatus()
         showLocalCanvasOnConnect()
+        publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Connect)
         val endpoint = connectedEndpoint
         val auth = activeGatewayAuth
         if (endpoint != null && auth != null) {
@@ -649,6 +651,61 @@ class NodeRuntime(
       reconnectPreferredGatewayOnForeground()
     } else {
       stopManualVoiceSession()
+      publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Background, throttleRecentSuccess = true)
+    }
+  }
+
+  private fun publishNodePresenceAliveBeacon(
+    trigger: NodePresenceAliveBeacon.Trigger,
+    throttleRecentSuccess: Boolean = false,
+  ) {
+    scope.launch {
+      sendNodePresenceAliveBeacon(trigger = trigger, throttleRecentSuccess = throttleRecentSuccess)
+    }
+  }
+
+  private suspend fun sendNodePresenceAliveBeacon(
+    trigger: NodePresenceAliveBeacon.Trigger,
+    throttleRecentSuccess: Boolean,
+  ) {
+    if (!_nodeConnected.value) return
+    val nowMs = System.currentTimeMillis()
+    if (
+      throttleRecentSuccess &&
+        NodePresenceAliveBeacon.shouldSkipRecentSuccess(
+          isGatewayConnected = true,
+          nowMs = nowMs,
+          lastSuccessAtMs = nodePresenceAliveLastSuccessAtMs,
+        )
+    ) {
+      return
+    }
+
+    val client = connectionManager.buildClientInfo(clientId = "openclaw-android", clientMode = "node")
+    val payloadJson =
+      NodePresenceAliveBeacon.makePayloadJson(
+        trigger = trigger,
+        sentAtMs = nowMs,
+        displayName = client.displayName?.trim()?.takeIf { it.isNotEmpty() } ?: "Android",
+        version = client.version,
+        platform = NodePresenceAliveBeacon.androidPlatformLabel(),
+        deviceFamily = client.deviceFamily,
+        modelIdentifier = client.modelIdentifier,
+      )
+    val result =
+      nodeSession.sendNodeEventDetailed(
+        event = NodePresenceAliveBeacon.EVENT_NAME,
+        payloadJson = payloadJson,
+      )
+    if (!result.ok) return
+    val response = NodePresenceAliveBeacon.decodeResponse(result.payloadJson)
+    if (response?.handled == true) {
+      nodePresenceAliveLastSuccessAtMs = nowMs
+    } else {
+      Log.d(
+        "OpenClawNode",
+        "node.presence.alive not handled: ${response?.reason ?: "unsupported"}",
+      )
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -202,11 +202,11 @@ class GatewaySession(
       val res = conn.request("node.event", params, timeoutMs = timeoutMs)
       return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
     } catch (err: Throwable) {
-      Log.w("OpenClawGateway", "node.event failed: ${err.message ?: err::class.java.simpleName}")
+      Log.w("OpenClawGateway", "node.event failed: ${err::class.java.simpleName}")
       return RpcResult(
         ok = false,
         payloadJson = null,
-        error = ErrorShape("UNAVAILABLE", err.message ?: "node.event failed"),
+        error = ErrorShape("UNAVAILABLE", "node.event failed"),
       )
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -182,19 +182,32 @@ class GatewaySession(
   fun currentCanvasHostUrl(): String? = canvasHostUrl
   fun currentMainSessionKey(): String? = mainSessionKey
 
-  suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean {
-    val conn = currentConnection ?: return false
+  suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean =
+    sendNodeEventDetailed(event = event, payloadJson = payloadJson).ok
+
+  suspend fun sendNodeEventDetailed(event: String, payloadJson: String?, timeoutMs: Long = 8_000): RpcResult {
+    val conn =
+      currentConnection
+        ?: return RpcResult(
+          ok = false,
+          payloadJson = null,
+          error = ErrorShape("UNAVAILABLE", "not connected"),
+        )
     val params =
       buildJsonObject {
         put("event", JsonPrimitive(event))
         put("payloadJSON", JsonPrimitive(payloadJson ?: "{}"))
       }
     try {
-      conn.request("node.event", params, timeoutMs = 8_000)
-      return true
+      val res = conn.request("node.event", params, timeoutMs = timeoutMs)
+      return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
     } catch (err: Throwable) {
       Log.w("OpenClawGateway", "node.event failed: ${err.message ?: err::class.java.simpleName}")
-      return false
+      return RpcResult(
+        ok = false,
+        payloadJson = null,
+        error = ErrorShape("UNAVAILABLE", err.message ?: "node.event failed"),
+      )
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -182,8 +182,20 @@ class GatewaySession(
   fun currentCanvasHostUrl(): String? = canvasHostUrl
   fun currentMainSessionKey(): String? = mainSessionKey
 
-  suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean =
-    sendNodeEventDetailed(event = event, payloadJson = payloadJson).ok
+  suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean {
+    val conn = currentConnection ?: return false
+    return try {
+      conn.request(
+        "node.event",
+        buildNodeEventParams(event = event, payloadJson = payloadJson),
+        timeoutMs = 8_000,
+      )
+      true
+    } catch (err: Throwable) {
+      Log.w("OpenClawGateway", "node.event failed: ${err::class.java.simpleName}")
+      false
+    }
+  }
 
   suspend fun sendNodeEventDetailed(event: String, payloadJson: String?, timeoutMs: Long = 8_000): RpcResult {
     val conn =
@@ -193,11 +205,7 @@ class GatewaySession(
           payloadJson = null,
           error = ErrorShape("UNAVAILABLE", "not connected"),
         )
-    val params =
-      buildJsonObject {
-        put("event", JsonPrimitive(event))
-        put("payloadJSON", JsonPrimitive(payloadJson ?: "{}"))
-      }
+    val params = buildNodeEventParams(event = event, payloadJson = payloadJson)
     try {
       val res = conn.request("node.event", params, timeoutMs = timeoutMs)
       return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
@@ -210,6 +218,12 @@ class GatewaySession(
       )
     }
   }
+
+  private fun buildNodeEventParams(event: String, payloadJson: String?): JsonObject =
+    buildJsonObject {
+      put("event", JsonPrimitive(event))
+      put("payloadJSON", JsonPrimitive(payloadJson ?: "{}"))
+    }
 
   suspend fun request(method: String, paramsJson: String?, timeoutMs: Long = 15_000): String {
     val res = requestDetailed(method = method, paramsJson = paramsJson, timeoutMs = timeoutMs)

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
@@ -33,12 +33,10 @@ internal object NodePresenceAliveBeacon {
   }
 
   fun shouldSkipRecentSuccess(
-    isGatewayConnected: Boolean,
     nowMs: Long,
     lastSuccessAtMs: Long?,
     minIntervalMs: Long = MIN_SUCCESS_INTERVAL_MS,
   ): Boolean {
-    if (!isGatewayConnected) return false
     val last = lastSuccessAtMs ?: return false
     if (last <= 0) return false
     val elapsed = nowMs - last
@@ -85,5 +83,13 @@ internal object NodePresenceAliveBeacon {
       handled = parseJsonBooleanFlag(obj, "handled"),
       reason = parseJsonString(obj, "reason"),
     )
+  }
+
+  fun sanitizeReasonForLog(raw: String?): String {
+    val value = raw?.trim()?.takeIf { it.isNotEmpty() } ?: "unsupported"
+    return value
+      .map { ch -> if (ch.isISOControl()) ' ' else ch }
+      .joinToString("")
+      .take(200)
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.buildJsonObject
 internal object NodePresenceAliveBeacon {
   const val EVENT_NAME: String = "node.presence.alive"
   const val MIN_SUCCESS_INTERVAL_MS: Long = 10 * 60 * 1000
+  private const val MAX_RESPONSE_JSON_CHARS: Int = 16 * 1024
 
   enum class Trigger(val rawValue: String) {
     Background("background"),
@@ -26,11 +27,6 @@ internal object NodePresenceAliveBeacon {
   )
 
   private val json = Json { ignoreUnknownKeys = true }
-
-  fun normalizeTrigger(raw: String): Trigger {
-    val normalized = raw.trim().lowercase()
-    return Trigger.values().firstOrNull { it.rawValue == normalized } ?: Trigger.Background
-  }
 
   fun shouldSkipRecentSuccess(
     nowMs: Long,
@@ -70,10 +66,11 @@ internal object NodePresenceAliveBeacon {
     }.toString()
 
   fun decodeResponse(payloadJson: String?): ResponsePayload? {
-    if (payloadJson.isNullOrBlank()) return null
+    val raw = payloadJson?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    if (raw.length > MAX_RESPONSE_JSON_CHARS) return null
     val obj =
       try {
-        json.parseToJsonElement(payloadJson).asObjectOrNull()
+        json.parseToJsonElement(raw).asObjectOrNull()
       } catch (_: Throwable) {
         null
       } ?: return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt
@@ -1,0 +1,89 @@
+package ai.openclaw.app.node
+
+import android.os.Build
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+internal object NodePresenceAliveBeacon {
+  const val EVENT_NAME: String = "node.presence.alive"
+  const val MIN_SUCCESS_INTERVAL_MS: Long = 10 * 60 * 1000
+
+  enum class Trigger(val rawValue: String) {
+    Background("background"),
+    SilentPush("silent_push"),
+    BackgroundAppRefresh("bg_app_refresh"),
+    SignificantLocation("significant_location"),
+    Manual("manual"),
+    Connect("connect"),
+  }
+
+  data class ResponsePayload(
+    val ok: Boolean?,
+    val event: String?,
+    val handled: Boolean?,
+    val reason: String?,
+  )
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  fun normalizeTrigger(raw: String): Trigger {
+    val normalized = raw.trim().lowercase()
+    return Trigger.values().firstOrNull { it.rawValue == normalized } ?: Trigger.Background
+  }
+
+  fun shouldSkipRecentSuccess(
+    isGatewayConnected: Boolean,
+    nowMs: Long,
+    lastSuccessAtMs: Long?,
+    minIntervalMs: Long = MIN_SUCCESS_INTERVAL_MS,
+  ): Boolean {
+    if (!isGatewayConnected) return false
+    val last = lastSuccessAtMs ?: return false
+    if (last <= 0) return false
+    val elapsed = nowMs - last
+    return elapsed >= 0 && elapsed < minIntervalMs
+  }
+
+  fun androidPlatformLabel(): String {
+    val release = Build.VERSION.RELEASE?.trim().orEmpty().ifEmpty { "unknown" }
+    return "Android $release (SDK ${Build.VERSION.SDK_INT})"
+  }
+
+  fun makePayloadJson(
+    trigger: Trigger,
+    sentAtMs: Long,
+    displayName: String,
+    version: String,
+    platform: String,
+    deviceFamily: String?,
+    modelIdentifier: String?,
+    pushTransport: String? = null,
+  ): String =
+    buildJsonObject {
+      put("trigger", JsonPrimitive(trigger.rawValue))
+      put("sentAtMs", JsonPrimitive(sentAtMs))
+      put("displayName", JsonPrimitive(displayName))
+      put("version", JsonPrimitive(version))
+      put("platform", JsonPrimitive(platform))
+      deviceFamily?.trim()?.takeIf { it.isNotEmpty() }?.let { put("deviceFamily", JsonPrimitive(it)) }
+      modelIdentifier?.trim()?.takeIf { it.isNotEmpty() }?.let { put("modelIdentifier", JsonPrimitive(it)) }
+      pushTransport?.trim()?.takeIf { it.isNotEmpty() }?.let { put("pushTransport", JsonPrimitive(it)) }
+    }.toString()
+
+  fun decodeResponse(payloadJson: String?): ResponsePayload? {
+    if (payloadJson.isNullOrBlank()) return null
+    val obj =
+      try {
+        json.parseToJsonElement(payloadJson).asObjectOrNull()
+      } catch (_: Throwable) {
+        null
+      } ?: return null
+    return ResponsePayload(
+      ok = parseJsonBooleanFlag(obj, "ok"),
+      event = parseJsonString(obj, "event"),
+      handled = parseJsonBooleanFlag(obj, "handled"),
+      reason = parseJsonString(obj, "reason"),
+    )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -531,6 +531,54 @@ class GatewaySessionInvokeTest {
     }
   }
 
+  @Test
+  fun sendNodeEvent_preservesCompletedRpcAsSuccessWhenGatewayReturnsError() = runBlocking {
+    val json = testJson()
+    val connected = CompletableDeferred<Unit>()
+    val nodeEventParams = CompletableDeferred<JsonObject>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      startGatewayServer(json) { webSocket, id, method, frame ->
+        when (method) {
+          "connect" -> {
+            webSocket.send(connectResponseFrame(id))
+          }
+          "node.event" -> {
+            if (!nodeEventParams.isCompleted) {
+              nodeEventParams.complete(frame["params"]?.jsonObject ?: JsonObject(emptyMap()))
+            }
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":false,"error":{"code":"RATE_LIMITED","message":"slow down"}}""",
+            )
+            webSocket.close(1000, "done")
+          }
+        }
+      }
+
+    val harness =
+      createNodeHarness(
+        connected = connected,
+        lastDisconnect = lastDisconnect,
+      ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+    try {
+      connectNodeSession(harness.session, server.port)
+      awaitConnectedOrThrow(connected, lastDisconnect, server)
+
+      val sent =
+        harness.session.sendNodeEvent(
+          event = "agent.request",
+          payloadJson = """{"message":"restore"}""",
+        )
+      val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+
+      assertEquals(true, sent)
+      assertEquals("agent.request", params["event"]?.jsonPrimitive?.content)
+    } finally {
+      shutdownHarness(harness, server)
+    }
+  }
+
   private fun testJson(): Json = Json { ignoreUnknownKeys = true }
 
   private fun createNodeHarness(

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -474,6 +474,63 @@ class GatewaySessionInvokeTest {
     }
   }
 
+  @Test
+  fun sendNodeEventDetailed_sendsPresenceAlivePayloadAndReturnsStructuredResponse() = runBlocking {
+    val json = testJson()
+    val connected = CompletableDeferred<Unit>()
+    val nodeEventParams = CompletableDeferred<JsonObject>()
+    val lastDisconnect = AtomicReference("")
+    val server =
+      startGatewayServer(json) { webSocket, id, method, frame ->
+        when (method) {
+          "connect" -> {
+            webSocket.send(connectResponseFrame(id))
+          }
+          "node.event" -> {
+            if (!nodeEventParams.isCompleted) {
+              nodeEventParams.complete(frame["params"]?.jsonObject ?: JsonObject(emptyMap()))
+            }
+            val payload =
+              """{"ok":true,"event":"node.presence.alive","handled":true,"reason":"persisted"}"""
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":true,"payload":$payload}""",
+            )
+            webSocket.close(1000, "done")
+          }
+        }
+      }
+
+    val harness =
+      createNodeHarness(
+        connected = connected,
+        lastDisconnect = lastDisconnect,
+      ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
+
+    try {
+      connectNodeSession(harness.session, server.port)
+      awaitConnectedOrThrow(connected, lastDisconnect, server)
+
+      val result =
+        harness.session.sendNodeEventDetailed(
+          event = "node.presence.alive",
+          payloadJson = """{"trigger":"connect","sentAtMs":123}""",
+          timeoutMs = TEST_TIMEOUT_MS,
+        )
+      val params = withTimeout(TEST_TIMEOUT_MS) { nodeEventParams.await() }
+      val response = json.parseToJsonElement(result.payloadJson.orEmpty()).jsonObject
+      val payload = json.parseToJsonElement(params["payloadJSON"]?.jsonPrimitive?.content.orEmpty()).jsonObject
+
+      assertEquals(true, result.ok)
+      assertEquals("node.presence.alive", params["event"]?.jsonPrimitive?.content)
+      assertEquals("connect", payload["trigger"]?.jsonPrimitive?.content)
+      assertEquals("123", payload["sentAtMs"]?.jsonPrimitive?.content)
+      assertEquals(true, response["handled"]?.jsonPrimitive?.content?.toBooleanStrict())
+      assertEquals("persisted", response["reason"]?.jsonPrimitive?.content)
+    } finally {
+      shutdownHarness(harness, server)
+    }
+  }
+
   private fun testJson(): Json = Json { ignoreUnknownKeys = true }
 
   private fun createNodeHarness(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
@@ -30,10 +30,9 @@ class NodePresenceAliveBeaconTest {
   }
 
   @Test
-  fun shouldSkipRecentSuccess_requiresConnectedGatewayAndFreshSuccess() {
+  fun shouldSkipRecentSuccess_requiresFreshSuccess() {
     assertTrue(
       NodePresenceAliveBeacon.shouldSkipRecentSuccess(
-        isGatewayConnected = true,
         nowMs = 2_000,
         lastSuccessAtMs = 1_500,
         minIntervalMs = 1_000,
@@ -41,15 +40,13 @@ class NodePresenceAliveBeaconTest {
     )
     assertFalse(
       NodePresenceAliveBeacon.shouldSkipRecentSuccess(
-        isGatewayConnected = false,
         nowMs = 2_000,
-        lastSuccessAtMs = 1_500,
+        lastSuccessAtMs = null,
         minIntervalMs = 1_000,
       ),
     )
     assertFalse(
       NodePresenceAliveBeacon.shouldSkipRecentSuccess(
-        isGatewayConnected = true,
         nowMs = 3_000,
         lastSuccessAtMs = 1_500,
         minIntervalMs = 1_000,
@@ -101,5 +98,15 @@ class NodePresenceAliveBeaconTest {
     assertEquals("node.presence.alive", response?.event)
     assertEquals(true, response?.handled)
     assertEquals("persisted", response?.reason)
+  }
+
+  @Test
+  fun sanitizeReasonForLog_removesControlCharactersAndBoundsLength() {
+    val raw = "bad\nreason\t${"x".repeat(240)}"
+    val sanitized = NodePresenceAliveBeacon.sanitizeReasonForLog(raw)
+
+    assertFalse(sanitized.contains("\n"))
+    assertFalse(sanitized.contains("\t"))
+    assertEquals(200, sanitized.length)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
@@ -1,0 +1,105 @@
+package ai.openclaw.app.node
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NodePresenceAliveBeaconTest {
+  @Test
+  fun normalizeTrigger_acceptsKnownWireValues() {
+    assertEquals(NodePresenceAliveBeacon.Trigger.Connect, NodePresenceAliveBeacon.normalizeTrigger(" CONNECT "))
+    assertEquals(
+      NodePresenceAliveBeacon.Trigger.BackgroundAppRefresh,
+      NodePresenceAliveBeacon.normalizeTrigger("bg_app_refresh"),
+    )
+    assertEquals(
+      NodePresenceAliveBeacon.Trigger.SignificantLocation,
+      NodePresenceAliveBeacon.normalizeTrigger("significant_location"),
+    )
+  }
+
+  @Test
+  fun normalizeTrigger_mapsUnknownValuesToBackground() {
+    assertEquals(NodePresenceAliveBeacon.Trigger.Background, NodePresenceAliveBeacon.normalizeTrigger("watch_prompt_action"))
+    assertEquals(NodePresenceAliveBeacon.Trigger.Background, NodePresenceAliveBeacon.normalizeTrigger(""))
+  }
+
+  @Test
+  fun shouldSkipRecentSuccess_requiresConnectedGatewayAndFreshSuccess() {
+    assertTrue(
+      NodePresenceAliveBeacon.shouldSkipRecentSuccess(
+        isGatewayConnected = true,
+        nowMs = 2_000,
+        lastSuccessAtMs = 1_500,
+        minIntervalMs = 1_000,
+      ),
+    )
+    assertFalse(
+      NodePresenceAliveBeacon.shouldSkipRecentSuccess(
+        isGatewayConnected = false,
+        nowMs = 2_000,
+        lastSuccessAtMs = 1_500,
+        minIntervalMs = 1_000,
+      ),
+    )
+    assertFalse(
+      NodePresenceAliveBeacon.shouldSkipRecentSuccess(
+        isGatewayConnected = true,
+        nowMs = 3_000,
+        lastSuccessAtMs = 1_500,
+        minIntervalMs = 1_000,
+      ),
+    )
+  }
+
+  @Test
+  fun makePayloadJson_includesAndroidPresenceMetadata() {
+    val payload =
+      Json.parseToJsonElement(
+        NodePresenceAliveBeacon.makePayloadJson(
+          trigger = NodePresenceAliveBeacon.Trigger.Connect,
+          sentAtMs = 123,
+          displayName = "Pixel Node",
+          version = "2026.4.28",
+          platform = "Android 15 (SDK 35)",
+          deviceFamily = "Android",
+          modelIdentifier = "Google Pixel 9",
+        ),
+      ).jsonObject
+
+    assertEquals("connect", payload["trigger"]?.jsonPrimitive?.content)
+    assertEquals("123", payload["sentAtMs"]?.jsonPrimitive?.content)
+    assertEquals("Pixel Node", payload["displayName"]?.jsonPrimitive?.content)
+    assertEquals("2026.4.28", payload["version"]?.jsonPrimitive?.content)
+    assertEquals("Android 15 (SDK 35)", payload["platform"]?.jsonPrimitive?.content)
+    assertEquals("Android", payload["deviceFamily"]?.jsonPrimitive?.content)
+    assertEquals("Google Pixel 9", payload["modelIdentifier"]?.jsonPrimitive?.content)
+    assertNull(payload["pushTransport"])
+  }
+
+  @Test
+  fun decodeResponse_leavesOldGatewayAckUnhandled() {
+    val response = NodePresenceAliveBeacon.decodeResponse("""{"ok":true}""")
+
+    assertEquals(true, response?.ok)
+    assertNull(response?.handled)
+  }
+
+  @Test
+  fun decodeResponse_readsHandledPresenceResult() {
+    val response =
+      NodePresenceAliveBeacon.decodeResponse(
+        """{"ok":true,"event":"node.presence.alive","handled":true,"reason":"persisted"}""",
+      )
+
+    assertEquals(true, response?.ok)
+    assertEquals("node.presence.alive", response?.event)
+    assertEquals(true, response?.handled)
+    assertEquals("persisted", response?.reason)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodePresenceAliveBeaconTest.kt
@@ -11,25 +11,6 @@ import org.junit.Test
 
 class NodePresenceAliveBeaconTest {
   @Test
-  fun normalizeTrigger_acceptsKnownWireValues() {
-    assertEquals(NodePresenceAliveBeacon.Trigger.Connect, NodePresenceAliveBeacon.normalizeTrigger(" CONNECT "))
-    assertEquals(
-      NodePresenceAliveBeacon.Trigger.BackgroundAppRefresh,
-      NodePresenceAliveBeacon.normalizeTrigger("bg_app_refresh"),
-    )
-    assertEquals(
-      NodePresenceAliveBeacon.Trigger.SignificantLocation,
-      NodePresenceAliveBeacon.normalizeTrigger("significant_location"),
-    )
-  }
-
-  @Test
-  fun normalizeTrigger_mapsUnknownValuesToBackground() {
-    assertEquals(NodePresenceAliveBeacon.Trigger.Background, NodePresenceAliveBeacon.normalizeTrigger("watch_prompt_action"))
-    assertEquals(NodePresenceAliveBeacon.Trigger.Background, NodePresenceAliveBeacon.normalizeTrigger(""))
-  }
-
-  @Test
   fun shouldSkipRecentSuccess_requiresFreshSuccess() {
     assertTrue(
       NodePresenceAliveBeacon.shouldSkipRecentSuccess(
@@ -98,6 +79,13 @@ class NodePresenceAliveBeaconTest {
     assertEquals("node.presence.alive", response?.event)
     assertEquals(true, response?.handled)
     assertEquals("persisted", response?.reason)
+  }
+
+  @Test
+  fun decodeResponse_rejectsOversizedPayloadBeforeParsing() {
+    assertNull(
+      NodePresenceAliveBeacon.decodeResponse("""{"ok":true,"reason":"${"x".repeat(16 * 1024)}"}"""),
+    )
   }
 
   @Test

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -107,6 +107,17 @@ After the first successful pairing, Android auto-reconnects on launch:
 - Manual endpoint (if enabled), otherwise
 - The last discovered gateway (best-effort).
 
+### Presence alive beacons
+
+After the authenticated node session connects, and when the app moves to the background while the
+foreground service is still connected, Android calls `node.event` with
+`event: "node.presence.alive"`. The gateway records this as `lastSeenAtMs`/`lastSeenReason` on the
+paired node/device metadata only after the authenticated node device identity is known.
+
+The app counts the beacon as successfully recorded only when the gateway response includes
+`handled: true`. Older gateways may acknowledge `node.event` with `{ "ok": true }`; that response is
+compatible but does not count as a durable last-seen update.
+
 ### 4) Approve pairing (CLI)
 
 On the gateway machine:


### PR DESCRIPTION
## Summary

- Problem: Android nodes currently rely on live WebSocket presence; after disconnect, paired node metadata can lose the most recent authenticated app-alive signal.
- Why it matters: this keeps Android parity with the newly landed iOS `node.presence.alive` path and makes `node.list` last-seen metadata useful after reconnects/background transitions.
- What changed: Android publishes authenticated `node.presence.alive` events on node connect and throttled background transitions, checks `handled: true`, and documents the behavior.
- What did NOT change (scope boundary): no Android push/wake transport was added; this only uses the existing authenticated node session and `node.event` RPC.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63123
- Related #73330
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `NodePresenceAliveBeaconTest`, `GatewaySessionInvokeTest`
- Scenario the test should lock in: Android builds the presence payload, treats old `{ ok: true }` acks as not durable, and preserves the structured `node.event` response.
- Why this is the smallest reliable guardrail: it covers the Android-owned payload/response logic and the GatewaySession RPC framing without requiring a live device.
- Existing test that already covers this (if any): gateway server tests already cover persistence and auth identity boundaries for `node.presence.alive`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Android paired nodes now publish durable last-seen metadata after node connect and background transitions when the gateway supports `node.presence.alive`.

## Diagram (if applicable)

```text
Before:
Android node connects -> live presence only -> disconnect hides newest alive signal

After:
Android node connects/backgrounds -> node.presence.alive -> paired metadata lastSeenAtMs/lastSeenReason
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: Android sends an existing authenticated `node.event` RPC over the already-paired node session. Gateway persistence remains bounded by the authenticated node device identity.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Android Gradle `:app:testPlayDebugUnitTest`, Android SDK at `~/Library/Android/sdk`
- Model/provider: N/A
- Integration/channel (if any): Android node app
- Relevant config (redacted): N/A

### Steps

1. Build the Android play debug unit test graph.
2. Run `NodePresenceAliveBeaconTest`.
3. Run `GatewaySessionInvokeTest`.

### Expected

- Beacon helper payload/response behavior passes.
- GatewaySession sends `node.event` params with `payloadJSON` and returns the structured response.

### Actual

- Passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused command:

```bash
ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.node.NodePresenceAliveBeaconTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest
```

Result after rebase:

```text
BUILD SUCCESSFUL in 3s
30 actionable tasks: 30 up-to-date
```

Also ran `git diff --check`.

Note: `./gradlew :app:ktlintFormat` is currently blocked by pre-existing Android ktlint debt across unrelated files; this PR did not include those cleanup changes.

## Human Verification (required)

- Verified scenarios: focused Android unit tests for payload generation, response decoding, old gateway ack handling, and `node.event` structured response framing.
- Edge cases checked: recent-success throttling requires a connected gateway; old `{ "ok": true }` responses do not count as handled.
- What you did **not** verify: real-device background transition or full Android app install.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Older gateways acknowledge `node.event` without durable presence support.
  - Mitigation: Android treats that as an RPC ack only and requires `handled: true` before recording a local success.
