### PR TITLE
fix(config): tolerate unknown keys during gateway config reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/config: tolerate unknown root and nested config keys during startup and read snapshots by warning and pruning them only for runtime validation, while keeping CLI validation and config writes strict and preserving the authored keys on disk. Fixes #40317 and #40268; carries forward #46213. Thanks @toutou205.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -41,6 +41,7 @@ openclaw gateway run
     - By default, the Gateway refuses to start unless `gateway.mode=local` is set in `~/.openclaw/openclaw.json`. Use `--allow-unconfigured` for ad-hoc/dev runs.
     - `openclaw onboard --mode local` and `openclaw setup` are expected to write `gateway.mode=local`. If the file exists but `gateway.mode` is missing, treat that as a broken or clobbered config and repair it instead of assuming local mode implicitly.
     - If the file exists and `gateway.mode` is missing, the Gateway treats that as suspicious config damage and refuses to "guess local" for you.
+    - Unknown config keys from newer or stale installs are ignored for Gateway startup reads with a warning. `openclaw config validate` stays strict; run `openclaw doctor --fix` to remove stale keys.
     - Binding beyond loopback without auth is blocked (safety guardrail).
     - `SIGUSR1` triggers an in-process restart when authorized (`commands.restart` is enabled by default; set `commands.restart: false` to block manual restart, while gateway tool/config apply/update remain allowed).
     - `SIGINT`/`SIGTERM` handlers stop the gateway process, but they don't restore any custom terminal state. If you wrap the CLI with a TUI or raw-mode input, restore the terminal before exit.

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -93,6 +93,24 @@ function expectRemovedPluginWarnings(
   }
 }
 
+function expectMissingPluginWarnings(
+  result: { ok: boolean; warnings?: Array<{ path: string; message: string }> },
+  pluginId: string,
+) {
+  expect(result.ok).toBe(true);
+  if (result.ok) {
+    const message = `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`;
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        { path: `plugins.entries.${pluginId}`, message },
+        { path: "plugins.allow", message },
+        { path: "plugins.deny", message },
+        { path: "plugins.slots.memory", message },
+      ]),
+    );
+  }
+}
+
 describe("config plugin validation", () => {
   let fixtureRoot = "";
   let suiteHome = "";
@@ -417,10 +435,10 @@ describe("config plugin validation", () => {
     expectRemovedPluginWarnings(res, removedId, removedId);
   });
 
-  it("warns for removed google gemini auth plugin ids instead of failing validation", async () => {
-    const removedId = "google-gemini-cli-auth";
-    const res = validateRemovedPluginConfig(removedId);
-    expectRemovedPluginWarnings(res, removedId, removedId);
+  it("warns for stale google gemini auth plugin ids without classifying them as removed", async () => {
+    const pluginId = "google-gemini-cli-auth";
+    const res = validateRemovedPluginConfig(pluginId);
+    expectMissingPluginWarnings(res, pluginId);
   });
 
   it("does not auto-allow config-loaded overrides of bundled web search plugin ids", async () => {

--- a/src/config/config.tolerant-validation.test.ts
+++ b/src/config/config.tolerant-validation.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createConfigIO,
+  readConfigFileSnapshot,
+  validateConfigObjectWithPlugins,
+} from "./config.js";
+import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
+
+describe("tolerant config reads", () => {
+  it("keeps strict config validation for unknown root and nested keys", () => {
+    const result = validateConfigObjectWithPlugins({
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "test-token",
+          staleAuthKey: true,
+        },
+      },
+      staleRootKey: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.map((issue) => issue.path)).toEqual(
+        expect.arrayContaining(["gateway.auth", ""]),
+      );
+    }
+  });
+
+  it("warns and ignores unknown keys during read snapshots without dropping them from source", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: "test-token",
+            staleAuthKey: true,
+          },
+        },
+        staleRootKey: true,
+      });
+
+      const snapshot = await readConfigFileSnapshot();
+
+      expect(snapshot.valid).toBe(true);
+      expect(snapshot.issues).toEqual([]);
+      expect(snapshot.warnings.map((warning) => warning.path)).toEqual(
+        expect.arrayContaining(["gateway.auth.staleAuthKey", "staleRootKey"]),
+      );
+      expect(
+        (snapshot.config.gateway?.auth as Record<string, unknown>).staleAuthKey,
+      ).toBeUndefined();
+      expect((snapshot.config as Record<string, unknown>).staleRootKey).toBeUndefined();
+      expect((snapshot.sourceConfig.gateway?.auth as Record<string, unknown>).staleAuthKey).toBe(
+        true,
+      );
+      expect((snapshot.sourceConfig as Record<string, unknown>).staleRootKey).toBe(true);
+    });
+  });
+
+  it("keeps semantic config failures fatal after pruning unknown keys", async () => {
+    await withTempHome(async (home) => {
+      await writeOpenClawConfig(home, {
+        gateway: {
+          bind: "lan",
+          tailscale: { mode: "serve" },
+          staleGatewayKey: true,
+        },
+      });
+
+      const snapshot = await readConfigFileSnapshot();
+
+      expect(snapshot.valid).toBe(false);
+      expect(snapshot.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "gateway.bind",
+          }),
+        ]),
+      );
+      expect(snapshot.warnings.map((warning) => warning.path)).toContain("gateway.staleGatewayKey");
+    });
+  });
+
+  it("preserves unknown keys when startup persists generated config fields", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        commands: {
+          ownerDisplay: "hash",
+        },
+        staleRootKey: true,
+      });
+      const logger = { warn: vi.fn(), error: vi.fn() };
+      const io = createConfigIO({
+        homedir: () => home,
+        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        logger,
+      });
+
+      io.loadConfig();
+
+      await vi.waitFor(async () => {
+        const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+          commands?: { ownerDisplaySecret?: string };
+          staleRootKey?: boolean;
+        };
+        expect(persisted.commands?.ownerDisplaySecret).toEqual(expect.any(String));
+        expect(persisted.staleRootKey).toBe(true);
+      });
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Failed to persist auto-generated commands.ownerDisplaySecret"),
+      );
+    });
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -109,6 +109,8 @@ import { resolveShellEnvExpectedKeys } from "./shell-env-expected-keys.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
   validateConfigObjectRawWithPlugins,
+  stripUnknownConfigKeysForValidation,
+  validateConfigObjectWithPluginsToleratingUnknownKeys,
   validateConfigObjectWithPlugins,
 } from "./validation.js";
 import { shouldWarnOnTouchedVersion } from "./version.js";
@@ -1550,7 +1552,7 @@ export function createConfigIO(
       if (preValidationDuplicates.length > 0) {
         throw new DuplicateAgentDirError(preValidationDuplicates);
       }
-      const validated = validateConfigObjectWithPlugins(effectiveConfigRaw, {
+      const validated = validateConfigObjectWithPluginsToleratingUnknownKeys(effectiveConfigRaw, {
         env: deps.env,
         pluginValidation: overrides.pluginValidation,
       });
@@ -1770,7 +1772,7 @@ export function createConfigIO(
         return pluginMetadataSnapshot;
       };
       const validated = await deps.measure("config.snapshot.read.validate", () =>
-        validateConfigObjectWithPlugins(effectiveConfigRaw, {
+        validateConfigObjectWithPluginsToleratingUnknownKeys(effectiveConfigRaw, {
           env: deps.env,
           pluginValidation: overrides.pluginValidation,
           loadPluginMetadataSnapshot: loadValidationPluginMetadataSnapshot,
@@ -2015,7 +2017,24 @@ export function createConfigIO(
 
     persistCandidate = applyUnsetPathsForWrite(persistCandidate as OpenClawConfig, unsetPaths);
 
-    const validated = validateConfigObjectRawWithPlugins(persistCandidate, { env: deps.env });
+    let validated = validateConfigObjectRawWithPlugins(persistCandidate, { env: deps.env });
+    if (!validated.ok) {
+      const strippedPersistCandidate = stripUnknownConfigKeysForValidation(persistCandidate);
+      if (
+        strippedPersistCandidate.warnings.length > 0 &&
+        stripUnknownConfigKeysForValidation(cfg).warnings.length === 0
+      ) {
+        const strippedValidation = validateConfigObjectRawWithPlugins(
+          strippedPersistCandidate.raw,
+          {
+            env: deps.env,
+          },
+        );
+        if (strippedValidation.ok) {
+          validated = strippedValidation;
+        }
+      }
+    }
     if (!validated.ok) {
       const issue = validated.issues[0];
       const pathLabel = issue?.path ? issue.path : "<root>";

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -42,10 +42,16 @@ import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
-const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
+const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
+const LEGACY_STALE_WARN_ONLY_PLUGIN_IDS = new Set(["google-gemini-cli-auth"]);
 
 type UnknownIssueRecord = Record<string, unknown>;
 type ConfigPathSegment = string | number;
+type UnrecognizedKeysValidationIssue = {
+  code: "unrecognized_keys";
+  path?: unknown;
+  keys?: unknown;
+};
 type AllowedValuesCollection = {
   values: unknown[];
   incomplete: boolean;
@@ -92,6 +98,74 @@ function toConfigPathSegments(path: unknown): ConfigPathSegment[] {
 
 function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
   return segments.join(".");
+}
+
+function isUnrecognizedKeysValidationIssue(
+  issue: unknown,
+): issue is UnrecognizedKeysValidationIssue {
+  const record = toIssueRecord(issue);
+  return record?.code === "unrecognized_keys" && Array.isArray(record.keys);
+}
+
+function resolveConfigPathTarget(
+  root: unknown,
+  pathSegments: readonly ConfigPathSegment[],
+): unknown {
+  let current = root;
+  for (const segment of pathSegments) {
+    if (typeof segment === "number") {
+      if (!Array.isArray(current) || segment < 0 || segment >= current.length) {
+        return null;
+      }
+      current = current[segment];
+      continue;
+    }
+    if (!isRecord(current)) {
+      return null;
+    }
+    if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+      return null;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+export function stripUnknownConfigKeysForValidation(raw: unknown): {
+  raw: unknown;
+  warnings: ConfigValidationIssue[];
+} {
+  const normalizedRaw = stripDeprecatedValidationKeys(raw);
+  const parsed = OpenClawSchema.safeParse(normalizedRaw);
+  if (parsed.success) {
+    return { raw: normalizedRaw, warnings: [] };
+  }
+
+  const next = structuredClone(normalizedRaw);
+  const warnings: ConfigValidationIssue[] = [];
+  for (const issue of parsed.error.issues) {
+    if (!isUnrecognizedKeysValidationIssue(issue)) {
+      continue;
+    }
+    const issuePath = toConfigPathSegments(issue.path);
+    const target = resolveConfigPathTarget(next, issuePath);
+    if (!isRecord(target)) {
+      continue;
+    }
+    for (const key of issue.keys) {
+      if (typeof key !== "string" || !Object.prototype.hasOwnProperty.call(target, key)) {
+        continue;
+      }
+      delete target[key];
+      const path = formatConfigPath([...issuePath, key]);
+      warnings.push({
+        path,
+        message: `Unknown config key ignored during read: ${path}. Run "openclaw doctor --fix" to remove stale config.`,
+      });
+    }
+  }
+
+  return { raw: next, warnings };
 }
 
 function asJsonSchemaLike(value: unknown): JsonSchemaLike | null {
@@ -729,6 +803,36 @@ export function validateConfigObjectWithPlugins(
   });
 }
 
+export function validateConfigObjectWithPluginsToleratingUnknownKeys(
+  raw: unknown,
+  params?: ValidateConfigWithPluginsParams,
+): ValidateConfigWithPluginsResult {
+  const strict = validateConfigObjectWithPlugins(raw, params);
+  if (strict.ok) {
+    return strict;
+  }
+
+  const stripped = stripUnknownConfigKeysForValidation(raw);
+  if (stripped.warnings.length === 0) {
+    return strict;
+  }
+
+  const tolerant = validateConfigObjectWithPlugins(stripped.raw, params);
+  if (!tolerant.ok) {
+    return {
+      ok: false,
+      issues: tolerant.issues,
+      warnings: [...stripped.warnings, ...tolerant.warnings],
+    };
+  }
+
+  return {
+    ok: true,
+    config: tolerant.config,
+    warnings: [...stripped.warnings, ...tolerant.warnings],
+  };
+}
+
 export function validateConfigObjectRawWithPlugins(
   raw: unknown,
   params?: ValidateConfigWithPluginsParams,
@@ -1166,7 +1270,7 @@ function validateConfigObjectWithPluginsBase(
       });
       return;
     }
-    if (opts?.warnOnly) {
+    if (opts?.warnOnly || LEGACY_STALE_WARN_ONLY_PLUGIN_IDS.has(pluginId)) {
       warnings.push({
         path,
         message: `plugin not found: ${pluginId} (stale config entry ignored; remove it from plugins config)`,


### PR DESCRIPTION
Addresses the narrower tolerant-read portion of #40317 and #40268. This should keep strict validation for config writes and CLI validation while allowing gateway startup/read handling to warn on unknown keys without taking the service down. Prior implementation work in https://github.com/openclaw/openclaw/pull/46213 by @toutou205 should be credited if reused. The implementation must avoid the prior review blockers: preserve type annotations, handle nested unknown keys via Zod issue.keys and issue.path, keep semantic config checks, keep snapshot/CLI guards strict, preserve unknown keys on disk during startup writes, normalize legacy web-search keys before tolerant parsing, and avoid misclassifying google-gemini-cli-auth as removed. Validate with focused config tests and pnpm check:changed.

ProjectClownfish replacement details:
- Cluster: ghcrawl-157012-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/46213
- Credit: Credit @toutou205 and source PR https://github.com/openclaw/openclaw/pull/46213 if the replacement uses the tolerant validation/pruning approach from that PR.; Preserve the bug reproduction examples from #40268 and the broader product framing from #40317.; Replacement preserves source PR credit: https://github.com/openclaw/openclaw/pull/46213
- Validation: pnpm -s vitest run src/config/config-misc.test.ts src/config/config.tolerant-validation.test.ts; pnpm check:changed
