### PR TITLE
ci: split codeql quality workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /.github/dependabot.yml @openclaw/secops
 /.github/codeql/ @openclaw/secops
 /.github/workflows/codeql.yml @openclaw/secops
+/.github/workflows/codeql-critical-quality.yml @openclaw/secops
 /src/security/ @openclaw/secops
 /src/secrets/ @openclaw/secops
 /src/config/*secret*.ts @openclaw/secops

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -1,0 +1,40 @@
+name: CodeQL Critical Quality
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 6 * * *"
+
+concurrency:
+  group: codeql-critical-quality-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.sha }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  javascript-typescript:
+    name: Critical Quality (javascript-typescript)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-javascript-typescript-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/javascript-typescript"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,14 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: CodeQL profile to run
+        description: CodeQL security profile to run
         required: false
         default: all
         type: choice
         options:
           - all
           - security
-          - quality
           - android-security
           - macos-security
   schedule:
@@ -63,28 +62,6 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-security/${{ matrix.language }}"
-
-  critical-quality:
-    name: Critical Quality (javascript-typescript)
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'quality' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 25
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: false
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
-        with:
-          languages: javascript-typescript
-          config-file: ./.github/codeql/codeql-javascript-typescript-critical-quality.yml
-
-      - name: Analyze
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
-        with:
-          category: "/codeql-critical-quality/javascript-typescript"
 
   android-security:
     name: Critical Security (android)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -223,15 +223,21 @@ listed PRs when `apply=true`. Before mutating GitHub, it verifies that the
 landed PR is merged and that each duplicate has either a shared referenced issue
 or overlapping changed hunks.
 
-The `CodeQL` workflow is intentionally a narrow first-pass scanner, not the
-full repository sweep. Daily and manual runs scan Actions workflow code plus the
-highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and gateway
-surfaces. The critical security lane uses high-precision security queries, and
-the separate critical quality lane runs only error-severity non-security
-queries over the same narrow JavaScript/TypeScript surface. Swift, Android,
-Python, UI, and bundled-plugin CodeQL expansion should be added back as scoped
-or sharded follow-up work only after the narrow profile has stable runtime and
-signal.
+The `CodeQL` workflow is intentionally a narrow first-pass security scanner,
+not the full repository sweep. Daily and manual runs scan Actions workflow code
+plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
+gateway surfaces with high-precision security queries. Android and macOS remain
+manual security shards so their runtime and alert quality can be tracked
+separately.
+
+The `CodeQL Critical Quality` workflow is the matching non-security shard. It
+runs only error-severity, non-security JavaScript/TypeScript quality queries
+over the same narrow auth, secrets, sandbox, cron, and gateway surface. Keep it
+separate from the security workflow so quality findings can be scheduled,
+measured, disabled, or expanded without obscuring security signal. Swift,
+Android, Python, UI, and bundled-plugin CodeQL expansion should be added back as
+scoped or sharded follow-up work only after the narrow profiles have stable
+runtime and signal.
 
 The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping
 existing docs aligned with recently landed changes. It has no pure schedule: a


### PR DESCRIPTION
## Summary

- Problem: non-security CodeQL quality checks were still coupled to the main `CodeQL` workflow, making the security/default surface noisier than it needs to be.
- Why it matters: security and quality findings should have separate schedules, run history, and expansion decisions.
- What changed: moved the JS/TS critical quality job into a dedicated `CodeQL Critical Quality` workflow and kept `CodeQL` focused on critical security.
- What did NOT change (scope boundary): no query expansion, no Android/macOS scheduling change, no broad/default CodeQL profile.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #73354
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context: the critical quality profile already existed, but sharing the security workflow made the operating model less clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/codeql.yml`, `.github/workflows/codeql-critical-quality.yml`
- Scenario the test should lock in: workflow sanity accepts the split workflow shape.
- Why this is the smallest reliable guardrail: this is workflow topology, not product runtime behavior.
- Existing test that already covers this: `pnpm check:workflows`
- If no new test is added, why not: no product behavior changed.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
CodeQL -> security + quality

After:
CodeQL -> security
CodeQL Critical Quality -> quality
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo workflow sanity
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Split the quality job into `.github/workflows/codeql-critical-quality.yml`.
2. Remove `profile=quality` from `.github/workflows/codeql.yml`.
3. Validate workflow syntax and repo workflow policy.

### Expected

- Security CodeQL remains focused on security categories.
- Quality CodeQL has its own scheduled/manual workflow.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```bash
pnpm check:workflows
git diff --check
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/codeql.yml .github/workflows/codeql-critical-quality.yml
```

## Human Verification (required)

- Verified scenarios: workflow sanity, YAML parse, whitespace check, docs update.
- Edge cases checked: new workflow has the same narrow JS/TS quality config and CodeQL category as the prior job.
- What you did **not** verify: GitHub manual dispatch of the new workflow, because newly added workflow files may not be dispatchable until present on the default branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: maintainers may look for `profile=quality` on the existing `CodeQL` workflow.
  - Mitigation: docs now point to the dedicated `CodeQL Critical Quality` workflow.

AI-assisted: yes.
