### PR TITLE
fix(mattermost): drop redundant system-event enqueue for inbound posts (#71795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/runtime deps: reuse enclosing versioned cache roots when bundled plugins resolve from nested staged paths, so plugin-runtime-deps no longer mints `openclaw-unknown-*` directories or loops on `ENOTEMPTY`. Fixes #72956. (#73205) Thanks @SymbolStar.
 - Agents/failover: classify CJK provider transport, quota, billing, auth, and overload error text so Chinese-language provider failures trigger fallback and user-facing transport copy instead of surfacing as unclassified raw errors. (#56242) Thanks @tomcatzh.
 - Agents/failover: seed non-claude-cli fallback prompts with Claude Code session context when a claude-cli attempt fails, so fallback models do not restart cold after billing or quota failover. (#72069) Thanks @stainlu.
+- Channels/Mattermost: stop enqueueing a redundant per-message system event for every inbound user post, so Mattermost user messages are presented to the model as user-role content via the inbound envelope instead of leaking in as `System: Mattermost message in <#channel> from @user: ...` lines that the model treated as system directives. Fixes #71795. Thanks @juan-flores077.
 
 ## 2026.4.27
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1488,16 +1488,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           directId: senderId,
         });
 
-        const preview = bodyText.replace(/\s+/g, " ").slice(0, 160);
-        const inboundLabel =
-          kind === "direct"
-            ? `Mattermost DM from ${senderName}`
-            : `Mattermost message in ${roomLabel} from ${senderName}`;
-        core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
-          sessionKey,
-          contextKey: `mattermost:message:${channelId}:${post.id ?? "unknown"}`,
-        });
-
+        // Inbound user messages flow through formatInboundEnvelope below as a
+        // proper user-role payload; do not also enqueue a redundant system
+        // event whose `${label}: ${preview}` text rendered as a leading
+        // `System: Mattermost message in <#channel> from @user: <preview>`
+        // line in every prompt and made the model treat ordinary user
+        // messages as system directives. Discord/Telegram only enqueue
+        // system events for actual non-message events (#71795).
         const textWithId = `${bodyText}\n[mattermost message id: ${post.id ?? "unknown"} channel: ${channelId}]`;
         const body = core.channel.reply.formatInboundEnvelope({
           channel: "Mattermost",


### PR DESCRIPTION
## What

[`extensions/mattermost/src/mattermost/monitor.ts`](extensions/mattermost/src/mattermost/monitor.ts) unconditionally enqueued a system event for every inbound Mattermost user post, in addition to formatting the same post into the inbound envelope that flows downstream as a proper user-role payload. The queued system event surfaced in the agent prompt as a leading `System: Mattermost message in #channel from @user: <preview>` line, so the model treated **every** ordinary Mattermost user message as a system directive.

Discord (same agent, same session, same model) does not exhibit this — it only enqueues system events when [`resolveDiscordSystemEvent`](extensions/discord/src/monitor/message-handler.preflight.ts) flags the message as an actual non-message event (channel updates, component clicks, reactions). Mattermost's own reaction handler in the same file (`core.system.enqueueSystemEvent("Mattermost reaction <action>: :emoji: by @user...")`) and slash-interaction handler also remain correct as system events. Only the redundant enqueue for regular posts is removed.

Closes #71795.

## Why this fix

The user-facing payload still carries the channel/sender label via the existing `core.channel.reply.formatInboundEnvelope({ channel: "Mattermost", from: fromLabel, ... })` call two lines below the deletion (`fromLabel` is built from `formatInboundFromLabel(...)` immediately above), so no metadata is lost — it is simply delivered through the user-role envelope path that Discord and Telegram already use. The change is a pure deletion of nine lines plus a short comment explaining why the deletion is safe.

The dual delivery (system event **and** envelope) was the bug: the model received the same channel-and-sender preview twice, once as a system directive and once as a user message, which is what produced the *"corrupts the intended conversation flow"* symptom described in the issue.

## Tests

The Mattermost extension's existing test suite (`extensions/mattermost/src/mattermost/monitor.test.ts`, `monitor.authz.test.ts`, `monitor.channel-kind.test.ts`, etc.) covers the named exports of the monitor module and does not assert on this specific `enqueueSystemEvent` call — confirmed via `grep`. The deletion does not change any exported function signature or shape, so the existing suite continues to apply unchanged.

I did not add a new unit test because the inbound post handler is an inline closure inside the larger `monitorMattermostProvider` factory and does not have a clean test seam without significant refactor of the surrounding code (which would expand the diff well beyond the spirit of a focused bug fix). The trade-off is documented; happy to extract a testable helper in a follow-up if reviewers prefer.

The reaction handler that legitimately keeps `core.system.enqueueSystemEvent` for *actual* non-message events (line 1908 of the post-edit file) is untouched and remains an example of the correct usage.

## Notes

- Single-area diff: `extensions/mattermost/src/mattermost/monitor.ts` and a one-line CHANGELOG entry under `## Unreleased` `### Fixes` with `Thanks @juan-flores077`.
- Net negative LOC (`-10` / `+8`).
- No Plugin SDK, core, or other-extension files touched. Owner-boundary respected.
- AI-assisted (Claude). Reviewed locally; please flag any oversight, especially if the system-event enqueue was intentionally redundant for some downstream consumer I missed (a code-search for `mattermost:message:${channelId}` context-key turned up no other references).

## Validation

Local CI is constrained on this machine; relying on CI for the canonical proof. I have:

- Verified by code-reading that the deleted `enqueueSystemEvent` call is the only caller producing the `"Mattermost {DM|message} in #... from @user: ..."` system-event text.
- Confirmed the same `fromLabel` (built from `formatInboundFromLabel`) and channel/sender metadata are still attached to the user-role payload via `formatInboundEnvelope` immediately below.
- Confirmed the changelog entry is single-line and credits a contributor (`@juan-flores077`).
- Confirmed no Mattermost test asserts that the deleted call fires (`grep -rn "enqueueSystemEvent" extensions/mattermost/`).

Happy to address Greptile/Codex review feedback or extract a testable helper if reviewers want unit coverage.