### PR TITLE
fix: resolve providerless configured image models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: resolve providerless `agents.defaults.imageModel` primary and fallback refs from uniquely configured image-capable provider models, and fail ambiguous bare refs before routing them through the default text provider. Fixes #38816; refs #60280. Thanks @alainasclaw and @wudano1.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -920,6 +920,128 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("resolves providerless explicit image models from unique configured image-capable providers", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "moondream",
+              fallbacks: ["qwen2.5vl:7b"],
+            },
+          },
+        },
+        models: {
+          providers: {
+            "ollama-local": {
+              baseUrl: "http://127.0.0.1:11434/v1",
+              api: "ollama",
+              models: [makeModelDefinition("ollama-local/moondream", ["text", "image"])],
+            },
+            litellm: {
+              baseUrl: "https://litellm.example.invalid/v1",
+              api: "openai-completions",
+              models: [makeModelDefinition("qwen2.5vl:7b", ["text", "image"])],
+            },
+          },
+        },
+      };
+
+      expect(resolveImageModelConfigForTool({ cfg, agentDir })).toEqual({
+        primary: "ollama-local/moondream",
+        fallbacks: ["litellm/qwen2.5vl:7b"],
+      });
+    });
+  });
+
+  it("runs providerless explicit image models on the inferred configured provider", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
+      await withTempAgentDir(async (agentDir) => {
+        const describeImage = vi.fn(async (params: ImageDescriptionRequest) => ({
+          text: "ok",
+          model: params.model,
+        }));
+        installImageUnderstandingProviderStubs({
+          id: "ollama-local",
+          capabilities: ["image"],
+          describeImage,
+        });
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              imageModel: { primary: "moondream" },
+            },
+          },
+          models: {
+            providers: {
+              "ollama-local": {
+                baseUrl: "http://127.0.0.1:11434/v1",
+                api: "ollama",
+                models: [makeModelDefinition("moondream", ["text", "image"])],
+              },
+            },
+          },
+        };
+
+        const tool = createRequiredImageTool({ config: cfg, agentDir, workspaceDir });
+        await expectImageToolExecOk(tool, imagePath);
+
+        expect(describeImage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            provider: "ollama-local",
+            model: "moondream",
+          }),
+        );
+      });
+    });
+  });
+
+  it("rejects ambiguous providerless explicit image models", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: { primary: "moondream" },
+          },
+        },
+        models: {
+          providers: {
+            "ollama-a": {
+              baseUrl: "http://127.0.0.1:11434/v1",
+              api: "ollama",
+              models: [makeModelDefinition("moondream", ["text", "image"])],
+            },
+            "ollama-b": {
+              baseUrl: "http://127.0.0.1:11435/v1",
+              api: "ollama",
+              models: [makeModelDefinition("moondream", ["text", "image"])],
+            },
+          },
+        },
+      };
+
+      expect(() => resolveImageModelConfigForTool({ cfg, agentDir })).toThrow(
+        /Image model "moondream" is missing a provider and matches multiple image-capable configured providers \(ollama-a, ollama-b\)/,
+      );
+    });
+  });
+
+  it("rejects unknown providerless explicit image models before default-provider fallback", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            imageModel: { primary: "moondream" },
+          },
+        },
+      };
+
+      expect(() => resolveImageModelConfigForTool({ cfg, agentDir })).toThrow(
+        /Image model "moondream" is missing a provider and does not match an image-capable model in models\.providers/,
+      );
+    });
+  });
+
   it("keeps image tool available when primary model supports images (for explicit requests)", async () => {
     // When the primary model supports images, we still keep the tool available
     // because images are auto-injected into prompts. The tool description is

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -94,6 +94,119 @@ export const __testing = {
   },
 } as const;
 
+type ConfiguredImageModelMatch = {
+  provider: string;
+  model: string;
+};
+
+function formatConfiguredImageModelRef(provider: string, model: string): string {
+  const providerId = normalizeMediaProviderId(provider);
+  const modelId = model.trim();
+  const slash = modelId.indexOf("/");
+  const modelProvider = slash === -1 ? "" : normalizeMediaProviderId(modelId.slice(0, slash));
+  return modelProvider && modelProvider === providerId ? modelId : `${providerId}/${modelId}`;
+}
+
+function findConfiguredImageModelMatches(params: {
+  cfg?: OpenClawConfig;
+  model: string;
+}): ConfiguredImageModelMatch[] {
+  const providers = params.cfg?.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return [];
+  }
+  const wanted = params.model.trim().toLowerCase();
+  if (!wanted) {
+    return [];
+  }
+  const matches: ConfiguredImageModelMatch[] = [];
+  const seen = new Set<string>();
+  for (const [providerKey, providerCfg] of Object.entries(providers)) {
+    const provider = normalizeMediaProviderId(providerKey);
+    if (!provider) {
+      continue;
+    }
+    for (const model of providerCfg?.models ?? []) {
+      const modelId = model?.id?.trim();
+      const providerPrefixedModelId = modelId?.toLowerCase() ?? "";
+      const providerPrefix = `${provider}/`;
+      const comparableModelId = providerPrefixedModelId.startsWith(providerPrefix)
+        ? providerPrefixedModelId.slice(providerPrefix.length)
+        : providerPrefixedModelId;
+      if (
+        !modelId ||
+        (providerPrefixedModelId !== wanted && comparableModelId !== wanted) ||
+        !Array.isArray(model?.input) ||
+        !model.input.includes("image")
+      ) {
+        continue;
+      }
+      const key = `${provider}/${modelId.toLowerCase()}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      matches.push({ provider, model: modelId });
+    }
+  }
+  return matches;
+}
+
+function resolveProviderlessExplicitImageModelRef(params: {
+  cfg?: OpenClawConfig;
+  raw: string;
+}): string {
+  const ref = params.raw.trim();
+  if (!ref || ref.includes("/")) {
+    return ref;
+  }
+  const matches = findConfiguredImageModelMatches({
+    cfg: params.cfg,
+    model: ref,
+  });
+  if (matches.length === 1) {
+    const match = matches[0];
+    return formatConfiguredImageModelRef(match.provider, match.model);
+  }
+  if (matches.length > 1) {
+    const providers = matches
+      .map((match) => match.provider)
+      .toSorted()
+      .join(", ");
+    throw new Error(
+      `Image model "${ref}" is missing a provider and matches multiple image-capable configured providers (${providers}). Set agents.defaults.imageModel to a provider-qualified ref such as "${matches[0].provider}/${ref}".`,
+    );
+  }
+  throw new Error(
+    `Image model "${ref}" is missing a provider and does not match an image-capable model in models.providers. Set agents.defaults.imageModel to a provider-qualified ref such as "provider/${ref}".`,
+  );
+}
+
+function resolveExplicitImageModelConfig(params: {
+  cfg?: OpenClawConfig;
+  explicit: ImageModelConfig;
+}): ImageModelConfig {
+  const primary = params.explicit.primary?.trim()
+    ? resolveProviderlessExplicitImageModelRef({
+        cfg: params.cfg,
+        raw: params.explicit.primary,
+      })
+    : undefined;
+  const fallbacks = (params.explicit.fallbacks ?? [])
+    .map((fallback) =>
+      resolveProviderlessExplicitImageModelRef({
+        cfg: params.cfg,
+        raw: fallback,
+      }),
+    )
+    .filter((fallback) => fallback.length > 0);
+  return {
+    ...(primary ? { primary } : {}),
+    ...(fallbacks.length > 0 ? { fallbacks } : {}),
+    ...(params.explicit.timeoutMs !== undefined ? { timeoutMs: params.explicit.timeoutMs } : {}),
+  };
+}
+
 function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requestedMaxTokens = 4096) {
   if (
     typeof modelMaxTokens !== "number" ||
@@ -123,7 +236,10 @@ export function resolveImageModelConfigForTool(params: {
   // The tool description is adjusted via modelHasVision to discourage redundant usage.
   const explicit = coerceImageModelConfig(params.cfg);
   if (hasToolModelConfig(explicit)) {
-    return explicit;
+    return resolveExplicitImageModelConfig({
+      cfg: params.cfg,
+      explicit,
+    });
   }
 
   const primary = resolveDefaultModelRef(params.cfg);


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/38816.

This should keep the existing provider-prefixed Ollama image routing behavior from https://github.com/openclaw/openclaw/issues/60280 intact, while covering the remaining providerless agents.defaults.imageModel case. The patch should be narrow: adjust image model resolution so bare configured image model ids such as moondream or qwen2.5vl:7b are resolved through configured provider evidence when unambiguous, or fail with a clear validation/runtime error when ambiguous, instead of defaulting to anthropic/<model>.

Validation: pnpm check:changed.

Credit: reported by @alainasclaw in #38816; related Ollama routing context from @wudano1 in #60280.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156977-autonomous-smoke
- Source PRs: none
- Credit: Fix requested by @alainasclaw in https://github.com/openclaw/openclaw/issues/38816.; Keep https://github.com/openclaw/openclaw/issues/60280 as historical context only; it was already closed as implemented for provider-prefixed Ollama image routing.
- Validation: pnpm check:changed
