### PR TITLE
fix(line): persist inbound media to ~/.openclaw/media/inbound/ via saveMediaBuffer

### DIFF
--- a/extensions/line/src/download.test.ts
+++ b/extensions/line/src/download.test.ts
@@ -1,9 +1,7 @@
-import fs from "node:fs";
-import path from "node:path";
-import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getMessageContentMock = vi.hoisted(() => vi.fn());
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: {
@@ -29,6 +27,15 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   logVerbose: () => {},
 }));
 
+vi.mock("openclaw/plugin-sdk/media-store", () => ({
+  saveMediaBuffer: (
+    buffer: Buffer,
+    contentType?: string,
+    subdir = "inbound",
+    maxBytes = 10 * 1024 * 1024,
+  ) => saveMediaBufferMock(buffer, contentType, subdir, maxBytes),
+}));
+
 let downloadLineMedia: typeof import("./download.js").downloadLineMedia;
 
 async function* chunks(parts: Buffer[]): AsyncGenerator<Buffer> {
@@ -45,41 +52,37 @@ describe("downloadLineMedia", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     getMessageContentMock.mockReset();
+    saveMediaBufferMock.mockReset();
+    saveMediaBufferMock.mockImplementation(
+      async (buffer: Buffer, contentType?: string) => ({
+        path: `/persisted/inbound/media-${contentType ?? "bin"}`,
+        size: buffer.length,
+        contentType,
+      }),
+    );
   });
 
-  it("does not derive temp file path from external messageId", async () => {
-    const messageId = "a/../../../../etc/passwd";
+  it("persists inbound media via saveMediaBuffer (inbound subdir)", async () => {
     const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0x00]);
     getMessageContentMock.mockResolvedValueOnce(chunks([jpeg]));
 
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
-
-    const result = await downloadLineMedia(messageId, "token");
-    const writtenPath = writeSpy.mock.calls[0]?.[0];
+    const result = await downloadLineMedia("mid", "token");
 
     expect(result.size).toBe(jpeg.length);
     expect(result.contentType).toBe("image/jpeg");
-    expect(typeof writtenPath).toBe("string");
-    if (typeof writtenPath !== "string") {
-      throw new Error("expected string temp file path");
-    }
-    expect(result.path).toBe(writtenPath);
-    expect(writtenPath).toContain("line-media-");
-    expect(writtenPath).toMatch(/\.jpg$/);
-    expect(writtenPath).not.toContain(messageId);
-    expect(writtenPath).not.toContain("..");
-
-    const tmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-    const rel = path.relative(tmpRoot, path.resolve(writtenPath));
-    expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
+    expect(saveMediaBufferMock).toHaveBeenCalledTimes(1);
+    const [bufferArg, contentTypeArg, subdirArg] = saveMediaBufferMock.mock.calls[0];
+    expect(Buffer.isBuffer(bufferArg)).toBe(true);
+    expect(contentTypeArg).toBe("image/jpeg");
+    expect(subdirArg).toBe("inbound");
+    expect(result.path).toBe("/persisted/inbound/media-image/jpeg");
   });
 
-  it("rejects oversized media before writing to disk", async () => {
+  it("rejects oversized media before persisting", async () => {
     getMessageContentMock.mockResolvedValueOnce(chunks([Buffer.alloc(4), Buffer.alloc(4)]));
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValue(undefined);
 
     await expect(downloadLineMedia("mid", "token", 7)).rejects.toThrow(/Media exceeds/i);
-    expect(writeSpy).not.toHaveBeenCalled();
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
   });
 
   it("classifies M4A ftyp major brand as audio/mp4", async () => {
@@ -87,14 +90,11 @@ describe("downloadLineMedia", () => {
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x4d, 0x34, 0x41, 0x20,
     ]);
     getMessageContentMock.mockResolvedValueOnce(chunks([m4aHeader]));
-    const writeSpy = vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
 
     const result = await downloadLineMedia("mid-audio", "token");
-    const writtenPath = writeSpy.mock.calls[0]?.[0];
 
     expect(result.contentType).toBe("audio/mp4");
-    expect(result.path).toMatch(/\.m4a$/);
-    expect(writtenPath).toBe(result.path);
+    expect(saveMediaBufferMock.mock.calls[0][1]).toBe("audio/mp4");
   });
 
   it("detects MP4 video from ftyp major brand (isom)", async () => {
@@ -102,11 +102,10 @@ describe("downloadLineMedia", () => {
       0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
     ]);
     getMessageContentMock.mockResolvedValueOnce(chunks([mp4]));
-    vi.spyOn(fs.promises, "writeFile").mockResolvedValueOnce(undefined);
 
     const result = await downloadLineMedia("mid-mp4", "token");
 
     expect(result.contentType).toBe("video/mp4");
-    expect(result.path).toMatch(/\.mp4$/);
+    expect(saveMediaBufferMock.mock.calls[0][1]).toBe("video/mp4");
   });
 });

--- a/extensions/line/src/download.ts
+++ b/extensions/line/src/download.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs";
 import { messagingApi } from "@line/bot-sdk";
+import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { buildRandomTempFilePath } from "openclaw/plugin-sdk/temp-path";
 import { lowercasePreservingWhitespace } from "openclaw/plugin-sdk/text-runtime";
 
 interface DownloadResult {
@@ -35,14 +34,11 @@ export async function downloadLineMedia(
 
   const buffer = Buffer.concat(chunks);
   const contentType = detectContentType(buffer);
-  const ext = getExtensionForContentType(contentType);
-  const filePath = buildRandomTempFilePath({ prefix: "line-media", extension: ext });
-
-  await fs.promises.writeFile(filePath, buffer);
-  logVerbose(`line: downloaded media ${messageId} to ${filePath} (${buffer.length} bytes)`);
+  const saved = await saveMediaBuffer(buffer, contentType, "inbound", maxBytes);
+  logVerbose(`line: persisted media ${messageId} to ${saved.path} (${buffer.length} bytes)`);
 
   return {
-    path: filePath,
+    path: saved.path,
     contentType,
     size: buffer.length,
   };
@@ -90,23 +86,4 @@ function detectContentType(buffer: Buffer): string {
   return "application/octet-stream";
 }
 
-function getExtensionForContentType(contentType: string): string {
-  switch (contentType) {
-    case "image/jpeg":
-      return ".jpg";
-    case "image/png":
-      return ".png";
-    case "image/gif":
-      return ".gif";
-    case "image/webp":
-      return ".webp";
-    case "video/mp4":
-      return ".mp4";
-    case "audio/mp4":
-      return ".m4a";
-    case "audio/mpeg":
-      return ".mp3";
-    default:
-      return ".bin";
-  }
-}
+


### PR DESCRIPTION
## What

LINE inbound media (images/audio/video from `downloadLineMedia`) is currently written to a random `line-media-*` file under the OpenClaw temp directory. The WhatsApp inbound monitor instead persists inbound media under `~/.openclaw/media/inbound/` via `saveMediaBuffer(..., "inbound", ...)`. That difference means LINE files don't survive temp-dir cleanup and break the cross-channel inbound media contract.

## Fix

Switch `downloadLineMedia` to call `saveMediaBuffer(buffer, contentType, "inbound", maxBytes)` (matching WhatsApp). Removed the now-unused `getExtensionForContentType` helper and `fs` / `buildRandomTempFilePath` imports — `saveMediaBuffer` already derives the extension from the detected MIME and writes under `media/inbound/` with the same secure mode policy.

The streaming size guard is preserved (returns the same `Media exceeds <N>MB limit` error before any write), and `saveMediaBuffer` re-enforces it on the final buffer.

## Tests

Updated `extensions/line/src/download.test.ts` to mock the new `saveMediaBuffer` dependency. All 4 existing cases pass:

```
✓ persists inbound media via saveMediaBuffer (inbound subdir)
✓ rejects oversized media before persisting
✓ classifies M4A ftyp major brand as audio/mp4
✓ detects MP4 video from ftyp major brand (isom)
```

The path-traversal-from-messageId concern from the prior test is now structurally moot: the path is computed by `saveMediaBuffer` from a random UUID, not from `messageId`.

## Diff

- `extensions/line/src/download.ts` — swap temp write for `saveMediaBuffer`, drop unused helper/imports.
- `extensions/line/src/download.test.ts` — mock `openclaw/plugin-sdk/media-store` instead of asserting on temp path semantics.

Fixes #73370