### PR TITLE
fix(codex): bridge app-server tool stream events

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -584,6 +584,278 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("emits normalized tool stream events for Codex command items", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "full",
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "echo ok",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "inProgress",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "ok\n",
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "echo ok",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok\n",
+          exitCode: 0,
+          durationMs: 7,
+        },
+      }),
+    );
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: expect.objectContaining({
+        phase: "start",
+        backend: "codex-app-server",
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        toolCallId: "cmd-1",
+        name: "bash",
+        args: { command: "echo ok", cwd: "/workspace" },
+      }),
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: expect.objectContaining({
+        phase: "update",
+        toolCallId: "cmd-1",
+        name: "bash",
+        partialResult: "ok\n",
+      }),
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: expect.objectContaining({
+        phase: "result",
+        backend: "codex-app-server",
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        toolCallId: "cmd-1",
+        name: "bash",
+        result: expect.objectContaining({
+          status: "completed",
+          exitCode: 0,
+          durationMs: 7,
+          text: "ok\n",
+        }),
+      }),
+    });
+  });
+
+  it("emits turn-completed tool stream results without duplicating item-completed results", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({ ...(await createParams()), onAgentEvent });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "dynamicToolCall",
+          id: "tool-1",
+          namespace: null,
+          tool: "read",
+          arguments: { path: "README.md" },
+          status: "completed",
+          contentItems: [{ type: "inputText", text: "file contents" }],
+          success: true,
+          durationMs: 12,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "dynamicToolCall",
+          id: "tool-1",
+          namespace: null,
+          tool: "read",
+          arguments: { path: "README.md" },
+          status: "completed",
+          contentItems: [{ type: "inputText", text: "file contents" }],
+          success: true,
+          durationMs: 12,
+        },
+        {
+          type: "mcpToolCall",
+          id: "mcp-1",
+          server: "fs",
+          tool: "stat",
+          status: "completed",
+          arguments: { path: "package.json" },
+          result: {
+            content: [{ type: "text", text: "size 123" }],
+            structuredContent: null,
+            _meta: null,
+          },
+          error: null,
+          durationMs: 4,
+        },
+      ]),
+    );
+
+    const toolResults = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "tool" && event.data.phase === "result");
+
+    expect(toolResults).toHaveLength(2);
+    expect(toolResults.map((event) => event.data.toolCallId)).toEqual(["tool-1", "mcp-1"]);
+    expect(toolResults[0]).toEqual(
+      expect.objectContaining({
+        stream: "tool",
+        data: expect.objectContaining({
+          toolCallId: "tool-1",
+          name: "read",
+          result: expect.objectContaining({
+            status: "completed",
+            success: true,
+            durationMs: 12,
+          }),
+        }),
+      }),
+    );
+    expect(toolResults[1]).toEqual(
+      expect.objectContaining({
+        stream: "tool",
+        data: expect.objectContaining({
+          toolCallId: "mcp-1",
+          name: "fs.stat",
+          result: expect.objectContaining({
+            status: "completed",
+            durationMs: 4,
+          }),
+        }),
+      }),
+    );
+    expect(JSON.stringify(toolResults)).not.toContain("file contents");
+    expect(JSON.stringify(toolResults)).not.toContain("size 123");
+  });
+
+  it("redacts bulky Codex tool stream payloads unless full output is enabled", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({ ...(await createParams()), onAgentEvent });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          senderThreadId: THREAD_ID,
+          receiverThreadIds: ["agent-1"],
+          prompt: "large delegated prompt with private context",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          agentsStates: {},
+        },
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "fileChange",
+          id: "patch-1",
+          status: "completed",
+          changes: [
+            {
+              path: "src/secret.ts",
+              kind: { type: "update", move_path: null },
+              diff: "-old secret\n+new secret",
+            },
+          ],
+        },
+        {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: THREAD_ID,
+          receiverThreadIds: ["agent-1"],
+          prompt: "large delegated prompt with private context",
+          model: "gpt-5.5",
+          reasoningEffort: "medium",
+          agentsStates: {
+            "agent-1": {
+              status: "completed",
+              message: "subagent final text with private context",
+            },
+          },
+        },
+      ]),
+    );
+
+    const toolEvents = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "tool");
+    const serialized = JSON.stringify(toolEvents);
+
+    expect(serialized).not.toContain("large delegated prompt");
+    expect(serialized).not.toContain("old secret");
+    expect(serialized).not.toContain("new secret");
+    expect(serialized).not.toContain("subagent final text");
+    expect(toolEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "start",
+            toolCallId: "collab-1",
+            args: expect.objectContaining({ promptChars: 43 }),
+          }),
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "result",
+            toolCallId: "patch-1",
+            result: {
+              status: "completed",
+              changes: [{ path: "src/secret.ts", kind: { type: "update", move_path: null } }],
+            },
+          }),
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "result",
+            toolCallId: "collab-1",
+            result: {
+              status: "completed",
+              agentsStates: { "agent-1": { status: "completed" } },
+            },
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("redacts secrets in verbose command summaries", async () => {
     const onToolResult = vi.fn();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -81,6 +81,8 @@ export class CodexAppServerEventProjector {
   private readonly toolResultSummaryItemIds = new Set<string>();
   private readonly toolResultOutputItemIds = new Set<string>();
   private readonly toolResultOutputStreamedItemIds = new Set<string>();
+  private readonly toolStreamStartedItemIds = new Set<string>();
+  private readonly toolStreamResultItemIds = new Set<string>();
   private readonly toolResultOutputDeltaState = new Map<
     string,
     { chars: number; messages: number; truncated: boolean }
@@ -357,7 +359,9 @@ export class CodexAppServerEventProjector {
         },
       });
     }
+    this.recordToolMeta(item);
     this.emitStandardItemEvent({ phase: "start", item });
+    this.emitToolStreamStart(item);
     this.emitToolResultSummary(item);
     this.emitAgentEvent({
       stream: "codex_app_server.item",
@@ -411,6 +415,7 @@ export class CodexAppServerEventProjector {
     }
     this.recordToolMeta(item);
     this.emitStandardItemEvent({ phase: "end", item });
+    this.emitToolStreamResult(item);
     this.emitToolResultSummary(item);
     this.emitToolResultOutput(item);
     this.emitAgentEvent({
@@ -506,6 +511,7 @@ export class CodexAppServerEventProjector {
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
+      this.emitToolStreamResult(item);
       this.emitToolResultSummary(item);
       this.emitToolResultOutput(item);
     }
@@ -550,6 +556,11 @@ export class CodexAppServerEventProjector {
     }
     this.toolResultOutputDeltaState.set(itemId, state);
     this.toolResultOutputStreamedItemIds.add(itemId);
+    this.emitToolStreamUpdate({
+      itemId,
+      name: this.toolMetas.get(itemId)?.toolName ?? toolName,
+      partialResult: chunk,
+    });
     this.emitToolResultMessage({
       itemId,
       text: formatToolOutput(
@@ -557,6 +568,71 @@ export class CodexAppServerEventProjector {
         undefined,
         reachedLimit ? `${chunk}\n...(truncated)...` : chunk,
       ),
+    });
+  }
+
+  private emitToolStreamStart(item: CodexThreadItem | undefined): void {
+    if (!item) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name || this.toolStreamStartedItemIds.has(item.id)) {
+      return;
+    }
+    this.toolStreamStartedItemIds.add(item.id);
+    this.emitAgentEvent({
+      stream: "tool",
+      data: {
+        phase: "start",
+        backend: "codex-app-server",
+        threadId: this.threadId,
+        turnId: this.turnId,
+        toolCallId: item.id,
+        name,
+        args: buildToolStreamArgs(item),
+      },
+    });
+  }
+
+  private emitToolStreamUpdate(params: {
+    itemId: string;
+    name: string;
+    partialResult: unknown;
+  }): void {
+    this.emitAgentEvent({
+      stream: "tool",
+      data: {
+        phase: "update",
+        backend: "codex-app-server",
+        threadId: this.threadId,
+        turnId: this.turnId,
+        toolCallId: params.itemId,
+        name: params.name,
+        partialResult: params.partialResult,
+      },
+    });
+  }
+
+  private emitToolStreamResult(item: CodexThreadItem | undefined): void {
+    if (!item) {
+      return;
+    }
+    const name = itemName(item);
+    if (!name || this.toolStreamResultItemIds.has(item.id)) {
+      return;
+    }
+    this.toolStreamResultItemIds.add(item.id);
+    this.emitAgentEvent({
+      stream: "tool",
+      data: {
+        phase: "result",
+        backend: "codex-app-server",
+        threadId: this.threadId,
+        turnId: this.turnId,
+        toolCallId: item.id,
+        name,
+        result: buildToolStreamResult(item, { includeOutput: this.shouldEmitToolOutput() }),
+      },
     });
   }
 
@@ -980,6 +1056,9 @@ function itemKind(
   switch (item.type) {
     case "dynamicToolCall":
     case "mcpToolCall":
+    case "collabAgentToolCall":
+    case "imageView":
+    case "imageGeneration":
       return "tool";
     case "commandExecution":
       return "command";
@@ -1007,6 +1086,12 @@ function itemTitle(item: CodexThreadItem): string {
       return "Tool";
     case "webSearch":
       return "Web search";
+    case "collabAgentToolCall":
+      return "Collab agent";
+    case "imageView":
+      return "Image view";
+    case "imageGeneration":
+      return "Image generation";
     case "contextCompaction":
       return "Context compaction";
     case "reasoning":
@@ -1044,6 +1129,15 @@ function itemName(item: CodexThreadItem): string | undefined {
   if (item.type === "webSearch") {
     return "web_search";
   }
+  if (item.type === "collabAgentToolCall") {
+    return item.tool;
+  }
+  if (item.type === "imageView") {
+    return "view_image";
+  }
+  if (item.type === "imageGeneration") {
+    return "image_generate";
+  }
   return undefined;
 }
 
@@ -1061,6 +1155,15 @@ function itemMeta(item: CodexThreadItem): string | undefined {
   if ((item.type === "dynamicToolCall" || item.type === "mcpToolCall") && toolName) {
     return inferToolMetaFromArgs(toolName, item.arguments);
   }
+  if (item.type === "imageView" && typeof item.path === "string") {
+    return item.path;
+  }
+  if (item.type === "imageGeneration" && typeof item.status === "string") {
+    return item.status;
+  }
+  if (item.type === "collabAgentToolCall" && typeof item.model === "string") {
+    return item.model;
+  }
   return undefined;
 }
 
@@ -1077,7 +1180,108 @@ function itemOutputText(item: CodexThreadItem): string | undefined {
     }
     return item.result ? stringifyJsonValue(item.result) : undefined;
   }
+  if (item.type === "imageGeneration") {
+    return item.result || item.savedPath || undefined;
+  }
   return undefined;
+}
+
+function buildToolStreamArgs(item: CodexThreadItem): Record<string, unknown> {
+  switch (item.type) {
+    case "commandExecution":
+      return { command: item.command, cwd: item.cwd };
+    case "fileChange":
+      return { changes: item.changes.length };
+    case "mcpToolCall":
+      return { server: item.server, tool: item.tool, arguments: item.arguments };
+    case "dynamicToolCall":
+      return { namespace: item.namespace, tool: item.tool, arguments: item.arguments };
+    case "collabAgentToolCall":
+      return {
+        tool: item.tool,
+        receiverThreadIds: item.receiverThreadIds,
+        model: item.model,
+        reasoningEffort: item.reasoningEffort,
+        ...(item.prompt ? { promptChars: item.prompt.length } : {}),
+      };
+    case "webSearch":
+      return { query: item.query, action: item.action };
+    case "imageView":
+      return { path: item.path };
+    case "imageGeneration":
+      return { status: item.status, revisedPrompt: item.revisedPrompt };
+    default:
+      return {};
+  }
+}
+
+function buildToolStreamResult(
+  item: CodexThreadItem,
+  opts: { includeOutput: boolean },
+): Record<string, unknown> {
+  switch (item.type) {
+    case "commandExecution":
+      return {
+        status: item.status,
+        exitCode: item.exitCode,
+        durationMs: item.durationMs,
+        ...(opts.includeOutput && item.aggregatedOutput ? { text: item.aggregatedOutput } : {}),
+      };
+    case "fileChange":
+      return {
+        status: item.status,
+        changes: opts.includeOutput ? item.changes : item.changes.map(redactFileChangeDiff),
+      };
+    case "mcpToolCall":
+      return {
+        status: item.status,
+        durationMs: item.durationMs,
+        ...(item.error ? { error: item.error } : {}),
+        ...(opts.includeOutput && item.result ? { result: item.result } : {}),
+      };
+    case "dynamicToolCall":
+      return {
+        status: item.status,
+        success: item.success,
+        durationMs: item.durationMs,
+        ...(opts.includeOutput && item.contentItems ? { contentItems: item.contentItems } : {}),
+      };
+    case "collabAgentToolCall":
+      return {
+        status: item.status,
+        agentsStates: opts.includeOutput
+          ? item.agentsStates
+          : redactCollabAgentStateMessages(item.agentsStates),
+      };
+    case "webSearch":
+      return { status: itemStatus(item), action: item.action };
+    case "imageView":
+      return { status: itemStatus(item), path: item.path };
+    case "imageGeneration":
+      return {
+        status: item.status,
+        savedPath: item.savedPath,
+        ...(opts.includeOutput && item.result ? { result: item.result } : {}),
+      };
+    default:
+      return { status: itemStatus(item), meta: itemMeta(item) };
+  }
+}
+
+function redactFileChangeDiff(
+  change: Extract<CodexThreadItem, { type: "fileChange" }>["changes"][number],
+): Pick<Extract<CodexThreadItem, { type: "fileChange" }>["changes"][number], "path" | "kind"> {
+  return { path: change.path, kind: change.kind };
+}
+
+function redactCollabAgentStateMessages(
+  agentsStates: Extract<CodexThreadItem, { type: "collabAgentToolCall" }>["agentsStates"],
+): Record<string, { status: string }> {
+  return Object.fromEntries(
+    Object.entries(agentsStates).flatMap(([agentId, state]) =>
+      state ? [[agentId, { status: state.status }]] : [],
+    ),
+  );
 }
 
 function collectDynamicToolContentText(


### PR DESCRIPTION
## Summary

- Problem: Codex app-server projects `item`, `codex_app_server.item`, and verbose `onToolResult` text, but it does not project Codex tool-like ThreadItems into the normalized `stream: "tool"` agent event contract.
- Why it matters: Gateway and Control UI already consume normalized tool events for live tool cards; Codex harness runs can therefore miss the same live start/update/result path that Pi-runner tools use.
- What changed: Map Codex tool-like ThreadItems into normalized tool start/result events, plus bounded command/file output update events when full tool output is enabled.
- What did NOT change (scope boundary): No Gateway, Control UI, channel, approval, or raw Codex trace viewer changes. Detailed output remains gated by the existing full-output policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Related #67563
- Related #61303
- Related #59358
- Related #70966
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Codex app-server projector handled Codex tool items for item lifecycle events and verbose text summaries, but never emitted the normalized `stream: "tool"` lifecycle events that downstream Gateway/UI subscribers already rely on.
- Missing detection / guardrail: Existing Codex projector tests covered verbose `onToolResult` behavior after #70966, but did not assert the normalized agent event contract.
- Contributing context (if known): Existing closed issues verified the generic Pi/Gateway/UI tool stream path, which can make this look already implemented unless the Codex app-server projector is checked directly.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/event-projector.test.ts`
- Scenario the test should lock in: Codex command items emit normalized `tool` start/update/result events; turn-completed tool items backfill result events without duplicating item-completed results.
- Why this is the smallest reliable guardrail: The bug is in the app-server event projector, before Gateway or UI behavior.
- Existing test that already covers this (if any): None for Codex normalized tool events.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex harness runs now surface live tool lifecycle cards through the same normalized agent tool stream consumed by Gateway and Control UI. Verbose chat text behavior is unchanged.

## Diagram (if applicable)

```text
Before:
Codex app-server item -> Codex projector -> item/codex_app_server.item + verbose text only

After:
Codex app-server item -> Codex projector -> item + stream:"tool" -> Gateway/UI tool cards
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu WSL
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: Codex app-server harness with GPT-5.5 through the configured OpenAI/Codex runtime
- Integration/channel (if any): Gateway/Control UI normalized tool event contract
- Relevant config (redacted): default agent runtime configured for Codex; no live provider secrets required for the unit test path

### Steps

1. Instantiate `CodexAppServerEventProjector` with `onAgentEvent`.
2. Send Codex `item/started`, `item/commandExecution/outputDelta`, and `item/completed` notifications for a `commandExecution` item.
3. Inspect emitted agent events.
4. Build the branch and run it with a local Gateway/WebUI setup.
5. Start a Codex harness session from Control UI/WebUI and inspect the live run.

### Expected

- Projector emits normalized `stream: "tool"` events for `start`, `update`, and `result`, keyed by the Codex item id as `toolCallId`.
- Control UI/WebUI renders live tool cards for Codex harness runs instead of only showing generic Codex item/verbose text events.

### Actual

- Before this patch, the projector emitted `item`/`codex_app_server.item` events and verbose text summaries, but no normalized `tool` stream events.
- After this patch, a local Gateway/WebUI run on this branch showed tool-chain cards during a Codex harness session.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Manual local WebUI verification
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified targeted projector coverage with `pnpm test extensions/codex/src/app-server/event-projector.test.ts`.
- Verified formatter and extension type checks with `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts` and `pnpm tsgo:extensions`.
- Ran the branch with a local Gateway/WebUI setup and confirmed the running Gateway was reachable on that branch.
- Confirmed the live run was using the Codex harness rather than the Pi runner by checking the active runtime configuration, loaded Gateway plugins, and the Codex app-server session metadata.
- Verified user-visible behavior in WebUI: the live Codex harness run displayed tool-chain cards after applying this branch, matching the normalized `stream: "tool"` projection this PR adds.
- Edge cases checked: result backfill from `turn/completed` does not duplicate an already seen `item/completed` result; detailed result payloads stay omitted unless full output is enabled.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Additional tool events could expose large Codex outputs through live UI paths.
  - Mitigation: Start/result lifecycle is always emitted, but detailed output remains gated by the existing full-output policy; update events are only emitted through the existing full-output path.
- Risk: `turn/completed` may repeat items already delivered via `item/completed`.
  - Mitigation: Result events are deduplicated by Codex item id.

Validation:

- `pnpm test extensions/codex/src/app-server/event-projector.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check upstream/main...HEAD`