### PR TITLE
ci: shard config codeql quality

### DIFF
--- a/.github/codeql/codeql-config-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-config-boundary-critical-quality.yml
@@ -1,0 +1,33 @@
+name: openclaw-codeql-config-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/config
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/codeql/codeql-javascript-typescript-critical-quality.yml
+++ b/.github/codeql/codeql-javascript-typescript-critical-quality.yml
@@ -22,7 +22,6 @@ paths:
   - src/agents/sandbox
   - src/agents/sandbox.ts
   - src/agents/sandbox-*.ts
-  - src/config
   - src/cron/service/jobs.ts
   - src/cron/stagger.ts
   - src/gateway/*auth*.ts

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -39,6 +39,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/javascript-typescript"
 
+  config-boundary:
+    name: Critical Quality (config-boundary)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-config-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/config-boundary"
+
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -246,13 +246,16 @@ default workflow because the macOS build dominates runtime even when clean.
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces. Its baseline job scans the same auth, secrets,
-sandbox, cron, and gateway surface as the security workflow. The plugin-boundary
-job scans loader, registry, public-surface, and Plugin SDK entrypoint contracts
-under a separate `/codeql-critical-quality/plugin-boundary` category. Keep the
-workflow separate from security so quality findings can be scheduled, measured,
-disabled, or expanded without obscuring security signal. Swift, Python, UI, and
-bundled-plugin CodeQL expansion should be added back as scoped or sharded
-follow-up work only after the narrow profiles have stable runtime and signal.
+sandbox, cron, and gateway surface as the security workflow. The config-boundary
+job scans config schema, migration, normalization, and IO contracts under the
+separate `/codeql-critical-quality/config-boundary` category. The
+plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
+entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
+category. Keep the workflow separate from security so quality findings can be
+scheduled, measured, disabled, or expanded without obscuring security signal.
+Swift, Python, UI, and bundled-plugin CodeQL expansion should be added back as
+scoped or sharded follow-up work only after the narrow profiles have stable
+runtime and signal.
 
 The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping
 existing docs aligned with recently landed changes. It has no pure schedule: a


### PR DESCRIPTION
## Summary
- split full `src/config` quality scanning out of the generic JS/TS quality category
- add a separate `config-boundary` CodeQL quality job/category
- keep security and plugin-boundary quality categories unchanged

## Proof
- YAML parse passed for CodeQL quality workflow/config files
- `git diff --check origin/main...HEAD`
- `pnpm check:workflows`
- config shard size: 193 prod TS files after test/generated ignores
