### PR TITLE
fix(ui): preserve code indentation in streaming markdown by closing unclosed fences (#54810)

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -466,6 +466,25 @@ describe("toSanitizedMarkdownHtml", () => {
       expect(html).toContain("json-collapse");
       expect(html).toContain("JSON");
     });
+
+    it("closes unclosed fenced blocks to preserve indentation (#54810)", () => {
+      const html = toSanitizedMarkdownHtml("```python\ndef hello():\n    print('world')");
+      expect(html).toContain("<pre>");
+      expect(html).toContain("<code");
+      expect(html).toContain("    print('world')");
+    });
+
+    it("does not double-close a fence that ends on its own line", () => {
+      const html = toSanitizedMarkdownHtml("```\ncode\n```");
+      expect(html).toContain("<pre>");
+      expect(html).toContain("code");
+    });
+
+    it("handles unclosed tilde fences", () => {
+      const html = toSanitizedMarkdownHtml("~~~go\nfunc main() {\n\tfmt.Println(\"hi\")");
+      expect(html).toContain("<pre>");
+      expect(html).toContain("\tfmt.Println");
+    });
   });
 
   describe("GFM features", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -475,6 +475,44 @@ md.renderer.rules.code_block = (tokens, idx) => {
   return `<div class="code-block-wrapper">${header}${codeBlock}</div>`;
 };
 
+/**
+ * Detect unclosed fenced code blocks (``` or ~~~) and append a closing fence.
+ * This prevents markdown-it from treating the fenced content as plain text,
+ * which would collapse leading whitespace and corrupt code indentation.
+ */
+function closeUnclosedFences(text: string): string {
+  const trimmed = text.trimEnd();
+  const lines = trimmed.split("\n");
+  let inFence = false;
+  let fenceChar = "";
+  let fenceLen = 0;
+
+  for (const line of lines) {
+    const backtickMatch = line.match(/^(`{3,})([^`]*)$/);
+    const tildeMatch = line.match(/^(~{3,})([^~]*)$/);
+    const match = backtickMatch || tildeMatch;
+    if (match) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = match[1][0];
+        fenceLen = match[1].length;
+      } else if (match[1][0] === fenceChar && match[1].length >= fenceLen) {
+        inFence = false;
+      }
+    }
+  }
+
+  if (inFence) {
+    const lastLine = lines[lines.length - 1];
+    const lastIsFence = /^(`{3,}|~{3,})/.test(lastLine);
+    if (!lastIsFence) {
+      return trimmed + "\n" + fenceChar.repeat(fenceLen);
+    }
+  }
+
+  return text;
+}
+
 export function toSanitizedMarkdownHtml(markdown: string): string {
   const input = markdown.trim();
   if (!input) {
@@ -504,7 +542,7 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
   }
   let rendered: string;
   try {
-    rendered = md.render(`${truncated.text}${suffix}`);
+    rendered = md.render(closeUnclosedFences(`${truncated.text}${suffix}`));
   } catch (err) {
     // Fall back to escaped plain text when md.render() throws (#36213).
     console.warn("[markdown] md.render failed, falling back to plain text:", err);


### PR DESCRIPTION
## Problem

在流式传输 markdown 内容时，未闭合的 fenced code block 会导致 markdown-it 错误解析代码块缩进，使代码显示格式异常。

## Solution

在 markdown.ts 中添加 closeUnclosedFences() 辅助函数，检测并临时关闭未完成的 fenced code block，使 markdown-it 在流式传输时正确解析代码块缩进。改动仅涉及 ui/src/ui/markdown.ts 及其对应测试文件，影响范围最小。

## Verification

- 本地运行相关测试通过
- 修改 2 个文件，无回归问题

Closes #54810.