### PR TITLE
fix(migrate): honor no-backup CLI option

### DIFF
--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -59,7 +59,7 @@ export function registerMigrateCommand(program: Command) {
           dryRun: Boolean(opts.dryRun),
           yes: Boolean(opts.yes),
           backupOutput: opts.backupOutput as string | undefined,
-          noBackup: opts.backup === false,
+          noBackup: Boolean(opts.noBackup),
           force: Boolean(opts.force),
           json: Boolean(opts.json),
         });
@@ -108,7 +108,7 @@ export function registerMigrateCommand(program: Command) {
           overwrite: Boolean(opts.overwrite),
           yes: Boolean(opts.yes),
           backupOutput: opts.backupOutput as string | undefined,
-          noBackup: opts.backup === false,
+          noBackup: Boolean(opts.noBackup),
           force: Boolean(opts.force),
           json: Boolean(opts.json),
         });


### PR DESCRIPTION
## Summary

- pass Commander’s parsed `--no-backup` value through `opts.noBackup`
- keeps both `openclaw migrate` and `openclaw migrate apply` aligned with the apply-layer `noBackup` option

Closes #73459

## Test Plan

- `pnpm exec oxfmt --check --threads=1 src/cli/program/register.migrate.ts`
- `pnpm test src/commands/migrate.test.ts`
