### PR TITLE
fix(signal): harden signal-cli archive download with SSRF guard, timeout, and size cap (#54153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
 - Acpx/runtime: validate the runtime session mode at the `AcpxRuntime.ensureSession` wrapper boundary so callers that pass anything other than `persistent` or `oneshot` get a clear `ACP_INVALID_RUNTIME_OPTION` error instead of silently round-tripping through the encoded handle as a default `persistent` mode and later throwing `SessionResumeRequiredError`. Investigation context: #73071. (#73548) Thanks @amknight.
+- Channels/Signal: harden the `signal-cli` archive download to use `fetchWithSsrFGuard` with a 5-minute timeout, redirect/proxy passthrough, and a 256 MiB content-length and streamed-bytes cap, replacing the raw `node:https` request that lacked timeout, SSRF guard, and size limit. Fixes #54153. Thanks @juan-flores077.
 
 ## 2026.4.27
 

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -1,14 +1,22 @@
 import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
-import { request } from "node:https";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { CONFIG_DIR, extractArchive, resolveBrewExecutable } from "openclaw/plugin-sdk/setup-tools";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+
+// Match the bound used by the sibling skills installer (`skills-install-download.ts`)
+// so signal-cli archive downloads cannot exhaust local disk via an
+// unbounded redirect or content-length attacker. signal-cli release
+// archives are well under 50 MiB; cap at 256 MiB for headroom.
+const SIGNAL_CLI_DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024;
+const SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
 export type ReleaseAsset = {
   name?: string;
@@ -94,29 +102,78 @@ export function pickAsset(
   return archives[0];
 }
 
-async function downloadToFile(url: string, dest: string, maxRedirects = 5): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const req = request(url, (res) => {
-      if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
-        const location = res.headers.location;
-        if (!location || maxRedirects <= 0) {
-          reject(new Error("Redirect loop or missing Location header"));
-          return;
-        }
-        const redirectUrl = new URL(location, url).href;
-        resolve(downloadToFile(redirectUrl, dest, maxRedirects - 1));
-        return;
-      }
-      if (!res.statusCode || res.statusCode >= 400) {
-        reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading file`));
-        return;
-      }
-      const out = createWriteStream(dest);
-      pipeline(res, out).then(resolve).catch(reject);
-    });
-    req.on("error", reject);
-    req.end();
+async function downloadToFile(url: string, dest: string): Promise<void> {
+  // SSRF-guarded download with a hard timeout, redirect/proxy support, and
+  // a download size cap. Replaces the previous raw `node:https` request which
+  // had none of these (#54153). The `fetchWithSsrFGuard` helper transparently
+  // honors HTTP_PROXY/HTTPS_PROXY env, validates redirect targets against the
+  // SSRF policy, and routes through the runtime dispatcher.
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    timeoutMs: SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS,
   });
+  try {
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP ${response.status} downloading file`);
+    }
+    const declaredLength = Number(response.headers.get("content-length") ?? "");
+    if (Number.isFinite(declaredLength) && declaredLength > SIGNAL_CLI_DOWNLOAD_MAX_BYTES) {
+      throw new Error(
+        `signal-cli archive exceeds the ${SIGNAL_CLI_DOWNLOAD_MAX_BYTES}-byte download cap (declared ${declaredLength}).`,
+      );
+    }
+    const out = createWriteStream(dest);
+    let received = 0;
+    const counter = new Readable({
+      read() {},
+    });
+    const reader = response.body.getReader();
+    // Always release the reader lock and cancel the underlying body, even on
+    // size-cap aborts or read-loop errors, so the connection is returned to
+    // the dispatcher and we do not leak a half-consumed stream (Greptile P1).
+    const releaseReader = async (cause?: Error) => {
+      try {
+        if (cause) {
+          await reader.cancel(cause).catch(() => {});
+        }
+      } finally {
+        try {
+          reader.releaseLock();
+        } catch {
+          // Already released — no-op.
+        }
+      }
+    };
+    void (async () => {
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) {
+            counter.push(null);
+            await releaseReader();
+            return;
+          }
+          received += value.byteLength;
+          if (received > SIGNAL_CLI_DOWNLOAD_MAX_BYTES) {
+            const capError = new Error(
+              `signal-cli archive exceeded the ${SIGNAL_CLI_DOWNLOAD_MAX_BYTES}-byte download cap mid-stream.`,
+            );
+            counter.destroy(capError);
+            await releaseReader(capError);
+            return;
+          }
+          counter.push(value);
+        }
+      } catch (err) {
+        const wrappedErr = err instanceof Error ? err : new Error(String(err));
+        counter.destroy(wrappedErr);
+        await releaseReader(wrappedErr);
+      }
+    })();
+    await pipeline(counter, out);
+  } finally {
+    await release();
+  }
 }
 
 async function findSignalCliBinary(root: string): Promise<string | null> {

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -2,8 +2,8 @@ import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Readable, Transform } from "node:stream";
-import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -30,9 +30,7 @@ function makeSizeCapTransform(maxBytes: number): Transform {
     transform(chunk: Buffer, _enc, cb) {
       received += chunk.byteLength;
       if (received > maxBytes) {
-        cb(
-          new Error(`signal-cli archive exceeded the ${maxBytes}-byte download cap mid-stream.`),
-        );
+        cb(new Error(`signal-cli archive exceeded the ${maxBytes}-byte download cap mid-stream.`));
         return;
       }
       cb(null, chunk);

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -1,7 +1,8 @@
 import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { Readable } from "node:stream";
+import { Readable, Transform } from "node:stream";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { pipeline } from "node:stream/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
@@ -17,6 +18,27 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 // archives are well under 50 MiB; cap at 256 MiB for headroom.
 const SIGNAL_CLI_DOWNLOAD_MAX_BYTES = 256 * 1024 * 1024;
 const SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+const SIGNAL_CLI_RELEASE_API_TIMEOUT_MS = 30_000;
+
+function isNodeReadableStream(value: unknown): value is NodeJS.ReadableStream {
+  return Boolean(value && typeof (value as NodeJS.ReadableStream).pipe === "function");
+}
+
+function makeSizeCapTransform(maxBytes: number): Transform {
+  let received = 0;
+  return new Transform({
+    transform(chunk: Buffer, _enc, cb) {
+      received += chunk.byteLength;
+      if (received > maxBytes) {
+        cb(
+          new Error(`signal-cli archive exceeded the ${maxBytes}-byte download cap mid-stream.`),
+        );
+        return;
+      }
+      cb(null, chunk);
+    },
+  });
+}
 
 export type ReleaseAsset = {
   name?: string;
@@ -103,11 +125,11 @@ export function pickAsset(
 }
 
 async function downloadToFile(url: string, dest: string): Promise<void> {
-  // SSRF-guarded download with a hard timeout, redirect/proxy support, and
-  // a download size cap. Replaces the previous raw `node:https` request which
-  // had none of these (#54153). The `fetchWithSsrFGuard` helper transparently
-  // honors HTTP_PROXY/HTTPS_PROXY env, validates redirect targets against the
-  // SSRF policy, and routes through the runtime dispatcher.
+  // SSRF-guarded download with a hard timeout, redirect/proxy support, and a
+  // download size cap. Replaces the previous raw `node:https` request which
+  // had none of these (#54153). Stream cancellation and reader-lock release
+  // are delegated to `Readable.fromWeb()` + `pipeline()`, matching the sibling
+  // skills installer.
   const { response, release } = await fetchWithSsrFGuard({
     url,
     timeoutMs: SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS,
@@ -116,61 +138,21 @@ async function downloadToFile(url: string, dest: string): Promise<void> {
     if (!response.ok || !response.body) {
       throw new Error(`HTTP ${response.status} downloading file`);
     }
-    const declaredLength = Number(response.headers.get("content-length") ?? "");
-    if (Number.isFinite(declaredLength) && declaredLength > SIGNAL_CLI_DOWNLOAD_MAX_BYTES) {
-      throw new Error(
-        `signal-cli archive exceeds the ${SIGNAL_CLI_DOWNLOAD_MAX_BYTES}-byte download cap (declared ${declaredLength}).`,
-      );
+    const rawLength = response.headers.get("content-length");
+    if (rawLength !== null) {
+      const declaredLength = Number(rawLength);
+      if (Number.isFinite(declaredLength) && declaredLength > SIGNAL_CLI_DOWNLOAD_MAX_BYTES) {
+        throw new Error(
+          `signal-cli archive exceeds the ${SIGNAL_CLI_DOWNLOAD_MAX_BYTES}-byte download cap (declared ${declaredLength}).`,
+        );
+      }
     }
     const out = createWriteStream(dest);
-    let received = 0;
-    const counter = new Readable({
-      read() {},
-    });
-    const reader = response.body.getReader();
-    // Always release the reader lock and cancel the underlying body, even on
-    // size-cap aborts or read-loop errors, so the connection is returned to
-    // the dispatcher and we do not leak a half-consumed stream (Greptile P1).
-    const releaseReader = async (cause?: Error) => {
-      try {
-        if (cause) {
-          await reader.cancel(cause).catch(() => {});
-        }
-      } finally {
-        try {
-          reader.releaseLock();
-        } catch {
-          // Already released — no-op.
-        }
-      }
-    };
-    void (async () => {
-      try {
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) {
-            counter.push(null);
-            await releaseReader();
-            return;
-          }
-          received += value.byteLength;
-          if (received > SIGNAL_CLI_DOWNLOAD_MAX_BYTES) {
-            const capError = new Error(
-              `signal-cli archive exceeded the ${SIGNAL_CLI_DOWNLOAD_MAX_BYTES}-byte download cap mid-stream.`,
-            );
-            counter.destroy(capError);
-            await releaseReader(capError);
-            return;
-          }
-          counter.push(value);
-        }
-      } catch (err) {
-        const wrappedErr = err instanceof Error ? err : new Error(String(err));
-        counter.destroy(wrappedErr);
-        await releaseReader(wrappedErr);
-      }
-    })();
-    await pipeline(counter, out);
+    const body = response.body as unknown;
+    const readable = isNodeReadableStream(body)
+      ? body
+      : Readable.fromWeb(body as NodeReadableStream);
+    await pipeline(readable, makeSizeCapTransform(SIGNAL_CLI_DOWNLOAD_MAX_BYTES), out);
   } finally {
     await release();
   }
@@ -278,21 +260,28 @@ async function installSignalCliViaBrew(runtime: RuntimeEnv): Promise<SignalInsta
 
 async function installSignalCliFromRelease(runtime: RuntimeEnv): Promise<SignalInstallResult> {
   const apiUrl = "https://api.github.com/repos/AsamK/signal-cli/releases/latest";
-  const response = await fetch(apiUrl, {
-    headers: {
-      "User-Agent": "openclaw",
-      Accept: "application/vnd.github+json",
+  const { response, release } = await fetchWithSsrFGuard({
+    url: apiUrl,
+    timeoutMs: SIGNAL_CLI_RELEASE_API_TIMEOUT_MS,
+    init: {
+      headers: {
+        "User-Agent": "openclaw",
+        Accept: "application/vnd.github+json",
+      },
     },
   });
-
-  if (!response.ok) {
-    return {
-      ok: false,
-      error: `Failed to fetch release info (${response.status})`,
-    };
+  let payload: ReleaseResponse;
+  try {
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `Failed to fetch release info (${response.status})`,
+      };
+    }
+    payload = (await response.json()) as ReleaseResponse;
+  } finally {
+    await release();
   }
-
-  const payload = (await response.json()) as ReleaseResponse;
   const version = payload.tag_name?.replace(/^v/, "") ?? "unknown";
   const assets = payload.assets ?? [];
   const asset = pickAsset(assets, process.platform, process.arch);


### PR DESCRIPTION
## What

[`extensions/signal/src/install-signal-cli.ts`](extensions/signal/src/install-signal-cli.ts) implemented the signal-cli release download via a raw `node:https` `request()` with **no timeout**, **no SSRF guard**, **no size limit**, and **no proxy support** — exactly the gaps the reporter at #54153 documented. The sibling skills installer (`skills-install-download.ts`) already uses the canonical `fetchWithSsrFGuard` helper for the same shape of work; this PR brings the signal-cli installer onto the same pattern.

Closes #54153.

## Why this fix

Replace `downloadToFile` with a `fetchWithSsrFGuard`-backed implementation that:

- **Timeout (5 min)** — `SIGNAL_CLI_DOWNLOAD_TIMEOUT_MS` is well above a normal multi-MB GitHub Releases download but bounded so a hung CDN cannot block the install loop forever. The previous implementation could wait indefinitely.
- **SSRF guard** — `fetchWithSsrFGuard` validates the URL and every redirect target against the runtime SSRF policy. The previous redirect chain was followed without any host check, so a compromised release entry or MITM could redirect to private/internal endpoints.
- **Size cap (256 MiB)** — both a `content-length` declared-size check **and** a streamed-bytes counter abort the pipeline if the cumulative payload exceeds 256 MiB. Real signal-cli archives are well under 50 MiB; 256 MiB leaves plenty of headroom while preventing disk exhaustion via a malicious or misconfigured server.
- **Proxy support** — `fetchWithSsrFGuard` honors `HTTP_PROXY` / `HTTPS_PROXY` / `EnvHttpProxyAgent` semantics through the runtime dispatcher; the old `node:https` request silently ignored proxy env entirely.

The streaming counter uses a `Readable` adapter so the size check runs **as bytes arrive**, not just on the trailing `content-length`. A malicious server that omits `content-length` and streams >256 MiB still gets aborted mid-stream.

## Tests

I did not add a network-fixture test because:

1. The sibling `skills-install-download.ts` is the canonical pattern this change mirrors and already has its SSRF/timeout/size-cap behavior covered through the central `fetchWithSsrFGuard` test suite in [src/infra/net/](src/infra/net/) — adding a duplicate suite around `installSignalCli` would just retest `fetchWithSsrFGuard`.
2. The new code path only changes the **transport** for an existing function (`downloadToFile`); the install state machine (`runInstallSignalCli` / `extractSignalCliArchive`) is unchanged and its existing coverage applies to the stronger transport too.

If reviewers want a focused unit test for the streamed-byte cap I am happy to add one with a `Readable.from` fixture.

## Notes

- Single-area diff: `extensions/signal/src/install-signal-cli.ts` and a one-line CHANGELOG entry under `## Unreleased` `### Fixes` with `Thanks @juan-flores077`.
- No public Plugin SDK additions — `fetchWithSsrFGuard` is already exported via `openclaw/plugin-sdk/ssrf-runtime`.
- AI-assisted (Claude). Reviewed locally; please flag if there is a known reason the signal-cli installer needs to bypass the SSRF policy on certain release URL shapes (I did not find one, but want to surface the question explicitly).

## Validation

Local CI is constrained on this machine; relying on CI for the canonical proof. I have:

- Mirrored the `fetchWithSsrFGuard({ url, timeoutMs })` + `release()` pattern from the sibling skills installer exactly so the change stays consistent with the rest of the codebase's hardened-download contract.
- Confirmed the SDK subpath (`openclaw/plugin-sdk/ssrf-runtime`) is already exported via [src/plugin-sdk/ssrf-runtime.ts:16](src/plugin-sdk/ssrf-runtime.ts#L16).
- Confirmed the changelog entry is single-line and credits a contributor.

Happy to address Greptile/Codex review feedback or extract the streamed-byte counter into a shared helper if other installers would benefit.