### PR TITLE
fix(gateway): defer pricing refresh until ready

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -141,15 +141,15 @@ describe("server-runtime-services", () => {
     expect(hoisted.stopModelPricingRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it("does not start model pricing refresh from initial runtime setup after early stop", async () => {
-    const services = startGatewayRuntimeServices({
+  it("does not start model pricing refresh after scheduled services stop before import settles", async () => {
+    const cron = { start: vi.fn(async () => undefined) };
+    const services = activateGatewayScheduledServices({
       minimalTestGateway: false,
       cfgAtStart: {} as never,
-      channelManager: {
-        getRuntimeSnapshot: vi.fn(),
-        isHealthMonitorEnabled: vi.fn(),
-        isManuallyStopped: vi.fn(),
-      } as never,
+      deps: {} as never,
+      sessionDeliveryRecoveryMaxEnqueuedAt: 123,
+      cron,
+      logCron: { error: vi.fn() },
       log: createLog(),
     });
 
@@ -157,6 +157,7 @@ describe("server-runtime-services", () => {
     await vi.dynamicImportSettled();
 
     expect(hoisted.startGatewayModelPricingRefresh).not.toHaveBeenCalled();
+    expect(hoisted.stopModelPricingRefresh).not.toHaveBeenCalled();
   });
 
   it("activates heartbeat, cron, and delivery recovery after sidecars are ready", async () => {

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -5,11 +5,13 @@ const hoisted = vi.hoisted(() => {
     stop: vi.fn(),
     updateConfig: vi.fn(),
   };
+  const stopModelPricingRefresh = vi.fn();
   return {
     heartbeatRunner,
     startHeartbeatRunner: vi.fn(() => heartbeatRunner),
     startChannelHealthMonitor: vi.fn(() => ({ stop: vi.fn() })),
-    startGatewayModelPricingRefresh: vi.fn(() => vi.fn()),
+    stopModelPricingRefresh,
+    startGatewayModelPricingRefresh: vi.fn(() => stopModelPricingRefresh),
     loadModelPricingCacheModule: vi.fn(),
     isVitestRuntimeEnv: vi.fn(() => false),
     recoverPendingDeliveries: vi.fn(async () => undefined),
@@ -61,6 +63,7 @@ describe("server-runtime-services", () => {
     hoisted.startHeartbeatRunner.mockClear();
     hoisted.startChannelHealthMonitor.mockClear();
     hoisted.startGatewayModelPricingRefresh.mockClear();
+    hoisted.stopModelPricingRefresh.mockClear();
     hoisted.loadModelPricingCacheModule.mockClear();
     hoisted.isVitestRuntimeEnv.mockReset().mockReturnValue(false);
     hoisted.recoverPendingDeliveries.mockClear();
@@ -69,14 +72,13 @@ describe("server-runtime-services", () => {
   });
 
   it("skips model pricing bootstrap import when pricing is disabled", async () => {
-    startGatewayRuntimeServices({
+    activateGatewayScheduledServices({
       minimalTestGateway: false,
       cfgAtStart: { models: { pricing: { enabled: false } } } as never,
-      channelManager: {
-        getRuntimeSnapshot: vi.fn(),
-        isHealthMonitorEnabled: vi.fn(),
-        isManuallyStopped: vi.fn(),
-      } as never,
+      deps: {} as never,
+      sessionDeliveryRecoveryMaxEnqueuedAt: 123,
+      cron: { start: vi.fn(async () => undefined) },
+      logCron: { error: vi.fn() },
       log: createLog(),
     });
 
@@ -86,7 +88,7 @@ describe("server-runtime-services", () => {
     expect(hoisted.startGatewayModelPricingRefresh).not.toHaveBeenCalled();
   });
 
-  it("keeps scheduled services inert during initial runtime setup", async () => {
+  it("keeps scheduled services and pricing refresh inert during initial runtime setup", async () => {
     const services = startGatewayRuntimeServices({
       minimalTestGateway: false,
       cfgAtStart: {} as never,
@@ -100,7 +102,8 @@ describe("server-runtime-services", () => {
 
     expect(hoisted.startChannelHealthMonitor).toHaveBeenCalledTimes(1);
     await vi.dynamicImportSettled();
-    expect(hoisted.startGatewayModelPricingRefresh).toHaveBeenCalledWith({ config: {} });
+    expect(hoisted.loadModelPricingCacheModule).not.toHaveBeenCalled();
+    expect(hoisted.startGatewayModelPricingRefresh).not.toHaveBeenCalled();
     expect(hoisted.startHeartbeatRunner).not.toHaveBeenCalled();
     expect(hoisted.recoverPendingDeliveries).not.toHaveBeenCalled();
 
@@ -108,32 +111,37 @@ describe("server-runtime-services", () => {
     expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
   });
 
-  it("passes startup plugin lookup metadata to the initial pricing refresh", async () => {
+  it("starts model pricing refresh after scheduled services activate", async () => {
     const pluginLookUpTable = {
       index: { plugins: [] },
       manifestRegistry: { plugins: [], diagnostics: [] },
     };
+    const cron = { start: vi.fn(async () => undefined) };
+    const log = createLog();
 
-    startGatewayRuntimeServices({
+    const services = activateGatewayScheduledServices({
       minimalTestGateway: false,
       cfgAtStart: {} as never,
-      channelManager: {
-        getRuntimeSnapshot: vi.fn(),
-        isHealthMonitorEnabled: vi.fn(),
-        isManuallyStopped: vi.fn(),
-      } as never,
-      log: createLog(),
+      deps: {} as never,
+      sessionDeliveryRecoveryMaxEnqueuedAt: 123,
+      cron,
+      logCron: { error: vi.fn() },
+      log,
       pluginLookUpTable: pluginLookUpTable as never,
     });
 
+    expect(hoisted.startHeartbeatRunner).toHaveBeenCalledTimes(1);
+    expect(cron.start).toHaveBeenCalledTimes(1);
     await vi.dynamicImportSettled();
     expect(hoisted.startGatewayModelPricingRefresh).toHaveBeenCalledWith({
       config: {},
       pluginLookUpTable,
     });
+    services.stopModelPricingRefresh();
+    expect(hoisted.stopModelPricingRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it("does not start model pricing refresh after early stop", async () => {
+  it("does not start model pricing refresh from initial runtime setup after early stop", async () => {
     const services = startGatewayRuntimeServices({
       minimalTestGateway: false,
       cfgAtStart: {} as never,

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -125,7 +125,6 @@ export function startGatewayRuntimeServices(params: {
   cfgAtStart: OpenClawConfig;
   channelManager: GatewayChannelManager;
   log: GatewayRuntimeServiceLogger;
-  pluginLookUpTable?: Pick<PluginLookUpTable, "index" | "manifestRegistry">;
 }): {
   heartbeatRunner: HeartbeatRunner;
   channelHealthMonitor: ChannelHealthMonitor | null;
@@ -139,14 +138,7 @@ export function startGatewayRuntimeServices(params: {
   return {
     heartbeatRunner: createNoopHeartbeatRunner(),
     channelHealthMonitor,
-    stopModelPricingRefresh:
-      !params.minimalTestGateway && !isVitestRuntimeEnv()
-        ? startGatewayModelPricingRefreshOnDemand({
-            config: params.cfgAtStart,
-            ...(params.pluginLookUpTable ? { pluginLookUpTable: params.pluginLookUpTable } : {}),
-            log: params.log,
-          })
-        : () => {},
+    stopModelPricingRefresh: () => {},
   };
 }
 
@@ -158,9 +150,10 @@ export function activateGatewayScheduledServices(params: {
   cron: { start: () => Promise<void> };
   logCron: { error: (message: string) => void };
   log: GatewayRuntimeServiceLogger;
-}): { heartbeatRunner: HeartbeatRunner } {
+  pluginLookUpTable?: Pick<PluginLookUpTable, "index" | "manifestRegistry">;
+}): { heartbeatRunner: HeartbeatRunner; stopModelPricingRefresh: () => void } {
   if (params.minimalTestGateway) {
-    return { heartbeatRunner: createNoopHeartbeatRunner() };
+    return { heartbeatRunner: createNoopHeartbeatRunner(), stopModelPricingRefresh: () => {} };
   }
   const heartbeatRunner = startHeartbeatRunner({ cfg: params.cfgAtStart });
   startGatewayCronWithLogging({
@@ -176,5 +169,12 @@ export function activateGatewayScheduledServices(params: {
     log: params.log,
     maxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
   });
-  return { heartbeatRunner };
+  const stopModelPricingRefresh = !isVitestRuntimeEnv()
+    ? startGatewayModelPricingRefreshOnDemand({
+        config: params.cfgAtStart,
+        ...(params.pluginLookUpTable ? { pluginLookUpTable: params.pluginLookUpTable } : {}),
+        log: params.log,
+      })
+    : () => {};
+  return { heartbeatRunner, stopModelPricingRefresh };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -668,7 +668,9 @@ export async function startGatewayServer(
   });
   deps.cron = runtimeState.cronState.cron;
 
+  let closePreludeStarted = false;
   const runClosePrelude = async () => {
+    closePreludeStarted = true;
     clearCurrentPluginMetadataSnapshot();
     const { runGatewayClosePrelude } = await loadGatewayCloseModule();
     await runGatewayClosePrelude({
@@ -950,6 +952,31 @@ export async function startGatewayServer(
     await startListening();
     startupTrace.mark("http.bound");
     const sessionDeliveryRecoveryMaxEnqueuedAt = Date.now();
+    let postAttachRuntimeReturned = false;
+    let scheduledServicesActivated = false;
+    const activateScheduledServicesWhenReady = () => {
+      if (
+        closePreludeStarted ||
+        !postAttachRuntimeReturned ||
+        !startupSidecarsReady ||
+        scheduledServicesActivated
+      ) {
+        return;
+      }
+      const activated = activateGatewayScheduledServices({
+        minimalTestGateway,
+        cfgAtStart,
+        deps,
+        sessionDeliveryRecoveryMaxEnqueuedAt,
+        cron: runtimeState.cronState.cron,
+        logCron,
+        log,
+        pluginLookUpTable,
+      });
+      scheduledServicesActivated = true;
+      runtimeState.heartbeatRunner = activated.heartbeatRunner;
+      runtimeState.stopModelPricingRefresh = activated.stopModelPricingRefresh;
+    };
     ({
       stopGatewayUpdateCheck: runtimeState.stopGatewayUpdateCheck,
       tailscaleCleanup: runtimeState.tailscaleCleanup,
@@ -985,25 +1012,15 @@ export async function startGatewayServer(
         },
         onSidecarsReady: () => {
           startupSidecarsReady = true;
+          activateScheduledServicesWhenReady();
         },
         startupTrace,
         deferSidecars: opts.deferStartupSidecars === true,
       }),
     ));
     startupTrace.mark("ready");
-
-    const activated = activateGatewayScheduledServices({
-      minimalTestGateway,
-      cfgAtStart,
-      deps,
-      sessionDeliveryRecoveryMaxEnqueuedAt,
-      cron: runtimeState.cronState.cron,
-      logCron,
-      log,
-      pluginLookUpTable,
-    });
-    runtimeState.heartbeatRunner = activated.heartbeatRunner;
-    runtimeState.stopModelPricingRefresh = activated.stopModelPricingRefresh;
+    postAttachRuntimeReturned = true;
+    activateScheduledServicesWhenReady();
 
     const { startManagedGatewayConfigReloader } = await import("./server-reload-handlers.js");
     runtimeState.configReloader = startManagedGatewayConfigReloader({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -814,7 +814,6 @@ export async function startGatewayServer(
         cfgAtStart,
         channelManager,
         log,
-        pluginLookUpTable,
       }),
     );
 
@@ -1001,8 +1000,10 @@ export async function startGatewayServer(
       cron: runtimeState.cronState.cron,
       logCron,
       log,
+      pluginLookUpTable,
     });
     runtimeState.heartbeatRunner = activated.heartbeatRunner;
+    runtimeState.stopModelPricingRefresh = activated.stopModelPricingRefresh;
 
     const { startManagedGatewayConfigReloader } = await import("./server-reload-handlers.js");
     runtimeState.configReloader = startManagedGatewayConfigReloader({


### PR DESCRIPTION
﻿## Summary

- Move the model-pricing refresh out of the initial Gateway runtime setup path.
- Start the pricing refresh only after sidecars/channels have reached the ready path and scheduled services are activated.
- Keep pricing enabled by default; this does not add another disable switch or change OpenRouter/LiteLLM fetch timeouts.

## Why

Issue #73323 reports Windows Gateway startup degradation where OpenRouter/LiteLLM pricing fetches time out and Telegram/channel startup is delayed. The remote pricing catalogs are optional cost enrichment, so they should not be able to compete with channel readiness during startup.

This is intentionally narrower than the broader runtime/network degradation investigation. It preserves the pricing feature while ensuring the refresh cannot run before Gateway/channel readiness.

## Validation

- `pnpm test src/gateway/server-runtime-services.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-runtime-services.ts src/gateway/server-runtime-services.test.ts src/gateway/server.impl.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check`

Related: #73323