### PR TITLE
feat(sandbox): add Docker GPU passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Sandbox/Docker: add opt-in `sandbox.docker.gpus` passthrough for Docker sandbox containers so local GPU workloads can run inside sandboxed agents when the host Docker runtime supports `--gpus`. Fixes #57976; carries forward #58124. Thanks @cyan-ember.
 - iOS/Gateway: add an authenticated `node.presence.alive` protocol event and `node.list` last-seen fields so background iOS wakes can mark paired nodes recently alive without treating them as connected. Carries forward #63123. Thanks @ngutman.
 - Android: publish authenticated `node.presence.alive` events after node connect and background transitions so paired Android nodes retain durable last-seen metadata after disconnects. Carries forward #63123. Thanks @ngutman.
 - Gateway/chat: accept non-image attachments through `chat.send` by staging them as agent-readable media paths, while keeping unsupported RPC attachment paths explicit instead of silently dropping files. Fixes #48123. (#67572) Thanks @samzong.

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -89,6 +89,8 @@ SSH-specific config lives under `agents.defaults.sandbox.ssh`. OpenShell-specifi
 
 Sandboxing is off by default. If you enable sandboxing and do not choose a backend, OpenClaw uses the Docker backend. It executes tools and sandbox browsers locally via the Docker daemon socket (`/var/run/docker.sock`). Sandbox container isolation is determined by Docker namespaces.
 
+To expose host GPUs to Docker sandboxes, set `agents.defaults.sandbox.docker.gpus` or the per-agent `agents.list[].sandbox.docker.gpus` override. The value is passed to Docker's `--gpus` flag as a separate argument, for example `"all"` or `"device=GPU-uuid"`, and requires a compatible host runtime such as NVIDIA Container Toolkit.
+
 <Warning>
 **Docker-out-of-Docker (DooD) constraints**
 

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -164,6 +164,21 @@ describe("buildSandboxCreateArgs", () => {
     );
   });
 
+  it("emits Docker GPU passthrough as a separate argument", () => {
+    const cfg = createSandboxConfig({
+      gpus: "device=GPU-123",
+    });
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-gpu",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    expect(args).toEqual(expect.arrayContaining(["--gpus", "device=GPU-123"]));
+  });
+
   it("emits -v flags for safe custom binds", () => {
     const cfg: SandboxDockerConfig = {
       image: "openclaw-sandbox:bookworm-slim",

--- a/src/agents/sandbox-merge.test.ts
+++ b/src/agents/sandbox-merge.test.ts
@@ -36,6 +36,29 @@ describe("sandbox config merges", () => {
     });
   });
 
+  it("resolves sandbox docker GPU passthrough with agent precedence", () => {
+    const inherited = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { gpus: "all" },
+      agentDocker: {},
+    });
+    expect(inherited.gpus).toBe("all");
+
+    const overridden = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { gpus: "all" },
+      agentDocker: { gpus: "device=GPU-123" },
+    });
+    expect(overridden.gpus).toBe("device=GPU-123");
+
+    const sharedScope = resolveSandboxDockerConfig({
+      scope: "shared",
+      globalDocker: { gpus: "all" },
+      agentDocker: { gpus: "device=GPU-123" },
+    });
+    expect(sharedScope.gpus).toBe("all");
+  });
+
   it("resolves docker binds and shared-scope override behavior", () => {
     for (const scenario of [
       {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -116,6 +116,7 @@ export function resolveSandboxDockerConfig(params: {
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,
     cpus: agentDocker?.cpus ?? globalDocker?.cpus,
+    gpus: normalizeOptionalString(agentDocker?.gpus ?? globalDocker?.gpus),
     ulimits,
     seccompProfile: agentDocker?.seccompProfile ?? globalDocker?.seccompProfile,
     apparmorProfile: agentDocker?.apparmorProfile ?? globalDocker?.apparmorProfile,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -444,6 +444,10 @@ export function buildSandboxCreateArgs(params: {
   if (typeof params.cfg.cpus === "number" && params.cfg.cpus > 0) {
     args.push("--cpus", String(params.cfg.cpus));
   }
+  const gpus = params.cfg.gpus?.trim();
+  if (gpus) {
+    args.push("--gpus", gpus);
+  }
   for (const [name, value] of Object.entries(params.cfg.ulimits ?? {})) {
     const formatted = formatUlimitValue(name, value);
     if (formatted) {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -62,6 +62,39 @@ describe("sandbox docker config", () => {
     }
   });
 
+  it("accepts non-empty Docker GPU passthrough config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              gpus: "all",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.agents?.defaults?.sandbox?.docker?.gpus).toBe("all");
+    }
+  });
+
+  it("rejects empty Docker GPU passthrough config", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              gpus: "",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
   it("rejects network host mode via Zod schema validation", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -422,6 +422,10 @@ export const FIELD_HELP: Record<string, string> = {
     "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Per-agent DANGEROUS override for container namespace joins in sandbox Docker network mode.",
+  "agents.defaults.sandbox.docker.gpus":
+    'Optional Docker GPU passthrough value passed to --gpus, for example "all" or "device=GPU-uuid". Requires a compatible host runtime such as NVIDIA Container Toolkit.',
+  "agents.list[].sandbox.docker.gpus":
+    "Per-agent Docker GPU passthrough override for sandbox containers.",
   "agents.defaults.sandbox.browser.cdpSourceRange":
     "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",
   "agents.list[].sandbox.browser.cdpSourceRange":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -635,6 +635,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.sandbox.browser.cdpSourceRange": "Sandbox Browser CDP Source Port Range",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Sandbox Docker Allow Container Namespace Join",
+  "agents.defaults.sandbox.docker.gpus": "Sandbox Docker GPUs",
   commands: "Commands",
   "commands.native": "Native Commands",
   "commands.nativeSkills": "Native Skill Commands",
@@ -879,6 +880,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list[].sandbox.browser.cdpSourceRange": "Agent Sandbox Browser CDP Source Port Range",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",
+  "agents.list[].sandbox.docker.gpus": "Agent Sandbox Docker GPUs",
   "discovery.mdns.mode": "mDNS Discovery Mode",
   plugins: "Plugins",
   "plugins.enabled": "Enable Plugins",

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -29,6 +29,8 @@ export type SandboxDockerSettings = {
   memorySwap?: string | number;
   /** Limit container CPU shares (e.g. 0.5, 1, 2). */
   cpus?: number;
+  /** GPU devices to expose via Docker --gpus (e.g. "all", "device=GPU-uuid"). */
+  gpus?: string;
   /**
    * Set ulimit values by name (e.g. nofile, nproc).
    * Use "soft:hard" string, a number, or { soft, hard }.

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -119,6 +119,7 @@ export const SandboxDockerSchema = z
     memory: z.union([z.string(), z.number()]).optional(),
     memorySwap: z.union([z.string(), z.number()]).optional(),
     cpus: z.number().positive().optional(),
+    gpus: z.string().min(1).optional(),
     ulimits: z
       .record(
         z.string(),


### PR DESCRIPTION
## Summary

- Problem: Docker sandboxes cannot opt into host GPU devices, blocking local GPU workloads such as Whisper inside sandboxed agents.
- Why it matters: users have to choose between slow CPU runs, out-of-sandbox services, or disabling sandboxing.
- What changed: added `sandbox.docker.gpus` config plumbing, schema validation, Docker `--gpus` arg emission, docs, changelog, and focused tests.
- What did NOT change (scope boundary): no default GPU exposure, no old generated baseline churn from #58124, and no non-Docker backend behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #57976
- Carries forward #58124 from @cyan-ember
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/sandbox-create-args.test.ts`, `src/agents/sandbox-merge.test.ts`, `src/config/config.sandbox-docker.test.ts`
- Scenario the test should lock in: non-empty GPU config is accepted, empty GPU config is rejected, agent/global precedence is preserved, and Docker receives `--gpus` as a separate argv pair.
- Why this is the smallest reliable guardrail: it covers config parsing, resolution, and arg construction without requiring a GPU host.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Opt-in `agents.defaults.sandbox.docker.gpus` and `agents.list[].sandbox.docker.gpus` config fields pass values through to Docker `--gpus` for Docker sandbox containers.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: GPU device exposure is opt-in operator config only. Values are passed as a separate Docker argv entry, not through a shell, and schema validation rejects empty strings.

## Repro + Verification

### Environment

- OS: Blacksmith Testbox CI runner
- Runtime/container: OpenClaw Docker sandbox config and arg builder
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `sandbox.docker.gpus: "all"`

### Steps

1. Validate targeted sandbox/config tests in Testbox.
2. Validate generated config docs are not stale in Testbox.
3. Run changed gate in Testbox.
4. Rebase on current `origin/main` and run `git diff --check` plus diff stat sanity.

### Expected

- GPU config is accepted when non-empty, rejected when empty, resolved with normal precedence, and emitted as `--gpus <value>`.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Testbox `tbx_01kq9t0rkpn807e4shbhenfd27`:
- `OPENCLAW_TESTBOX=1 pnpm test:serial src/agents/sandbox-create-args.test.ts src/agents/sandbox-merge.test.ts src/config/config.sandbox-docker.test.ts src/config/schema.help.quality.test.ts` passed.
- `OPENCLAW_TESTBOX=1 pnpm config:docs:check` passed.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed before the clean rebase; post-rebase diff stayed 11 files / 88 insertions and `git diff --check` passed.

## Human Verification (required)

- Verified scenarios: config parse/reject behavior, config precedence, Docker argv construction, docs/config baseline check, changed gate.
- Edge cases checked: empty string rejected; shared-scope ignores per-agent GPU override; arg-array emission avoids shell interpolation.
- What you did **not** verify: live GPU access on a host with NVIDIA Container Toolkit.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

The original #58124 Greptile/Codex threads were inspected. This replacement addresses the empty-string validation and current generated config baseline concern without carrying the old generated drift.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: Set `agents.defaults.sandbox.docker.gpus` or per-agent `agents.list[].sandbox.docker.gpus` and recreate sandbox containers.

## Risks and Mitigations

- Risk: GPU passthrough expands device access for a sandbox container.
  - Mitigation: opt-in only; no default behavior change; operator-owned Docker config; separate argv emission.
