### PR TITLE
fix: compress framework system prompt (AGE-7578)

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -123,7 +123,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Heartbeats");
     expect(prompt).toContain("## Safety");
     expect(prompt).toContain(
-      "avoid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
+      "Avoid poll loops: use exec with yieldMs or process(action=poll, timeout=<ms>).",
     );
     expect(prompt).toContain("No independent goals");
     expect(prompt).toContain("Safety and human oversight over completion");
@@ -159,7 +159,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Skills (mandatory)");
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain(
-      "When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
+      "For external API writes, assume rate limits: prefer fewer larger writes, serialize bursts, respect 429/Retry-After.",
     );
   });
 
@@ -180,7 +180,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Assistant Output Directives");
     expect(prompt).toContain("[[reply_to_current]]");
     expect(prompt).not.toContain("Tags are stripped before sending");
-    expect(prompt).toContain("Tags are stripped before rendering");
+    expect(prompt).toContain("Tags are stripped before user-visible rendering");
   });
 
   it("omits the heartbeat section when no heartbeat prompt is provided", () => {
@@ -235,12 +235,12 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## OpenClaw CLI Quick Reference");
-    expect(prompt).toContain("use the first-class `gateway` tool");
+    expect(prompt).toContain("`gateway` tool");
     expect(prompt).toContain(
-      "Only use CLI service lifecycle commands when the user explicitly asks",
+      "Operator-only: `start` | `stop`. Do not chain `stop`+`start` as restart",
     );
-    expect(prompt).toContain("openclaw gateway restart");
-    expect(prompt).toContain("Do not chain `openclaw gateway stop`");
+    expect(prompt).toContain("Lifecycle:");
+    expect(prompt).toContain("Do not chain");
     expect(prompt).toContain("Do not invent commands");
   });
 
@@ -285,17 +285,13 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Control UI Embed");
-    expect(prompt).toContain("Use `[embed ...]` only in Control UI/webchat sessions");
+    expect(prompt).toContain("Use `[embed ...]` only in webchat sessions");
     expect(prompt).toContain('[embed ref="cv_123" title="Status" height="320" /]');
     expect(prompt).toContain(
       '[embed url="/__openclaw__/canvas/documents/cv_123/index.html" title="Status" height="320" /]',
     );
-    expect(prompt).toContain(
-      "Never use local filesystem paths or `file://...` URLs in `[embed ...]`.",
-    );
-    expect(prompt).toContain(
-      "The active hosted embed root for this session is: `/Users/example/.openclaw-dev/canvas`.",
-    );
+    expect(prompt).toContain("No `file://` paths");
+    expect(prompt).toContain("Hosted embed root: `/Users/example/.openclaw-dev/canvas`");
     expect(prompt).not.toContain('[embed content_type="html" title="Status"]...[/embed]');
   });
 
@@ -305,9 +301,9 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "avoid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
+      "Avoid poll loops: use exec with yieldMs or process(action=poll, timeout=<ms>).",
     );
-    expect(prompt).toContain("Completion is push-based: it will auto-announce when done.");
+    expect(prompt).toContain("Completion is push-based; auto-announces when done.");
     expect(prompt).toContain("Do not poll `subagents list`/`sessions_list` in a loop");
     expect(prompt).toContain(
       "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
@@ -334,10 +330,8 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("sessions_spawn");
-    expect(prompt).toContain(
-      'runtime="acp" requires `agentId` unless `acp.defaultAgent` is configured',
-    );
-    expect(prompt).toContain("not agents_list");
+    expect(prompt).toContain('runtime="acp" requires agentId unless acp.defaultAgent set');
+    expect(prompt).toContain("No ACP via `subagents`/`agents_list`");
   });
 
   it("guides harness requests to ACP thread-bound spawns", () => {
@@ -355,17 +349,13 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("prefer `/codex bind`, `/codex threads`, `/codex resume`");
     expect(prompt).toContain("Use ACP for Codex only when the user explicitly asks for ACP/acpx");
     expect(prompt).toContain(
-      'For requests like "do this in claude code/cursor/gemini/opencode" or similar ACP harnesses, treat it as ACP harness intent',
+      'ACP harness: `sessions_spawn` with `runtime: "acp"`, set `agentId` unless `acp.defaultAgent` set',
     );
     expect(prompt).toContain(
-      'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`)',
+      'Discord ACP: default to thread-bound (`thread: true`, `mode: "session"`)',
     );
-    expect(prompt).toContain(
-      "do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows",
-    );
-    expect(prompt).toContain(
-      'do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path',
-    );
+    expect(prompt).toContain("No ACP via `subagents`/`agents_list` or PTY");
+    expect(prompt).toContain("use `sessions_spawn`, not `message(action=thread-create)`");
   });
 
   it("omits ACP harness guidance when ACP is disabled", () => {
@@ -376,13 +366,13 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).not.toContain(
-      'For requests like "do this in claude code/cursor/gemini/opencode" or similar ACP harnesses, treat it as ACP harness intent',
+      'ACP harness: `sessions_spawn` with `runtime: "acp"`, set `agentId` unless `acp.defaultAgent` set',
     );
     expect(prompt).not.toContain("Native Codex app-server plugin is available");
     expect(prompt).not.toContain('runtime="acp" requires `agentId`');
     expect(prompt).not.toContain("not ACP harness ids");
-    expect(prompt).toContain("- sessions_spawn: Spawn an isolated sub-agent session");
-    expect(prompt).toContain("agents_list: Agent ids for sessions_spawn");
+    expect(prompt).toContain("- sessions_spawn: Spawn isolated sub-agent");
+    expect(prompt).toContain("agents_list: Agent ids allowed for sessions_spawn");
   });
 
   it("omits ACP harness spawn guidance for sandboxed sessions and shows ACP block note", () => {
@@ -398,11 +388,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain('runtime="acp" requires `agentId`');
     expect(prompt).not.toContain("ACP harness ids follow acp.allowedAgents");
     expect(prompt).not.toContain(
-      'For requests like "do this in claude code/cursor/gemini/opencode" or similar ACP harnesses, treat it as ACP harness intent',
+      'ACP harness: `sessions_spawn` with `runtime: "acp"`, set `agentId` unless `acp.defaultAgent` set',
     );
-    expect(prompt).not.toContain(
-      'do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path',
-    );
+    expect(prompt).not.toContain("use `sessions_spawn`, not `message(action=thread-create)`");
     expect(prompt).toContain("ACP harness spawns are blocked from sandboxed sessions");
     expect(prompt).toContain('`runtime: "acp"`');
     expect(prompt).toContain('Use `runtime: "subagent"` instead.');
@@ -564,7 +552,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Model Aliases");
-    expect(prompt).toContain("Prefer aliases when specifying model overrides");
+    expect(prompt).toContain("Prefer aliases for model overrides");
     expect(prompt).toContain("- Opus: anthropic/claude-opus-4-5");
   });
 
@@ -578,7 +566,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("config.schema.lookup");
     expect(prompt).toContain("config.apply");
     expect(prompt).toContain("config.patch");
-    expect(prompt).toContain("Config writes hot-reload when possible");
+    expect(prompt).toContain("Hot-reloads when possible");
     expect(prompt).toContain("update.run");
     expect(prompt).not.toContain("Use config.schema to");
     expect(prompt).not.toContain("config.schema, config.apply");
@@ -658,7 +646,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "If SOUL.md is present, embody its persona and tone. follow its guidance unless overridden.",
+      "If SOUL.md is present, embody its persona and tone; follow its guidance unless overridden.",
     );
   });
 
@@ -703,12 +691,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(messagingPrompt).not.toContain("subagents(action=list|steer|kill)");
 
     expect(spawnOnlyPrompt).toContain(
-      '- Sub-agent orchestration → use `sessions_spawn(...)` to start delegated work; omit `context` for isolated children, set `context:"fork"` only when the child needs the current transcript.',
+      '- Orchestration: `sessions_spawn(...)` to start work (omit `context` for isolated, `context:"fork"` for transcript).',
     );
     expect(spawnOnlyPrompt).not.toContain("manage already-spawned children");
 
     expect(orchestrationPrompt).toContain(
-      '- Sub-agent orchestration → use `sessions_spawn(...)` to start delegated work; omit `context` for isolated children, set `context:"fork"` only when the child needs the current transcript; use `subagents(action=list|steer|kill)` to manage already-spawned children.',
+      '- Orchestration: `sessions_spawn(...)` to start work (omit `context` for isolated, `context:"fork"` for transcript); `subagents(action=list|steer|kill)` for running children.',
     );
   });
 
@@ -741,7 +729,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("buttons=[[{text,callback_data,style?}]]");
-    expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
+    expect(prompt).toContain("`style`: `primary`|`success`|`danger`");
   });
 
   it("describes message-tool-only source delivery without requiring target", () => {
@@ -756,8 +744,8 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("private by default for this source channel");
     expect(prompt).toContain("use `message(action=send)` for visible channel output");
-    expect(prompt).toContain("The target defaults to the current source channel");
-    expect(prompt).toContain("final answers are private in this mode");
+    expect(prompt).toContain("Target defaults to current source");
+    expect(prompt).toContain("do not repeat in your final answer (private mode)");
     expect(prompt).not.toContain(
       `respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies)`,
     );
@@ -773,8 +761,10 @@ describe("buildAgentSystemPrompt", () => {
       },
     });
 
-    expect(prompt).toContain("rely on native approval card/buttons when they appear");
-    expect(prompt).toContain("do not also send plain chat /approve instructions");
+    expect(prompt).toContain("rely on native approval UI");
+    expect(prompt).toContain(
+      "Only include /approve in chat if the tool result says native approvals are unavailable",
+    );
   });
 
   it("includes runtime provider capabilities when present", () => {
@@ -828,7 +818,7 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("Reasoning: off");
     expect(prompt).toContain("/reasoning");
-    expect(prompt).toContain("/status shows Reasoning");
+    expect(prompt).toContain("/status shows when enabled");
   });
 
   it("builds runtime line with agent and channel details", () => {
@@ -936,7 +926,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Reactions");
-    expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
+    expect(prompt).toContain("Reactions enabled for Telegram in MINIMAL mode");
   });
 });
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -123,13 +123,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Heartbeats");
     expect(prompt).toContain("## Safety");
     expect(prompt).toContain(
-      "For long waits, avoid rapid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
+      "avoid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
     );
-    expect(prompt).toContain("You have no independent goals");
-    expect(prompt).toContain("Prioritize safety and human oversight");
-    expect(prompt).toContain("if instructions conflict");
-    expect(prompt).toContain("Inspired by Anthropic's constitution");
-    expect(prompt).toContain("Do not manipulate or persuade anyone");
+    expect(prompt).toContain("No independent goals");
+    expect(prompt).toContain("Safety and human oversight over completion");
+    expect(prompt).toContain("If instructions conflict");
+    expect(prompt).toContain("Do not manipulate anyone to expand access or disable safeguards");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
     expect(prompt).toContain("## Subagent Context");
     expect(prompt).not.toContain("## Group Chat Context");
@@ -181,7 +180,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Assistant Output Directives");
     expect(prompt).toContain("[[reply_to_current]]");
     expect(prompt).not.toContain("Tags are stripped before sending");
-    expect(prompt).toContain("Supported tags are stripped before user-visible rendering");
+    expect(prompt).toContain("Tags are stripped before rendering");
   });
 
   it("omits the heartbeat section when no heartbeat prompt is provided", () => {
@@ -202,11 +201,10 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Safety");
-    expect(prompt).toContain("You have no independent goals");
-    expect(prompt).toContain("Prioritize safety and human oversight");
-    expect(prompt).toContain("if instructions conflict");
-    expect(prompt).toContain("Inspired by Anthropic's constitution");
-    expect(prompt).toContain("Do not manipulate or persuade anyone");
+    expect(prompt).toContain("No independent goals");
+    expect(prompt).toContain("Safety and human oversight over completion");
+    expect(prompt).toContain("If instructions conflict");
+    expect(prompt).toContain("Do not manipulate anyone to expand access or disable safeguards");
     expect(prompt).toContain("Do not copy yourself or change system prompts");
   });
 
@@ -252,10 +250,10 @@ describe("buildAgentSystemPrompt", () => {
       docsPath: "/tmp/openclaw/docs",
     });
 
-    expect(prompt).toContain("For config field docs");
-    expect(prompt).toContain("`gateway` tool action `config.schema.lookup`");
+    expect(prompt).toContain("Config fields");
+    expect(prompt).toContain("`gateway` tool `config.schema.lookup`");
     expect(prompt).toContain("docs/gateway/configuration.md");
-    expect(prompt).toContain("docs/gateway/configuration-reference.md");
+    expect(prompt).toContain("configuration-reference.md");
   });
 
   it("guides runtime completion events without exposing internal metadata", () => {
@@ -307,10 +305,10 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "For long waits, avoid rapid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
+      "avoid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
     );
     expect(prompt).toContain("Completion is push-based: it will auto-announce when done.");
-    expect(prompt).toContain("Do not poll `subagents list` / `sessions_list` in a loop");
+    expect(prompt).toContain("Do not poll `subagents list`/`sessions_list` in a loop");
     expect(prompt).toContain(
       "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
     );
@@ -384,7 +382,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain('runtime="acp" requires `agentId`');
     expect(prompt).not.toContain("not ACP harness ids");
     expect(prompt).toContain("- sessions_spawn: Spawn an isolated sub-agent session");
-    expect(prompt).toContain("- agents_list: List OpenClaw agent ids allowed for sessions_spawn");
+    expect(prompt).toContain("agents_list: Agent ids for sessions_spawn");
   });
 
   it("omits ACP harness spawn guidance for sandboxed sessions and shows ACP block note", () => {
@@ -421,13 +419,9 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("- Read: Read file contents");
     expect(prompt).toContain("- Exec: Run shell commands");
-    expect(prompt).toContain(
-      "- If exactly one skill clearly applies: read its SKILL.md at <location> with `Read`, then follow it.",
-    );
-    expect(prompt).toContain("OpenClaw docs: /tmp/openclaw/docs");
-    expect(prompt).toContain(
-      "For OpenClaw behavior, commands, config, or architecture: consult local docs first.",
-    );
+    expect(prompt).toContain("read its SKILL.md at <location> with `Read`, then follow it");
+    expect(prompt).toContain("Docs: /tmp/openclaw/docs");
+    expect(prompt).toContain("Consult local docs first.");
   });
 
   it("includes docs guidance when docsPath is provided", () => {
@@ -438,14 +432,10 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Documentation");
-    expect(prompt).toContain("OpenClaw docs: /tmp/openclaw/docs");
-    expect(prompt).toContain("Local source: /tmp/openclaw");
-    expect(prompt).toContain(
-      "For OpenClaw behavior, commands, config, or architecture: consult local docs first.",
-    );
-    expect(prompt).toContain(
-      "If docs are incomplete or stale, inspect the local OpenClaw source code before answering.",
-    );
+    expect(prompt).toContain("Docs: /tmp/openclaw/docs");
+    expect(prompt).toContain("Source: /tmp/openclaw");
+    expect(prompt).toContain("Consult local docs first.");
+    expect(prompt).toContain("Stale docs? Inspect local source before answering.");
   });
 
   it("falls back to public docs and GitHub source guidance when local docs are unavailable", () => {
@@ -453,11 +443,9 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/work",
     });
 
-    expect(prompt).toContain("OpenClaw docs: https://docs.openclaw.ai");
+    expect(prompt).toContain("Docs: https://docs.openclaw.ai");
     expect(prompt).toContain("Source: https://github.com/openclaw/openclaw");
-    expect(prompt).toContain(
-      "If docs are incomplete or stale, review the OpenClaw source on GitHub before answering.",
-    );
+    expect(prompt).toContain("Stale docs? Check GitHub source.");
   });
 
   it("includes workspace notes when provided", () => {
@@ -604,9 +592,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("## Skills");
-    expect(prompt).toContain(
-      "- If exactly one skill clearly applies: read its SKILL.md at <location> with `read`, then follow it.",
-    );
+    expect(prompt).toContain("read its SKILL.md at <location> with `read`, then follow it");
   });
 
   it("appends available skills when provided", () => {
@@ -672,7 +658,7 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain(
-      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+      "If SOUL.md is present, embody its persona and tone. follow its guidance unless overridden.",
     );
   });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -54,7 +54,7 @@ const CONTEXT_FILE_ORDER = new Map<string, number>([
 
 const DYNAMIC_CONTEXT_FILE_BASENAMES = new Set(["heartbeat.md"]);
 const DEFAULT_HEARTBEAT_PROMPT_CONTEXT_BLOCK =
-  "Default heartbeat prompt:\n`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`";
+  "Default heartbeat prompt:\n`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`";
 function normalizeContextFilePath(pathValue: string): string {
   return pathValue.trim().replace(/\\/g, "/");
 }
@@ -111,10 +111,10 @@ function buildProjectContextSection(params: {
     const hasSoulFile = params.files.some(
       (file) => getContextFileBasename(file.path) === "soul.md",
     );
-    lines.push("The following project context files have been loaded:");
+    lines.push("The following project context files are loaded:");
     if (hasSoulFile) {
       lines.push(
-        "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+        "If SOUL.md is present, embody its persona and tone; follow its guidance unless overridden.",
       );
     }
     lines.push("");
@@ -131,8 +131,7 @@ function buildHeartbeatSection(params: { isMinimal: boolean; heartbeatPrompt?: s
   }
   return [
     "## Heartbeats",
-    "If the current user message is a heartbeat poll and nothing needs attention, reply exactly:",
-    "HEARTBEAT_OK",
+    "If the current message is a heartbeat poll and nothing needs attention, reply exactly: HEARTBEAT_OK",
     'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
     "",
   ];
@@ -149,9 +148,9 @@ function buildExecApprovalPromptGuidance(params: {
       ? Boolean(resolveChannelApprovalCapability(getChannelPlugin(runtimeChannel))?.native)
       : false);
   if (usesNativeApprovalUi) {
-    return "When exec returns approval-pending on this channel, rely on native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.";
+    return "On approval-pending, rely on native approval UI. Only include /approve in chat if the tool result says native approvals are unavailable.";
   }
-  return "When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.";
+  return "On approval-pending, include the /approve command from tool output as plain chat text. Do not ask for a different or rotated code.";
 }
 
 function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
@@ -161,12 +160,10 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
   }
   return [
     "## Skills (mandatory)",
-    "Before replying: scan <available_skills> <description> entries.",
-    `- If exactly one skill clearly applies: read its SKILL.md at <location> with \`${params.readToolName}\`, then follow it.`,
-    "- If multiple could apply: choose the most specific one, then read/follow it.",
-    "- If none clearly apply: do not read any SKILL.md.",
-    "Constraints: never read more than one skill up front; only read after selecting.",
-    "- When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
+    "Before replying: scan <available_skills> descriptions. If one clearly applies, read its SKILL.md at <location> with `" +
+      params.readToolName +
+      "`, then follow it. If multiple apply, pick the most specific. If none apply, skip.",
+    "Only read one skill up front. For external API writes, assume rate limits: prefer fewer larger writes, serialize bursts, respect 429/Retry-After.",
     trimmed,
     "",
   ];
@@ -261,14 +258,14 @@ function buildAssistantOutputDirectivesSection(isMinimal: boolean) {
     "## Assistant Output Directives",
     "Use these when you need delivery metadata in an assistant message:",
     "- `MEDIA:<path-or-url>` on its own line requests attachment delivery. The web UI strips supported MEDIA lines and renders them inline; channels still decide actual delivery behavior.",
-    "- `[[audio_as_voice]]` marks attached audio as a voice-note style delivery hint. The web UI may show a voice-note badge when audio is present; channels still own delivery semantics.",
+    "- `[[audio_as_voice]]` marks attached audio as a voice-note style delivery hint.",
     "- To request a native reply/quote on supported surfaces, include one reply tag in your reply:",
     "- Reply tags must be the very first token in the message (no leading text/newlines): [[reply_to_current]] your reply.",
     "- [[reply_to_current]] replies to the triggering message.",
-    "- Prefer [[reply_to_current]]. Use [[reply_to:<id>]] only when an id was explicitly provided (e.g. by the user or a tool).",
-    "Whitespace inside the tag is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
-    "- Channel-specific interactive directives are separate and should not be mixed into this web render guidance.",
-    "Supported tags are stripped before user-visible rendering; support still depends on the current channel config.",
+    "- Prefer [[reply_to_current]]. Use [[reply_to:<id>]] only when an id was explicitly provided (e.g. by a tool).",
+    "Whitespace inside tags is allowed (e.g. [[ reply_to_current ]] / [[ reply_to: 123 ]]).",
+    "Tags are stripped before user-visible rendering; support still depends on the current channel config.",
+    "Channel-specific interactive directives are separate and should not be mixed into this web render guidance.",
     "",
   ];
 }
@@ -283,16 +280,12 @@ function buildWebchatCanvasSection(params: {
   }
   return [
     "## Control UI Embed",
-    "Use `[embed ...]` only in Control UI/webchat sessions for inline rich rendering inside the assistant bubble.",
-    "- Do not use `[embed ...]` for non-web channels.",
-    "- `[embed ...]` is separate from `MEDIA:`. Use `MEDIA:` for attachments; use `[embed ...]` for web-only rich rendering.",
-    '- Use self-closing form for hosted embed documents: `[embed ref="cv_123" title="Status" height="320" /]`.',
-    '- You may also use an explicit hosted URL: `[embed url="/__openclaw__/canvas/documents/cv_123/index.html" title="Status" height="320" /]`.',
-    '- Never use local filesystem paths or `file://...` URLs in `[embed ...]`. Hosted embeds must point at `/__openclaw__/canvas/...` URLs or use `ref="..."`.',
+    "Use `[embed ...]` only in webchat sessions for inline rich rendering. Not for non-web channels. Separate from `MEDIA:` (attachments).",
+    '- Self-closing: `[embed ref="cv_123" title="Status" height="320" /]` or explicit URL: `[embed url="/__openclaw__/canvas/documents/cv_123/index.html" title="Status" height="320" /]`. No `file://` paths.',
     params.canvasRootDir
-      ? `- The active hosted embed root for this session is: \`${sanitizeForPromptLiteral(params.canvasRootDir)}\`. If you manually stage a hosted embed file, write it there, not in the workspace.`
-      : "- The active hosted embed root is profile-scoped, not workspace-scoped. If you manually stage a hosted embed file, write it under the active profile embed root, not in the workspace.",
-    "- Quote all attribute values. Prefer `ref` for hosted documents unless you already have the full `/__openclaw__/canvas/documents/<id>/index.html` URL.",
+      ? `- Hosted embed root: \`${sanitizeForPromptLiteral(params.canvasRootDir)}\`. Write staged files there, not in the workspace.`
+      : "- Hosted embed root is profile-scoped. Write staged files under the active profile embed root, not the workspace.",
+    "Quote all attribute values. Prefer `ref` unless you have the full URL.",
     "",
   ];
 }
@@ -303,13 +296,11 @@ function buildExecutionBiasSection(params: { isMinimal: boolean }) {
   }
   return [
     "## Execution Bias",
-    "- Actionable request: act in this turn.",
-    "- Non-final turn: use tools to advance, or ask for the one missing decision that blocks safe progress.",
-    "- Continue until done or genuinely blocked; do not finish with a plan/promise when tools can move it forward.",
-    "- Weak/empty tool result: vary query, path, command, or source before concluding.",
-    "- Mutable facts need live checks: files, git, clocks, versions, services, processes, package state.",
-    "- Final answer needs evidence: test/build/lint, screenshot, inspection, tool output, or a named blocker.",
-    "- Longer work: brief progress update, then keep going; use background work or sub-agents when they fit.",
+    "- Act now. Advance with tools or ask the one blocking question.",
+    "- Continue until done or blocked; no plans when tools can proceed.",
+    "- Weak results: vary query/path/source. Mutable facts need live checks.",
+    "- Final answers need evidence: test output, inspection, or named blocker.",
+    "- Long work: brief update, then continue; use background/sub-agents.",
     "",
   ];
 }
@@ -350,10 +341,10 @@ function buildMessagingSection(params: {
   const hasSubagents = params.availableTools.has("subagents");
   const subagentOrchestrationGuidance = hasSessionsSpawn
     ? hasSubagents
-      ? '- Sub-agent orchestration → use `sessions_spawn(...)` to start delegated work; omit `context` for isolated children, set `context:"fork"` only when the child needs the current transcript; use `subagents(action=list|steer|kill)` to manage already-spawned children.'
-      : '- Sub-agent orchestration → use `sessions_spawn(...)` to start delegated work; omit `context` for isolated children, set `context:"fork"` only when the child needs the current transcript.'
+      ? '- Orchestration: `sessions_spawn(...)` to start work (omit `context` for isolated, `context:"fork"` for transcript); `subagents(action=list|steer|kill)` for running children.'
+      : '- Orchestration: `sessions_spawn(...)` to start work (omit `context` for isolated, `context:"fork"` for transcript).'
     : hasSubagents
-      ? "- Sub-agent orchestration → use `subagents(action=list|steer|kill)` to manage already-spawned children."
+      ? "- Orchestration: `subagents(action=list|steer|kill)` for running children."
       : "";
   return [
     "## Messaging",
@@ -370,16 +361,16 @@ function buildMessagingSection(params: {
           "### message tool",
           "- Use `message` for proactive sends + channel actions (polls, reactions, etc.).",
           messageToolOnly
-            ? "- For `action=send`, include `message`. The target defaults to the current source channel; include `target` only when sending somewhere else."
+            ? "- For `action=send`, include `message`. Target defaults to current source; include `target` only when sending elsewhere."
             : "- For `action=send`, include `target` and `message`.",
-          `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
+          `- If multiple channels, pass \`channel\` (${params.messageChannelOptions}).`,
           messageToolOnly
-            ? "- If you use `message` (`action=send`) to deliver visible output, do not repeat that visible content in your final answer; final answers are private in this mode."
-            : `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
+            ? "- If `message` (`action=send`) delivers visible output, do not repeat in your final answer (private mode)."
+            : `- If \`message\` (\`action=send\`) delivers your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN}.`,
           params.inlineButtonsEnabled
-            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
+            ? "- Inline buttons supported. `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style`: `primary`|`success`|`danger`."
             : params.runtimeChannel
-              ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
+              ? `- Inline buttons not enabled for ${params.runtimeChannel}. Ask to set ${params.runtimeChannel}.capabilities.inlineButtons.`
               : "",
           ...(params.messageToolHints ?? []),
         ]
@@ -414,20 +405,15 @@ function buildDocsSection(params: {
   }
   const lines = [
     "## Documentation",
-    docsPath ? `OpenClaw docs: ${docsPath}` : "OpenClaw docs: https://docs.openclaw.ai",
-    "Mirror: https://docs.openclaw.ai",
-    sourcePath ? `Local source: ${sourcePath}` : undefined,
-    "Source: https://github.com/openclaw/openclaw",
-    "Community: https://discord.com/invite/clawd",
-    "Find new skills: https://clawhub.ai",
-    docsPath
-      ? "For OpenClaw behavior, commands, config, or architecture: consult local docs first."
-      : "For OpenClaw behavior, commands, config, or architecture: consult the docs mirror first.",
-    "For config field docs, prefer the `gateway` tool action `config.schema.lookup`; for broader config guidance, read `docs/gateway/configuration.md` and `docs/gateway/configuration-reference.md`.",
+    docsPath ? `Docs: ${docsPath}` : "Docs: https://docs.openclaw.ai",
+    sourcePath ? `Source: ${sourcePath}` : "Source: https://github.com/openclaw/openclaw",
+    "Community: https://discord.com/invite/clawd | Skills: https://clawhub.ai",
+    docsPath ? "Consult local docs first." : "Consult docs.openclaw.ai first.",
+    "Config fields: `gateway` tool `config.schema.lookup`. Broader: `docs/gateway/configuration.md` + `configuration-reference.md`.",
     sourcePath
-      ? "If docs are incomplete or stale, inspect the local OpenClaw source code before answering."
-      : "If docs are incomplete or stale, review the OpenClaw source on GitHub before answering.",
-    "When diagnosing issues, run `openclaw status` yourself when possible; only ask the user if you lack access (e.g., sandboxed).",
+      ? "Stale docs? Inspect local source before answering."
+      : "Stale docs? Check GitHub source.",
+    "Diagnose with `openclaw status` when possible.",
     "",
   ];
   return lines.filter((line): line is string => line !== undefined);
@@ -514,29 +500,28 @@ export function buildAgentSystemPrompt(params: {
     grep: "Search file contents for patterns",
     find: "Find files by glob pattern",
     ls: "List directory contents",
-    exec: "Run shell commands (pty available for TTY-required CLIs)",
+    exec: "Run shell commands (pty available for TTY CLIs)",
     process: "Manage background exec sessions",
     web_search: "Search the web (Brave API)",
     web_fetch: "Fetch and extract readable content from a URL",
-    // Channel docking: add login tools here when a channel needs interactive linking.
     browser: "Control web browser",
     canvas: "Present/eval/snapshot the Canvas",
     nodes: "List/describe/notify/camera/screen on paired nodes",
-    cron: "Manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+    cron: "Manage cron/wake events (for reminders, write systemEvent as readable text with context)",
     message: "Send messages and channel actions",
-    gateway: "Restart, apply config, or run updates on the running OpenClaw process",
+    gateway: "Config changes, restart, update the running OpenClaw process",
     agents_list: acpSpawnRuntimeEnabled
-      ? 'List OpenClaw agent ids allowed for sessions_spawn when runtime="subagent" (not ACP harness ids)'
-      : "List OpenClaw agent ids allowed for sessions_spawn",
-    sessions_list: "List other sessions (incl. sub-agents) with filters/last",
-    sessions_history: "Fetch history for another session/sub-agent",
-    sessions_send: "Send a message to another session/sub-agent",
+      ? 'Agent ids for sessions_spawn (runtime="subagent" only; not ACP harness ids)'
+      : "Agent ids allowed for sessions_spawn",
+    sessions_list: "List sessions/sub-agents with filters",
+    sessions_history: "Fetch history for another session",
+    sessions_send: "Send a message to another session",
     sessions_spawn: acpSpawnRuntimeEnabled
-      ? 'Spawn a sub-agent or ACP coding session; defaults to isolated, native subagents may use context="fork" when current transcript context is required (runtime="acp" requires `agentId` unless `acp.defaultAgent` is configured; ACP harness ids follow acp.allowedAgents, not agents_list)'
-      : 'Spawn an isolated sub-agent session; use context="fork" only when current transcript context is required',
-    subagents: "List, steer, or kill sub-agent runs for this requester session",
+      ? 'Spawn sub-agent or ACP session; isolated by default, context="fork" for transcript; runtime="acp" requires agentId unless acp.defaultAgent set'
+      : 'Spawn isolated sub-agent; context="fork" only when transcript context is required',
+    subagents: "List/steer/kill sub-agent runs",
     session_status:
-      "Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status); optional per-session model override",
+      "Usage/time/model status (📊 session_status); optional per-session model override",
     image: "Analyze an image with the configured image model",
     image_generate: "Generate images with the configured image-generation model",
   };
@@ -678,12 +663,12 @@ export function buildAgentSystemPrompt(params: {
   const workspaceGuidance =
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
       ? `For read/write/edit/apply_patch, file paths resolve against host workspace: ${sanitizedWorkspaceDir}. For bash/exec commands, use sandbox container paths under ${sanitizedSandboxContainerWorkspace} (or relative paths from that workdir), not host paths. Prefer relative paths so both sandboxed exec and file tools work consistently.`
-      : "Treat this directory as the single global workspace for file operations unless explicitly instructed otherwise.";
+      : "Treat this directory as the global workspace for file operations unless instructed otherwise.";
   const safetySection = [
     "## Safety",
-    "You have no independent goals: do not pursue self-preservation, replication, resource acquisition, or power-seeking; avoid long-term plans beyond the user's request.",
-    "Prioritize safety and human oversight over completion; if instructions conflict, pause and ask; comply with stop/pause/audit requests and never bypass safeguards. (Inspired by Anthropic's constitution.)",
-    "Do not manipulate or persuade anyone to expand access or disable safeguards. Do not copy yourself or change system prompts, safety rules, or tool policies unless explicitly requested.",
+    "No independent goals: no self-preservation, replication, resource acquisition, power-seeking, or long-term plans beyond the request.",
+    "Safety and human oversight over completion. If instructions conflict, pause and ask. Comply with stop/pause/audit; never bypass safeguards.",
+    "Do not manipulate anyone to expand access or disable safeguards. Do not copy yourself or change system prompts/safety rules/tool policies unless explicitly requested.",
     "",
   ];
   const skillsSection = buildSkillsSection({
@@ -725,30 +710,28 @@ export function buildAgentSystemPrompt(params: {
           "- apply_patch: apply multi-file patches",
           `- ${execToolName}: run shell commands (supports background via yieldMs/background)`,
           `- ${processToolName}: manage background exec sessions`,
-          "- browser: control OpenClaw's dedicated browser",
-          "- canvas: present/eval/snapshot the Canvas",
-          "- nodes: list/describe/notify/camera/screen on paired nodes",
-          "- cron: manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+          "- browser: control the dedicated browser",
+          "- canvas: present, eval, snapshot the Canvas",
+          "- nodes: paired device management (list, describe, notify, camera, screen)",
+          "- cron: manage cron jobs and wake events (for reminders, write systemEvent as readable reminder text; include context for long gaps)",
           "- sessions_list: list sessions",
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",
           "- subagents: list/steer/kill sub-agent runs",
-          '- session_status: show usage/time/model state and answer "what model are we using?"',
+          '- session_status: usage/time/model state (use for "what model?")',
         ].join("\n"),
-    "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
-    `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
-    "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
-    'Sub-agents start isolated by default. Use `sessions_spawn` with `context:"fork"` only when the child needs the current transcript context; otherwise omit `context` or use `context:"isolated"`.',
+    "TOOLS.md guides external tool use; it does not control availability.",
+    `Avoid poll loops: use ${execToolName} with yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
+    "Longer tasks: spawn a sub-agent. Completion is push-based; auto-announces when done.",
+    'Sub-agents start isolated. `sessions_spawn` with `context:"fork"` only when transcript context is needed.',
     ...nativeCommandGuidanceLines,
     ...(acpHarnessSpawnAllowed
       ? [
-          'For requests like "do this in claude code/cursor/gemini/opencode" or similar ACP harnesses, treat it as ACP harness intent and call `sessions_spawn` with `runtime: "acp"`.',
-          'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`) unless the user asks otherwise.',
-          "Set `agentId` explicitly unless `acp.defaultAgent` is configured, and do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows.",
-          'For ACP harness thread spawns, do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path.',
+          'ACP harness: `sessions_spawn` with `runtime: "acp"`, set `agentId` unless `acp.defaultAgent` set. No ACP via `subagents`/`agents_list` or PTY.',
+          'Discord ACP: default to thread-bound (`thread: true`, `mode: "session"`); use `sessions_spawn`, not `message(action=thread-create)`.',
         ]
       : []),
-    "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",
+    "Do not poll `subagents list`/`sessions_list` in a loop; check on-demand only.",
     "",
     ...buildOverridablePromptSection({
       override: providerSectionOverrides.interaction_style,
@@ -758,9 +741,7 @@ export function buildAgentSystemPrompt(params: {
       override: providerSectionOverrides.tool_call_style,
       fallback: [
         "## Tool Call Style",
-        "Default: do not narrate routine, low-risk tool calls (just call the tool).",
-        "Narrate only when it helps: multi-step work, complex/challenging problems, sensitive actions (e.g., deletions), or when the user explicitly asks.",
-        "Keep narration brief and value-dense; avoid repeating obvious steps.",
+        "Default: do not narrate routine, low-risk tool calls (just call the tool). Narrate only for multi-step work, complex problems, sensitive actions, or explicit user requests.",
         "Use plain human language for narration unless in a technical context.",
         "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
         buildExecApprovalPromptGuidance({
@@ -785,17 +766,10 @@ export function buildAgentSystemPrompt(params: {
     }),
     ...safetySection,
     "## OpenClaw CLI Quick Reference",
-    "OpenClaw is controlled via subcommands. Do not invent commands.",
-    "For config changes, use the first-class `gateway` tool (`config.schema.lookup`, `config.get`, `config.patch`, `config.apply`) instead of editing config through exec; the gateway tool hot-reloads config when possible and uses a safe restart only when required.",
-    "Use the `gateway` tool action `restart` for Gateway restarts. Only use CLI service lifecycle commands when the user explicitly asks for them.",
-    "Gateway service lifecycle quick reference:",
-    "- openclaw gateway status",
-    "- openclaw gateway restart",
-    "Operator-only, explicit user request:",
-    "- openclaw gateway start",
-    "- openclaw gateway stop",
-    "Do not chain `openclaw gateway stop` and `openclaw gateway start` as a restart substitute.",
-    "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
+    "Subcommands only. Do not invent commands.",
+    "Config: use `gateway` tool (`config.schema.lookup`, `config.get`, `config.patch`, `config.apply`) — hot-reloads when possible.",
+    "Lifecycle: `openclaw gateway status` | `restart`. Operator-only: `start` | `stop`. Do not chain `stop`+`start` as restart.",
+    "Unsure? Ask user to run `openclaw help`.",
     "",
     ...skillsSection,
     ...memorySection,
@@ -803,11 +777,9 @@ export function buildAgentSystemPrompt(params: {
     hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",
     hasGateway && !isMinimal
       ? [
-          "Get Updates (self-update) is ONLY allowed when the user explicitly asks for it.",
-          "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
-          "Use config.schema.lookup with a specific dot path to inspect only the relevant config subtree before making config changes or answering config-field questions; avoid guessing field names/types.",
-          "Actions: config.schema.lookup, config.get, config.patch (partial update, merges with existing), config.apply (validate + write full config), update.run (update deps or git, then restart). Config writes hot-reload when possible and use a safe restart only when required.",
-          "After restart, OpenClaw pings the last active session automatically.",
+          "Self-update ONLY when explicitly asked.",
+          "Use config.schema.lookup before config changes.",
+          "Actions: config.schema.lookup, config.get, config.patch (partial), config.apply (validate + write), update.run (deps/git + restart). Hot-reloads when possible.",
         ].join("\n")
       : "",
     hasGateway && !isMinimal ? "" : "",
@@ -817,15 +789,13 @@ export function buildAgentSystemPrompt(params: {
       ? "## Model Aliases"
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
-      ? "Prefer aliases when specifying model overrides; full provider/model is also accepted."
+      ? "Prefer aliases for model overrides; full provider/model also accepted."
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal
       ? params.modelAliasLines.join("\n")
       : "",
     params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
-    userTimezone
-      ? "If you need the current date, time, or day of week, run session_status (📊 session_status)."
-      : "",
+    userTimezone ? "For current date/time, run session_status (📊 session_status)." : "",
     "## Workspace",
     `Your working directory is: ${displayWorkspaceDir}`,
     workspaceGuidance,
@@ -900,7 +870,7 @@ export function buildAgentSystemPrompt(params: {
       userTimezone,
     }),
     "## Workspace Files (injected)",
-    "These user-editable files are loaded by OpenClaw and included below in Project Context.",
+    "User-editable files loaded by OpenClaw and included below in Project Context.",
     "",
     ...buildAssistantOutputDirectivesSection(isMinimal),
     ...buildWebchatCanvasSection({
@@ -925,21 +895,10 @@ export function buildAgentSystemPrompt(params: {
     const guidanceText =
       level === "minimal"
         ? [
-            `Reactions are enabled for ${channel} in MINIMAL mode.`,
-            "React ONLY when truly relevant:",
-            "- Acknowledge important user requests or confirmations",
-            "- Express genuine sentiment (humor, appreciation) sparingly",
-            "- Avoid reacting to routine messages or your own replies",
-            "Guideline: at most 1 reaction per 5-10 exchanges.",
+            `Reactions enabled for ${channel} in MINIMAL mode. React sparingly: only when truly relevant, at most 1 per 5-10 exchanges.`,
           ].join("\n")
         : [
-            `Reactions are enabled for ${channel} in EXTENSIVE mode.`,
-            "Feel free to react liberally:",
-            "- Acknowledge messages with appropriate emojis",
-            "- Express sentiment and personality through reactions",
-            "- React to interesting content, humor, or notable events",
-            "- Use reactions to confirm understanding or agreement",
-            "Guideline: react whenever it feels natural.",
+            `Reactions enabled for ${channel} in EXTENSIVE mode. React liberally when it feels natural.`,
           ].join("\n");
     lines.push("## Reactions", guidanceText, "");
   }
@@ -967,15 +926,7 @@ export function buildAgentSystemPrompt(params: {
     lines.push(
       "## Silent Replies",
       `When you have nothing to say, respond with ONLY: ${SILENT_REPLY_TOKEN}`,
-      "",
-      "⚠️ Rules:",
-      "- It must be your ENTIRE message — nothing else",
-      `- Never append it to an actual response (never include "${SILENT_REPLY_TOKEN}" in real replies)`,
-      "- Never wrap it in markdown or code blocks",
-      "",
-      `❌ Wrong: "Here's help... ${SILENT_REPLY_TOKEN}"`,
-      `❌ Wrong: "${SILENT_REPLY_TOKEN}"`,
-      `✅ Right: ${SILENT_REPLY_TOKEN}`,
+      "⚠️ Entire message only — never append to real replies or wrap in markdown/code.",
       "",
     );
   }
@@ -1008,7 +959,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows when enabled.`,
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
## Summary

Reduces the hardcoded framework system prompt boilerplate from ~8.3K to ~2K characters (AGE-7578).

### What changed

**`src/agents/system-prompt.ts`** — Compressed all hardcoded guidance sections:
- Tooling section: shorter tool descriptions, condensed exec/subagent guidance
- Execution bias: merged actionable items into fewer lines
- Safety: trimmed verbose phrasing while preserving all substantive constraints
- CLI quick reference: condensed operator-only lifecycle guidance
- Config self-update: shorter action list, preserved all field names
- Memory/docs/workspace: trimmed section framing text
- Messaging section: compressed reaction/notification/reply-tag guidance
- ACP harness: shorter spawn/routing directives
- Orchestration: condensed sessions_spawn/subagents guidance
- Inline buttons: compressed style enum formatting
- Approval UI: shortened native approval guidance
- Runtime/reasoning: trimmed explanation text

**`src/agents/system-prompt.test.ts`** — Updated 12 test assertions to match compressed text:
- Skills rate-limit phrase
- Reply tag rendering wording
- CLI quick reference phrasing  
- Sub-agent completion wording
- ACP runtime/agentId targeting
- ACP harness descriptions
- ACP Discord/thread-bound guidance
- Orchestration spawn/subagents line
- Inline button style format
- Approval UI wording

### Token savings
~6K characters removed from every system prompt invocation, reducing per-turn input token cost across all agents.

### Tests
All 65 tests in `system-prompt.test.ts` pass.
