### PR TITLE
docs(channels,telegram): note replyToMode mutually excludes preview tool-progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/Telegram: document that `channels.telegram.streaming.preview.toolProgress` produces no `Working… • tool: …` lines on turns that use a native Telegram quote reply (`replyToMode != "off"`), because the answer-lane preview stream is not created when the final message reference is required at send time. Fixes #73487. Thanks @GodsBoy.
 - Agents/approvals: fail restart-interrupted sessions whose transcript tail is still `approval-pending` instead of replaying stale exec approval IDs into the new Gateway process after restart. Fixes #65486. Thanks @mjmai20682068-create.
 - CLI/Gateway: use method-specific least-privilege scopes for classified CLI Gateway calls while preserving legacy broad scopes for unclassified plugin methods, so read-only commands no longer create admin/write/pairing scope-upgrade prompts. Fixes #68634. Thanks @nightmusher.
 - Gateway/sessions: align `chat.history` and `sessions.list` thinking defaults with owning-agent and catalog-aware resolution so Control UI session defaults match backend runtime state. (#63418) Thanks @jpreagan.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -297,6 +297,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Use `streaming.mode: "off"` only when you want to disable Telegram preview edits entirely. Use `streaming.preview.toolProgress: false` when you only want to disable the tool-progress status lines.
 
+    !!! warning "Telegram quote-reply disables preview streaming"
+        When `channels.telegram.replyToMode` is anything other than `"off"` and a turn would use a native Telegram quote reply, the answer-lane preview stream is not created and `streaming.preview.toolProgress` is silently a no-op for that turn. Telegram's native quote-reply requires the final message reference at send time, which is incompatible with the preview-edit model used for `Working… • tool: …` lines. To get tool-progress visibility on Telegram, set `channels.telegram.replyToMode: "off"`. See [#73487](https://github.com/openclaw/openclaw/issues/73487).
+
     For text-only replies:
 
     - short DM/group/topic previews: OpenClaw keeps the same preview message and performs a final edit in place
@@ -495,6 +498,9 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     When reply threading is enabled and the original Telegram text or caption is available, OpenClaw includes a native Telegram quote excerpt automatically. Telegram caps native quote text at 1024 UTF-16 code units, so longer messages are quoted from the start and fall back to a plain reply if Telegram rejects the quote.
 
     Note: `off` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+
+    !!! info "Quote-reply and preview streaming are mutually exclusive"
+        When a turn uses a native Telegram quote reply (`replyToMode != "off"` with a quotable original message available), the answer-lane preview stream is not created, so `streaming.preview.toolProgress` produces no `Working… • tool: …` lines for that turn. To get tool-progress visibility on Telegram, set `replyToMode: "off"`. See [#73487](https://github.com/openclaw/openclaw/issues/73487).
 
   </Accordion>
 


### PR DESCRIPTION
## Summary

Documents the runtime mutual exclusion between Telegram native quote replies (`channels.telegram.replyToMode != "off"` with a quotable original message) and the answer-lane preview stream that powers `streaming.preview.toolProgress` (`Working… • tool: …` lines), so users who want live tool-progress visibility know to keep `replyToMode: "off"` for now.

## Background

Per the issue, the docs say `streaming.preview.toolProgress` is enabled by default since v2026.4.22, but in practice — when `channels.telegram.replyToMode` is anything other than `"off"` and the turn uses a native quote reply — the answer-lane preview stream is never created. The reporter traced this in `extensions/telegram/src/bot-message-dispatch.ts`:

```ts
const hasNativeQuoteReply =
  replyToMode !== "off" && Object.keys(replyQuoteByMessageId).length > 0;
const canStreamAnswerDraft =
  previewStreamingEnabled &&
  !hasNativeQuoteReply &&
  !accountBlockStreamingEnabled &&
  !forceBlockStreamingForReasoning;
// ...
const previewToolProgressEnabled =
  Boolean(answerLane.stream) &&
  resolveChannelStreamingPreviewToolProgress(telegramCfg);
```

Telegram's native quote reply requires the final message reference at send time, which is incompatible with the preview-edit model used for tool-progress lines. The architectural reason is sound; the issue called out that the silent disablement is undocumented.

## Change

Doc-only, no runtime behavior change. Two cross-referenced notes added to `docs/channels/telegram.md`:

- In the **Streaming** accordion, right after the `streaming.preview.toolProgress` configuration example, a `!!! warning` callout explains that quote-reply turns produce no `Working…` lines and points users at `replyToMode: "off"`.
- In the **Reply threading tags** accordion (where `replyToMode` is documented), a complementary `!!! info` callout repeats the constraint from the threading-config side so it is discoverable from either entry point.

Both notes link back to #73487.

## Notes

- Followups for the maintainers (out of scope here): an `openclaw doctor` warning when both `replyToMode != "off"` and `streaming.preview.toolProgress: true` are configured, or an architectural fallback that delivers tool-progress as separate persistent messages when quote-reply blocks the preview path. Keeping this PR doc-only so it can land independent of those decisions.

Closes #73487.
