### PR TITLE
fix(mattermost): respect blockStreaming config in draft-preview reply path [AI-assisted]

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1744,7 +1744,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 dispatcher,
                 replyOptions: {
                   ...replyOptions,
-                  disableBlockStreaming: true,
+                  disableBlockStreaming:
+                    typeof account.blockStreaming === "boolean"
+                      ? !account.blockStreaming
+                      : undefined,
                   onModelSelected,
                   onPartialReply: (payload) => {
                     updateDraftFromPartial(payload.text);


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration). Test level: lightly tested (pattern-consistency fix, no new test — no existing blockStreaming test coverage in the Mattermost plugin). Prompt summary available on request.

## Summary
- Problem: The draft-preview streaming code path in the Mattermost monitor hardcodes `disableBlockStreaming: true`, ignoring the user's `blockStreaming` config. Users who set `blockStreaming: true` in their Mattermost account config cannot disable streaming on this code path.
- Why it matters: Users expect `blockStreaming: true` to disable streaming across all reply paths, but messages sent through the draft-preview path still stream, causing "disappearing message" UX issues (draft post is deleted before the final post is created).
- What changed: Replaced the hardcoded `disableBlockStreaming: true` with the same config-reading pattern used by the two other reply paths in the same file (lines 743 and 958).
- What did NOT change (scope boundary): No changes to the block streaming core logic, no changes to other channels, no changes to the draft-preview streaming mechanism itself.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Plugin / extension

## Linked Issue/PR
- Closes #70253
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: When the draft-preview streaming path was added (or refactored), `disableBlockStreaming` was hardcoded to `true` instead of reading from `account.blockStreaming` like the other two reply paths in the same file.
- Missing detection / guardrail: No test coverage for `blockStreaming` config propagation in any of the three Mattermost reply paths.
- Contributing context: The two other paths (button-click reply at line 743, standard reply at line 958) already correctly read the config — this was a copy-paste omission on the third path.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/mattermost/src/mattermost/monitor.test.ts`
- Scenario the test should lock in: When `account.blockStreaming` is `true`, `disableBlockStreaming` should be `false` (not hardcoded `true`) on the draft-preview reply path.
- Why this is the smallest reliable guardrail: A config-propagation assertion on the reply options would catch any future regression.
- If no new test is added, why not: The Mattermost monitor test harness is complex (requires WS mock, auth, full message flow), and there is zero existing `blockStreaming` test coverage. Adding a test for one path without covering the other two would be inconsistent. This is a pattern-consistency fix (aligning one line with two identical siblings) with very low regression risk.

## User-visible / Behavior Changes
- Users with `blockStreaming: true` in their Mattermost account config will now see streaming correctly disabled on the draft-preview path, matching the behavior of the other two reply paths.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only changes how the existing `blockStreaming` config value is propagated. No security surface changes.
