### PR TITLE
fix(ollama): restore thinking level support for discovered models

### DIFF
--- a/extensions/ollama/api.ts
+++ b/extensions/ollama/api.ts
@@ -10,6 +10,7 @@ export {
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
   isReasoningModelHeuristic,
+  ollamaDiscoveredThinkingModels,
   queryOllamaContextWindow,
   queryOllamaModelShowInfo,
   resolveOllamaApiBase,

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -24,12 +24,16 @@ const createConfiguredOllamaStreamFnMock = vi.hoisted(() =>
   vi.fn((_params: { model: unknown; providerBaseUrl?: string }) => ({}) as never),
 );
 
-vi.mock("./api.js", () => ({
-  promptAndConfigureOllama: promptAndConfigureOllamaMock,
-  ensureOllamaModelPulled: ensureOllamaModelPulledMock,
-  configureOllamaNonInteractive: vi.fn(),
-  buildOllamaProvider: buildOllamaProviderMock,
-}));
+vi.mock("./api.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api.js")>();
+  return {
+    ...actual,
+    promptAndConfigureOllama: promptAndConfigureOllamaMock,
+    ensureOllamaModelPulled: ensureOllamaModelPulledMock,
+    configureOllamaNonInteractive: vi.fn(),
+    buildOllamaProvider: buildOllamaProviderMock,
+  };
+});
 
 vi.mock("./src/stream.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./src/stream.js")>();
@@ -778,6 +782,29 @@ describe("ollama plugin", () => {
       levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
       defaultLevel: "off",
     });
+  });
+
+  it("exposes thinking levels for discovered thinking-capable models even without catalog", async () => {
+    const { ollamaDiscoveredThinkingModels } = await import("./api.js");
+    const provider = registerProvider();
+
+    // Simulate discovery: model was seen with thinking capability
+    ollamaDiscoveredThinkingModels.add("qwen3.6:35b-a3b-mxfp8");
+
+    // Without catalog, reasoning is undefined — but discovered set should kick in
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "ollama",
+        modelId: "qwen3.6:35b-a3b-mxfp8",
+        reasoning: undefined,
+      }),
+    ).toEqual({
+      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+      defaultLevel: "off",
+    });
+
+    // Clean up
+    ollamaDiscoveredThinkingModels.delete("qwen3.6:35b-a3b-mxfp8");
   });
 
   it("wraps native Ollama payloads with top-level think effort when thinking is enabled", () => {

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -22,6 +22,8 @@ import {
   buildOllamaProvider,
   configureOllamaNonInteractive,
   ensureOllamaModelPulled,
+  isReasoningModelHeuristic,
+  ollamaDiscoveredThinkingModels,
   promptAndConfigureOllama,
 } from "./api.js";
 import {
@@ -223,9 +225,11 @@ export default definePluginEntry({
       contributeResolvedModelCompat: ({ model }) =>
         usesOllamaOpenAICompatTransport(model) ? { supportsUsageInStreaming: true } : undefined,
       resolveReasoningOutputMode: () => "native",
-      resolveThinkingProfile: ({ reasoning }) => ({
+      resolveThinkingProfile: ({ reasoning, modelId }) => ({
         levels:
-          reasoning === true
+          reasoning === true ||
+          ollamaDiscoveredThinkingModels.has(modelId) ||
+          (reasoning === undefined && isReasoningModelHeuristic(modelId))
             ? [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }]
             : [{ id: "off" }],
         defaultLevel: "off",

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -33,6 +33,14 @@ const OLLAMA_SHOW_CONCURRENCY = 8;
 const OLLAMA_CONTEXT_ENRICH_LIMIT = 200;
 const MAX_OLLAMA_SHOW_CACHE_ENTRIES = 256;
 const ollamaModelShowInfoCache = new Map<string, Promise<OllamaModelShowInfo>>();
+
+/**
+ * Synchronous set of model IDs whose `/api/show` capabilities include
+ * "thinking".  Populated during {@link enrichOllamaModelsWithContext} so that
+ * the provider-level thinking-profile resolver can determine reasoning
+ * support without needing the async catalog.
+ */
+export const ollamaDiscoveredThinkingModels = new Set<string>();
 const OLLAMA_ALWAYS_BLOCKED_HOSTNAMES = new Set(["metadata.google.internal"]);
 
 export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string) {
@@ -221,6 +229,9 @@ export async function enrichOllamaModelsWithContext(
     const batchResults = await Promise.all(
       batch.map(async (model) => {
         const showInfo = await queryOllamaModelShowInfoCached(apiBase, model);
+        if (showInfo.capabilities?.includes("thinking")) {
+          ollamaDiscoveredThinkingModels.add(model.name);
+        }
         return Object.assign({}, model, {
           contextWindow: showInfo.contextWindow,
           capabilities: showInfo.capabilities,
@@ -318,4 +329,5 @@ export async function buildOllamaProvider(
 
 export function resetOllamaModelShowInfoCacheForTest(): void {
   ollamaModelShowInfoCache.clear();
+  ollamaDiscoveredThinkingModels.clear();
 }


### PR DESCRIPTION
## Summary

After [`7a45743`](https://github.com/openclaw/openclaw/commit/7a4574376a79568cf619ea16d01770d700a858cb) ("honor native model capabilities"), the Ollama provider's thinking-profile resolver gates on `reasoning === true` from the catalog context. Most call sites (e.g. `/think` command, `formatThinkingLevels`, `listThinkingLevels`) invoke the resolver **without a catalog**, so `reasoning` is always `undefined` and only the `off` level is returned — breaking thinking for every Ollama model.

## Root Cause

The flow:
1. `/think medium` → `isThinkingLevelSupported({ provider: "ollama", model: "qwen3.6:...", level: "medium" })`
2. → `resolveThinkingProfile({ provider: "ollama", model: "qwen3.6:...", catalog: undefined })`
3. → `resolveThinkingPolicyContext()` sets `reasoning: undefined` (no catalog to look up)
4. → Ollama plugin's `resolveThinkingProfile({ reasoning: undefined })` → `reasoning === true` is false → returns `[{ id: "off" }]`
5. → "Thinking level 'medium' is not supported. Use one of: off."

Before the regression, `reasoning` was determined by `isReasoningModelHeuristic(modelId)` which worked for models with "think"/"reason" in the name. After the commit, it relies on `/api/show` capabilities, but those are only available during discovery — not at thinking-level check time.

## Fix

Maintain a synchronous `Set<string>` (`ollamaDiscoveredThinkingModels`) of model IDs whose `/api/show` response includes the `thinking` capability, populated during `enrichOllamaModelsWithContext`. The thinking-profile resolver now checks three sources:

1. `reasoning === true` — catalog present (existing path)
2. `ollamaDiscoveredThinkingModels.has(modelId)` — post-discovery sync lookup (new)
3. `isReasoningModelHeuristic(modelId)` — name-based fallback when neither source has data (restored)

## Testing

- Existing tests pass (30/30 in `index.test.ts`, 13/13 in `provider-models.test.ts`)
- Added test: "exposes thinking levels for discovered thinking-capable models even without catalog" — verifies that adding a model to `ollamaDiscoveredThinkingModels` makes thinking levels available even with `reasoning: undefined`
- Fixed `vi.mock` for `./api.js` to use `importOriginal` pattern (was missing real exports like the new `ollamaDiscoveredThinkingModels`)

Closes #73366