### PR TITLE
fix(agents/gateway-tool): drop redacted config from patch/apply responses (#47610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/nodes: allow Windows companion nodes to use safe declared commands such as canvas, camera list, location, device info, and screen snapshot by default while keeping dangerous media commands opt-in. (#71884) Thanks @shanselman.
+- Agents/gateway tool: strip the redacted full config payload from `gateway` tool `config.patch` and `config.apply` responses before they reach the agent transcript, so multi-write sessions no longer accumulate ~10–15K wasted tokens per call while direct RPC callers (Control UI, scripts) still receive the same response shape. Fixes #47610. Thanks @juan-flores077.
 
 ## 2026.4.27
 

--- a/src/agents/tools/gateway-tool-strip-config-payload.test.ts
+++ b/src/agents/tools/gateway-tool-strip-config-payload.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { stripConfigWriteResultPayloadForTest as strip } from "./gateway-tool.js";
+
+// Regression coverage for #47610: the agent-facing `gateway` tool wraps the
+// Gateway RPC `config.patch`/`config.apply` results, and the redacted full
+// config that those RPCs return for direct callers must not be forwarded into
+// the agent transcript.
+describe("stripConfigWriteResultPayload", () => {
+  it("removes the `config` field from a typical config.patch/config.apply success result", () => {
+    const result = {
+      ok: true,
+      path: "/tmp/openclaw.json",
+      config: { agents: { defaults: { thinkingDefault: "high" } } },
+      restart: { ok: true },
+      sentinel: { path: "/tmp/restart", payload: { reason: "config.patch" } },
+    };
+
+    const stripped = strip(result) as Record<string, unknown>;
+
+    expect(stripped).not.toHaveProperty("config");
+    expect(stripped).toMatchObject({
+      ok: true,
+      path: "/tmp/openclaw.json",
+      restart: { ok: true },
+      sentinel: { path: "/tmp/restart", payload: { reason: "config.patch" } },
+    });
+  });
+
+  it("preserves a noop config.patch result while still dropping the redacted config", () => {
+    const result = {
+      ok: true,
+      noop: true,
+      path: "/tmp/openclaw.json",
+      config: { agents: { defaults: { thinkingDefault: "high" } } },
+    };
+
+    expect(strip(result)).toEqual({
+      ok: true,
+      noop: true,
+      path: "/tmp/openclaw.json",
+    });
+  });
+
+  it("returns results without a `config` field unchanged", () => {
+    const result = { ok: true, restart: { ok: true } };
+    expect(strip(result)).toBe(result);
+  });
+
+  it("passes through non-object results (null, undefined, strings, arrays)", () => {
+    expect(strip(null)).toBeNull();
+    expect(strip(undefined)).toBeUndefined();
+    expect(strip("error")).toBe("error");
+    const arr: unknown[] = [{ config: { dropped: true } }];
+    expect(strip(arr)).toBe(arr);
+  });
+
+  it("does not deep-strip nested `config` keys, only the top-level field", () => {
+    const result = {
+      ok: true,
+      restart: { ok: true, config: "inner-untouched" },
+    };
+    expect(strip(result)).toEqual({
+      ok: true,
+      restart: { ok: true, config: "inner-untouched" },
+    });
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -345,6 +345,38 @@ const GatewayToolSchema = Type.Object({
 // - Claude/Vertex has other JSON Schema quirks.
 // Conditional requirements (like `raw` for config.apply) are enforced at runtime.
 
+/**
+ * Strip the full resolved config payload from `config.patch` / `config.apply`
+ * results before they are returned to the agent.
+ *
+ * The Gateway RPC handlers ({@link "../../gateway/server-methods/config.ts"})
+ * include a redacted copy of the validated config in the success response so
+ * direct RPC callers (e.g. Control UI) can reuse it. When the same response is
+ * surfaced through the agent-facing `gateway` tool, that ~10–15K-token payload
+ * lands in the agent transcript on every config write — even though the agent
+ * already had the previous config in context and the patched fields are local
+ * to the request body. Multiple writes per session compound into ~100K wasted
+ * tokens (#47610).
+ *
+ * Drop the `config` field at the agent-tool boundary only; the RPC method's
+ * shape stays unchanged for non-agent callers.
+ */
+/** @internal Exposed for regression tests only; do not import from runtime code. */
+export function stripConfigWriteResultPayloadForTest(result: unknown): unknown {
+  return stripConfigWriteResultPayload(result);
+}
+
+function stripConfigWriteResultPayload(result: unknown): unknown {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  if (!Object.hasOwn(result as Record<string, unknown>, "config")) {
+    return result;
+  }
+  const { config: _config, ...rest } = result as Record<string, unknown>;
+  return rest;
+}
+
 export function createGatewayTool(opts?: {
   agentSessionKey?: string;
   config?: OpenClawConfig;
@@ -481,7 +513,7 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result });
+        return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
       }
       if (action === "config.patch") {
         const { raw, baseHash, snapshotConfig, sessionKey, note, restartDelayMs } =
@@ -498,7 +530,7 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result });
+        return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
       }
       if (action === "update.run") {
         const { sessionKey, note, restartDelayMs } = resolveGatewayWriteMeta();


### PR DESCRIPTION
## What

The Gateway RPC handlers `config.patch` and `config.apply` ([src/gateway/server-methods/config.ts:472-486](src/gateway/server-methods/config.ts#L472-L486)) attach a redacted copy of the validated config to the success response so direct callers (Control UI, scripts) can reuse it without a follow-up `config.get` round-trip. The agent-facing `gateway` tool ([src/agents/tools/gateway-tool.ts:486-501](src/agents/tools/gateway-tool.ts#L486-L501)) wraps the same response and forwards it verbatim to the model — which lands the ~10–15K-token redacted-config payload in the agent transcript on every config write, even though the agent already had the previous config in context and the actually-patched fields are local to the request body.

Multiple writes per session compound into ~100K wasted tokens in real multi-agent setups, accelerating compaction 3–5×.

Closes #47610.

## Why this fix

Strip the `config` field at the **agent-tool boundary**, not at the RPC method. That way:

- Direct RPC callers (Control UI dreaming controller, config presets, any script using `config.patch` / `config.apply`) keep getting the same response shape — no breakage.
- The agent transcript only carries `{ ok, path, restart, sentinel }` (and `noop` for no-op writes), which is exactly what the agent needs to act on.

Implementation:

1. New private helper `stripConfigWriteResultPayload(result)` in [src/agents/tools/gateway-tool.ts](src/agents/tools/gateway-tool.ts) that drops the top-level `config` key from a plain-object RPC result; pass-through for non-objects, results without `config`, or noop results — only the top-level `config` is stripped, never nested ones.
2. Wrap the existing `jsonResult({ ok: true, result })` calls in the `config.apply` and `config.patch` branches with the helper.
3. Export `stripConfigWriteResultPayloadForTest` (`@internal`) so the regression test can pin the contract without re-implementing all of the gateway-tool's mock setup.

Net change: 36 LOC in `gateway-tool.ts` (mostly the helper + comment + test export), plus a focused new test file.

## Tests

Added [`src/agents/tools/gateway-tool-strip-config-payload.test.ts`](src/agents/tools/gateway-tool-strip-config-payload.test.ts) with five cases pinning the contract:

- Strips `config` from a typical `config.patch`/`config.apply` success result while preserving `ok` / `path` / `restart` / `sentinel`.
- Strips `config` from a noop `config.patch` result while preserving `noop` and `path`.
- Pass-through for results that already lack a `config` field (returns the same reference, so no allocation).
- Pass-through for non-object results: `null`, `undefined`, strings, arrays.
- Confirms the strip is **top-level only**: a nested `restart.config` field is left intact.

The existing extensive `gateway-tool.test.ts` continues to apply unchanged — the strip is a thin post-processing step on top of the same `callGatewayTool` round-trip the existing tests already cover.

## Notes

- Single-area diff: `src/agents/tools/gateway-tool.ts`, a new colocated test, and a one-line CHANGELOG entry under `## Unreleased` `### Fixes` with `Thanks @juan-flores077`.
- No changes to the RPC method shape, no changes to other extensions, no Plugin SDK changes. Owner-boundary respected per `src/agents/tools/CLAUDE.md`.
- The 24-hour `prompt cache` impact called out in the issue is a side-benefit: the per-write payload that was being cached but never read is now simply not emitted.
- AI-assisted (Claude). Reviewed locally; please flag if there is a non-obvious agent flow that legitimately reads `result.config` from a `config.patch` response — a search of `src/`, `ui/src/`, and `extensions/` for `config.patch` callers turned up only the Control UI dreaming controller and config presets, both of which call the **RPC directly** (not via `gateway-tool`), so they are not affected by this change.

## Validation

Local CI is constrained on this machine; relying on CI for the canonical proof. I have:

- Verified by code-reading that the only direct consumers of `config.patch` / `config.apply` results outside the agent tool ([`ui/src/ui/controllers/dreaming.ts:943`](ui/src/ui/controllers/dreaming.ts#L943) and [`ui/src/ui/views/config-presets.ts`](ui/src/ui/views/config-presets.ts)) call the RPC directly through `state.client.request(...)` and so bypass the agent-tool wrapping that this PR modifies.
- Confirmed the existing `gateway-tool.test.ts` does not assert on the `result.config` field of patch/apply responses, so the change does not break existing coverage.
- Confirmed the changelog entry is single-line and credits a contributor.

Happy to address Greptile/Codex review feedback or extend the strip to additional fields if reviewers see other large-payload offenders.