### PR TITLE
fix(discord): route message actions to gateway to fix CLI read/search hang

### DIFF
--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -161,6 +161,7 @@ function describeDiscordMessageTool({
 
 export const discordMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeDiscordMessageTool,
+  resolveExecutionMode: () => "gateway",
   extractToolSend: ({ args }) => {
     const action = normalizeOptionalString(args.action) ?? "";
     if (action === "sendMessage") {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -139,6 +139,7 @@ function resolveRuntimeDiscordMessageActions() {
 }
 
 const discordMessageActions = {
+  resolveExecutionMode: discordMessageActionsImpl.resolveExecutionMode,
   describeMessageTool: (
     ctx: Parameters<NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>>[0],
   ): ChannelMessageToolDiscovery | null =>


### PR DESCRIPTION
## Summary

Fixes #73431 — `openclaw message read --channel discord` and `openclaw message search --channel discord` hang indefinitely in CLI mode.

## Root Cause

Discord's channel action adapter did not define `resolveExecutionMode`, so it defaulted to `"local"`. When the CLI invokes a message action, the execution mode determines whether the action is forwarded to the gateway (where the Discord bot runtime lives) or executed in-process.

With `"local"` mode, the CLI attempts to execute Discord REST calls directly. However, in CLI context the Discord bot client/runtime is not initialized — the bot runs exclusively in the gateway process. This causes the action to hang indefinitely waiting for a runtime that will never be available.

Other channels like Telegram correctly return `"gateway"` from `resolveExecutionMode`, so the CLI forwards the action to the gateway via `callGatewayMessageAction`, which then dispatches it locally where the bot runtime is active.

## Fix

Add `resolveExecutionMode: () => "gateway"` to Discord's `discordMessageActions` adapter (in `channel-actions.ts`) and forward it through the wrapper in `channel.ts`.

## Regarding inbound hooks (`message_received` / `inbound_claim`)

The issue also asks about missing hook emissions. After code inspection, Discord inbound messages **do** fire `message_received` and `triggerInternalHook` hooks — they are emitted by the generic `dispatchReplyFromConfig` path (lines 702–725 of `src/auto-reply/reply/dispatch-from-config.ts`), which Discord reaches via `dispatchInboundMessage` in `message-handler.process.ts`. The `hookCount: 0` in `plugins list` output reflects that the Discord plugin itself does not *register* any hooks (it is a channel provider, not a hook consumer) — this is correct behavior.

## Verification

- No `pnpm` available locally; typecheck and tests cannot be run.
- Verified via code inspection that the fix matches the Telegram pattern exactly.
- The change is minimal (2 insertions) and cannot regress: it only affects the CLI→gateway routing decision for Discord actions.