### PR TITLE
fix(feishu): support form_value in card action callbacks

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -22,6 +22,8 @@ export type FeishuCardActionEvent = {
     value: Record<string, unknown>;
     tag: string;
     form_value?: Record<string, unknown>;
+    option?: string;
+    options?: string[];
   };
   open_message_id?: string;
   context: {
@@ -329,7 +331,7 @@ export async function handleFeishuCardAction(params: {
     }
 
     if (decoded.kind === "structured") {
-      const { envelope, formValue } = decoded;
+      const { envelope, formValue, option, options } = decoded;
       log(
         `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
       );
@@ -391,9 +393,18 @@ export async function handleFeishuCardAction(params: {
         // If form_value exists, append it to the command
         if (formValue && Object.keys(formValue).length > 0) {
           const formText = Object.entries(formValue)
-            .map(([key, value]) => `${key}=${value}`)
+            .map(([key, value]) => `${key}=${String(value)}`)
             .join(" ");
           command = command ? `${command} ${formText}` : formText;
+        }
+
+        if (option !== undefined) {
+          command = command ? `${command} option=${option}` : `option=${option}`;
+        }
+
+        if (options && options.length > 0) {
+          const optionsText = `options=${options.join(",")}`;
+          command = command ? `${command} ${optionsText}` : optionsText;
         }
 
         if (!command) {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -21,6 +21,7 @@ export type FeishuCardActionEvent = {
   action: {
     value: Record<string, unknown>;
     tag: string;
+    form_value?: Record<string, unknown>;
   };
   open_message_id?: string;
   context: {
@@ -328,7 +329,7 @@ export async function handleFeishuCardAction(params: {
     }
 
     if (decoded.kind === "structured") {
-      const { envelope } = decoded;
+      const { envelope, formValue } = decoded;
       log(
         `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
       );
@@ -385,7 +386,16 @@ export async function handleFeishuCardAction(params: {
       }
 
       if (envelope.a === FEISHU_APPROVAL_CONFIRM_ACTION || envelope.k === "quick") {
-        const command = envelope.q?.trim();
+        let command = envelope.q?.trim();
+
+        // If form_value exists, append it to the command
+        if (formValue && Object.keys(formValue).length > 0) {
+          const formText = Object.entries(formValue)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(" ");
+          command = command ? `${command} ${formText}` : formText;
+        }
+
         if (!command) {
           await sendInvalidInteractionNotice({
             cfg,

--- a/extensions/feishu/src/card-interaction.test.ts
+++ b/extensions/feishu/src/card-interaction.test.ts
@@ -102,6 +102,80 @@ describe("feishu card interaction decoder", () => {
     expect(text).toBe("{} Input_xxx=user input");
   });
 
+  it("includes option in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          option: "opt_a",
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        option: "opt_a",
+      }),
+    );
+  });
+
+  it("includes options in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          options: ["opt_a", "opt_b"],
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        options: ["opt_a", "opt_b"],
+      }),
+    );
+  });
+
+  it("appends option to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/select" },
+        option: "opt_a",
+      },
+    });
+
+    expect(text).toBe("/select option=opt_a");
+  });
+
+  it("appends options to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/select" },
+        options: ["opt_a", "opt_b"],
+      },
+    });
+
+    expect(text).toBe("/select options=opt_a,opt_b");
+  });
+
   it("rejects malformed structured payloads", () => {
     const result = decodeFeishuCardAction({
       event: {

--- a/extensions/feishu/src/card-interaction.test.ts
+++ b/extensions/feishu/src/card-interaction.test.ts
@@ -52,6 +52,56 @@ describe("feishu card interaction decoder", () => {
     ).toBe("/new");
   });
 
+  it("includes form_value in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          form_value: { Input_xxx: "user input", Select_yyy: "option1" },
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        formValue: { Input_xxx: "user input", Select_yyy: "option1" },
+      }),
+    );
+  });
+
+  it("appends form_value to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/command" },
+        form_value: { Input_xxx: "user input" },
+      },
+    });
+
+    expect(text).toBe("/command Input_xxx=user input");
+  });
+
+  it("handles form_value without value", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: {},
+        form_value: { Input_xxx: "user input" },
+      },
+    });
+
+    expect(text).toBe("{} Input_xxx=user input");
+  });
+
   it("rejects malformed structured payloads", () => {
     const result = decodeFeishuCardAction({
       event: {

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -35,6 +35,7 @@ export type FeishuCardActionEventLike = {
   };
   action: {
     value: unknown;
+    form_value?: Record<string, unknown>;
   };
   context: {
     chat_id?: string;
@@ -45,6 +46,7 @@ export type DecodedFeishuCardAction =
   | {
       kind: "structured";
       envelope: FeishuCardInteractionEnvelope;
+      formValue?: Record<string, unknown>;
     }
   | {
       kind: "legacy";
@@ -80,16 +82,31 @@ export function createFeishuCardInteractionEnvelope(
 
 export function buildFeishuCardActionTextFallback(event: FeishuCardActionEventLike): string {
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+
+  // Build base text from action.value
+  let text = "";
   if (isRecord(actionValue)) {
     if (typeof actionValue.text === "string") {
-      return actionValue.text;
+      text = actionValue.text;
+    } else if (typeof actionValue.command === "string") {
+      text = actionValue.command;
+    } else {
+      text = JSON.stringify(actionValue);
     }
-    if (typeof actionValue.command === "string") {
-      return actionValue.command;
-    }
-    return JSON.stringify(actionValue);
+  } else {
+    text = String(actionValue);
   }
-  return String(actionValue);
+
+  // If form_value exists, append it to the text
+  if (formValue && Object.keys(formValue).length > 0) {
+    const formText = Object.entries(formValue)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(" ");
+    text = text ? `${text} ${formText}` : formText;
+  }
+
+  return text;
 }
 
 export function decodeFeishuCardAction(params: {
@@ -98,6 +115,8 @@ export function decodeFeishuCardAction(params: {
 }): DecodedFeishuCardAction {
   const { event, now = Date.now() } = params;
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+
   if (!isRecord(actionValue) || actionValue.oc !== FEISHU_CARD_INTERACTION_VERSION) {
     return {
       kind: "legacy",
@@ -162,5 +181,6 @@ export function decodeFeishuCardAction(params: {
   return {
     kind: "structured",
     envelope: actionValue as FeishuCardInteractionEnvelope,
+    formValue,
   };
 }

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -36,6 +36,8 @@ export type FeishuCardActionEventLike = {
   action: {
     value: unknown;
     form_value?: Record<string, unknown>;
+    option?: string;
+    options?: string[];
   };
   context: {
     chat_id?: string;
@@ -47,6 +49,8 @@ export type DecodedFeishuCardAction =
       kind: "structured";
       envelope: FeishuCardInteractionEnvelope;
       formValue?: Record<string, unknown>;
+      option?: string;
+      options?: string[];
     }
   | {
       kind: "legacy";
@@ -83,6 +87,8 @@ export function createFeishuCardInteractionEnvelope(
 export function buildFeishuCardActionTextFallback(event: FeishuCardActionEventLike): string {
   const actionValue = event.action.value;
   const formValue = event.action.form_value;
+  const option = event.action.option;
+  const options = event.action.options;
 
   // Build base text from action.value
   let text = "";
@@ -101,9 +107,19 @@ export function buildFeishuCardActionTextFallback(event: FeishuCardActionEventLi
   // If form_value exists, append it to the text
   if (formValue && Object.keys(formValue).length > 0) {
     const formText = Object.entries(formValue)
-      .map(([key, value]) => `${key}=${value}`)
+      .map(([key, value]) => `${key}=${String(value)}`)
       .join(" ");
     text = text ? `${text} ${formText}` : formText;
+  }
+
+  if (option !== undefined) {
+    const optionText = `option=${option}`;
+    text = text ? `${text} ${optionText}` : optionText;
+  }
+
+  if (options && options.length > 0) {
+    const optionsText = `options=${options.join(",")}`;
+    text = text ? `${text} ${optionsText}` : optionsText;
   }
 
   return text;
@@ -116,6 +132,8 @@ export function decodeFeishuCardAction(params: {
   const { event, now = Date.now() } = params;
   const actionValue = event.action.value;
   const formValue = event.action.form_value;
+  const option = event.action.option;
+  const options = event.action.options;
 
   if (!isRecord(actionValue) || actionValue.oc !== FEISHU_CARD_INTERACTION_VERSION) {
     return {
@@ -182,5 +200,7 @@ export function decodeFeishuCardAction(params: {
     kind: "structured",
     envelope: actionValue as FeishuCardInteractionEnvelope,
     formValue,
+    option,
+    options,
   };
 }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -210,11 +210,11 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   const unionId = firstString(operator.union_id);
   const tag = readString(action.tag);
   const actionValue = action.value;
-  const formValue = isRecord(action.form_value) ? (action.form_value as Record<string, unknown>) : undefined;
+  const formValue = isRecord(action.form_value) ? action.form_value : undefined;
   const option = readString(action.option);
   const options =
     Array.isArray(action.options) && action.options.every((item) => typeof item === "string")
-      ? (action.options as string[])
+      ? action.options
       : undefined;
   const openMessageId = firstString(value.open_message_id, context.open_message_id);
   const contextOpenId = firstString(context.open_id, openId);

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -210,6 +210,12 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   const unionId = firstString(operator.union_id);
   const tag = readString(action.tag);
   const actionValue = action.value;
+  const formValue = isRecord(action.form_value) ? (action.form_value as Record<string, unknown>) : undefined;
+  const option = readString(action.option);
+  const options =
+    Array.isArray(action.options) && action.options.every((item) => typeof item === "string")
+      ? (action.options as string[])
+      : undefined;
   const openMessageId = firstString(value.open_message_id, context.open_message_id);
   const contextOpenId = firstString(context.open_id, openId);
   const contextUserId = firstString(context.user_id, userId);
@@ -227,6 +233,9 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
     action: {
       value: actionValue,
       tag,
+      ...(formValue !== undefined ? { form_value: formValue } : {}),
+      ...(option !== undefined ? { option } : {}),
+      ...(options !== undefined ? { options } : {}),
     },
     ...(openMessageId ? { open_message_id: openMessageId } : {}),
     context: {


### PR DESCRIPTION
## Summary

  - Problem: When users submit a Feishu card with a form container (input fields), the submitted values arrive in `event.action.form_value`, but OpenClaw only processed `event.action.value` and silently ignored `form_value`.
  - Why it matters: Interactive cards with input fields are completely broken — user-entered values are never passed to the bot command.
  - What changed: Added `form_value` to type definitions, extracted it in `decodeFeishuCardAction`, appended it to the command string in `handleFeishuCardAction` and `buildFeishuCardActionTextFallback`, and added unit tests.
  - What did NOT change: Card routing logic, approval flow, legacy text fallback behavior for cards without form fields.

  ## Change Type

  - [x] Bug fix

  ## Scope

  - [x] Integrations

  ## Linked Issue/PR

  - [ ] This PR fixes a bug or regression

  ## Root Cause

  - Root cause: `form_value` was never included in the type definitions or processing pipeline. The Feishu card action handler only read `event.action.value`, which contains the button's static payload, not the dynamic form input values.
  - Missing detection / guardrail: No test covered the form container submission path.
  - Contributing context: Feishu's form container feature sends data via a separate `form_value` field rather than `value`.

  ## Regression Test Plan

  - Coverage level that should have caught this:
    - [x] Unit test
  - Target test or file: `extensions/feishu/src/card-interaction.test.ts`
  - Scenario the test should lock in: `decodeFeishuCardAction` returns `formValue`; `buildFeishuCardActionTextFallback` appends form values to output text.
  - Why this is the smallest reliable guardrail: The entire pipeline is pure functions — unit tests fully cover the decode + append logic.
  - If no new test is added, why not: Tests were added.

  ## User-visible / Behavior Changes

  When a user submits a Feishu card form, the input field values are now appended to the command string as `key=value` pairs (space-separated), e.g. `/confirm fuel=11 mileage=1000`.

  ## Diagram

  ```text
  Before:
  [user submits form] -> event.action.form_value ignored -> bot receives `/confirm` only

  After:
  [user submits form] -> form_value extracted -> appended to command -> bot receives `/confirm fuel=11 mileage=1000`

  Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No — form values are appended as plain text to the existing command string, subject to the same downstream handling.
  - Data access scope changed? No

  Repro + Verification

  Steps

  1. Create a Feishu card with a form container containing input fields and a submit button
  2. Configure the button's value with an OpenClaw interaction envelope (e.g. k: "quick", q: "/confirm")
  3. Submit the form with values filled in

  Expected

  Bot receives /confirm Input_field=user_value

  Actual (before fix)

  Bot receives /confirm with no form values

  Evidence

  - Unit tests added: card-interaction.test.ts covers form_value extraction and appending

  Human Verification

  - Verified scenarios: Unit tests pass locally
  - What you did not verify: Live Feishu environment end-to-end test

  Compatibility / Migration

  - Backward compatible? Yes — cards without form_value are unaffected
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: If form_value keys contain spaces or special characters, the appended string could be ambiguous.
    - Mitigation: This matches existing behavior for the q command field; downstream parsing is the bot's responsibility.

  ---