### PR TITLE
fix: clear stale disabled cron state

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -149,6 +149,48 @@ describe("applyJobPatch", () => {
     expect(job.delivery?.accountId).toBeUndefined();
   });
 
+  it("clears stale error and delivery noise when a job is disabled", () => {
+    const job = createIsolatedAgentTurnJob("job-disable-stale", {
+      mode: "announce",
+      channel: "telegram",
+      to: "123",
+    });
+    job.state = {
+      nextRunAtMs: 123,
+      runningAtMs: 124,
+      lastRunAtMs: 125,
+      lastRunStatus: "error",
+      lastStatus: "error",
+      lastError: "old failure",
+      lastDurationMs: 126,
+      consecutiveErrors: 2,
+      consecutiveSkipped: 1,
+      lastFailureAlertAtMs: 127,
+      lastDeliveryStatus: "unknown",
+      lastDeliveryError: "old delivery failure",
+      lastDelivered: false,
+    };
+
+    applyJobPatch(job, { enabled: false });
+
+    expect(job.enabled).toBe(false);
+    expect(job.state).toMatchObject({
+      lastRunAtMs: 125,
+      lastDurationMs: 126,
+    });
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.state.runningAtMs).toBeUndefined();
+    expect(job.state.lastRunStatus).toBeUndefined();
+    expect(job.state.lastStatus).toBeUndefined();
+    expect(job.state.lastError).toBeUndefined();
+    expect(job.state.consecutiveErrors).toBeUndefined();
+    expect(job.state.consecutiveSkipped).toBeUndefined();
+    expect(job.state.lastFailureAlertAtMs).toBeUndefined();
+    expect(job.state.lastDeliveryStatus).toBeUndefined();
+    expect(job.state.lastDeliveryError).toBeUndefined();
+    expect(job.state.lastDelivered).toBeUndefined();
+  });
+
   it("persists agentTurn payload.lightContext updates when editing existing jobs", () => {
     const job = createIsolatedAgentTurnJob("job-light-context", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -249,6 +249,26 @@ export function isJobEnabled(job: Pick<CronJob, "enabled">): boolean {
   return job.enabled ?? true;
 }
 
+export function clearDisabledJobStaleRuntimeState(job: Pick<CronJob, "enabled" | "state">): void {
+  if (isJobEnabled(job) || !job.state) {
+    return;
+  }
+
+  job.state.nextRunAtMs = undefined;
+  job.state.runningAtMs = undefined;
+  job.state.lastRunStatus = undefined;
+  job.state.lastStatus = undefined;
+  job.state.lastError = undefined;
+  job.state.lastErrorReason = undefined;
+  job.state.consecutiveErrors = undefined;
+  job.state.consecutiveSkipped = undefined;
+  job.state.lastFailureAlertAtMs = undefined;
+  job.state.scheduleErrorCount = undefined;
+  job.state.lastDeliveryStatus = undefined;
+  job.state.lastDeliveryError = undefined;
+  job.state.lastDelivered = undefined;
+}
+
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {
   if (!isJobEnabled(job)) {
     return undefined;
@@ -677,6 +697,7 @@ export function applyJobPatch(
   if (patch.state) {
     job.state = { ...job.state, ...patch.state };
   }
+  clearDisabledJobStaleRuntimeState(job);
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);
   }

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -208,6 +208,77 @@ describe("cron service store seam coverage", () => {
     );
   });
 
+  it("clears stale disabled-job error state loaded from the split state sidecar", async () => {
+    const { storePath } = await makeStorePath();
+    const statePath = storePath.replace(/\.json$/, "-state.json");
+    const job = createReloadCronJob({ id: "disabled-stale", enabled: false });
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({ version: 1, jobs: [{ ...job, state: {} }] }, null, 2),
+      "utf-8",
+    );
+    await fs.writeFile(
+      statePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: {
+            "disabled-stale": {
+              updatedAtMs: job.updatedAtMs,
+              state: {
+                nextRunAtMs: STORE_TEST_NOW + 60_000,
+                runningAtMs: STORE_TEST_NOW - 1,
+                lastRunAtMs: STORE_TEST_NOW - 30_000,
+                lastRunStatus: "error",
+                lastStatus: "error",
+                lastError: "old failure",
+                lastDurationMs: 600_009,
+                consecutiveErrors: 1,
+                consecutiveSkipped: 1,
+                lastFailureAlertAtMs: STORE_TEST_NOW - 10_000,
+                lastDeliveryStatus: "unknown",
+                lastDeliveryError: "unknown delivery target",
+                lastDelivered: false,
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state);
+    await persist(state, { skipBackup: true });
+
+    const loadedJob = findJobOrThrow(state, "disabled-stale");
+    expect(loadedJob.state.lastRunAtMs).toBe(STORE_TEST_NOW - 30_000);
+    expect(loadedJob.state.lastDurationMs).toBe(600_009);
+    expect(loadedJob.state.nextRunAtMs).toBeUndefined();
+    expect(loadedJob.state.runningAtMs).toBeUndefined();
+    expect(loadedJob.state.lastRunStatus).toBeUndefined();
+    expect(loadedJob.state.lastStatus).toBeUndefined();
+    expect(loadedJob.state.lastError).toBeUndefined();
+    expect(loadedJob.state.consecutiveErrors).toBeUndefined();
+    expect(loadedJob.state.consecutiveSkipped).toBeUndefined();
+    expect(loadedJob.state.lastFailureAlertAtMs).toBeUndefined();
+    expect(loadedJob.state.lastDeliveryStatus).toBeUndefined();
+    expect(loadedJob.state.lastDeliveryError).toBeUndefined();
+    expect(loadedJob.state.lastDelivered).toBeUndefined();
+
+    const persistedState = JSON.parse(await fs.readFile(statePath, "utf-8"));
+    expect(persistedState.jobs["disabled-stale"].state).toMatchObject({
+      lastRunAtMs: STORE_TEST_NOW - 30_000,
+      lastDurationMs: 600_009,
+    });
+    expect(persistedState.jobs["disabled-stale"].state.lastError).toBeUndefined();
+    expect(persistedState.jobs["disabled-stale"].state.lastDeliveryStatus).toBeUndefined();
+  });
+
   it("clears stale nextRunAtMs after force reload when cron schedule expression changes", async () => {
     const { storePath } = await makeStorePath();
     const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -5,7 +5,7 @@ import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import { clearDisabledJobStaleRuntimeState, recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
 function invalidateStaleNextRunOnScheduleChange(params: {
@@ -84,6 +84,7 @@ export async function ensureLoaded(
     if (typeof hydrated.enabled !== "boolean") {
       hydrated.enabled = true;
     }
+    clearDisabledJobStaleRuntimeState(hydrated);
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
     // Same shape: persisted jobs missing `sessionTarget` crash downstream
     // on any code path that dereferences `.startsWith` (e.g.


### PR DESCRIPTION
## Summary
- clear stale runtime error/skipped/delivery-noise fields when disabled cron jobs are patched/loaded
- sanitize split jobs-state sidecars on load/persist while preserving last run timestamp/duration
- add focused coverage for disabled cron state hygiene

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.jobs.test.ts src/cron/service/store.test.ts src/cron/service/timeout-policy.test.ts` (63 tests passed, per Rex)
- `vet "Cron disabled-job state hygiene: clear stale runtime error/delivery noise for disabled cron jobs while preserving last run timestamp/duration"` (No issues found, per Rex)

Task: 6a4cfa0f