### PR TITLE
ci: schedule android codeql shard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 /.github/dependabot.yml @openclaw/secops
 /.github/codeql/ @openclaw/secops
 /.github/workflows/codeql.yml @openclaw/secops
+/.github/workflows/codeql-android-critical-security.yml @openclaw/secops
 /.github/workflows/codeql-critical-quality.yml @openclaw/secops
 /src/security/ @openclaw/secops
 /src/secrets/ @openclaw/secops

--- a/.github/workflows/codeql-android-critical-security.yml
+++ b/.github/workflows/codeql-android-critical-security.yml
@@ -1,0 +1,51 @@
+name: CodeQL Android Critical Security
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *"
+
+concurrency:
+  group: codeql-android-critical-security-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.sha }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  android:
+    name: Critical Security (android)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+          config-file: ./.github/codeql/codeql-android-critical-security.yml
+
+      - name: Build Android for CodeQL
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:assemblePlayDebug
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-security/android"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,6 @@ on:
         options:
           - all
           - security
-          - android-security
           - macos-security
   schedule:
     - cron: "0 6 * * *"
@@ -62,39 +61,6 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-security/${{ matrix.language }}"
-
-  android-security:
-    name: Critical Security (android)
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'android-security' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: false
-
-      - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
-        with:
-          languages: java-kotlin
-          build-mode: manual
-          config-file: ./.github/codeql/codeql-android-critical-security.yml
-
-      - name: Build Android for CodeQL
-        working-directory: apps/android
-        run: ./gradlew --no-daemon :app:assemblePlayDebug
-
-      - name: Analyze
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
-        with:
-          category: "/codeql-critical-security/android"
 
   macos-security:
     name: Critical Security (macOS)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -230,18 +230,22 @@ or overlapping changed hunks.
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner,
 not the full repository sweep. Daily and manual runs scan Actions workflow code
 plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
-gateway surfaces with high-precision security queries. Android and macOS remain
-manual security shards so their runtime and alert quality can be tracked
-separately.
+gateway surfaces with high-precision security queries. macOS remains a manual
+security shard so its runtime and alert quality can be tracked separately.
+
+The `CodeQL Android Critical Security` workflow is the scheduled Android
+security shard. It builds the Android app manually for CodeQL on the smallest
+Blacksmith Linux runner label accepted by workflow sanity and uploads results
+under the `/codeql-critical-security/android` category.
 
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over the same narrow auth, secrets, sandbox, cron, and gateway surface. Keep it
 separate from the security workflow so quality findings can be scheduled,
 measured, disabled, or expanded without obscuring security signal. Swift,
-Android, Python, UI, and bundled-plugin CodeQL expansion should be added back as
-scoped or sharded follow-up work only after the narrow profiles have stable
-runtime and signal.
+Python, UI, and bundled-plugin CodeQL expansion should be added back as scoped
+or sharded follow-up work only after the narrow profiles have stable runtime and
+signal.
 
 The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping
 existing docs aligned with recently landed changes. It has no pure schedule: a


### PR DESCRIPTION
## Summary

- Problem: Android CodeQL was still coupled to the main `CodeQL` workflow as a manual profile.
- Why it matters: Android has different runtime and build requirements, so it should have its own schedule and run history.
- What changed: moved Android critical security scanning into a dedicated scheduled/manual workflow.
- What did NOT change (scope boundary): no query expansion, no Android source changes, no macOS scheduling change.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #73404
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context: Android critical security is clean and fast enough to schedule, but it should stay separately measurable from JS/TS and Actions CodeQL.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/codeql.yml`, `.github/workflows/codeql-android-critical-security.yml`
- Scenario the test should lock in: workflow sanity accepts the split Android workflow.
- Why this is the smallest reliable guardrail: this is workflow topology, not product runtime behavior.
- Existing test that already covers this: `pnpm check:workflows`
- If no new test is added, why not: no product behavior changed.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
CodeQL -> JS/TS security + Actions security + manual Android + manual macOS

After:
CodeQL -> JS/TS security + Actions security + manual macOS
CodeQL Android Critical Security -> scheduled/manual Android
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo workflow sanity
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Split Android CodeQL into `.github/workflows/codeql-android-critical-security.yml`.
2. Remove `profile=android-security` from `.github/workflows/codeql.yml`.
3. Validate workflow syntax and repo workflow policy.

### Expected

- Security CodeQL remains focused on JS/TS and Actions categories.
- Android CodeQL has its own scheduled/manual workflow.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```bash
pnpm check:workflows
git diff --check origin/main...HEAD
ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/codeql.yml .github/workflows/codeql-critical-quality.yml .github/workflows/codeql-android-critical-security.yml
```

## Human Verification (required)

- Verified scenarios: workflow sanity, YAML parse, whitespace check, docs update.
- Edge cases checked: new workflow preserves the same Android CodeQL config, manual Gradle build, and `/codeql-critical-security/android` category.
- What you did **not** verify: GitHub manual dispatch of the new workflow, because newly added workflow files may not be dispatchable until present on the default branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: maintainers may look for `profile=android-security` on the existing `CodeQL` workflow.
  - Mitigation: docs now point to the dedicated `CodeQL Android Critical Security` workflow.

AI-assisted: yes.
