### PR TITLE
fix(reply): short-circuit bare /reset and /new instead of calling provider with empty input

### DIFF
--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -166,5 +166,13 @@ export async function maybeHandleResetCommand(
     previousSessionEntry: params.previousSessionEntry,
     workspaceDir: params.workspaceDir,
   });
+  if (!resetTail) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: commandAction === "reset" ? "✅ Session reset." : "✅ New session started.",
+      },
+    };
+  }
   return null;
 }


### PR DESCRIPTION
## What

When a user sends a bare `/reset` or `/new` (no trailing text) on a non-ACP-bound channel, `maybeHandleResetCommand` emits the reset hooks and returns `null`, which lets the rest of the auto-reply pipeline continue and call the model provider with an empty body. The OpenAI Responses‑compatible API surfaces this as:

> One of "input" or "previous_response_id" or "prompt" or "conversation_id" must be provided.

…instead of the user getting a reset acknowledgement.

## Fix

After running the reset hooks, if `resetTail` is empty, stop the pipeline and reply with a plain ack:

- `/reset` → `✅ Session reset.`
- `/new` → `✅ New session started.`

`/reset <message>` and `/new <message>` are unchanged — they still fall through and seed the next turn with the tail, matching the existing intent.

This mirrors the existing behaviour on the ACP-bound branch above (which already returns an explicit ack when `resetTail` is empty).

## Diff

`src/auto-reply/reply/commands-reset.ts` — 8 lines added at the bottom of `maybeHandleResetCommand`, no other changes.

Fixes #73367