### PR TITLE
fix(memory-core): retry dreaming cron startup reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
+- Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
 
 ## 2026.4.27
 

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -59,7 +59,11 @@ async function writeDailyMemoryNote(
 
 function createCronHarness(
   initialJobs: CronJobLike[] = [],
-  opts?: { removeResult?: "boolean" | "unknown"; removeThrowsForIds?: string[] },
+  opts?: {
+    listThrowsForFirstCalls?: number;
+    removeResult?: "boolean" | "unknown";
+    removeThrowsForIds?: string[];
+  },
 ) {
   const jobs: CronJobLike[] = [...initialJobs];
   let listCalls = 0;
@@ -70,6 +74,9 @@ function createCronHarness(
   const cron: CronParam = {
     async list() {
       listCalls += 1;
+      if (opts?.listThrowsForFirstCalls && listCalls <= opts.listThrowsForFirstCalls) {
+        throw new Error(`list failed on call ${listCalls}`);
+      }
       return jobs.map((job) => ({
         ...job,
         ...(job.schedule ? { schedule: { ...job.schedule } } : {}),
@@ -173,11 +180,34 @@ function getGatewayStartHandler(
   ) => Promise<unknown>;
 }
 
+function getGatewayStopHandler(
+  onMock: ReturnType<typeof vi.fn>,
+): (
+  event: { reason?: string },
+  ctx: { config?: OpenClawConfig; workspaceDir?: string; getCron?: () => unknown },
+) => Promise<unknown> | void {
+  const call = onMock.mock.calls.find(([eventName]) => eventName === "gateway_stop");
+  if (!call) {
+    throw new Error("gateway_stop hook was not registered");
+  }
+  return call[1] as (
+    event: { reason?: string },
+    ctx: { config?: OpenClawConfig; workspaceDir?: string; getCron?: () => unknown },
+  ) => Promise<unknown> | void;
+}
+
 async function triggerGatewayStart(
   onMock: ReturnType<typeof vi.fn>,
   ctx: { config?: OpenClawConfig; workspaceDir?: string; getCron?: () => unknown },
 ): Promise<void> {
   await getGatewayStartHandler(onMock)({ port: 18789 }, ctx);
+}
+
+async function triggerGatewayStop(
+  onMock: ReturnType<typeof vi.fn>,
+  ctx: { config?: OpenClawConfig; workspaceDir?: string; getCron?: () => unknown } = {},
+): Promise<void> {
+  await getGatewayStopHandler(onMock)({ reason: "test" }, ctx);
 }
 
 function registerShortTermPromotionDreamingForTest(api: DreamingPluginApiTestDouble): void {
@@ -1328,6 +1358,191 @@ describe("gateway startup reconciliation", () => {
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
     } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("retries startup cron reconciliation until cron is available without a heartbeat (regression #72841)", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      expect(harness.addCalls).toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("cron service not yet available at gateway_start"),
+      );
+
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+      expect(harness.addCalls).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
+
+      cronAvailable = true;
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(harness.addCalls).toHaveLength(1);
+      expect(harness.addCalls[0]).toMatchObject({
+        name: "Memory Dreaming Promotion",
+        schedule: {
+          kind: "cron",
+          expr: "15 4 * * *",
+          tz: "UTC",
+        },
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: constants.DREAMING_SYSTEM_EVENT_TEXT,
+          lightContext: true,
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("does not reschedule startup cron retry from stale enabled config after runtime config disables dreaming", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness([], { listThrowsForFirstCalls: 1 });
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      api.config = {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      cronAvailable = true;
+
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+      await vi.advanceTimersByTimeAsync(constants.STARTUP_CRON_RETRY_DELAY_MS);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("deferred dreaming cron retry failed"),
+      );
+      expect(harness.listCalls).toBe(1);
+      expect(harness.addCalls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+      clearInternalHooks();
+    }
+  });
+
+  it("clears pending startup cron retry on gateway stop", async () => {
+    vi.useFakeTimers();
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      let cronAvailable = false;
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => (cronAvailable ? harness.cron : undefined),
+      });
+
+      await triggerGatewayStop(onMock);
+      cronAvailable = true;
+      await vi.advanceTimersByTimeAsync(
+        constants.STARTUP_CRON_RETRY_DELAY_MS * constants.STARTUP_CRON_RETRY_MAX_ATTEMPTS,
+      );
+
+      expect(harness.addCalls).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
       clearInternalHooks();
     }
   });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -41,6 +41,8 @@ import {
 } from "./short-term-promotion.js";
 
 const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
+const STARTUP_CRON_RETRY_DELAY_MS = 5_000;
+const STARTUP_CRON_RETRY_MAX_ATTEMPTS = 12;
 const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
@@ -682,9 +684,43 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
   let lastRuntimeReconcileAtMs = 0;
   let lastRuntimeConfigKey: string | null = null;
   let lastRuntimeCronRef: CronServiceLike | null = null;
+  let startupCronRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  let startupCronRetryAttempts = 0;
+  let disposed = false;
 
   const resolveCurrentConfig = (): OpenClawConfig =>
     (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
+
+  const resolveCurrentDreamingConfig = (): ShortTermPromotionDreamingConfig => {
+    const cfg = resolveCurrentConfig();
+    return resolveShortTermPromotionDreamingConfig({
+      pluginConfig: resolveMemoryCorePluginConfig(cfg),
+      cfg,
+    });
+  };
+
+  const clearStartupCronRetry = (): void => {
+    if (startupCronRetryTimer) {
+      clearTimeout(startupCronRetryTimer);
+      startupCronRetryTimer = null;
+    }
+    startupCronRetryAttempts = 0;
+  };
+
+  const hasStartupCron = (): boolean => {
+    try {
+      return Boolean(resolveStartupCron?.());
+    } catch {
+      return false;
+    }
+  };
+
+  const disposeStartupCronRetry = (): void => {
+    disposed = true;
+    clearStartupCronRetry();
+    gatewayContext = null;
+    resolveStartupCron = null;
+  };
 
   const runtimeConfigKey = (config: ShortTermPromotionDreamingConfig): string =>
     [
@@ -756,6 +792,7 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     }
     if (cron) {
       unavailableCronWarningEmitted = false;
+      clearStartupCronRetry();
     }
     if (params.reason === "runtime") {
       const now = Date.now();
@@ -780,20 +817,66 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     return config;
   };
 
+  const scheduleStartupCronRetry = (config: ShortTermPromotionDreamingConfig): void => {
+    if (disposed || !config.enabled || hasStartupCron()) {
+      clearStartupCronRetry();
+      return;
+    }
+    if (startupCronRetryTimer || startupCronRetryAttempts >= STARTUP_CRON_RETRY_MAX_ATTEMPTS) {
+      return;
+    }
+    startupCronRetryTimer = setTimeout(() => {
+      startupCronRetryTimer = null;
+      if (disposed) {
+        return;
+      }
+      startupCronRetryAttempts += 1;
+      void reconcileManagedDreamingCron({ reason: "runtime" })
+        .then((latestConfig) => {
+          if (disposed || !latestConfig.enabled || hasStartupCron()) {
+            clearStartupCronRetry();
+            return;
+          }
+          scheduleStartupCronRetry(latestConfig);
+        })
+        .catch((err) => {
+          if (disposed) {
+            return;
+          }
+          api.logger.error(
+            `memory-core: deferred dreaming cron retry failed: ${formatErrorMessage(err)}`,
+          );
+          try {
+            scheduleStartupCronRetry(resolveCurrentDreamingConfig());
+          } catch (configErr) {
+            api.logger.error(
+              `memory-core: deferred dreaming cron retry config refresh failed: ${formatErrorMessage(configErr)}`,
+            );
+          }
+        });
+    }, STARTUP_CRON_RETRY_DELAY_MS);
+  };
+
   api.on("gateway_start", async (_event, ctx) => {
+    disposed = false;
     // Store the gateway context for runtime cron resolution retries.
     gatewayContext = ctx as unknown as { getCron?: () => CronServiceLike | null };
     try {
-      await reconcileManagedDreamingCron({
+      const config = await reconcileManagedDreamingCron({
         reason: "startup",
         startupConfig: ctx.config,
         startupCron: () => resolveCronServiceFromGatewayContext(ctx),
       });
+      scheduleStartupCronRetry(config);
     } catch (err) {
       api.logger.error(
         `memory-core: dreaming startup reconciliation failed: ${formatErrorMessage(err)}`,
       );
     }
+  });
+
+  api.on("gateway_stop", () => {
+    disposeStartupCronRetry();
   });
 
   api.on("before_agent_reply", async (event, ctx) => {
@@ -846,5 +929,7 @@ export const __testing = {
     DEFAULT_DREAMING_MIN_RECALL_COUNT: DEFAULT_MEMORY_DREAMING_MIN_RECALL_COUNT,
     DEFAULT_DREAMING_MIN_UNIQUE_QUERIES: DEFAULT_MEMORY_DREAMING_MIN_UNIQUE_QUERIES,
     DEFAULT_DREAMING_RECENCY_HALF_LIFE_DAYS: DEFAULT_MEMORY_DREAMING_RECENCY_HALF_LIFE_DAYS,
+    STARTUP_CRON_RETRY_DELAY_MS,
+    STARTUP_CRON_RETRY_MAX_ATTEMPTS,
   },
 };

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -41,7 +41,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
     "subagent_ended",
     "subagent_spawning",
   ],
-  "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start"],
+  "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/skill-workshop/index.ts": ["agent_end", "before_prompt_build"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],


### PR DESCRIPTION
## Summary

- Problem: memory-core dreaming cron reconciliation can run before the Gateway cron service is reachable, leaving the managed Memory Dreaming Promotion job unregistered.
- Why it matters: enabled dreaming setups can keep `jobs.json` entries but never execute scheduled promotion after startup.
- What changed: add a bounded startup retry loop that reuses the live Gateway cron getter until cron is available, then reconciles the managed job without waiting for heartbeat traffic.
- What did NOT change (scope boundary): no core Gateway lifecycle changes, no cron service contract changes, and no dreaming schedule/payload behavior changes beyond startup recovery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72841
- Related #73170
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `gateway_start` can observe `ctx.getCron()` as unavailable while the cron runtime is still attaching. The existing fallback only retried during heartbeat/cron-triggered `before_agent_reply`, so a missing managed cron registration could deadlock because the cron event needed to trigger recovery never existed.
- Missing detection / guardrail: no startup-independent retry covered the cron-unavailable-at-startup path.
- Contributing context (if known): earlier behavior intentionally demoted startup cron-unavailable logs to debug, preserving the runtime warning but still requiring later runtime traffic.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`
- Scenario the test should lock in: cron is unavailable at `gateway_start`, no heartbeat occurs, cron becomes available during the bounded retry window, and the managed Memory Dreaming Promotion job is registered with the expected isolated agent-turn payload.
- Why this is the smallest reliable guardrail: it exercises the plugin-owned lifecycle/reconciliation logic directly without depending on wall-clock Gateway startup timing.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Enabled memory-core dreaming now self-recovers when cron is briefly unavailable during Gateway startup, so the scheduled Memory Dreaming Promotion sweep can register and run without requiring unrelated heartbeat traffic.

## Diagram (if applicable)

```text
Before:
Gateway startup -> memory-core sees no cron -> no managed cron registration -> no scheduled dreaming run

After:
Gateway startup -> memory-core sees no cron -> bounded retry -> cron available -> managed cron registration
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local dev worktree
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): memory-core managed cron
- Relevant config (redacted): `plugins.entries.memory-core.config.dreaming.enabled: true`

### Steps

1. Start memory-core dreaming while `gateway_start` cron resolution returns unavailable.
2. Allow the startup retry timer to fire before heartbeat/cron traffic occurs.
3. Make the cron service available through the stored Gateway cron getter.

### Expected

- The managed `Memory Dreaming Promotion` cron job is registered with the configured schedule and isolated agent-turn payload.

### Actual

- Before this fix, registration depended on later heartbeat/cron-triggered reconciliation and could never happen if the managed cron was the missing trigger.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios: focused dreaming regression test, changed extension typecheck/lint/import-cycle gate, changed-test wrapper.
- Edge cases checked: cron unavailable at startup, runtime warning still emitted while unavailable, cron registers when later available without heartbeat traffic.
- What I did **not** verify: live WSL2/systemd gateway startup against a real user cron store.

Commands run:

- `pnpm docs:list`
- `pnpm install`
- `pnpm exec oxfmt --write --threads=1 extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts`
- `pnpm test extensions/memory-core/src/dreaming.test.ts`
- `pnpm check:changed`
- `pnpm test:changed`
- `git diff --check`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: retrying too aggressively during startup could add noisy cron reconciliation attempts.
  - Mitigation: retry is bounded to 12 attempts at 5-second intervals, stops when cron is available, and stops when dreaming is disabled.
