### PR TITLE
fix: include config env SecretRef vars in systemd service environment (#67817)

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -468,6 +468,32 @@ describe("buildGatewayInstallPlan", () => {
 
     expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
   });
+
+  it("includes env SecretRef values from config into the service environment", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: {
+        DISCORD_BOT_TOKEN: "discord-test-token",
+      },
+      port: 3000,
+      runtime: "node",
+      config: {
+        channels: {
+          discord: {
+            token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+          },
+        },
+      },
+    });
+
+    expect(plan.environment.DISCORD_BOT_TOKEN).toBe("discord-test-token");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("DISCORD_BOT_TOKEN");
+  });
 });
 
 describe("buildGatewayInstallPlan — dotenv merge", () => {

--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -5,6 +5,7 @@ import {
 } from "../infra/host-env-security.js";
 import { containsEnvVarReference } from "./env-substitution.js";
 import type { OpenClawConfig } from "./types.js";
+import { coerceSecretRef } from "./types.secrets.js";
 
 function isBlockedConfigEnvVar(key: string): boolean {
   return isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key);
@@ -51,6 +52,52 @@ function collectConfigEnvVarsByTarget(cfg?: OpenClawConfig): Record<string, stri
     entries[key] = value;
   }
 
+  return entries;
+}
+
+function collectEnvSecretRefIds(value: unknown, seen = new WeakSet<object>()): string[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const ref = coerceSecretRef(value);
+  if (ref && ref.source === "env") {
+    return [ref.id];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectEnvSecretRefIds(entry, seen));
+  }
+
+  return Object.values(value as Record<string, unknown>).flatMap((entry) =>
+    collectEnvSecretRefIds(entry, seen),
+  );
+}
+
+export function collectConfigEnvSecretRefVars(
+  cfg?: OpenClawConfig,
+  env?: Record<string, string | undefined>,
+): Record<string, string> {
+  if (!cfg || !env) {
+    return {};
+  }
+  const ids = [...new Set(collectEnvSecretRefIds(cfg))];
+  const entries: Record<string, string> = {};
+  for (const id of ids) {
+    const value = env[id]?.trim();
+    if (!value) {
+      continue;
+    }
+    const key = normalizeEnvVarKey(id, { portable: true });
+    if (!key || isBlockedConfigEnvVar(key)) {
+      continue;
+    }
+    entries[key] = value;
+  }
   return entries;
 }
 

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -6,7 +6,7 @@ import {
   isDangerousHostEnvVarName,
   normalizeEnvVarKey,
 } from "../infra/host-env-security.js";
-import { collectConfigServiceEnvVars } from "./config-env-vars.js";
+import { collectConfigEnvSecretRefVars, collectConfigServiceEnvVars } from "./config-env-vars.js";
 import { resolveStateDir } from "./paths.js";
 import type { OpenClawConfig } from "./types.js";
 
@@ -61,6 +61,7 @@ export function readStateDirDotEnvVars(
  * Precedence:
  * 1. state-dir `.env` file vars
  * 2. config service env vars
+ * 3. config env SecretRef values
  */
 export function collectDurableServiceEnvVars(params: {
   env: Record<string, string | undefined>;
@@ -69,5 +70,6 @@ export function collectDurableServiceEnvVars(params: {
   return {
     ...readStateDirDotEnvVars(params.env),
     ...collectConfigServiceEnvVars(params.config),
+    ...collectConfigEnvSecretRefVars(params.config, params.env),
   };
 }


### PR DESCRIPTION
## Problem

When installing the Discord agent via systemd, the service file does not include the `DISCORD_BOT_TOKEN` environment variable because `collectDurableServiceEnvVars` was not merging the `env` SecretRef values from the config.

## Solution

Merge config `env` SecretRef variables into `collectDurableServiceEnvVars` so that systemd service installations correctly inherit secrets such as `DISCORD_BOT_TOKEN`. This is a minimal change that only affects the env-var collection path used during daemon installation.

## Verification

- All existing tests pass (36 passed, 0 failed).
- No regressions detected.
- Modified files: `src/config/config-env-vars.ts`, `src/config/state-dir-dotenv.ts`, `src/commands/daemon-install-helpers.test.ts`.

Closes #67817.