### PR TITLE
fix(plugins): enable metadata snapshot cache for status diagnostics

### DIFF
--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -58,7 +58,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
         workspaceDir: "/workspace",
         env: { HOME: "/tmp/openclaw-home" },
         onlyPluginIds: ["demo"],
-        cache: false,
+        cache: true,
         activate: false,
         mode: "validate",
         loadModules: undefined,

--- a/src/plugins/runtime/metadata-registry-loader.ts
+++ b/src/plugins/runtime/metadata-registry-loader.ts
@@ -19,7 +19,7 @@ export function loadPluginMetadataRegistrySnapshot(options?: {
   return loadOpenClawPlugins(
     buildPluginRuntimeLoadOptions(context, {
       throwOnLoadError: true,
-      cache: false,
+      cache: true,
       activate: false,
       mode: "validate",
       loadModules: options?.loadModules,


### PR DESCRIPTION
# fix(plugins): enable metadata snapshot cache for status diagnostics

## Summary

Fixes #73291.

This PR enables plugin metadata snapshot caching (default 1 second TTL) for validate-mode metadata loads used by status diagnostics, reducing repeated manifest discovery/parse work during `openclaw status` text-mode scans.

## Issue Evidence Is Clear

- Issue report shows `openclaw status` text mode taking ~20-30s while `--json` is much faster.
- Shared evidence includes high sync filesystem activity (`statx` / `realpathSync` storms) and heavy manifest parse stacks.
- Code-path verification in this branch confirms text-mode status performs plugin compatibility snapshot loading, which previously forced `cache: false` in metadata snapshot loads.
- Linked issue: https://github.com/openclaw/openclaw/issues/73291

## What Changed

- Updated `src/plugins/runtime/metadata-registry-loader.ts`
  - Changed metadata snapshot load option from `cache: false` to `cache: true`.
  - Keeps behavior read-only (`activate: false`, `mode: "validate"`), only allowing short-lived manifest/discovery cache reuse.
- Updated `src/plugins/runtime/metadata-registry-loader.test.ts`
  - Updated expectation to assert `cache: true`.

## Why This Small Fix

- Uses existing cache implementation and defaults (1 second TTL) with no new flags or config surface.
- Keeps blast radius minimal and aligned with issue request for a low-cost, practical fix.
- Accepts tiny short-window staleness in diagnostics for significantly lower repeated filesystem/manifest overhead.

## Validation

- `pnpm docs:list`
- `pnpm test src/plugins/runtime/metadata-registry-loader.test.ts`

## Risk

- Very low: metadata may be up to ~1 second stale in read-only diagnostics paths.
- No activation/runtime behavior changes; only snapshot cache policy changed.

## AI-assisted

- [x] AI-assisted and manually reviewed
