### PR TITLE
fix(plugins): regenerate bundled wrappers with correct specifier in staged runtime root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
+- Plugins/bundled-runtime: regenerate bundled plugin wrappers at the staged install root so their relative specifier resolves to the staged dist impl rather than back to the wrapper itself. Without this, copying a `<openclaw>/dist-runtime/extensions/<plugin>/<file>.js` wrapper verbatim into a fresh install root produced a self-import that stripped the `defineBundledChannelEntry` contract, causing the channel registry to skip the plugin and JSON-schema validation to surface the misleading `must NOT have additional properties` error. Triggers on read-only-source-tree deployments (e.g. Docker containers running OpenClaw as a non-root user against `/opt/openclaw/` mounted root-owned and not group-writable); native installs against a writable source tree never staged the bundled root and therefore never hit the bug. (#73497) Thanks @coletebou.
 
 ## 2026.4.27
 

--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -516,7 +516,7 @@ describe("prepareBundledPluginRuntimeRoot", () => {
     const wrapperContent = fs.readFileSync(stagedWrapperPath, "utf8");
     const specifierMatch = wrapperContent.match(/^export \* from ["']([^"']+)["']/m);
     expect(specifierMatch, "wrapper must contain an export * from <specifier> line").toBeTruthy();
-    const specifier = specifierMatch![1] as string;
+    const specifier = specifierMatch![1];
 
     // The specifier must resolve away from the wrapper itself: a self-import
     // is the exact bug the fix addresses.

--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -414,6 +414,178 @@ describe("prepareBundledPluginRuntimeRoot", () => {
     expect(fs.readFileSync(mirrorEntry, "utf8")).toContain("v1");
   });
 
+  it("regenerates wrappers in the staged dist-runtime tree so they resolve to the staged impl, not back to themselves", () => {
+    // Repro for the read-only-source-tree crash-loop on Docker non-root
+    // deployments: the wrapper at <openclaw>/dist-runtime/extensions/<plugin>/index.js
+    // has a build-time-baked relative specifier `path.relative(wrapperDir,
+    // implPath)` that points to <openclaw>/dist/extensions/<plugin>/index.js.
+    // When mirrorBundledPluginRuntimeRoot copies that wrapper verbatim into
+    // <installRoot>/dist-runtime/extensions/<plugin>/index.js, the specifier
+    // (still computed relative to the SOURCE layout) resolves back to the
+    // staged wrapper itself — a self-import that strips the
+    // bundled-channel-entry contract from the wrapper's default export.
+    //
+    // After the fix, regenerateBundledPluginRuntimeWrappers rewrites the
+    // staged wrapper using path.relative(stagedWrapperDir, stagedImplPath),
+    // which correctly resolves to the staged impl.
+    const packageRoot = makeTempRoot();
+    const stageDir = makeTempRoot();
+    const canonicalPluginRoot = path.join(packageRoot, "dist", "extensions", "qqbot");
+    const runtimePluginRoot = path.join(packageRoot, "dist-runtime", "extensions", "qqbot");
+    const env = { ...process.env, OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    fs.mkdirSync(canonicalPluginRoot, { recursive: true });
+    fs.mkdirSync(runtimePluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.27", type: "module" }),
+      "utf8",
+    );
+    // Canonical impl carries a sentinel string that proves the wrapper resolves
+    // to the impl (not back to itself, which has no contract sentinel).
+    const contractSentinel = "__bundled_channel_entry_contract__";
+    fs.writeFileSync(
+      path.join(canonicalPluginRoot, "index.js"),
+      `export const ${contractSentinel} = true;\nexport default { id: "qqbot" };\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(canonicalPluginRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/qqbot",
+          version: "1.0.0",
+          type: "module",
+          dependencies: { "qqbot-runtime": "1.0.0" },
+          openclaw: { extensions: ["./index.js"] },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    // Runtime wrapper as it would be emitted at build time. The relative
+    // specifier here is correct for the SOURCE layout but resolves to the
+    // wrong path once copied verbatim into the staged install root.
+    fs.writeFileSync(
+      path.join(runtimePluginRoot, "index.js"),
+      `export * from ${JSON.stringify("../../../dist/extensions/qqbot/index.js")};\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(runtimePluginRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/qqbot",
+          version: "1.0.0",
+          type: "module",
+          dependencies: { "qqbot-runtime": "1.0.0" },
+          openclaw: { extensions: ["./index.js"] },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(runtimePluginRoot, { env });
+    fs.mkdirSync(path.join(installRoot, "node_modules", "qqbot-runtime"), { recursive: true });
+    fs.writeFileSync(
+      path.join(installRoot, "node_modules", "qqbot-runtime", "package.json"),
+      JSON.stringify({ name: "qqbot-runtime", version: "1.0.0", type: "module" }),
+      "utf8",
+    );
+
+    prepareBundledPluginRuntimeRoot({
+      pluginId: "qqbot",
+      pluginRoot: runtimePluginRoot,
+      modulePath: path.join(runtimePluginRoot, "index.js"),
+      env,
+    });
+
+    const stagedWrapperPath = path.join(
+      installRoot,
+      "dist-runtime",
+      "extensions",
+      "qqbot",
+      "index.js",
+    );
+    const stagedImplPath = path.join(installRoot, "dist", "extensions", "qqbot", "index.js");
+    expect(fs.existsSync(stagedWrapperPath)).toBe(true);
+    expect(fs.existsSync(stagedImplPath)).toBe(true);
+
+    // Extract the wrapper's first relative-specifier (the `export *` line).
+    const wrapperContent = fs.readFileSync(stagedWrapperPath, "utf8");
+    const specifierMatch = wrapperContent.match(/^export \* from ["']([^"']+)["']/m);
+    expect(specifierMatch, "wrapper must contain an export * from <specifier> line").toBeTruthy();
+    const specifier = specifierMatch![1] as string;
+
+    // The specifier must resolve away from the wrapper itself: a self-import
+    // is the exact bug the fix addresses.
+    const resolvedFromWrapper = path.resolve(path.dirname(stagedWrapperPath), specifier);
+    expect(resolvedFromWrapper).not.toBe(stagedWrapperPath);
+
+    // And it must resolve to the staged impl, which carries the contract
+    // sentinel.
+    expect(resolvedFromWrapper).toBe(stagedImplPath);
+    expect(fs.readFileSync(resolvedFromWrapper, "utf8")).toContain(contractSentinel);
+  });
+
+  it("leaves wrappers alone when no corresponding impl exists in the staged dist tree", () => {
+    // Defensive: regeneration must only fire when the impl is actually
+    // present at the expected staged path. Otherwise we'd risk overwriting
+    // a wrapper that's already correct (or fabricating broken imports).
+    const packageRoot = makeTempRoot();
+    const stageDir = makeTempRoot();
+    const runtimePluginRoot = path.join(packageRoot, "dist-runtime", "extensions", "orphan");
+    const env = { ...process.env, OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    fs.mkdirSync(runtimePluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.27", type: "module" }),
+      "utf8",
+    );
+    // No canonical dist tree for this plugin — only the runtime wrapper.
+    const wrapperBefore = `export const orphan = true;\n`;
+    fs.writeFileSync(path.join(runtimePluginRoot, "index.js"), wrapperBefore, "utf8");
+    fs.writeFileSync(
+      path.join(runtimePluginRoot, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/orphan",
+          version: "1.0.0",
+          type: "module",
+          dependencies: { "orphan-runtime": "1.0.0" },
+          openclaw: { extensions: ["./index.js"] },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(runtimePluginRoot, { env });
+    fs.mkdirSync(path.join(installRoot, "node_modules", "orphan-runtime"), { recursive: true });
+    fs.writeFileSync(
+      path.join(installRoot, "node_modules", "orphan-runtime", "package.json"),
+      JSON.stringify({ name: "orphan-runtime", version: "1.0.0", type: "module" }),
+      "utf8",
+    );
+
+    prepareBundledPluginRuntimeRoot({
+      pluginId: "orphan",
+      pluginRoot: runtimePluginRoot,
+      modulePath: path.join(runtimePluginRoot, "index.js"),
+      env,
+    });
+
+    const stagedWrapperPath = path.join(
+      installRoot,
+      "dist-runtime",
+      "extensions",
+      "orphan",
+      "index.js",
+    );
+    expect(fs.readFileSync(stagedWrapperPath, "utf8")).toBe(wrapperBefore);
+  });
+
   it("refreshes external runtime mirrors when source files change", async () => {
     const packageRoot = makeTempRoot();
     const stageDir = makeTempRoot();

--- a/src/plugins/bundled-runtime-root.ts
+++ b/src/plugins/bundled-runtime-root.ts
@@ -137,13 +137,32 @@ function mirrorBundledPluginRuntimeRoot(params: {
       if (path.resolve(preparedMirrorRoot) === path.resolve(params.pluginRoot)) {
         return preparedMirrorRoot;
       }
-      refreshBundledPluginRuntimeMirrorRoot({
+      const didRefresh = refreshBundledPluginRuntimeMirrorRoot({
         pluginId: params.pluginId,
         sourceRoot: params.pluginRoot,
         targetRoot: preparedMirrorRoot,
         tempDirParent: preparedMirrorParent,
         precomputedSourceMetadata: precomputedPluginRootMetadata,
       });
+      if (didRefresh && path.basename(sourceDistRoot) === "dist-runtime") {
+        // Wrappers under <openclaw>/dist-runtime/extensions/<plugin>/ are
+        // generated at build time with a relative specifier that points to
+        // the source dist impl. When copied verbatim into the staged
+        // install root, that specifier resolves back to the wrapper itself
+        // (a self-import), stripping the `defineBundledChannelEntry`
+        // contract and causing the channel registry to skip the plugin.
+        // Symptom on read-only Docker deployments running as non-root:
+        //   bundled channel entry <plugin> missing bundled-channel-entry contract; skipping
+        //   channels.<plugin>: invalid config: must NOT have additional properties
+        // Regenerate each .js wrapper at the staged location so its
+        // specifier resolves to the staged impl in the corresponding
+        // <installRoot>/dist/extensions/<plugin>/ tree.
+        regenerateBundledPluginRuntimeWrappers({
+          stagedWrapperRoot: preparedMirrorRoot,
+          pluginId: params.pluginId,
+          installRoot: params.installRoot,
+        });
+      }
       return preparedMirrorRoot;
     },
   );
@@ -294,6 +313,38 @@ function ensureBundledRuntimeDistPackageJson(mirrorDistRoot: string): void {
 function writeRuntimeJsonFile(targetPath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
   fs.writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function regenerateBundledPluginRuntimeWrappers(params: {
+  stagedWrapperRoot: string;
+  pluginId: string;
+  installRoot: string;
+}): void {
+  const stagedImplRoot = path.join(params.installRoot, "dist", "extensions", params.pluginId);
+  if (!fs.existsSync(stagedImplRoot)) {
+    return;
+  }
+  rewriteWrappersWhereImplExists(params.stagedWrapperRoot, stagedImplRoot);
+}
+
+function rewriteWrappersWhereImplExists(stagedDir: string, implDir: string): void {
+  for (const entry of fs.readdirSync(stagedDir, { withFileTypes: true })) {
+    const stagedPath = path.join(stagedDir, entry.name);
+    const implPath = path.join(implDir, entry.name);
+    if (entry.isDirectory()) {
+      if (fs.existsSync(implPath) && fs.statSync(implPath).isDirectory()) {
+        rewriteWrappersWhereImplExists(stagedPath, implPath);
+      }
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".js")) {
+      continue;
+    }
+    if (!fs.existsSync(implPath) || !fs.statSync(implPath).isFile()) {
+      continue;
+    }
+    writeRuntimeModuleWrapper(implPath, stagedPath);
+  }
 }
 
 function hasRuntimeDefaultExport(sourcePath: string): boolean {


### PR DESCRIPTION
## Summary

`prepareBundledPluginRuntimeRoot` (in `src/plugins/bundled-runtime-root.ts`) currently calls `copyBundledPluginRuntimeRoot` which `fs.copyFileSync`s wrappers verbatim from `<openclaw>/dist-runtime/extensions/<plugin>/<file>.js` into `<installRoot>/dist/extensions/<plugin>/<file>.js`. Each wrapper has a build-time-baked relative specifier `path.relative(wrapperDir, sourceImpl)` — typically `../../../dist/extensions/<plugin>/<file>.js` — which is correct for the **source** layout but resolves back to the wrapper itself in the **staged** layout.

That self-import strips the `defineBundledChannelEntry` contract from the wrapper\s default export, the channel registry skips the plugin, and the JSON-schema validator emits `must NOT have additional properties` against the runtime-injected channel config.

This fix threads the source impl root through `copyBundledPluginRuntimeRoot`. For `.js` files inside a built bundled plugin tree (detected via the existing `dist-runtime/extensions/<pluginId>/` pattern), instead of `fs.copyFileSync`, the existing `writeRuntimeModuleWrapper` helper is called to regenerate the wrapper at the staged location pointing at the source impl. `writeRuntimeModuleWrapper` computes a fresh `path.relative(stagedWrapperDir, sourceImpl)` specifier that correctly references the implementation from the new location.

The pattern follows what `ensureOpenClawPluginSdkAlias` already does for the `dist/extensions/node_modules/openclaw/` plugin-sdk alias — wrappers are regenerated, not copied, when their location changes during staging.

## Symptom

OpenClaw 4.20+ running as a non-root user against a read-only source tree (the standard Docker deployment shape: agent uid 1001 with `/opt/openclaw/` owned by root and not group-writable) crash-loops on boot:

```
[channels] bundled channel entry bluebubbles missing bundled-channel-entry contract; skipping
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - channels.bluebubbles: invalid config: must NOT have additional properties

Run: openclaw doctor --fix
```

The error string `missing bundled-channel-entry contract; skipping` is the actual diagnostic — the `must NOT have additional properties` follow-up is a misleading downstream symptom (the schema for the channel was never registered because the contract check skipped the plugin).

Native installations don\t hit this because the source tree is writable (no fallback to staging). The bug only triggers on the `mirrorBundledPluginRuntimeRoot` code path, which fires when `installRoot ≠ pluginRoot`.

## Reproduction

1. Build OpenClaw 4.20+ (e.g. `v2026.4.26` tag) into a Docker image.
2. Run as a non-root user (e.g. `useradd -m agent && USER agent` in Dockerfile).
3. Mount/configure any bundled channel plugin (e.g. `bluebubbles`) in the user\s `openclaw.json`.
4. Container crash-loops with the diagnostic above.

Verified against `v2026.4.25` and `v2026.4.26`. Native cole-master (root, writable source) is fine on the same versions.

## Fix verification

After applying this commit:
- Container boots cleanly, `bluebubbles` plugin appears in the gateway\s plugin list at startup
- No `missing bundled-channel-entry contract` log line
- No `must NOT have additional properties` config-load error
- Restart count stays at 0 across multiple recreations

## Test plan

- [ ] Add a unit test that asserts `copyBundledPluginRuntimeRoot` regenerates wrappers when `regenerateWrappersFromImplRoot` is provided, and the staged wrapper\s specifier resolves to the impl path (not back to itself)
- [ ] Verify against the existing `bundled-runtime-deps.test.ts` suite — the change should not break any currently-passing tests
- [ ] Sanity-check on a Docker container running as non-root: the bluebubbles plugin loads and `gateway http server listening` includes `bluebubbles` in the plugin list

## Notes

- Patch is local-only on my fleet today (`coletebou/openclaw` fork). I\m happy to add tests in a follow-up commit if the approach is acceptable.
- The fix is symmetric to the existing `ensureOpenClawPluginSdkAlias` pattern — bundled plugin wrappers are now regenerated using the same `writeRuntimeModuleWrapper` helper, just with a different resolution source.
- Blast radius is narrow: only `.js` files inside built bundled plugin trees are affected (gated on `regenerateWrappersFromImplRoot` being passed and `dist-runtime/extensions/<pluginId>/` being detected).