### PR TITLE
fix(gateway,proxy): bypass Windows proxy for localhost gateway connections

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -17,7 +17,6 @@ import { dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane } from "../
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { rawDataToString } from "../infra/ws.js";
 import { logDebug, logError } from "../logger.js";
-import { isLoopbackIpAddress } from "../shared/net/ip.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -100,7 +99,7 @@ function createDirectGatewayAgent(url: string): http.Agent | https.Agent | undef
   } catch {
     return undefined;
   }
-  if (!isLoopbackIpAddress(hostname)) {
+  if (!isLoopbackHost(hostname)) {
     return undefined;
   }
   return url.startsWith("wss://") ? new https.Agent() : new http.Agent();

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -105,12 +105,12 @@ describe("GatewayClient", () => {
     expect(last?.opts.agent).toBeDefined();
   });
 
-  test("does not use the direct control-plane bypass for localhost hostnames", () => {
+  test("uses the direct control-plane bypass for localhost hostnames", () => {
     const client = new GatewayClient({ url: "ws://localhost:1" });
     client.start();
     const last = wsMockState.last as { opts: { agent?: unknown } } | null;
 
-    expect(last?.opts.agent).toBeUndefined();
+    expect(last?.opts.agent).toBeDefined();
   });
 
   test("does not force a direct agent for remote Gateway WebSocket connections", () => {

--- a/src/infra/net/proxy/proxy-lifecycle.test.ts
+++ b/src/infra/net/proxy/proxy-lifecycle.test.ts
@@ -378,7 +378,7 @@ describe("startProxy", () => {
     await stopProxy(handle);
   });
 
-  it("allows the Gateway control-plane bypass for literal loopback IPs only", () => {
+  it("allows the Gateway control-plane bypass for literal loopback IPs and localhost", () => {
     expect(
       dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane(
         "ws://127.0.0.1:18789",
@@ -388,12 +388,12 @@ describe("startProxy", () => {
     expect(
       dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane("ws://[::1]:18789", () => "ok"),
     ).toBe("ok");
-    expect(() =>
+    expect(
       dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane(
         "ws://localhost:18789",
-        () => undefined,
+        () => "ok",
       ),
-    ).toThrow("loopback-only");
+    ).toBe("ok");
   });
 
   it("rejects dangerous Gateway control-plane bypass for non-loopback URLs", () => {

--- a/src/infra/net/proxy/proxy-lifecycle.ts
+++ b/src/infra/net/proxy/proxy-lifecycle.ts
@@ -13,6 +13,7 @@ import { bootstrap as bootstrapGlobalAgent } from "global-agent";
 import type { ProxyConfig } from "../../../config/zod-schema.proxy.js";
 import { logInfo, logWarn } from "../../../logger.js";
 import { isLoopbackIpAddress } from "../../../shared/net/ip.js";
+import { isLoopbackHost } from "../../../gateway/net.js";
 import { forceResetGlobalDispatcher } from "../undici-global-dispatcher.js";
 
 export type ProxyHandle = {
@@ -371,7 +372,7 @@ function isGatewayLoopbackControlPlaneUrl(value: string): boolean {
   ) {
     return false;
   }
-  return isLoopbackIpAddress(url.hostname);
+  return isLoopbackHost(url.hostname);
 }
 
 export function dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane<T>(
@@ -384,7 +385,34 @@ export function dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane<T>(
 
   const snapshot = nodeHttpStackSnapshot;
   if (!snapshot) {
-    return run();
+    const savedProxyEnv: Record<string, string | undefined> = {};
+    for (const key of ALL_PROXY_ENV_KEYS) {
+      savedProxyEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    const lowercaseKeys = ["all_proxy"];
+    for (const key of lowercaseKeys) {
+      savedProxyEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    try {
+      return run();
+    } finally {
+      for (const key of ALL_PROXY_ENV_KEYS) {
+        if (savedProxyEnv[key] !== undefined) {
+          process.env[key] = savedProxyEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+      for (const key of lowercaseKeys) {
+        if (savedProxyEnv[key] !== undefined) {
+          process.env[key] = savedProxyEnv[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+    }
   }
 
   // Security-sensitive: this temporarily removes managed proxy hooks for the

--- a/src/infra/net/proxy/proxy-lifecycle.ts
+++ b/src/infra/net/proxy/proxy-lifecycle.ts
@@ -389,7 +389,7 @@ export function dangerouslyBypassManagedProxyForGatewayLoopbackControlPlane<T>(
       savedProxyEnv[key] = process.env[key];
       delete process.env[key];
     }
-    const lowercaseKeys = ["all_proxy"];
+    const lowercaseKeys = ["all_proxy", "ALL_PROXY"];
     for (const key of lowercaseKeys) {
       savedProxyEnv[key] = process.env[key];
       delete process.env[key];

--- a/src/infra/net/proxy/proxy-lifecycle.ts
+++ b/src/infra/net/proxy/proxy-lifecycle.ts
@@ -12,7 +12,6 @@ import https from "node:https";
 import { bootstrap as bootstrapGlobalAgent } from "global-agent";
 import type { ProxyConfig } from "../../../config/zod-schema.proxy.js";
 import { logInfo, logWarn } from "../../../logger.js";
-import { isLoopbackIpAddress } from "../../../shared/net/ip.js";
 import { isLoopbackHost } from "../../../gateway/net.js";
 import { forceResetGlobalDispatcher } from "../undici-global-dispatcher.js";
 


### PR DESCRIPTION
## Summary

Fix an issue where OpenClaw CLI fails to connect to the local gateway at ws://127.0.0.1:18789 or ws://localhost:18789 when Windows proxy environment variables are inherited by WSL.

## Problem

When running OpenClaw CLI in WSL on Windows, connections to the local gateway timeout because the HTTP/WebSocket client respects the Windows proxy settings even for localhost connections.

## Changes

### src/gateway/client.ts
- Use isLoopbackHost instead of isLoopbackIpAddress for better localhost detection

### src/infra/net/proxy/proxy-lifecycle.ts
- Clear proxy environment variables when OpenClaw proxy is inactive but system proxy may be set

## Testing

Build: pnpm build - PASSED