### PR TITLE
fix(docs): preserve page path when switching locale

### DIFF
--- a/docs/locale-path-preserve.js
+++ b/docs/locale-path-preserve.js
@@ -1,0 +1,92 @@
+/**
+ * Preserve the current page path when switching locales via the Mintlify
+ * language dropdown. Without this, Mintlify navigates to the target
+ * locale's homepage instead of the equivalent page.
+ *
+ * Uses the same CSS selectors Mintlify documents for the localization
+ * dropdown: #localization-select-content, #localization-select-item.
+ */
+(() => {
+  const SELECTOR_CONTENT = "#localization-select-content";
+  const SELECTOR_ITEM = "#localization-select-item";
+  const KNOWN_PREFIXES = new Set([
+    "zh-CN",
+    "ja-JP",
+    "es",
+    "pt-BR",
+    "ko",
+    "de",
+    "fr",
+    "ar",
+    "it",
+    "tr",
+    "uk",
+    "id",
+    "pl",
+  ]);
+
+  const cleanPath = (pathname) => {
+    let path = pathname;
+    for (const prefix of KNOWN_PREFIXES) {
+      if (
+        path === `/${prefix}` ||
+        path.startsWith(`/${prefix}/`)
+      ) {
+        path = path.slice(prefix.length + 1) || "/";
+        break;
+      }
+    }
+    if (path.length > 1 && path.endsWith("/")) {
+      path = path.slice(0, -1);
+    }
+    return path;
+  };
+
+  const targetLocale = (href) => {
+    const seg = new URL(href, location.origin).pathname.split("/")[1];
+    return KNOWN_PREFIXES.has(seg) ? seg : "";
+  };
+
+  const handleClick = (event) => {
+    const item = event.target.closest(SELECTOR_ITEM);
+    if (!item) return;
+
+    const href = item.getAttribute("href");
+    if (!href) return;
+
+    const locale = targetLocale(href);
+    const currentLocale = (() => {
+      const seg = location.pathname.split("/")[1];
+      return KNOWN_PREFIXES.has(seg) ? seg : "";
+    })();
+
+    if (locale === currentLocale) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const base = cleanPath(location.pathname);
+    const targetPath = locale ? `/${locale}${base}` : base;
+    const url = `${targetPath}${location.search}${location.hash}`;
+    window.location.href = url;
+  };
+
+  const attach = () => {
+    const dropdown = document.querySelector(SELECTOR_CONTENT);
+    if (!dropdown || dropdown.dataset.lpAttached) return;
+    dropdown.dataset.lpAttached = "1";
+    dropdown.addEventListener("click", handleClick, true);
+  };
+
+  const observer = new MutationObserver(attach);
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      attach();
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  } else {
+    attach();
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+})();

--- a/docs/locale-path-preserve.js
+++ b/docs/locale-path-preserve.js
@@ -3,12 +3,27 @@
  * language dropdown. Without this, Mintlify navigates to the target
  * locale's homepage instead of the equivalent page.
  *
- * Uses the same CSS selectors Mintlify documents for the localization
- * dropdown: #localization-select-content, #localization-select-item.
+ * The dropdown items are <div role="menuitem"> elements (not <a> links)
+ * with no href. Each item's id encodes the Mintlify language code, e.g.
+ * "localization-select-item-zh-Hans". We map that to the URL prefix
+ * used in docs.json navigation (e.g. "zh-Hans" → "zh-CN") and navigate
+ * directly.
  */
 (() => {
   const SELECTOR_CONTENT = "#localization-select-content";
-  const SELECTOR_ITEM = "#localization-select-item";
+  const SELECTOR_ITEM = '[data-component-part="localization-select-item"]';
+  const ITEM_ID_PREFIX = "localization-select-item-";
+
+  // Mintlify language code → URL path prefix.
+  // Entries where the code itself is the prefix are omitted;
+  // only the mismatches need listing here.
+  const LOCALE_TO_PREFIX = {
+    en: "",
+    "zh-Hans": "zh-CN",
+    ja: "ja-JP",
+  };
+
+  // All known URL prefixes, used to strip the current locale from the path.
   const KNOWN_PREFIXES = new Set([
     "zh-CN",
     "ja-JP",
@@ -25,50 +40,47 @@
     "pl",
   ]);
 
-  const cleanPath = (pathname) => {
-    let path = pathname;
-    for (const prefix of KNOWN_PREFIXES) {
-      if (
-        path === `/${prefix}` ||
-        path.startsWith(`/${prefix}/`)
-      ) {
-        path = path.slice(prefix.length + 1) || "/";
-        break;
-      }
-    }
-    if (path.length > 1 && path.endsWith("/")) {
-      path = path.slice(0, -1);
-    }
-    return path;
+  const prefixFor = (locale) =>
+    locale in LOCALE_TO_PREFIX ? LOCALE_TO_PREFIX[locale] : locale;
+
+  const localeFromId = (id) => {
+    if (!id.startsWith(ITEM_ID_PREFIX)) return null;
+    return id.slice(ITEM_ID_PREFIX.length) || null;
   };
 
-  const targetLocale = (href) => {
-    const seg = new URL(href, location.origin).pathname.split("/")[1];
+  const currentPrefix = () => {
+    const seg = location.pathname.split("/")[1];
     return KNOWN_PREFIXES.has(seg) ? seg : "";
+  };
+
+  const cleanPath = (pathname) => {
+    for (const prefix of KNOWN_PREFIXES) {
+      if (pathname === `/${prefix}` || pathname.startsWith(`/${prefix}/`)) {
+        return pathname.slice(prefix.length + 1) || "/";
+      }
+    }
+    return pathname;
   };
 
   const handleClick = (event) => {
     const item = event.target.closest(SELECTOR_ITEM);
-    if (!item) return;
+    if (!item || item.dataset.selected === "true") return;
 
-    const href = item.getAttribute("href");
-    if (!href) return;
+    const locale = localeFromId(item.id);
+    if (!locale) return;
 
-    const locale = targetLocale(href);
-    const currentLocale = (() => {
-      const seg = location.pathname.split("/")[1];
-      return KNOWN_PREFIXES.has(seg) ? seg : "";
-    })();
+    const targetPrefix = prefixFor(locale);
+    const activePrefix = currentPrefix();
 
-    if (locale === currentLocale) return;
+    // Already on the target locale — let Mintlify handle it.
+    if (targetPrefix === activePrefix) return;
 
     event.preventDefault();
     event.stopPropagation();
 
     const base = cleanPath(location.pathname);
-    const targetPath = locale ? `/${locale}${base}` : base;
-    const url = `${targetPath}${location.search}${location.hash}`;
-    window.location.href = url;
+    const targetPath = targetPrefix ? `/${targetPrefix}${base}` : base;
+    window.location.href = `${targetPath}${location.search}${location.hash}`;
   };
 
   const attach = () => {


### PR DESCRIPTION
## Summary

Mintlify's built-in language switcher navigates to the target locale's **homepage** instead of the equivalent page. For example, switching from `/start/getting-started` (English) to Chinese goes to `/zh-CN` instead of `/zh-CN/start/getting-started`.

This PR adds a lightweight client-side script (`docs/locale-path-preserve.js`) that intercepts locale selection clicks and constructs the correct path, preserving the current page's path across locale switches.

## How it works

- Attaches a capturing click listener to Mintlify's `#localization-select-content` dropdown (using [documented CSS selectors](https://mintlify.com/docs/customize/custom-scripts))
- Extracts the target locale prefix from the clicked item's `href`
- Strips the current locale prefix from `location.pathname` and prepends the target locale prefix
- Falls through to the default page (e.g. `/zh-CN/start/getting-started` 404s gracefully if the page hasn't been translated yet)

## Example

| Current URL | Switch to | Navigates to |
|---|---|---|
| `/start/getting-started` | 中文 | `/zh-CN/start/getting-started` |
| `/zh-CN/start/getting-started` | English | `/start/getting-started` |
| `/gateway/configuration` | 日本語 | `/ja-JP/gateway/configuration` |

## Notes

- `KNOWN_PREFIXES` are derived from the `docs.json` `navigation.languages` configuration (`zh-CN`, `ja-JP`, `es`, `pt-BR`, `ko`, `de`, `fr`, `ar`, `it`, `tr`, `uk`, `id`, `pl`)
- Same pattern as the existing `nav-tabs-underline.js` custom script — IIFE, MutationObserver for SPA navigation, `dataset` flag to prevent double-attach

🤖 Generated with [Claude Code](https://claude.ai/code)