### PR TITLE
fix(plugin-sdk): backfill reasoning_content on all DeepSeek V4 assistant messages

### DIFF
--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -4,6 +4,7 @@ import {
   buildCopilotDynamicHeaders,
   createHtmlEntityToolCallArgumentDecodingWrapper,
   createAnthropicThinkingPrefillPayloadWrapper,
+  createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createPayloadPatchStreamWrapper,
   defaultToolStreamExtraParams,
   decodeHtmlEntitiesInObject,
@@ -319,6 +320,87 @@ describe("stripTrailingAnthropicAssistantPrefillWhenThinking", () => {
 
     expect(stripTrailingAnthropicAssistantPrefillWhenThinking(payload)).toBe(0);
     expect(payload.messages).toHaveLength(2);
+  });
+});
+
+describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
+  function capturePayload(
+    thinkingLevel: string,
+    messages: Record<string, unknown>[],
+  ): Record<string, unknown>[] {
+    const payload = { messages: structuredClone(messages) };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: thinkingLevel as never,
+      shouldPatchModel: () => true,
+    });
+    void wrapped!({} as never, {} as never, {});
+    return payload.messages;
+  }
+
+  it("backfills reasoning_content on assistant messages with tool_calls", () => {
+    const messages = capturePayload("high", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", tool_calls: [{ id: "call_1", name: "Read" }] },
+      { role: "tool", content: "file content" },
+    ]);
+    expect(messages[1]).toHaveProperty("reasoning_content", "");
+    expect(messages[0]).not.toHaveProperty("reasoning_content");
+    expect(messages[2]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("backfills reasoning_content on plain assistant messages without tool_calls", () => {
+    const messages = capturePayload("high", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+      { role: "user", content: "Thanks" },
+      { role: "assistant", content: "You're welcome" },
+    ]);
+    expect(messages[1]).toHaveProperty("reasoning_content", "");
+    expect(messages[3]).toHaveProperty("reasoning_content", "");
+    expect(messages[0]).not.toHaveProperty("reasoning_content");
+    expect(messages[2]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("preserves existing reasoning_content on assistant messages", () => {
+    const messages = capturePayload("high", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Thinking...", reasoning_content: "I should greet" },
+    ]);
+    expect(messages[1]).toHaveProperty("reasoning_content", "I should greet");
+  });
+
+  it("handles mixed assistant messages with and without tool_calls", () => {
+    const messages = capturePayload("high", [
+      { role: "user", content: "read file" },
+      { role: "assistant", tool_calls: [{ id: "call_1", name: "Read" }] },
+      { role: "tool", content: "file content" },
+      { role: "assistant", content: "Here is the file" },
+    ]);
+    expect(messages[1]).toHaveProperty("reasoning_content", "");
+    expect(messages[3]).toHaveProperty("reasoning_content", "");
+  });
+
+  it("strips reasoning_content when thinking is disabled", () => {
+    const messages = capturePayload("off", [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi", reasoning_content: "thinking" },
+    ]);
+    expect(messages[1]).not.toHaveProperty("reasoning_content");
+  });
+
+  it("returns undefined when baseStreamFn is undefined", () => {
+    const result = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn: undefined,
+      thinkingLevel: "high" as never,
+      shouldPatchModel: () => true,
+    });
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -259,7 +259,7 @@ function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void
   }
 }
 
-function ensureDeepSeekV4ToolCallReasoningContent(payload: Record<string, unknown>): void {
+function ensureDeepSeekV4AssistantReasoningContent(payload: Record<string, unknown>): void {
   if (!Array.isArray(payload.messages)) {
     return;
   }
@@ -268,7 +268,7 @@ function ensureDeepSeekV4ToolCallReasoningContent(payload: Record<string, unknow
       continue;
     }
     const record = message as Record<string, unknown>;
-    if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+    if (record.role !== "assistant") {
       continue;
     }
     if (!("reasoning_content" in record)) {
@@ -302,7 +302,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
 
       payload.thinking = { type: "enabled" };
       payload.reasoning_effort = resolveDeepSeekV4ReasoningEffort(params.thinkingLevel);
-      ensureDeepSeekV4ToolCallReasoningContent(payload);
+      ensureDeepSeekV4AssistantReasoningContent(payload);
     });
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** [#73417](https://github.com/openclaw/openclaw/issues/73417) — DeepSeek V4 returns 400 (`The reasoning_content in the thinking mode must be passed back to the API`) when conversation history contains plain assistant text replies without `reasoning_content`.
- **Root cause:** `ensureDeepSeekV4ToolCallReasoningContent` only backfilled `reasoning_content` on assistant messages with `tool_calls`. DeepSeek V4's API requires it on **all** assistant messages when thinking mode is enabled — including plain text replies.
- **Fix:** Remove the `!Array.isArray(record.tool_calls)` guard so `reasoning_content: ""` is backfilled on every assistant message missing it. Rename the helper to `ensureDeepSeekV4AssistantReasoningContent` to reflect the broader scope.
- **Verified locally** by the issue reporter who patched the bundled JS and confirmed the fix resolves the 400.

## Change Type

- [x] Bug fix

## Scope

- [x] API / contracts

## Linked Issue

- Closes #73417
- Related #71372 (original tool-call-only fix)

## Root Cause

```typescript
// Before: skips plain assistant messages
if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) continue;

// After: applies to all assistant messages
if (record.role !== "assistant") continue;
```

Per [DeepSeek official docs](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode): when thinking mode is enabled, `reasoning_content` must be passed back on **all** assistant messages in subsequent requests, not just tool-call turns.

## Tests

6 new tests covering:
1. Backfill on assistant messages with tool_calls (existing behavior preserved)
2. Backfill on plain assistant messages without tool_calls (the fix)
3. Preserves existing reasoning_content values
4. Mixed conversation with both tool-call and plain assistant messages
5. Strips reasoning_content when thinking is disabled
6. Returns undefined when baseStreamFn is undefined

All tests exercise the exported `createDeepSeekV4OpenAICompatibleThinkingWrapper` wrapper.