### PR TITLE
fix(gateway,agent): only enforce session sendPolicy=deny when delivering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/agent: only enforce `session.sendPolicy=deny` on the gateway `agent` request path when the caller asks the gateway to deliver the reply (`request.deliver === true`), so non-delivery quick-agent smoke calls and other internal agent invocations are no longer rejected with `send blocked by session policy` while outbound delivery remains gated. Fixes #73381. Thanks @marcusglee11.
 - Agents/media: register detached `video_generate` and `music_generate` tool run contexts until terminal status, so Discord-backed provider jobs stay live in `/tasks` instead of becoming `lost` when the parent chat run context disappears. Thanks @vincentkoc.
 - Tasks/media: infer agent ownership for session-scoped task records so `/tasks` agent-local fallback includes session-backed `video_generate` and other async media jobs even when the current chat session has no linked rows. Thanks @vincentkoc.
 - Agents/media: keep long-running `video_generate` and `music_generate` tasks fresh while provider jobs are still pending, so task maintenance does not mark active Discord media renders lost before completion. Thanks @vincentkoc.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   loadConfigReturn: {} as Record<string, unknown>,
   loadVoiceWakeRoutingConfig: vi.fn(),
   resolveVoiceWakeRouteByTrigger: vi.fn(),
+  resolveSendPolicy: vi.fn(() => "allow"),
 }));
 
 vi.mock("../session-utils.js", async () => {
@@ -125,7 +126,8 @@ vi.mock("../../infra/voicewake-routing.js", () => ({
 }));
 
 vi.mock("../../sessions/send-policy.js", () => ({
-  resolveSendPolicy: () => "allow",
+  resolveSendPolicy: (...args: unknown[]) =>
+    (mocks.resolveSendPolicy as (...args: unknown[]) => unknown)(...args),
 }));
 
 vi.mock("../../utils/delivery-context.js", async () => {
@@ -368,6 +370,7 @@ describe("gateway agent handler", () => {
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
+    mocks.resolveSendPolicy.mockReset().mockReturnValue("allow");
   });
 
   it("preserves ACP metadata from the current stored session entry", async () => {
@@ -2410,6 +2413,44 @@ describe("gateway agent handler", () => {
       }),
       undefined,
     );
+  });
+
+  it("allows non-delivery agent invocations even when sendPolicy is deny (#73381)", async () => {
+    primeMainAgentRun();
+    mocks.resolveSendPolicy.mockReturnValue("deny");
+
+    const respond = await runMainAgent("smoke", "non-delivery-deny");
+
+    expect(respond).not.toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "send blocked by session policy" }),
+    );
+    expect(mocks.agentCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks delivery=true agent invocations when sendPolicy is deny (#73381)", async () => {
+    primeMainAgentRun();
+    mocks.resolveSendPolicy.mockReturnValue("deny");
+
+    const respond = vi.fn();
+    await invokeAgent(
+      {
+        message: "smoke",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "delivery-deny",
+        deliver: true,
+      },
+      { respond, reqId: "delivery-deny" },
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "send blocked by session policy" }),
+    );
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
   });
 });
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -905,20 +905,28 @@ export const agentHandlers: GatewayRequestHandlers = {
         claudeCliSessionId: entry?.claudeCliSessionId,
       };
       sessionEntry = mergeSessionEntry(entry, nextEntryPatch);
-      const sendPolicy = resolveSendPolicy({
-        cfg,
-        entry,
-        sessionKey: canonicalKey,
-        channel: entry?.channel,
-        chatType: entry?.chatType,
-      });
-      if (sendPolicy === "deny") {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
-        );
-        return;
+      // Mirror the agent-command runtime gate (`agent-command.ts`): only block
+      // when the caller is asking the gateway to actually deliver the agent's
+      // reply externally. A non-delivery invocation (smoke checks, gateway
+      // agent calls without `deliver: true`) is internal-only and must not be
+      // rejected by `session.sendPolicy=deny`, which targets outbound
+      // delivery, not internal agent execution. Fixes #73381.
+      if (request.deliver === true) {
+        const sendPolicy = resolveSendPolicy({
+          cfg,
+          entry,
+          sessionKey: canonicalKey,
+          channel: entry?.channel,
+          chatType: entry?.chatType,
+        });
+        if (sendPolicy === "deny") {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+          );
+          return;
+        }
       }
       resolvedSessionId = sessionId;
       const canonicalSessionKey = canonicalKey;


### PR DESCRIPTION
## Summary

Gates the gateway `agent` request handler's `sendPolicy=deny` rejection on `request.deliver === true`, mirroring the runtime gate already present in `src/agents/agent-command.ts`. Non-delivery `agent` invocations (quick-agent smoke checks, internal gateway agent calls without external delivery) no longer fail with `send blocked by session policy`; the deny check still fires for explicit delivery requests.

## Root cause

`src/gateway/server-methods/agent.ts` called `resolveSendPolicy(...)` and rejected with `INVALID_REQUEST` before differentiating "deliver externally" from "execute internally". `agent-command.ts` already wrapped the same check in `if (opts.deliver === true)`. The mismatch made `session.sendPolicy=deny` block runtime readiness checks even when no external send was requested.

## Change

```diff
-      const sendPolicy = resolveSendPolicy({ ... });
-      if (sendPolicy === "deny") {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"));
-        return;
-      }
+      if (request.deliver === true) {
+        const sendPolicy = resolveSendPolicy({ ... });
+        if (sendPolicy === "deny") {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"));
+          return;
+        }
+      }
```

Outbound delivery remains gated; the change keeps the existing `agent-command.ts` deny path identical, so two-layer protection still applies for any `deliver: true` call.

## Tests

`src/gateway/server-methods/agent.test.ts`:

- New: `allows non-delivery agent invocations even when sendPolicy is deny (#73381)` — sets `resolveSendPolicy` to return `"deny"` and asserts `agentCommand` runs and no `send blocked by session policy` rejection is sent.
- New: `blocks delivery=true agent invocations when sendPolicy is deny (#73381)` — same fixture but with `deliver: true`; asserts the rejection still fires and `agentCommand` is not called.

The existing `resolveSendPolicy` mock was promoted to a `vi.fn` that resets to `"allow"` between tests so deny-cases can be opted into per test.

Closes #73381.
