### PR TITLE
ci: add plugin boundary codeql quality shard

### DIFF
--- a/.github/codeql/codeql-plugin-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-plugin-boundary-critical-quality.yml
@@ -1,0 +1,76 @@
+name: openclaw-codeql-plugin-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/plugins/activation-planner.ts
+  - src/plugins/api-builder.ts
+  - src/plugins/bundled-compat.ts
+  - src/plugins/bundled-dir.ts
+  - src/plugins/bundled-plugin-metadata.ts
+  - src/plugins/bundled-public-surface-runtime-root.ts
+  - src/plugins/bundled-runtime-deps.ts
+  - src/plugins/bundled-runtime-root.ts
+  - src/plugins/captured-registration.ts
+  - src/plugins/config-activation-shared.ts
+  - src/plugins/config-contracts.ts
+  - src/plugins/config-normalization-shared.ts
+  - src/plugins/config-policy.ts
+  - src/plugins/config-schema.ts
+  - src/plugins/config-state.ts
+  - src/plugins/discovery.ts
+  - src/plugins/effective-plugin-ids.ts
+  - src/plugins/externalized-bundled-plugins.ts
+  - src/plugins/installed-plugin-index*.ts
+  - src/plugins/loader*.ts
+  - src/plugins/manifest*.ts
+  - src/plugins/module-export.ts
+  - src/plugins/package-entrypoints.ts
+  - src/plugins/plugin-registry*.ts
+  - src/plugins/provider-contract-public-artifacts.ts
+  - src/plugins/provider-public-artifacts.ts
+  - src/plugins/public-surface*.ts
+  - src/plugins/registry.ts
+  - src/plugins/registry-types.ts
+  - src/plugins/runtime
+  - src/plugins/runtime-state.ts
+  - src/plugins/runtime.ts
+  - src/plugins/sdk-alias.ts
+  - src/plugins/source-loader.ts
+  - src/plugins/types.ts
+  - src/plugins/validation-diagnostics.ts
+  - src/plugins/web-provider-public-artifacts*.ts
+  - src/plugin-sdk/*entry*.ts
+  - src/plugin-sdk/*facade*.ts
+  - src/plugin-sdk/api-baseline.ts
+  - src/plugin-sdk/config-schema.ts
+  - src/plugin-sdk/config-types.ts
+  - src/plugin-sdk/core.ts
+  - src/plugin-sdk/extension-shared.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -38,3 +38,24 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/javascript-typescript"
+
+  plugin-boundary:
+    name: Critical Quality (plugin-boundary)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-plugin-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/plugin-boundary"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -240,12 +240,14 @@ under the `/codeql-critical-security/android` category.
 
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
-over the same narrow auth, secrets, sandbox, cron, and gateway surface. Keep it
-separate from the security workflow so quality findings can be scheduled,
-measured, disabled, or expanded without obscuring security signal. Swift,
-Python, UI, and bundled-plugin CodeQL expansion should be added back as scoped
-or sharded follow-up work only after the narrow profiles have stable runtime and
-signal.
+over narrow high-value surfaces. Its baseline job scans the same auth, secrets,
+sandbox, cron, and gateway surface as the security workflow. The plugin-boundary
+job scans loader, registry, public-surface, and Plugin SDK entrypoint contracts
+under a separate `/codeql-critical-quality/plugin-boundary` category. Keep the
+workflow separate from security so quality findings can be scheduled, measured,
+disabled, or expanded without obscuring security signal. Swift, Python, UI, and
+bundled-plugin CodeQL expansion should be added back as scoped or sharded
+follow-up work only after the narrow profiles have stable runtime and signal.
 
 The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping
 existing docs aligned with recently landed changes. It has no pure schedule: a


### PR DESCRIPTION
## Summary

- Problem: the non-security CodeQL shard was clean, but the next quality expansion needed to stay surface-scoped instead of widening the existing category.
- Why it matters: plugin loader, registry, public-surface, and Plugin SDK entrypoint regressions are critical quality issues, but they should not pollute security signal or the baseline quality category.
- What changed: added a dedicated plugin-boundary CodeQL quality config and job with category `/codeql-critical-quality/plugin-boundary`.
- What did NOT change (scope boundary): no broad/default CodeQL, no macOS scheduling, no Android/security profile changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/73404
- Related https://github.com/openclaw/openclaw/pull/73430
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
CodeQL Critical Quality -> /codeql-critical-quality/javascript-typescript

After:
CodeQL Critical Quality -> /codeql-critical-quality/javascript-typescript
                        -> /codeql-critical-quality/plugin-boundary
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS worktree
- Runtime/container: local Node/pnpm for workflow sanity; GitHub Actions/Blacksmith runners for CodeQL execution
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check:workflows`
2. `git diff --check origin/main...HEAD`
3. YAML parse for touched workflow/config files
4. Matched-file count for plugin-boundary config

### Expected

- Workflow config is valid.
- The new quality shard remains narrow and category-isolated.

### Actual

- `pnpm check:workflows` passed.
- `git diff --check origin/main...HEAD` passed.
- YAML parse passed.
- Plugin-boundary config currently matches 107 production TypeScript files.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: workflow sanity, YAML parse, whitespace check, path scope count.
- Edge cases checked: kept existing `/codeql-critical-quality/javascript-typescript` category unchanged; plugin-boundary uses a separate category.
- What you did **not** verify: branch CodeQL dispatch is pending after PR creation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: quality workflow runtime increases.
  - Mitigation: new job is separate, scoped to 107 prod TS files, category-isolated, and can be disabled without touching the baseline quality category.
