### PR TITLE
fix: sanitize subprocess call in DebugHandler.kt

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt
@@ -86,7 +86,8 @@ class DebugHandler(
       try {
         val tmpFile = java.io.File(appContext.cacheDir, "debug_logs.txt")
         if (tmpFile.exists()) tmpFile.delete()
-        val pb = ProcessBuilder(LOGCAT_PATH, "-d", "-t", "200", "--pid=$pid")
+        val pidStr = pid.toString().filter { it.isDigit() }
+        val pb = ProcessBuilder(LOGCAT_PATH, "-d", "-t", "200", "--pid=$pidStr")
         pb.redirectOutput(tmpFile)
         pb.redirectErrorStream(true)
         val proc = pb.start()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt:89` |

**Description**: DebugHandler.kt:89 constructs a ProcessBuilder command using Kotlin string interpolation with a `pid` variable (`--pid=$pid`). If `pid` is derived from user-controlled input (API parameter, Android intent extra) without strict numeric validation, an attacker can inject additional logcat arguments (argument injection). While ProcessBuilder's array form prevents shell metacharacter injection, injecting logcat flags like `--output=/sdcard/evil.txt` or accessing other process logs remains possible. The Python subprocess calls in model_usage.py also require audit to confirm no user-controlled data reaches `cmd` without sanitization, particularly if shell=True is used anywhere in the call chain.

## Changes
- `apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
