### PR TITLE
docs(mistral): mention MCP option for specialized API capabilities

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -165,6 +165,33 @@ matching `sampleRate` only if your upstream stream is already raw PCM.
   </Accordion>
 </AccordionGroup>
 
+## Specialized capabilities via MCP
+
+The built-in Mistral provider covers the main model-provider path for chat,
+image, embeddings, and Voxtral transcription.
+
+Some Mistral APIs are useful in agent workflows but sit outside the normal
+chat-completion provider flow:
+
+- **Codestral FIM** for fill-in-the-middle code completion
+- **OCR** for document and image extraction
+- **Batch jobs** for async API workloads
+- **Mistral Agents**
+- **Moderation and classification** endpoints
+
+For these tool-style workflows, you can use a third-party MCP server such as
+[`mistral-mcp`](https://github.com/Swih/mistral-mcp), which exposes these
+capabilities as MCP tools.
+
+```bash
+npx -y mistral-mcp
+```
+
+<Note>
+This is a community project and is not maintained by OpenClaw. It uses the same
+`MISTRAL_API_KEY` as the built-in Mistral provider.
+</Note>
+
 ## Related
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

Adds a short section to the Mistral provider docs about specialized Mistral API capabilities that sit outside the normal chat/provider path: Codestral FIM, OCR, batch jobs, agents, moderation, and classification.

The built-in OpenClaw Mistral provider already covers the main provider use case (chat, image, embeddings, Voxtral). This section only points users toward MCP as a third-party option for tool-style workflows.

## Why

OpenClaw's contribution guide recommends keeping many integrations in third-party plugins rather than expanding core. MCP fits that direction well for provider-adjacent tools, and these capabilities (FIM, OCR, batch, agents, moderation) aren't reachable through the chat-completion provider today.

## Notes

- Single-file docs change.
- `mistral-mcp` is marked clearly as a community project, not maintained by OpenClaw.
- Uses the same `MISTRAL_API_KEY` already documented for the built-in provider, so there's no extra onboarding surface.
- Happy to move this to a community integrations page if provider docs should avoid third-party links.