### PR TITLE
fix: include config env SecretRef vars in systemd service environment (#67817) [replaced]

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   resolveSystemNodeInfo: vi.fn(),
   renderSystemNodeWarning: vi.fn(),
   buildServiceEnvironment: vi.fn(),
+  resolveOpenClawWrapperPath: vi.fn(),
 }));
 
 vi.mock("./daemon-install-auth-profiles-source.runtime.js", () => ({
@@ -29,7 +30,9 @@ vi.mock("../daemon/runtime-paths.js", () => ({
 }));
 
 vi.mock("../daemon/program-args.js", () => ({
+  OPENCLAW_WRAPPER_ENV_KEY: "OPENCLAW_WRAPPER",
   resolveGatewayProgramArguments: mocks.resolveGatewayProgramArguments,
+  resolveOpenClawWrapperPath: mocks.resolveOpenClawWrapperPath,
 }));
 
 vi.mock("../daemon/service-env.js", () => ({
@@ -66,13 +69,18 @@ function mockNodeGatewayPlanFixture(
   } = {},
 ) {
   const {
-    workingDirectory = "/Users/me",
     version = "22.0.0",
     supported = true,
     warning,
     serviceEnvironment = { OPENCLAW_PORT: "3000" },
   } = params;
+  const workingDirectory = Object.hasOwn(params, "workingDirectory")
+    ? params.workingDirectory
+    : "/Users/me";
   mocks.resolvePreferredNodePath.mockResolvedValue("/opt/node");
+  mocks.resolveOpenClawWrapperPath.mockImplementation(async (value: string | undefined) =>
+    value?.trim() ? path.resolve(value) : undefined,
+  );
   mocks.resolveGatewayProgramArguments.mockResolvedValue({
     programArguments: ["node", "gateway"],
     workingDirectory,
@@ -99,6 +107,10 @@ describe("buildGatewayInstallPlan", () => {
   });
   afterEach(() => {
     fs.rmSync(isolatedHome, { recursive: true, force: true });
+  });
+  const isolatedPlanEnv = (env: Record<string, string | undefined> = {}) => ({
+    HOME: isolatedHome,
+    ...env,
   });
 
   it("uses provided nodePath and returns plan", async () => {
@@ -152,7 +164,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     await buildGatewayInstallPlan({
-      env: {},
+      env: isolatedPlanEnv(),
       port: 3000,
       runtime: "node",
       warn,
@@ -162,105 +174,76 @@ describe("buildGatewayInstallPlan", () => {
     expect(mocks.resolvePreferredNodePath).toHaveBeenCalled();
   });
 
-  it("merges config env vars into the environment", async () => {
+  it("uses the state dir as the default macOS launchd working directory", async () => {
+    mockNodeGatewayPlanFixture({
+      workingDirectory: undefined,
+      serviceEnvironment: {},
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv(),
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+    });
+
+    expect(plan.workingDirectory).toBe(path.join(isolatedHome, ".openclaw"));
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platform: "darwin",
+      }),
+    );
+  });
+
+  it("does not invent a working directory for non-macOS service installs", async () => {
+    mockNodeGatewayPlanFixture({
+      workingDirectory: undefined,
+      serviceEnvironment: {},
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv(),
+      port: 3000,
+      runtime: "node",
+      platform: "linux",
+    });
+
+    expect(plan.workingDirectory).toBeUndefined();
+  });
+
+  it("passes OPENCLAW_WRAPPER through program args and managed service env", async () => {
+    const wrapperPath = path.resolve("/usr/local/bin/openclaw-doppler");
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
-        HOME: "/Users/me",
+        OPENCLAW_WRAPPER: wrapperPath,
       },
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: isolatedPlanEnv({
+        OPENCLAW_WRAPPER: wrapperPath,
+      }),
       port: 3000,
       runtime: "node",
-      config: {
-        env: {
-          vars: {
-            GOOGLE_API_KEY: "test-key", // pragma: allowlist secret
-          },
-          CUSTOM_VAR: "custom-value",
-        },
-      },
     });
 
-    // Config env vars should be present
-    expect(plan.environment.GOOGLE_API_KEY).toBe("test-key");
-    expect(plan.environment.CUSTOM_VAR).toBe("custom-value");
-    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("CUSTOM_VAR,GOOGLE_API_KEY");
-    // Service environment vars should take precedence
-    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
-    expect(plan.environment.HOME).toBe("/Users/me");
+    expect(mocks.resolveGatewayProgramArguments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wrapperPath,
+      }),
+    );
+    expect(mocks.buildServiceEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          OPENCLAW_WRAPPER: wrapperPath,
+        }),
+      }),
+    );
+    expect(plan.environment.OPENCLAW_WRAPPER).toBe(wrapperPath);
   });
 
-  it("drops dangerous config env vars before service merge", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        OPENCLAW_PORT: "3000",
-      },
-    });
-
-    const plan = await buildGatewayInstallPlan({
-      env: {},
-      port: 3000,
-      runtime: "node",
-      config: {
-        env: {
-          vars: {
-            NODE_OPTIONS: "--require /tmp/evil.js",
-            SAFE_KEY: "safe-value",
-          },
-        },
-      },
-    });
-
-    expect(plan.environment.NODE_OPTIONS).toBeUndefined();
-    expect(plan.environment.SAFE_KEY).toBe("safe-value");
-  });
-
-  it("does not include empty config env values", async () => {
-    mockNodeGatewayPlanFixture();
-
-    const plan = await buildGatewayInstallPlan({
-      env: {},
-      port: 3000,
-      runtime: "node",
-      config: {
-        env: {
-          vars: {
-            VALID_KEY: "valid",
-            EMPTY_KEY: "",
-          },
-        },
-      },
-    });
-
-    expect(plan.environment.VALID_KEY).toBe("valid");
-    expect(plan.environment.EMPTY_KEY).toBeUndefined();
-  });
-
-  it("drops whitespace-only config env values", async () => {
-    mockNodeGatewayPlanFixture({ serviceEnvironment: {} });
-
-    const plan = await buildGatewayInstallPlan({
-      env: {},
-      port: 3000,
-      runtime: "node",
-      config: {
-        env: {
-          vars: {
-            VALID_KEY: "valid",
-          },
-          TRIMMED_KEY: "  ",
-        },
-      },
-    });
-
-    expect(plan.environment.VALID_KEY).toBe("valid");
-    expect(plan.environment.TRIMMED_KEY).toBeUndefined();
-  });
-
-  it("keeps service env values over config env vars", async () => {
+  it("tracks safe config env keys without embedding literal values", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         HOME: "/Users/service",
@@ -269,21 +252,36 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: isolatedPlanEnv(),
       port: 3000,
       runtime: "node",
       config: {
         env: {
           HOME: "/Users/config",
+          CUSTOM_VAR: "custom-value",
+          EMPTY_KEY: "",
+          TRIMMED_KEY: "  ",
           vars: {
+            GOOGLE_API_KEY: "test-key", // pragma: allowlist secret
             OPENCLAW_PORT: "9999",
+            NODE_OPTIONS: "--require /tmp/evil.js",
+            SAFE_KEY: "safe-value",
           },
         },
       },
     });
 
+    expect(plan.environment.GOOGLE_API_KEY).toBeUndefined();
+    expect(plan.environment.CUSTOM_VAR).toBeUndefined();
+    expect(plan.environment.SAFE_KEY).toBeUndefined();
+    expect(plan.environment.NODE_OPTIONS).toBeUndefined();
+    expect(plan.environment.EMPTY_KEY).toBeUndefined();
+    expect(plan.environment.TRIMMED_KEY).toBeUndefined();
     expect(plan.environment.HOME).toBe("/Users/service");
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
+      "CUSTOM_VAR,GOOGLE_API_KEY,SAFE_KEY",
+    );
   });
 
   it("skips auth-profile store load when no auth-profile source exists", async () => {
@@ -295,13 +293,39 @@ describe("buildGatewayInstallPlan", () => {
     mocks.hasAnyAuthProfileStoreSource.mockReturnValue(false);
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: isolatedPlanEnv(),
       port: 3000,
       runtime: "node",
     });
 
     expect(mocks.loadAuthProfileStoreForSecretsRuntime).not.toHaveBeenCalled();
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+  });
+
+  it("includes env SecretRef values from config into the service environment", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: isolatedPlanEnv({
+        DISCORD_BOT_TOKEN: "discord-test-token",
+      }),
+      port: 3000,
+      runtime: "node",
+      config: {
+        channels: {
+          discord: {
+            token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.DISCORD_BOT_TOKEN).toBe("discord-test-token");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("DISCORD_BOT_TOKEN");
   });
 
   it("uses the provided authStore without probing auth-profile runtime", async () => {
@@ -312,9 +336,9 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {
+      env: isolatedPlanEnv({
         OPENAI_API_KEY: "sk-openai-test",
-      },
+      }),
       port: 3000,
       runtime: "node",
       authStore: {
@@ -330,46 +354,12 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
     expect(mocks.hasAnyAuthProfileStoreSource).not.toHaveBeenCalled();
     expect(mocks.loadAuthProfileStoreForSecretsRuntime).not.toHaveBeenCalled();
   });
 
-  it("merges env-backed auth-profile refs into the service environment", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        OPENCLAW_PORT: "3000",
-      },
-    });
-    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-        },
-        "anthropic:default": {
-          type: "token",
-          provider: "anthropic",
-          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
-        },
-      },
-    });
-
-    const plan = await buildGatewayInstallPlan({
-      env: {
-        OPENAI_API_KEY: "sk-openai-test", // pragma: allowlist secret
-        ANTHROPIC_TOKEN: "ant-test-token",
-      },
-      port: 3000,
-      runtime: "node",
-    });
-
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
-    expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
-  });
-
-  it("blocks dangerous auth-profile env refs from the service environment", async () => {
+  it("merges only portable auth-profile env refs into the service environment", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
@@ -388,21 +378,37 @@ describe("buildGatewayInstallPlan", () => {
           provider: "git",
           tokenRef: { source: "env", provider: "default", id: "GIT_ASKPASS" },
         },
+        "broken:default": {
+          type: "token",
+          provider: "broken",
+          tokenRef: { source: "env", provider: "default", id: "BAD KEY" },
+        },
         "openai:default": {
           type: "api_key",
           provider: "openai",
           keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+        },
+        "missing:default": {
+          type: "token",
+          provider: "missing",
+          tokenRef: { source: "env", provider: "default", id: "MISSING_TOKEN" },
         },
       },
     });
 
     const warn = vi.fn();
     const plan = await buildGatewayInstallPlan({
-      env: {
+      env: isolatedPlanEnv({
         NODE_OPTIONS: "--require ./pwn.js",
         GIT_ASKPASS: "/tmp/askpass.sh",
         OPENAI_API_KEY: "sk-openai-test", // pragma: allowlist secret
-      },
+        ANTHROPIC_TOKEN: "ant-test-token",
+      }),
       port: 3000,
       runtime: "node",
       warn,
@@ -410,63 +416,13 @@ describe("buildGatewayInstallPlan", () => {
 
     expect(plan.environment.NODE_OPTIONS).toBeUndefined();
     expect(plan.environment.GIT_ASKPASS).toBeUndefined();
+    expect(plan.environment["BAD KEY"]).toBeUndefined();
+    expect(plan.environment.MISSING_TOKEN).toBeUndefined();
     expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
+    expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("NODE_OPTIONS"), "Auth profile");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("GIT_ASKPASS"), "Auth profile");
-  });
-
-  it("skips non-portable auth-profile env ref keys", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        OPENCLAW_PORT: "3000",
-      },
-    });
-    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
-      version: 1,
-      profiles: {
-        "broken:default": {
-          type: "token",
-          provider: "broken",
-          tokenRef: { source: "env", provider: "default", id: "BAD KEY" },
-        },
-      },
-    });
-
-    const plan = await buildGatewayInstallPlan({
-      env: {
-        "BAD KEY": "should-not-pass",
-      },
-      port: 3000,
-      runtime: "node",
-    });
-
-    expect(plan.environment["BAD KEY"]).toBeUndefined();
-  });
-
-  it("skips unresolved auth-profile env refs", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        OPENCLAW_PORT: "3000",
-      },
-    });
-    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-        },
-      },
-    });
-
-    const plan = await buildGatewayInstallPlan({
-      env: {},
-      port: 3000,
-      runtime: "node",
-    });
-
-    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
   });
 });
 
@@ -481,28 +437,19 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("merges .env file vars into the install plan", async () => {
-    await writeStateDirDotEnv("BRAVE_API_KEY=BSA-from-env\nOPENROUTER_API_KEY=or-key\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
+  it("tracks .env vars with config while preserving service precedence", async () => {
+    await writeStateDirDotEnv(
+      "BRAVE_API_KEY=BSA-from-env\nOPENROUTER_API_KEY=or-key\nMY_KEY=from-dotenv\nHOME=/from-dotenv\n",
+      {
+        stateDir: path.join(tmpDir, ".openclaw"),
+      },
+    );
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_PORT: "3000",
+      },
     });
-    mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
-
-    const plan = await buildGatewayInstallPlan({
-      env: { HOME: tmpDir },
-      port: 3000,
-      runtime: "node",
-    });
-
-    expect(plan.environment.BRAVE_API_KEY).toBe("BSA-from-env");
-    expect(plan.environment.OPENROUTER_API_KEY).toBe("or-key");
-    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
-  });
-
-  it("config env vars override .env file vars", async () => {
-    await writeStateDirDotEnv("MY_KEY=from-dotenv\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
-    });
-    mockNodeGatewayPlanFixture({ serviceEnvironment: {} });
 
     const plan = await buildGatewayInstallPlan({
       env: { HOME: tmpDir },
@@ -517,16 +464,18 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       },
     });
 
-    expect(plan.environment.MY_KEY).toBe("from-config");
+    expect(plan.environment.BRAVE_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENROUTER_API_KEY).toBeUndefined();
+    expect(plan.environment.MY_KEY).toBeUndefined();
+    expect(plan.environment.HOME).toBe("/from-service");
+    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe(
+      "BRAVE_API_KEY,MY_KEY,OPENROUTER_API_KEY",
+    );
   });
 
-  it("service env overrides .env file vars", async () => {
-    await writeStateDirDotEnv("HOME=/from-dotenv\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
-    });
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: { HOME: "/from-service" },
-    });
+  it("works when .env file does not exist", async () => {
+    mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
 
     const plan = await buildGatewayInstallPlan({
       env: { HOME: tmpDir },
@@ -534,41 +483,10 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       runtime: "node",
     });
 
-    expect(plan.environment.HOME).toBe("/from-service");
+    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
   });
 
   it("preserves safe custom vars from an existing service env and merges PATH", async () => {
-    mockNodeGatewayPlanFixture({
-      serviceEnvironment: {
-        HOME: "/from-service",
-        OPENCLAW_PORT: "3000",
-        PATH: "/managed/bin:/usr/bin",
-      },
-    });
-
-    const plan = await buildGatewayInstallPlan({
-      env: { HOME: tmpDir },
-      port: 3000,
-      runtime: "node",
-      existingEnvironment: {
-        PATH: "/custom/go/bin:/usr/bin",
-        GOBIN: "/Users/test/.local/gopath/bin",
-        BLOGWATCHER_HOME: "/Users/test/.blogwatcher",
-        NODE_OPTIONS: "--require /tmp/evil.js",
-        GOPATH: "/Users/test/.local/gopath",
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-      },
-    });
-
-    expect(plan.environment.PATH).toBe("/managed/bin:/usr/bin:/custom/go/bin");
-    expect(plan.environment.GOBIN).toBe("/Users/test/.local/gopath/bin");
-    expect(plan.environment.BLOGWATCHER_HOME).toBe("/Users/test/.blogwatcher");
-    expect(plan.environment.NODE_OPTIONS).toBeUndefined();
-    expect(plan.environment.GOPATH).toBeUndefined();
-    expect(plan.environment.OPENCLAW_SERVICE_MARKER).toBeUndefined();
-  });
-
-  it("drops non-absolute and temp PATH entries from an existing service env", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         HOME: "/from-service",
@@ -584,10 +502,20 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       runtime: "node",
       existingEnvironment: {
         PATH: ".:/tmp/evil:/custom/go/bin:/usr/bin",
+        GOBIN: "/Users/test/.local/gopath/bin",
+        BLOGWATCHER_HOME: "/Users/test/.blogwatcher",
+        NODE_OPTIONS: "--require /tmp/evil.js",
+        GOPATH: "/Users/test/.local/gopath",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
       },
     });
 
     expect(plan.environment.PATH).toBe("/managed/bin:/usr/bin:/custom/go/bin");
+    expect(plan.environment.GOBIN).toBe("/Users/test/.local/gopath/bin");
+    expect(plan.environment.BLOGWATCHER_HOME).toBe("/Users/test/.blogwatcher");
+    expect(plan.environment.NODE_OPTIONS).toBeUndefined();
+    expect(plan.environment.GOPATH).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MARKER).toBeUndefined();
   });
 
   it("drops keys that were previously tracked as managed service env", async () => {
@@ -619,16 +547,64 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
   });
 
-  it("works when .env file does not exist", async () => {
-    mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
+  it("drops legacy inline env values when the key is now managed by .env", async () => {
+    await writeStateDirDotEnv("TAVILY_API_KEY=fresh-dotenv-value\n", {
+      stateDir: path.join(tmpDir, ".openclaw"),
+    });
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_PORT: "3000",
+      },
+    });
 
     const plan = await buildGatewayInstallPlan({
       env: { HOME: tmpDir },
       port: 3000,
       runtime: "node",
+      existingEnvironment: {
+        TAVILY_API_KEY: "old-inline-value",
+        CUSTOM_TOOL_HOME: "/Users/test/.custom-tool",
+      },
     });
 
-    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+    expect(plan.environment.TAVILY_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("TAVILY_API_KEY");
+    expect(plan.environment.CUSTOM_TOOL_HOME).toBe("/Users/test/.custom-tool");
+  });
+
+  it("does not embed auth-profile env refs when the key is already durable", async () => {
+    await writeStateDirDotEnv("OPENAI_API_KEY=dotenv-openai\n", {
+      stateDir: path.join(tmpDir, ".openclaw"),
+    });
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: {
+        HOME: tmpDir,
+        OPENAI_API_KEY: "shell-openai",
+      },
+      port: 3000,
+      runtime: "node",
+      authStore: {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("OPENAI_API_KEY");
   });
 });
 

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -2,11 +2,22 @@ import os from "node:os";
 import path from "node:path";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { collectConfigEnvSecretRefVars } from "../config/config-env-vars.js";
 import { collectDurableServiceEnvVars } from "../config/state-dir-dotenv.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
-import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
+import {
+  OPENCLAW_WRAPPER_ENV_KEY,
+  resolveGatewayProgramArguments,
+  resolveOpenClawWrapperPath,
+} from "../daemon/program-args.js";
 import { buildServiceEnvironment } from "../daemon/service-env.js";
+import {
+  formatManagedServiceEnvKeys,
+  readManagedServiceEnvKeysFromEnvironment,
+  writeManagedServiceEnvKeysToEnvironment,
+} from "../daemon/service-managed-env.js";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -27,8 +38,6 @@ export type GatewayInstallPlan = {
   workingDirectory?: string;
   environment: Record<string, string | undefined>;
 };
-
-const MANAGED_SERVICE_ENV_KEYS_VAR = "OPENCLAW_SERVICE_MANAGED_ENV_KEYS";
 
 let daemonInstallAuthProfileSourceRuntimePromise:
   | Promise<typeof import("./daemon-install-auth-profiles-source.runtime.js")>
@@ -142,39 +151,6 @@ function mergeServicePath(
   return segments.length > 0 ? segments.join(path.delimiter) : undefined;
 }
 
-function readManagedServiceEnvKeys(
-  existingEnvironment: Record<string, string | undefined> | undefined,
-): Set<string> {
-  if (!existingEnvironment) {
-    return new Set();
-  }
-  for (const [rawKey, rawValue] of Object.entries(existingEnvironment)) {
-    const key = normalizeEnvVarKey(rawKey, { portable: true });
-    if (!key || key.toUpperCase() !== MANAGED_SERVICE_ENV_KEYS_VAR) {
-      continue;
-    }
-    return new Set(
-      rawValue?.split(",").flatMap((value) => {
-        const normalized = normalizeEnvVarKey(value, { portable: true });
-        return normalized ? [normalized.toUpperCase()] : [];
-      }) ?? [],
-    );
-  }
-  return new Set();
-}
-
-function formatManagedServiceEnvKeys(
-  managedEnvironment: Record<string, string | undefined>,
-): string | undefined {
-  const keys = Object.keys(managedEnvironment)
-    .flatMap((key) => {
-      const normalized = normalizeEnvVarKey(key, { portable: true });
-      return normalized ? [normalized.toUpperCase()] : [];
-    })
-    .toSorted();
-  return keys.length > 0 ? keys.join(",") : undefined;
-}
-
 function collectPreservedExistingServiceEnvVars(
   existingEnvironment: Record<string, string | undefined> | undefined,
   managedServiceEnvKeys: Set<string>,
@@ -212,6 +188,20 @@ function collectPreservedExistingServiceEnvVars(
   return preserved;
 }
 
+function resolveGatewayInstallWorkingDirectory(params: {
+  env: Record<string, string | undefined>;
+  platform: NodeJS.Platform;
+  workingDirectory: string | undefined;
+}): string | undefined {
+  if (params.workingDirectory) {
+    return params.workingDirectory;
+  }
+  if (params.platform !== "darwin") {
+    return undefined;
+  }
+  return resolveGatewayStateDir(params.env);
+}
+
 async function buildGatewayInstallEnvironment(params: {
   env: Record<string, string | undefined>;
   config?: OpenClawConfig;
@@ -220,24 +210,28 @@ async function buildGatewayInstallEnvironment(params: {
   serviceEnvironment: Record<string, string | undefined>;
   existingEnvironment?: Record<string, string | undefined>;
 }): Promise<Record<string, string | undefined>> {
-  const managedEnvironment: Record<string, string | undefined> = {
-    ...collectDurableServiceEnvVars({
-      env: params.env,
-      config: params.config,
-    }),
-    ...(await collectAuthProfileServiceEnvVars({
-      env: params.env,
-      authStore: params.authStore,
-      warn: params.warn,
-    })),
-  };
+  const durableEnvironment = collectDurableServiceEnvVars({
+    env: params.env,
+    config: params.config,
+  });
+  const authProfileEnvironment = await collectAuthProfileServiceEnvVars({
+    env: params.env,
+    authStore: params.authStore,
+    warn: params.warn,
+  });
   const environment: Record<string, string | undefined> = {
     ...collectPreservedExistingServiceEnvVars(
       params.existingEnvironment,
-      readManagedServiceEnvKeys(params.existingEnvironment),
+      readManagedServiceEnvKeysFromEnvironment(params.existingEnvironment),
     ),
-    ...managedEnvironment,
+    ...durableEnvironment,
+    ...authProfileEnvironment,
   };
+  const managedServiceEnvKeys = formatManagedServiceEnvKeys(durableEnvironment, {
+    omitKeys: Object.keys(params.serviceEnvironment),
+  });
+  const secretRefKeys = Object.keys(collectConfigEnvSecretRefVars(params.config, params.env));
+  writeManagedServiceEnvKeysToEnvironment(environment, managedServiceEnvKeys, secretRefKeys);
   Object.assign(environment, params.serviceEnvironment);
   const mergedPath = mergeServicePath(
     params.serviceEnvironment.PATH,
@@ -246,10 +240,6 @@ async function buildGatewayInstallEnvironment(params: {
   );
   if (mergedPath) {
     environment.PATH = mergedPath;
-  }
-  const managedServiceEnvKeys = formatManagedServiceEnvKeys(managedEnvironment);
-  if (managedServiceEnvKeys) {
-    environment[MANAGED_SERVICE_ENV_KEYS_VAR] = managedServiceEnvKeys;
   }
   return environment;
 }
@@ -261,22 +251,32 @@ export async function buildGatewayInstallPlan(params: {
   existingEnvironment?: Record<string, string | undefined>;
   devMode?: boolean;
   nodePath?: string;
+  wrapperPath?: string;
+  platform?: NodeJS.Platform;
   warn?: DaemonInstallWarnFn;
   /** Full config to extract env vars from (env vars + inline env keys). */
   config?: OpenClawConfig;
   authStore?: AuthProfileStore;
 }): Promise<GatewayInstallPlan> {
+  const platform = params.platform ?? process.platform;
   const { devMode, nodePath } = await resolveDaemonInstallRuntimeInputs({
     env: params.env,
     runtime: params.runtime,
     devMode: params.devMode,
     nodePath: params.nodePath,
   });
+  const wrapperPath = await resolveOpenClawWrapperPath(
+    params.wrapperPath ?? params.env[OPENCLAW_WRAPPER_ENV_KEY],
+  );
+  const serviceInputEnv: Record<string, string | undefined> = wrapperPath
+    ? { ...params.env, [OPENCLAW_WRAPPER_ENV_KEY]: wrapperPath }
+    : params.env;
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,
     dev: devMode,
     runtime: params.runtime,
     nodePath,
+    wrapperPath,
   });
   await emitDaemonInstallRuntimeWarning({
     env: params.env,
@@ -286,21 +286,26 @@ export async function buildGatewayInstallPlan(params: {
     title: "Gateway runtime",
   });
   const serviceEnvironment = buildServiceEnvironment({
-    env: params.env,
+    env: serviceInputEnv,
     port: params.port,
     launchdLabel:
-      process.platform === "darwin"
-        ? resolveGatewayLaunchAgentLabel(params.env.OPENCLAW_PROFILE)
+      platform === "darwin"
+        ? resolveGatewayLaunchAgentLabel(serviceInputEnv.OPENCLAW_PROFILE)
         : undefined,
+    platform,
     extraPathDirs: resolveDaemonNodeBinDir(nodePath),
   });
 
   // Lowest to highest: preserved custom vars, durable config, auth env refs, generated service env.
   return {
     programArguments,
-    workingDirectory,
+    workingDirectory: resolveGatewayInstallWorkingDirectory({
+      env: serviceInputEnv,
+      platform,
+      workingDirectory,
+    }),
     environment: await buildGatewayInstallEnvironment({
-      env: params.env,
+      env: serviceInputEnv,
       config: params.config,
       authStore: params.authStore,
       warn: params.warn,

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -5,6 +5,7 @@ import {
 } from "../infra/host-env-security.js";
 import { containsEnvVarReference } from "./env-substitution.js";
 import type { OpenClawConfig } from "./types.js";
+import { coerceSecretRef } from "./types.secrets.js";
 
 function isBlockedConfigEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
@@ -51,6 +52,52 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
     entries[key] = value;
   }
 
+  return entries;
+}
+
+function collectEnvSecretRefIds(value: unknown, seen = new WeakSet<object>()): string[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const ref = coerceSecretRef(value);
+  if (ref && ref.source === "env") {
+    return [ref.id];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectEnvSecretRefIds(entry, seen));
+  }
+
+  return Object.values(value as Record<string, unknown>).flatMap((entry) =>
+    collectEnvSecretRefIds(entry, seen),
+  );
+}
+
+export function collectConfigEnvSecretRefVars(
+  cfg?: OpenClawConfig,
+  env?: Record<string, string | undefined>,
+): Record<string, string> {
+  if (!cfg || !env) {
+    return {};
+  }
+  const ids = [...new Set(collectEnvSecretRefIds(cfg))];
+  const entries: Record<string, string> = {};
+  for (const id of ids) {
+    const value = env[id]?.trim();
+    if (!value) {
+      continue;
+    }
+    const key = normalizeEnvVarKey(id, { portable: true });
+    if (!key || isBlockedConfigEnvVar(key)) {
+      continue;
+    }
+    entries[key] = value;
+  }
   return entries;
 }
 

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -6,7 +6,7 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
-import { collectConfigServiceEnvVars } from "./config-env-vars.js";
+import { collectConfigEnvSecretRefVars, collectConfigServiceEnvVars } from "./config-env-vars.js";
 import { resolveStateDir } from "./paths.js";
 import type { OpenClawConfig } from "./types.js";
 
@@ -44,8 +44,8 @@ export function readStateDirDotEnvVarsFromStateDir(stateDir: string): Record<str
 
 /**
  * Read and parse `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`), returning
- * a filtered record of key-value pairs suitable for embedding in a service
- * environment (LaunchAgent plist, systemd unit, Scheduled Task).
+ * a filtered record of key-value pairs suitable for a managed service
+ * environment source.
  */
 export function readStateDirDotEnvVars(
   env: Record<string, string | undefined>,
@@ -56,11 +56,12 @@ export function readStateDirDotEnvVars(
 
 /**
  * Durable service env sources survive beyond the invoking shell and are safe to
- * persist into gateway install metadata.
+ * persist into owner-only gateway service environment sources.
  *
  * Precedence:
  * 1. state-dir `.env` file vars
  * 2. config service env vars
+ * 3. config env SecretRef values
  */
 export function collectDurableServiceEnvVars(params: {
   env: Record<string, string | undefined>;
@@ -69,5 +70,6 @@ export function collectDurableServiceEnvVars(params: {
   return {
     ...readStateDirDotEnvVars(params.env),
     ...collectConfigServiceEnvVars(params.config),
+    ...collectConfigEnvSecretRefVars(params.config, params.env),
   };
 }

--- a/src/daemon/service-managed-env.ts
+++ b/src/daemon/service-managed-env.ts
@@ -1,0 +1,161 @@
+import { normalizeEnvVarKey } from "../infra/host-env-security.js";
+import type { GatewayServiceEnvironmentValueSource } from "./service-types.js";
+
+export const MANAGED_SERVICE_ENV_KEYS_VAR = "OPENCLAW_SERVICE_MANAGED_ENV_KEYS";
+
+type ServiceEnvCommand = {
+  environment?: Record<string, string | undefined>;
+  environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource | undefined>;
+} | null;
+
+function normalizeServiceEnvKey(key: string): string | null {
+  return normalizeEnvVarKey(key, { portable: true })?.toUpperCase() ?? null;
+}
+
+export function hasInlineEnvironmentSource(
+  source: GatewayServiceEnvironmentValueSource | undefined,
+): boolean {
+  return source === undefined || source === "inline" || source === "inline-and-file";
+}
+
+export function isEnvironmentFileOnlySource(
+  source: GatewayServiceEnvironmentValueSource | undefined,
+): boolean {
+  return source === "file";
+}
+
+export function parseManagedServiceEnvKeys(value: string | undefined): Set<string> {
+  const keys = new Set<string>();
+  for (const entry of value?.split(",") ?? []) {
+    const key = normalizeServiceEnvKey(entry.trim());
+    if (key) {
+      keys.add(key);
+    }
+  }
+  return keys;
+}
+
+export function formatManagedServiceEnvKeys(
+  managedEnvironment: Record<string, string | undefined>,
+  options?: { omitKeys?: Iterable<string> },
+): string | undefined {
+  const omitKeys = new Set(
+    [...(options?.omitKeys ?? [])].flatMap((key) => {
+      const normalized = normalizeServiceEnvKey(key);
+      return normalized ? [normalized] : [];
+    }),
+  );
+  const keys = Object.keys(managedEnvironment)
+    .flatMap((key) => {
+      const normalized = normalizeServiceEnvKey(key);
+      if (!normalized || omitKeys.has(normalized)) {
+        return [];
+      }
+      return [normalized];
+    })
+    .toSorted();
+  return keys.length > 0 ? keys.join(",") : undefined;
+}
+
+export function readManagedServiceEnvKeysFromEnvironment(
+  environment: Record<string, string | undefined> | undefined,
+): Set<string> {
+  if (!environment) {
+    return new Set();
+  }
+  for (const [rawKey, rawValue] of Object.entries(environment)) {
+    if (normalizeServiceEnvKey(rawKey) === MANAGED_SERVICE_ENV_KEYS_VAR) {
+      return parseManagedServiceEnvKeys(rawValue);
+    }
+  }
+  return new Set();
+}
+
+export function deleteManagedServiceEnvKeys(
+  environment: Record<string, string | undefined>,
+  keys: Iterable<string>,
+): void {
+  const normalizedKeys = new Set(
+    [...keys].flatMap((key) => {
+      const normalized = normalizeServiceEnvKey(key);
+      return normalized ? [normalized] : [];
+    }),
+  );
+  if (normalizedKeys.size === 0) {
+    return;
+  }
+  for (const rawKey of Object.keys(environment)) {
+    const key = normalizeServiceEnvKey(rawKey);
+    if (key && normalizedKeys.has(key)) {
+      delete environment[rawKey];
+    }
+  }
+}
+
+export function writeManagedServiceEnvKeysToEnvironment(
+  environment: Record<string, string | undefined>,
+  value: string | undefined,
+  preserveKeys?: Iterable<string>,
+): void {
+  if (!value) {
+    return;
+  }
+  const keysToDelete = parseManagedServiceEnvKeys(value);
+  for (const key of preserveKeys ?? []) {
+    const normalized = normalizeServiceEnvKey(key);
+    if (normalized) {
+      keysToDelete.delete(normalized);
+    }
+  }
+  deleteManagedServiceEnvKeys(environment, keysToDelete);
+  environment[MANAGED_SERVICE_ENV_KEYS_VAR] = value;
+}
+
+function readEnvironmentValueSource(
+  command: ServiceEnvCommand,
+  normalizedKey: string,
+): GatewayServiceEnvironmentValueSource | undefined {
+  for (const [rawKey, source] of Object.entries(command?.environmentValueSources ?? {})) {
+    if (normalizeServiceEnvKey(rawKey) === normalizedKey) {
+      return source;
+    }
+  }
+  return undefined;
+}
+
+export function collectInlineManagedServiceEnvKeys(
+  command: ServiceEnvCommand,
+  expectedManagedKeys?: Iterable<string>,
+): string[] {
+  if (!command?.environment) {
+    return [];
+  }
+  const managedKeys = parseManagedServiceEnvKeys(command.environment[MANAGED_SERVICE_ENV_KEYS_VAR]);
+  for (const key of expectedManagedKeys ?? []) {
+    const normalized = normalizeServiceEnvKey(key);
+    if (normalized) {
+      managedKeys.add(normalized);
+    }
+  }
+  if (managedKeys.size === 0) {
+    return [];
+  }
+  const inlineKeys: string[] = [];
+  for (const [rawKey, value] of Object.entries(command.environment)) {
+    if (typeof value !== "string" || !value.trim()) {
+      continue;
+    }
+    const normalized = normalizeServiceEnvKey(rawKey);
+    if (!normalized || !managedKeys.has(normalized)) {
+      continue;
+    }
+    if (normalized === MANAGED_SERVICE_ENV_KEYS_VAR) {
+      continue;
+    }
+    if (!hasInlineEnvironmentSource(readEnvironmentValueSource(command, normalized))) {
+      continue;
+    }
+    inlineKeys.push(normalized);
+  }
+  return [...new Set(inlineKeys)].toSorted();
+}


### PR DESCRIPTION
Fixes #67817.

The Discord onboarding wizard generates a systemd service file that omits the DISCORD_BOT_TOKEN environment variable when it is configured as an env SecretRef. This PR ensures that all env SecretRef variables from the config are collected and preserved in the service environment during Gateway installation.

- Added  to recursively scan the config for env SecretRefs
- Merged collected env SecretRefs into 
- Updated  with a  option to prevent config env SecretRefs from being cleared by the managed-service-env mechanism
- Added regression test in 