### PR TITLE
fix(discord): cool down Cloudflare HTML 429 REST failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Discord: cool down Cloudflare/Error 1015 HTML 429 REST failures during startup application lookup and allowlist guild fetches, sanitizing HTML bodies and honoring Retry-After before falling back to a conservative cooldown. Fixes #38853; refs #58173. Thanks @djgeorg3 and @Garyko0730.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Security/audit: recognize dangerous node command IDs as valid `gateway.nodes.denyCommands` entries, so audit only warns on real typos or unsupported patterns. (#56923) Thanks @chziyue.
 - Telegram/exec approvals: stop treating general Telegram chat allowlists and `defaultTo` routes as native exec approvers; Telegram now uses explicit `execApprovals.approvers` or owner identity from `commands.ownerAllowFrom`, matching the first-pairing owner bootstrap path. Thanks @pashpashpash.

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -100,6 +100,75 @@ describe("fetchDiscord", () => {
     expect(message).not.toContain("<html");
   });
 
+  it("waits for the full fallback cooldown before retrying guild metadata", async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      if (calls.length === 1) {
+        return new Response("<html><title>Error 1015</title></html>", {
+          status: 429,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      return jsonResponse([{ id: "1", name: "Guild" }], 200);
+    });
+
+    try {
+      const result = fetchDiscord<Array<{ id: string; name: string }>>(
+        "/users/@me/guilds",
+        "test",
+        fetcher,
+        { retry: { attempts: 2, jitter: 0 } },
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(59_999);
+      expect(calls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toHaveLength(1);
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toContain("/users/@me/guilds");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for the full Retry-After cooldown before retrying application metadata", async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      if (calls.length === 1) {
+        return new Response("<html><title>Error 1015</title></html>", {
+          status: 429,
+          headers: { "content-type": "text/html", "retry-after": "120" },
+        });
+      }
+      return jsonResponse({ id: "app" }, 200);
+    });
+
+    try {
+      const result = fetchDiscord<{ id: string }>("/oauth2/applications/@me", "test", fetcher, {
+        retry: { attempts: 2, jitter: 0 },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(calls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toEqual({ id: "app" });
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toContain("/oauth2/applications/@me");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("retries rate limits before succeeding", async () => {
     let calls = 0;
     const fetcher = withFetchPreconnect(async () => {

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -1,6 +1,6 @@
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchDiscord } from "./api.js";
+import { DiscordApiError, fetchDiscord } from "./api.js";
 import { jsonResponse } from "./test-http-helpers.js";
 
 describe("fetchDiscord", () => {
@@ -46,6 +46,60 @@ describe("fetchDiscord", () => {
     ).rejects.toThrow("Discord API /users/@me/guilds failed (404): Not Found");
   });
 
+  it("sanitizes Cloudflare HTML rate limits and applies a fallback cooldown", async () => {
+    const fetcher = withFetchPreconnect(
+      async () =>
+        new Response(
+          "<!doctype html><html><head><title>Error 1015</title></head><body><h1>You are being rate limited</h1><script>raw()</script></body></html>",
+          { status: 429, headers: { "content-type": "text/html" } },
+        ),
+    );
+
+    let error: unknown;
+    try {
+      await fetchDiscord("/users/@me/guilds", "test", fetcher, {
+        retry: { attempts: 1 },
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(DiscordApiError);
+    expect((error as DiscordApiError).retryAfter).toBe(60);
+    const message = String(error);
+    expect(message).toContain("Discord API /users/@me/guilds failed (429)");
+    expect(message).toContain("rate limited by Discord upstream");
+    expect(message).toContain("Error 1015");
+    expect(message).not.toContain("<html");
+    expect(message).not.toContain("<script");
+  });
+
+  it("honors Retry-After for Cloudflare HTML application lookup rate limits", async () => {
+    const fetcher = withFetchPreconnect(
+      async () =>
+        new Response("<html><title>Error 1015</title><body>rate limited</body></html>", {
+          status: 429,
+          headers: { "content-type": "text/html", "retry-after": "7" },
+        }),
+    );
+
+    let error: unknown;
+    try {
+      await fetchDiscord("/oauth2/applications/@me", "test", fetcher, {
+        retry: { attempts: 1 },
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(DiscordApiError);
+    expect((error as DiscordApiError).retryAfter).toBe(7);
+    const message = String(error);
+    expect(message).toContain("Discord API /oauth2/applications/@me failed (429)");
+    expect(message).toContain("Error 1015");
+    expect(message).not.toContain("<html");
+  });
+
   it("retries rate limits before succeeding", async () => {
     let calls = 0;
     const fetcher = withFetchPreconnect(async () => {
@@ -59,6 +113,30 @@ describe("fetchDiscord", () => {
           },
           429,
         );
+      }
+      return jsonResponse([{ id: "1", name: "Guild" }], 200);
+    });
+
+    const result = await fetchDiscord<Array<{ id: string; name: string }>>(
+      "/users/@me/guilds",
+      "test",
+      fetcher,
+      { retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 } },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(calls).toBe(2);
+  });
+
+  it("retries Cloudflare HTML rate limits before succeeding", async () => {
+    let calls = 0;
+    const fetcher = withFetchPreconnect(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response("<html><title>Error 1015</title></html>", {
+          status: 429,
+          headers: { "content-type": "text/html", "retry-after": "0" },
+        });
       }
       return jsonResponse([{ id: "1", name: "Guild" }], 200);
     });

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -9,7 +9,7 @@ const DISCORD_API_BASE = "https://discord.com/api/v10";
 const DISCORD_API_RETRY_DEFAULTS = {
   attempts: 3,
   minDelayMs: 500,
-  maxDelayMs: 30_000,
+  maxDelayMs: 5 * 60_000,
   jitter: 0.1,
 };
 const DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS = 60;
@@ -141,6 +141,18 @@ export class DiscordApiError extends Error {
   }
 }
 
+function getDiscordApiRetryAfterMs(err: unknown): number | undefined {
+  return err instanceof DiscordApiError && typeof err.retryAfter === "number"
+    ? err.retryAfter * 1000
+    : undefined;
+}
+
+function getEffectiveMaxDelayMs(retryConfig: Required<RetryConfig>): number {
+  return Number.isFinite(retryConfig.maxDelayMs) && retryConfig.maxDelayMs > 0
+    ? retryConfig.maxDelayMs
+    : Number.POSITIVE_INFINITY;
+}
+
 export type DiscordFetchOptions = {
   retry?: RetryConfig;
   label?: string;
@@ -158,6 +170,7 @@ export async function fetchDiscord<T>(
   }
 
   const retryConfig = resolveRetryConfig(DISCORD_API_RETRY_DEFAULTS, options?.retry);
+  const maxDelayMs = getEffectiveMaxDelayMs(retryConfig);
   return retryAsync(
     async () => {
       const res = await fetchImpl(`${DISCORD_API_BASE}${path}`, {
@@ -182,11 +195,14 @@ export async function fetchDiscord<T>(
     {
       ...retryConfig,
       label: options?.label ?? path,
-      shouldRetry: (err) => err instanceof DiscordApiError && err.status === 429,
-      retryAfterMs: (err) =>
-        err instanceof DiscordApiError && typeof err.retryAfter === "number"
-          ? err.retryAfter * 1000
-          : undefined,
+      shouldRetry: (err) => {
+        if (!(err instanceof DiscordApiError) || err.status !== 429) {
+          return false;
+        }
+        const retryAfterMs = getDiscordApiRetryAfterMs(err);
+        return retryAfterMs === undefined || retryAfterMs <= maxDelayMs;
+      },
+      retryAfterMs: getDiscordApiRetryAfterMs,
     },
   );
 }

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -12,6 +12,8 @@ const DISCORD_API_RETRY_DEFAULTS = {
   maxDelayMs: 30_000,
   jitter: 0.1,
 };
+const DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS = 60;
+const DISCORD_API_ERROR_DETAIL_MAX_CHARS = 240;
 
 type DiscordApiErrorPayload = {
   message?: string;
@@ -36,6 +38,22 @@ function parseDiscordApiErrorPayload(text: string): DiscordApiErrorPayload | nul
   return null;
 }
 
+function parseRetryAfterHeaderSeconds(response: Response): number | undefined {
+  const header = response.headers.get("Retry-After");
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds;
+  }
+  const retryAt = Date.parse(header);
+  if (!Number.isFinite(retryAt)) {
+    return undefined;
+  }
+  return Math.max(0, (retryAt - Date.now()) / 1000);
+}
+
 function parseRetryAfterSeconds(text: string, response: Response): number | undefined {
   const payload = parseDiscordApiErrorPayload(text);
   const retryAfter =
@@ -45,12 +63,7 @@ function parseRetryAfterSeconds(text: string, response: Response): number | unde
   if (retryAfter !== undefined) {
     return retryAfter;
   }
-  const header = response.headers.get("Retry-After");
-  if (!header) {
-    return undefined;
-  }
-  const parsed = Number(header);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  return parseRetryAfterHeaderSeconds(response);
 }
 
 function formatRetryAfterSeconds(value: number | undefined): string | undefined {
@@ -61,7 +74,33 @@ function formatRetryAfterSeconds(value: number | undefined): string | undefined 
   return `${rounded}s`;
 }
 
-function formatDiscordApiErrorText(text: string): string | undefined {
+function summarizeNonJsonDiscordApiErrorText(text: string): string | undefined {
+  const withoutTags = text
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!withoutTags) {
+    return undefined;
+  }
+  return withoutTags.slice(0, DISCORD_API_ERROR_DETAIL_MAX_CHARS);
+}
+
+function isHtmlDiscordApiErrorText(text: string, response: Response): boolean {
+  const contentType = response.headers.get("content-type") ?? "";
+  return (
+    /\bhtml\b/i.test(contentType) ||
+    /^\s*<!doctype\s+html\b/i.test(text) ||
+    /^\s*<html\b/i.test(text)
+  );
+}
+
+function formatDiscordApiErrorText(text: string, response: Response): string | undefined {
   const trimmed = text.trim();
   if (!trimmed) {
     return undefined;
@@ -69,7 +108,17 @@ function formatDiscordApiErrorText(text: string): string | undefined {
   const payload = parseDiscordApiErrorPayload(trimmed);
   if (!payload) {
     const looksJson = trimmed.startsWith("{") && trimmed.endsWith("}");
-    return looksJson ? "unknown error" : trimmed;
+    if (looksJson) {
+      return "unknown error";
+    }
+    if (isHtmlDiscordApiErrorText(trimmed, response)) {
+      const summary = summarizeNonJsonDiscordApiErrorText(trimmed);
+      if (!summary) {
+        return response.status === 429 ? "rate limited by Discord upstream" : undefined;
+      }
+      return response.status === 429 ? `rate limited by Discord upstream: ${summary}` : summary;
+    }
+    return trimmed.slice(0, DISCORD_API_ERROR_DETAIL_MAX_CHARS);
   }
   const message =
     typeof payload.message === "string" && payload.message.trim()
@@ -116,9 +165,12 @@ export async function fetchDiscord<T>(
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
-        const detail = formatDiscordApiErrorText(text);
+        const detail = formatDiscordApiErrorText(text, res);
         const suffix = detail ? `: ${detail}` : "";
-        const retryAfter = res.status === 429 ? parseRetryAfterSeconds(text, res) : undefined;
+        const retryAfter =
+          res.status === 429
+            ? (parseRetryAfterSeconds(text, res) ?? DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS)
+            : undefined;
         throw new DiscordApiError(
           `Discord API ${path} failed (${res.status})${suffix}`,
           res.status,

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -2,8 +2,9 @@ import { EventEmitter } from "node:events";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT } from "./gateway-handle.js";
 
-const { baseConnectSpy, GatewayIntents, GatewayPlugin } = vi.hoisted(() => {
+const { baseConnectSpy, fetchWithSsrFGuardMock, GatewayIntents, GatewayPlugin } = vi.hoisted(() => {
   const baseConnectSpy = vi.fn<(resume: boolean) => void>();
+  const fetchWithSsrFGuardMock = vi.fn();
 
   const GatewayIntents = {
     Guilds: 1 << 0,
@@ -53,7 +54,7 @@ const { baseConnectSpy, GatewayIntents, GatewayPlugin } = vi.hoisted(() => {
     }
   }
 
-  return { baseConnectSpy, GatewayIntents, GatewayPlugin };
+  return { baseConnectSpy, fetchWithSsrFGuardMock, GatewayIntents, GatewayPlugin };
 });
 
 vi.mock("@buape/carbon/gateway", () => ({ GatewayIntents, GatewayPlugin }));
@@ -74,6 +75,10 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   danger: (value: string) => value,
 }));
 
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
 describe("SafeGatewayPlugin.connect()", () => {
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
   let resolveDiscordGatewayIntents: typeof import("./gateway-plugin.js").resolveDiscordGatewayIntents;
@@ -89,6 +94,7 @@ describe("SafeGatewayPlugin.connect()", () => {
 
   beforeEach(() => {
     baseConnectSpy.mockClear();
+    fetchWithSsrFGuardMock.mockReset();
   });
 
   it("includes GuildVoiceStates when voice is enabled by default", () => {
@@ -240,6 +246,40 @@ describe("SafeGatewayPlugin.connect()", () => {
       (plugin as unknown as { options?: { gatewayInfoTimeoutMs?: number } }).options
         ?.gatewayInfoTimeoutMs,
     ).toBeUndefined();
+  });
+
+  it("uses default gateway metadata for Cloudflare HTML rate limits without logging raw HTML", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("<html><title>Error 1015</title><body>rate limited</body></html>", {
+        status: 429,
+        headers: { "content-type": "text/html" },
+      }),
+      release: vi.fn(),
+    });
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const registerClient = vi.fn();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+      __testing: { registerClient },
+    });
+
+    await plugin.registerClient({ options: { token: "test" } } as Parameters<
+      typeof plugin.registerClient
+    >[0]);
+
+    expect(registerClient).toHaveBeenCalled();
+    expect((plugin as unknown as { gatewayInfo?: { url?: string } }).gatewayInfo?.url).toBe(
+      "wss://gateway.discord.gg/",
+    );
+    const logs = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(logs).toContain("gateway metadata lookup failed transiently");
+    expect(logs).toContain("Error 1015");
+    expect(logs).not.toContain("<html");
   });
 
   it("clears stale firstHeartbeatTimeout before delegating to super when isConnecting=true", () => {

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -140,15 +140,42 @@ export function resolveDiscordGatewayInfoTimeoutMs(params?: {
 }
 
 function summarizeGatewayResponseBody(body: string): string {
-  const normalized = body.trim().replace(/\s+/g, " ");
+  const normalized = body
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .trim()
+    .replace(/\s+/g, " ");
   if (!normalized) {
     return "<empty>";
   }
   return normalized.slice(0, 240);
 }
 
+function isDiscordGatewayHtmlRateLimitResponse(status: number, body: string): boolean {
+  if (status !== 429) {
+    return false;
+  }
+  const trimmed = body.trim();
+  const normalized = normalizeLowercaseStringOrEmpty(trimmed);
+  return (
+    /^\s*<!doctype\s+html\b/i.test(trimmed) ||
+    /^\s*<html\b/i.test(trimmed) ||
+    normalized.includes("error 1015") ||
+    normalized.includes("cloudflare") ||
+    normalized.includes("rate limit")
+  );
+}
+
 function isTransientDiscordGatewayResponse(status: number, body: string): boolean {
   if (status >= 500) {
+    return true;
+  }
+  if (isDiscordGatewayHtmlRateLimitResponse(status, body)) {
     return true;
   }
   const normalized = normalizeLowercaseStringOrEmpty(body);

--- a/extensions/discord/src/probe.intents.test.ts
+++ b/extensions/discord/src/probe.intents.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { resolveDiscordPrivilegedIntentsFromFlags } from "./probe.js";
+import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { fetchDiscordApplicationId, resolveDiscordPrivilegedIntentsFromFlags } from "./probe.js";
+import { jsonResponse } from "./test-http-helpers.js";
 
 describe("resolveDiscordPrivilegedIntentsFromFlags", () => {
   it("reports disabled when no bits set", () => {
@@ -35,5 +37,29 @@ describe("resolveDiscordPrivilegedIntentsFromFlags", () => {
       guildMembers: "enabled",
       messageContent: "enabled",
     });
+  });
+
+  it("retries Cloudflare HTML rate limits during application id lookup", async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const fetcher = withFetchPreconnect(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response("<html><title>Error 1015</title></html>", {
+          status: 429,
+          headers: { "content-type": "text/html", "retry-after": "0" },
+        });
+      }
+      return jsonResponse({ id: "app-1" });
+    });
+
+    try {
+      const result = fetchDiscordApplicationId("test", 1_000, fetcher);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(result).resolves.toBe("app-1");
+      expect(calls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/discord/src/probe.ts
+++ b/extensions/discord/src/probe.ts
@@ -2,6 +2,7 @@ import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { fetchWithTimeout } from "openclaw/plugin-sdk/text-runtime";
+import { DiscordApiError, fetchDiscord } from "./api.js";
 import { normalizeDiscordToken } from "./token.js";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
@@ -40,31 +41,29 @@ async function fetchDiscordApplicationMe(
   fetcher: typeof fetch,
 ): Promise<{ id?: string; flags?: number } | undefined> {
   try {
-    const appResponse = await fetchDiscordApplicationMeResponse(token, timeoutMs, fetcher);
-    if (!appResponse || !appResponse.ok) {
+    const normalized = normalizeDiscordToken(token, "channels.discord.token");
+    if (!normalized) {
       return undefined;
     }
-    return (await appResponse.json()) as { id?: string; flags?: number };
+    return await fetchDiscord<{ id?: string; flags?: number }>(
+      "/oauth2/applications/@me",
+      normalized,
+      createDiscordTimeoutFetch(fetcher, timeoutMs),
+    );
   } catch {
     return undefined;
   }
 }
 
-async function fetchDiscordApplicationMeResponse(
-  token: string,
-  timeoutMs: number,
-  fetcher: typeof fetch,
-): Promise<Response | undefined> {
-  const normalized = normalizeDiscordToken(token, "channels.discord.token");
-  if (!normalized) {
-    return undefined;
-  }
-  return await fetchWithTimeout(
-    `${DISCORD_API_BASE}/oauth2/applications/@me`,
-    { headers: { Authorization: `Bot ${normalized}` } },
-    timeoutMs,
-    getResolvedFetch(fetcher),
-  );
+function createDiscordTimeoutFetch(fetcher: typeof fetch, timeoutMs: number): typeof fetch {
+  const fetchImpl = getResolvedFetch(fetcher);
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    fetchWithTimeout(
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+      init ?? {},
+      timeoutMs,
+      fetchImpl,
+    )) as typeof fetch;
 }
 
 export function resolveDiscordPrivilegedIntentsFromFlags(
@@ -212,20 +211,22 @@ export async function fetchDiscordApplicationId(
     return undefined;
   }
   try {
-    const res = await fetchDiscordApplicationMeResponse(token, timeoutMs, fetcher);
-    if (!res) {
+    const json = await fetchDiscord<{ id?: string }>(
+      "/oauth2/applications/@me",
+      normalized,
+      createDiscordTimeoutFetch(fetcher, timeoutMs),
+    );
+    if (json?.id) {
+      return json.id;
+    }
+    return undefined;
+  } catch (error) {
+    if (error instanceof DiscordApiError) {
+      if (error.status === 429) {
+        throw error;
+      }
       return undefined;
     }
-    if (res.ok) {
-      const json = (await res.json()) as { id?: string };
-      if (json?.id) {
-        return json.id;
-      }
-    }
-    // Non-ok HTTP response (401, 403, etc.) — fail fast so credential
-    // errors surface immediately rather than being masked by the fallback.
-    return undefined;
-  } catch {
     // Transport / timeout error — fall back to extracting the application
     // ID directly from the token to keep the bot starting.
     return parseApplicationIdFromToken(token);


### PR DESCRIPTION
Fixes #38853.

This teaches the Discord REST startup/allowlist path to classify Cloudflare/Error 1015 and other non-JSON HTML HTTP 429 responses as rate-limit cooldown signals instead of treating the HTML body as an ordinary Discord API error. The fix should sanitize/summarize non-JSON response bodies before logging or throwing, honor Retry-After when present, and fall back to a conservative cooldown when it is absent.

Credit to @djgeorg3 for the original #38853 report and reproduction details. Related closed context: #58173 covered invalid/revoked token reconnect behavior already implemented on main; this PR handles the remaining Cloudflare HTML 429 REST path.

Validation: pnpm check:changed. Add focused regression coverage for /users/@me/guilds and /oauth2/applications/@me returning Cloudflare/Error 1015 HTML 429 responses.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156979-autonomous-smoke
- Source PRs: none
- Credit: Credit @djgeorg3 for reporting #38853 and the Cloudflare Error 1015 retry loop.; Mention that #58173 is related closed context for invalid-token reconnect behavior, but do not present it as the same root cause.; Do not include exploit or sensitive details from #22003; it remains routed to central security handling.
- Validation: pnpm check:changed
