### PR TITLE
docs: add clawhub rescan recovery guidance

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -95,7 +95,7 @@ Bare package names are checked against ClawHub first, then npm. Treat plugin ins
 
     This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs use the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
 
-    For ClawHub-hosted package scan recovery, use the publisher flow documented in [ClawHub](/tools/clawhub).
+    If a plugin you published on ClawHub is blocked by a registry scan, use the publisher steps in [ClawHub](/tools/clawhub).
 
   </Accordion>
   <Accordion title="Hook packs and npm specs">

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -95,6 +95,8 @@ Bare package names are checked against ClawHub first, then npm. Treat plugin ins
 
     This CLI flag applies to plugin install/update flows. Gateway-backed skill dependency installs use the matching `dangerouslyForceUnsafeInstall` request override, while `openclaw skills install` remains a separate ClawHub skill download/install flow.
 
+    For ClawHub-hosted package scan recovery, use the publisher flow documented in [ClawHub](/tools/clawhub).
+
   </Accordion>
   <Accordion title="Hook packs and npm specs">
     `plugins install` is also the install surface for hook packs that expose `openclaw.hooks` in `package.json`. Use `openclaw hooks` for filtered hook visibility and per-hook enablement, not package installation.

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -152,16 +152,6 @@ abuse without blocking legitimate contributors.
     install surfaces while still visible to their owner in `/dashboard`.
 
   </Accordion>
-  <Accordion title="Owner recovery">
-    Owners can use `/dashboard` to find their own unavailable or scan-held
-    skills and plugins, open scanner detail pages, and request a fresh scan
-    when a result looks like a false positive.
-
-    Rescans apply to the latest published skill version or plugin release.
-    ClawHub limits owner-requested rescans per version/release and blocks
-    duplicate requests while a rescan is already in progress.
-
-  </Accordion>
   <Accordion title="Reporting">
     - Any signed-in user can report a skill.
     - Report reasons are required and recorded.

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -121,15 +121,19 @@ shared, and gated, see [Skills](/tools/skills).
 
 ## Service features
 
-| Feature            | Notes                                                      |
-| ------------------ | ---------------------------------------------------------- |
-| Public browsing    | Skills and their `SKILL.md` content are publicly viewable. |
-| Search             | Embedding-powered (vector search), not just keywords.      |
-| Versioning         | Semver, changelogs, and tags (including `latest`).         |
-| Downloads          | Zip per version.                                           |
-| Stars and comments | Community feedback.                                        |
-| Moderation         | Approvals and audits.                                      |
-| CLI-friendly API   | Suitable for automation and scripting.                     |
+| Feature                  | Notes                                                               |
+| ------------------------ | ------------------------------------------------------------------- |
+| Public browsing          | Skills and their `SKILL.md` content are publicly viewable.          |
+| Search                   | Embedding-powered (vector search), not just keywords.               |
+| Versioning               | Semver, changelogs, and tags (including `latest`).                  |
+| Downloads                | Zip per version.                                                    |
+| Stars and comments       | Community feedback.                                                 |
+| Security scan summaries  | Detail pages show the latest scan state before install or download. |
+| Scanner detail pages     | VirusTotal, ClawScan, and static-analysis results have deep links.  |
+| Owner recovery dashboard | Publishers can see scan-held owned content from `/dashboard`.       |
+| Owner-requested rescans  | Owners can request limited rescans for false-positive recovery.     |
+| Moderation               | Approvals and audits.                                               |
+| CLI-friendly API         | Suitable for automation and scripting.                              |
 
 ## Security and moderation
 
@@ -138,6 +142,26 @@ account must be **at least one week old** to publish. This slows down
 abuse without blocking legitimate contributors.
 
 <AccordionGroup>
+  <Accordion title="Security scans">
+    ClawHub runs automated security checks on published skills and plugin
+    releases. Public detail pages summarize the current result, and scanner
+    rows link to dedicated detail pages for VirusTotal, ClawScan, and static
+    analysis.
+
+    Scan-held or blocked releases may be unavailable on public catalog and
+    install surfaces while still visible to their owner in `/dashboard`.
+
+  </Accordion>
+  <Accordion title="Owner recovery">
+    Owners can use `/dashboard` to find their own unavailable or scan-held
+    skills and plugins, open scanner detail pages, and request a fresh scan
+    when a result looks like a false positive.
+
+    Rescans apply to the latest published skill version or plugin release.
+    ClawHub limits owner-requested rescans per version/release and blocks
+    duplicate requests while a rescan is already in progress.
+
+  </Accordion>
   <Accordion title="Reporting">
     - Any signed-in user can report a skill.
     - Report reasons are required and recorded.
@@ -245,6 +269,23 @@ publish/sync.
     - `--dry-run` — build the exact publish plan without uploading anything.
     - `--json` — emit machine-readable output for CI.
     - `--source-repo`, `--source-commit`, `--source-ref` — optional overrides when auto-detection is not enough.
+
+  </Accordion>
+  <Accordion title="Request rescans">
+    ```bash
+    clawhub skill rescan <slug>
+    clawhub skill rescan <slug> --yes --json
+
+    clawhub package rescan <name>
+    clawhub package rescan <name> --yes --json
+    ```
+
+    Rescan commands require a logged-in owner token and target the latest
+    published skill version or plugin release. In non-interactive runs, pass
+    `--yes`.
+
+    JSON responses include the target kind, name, version, rescan status, and
+    remaining/max request counts for that version or release.
 
   </Accordion>
   <Accordion title="Delete / undelete (owner or admin)">

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -405,10 +405,11 @@ dependency installs use the matching `dangerouslyForceUnsafeInstall` request
 override instead, while `openclaw skills install` remains the separate ClawHub
 skill download/install flow.
 
-For a ClawHub-hosted plugin release that is scan-held in the registry, publishers
-should use the ClawHub dashboard or `clawhub package rescan <name>` to request a
-fresh registry scan. The unsafe-install override is local to OpenClaw
-install/update flows and does not request or bypass ClawHub registry rescans.
+If a plugin you published on ClawHub is hidden or blocked by a scan, open the
+ClawHub dashboard or run `clawhub package rescan <name>` to ask ClawHub to check
+it again. `--dangerously-force-unsafe-install` only affects installs on your own
+machine; it does not ask ClawHub to rescan the plugin or make a blocked release
+public.
 
 Compatible bundles participate in the same plugin list/inspect/enable/disable
 flow. Current runtime support includes bundle skills, Claude command-skills,

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -405,6 +405,11 @@ dependency installs use the matching `dangerouslyForceUnsafeInstall` request
 override instead, while `openclaw skills install` remains the separate ClawHub
 skill download/install flow.
 
+For a ClawHub-hosted plugin release that is scan-held in the registry, publishers
+should use the ClawHub dashboard or `clawhub package rescan <name>` to request a
+fresh registry scan. The unsafe-install override is local to OpenClaw
+install/update flows and does not request or bypass ClawHub registry rescans.
+
 Compatible bundles participate in the same plugin list/inspect/enable/disable
 flow. Current runtime support includes bundle skills, Claude command-skills,
 Claude `settings.json` defaults, Claude `.lsp.json` and manifest-declared

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -131,6 +131,12 @@ Native `openclaw skills install` installs into the active workspace
 configured OpenClaw workspace). OpenClaw picks that up as
 `<workspace>/skills` on the next session.
 
+ClawHub skill pages expose the latest security scan state before install,
+with scanner detail pages for VirusTotal, ClawScan, and static analysis.
+`openclaw skills install <slug>` remains only the install path; publishers
+recover false positives through the ClawHub dashboard or
+`clawhub skill rescan <slug>`.
+
 ## Security
 
 <Warning>


### PR DESCRIPTION
## Summary

This updates the OpenClaw docs to match the ClawHub owner rescan and security-detail work from ClawHub PR #1861. The ClawHub guide now documents scan summaries, scanner-specific detail pages, owner dashboard recovery for scan-held content, and authenticated owner-requested rescans for skills and plugin packages.

## Issue

ClawHub publishers now have recovery tools for false positives and scan-held releases, but the OpenClaw docs still described ClawHub mostly as a search/install/publish registry. That left publishers without a clear path from a blocked skill or plugin release to the dashboard, scanner detail pages, or the new rescan commands.

## Cause and user impact

The docs predated the owner-facing recovery flow. Users could see install warnings and registry scan state in product surfaces, but the docs did not distinguish native OpenClaw install behavior from ClawHub registry recovery behavior. Plugin publishers in particular could confuse `--dangerously-force-unsafe-install`, which is local to OpenClaw install/update flows, with the registry-side rescan path.

## Fix

The ClawHub guide now lists security scan summaries, scanner detail pages, owner dashboard recovery, and owner-requested rescans as service features. Its security section explains scan-held owner visibility and rescan limits, and its CLI section documents `clawhub skill rescan <slug>` and `clawhub package rescan <name>` with `--yes` and `--json` examples.

The skills and plugin docs now add short cross-references: skill installs remain native OpenClaw install flows, while publishers use ClawHub dashboard or `clawhub skill rescan` for false-positive recovery; plugin scan recovery points to the ClawHub dashboard or `clawhub package rescan` and keeps the unsafe-install override scoped to local install/update behavior. The OpenClaw plugin CLI reference links back to the ClawHub guide without adding new native command syntax.

## Validation

- `pnpm exec oxfmt --write docs/tools/clawhub.md docs/tools/skills.md docs/tools/plugin.md docs/cli/plugins.md`
- `pnpm check:docs` passed format, markdown lint, and MDX checks, then stopped at `docs:check-i18n-glossary` on an existing repo-wide missing zh-CN glossary list unrelated to these four docs edits.
- `pnpm docs:check-links` passed with `broken_links=0`.
- Targeted search confirmed `clawhub skill rescan`, `clawhub package rescan`, `Request rescans`, scan-held wording, and `/tools/clawhub` links are present.
