### PR TITLE
fix(docs): preserve page path when switching locale

### DIFF
--- a/docs/locale-path-preserve.js
+++ b/docs/locale-path-preserve.js
@@ -1,0 +1,104 @@
+/**
+ * Preserve the current page path when switching locales via the Mintlify
+ * language dropdown. Without this, Mintlify navigates to the target
+ * locale's homepage instead of the equivalent page.
+ *
+ * The dropdown items are <div role="menuitem"> elements (not <a> links)
+ * with no href. Each item's id encodes the Mintlify language code, e.g.
+ * "localization-select-item-zh-Hans". We map that to the URL prefix
+ * used in docs.json navigation (e.g. "zh-Hans" → "zh-CN") and navigate
+ * directly.
+ */
+(() => {
+  const SELECTOR_CONTENT = "#localization-select-content";
+  const SELECTOR_ITEM = '[data-component-part="localization-select-item"]';
+  const ITEM_ID_PREFIX = "localization-select-item-";
+
+  // Mintlify language code → URL path prefix.
+  // Entries where the code itself is the prefix are omitted;
+  // only the mismatches need listing here.
+  const LOCALE_TO_PREFIX = {
+    en: "",
+    "zh-Hans": "zh-CN",
+    ja: "ja-JP",
+  };
+
+  // All known URL prefixes, used to strip the current locale from the path.
+  const KNOWN_PREFIXES = new Set([
+    "zh-CN",
+    "ja-JP",
+    "es",
+    "pt-BR",
+    "ko",
+    "de",
+    "fr",
+    "ar",
+    "it",
+    "tr",
+    "uk",
+    "id",
+    "pl",
+  ]);
+
+  const prefixFor = (locale) =>
+    locale in LOCALE_TO_PREFIX ? LOCALE_TO_PREFIX[locale] : locale;
+
+  const localeFromId = (id) => {
+    if (!id.startsWith(ITEM_ID_PREFIX)) return null;
+    return id.slice(ITEM_ID_PREFIX.length) || null;
+  };
+
+  const currentPrefix = () => {
+    const seg = location.pathname.split("/")[1];
+    return KNOWN_PREFIXES.has(seg) ? seg : "";
+  };
+
+  const cleanPath = (pathname) => {
+    for (const prefix of KNOWN_PREFIXES) {
+      if (pathname === `/${prefix}` || pathname.startsWith(`/${prefix}/`)) {
+        return pathname.slice(prefix.length + 1) || "/";
+      }
+    }
+    return pathname;
+  };
+
+  const handleClick = (event) => {
+    const item = event.target.closest(SELECTOR_ITEM);
+    if (!item || item.dataset.selected === "true") return;
+
+    const locale = localeFromId(item.id);
+    if (!locale) return;
+
+    const targetPrefix = prefixFor(locale);
+    const activePrefix = currentPrefix();
+
+    // Already on the target locale — let Mintlify handle it.
+    if (targetPrefix === activePrefix) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const base = cleanPath(location.pathname);
+    const targetPath = targetPrefix ? `/${targetPrefix}${base}` : base;
+    window.location.href = `${targetPath}${location.search}${location.hash}`;
+  };
+
+  const attach = () => {
+    const dropdown = document.querySelector(SELECTOR_CONTENT);
+    if (!dropdown || dropdown.dataset.lpAttached) return;
+    dropdown.dataset.lpAttached = "1";
+    dropdown.addEventListener("click", handleClick, true);
+  };
+
+  const observer = new MutationObserver(attach);
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      attach();
+      observer.observe(document.body, { childList: true, subtree: true });
+    });
+  } else {
+    attach();
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+})();


### PR DESCRIPTION
## Summary

Mintlify's built-in language switcher navigates to the target locale's **homepage** instead of the equivalent page. For example, switching from `/start/getting-started` (English) to Chinese goes to `/zh-CN` instead of `/zh-CN/start/getting-started`.

This PR adds a lightweight client-side script (`docs/locale-path-preserve.js`) that intercepts locale selection and constructs the correct path.

## How it works

The dropdown items are `<div role="menuitem">` elements with **no href** — each item's `id` encodes the Mintlify locale code (e.g. `localization-select-item-zh-Hans`). The script:

1. Attaches a capturing click listener to `#localization-select-content` (appears lazily via Radix UI portal when the dropdown opens)
2. Extracts the locale from the item's `id`
3. Maps Mintlify language codes to URL prefixes (`zh-Hans` → `zh-CN`, `ja` → `ja-JP`, others use the code directly)
4. Strips the current locale prefix from `location.pathname` and prepends the target prefix
5. Navigates via `window.location.href`

## Example

| Current URL | Switch to | Navigates to |
|---|---|---|
| `/start/getting-started` | 中文 | `/zh-CN/start/getting-started` |
| `/zh-CN/start/getting-started` | English | `/start/getting-started` |
| `/gateway/configuration` | 日本語 | `/ja-JP/gateway/configuration` |

## How to verify the fix works

The easiest way is to inject the script into the live site and test manually.

### Option A: Browser console (quickest)

1. Open https://docs.openclaw.ai/start/getting-started
2. Open DevTools → Console
3. Paste the entire contents of `docs/locale-path-preserve.js` and press Enter
4. Click the language dropdown (top-left, next to the logo) → select **简体中文**
5. **Expected**: URL becomes `/zh-CN/start/getting-started` and the page loads the Chinese translation
6. **Without the fix**: URL would be `/zh-CN` (the Chinese homepage)

### Option B: Mintlify local preview

```bash
npx mintlify dev
```

Then repeat the same steps as above on `localhost:3000`. The script is auto-included by Mintlify because it's a `.js` file inside the `docs/` directory.

## DOM verification

The implementation is based on live DOM inspection of `docs.openclaw.ai` via Puppeteer. The key finding is that Mintlify's language dropdown items are **not** `<a>` links — they are `<div role="menuitem">` elements with no `href`, rendered lazily by Radix UI when the dropdown opens.

To reproduce:

```bash
cd /tmp && npm install puppeteer-core
```

```js
import puppeteer from 'puppeteer-core';

const browser = await puppeteer.launch({
  headless: 'new',
  executablePath: '<your-chrome-binary>',
  args: ['--no-sandbox']
});
const page = await browser.newPage();
await page.setViewport({ width: 1280, height: 900 });
await page.goto('https://docs.openclaw.ai/start/getting-started', { waitUntil: 'networkidle2' });

const { x, y } = await page.evaluate(() => {
  const r = document.querySelector('#localization-select-trigger').getBoundingClientRect();
  return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
});
await page.mouse.click(x, y);
await new Promise(r => setTimeout(r, 2000));

const items = await page.evaluate(() =>
  Array.from(document.querySelectorAll('[role=menuitem]')).map(el => ({
    id: el.id,                    // "localization-select-item-zh-Hans"
    tag: el.tagName,              // "DIV" — not "A"
    href: el.getAttribute('href'),// null — no href
    text: el.textContent.trim(),  // "简体中文"
    selected: el.dataset.selected
  }))
);
console.log(JSON.stringify(items, null, 2));
await browser.close();
```

Or in-browser: F12 → Console → expand language dropdown → run:

```js
document.querySelectorAll('[role=menuitem]').forEach(el =>
  console.log(el.id, el.tagName, el.getAttribute('href'))
);
```

## Notes

- Same pattern as the existing `nav-tabs-underline.js` — IIFE, MutationObserver for SPA navigation, `dataset` flag to prevent double-attach
- Pages without a translated equivalent will 404 gracefully
- `LOCALE_TO_PREFIX` map only needs entries where the Mintlify language code differs from the URL prefix

🤖 Generated with [Claude Code](https://claude.ai/code)