### PR TITLE
fix(gateway): resolve tools.effective cold misses synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
 - Acpx/runtime: validate the runtime session mode at the `AcpxRuntime.ensureSession` wrapper boundary so callers that pass anything other than `persistent` or `oneshot` get a clear `ACP_INVALID_RUNTIME_OPTION` error instead of silently round-tripping through the encoded handle as a default `persistent` mode and later throwing `SessionResumeRequiredError`. Investigation context: #73071. (#73548) Thanks @amknight.
+- Gateway/tools: resolve cold effective tool inventory cache misses synchronously and keep stale refresh fallbacks bounded, avoiding an extra deferred turn without moving inventory work into Gateway startup. Refs #73428. Thanks @amknight.
 
 ## 2026.4.27
 

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -174,6 +174,15 @@ describe("tools.effective handler", () => {
     );
   });
 
+  it("resolves cold cache misses synchronously", async () => {
+    const { invoke } = createInvokeParams({ sessionKey: "main:abc" });
+
+    const pending = invoke();
+
+    expect(runtimeMocks.resolveEffectiveToolInventory).toHaveBeenCalledTimes(1);
+    await pending;
+  });
+
   it("serves repeated requests from the fresh inventory cache", async () => {
     const first = createInvokeParams({ sessionKey: "main:abc" });
     await first.invoke();
@@ -271,6 +280,76 @@ describe("tools.effective handler", () => {
     const fresh = createInvokeParams({ sessionKey: "main:abc" });
     await fresh.invoke();
     expect((fresh.respond.mock.calls[0] as RespondCall | undefined)?.[1]).toBe(refreshedPayload);
+  });
+
+  it("uses the stale refresh timeout fallback when setImmediate is delayed", async () => {
+    let now = 1_000;
+    __testing.setToolsEffectiveNowForTest(() => now);
+    const initialPayload = {
+      agentId: "main",
+      profile: "coding",
+      groups: [
+        {
+          id: "core",
+          label: "Built-in tools",
+          source: "core",
+          tools: [
+            {
+              id: "read",
+              label: "Read",
+              description: "Read files",
+              rawDescription: "Read files",
+              source: "core",
+            },
+          ],
+        },
+      ],
+    };
+    const refreshedPayload = {
+      agentId: "main",
+      profile: "coding",
+      groups: [
+        {
+          id: "core",
+          label: "Built-in tools",
+          source: "core",
+          tools: [
+            {
+              id: "exec",
+              label: "Exec",
+              description: "Run shell commands",
+              rawDescription: "Run shell commands",
+              source: "core",
+            },
+          ],
+        },
+      ],
+    };
+    runtimeMocks.resolveEffectiveToolInventory
+      .mockReturnValueOnce(initialPayload)
+      .mockReturnValueOnce(refreshedPayload);
+    const immediateSpy = vi
+      .spyOn(globalThis, "setImmediate")
+      .mockImplementation(
+        (() => undefined as unknown as NodeJS.Immediate) as unknown as typeof setImmediate,
+      );
+
+    try {
+      const initial = createInvokeParams({ sessionKey: "main:abc" });
+      await initial.invoke();
+      now += 11_000;
+
+      const stale = createInvokeParams({ sessionKey: "main:abc" });
+      await stale.invoke();
+
+      expect((stale.respond.mock.calls[0] as RespondCall | undefined)?.[1]).toBe(initialPayload);
+      expect(runtimeMocks.resolveEffectiveToolInventory).toHaveBeenCalledTimes(1);
+
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(runtimeMocks.resolveEffectiveToolInventory).toHaveBeenCalledTimes(2);
+    } finally {
+      immediateSpy.mockRestore();
+    }
   });
 
   it("falls back to origin.threadId when delivery context omits thread metadata", async () => {

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -1,6 +1,8 @@
 import type { EffectiveToolInventoryResult } from "../../agents/tools-effective-inventory.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { logDebug, logWarn } from "../../logger.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
@@ -28,6 +30,7 @@ const TOOLS_EFFECTIVE_FRESH_TTL_MS = 10_000;
 const TOOLS_EFFECTIVE_STALE_TTL_MS = 120_000;
 const TOOLS_EFFECTIVE_SLOW_LOG_MS = 250;
 const TOOLS_EFFECTIVE_CACHE_LIMIT = 128;
+const TOOLS_EFFECTIVE_REFRESH_FALLBACK_MS = 100;
 
 let nowForToolsEffectiveCache = () => Date.now();
 
@@ -123,50 +126,99 @@ function cacheToolsEffectiveResult(key: string, value: EffectiveToolInventoryRes
   trimToolsEffectiveCache();
 }
 
+function resolveAndCacheToolsEffectiveResult(params: {
+  key: string;
+  context: TrustedToolsEffectiveContext;
+  startedAt: number;
+}): EffectiveToolInventoryResult {
+  const value = resolveEffectiveToolInventory({
+    cfg: params.context.cfg,
+    agentId: params.context.agentId,
+    sessionKey: params.context.sessionKey,
+    messageProvider: params.context.messageProvider,
+    modelProvider: params.context.modelProvider,
+    modelId: params.context.modelId,
+    senderIsOwner: params.context.senderIsOwner,
+    currentChannelId: params.context.currentChannelId,
+    currentThreadTs: params.context.currentThreadTs,
+    accountId: params.context.accountId,
+    groupId: params.context.groupId,
+    groupChannel: params.context.groupChannel,
+    groupSpace: params.context.groupSpace,
+    replyToMode: params.context.replyToMode,
+  });
+  cacheToolsEffectiveResult(params.key, value);
+  const durationMs = nowForToolsEffectiveCache() - params.startedAt;
+  if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
+    const toolCount = value.groups.reduce((sum, group) => sum + group.tools.length, 0);
+    logDebug(
+      `tools-effective: refresh durationMs=${durationMs} agent=${params.context.agentId} session=${redactIdentifier(params.context.sessionKey)} tools=${toolCount}`,
+    );
+  }
+  return value;
+}
+
 function scheduleToolsEffectiveRefresh(
   key: string,
   context: TrustedToolsEffectiveContext,
+  options: { defer?: boolean } = {},
 ): Promise<EffectiveToolInventoryResult> {
   const existing = toolsEffectiveInflight.get(key);
   if (existing) {
     return existing;
   }
   const startedAt = nowForToolsEffectiveCache();
+  let completed = false;
+  let resolveTask!: (value: EffectiveToolInventoryResult) => void;
+  let rejectTask!: (reason: unknown) => void;
   const task = new Promise<EffectiveToolInventoryResult>((resolve, reject) => {
-    setImmediate(() => {
-      try {
-        const value = resolveEffectiveToolInventory({
-          cfg: context.cfg,
-          agentId: context.agentId,
-          sessionKey: context.sessionKey,
-          messageProvider: context.messageProvider,
-          modelProvider: context.modelProvider,
-          modelId: context.modelId,
-          senderIsOwner: context.senderIsOwner,
-          currentChannelId: context.currentChannelId,
-          currentThreadTs: context.currentThreadTs,
-          accountId: context.accountId,
-          groupId: context.groupId,
-          groupChannel: context.groupChannel,
-          groupSpace: context.groupSpace,
-          replyToMode: context.replyToMode,
-        });
-        cacheToolsEffectiveResult(key, value);
-        const durationMs = nowForToolsEffectiveCache() - startedAt;
-        if (durationMs >= TOOLS_EFFECTIVE_SLOW_LOG_MS) {
-          logDebug(
-            `tools-effective: refresh durationMs=${durationMs} agent=${context.agentId} session=${context.sessionKey} tools=${value.groups.reduce((sum, group) => sum + group.tools.length, 0)}`,
-          );
-        }
-        resolve(value);
-      } catch (err) {
-        reject(err);
-      } finally {
-        toolsEffectiveInflight.delete(key);
-      }
-    });
+    resolveTask = resolve;
+    rejectTask = reject;
   });
   toolsEffectiveInflight.set(key, task);
+
+  const run = () => {
+    if (completed) {
+      return;
+    }
+    completed = true;
+    try {
+      resolveTask(resolveAndCacheToolsEffectiveResult({ key, context, startedAt }));
+    } catch (err) {
+      rejectTask(err);
+    } finally {
+      toolsEffectiveInflight.delete(key);
+    }
+  };
+
+  if (options.defer === false) {
+    run();
+    return task;
+  }
+
+  let immediateHandle: ReturnType<typeof setImmediate> | undefined;
+  let fallbackHandle: ReturnType<typeof setTimeout> | undefined;
+  const runAndCleanup = () => {
+    if (completed) {
+      return;
+    }
+    if (immediateHandle) {
+      clearImmediate(immediateHandle);
+    }
+    if (fallbackHandle) {
+      clearTimeout(fallbackHandle);
+    }
+    run();
+  };
+
+  try {
+    immediateHandle = setImmediate(runAndCleanup);
+    fallbackHandle = setTimeout(runAndCleanup, TOOLS_EFFECTIVE_REFRESH_FALLBACK_MS);
+    fallbackHandle.unref?.();
+  } catch {
+    run();
+  }
+
   return task;
 }
 
@@ -175,7 +227,7 @@ function refreshToolsEffectiveInBackground(
   context: TrustedToolsEffectiveContext,
 ): void {
   void scheduleToolsEffectiveRefresh(key, context).catch((err) => {
-    logWarn(`tools-effective: background refresh failed: ${String(err)}`);
+    logWarn(`tools-effective: background refresh failed: ${formatErrorMessage(err)}`);
   });
 }
 
@@ -196,7 +248,7 @@ async function resolveCachedToolsEffective(params: {
       return cached.value;
     }
   }
-  return scheduleToolsEffectiveRefresh(key, params.context);
+  return scheduleToolsEffectiveRefresh(key, params.context, { defer: false });
 }
 
 function resolveTrustedToolsEffectiveContext(params: {


### PR DESCRIPTION
## Summary

- Problem: `tools.effective` cold cache misses used the same deferred `setImmediate` refresh path as stale background refreshes.
- Why it matters: Control UI/WebChat can hit `tools.effective` on an interactive path; cold misses should start resolving immediately, and stale refreshes should not depend solely on the immediate queue.
- What changed: cold misses now resolve synchronously through the shared cache/update helper; stale-cache requests still return stale data immediately but their background refresh has a bounded timer fallback; refresh logs redact session identifiers and sanitize errors.
- What did NOT change (scope boundary): no Gateway startup prewarm. Local E2E showed blocking startup prewarm moved ~5s of first-request work into Gateway readiness, so this PR avoids startup-speed regression.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #73428
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: cold effective tool inventory cache misses deferred inventory resolution through `setImmediate`, adding an avoidable event-loop turn before the expensive work could begin.
- Missing detection / guardrail: tests covered cache hits/coalescing/stale refreshes, but not cold-miss synchronicity or delayed-`setImmediate` fallback behavior.
- Contributing context (if known): first inventory computation can still be expensive; that underlying cost should be profiled separately rather than moved into startup.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/tools-effective.test.ts`
- Scenario the test should lock in:
  - cold cache misses call `resolveEffectiveToolInventory` synchronously
  - repeated requests still hit the fresh cache
  - stale cache responses still return immediately
  - stale background refresh falls back when `setImmediate` is delayed
- Why this is the smallest reliable guardrail: it isolates cache/scheduler semantics without full Gateway startup or provider runtime noise.
- Existing test that already covers this (if any): existing cache hit/coalescing/stale refresh tests remain in place.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Cold `tools.effective` cache misses begin resolving immediately instead of waiting for `setImmediate`. This avoids an extra deferral but does not claim to eliminate the underlying first inventory computation cost.

## Diagram (if applicable)

```text
Before:
cold tools.effective -> setImmediate -> resolve inventory -> cache -> response
stale tools.effective -> stale response + setImmediate refresh

After:
cold tools.effective -> resolve inventory -> cache -> response
stale tools.effective -> stale response + setImmediate refresh (timer fallback)
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local dev host
- Runtime/container: Node/pnpm workspace
- Model/provider: N/A for targeted cache tests
- Integration/channel (if any): Gateway Control UI/WebChat `tools.effective` path
- Relevant config (redacted): local isolated Gateway fixture used for timing checks; plugins restricted to OpenAI + memory-core for parity with #73428 investigation.

### Steps

1. Seed an isolated Gateway state with `agent:main:main`.
2. Start a real foreground Gateway with startup tracing.
3. Connect over WebSocket as an operator/backend client.
4. Call `tools.effective` repeatedly and compare first vs cached timings.
5. Run targeted unit tests and changed gate.

### Expected

- No `sidecars.tools-effective-prewarm` startup trace.
- Cold miss starts resolving synchronously.
- Repeated requests hit cache.
- Stale refresh fallback still runs when `setImmediate` is delayed.

### Actual

- No startup prewarm path remains in the diff.
- Targeted tests, changed gate, and build pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Validation:

```text
pnpm test src/gateway/server-methods/tools-effective.test.ts -- --reporter=verbose
# 1 file passed, 15 tests passed

pnpm check:changed
# passed

pnpm build
# passed
```

Local E2E comparison notes from the discarded startup-prewarm prototype:

```text
origin/main (3 runs): first tools.effective p50 ≈ 5.85s, no startup prewarm
blocking startup-prewarm prototype: first tools.effective p50 ≈ 369ms, but sidecars.tools-effective-prewarm p50 ≈ 5.3s and Gateway ready regressed similarly
current PR: startup prewarm removed; no startup-speed regression from this change
```

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - targeted Gateway tests for cold miss, cache hit, stale refresh, delayed-`setImmediate` fallback
  - changed-gate typecheck/lint/import-cycle/runtime-loader guards
  - production build after production-source changes
  - local real-Gateway timing before removing the blocking startup-prewarm prototype
- Edge cases checked:
  - unknown/invalid session handling remains rejected
  - admin-scoped callers still pass `senderIsOwner=true`
  - stale cached value is returned immediately while refresh happens later
  - delayed `setImmediate` fallback updates the cache
- What you did **not** verify:
  - live 2 vCPU / 4 GB Docker VPS reproduction with WebChat and OpenAI

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: this does not remove the underlying cost of first inventory computation.
  - Mitigation: this PR avoids startup regression and narrows the fix to safe scheduler/cache semantics; deeper inventory laziness should be handled separately with profiling.
