### PR TITLE
feat: add auto-recall plugin — automatic memory retrieval for prompt enrichment

### DIFF
--- a/extensions/auto-recall/MIGRATION.md
+++ b/extensions/auto-recall/MIGRATION.md
@@ -1,0 +1,125 @@
+# Migration from auto-recall-mnemostack
+
+This plugin is the universal Phase 1 extraction of `auto-recall-mnemostack`.
+
+## Removed workspace-specific behavior
+
+- No hardcoded `/root/.openclaw/workspace/...` paths.
+- No mnemostack-specific daemon route assumptions.
+- No `recall-selfeval.sh` default.
+- No strategy-memory side lookup.
+- No MemorySearchBackend yet; SDK integration is Phase 2.
+
+## Map old config to new config
+
+Old mnemostack daemon:
+
+```json
+{
+  "recallDaemonUrl": "http://127.0.0.1:18793",
+  "recallDaemonTimeoutMs": 9000,
+  "minConfidence": 0.4
+}
+```
+
+New HTTP backend:
+
+```json
+{
+  "minConfidence": 0.4,
+  "backends": [
+    {
+      "type": "http",
+      "name": "mnemostack",
+      "url": "http://127.0.0.1:18793/recall-answer",
+      "timeoutMs": 9000,
+      "responseMapping": {
+        "answerPath": "answer",
+        "confidencePath": "confidence",
+        "sourcesPath": "sources",
+        "degradedPath": "degraded"
+      }
+    }
+  ]
+}
+```
+
+Old script fallback:
+
+```json
+{
+  "recallScript": "/path/to/recall-selfeval.sh",
+  "timeoutMs": 7000
+}
+```
+
+New script backend:
+
+```json
+{
+  "backends": [
+    {
+      "type": "script",
+      "name": "selfeval",
+      "command": "/path/to/recall-selfeval.sh",
+      "args": ["--answer"],
+      "queryMode": "stdin",
+      "protocol": "text",
+      "timeoutMs": 7000
+    }
+  ]
+}
+```
+
+To preserve daemon-then-script fallback:
+
+```json
+{
+  "backends": [
+    { "type": "http", "name": "mnemostack", "url": "http://127.0.0.1:18793/recall-answer" },
+    {
+      "type": "script",
+      "name": "selfeval",
+      "command": "/path/to/recall-selfeval.sh",
+      "args": ["--answer"],
+      "queryMode": "stdin",
+      "protocol": "text"
+    }
+  ]
+}
+```
+
+## Triggers
+
+Old `triggersPath` becomes:
+
+```json
+{
+  "triggers": { "customPath": "/path/to/triggers.json" }
+}
+```
+
+Reload is now explicit with `SIGUSR2`; malformed reloads keep the previous valid snapshot.
+
+## Cache
+
+Old:
+
+```json
+{ "cacheSuccessTtlMs": 1800000, "cacheNegativeTtlMs": 600000, "cacheMaxEntries": 500 }
+```
+
+New:
+
+```json
+{
+  "cache": {
+    "okTtlMs": 1800000,
+    "notFoundTtlMs": 600000,
+    "errorTtlMs": 0,
+    "maxEntries": 500
+  }
+}
+```
+
+Timeout and other infrastructure failures are not negative-cached.

--- a/extensions/auto-recall/README.md
+++ b/extensions/auto-recall/README.md
@@ -1,0 +1,176 @@
+# auto-recall
+
+Universal OpenClaw community plugin that detects recall-style user questions, queries one or more configured recall backends, and injects a bounded memory answer into `before_prompt_build` context.
+
+It has no built-in memory store. You provide an HTTP service or a script backend.
+
+## Quick start
+
+```json
+{
+  "enabled": true,
+  "allowedChatTypes": ["direct", "group"],
+  "minConfidence": 0.4,
+  "backends": [
+    {
+      "type": "http",
+      "url": "http://127.0.0.1:18793/recall",
+      "timeoutMs": 7000
+    }
+  ]
+}
+```
+
+The HTTP backend receives JSON by default:
+
+```json
+{
+  "query": "user text",
+  "normalizedQuery": "user text normalized for cache",
+  "maxResults": 5,
+  "minConfidence": 0.4,
+  "trigger": { "patternId": "memory_keyword", "matchedText": "remember" },
+  "session": { "agentId": "main", "provider": "telegram", "chatType": "direct" }
+}
+```
+
+Expected JSON response:
+
+```json
+{
+  "status": "ok",
+  "answer": "The thing you decided was...",
+  "confidence": 0.86,
+  "sources": [{ "title": "notes.md", "uri": "file:///notes.md", "score": 0.74 }]
+}
+```
+
+`status` can be `ok`, `not_found`, `degraded`, or `error`.
+
+## Security notes
+
+HTTP backends call the URL you configure from the OpenClaw Gateway process. Treat this as an SSRF-capable setting: do not expose plugin configuration to untrusted users, and prefer loopback/private endpoints you control. The plugin does not try to validate whether your configured URL is safe.
+
+Script backends never use `shell: true`. Configure `command` and `args` arrays; user text is passed via stdin by default or as a single argument if `queryMode: "arg"` is set.
+
+## Config reference
+
+| Key                                 | Default              | Description                                                                                   |
+| ----------------------------------- | -------------------- | --------------------------------------------------------------------------------------------- |
+| `enabled`                           | `true`               | Register the hook when plugin is enabled.                                                     |
+| `agents`                            | `[]`                 | Optional allow-list of agent ids. Empty means all.                                            |
+| `allowedChatTypes`                  | `["direct","group"]` | Chat types allowed for recall. Missing/unknown chat type is skipped.                          |
+| `timeoutMs`                         | `7000`               | Per-hook timeout passed to backends via `AbortSignal`.                                        |
+| `maxResults`                        | `5`                  | Hint for backend result count.                                                                |
+| `minConfidence`                     | `0.4`                | Minimum confidence required for injection.                                                    |
+| `allowDegraded`                     | `false`              | Allow `degraded` backend results to inject.                                                   |
+| `logPath`                           | unset                | Optional JSONL diagnostics path. If unwritable, warns once and continues.                     |
+| `recallMinChars` / `recallMaxChars` | `8` / `8000`         | Bounds input sent to backends.                                                                |
+| `backends`                          | `[]`                 | Ordered backend chain.                                                                        |
+| `triggers.customPath`               | unset                | Optional `triggers.json`; reload with `SIGUSR2`. Malformed reload keeps last-known-good.      |
+| `triggers.reloadSignal`             | `SIGUSR2`            | Process signal used for trigger reload. Set to `false` to avoid process-wide signal handlers. |
+| `cache.enabled`                     | `true`               | In-memory cache.                                                                              |
+| `cache.okTtlMs`                     | `1800000`            | TTL for successful answers.                                                                   |
+| `cache.notFoundTtlMs`               | `600000`             | TTL for `not_found` negative cache.                                                           |
+| `cache.degradedTtlMs`               | `1800000`            | TTL for `degraded` candidates.                                                                |
+| `cache.errorTtlMs`                  | `0`                  | Error cache TTL. Timeout/infra failures are not cached.                                       |
+| `cache.maxEntries`                  | `500`                | Max cache entries; expired/LRU sweep.                                                         |
+| `injection.maxLength`               | `2000`               | Maximum injected body length.                                                                 |
+| `injection.tag`                     | `active_memory`      | XML-ish envelope tag.                                                                         |
+
+## Backend chain behavior
+
+Backends are tried in order. The chain stops on the first `ok` result with `confidence >= minConfidence`. `not_found` and `error` continue to the next backend. `degraded` results are saved as candidates and injected only when `allowDegraded: true`.
+
+Cache keys include backend type, backend name, backend config hash, optional backend cache suffix, and normalized query text. In-flight requests with the same key are de-duplicated and cleaned up with `finally` on all paths.
+
+## HTTP backend
+
+```json
+{
+  "type": "http",
+  "name": "local-rag",
+  "url": "http://127.0.0.1:18793/recall",
+  "method": "POST",
+  "headers": { "authorization": "Bearer ..." },
+  "timeoutMs": 7000,
+  "maxResponseBytes": 262144,
+  "allowedHosts": ["127.0.0.1"],
+  "requestMode": "default",
+  "responseMapping": {
+    "answerPath": "answer",
+    "confidencePath": "confidence",
+    "sourcesPath": "sources",
+    "statusPath": "status",
+    "degradedPath": "degraded"
+  }
+}
+```
+
+`requestMode` options:
+
+- `default`: structured payload shown above.
+- `query`: `{ "query": text }`.
+- `normalizedQuery`: `{ "query": normalizedText }`.
+- `text`: raw text body.
+
+JSON response parsing is the default and only supported mode in Phase 1.
+
+When `allowedHosts` is set, the backend validates the configured URL host and does not follow HTTP redirects automatically. Redirect responses are returned as `redirect_blocked` so an allow-listed local endpoint cannot bounce recall traffic to an internal metadata service or another unexpected host.
+
+## Script backend
+
+```json
+{
+  "type": "script",
+  "name": "local-script",
+  "command": "/usr/local/bin/recall-answer",
+  "args": ["--json"],
+  "queryMode": "stdin",
+  "protocol": "json",
+  "timeoutMs": 7000,
+  "maxStdoutBytes": 262144,
+  "maxStderrBytes": 32768,
+  "cwd": "/safe/working/dir",
+  "env": { "RECALL_MODE": "answer" }
+}
+```
+
+For argument mode:
+
+```json
+{ "queryMode": "arg", "queryArg": "{query}" }
+```
+
+Supported output protocols:
+
+```json
+{ "status": "ok", "answer": "...", "confidence": 0.87, "sources": [] }
+```
+
+or text:
+
+```text
+ANSWER: ...
+CONFIDENCE: 0.87
+SOURCES:
+  - source one
+```
+
+## Triggers
+
+Bilingual English/Russian defaults are embedded in code. You can add triggers for any language — just provide your own `triggers.json` with locale-specific keywords and phrases. The plugin is language-agnostic; built-in defaults cover English and Russian as a starting point.
+
+Custom `triggers.json` can override/extend categories:
+
+```json
+{
+  "memory_keywords": ["remember", "помнишь"],
+  "past_references": ["last time", "мы решили"],
+  "named_entities": ["Project Codename"],
+  "internal_prompt_denylist": ["You are a memory search agent"],
+  "term_whitelist": ["OpenClaw"]
+}
+```
+
+Send `SIGUSR2` to the Gateway process to reload. If the file is malformed, the plugin logs `triggers_reload_failed` and keeps the last-known-good immutable snapshot for in-flight hooks. Set `triggers.reloadSignal` to `false` if the host process already owns `SIGUSR2`.

--- a/extensions/auto-recall/index.js
+++ b/extensions/auto-recall/index.js
@@ -1,0 +1,11 @@
+export { plugin as default } from "./src/plugin.js";
+export * from "./src/plugin.js";
+export * from "./src/triggers.js";
+export * from "./src/strip-envelope.js";
+export * from "./src/cache.js";
+export * from "./src/inflight.js";
+export * from "./src/injection.js";
+export * from "./src/config.js";
+export * from "./src/logging.js";
+export * from "./src/backends/http.js";
+export * from "./src/backends/script.js";

--- a/extensions/auto-recall/openclaw.plugin.json
+++ b/extensions/auto-recall/openclaw.plugin.json
@@ -1,5 +1,8 @@
 {
   "id": "auto-recall",
+  "activation": {
+    "onStartup": false
+  },
   "name": "Auto Recall",
   "description": "Triggers configurable recall backends from user questions and injects relevant memory into prompt context.",
   "enabledByDefault": false,

--- a/extensions/auto-recall/openclaw.plugin.json
+++ b/extensions/auto-recall/openclaw.plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "auto-recall",
+  "name": "Auto Recall",
+  "description": "Triggers configurable recall backends from user questions and injects relevant memory into prompt context.",
+  "enabledByDefault": false,
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "agents": { "type": "array", "items": { "type": "string" } },
+      "allowedChatTypes": { "type": "array", "items": { "type": "string" } },
+      "timeoutMs": { "type": "integer", "minimum": 100, "maximum": 60000 },
+      "maxResults": { "type": "integer", "minimum": 1, "maximum": 50 },
+      "minConfidence": { "type": "number", "minimum": 0, "maximum": 1 },
+      "allowDegraded": { "type": "boolean" },
+      "logPath": { "type": "string" },
+      "recallMinChars": { "type": "integer", "minimum": 1 },
+      "recallMaxChars": { "type": "integer", "minimum": 100 },
+      "triggers": { "type": "object" },
+      "cache": { "type": "object" },
+      "injection": { "type": "object" },
+      "backends": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "type": "string", "enum": ["http", "script"] }
+          },
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/extensions/auto-recall/package.json
+++ b/extensions/auto-recall/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@openclaw/auto-recall",
+  "version": "2026.4.27",
+  "private": true,
+  "description": "OpenClaw plugin that injects bounded recall results into prompts.",
+  "keywords": [
+    "memory",
+    "openclaw",
+    "plugin",
+    "rag",
+    "recall"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/openclaw.git",
+    "directory": "extensions/auto-recall"
+  },
+  "files": [
+    "index.js",
+    "src",
+    "README.md",
+    "MIGRATION.md",
+    "openclaw.plugin.json"
+  ],
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.27"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
+}

--- a/extensions/auto-recall/src/backends/http.js
+++ b/extensions/auto-recall/src/backends/http.js
@@ -23,15 +23,21 @@ function timeoutSignal(parent, timeoutMs) {
     controller.abort(signal?.reason || new Error("aborted"));
   };
   if (parent) {
-    if (parent.aborted) abort();
-    else parent.addEventListener("abort", abort, { once: true });
+    if (parent.aborted) {
+      abort();
+    } else {
+      parent.addEventListener("abort", abort, { once: true });
+    }
   }
-  if (timeoutMs > 0)
+  if (timeoutMs > 0) {
     timer = setTimeout(() => controller.abort(new Error("timeout")), timeoutMs).unref?.();
+  }
   return {
     signal: controller.signal,
     cleanup: () => {
-      if (timer) clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       parent?.removeEventListener?.("abort", abort);
     },
   };
@@ -41,14 +47,18 @@ async function readBounded(response, maxBytes) {
   const reader = response.body?.getReader?.();
   if (!reader) {
     const text = await response.text();
-    if (Buffer.byteLength(text) > maxBytes) throw new Error("response_too_large");
+    if (Buffer.byteLength(text) > maxBytes) {
+      throw new Error("response_too_large");
+    }
     return text;
   }
   const chunks = [];
   let size = 0;
   while (true) {
     const { done, value } = await reader.read();
-    if (done) break;
+    if (done) {
+      break;
+    }
     size += value.byteLength;
     if (size > maxBytes) {
       await reader.cancel().catch(() => {});
@@ -60,15 +70,21 @@ async function readBounded(response, maxBytes) {
 }
 
 function getPath(obj, path) {
-  if (!path) return undefined;
+  if (!path) {
+    return undefined;
+  }
   return String(path)
     .split(".")
     .reduce((cur, key) => (cur == null ? undefined : cur[key]), obj);
 }
 
 function normalizeSource(source) {
-  if (typeof source === "string") return { title: source };
-  if (!source || typeof source !== "object") return undefined;
+  if (typeof source === "string") {
+    return { title: source };
+  }
+  if (!source || typeof source !== "object") {
+    return undefined;
+  }
   return {
     id: source.id != null ? String(source.id) : undefined,
     title: source.title != null ? String(source.title) : undefined,
@@ -103,9 +119,15 @@ export function mapJsonToResult(json, mapping = {}) {
 }
 
 function buildBody(mode, request, template = {}) {
-  if (mode === "text") return request.text;
-  if (mode === "query") return JSON.stringify({ query: request.text });
-  if (mode === "normalizedQuery") return JSON.stringify({ query: request.normalizedText });
+  if (mode === "text") {
+    return request.text;
+  }
+  if (mode === "query") {
+    return JSON.stringify({ query: request.text });
+  }
+  if (mode === "normalizedQuery") {
+    return JSON.stringify({ query: request.normalizedText });
+  }
   return JSON.stringify({
     ...template.static,
     query: request.text,
@@ -127,7 +149,9 @@ function defaultContentType(mode) {
  */
 export class HttpBackend {
   constructor(config = {}) {
-    if (!config.url) throw new Error("http backend requires url");
+    if (!config.url) {
+      throw new Error("http backend requires url");
+    }
     this.name = config.name || "http";
     this.kind = "http";
     this.config = {
@@ -146,7 +170,9 @@ export class HttpBackend {
   }
 
   hostAllowed() {
-    if (!this.config.allowedHosts.length) return true;
+    if (!this.config.allowedHosts.length) {
+      return true;
+    }
     try {
       return this.config.allowedHosts.includes(new URL(this.config.url).hostname.toLowerCase());
     } catch {
@@ -178,8 +204,9 @@ export class HttpBackend {
         signal,
         redirect: this.config.allowedHosts.length ? "manual" : "follow",
       };
-      if (!/^(GET|HEAD)$/i.test(this.config.method))
+      if (!/^(GET|HEAD)$/i.test(this.config.method)) {
         init.body = buildBody(this.config.requestMode, request, this.config.bodyTemplate);
+      }
       const response = await fetch(this.config.url, init);
       if (
         this.config.allowedHosts.length &&
@@ -231,7 +258,7 @@ export class HttpBackend {
       return {
         ...result,
         diagnostics: {
-          ...(result.diagnostics || {}),
+          ...result.diagnostics,
           httpStatus: response.status,
           latencyMs: Date.now() - started,
         },
@@ -254,8 +281,9 @@ export class HttpBackend {
   async healthCheck(signal) {
     const started = Date.now();
     try {
-      if (!this.hostAllowed())
+      if (!this.hostAllowed()) {
         return { ok: false, reason: "url_not_allowed", latencyMs: Date.now() - started };
+      }
       const response = await fetch(this.config.url, {
         method: "HEAD",
         signal,

--- a/extensions/auto-recall/src/backends/http.js
+++ b/extensions/auto-recall/src/backends/http.js
@@ -1,0 +1,285 @@
+import { configHash } from "../cache.js";
+
+function normalizeAllowedHosts(value) {
+  return Array.isArray(value)
+    ? value.map((host) => String(host).trim().toLowerCase()).filter(Boolean)
+    : [];
+}
+
+function object(value, fallback = {}) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : fallback;
+}
+
+function int(value, fallback, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.min(max, Math.max(min, Math.trunc(n))) : fallback;
+}
+
+function timeoutSignal(parent, timeoutMs) {
+  const controller = new AbortController();
+  let timer;
+  const abort = (event) => {
+    const signal = event?.target || parent;
+    controller.abort(signal?.reason || new Error("aborted"));
+  };
+  if (parent) {
+    if (parent.aborted) abort();
+    else parent.addEventListener("abort", abort, { once: true });
+  }
+  if (timeoutMs > 0)
+    timer = setTimeout(() => controller.abort(new Error("timeout")), timeoutMs).unref?.();
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      if (timer) clearTimeout(timer);
+      parent?.removeEventListener?.("abort", abort);
+    },
+  };
+}
+
+async function readBounded(response, maxBytes) {
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    const text = await response.text();
+    if (Buffer.byteLength(text) > maxBytes) throw new Error("response_too_large");
+    return text;
+  }
+  const chunks = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new Error("response_too_large");
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
+}
+
+function getPath(obj, path) {
+  if (!path) return undefined;
+  return String(path)
+    .split(".")
+    .reduce((cur, key) => (cur == null ? undefined : cur[key]), obj);
+}
+
+function normalizeSource(source) {
+  if (typeof source === "string") return { title: source };
+  if (!source || typeof source !== "object") return undefined;
+  return {
+    id: source.id != null ? String(source.id) : undefined,
+    title: source.title != null ? String(source.title) : undefined,
+    uri: source.uri || source.url || source.path,
+    excerpt: source.excerpt != null ? String(source.excerpt) : undefined,
+    score: Number.isFinite(Number(source.score)) ? Number(source.score) : undefined,
+  };
+}
+
+/**
+ * Map backend JSON response fields into the normalized recall result shape.
+ * @param {object} json Backend JSON response.
+ * @param {object} [mapping={}] Dot-path response mapping options.
+ * @returns {object} Normalized recall result.
+ */
+export function mapJsonToResult(json, mapping = {}) {
+  const answer = getPath(json, mapping.answerPath || "answer");
+  const confidence = getPath(json, mapping.confidencePath || "confidence");
+  const rawStatus = getPath(json, mapping.statusPath || "status");
+  const degraded = Boolean(getPath(json, mapping.degradedPath || "degraded"));
+  const sourceValue = getPath(json, mapping.sourcesPath || "sources");
+  const status = rawStatus || (degraded ? "degraded" : answer ? "ok" : "not_found");
+  return {
+    status: ["ok", "not_found", "degraded", "error"].includes(status) ? status : "error",
+    answer: answer == null ? undefined : String(answer),
+    confidence: Number.isFinite(Number(confidence)) ? Number(confidence) : answer ? 1 : 0,
+    sources: Array.isArray(sourceValue) ? sourceValue.map(normalizeSource).filter(Boolean) : [],
+    diagnostics:
+      json?.diagnostics && typeof json.diagnostics === "object" ? json.diagnostics : undefined,
+    cache: json?.cache && typeof json.cache === "object" ? json.cache : undefined,
+  };
+}
+
+function buildBody(mode, request, template = {}) {
+  if (mode === "text") return request.text;
+  if (mode === "query") return JSON.stringify({ query: request.text });
+  if (mode === "normalizedQuery") return JSON.stringify({ query: request.normalizedText });
+  return JSON.stringify({
+    ...template.static,
+    query: request.text,
+    normalizedQuery: request.normalizedText,
+    maxResults: request.maxResults,
+    minConfidence: request.minConfidence,
+    trigger: request.trigger,
+    locale: request.locale,
+    session: request.session,
+  });
+}
+
+function defaultContentType(mode) {
+  return mode === "text" ? "text/plain; charset=utf-8" : "application/json";
+}
+
+/**
+ * Recall backend that calls a configured HTTP endpoint.
+ */
+export class HttpBackend {
+  constructor(config = {}) {
+    if (!config.url) throw new Error("http backend requires url");
+    this.name = config.name || "http";
+    this.kind = "http";
+    this.config = {
+      method: config.method || "POST",
+      url: config.url,
+      headers: object(config.headers),
+      timeoutMs:
+        config.timeoutMs == null ? undefined : int(config.timeoutMs, undefined, 100, 60_000),
+      maxResponseBytes: int(config.maxResponseBytes, 256_000, 1024, 10_000_000),
+      requestMode: config.requestMode || "default",
+      bodyTemplate: object(config.bodyTemplate),
+      responseMapping: object(config.responseMapping),
+      allowedHosts: normalizeAllowedHosts(config.allowedHosts),
+    };
+    this.configHash = configHash(this.config);
+  }
+
+  hostAllowed() {
+    if (!this.config.allowedHosts.length) return true;
+    try {
+      return this.config.allowedHosts.includes(new URL(this.config.url).hostname.toLowerCase());
+    } catch {
+      return false;
+    }
+  }
+
+  async query(request) {
+    const started = Date.now();
+    const timeoutMs = this.config.timeoutMs || request.timeoutMs;
+    const { signal, cleanup } = timeoutSignal(request.signal, timeoutMs);
+    try {
+      if (!this.hostAllowed()) {
+        return {
+          status: "error",
+          confidence: 0,
+          diagnostics: { reason: "url_not_allowed", latencyMs: Date.now() - started },
+          cache: { cacheable: false },
+        };
+      }
+      const headers = {
+        accept: "application/json",
+        "content-type": defaultContentType(this.config.requestMode),
+        ...this.config.headers,
+      };
+      const init = {
+        method: this.config.method,
+        headers,
+        signal,
+        redirect: this.config.allowedHosts.length ? "manual" : "follow",
+      };
+      if (!/^(GET|HEAD)$/i.test(this.config.method))
+        init.body = buildBody(this.config.requestMode, request, this.config.bodyTemplate);
+      const response = await fetch(this.config.url, init);
+      if (
+        this.config.allowedHosts.length &&
+        response.status >= 300 &&
+        response.status < 400 &&
+        response.headers.get("location")
+      ) {
+        return {
+          status: "error",
+          confidence: 0,
+          diagnostics: {
+            reason: "redirect_blocked",
+            httpStatus: response.status,
+            latencyMs: Date.now() - started,
+          },
+          cache: { cacheable: false },
+        };
+      }
+      const text = await readBounded(response, this.config.maxResponseBytes);
+      if (!response.ok) {
+        return {
+          status: response.status === 404 ? "not_found" : "error",
+          confidence: 0,
+          diagnostics: {
+            httpStatus: response.status,
+            body: text.slice(0, 1000),
+            latencyMs: Date.now() - started,
+          },
+          cache: { cacheable: response.status === 404 },
+        };
+      }
+      let json;
+      try {
+        json = JSON.parse(text);
+      } catch (error) {
+        return {
+          status: "error",
+          confidence: 0,
+          diagnostics: {
+            reason: "malformed_json",
+            body: text.slice(0, 1000),
+            error: error.message,
+            latencyMs: Date.now() - started,
+          },
+          cache: { cacheable: false },
+        };
+      }
+      const result = mapJsonToResult(json, this.config.responseMapping);
+      return {
+        ...result,
+        diagnostics: {
+          ...(result.diagnostics || {}),
+          httpStatus: response.status,
+          latencyMs: Date.now() - started,
+        },
+      };
+    } catch (error) {
+      const reason = signal.aborted
+        ? signal.reason?.message || "aborted"
+        : error?.message || String(error);
+      return {
+        status: "error",
+        confidence: 0,
+        diagnostics: { reason, latencyMs: Date.now() - started },
+        cache: { cacheable: false },
+      };
+    } finally {
+      cleanup();
+    }
+  }
+
+  async healthCheck(signal) {
+    const started = Date.now();
+    try {
+      if (!this.hostAllowed())
+        return { ok: false, reason: "url_not_allowed", latencyMs: Date.now() - started };
+      const response = await fetch(this.config.url, {
+        method: "HEAD",
+        signal,
+        redirect: this.config.allowedHosts.length ? "manual" : "follow",
+      });
+      if (
+        this.config.allowedHosts.length &&
+        response.status >= 300 &&
+        response.status < 400 &&
+        response.headers.get("location")
+      ) {
+        return { ok: false, reason: "redirect_blocked", latencyMs: Date.now() - started };
+      }
+      return {
+        ok: response.ok,
+        reason: response.ok ? undefined : `http_${response.status}`,
+        latencyMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: error?.message || String(error),
+        latencyMs: Date.now() - started,
+      };
+    }
+  }
+}

--- a/extensions/auto-recall/src/backends/script.js
+++ b/extensions/auto-recall/src/backends/script.js
@@ -175,15 +175,19 @@ export class ScriptBackend {
           cache: { cacheable: false },
         });
       };
-      const timer = setTimeout(() => {
-        killGroup();
-        finish({
-          status: "error",
-          confidence: 0,
-          diagnostics: { reason: "timeout" },
-          cache: { cacheable: false },
-        });
-      }, timeoutMs).unref?.();
+      const timer =
+        timeoutMs > 0
+          ? setTimeout(() => {
+              killGroup();
+              finish({
+                status: "error",
+                confidence: 0,
+                diagnostics: { reason: "timeout" },
+                cache: { cacheable: false },
+              });
+            }, timeoutMs)
+          : undefined;
+      timer?.unref?.();
       request.signal?.addEventListener?.("abort", onAbort, { once: true });
 
       child.stdout.on("data", (chunk) => {
@@ -192,6 +196,7 @@ export class ScriptBackend {
       child.stderr.on("data", (chunk) => {
         stderr = appendLimited(stderr, chunk, this.config.maxStderrBytes);
       });
+      child.stdin.on("error", () => {});
       child.on("error", (error) =>
         finish({
           status: "error",

--- a/extensions/auto-recall/src/backends/script.js
+++ b/extensions/auto-recall/src/backends/script.js
@@ -2,9 +2,12 @@ import { spawn } from "node:child_process";
 import { configHash } from "../cache.js";
 
 function toSources(value) {
-  if (!value) return [];
-  if (Array.isArray(value))
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
     return value.map((item) => (typeof item === "string" ? { title: item } : item)).filter(Boolean);
+  }
   return String(value)
     .split(/\r?\n/)
     .map((line) => line.replace(/^\s*-\s*/, "").trim())
@@ -28,8 +31,10 @@ function int(value, fallback, min = 0, max = Number.MAX_SAFE_INTEGER) {
  * @returns {object} Normalized recall result.
  */
 export function parseScriptOutput(stdout, protocol = "json") {
-  const text = String(stdout || "").trim();
-  if (!text) return { status: "not_found", confidence: 0 };
+  const text = (stdout == null ? "" : String(stdout)).trim();
+  if (!text) {
+    return { status: "not_found", confidence: 0 };
+  }
   if (protocol === "json") {
     try {
       const obj = JSON.parse(text);
@@ -63,7 +68,7 @@ export function parseScriptOutput(stdout, protocol = "json") {
   const confidenceMatch = text.match(/^CONFIDENCE:\s*([0-9]*\.?[0-9]+)/im);
   const sourcesMatch = text.match(/^SOURCES:\s*([\s\S]*)$/im);
   const answer = answerMatch?.[1]?.trim();
-  const confidence = confidenceMatch ? Number(confidenceMatch[1]) : NaN;
+  const confidence = confidenceMatch ? Number(confidenceMatch[1]) : Number.NaN;
   if (!answer || !Number.isFinite(confidence)) {
     return {
       status: "error",
@@ -85,9 +90,12 @@ function appendLimited(target, chunk, maxBytes) {
  */
 export class ScriptBackend {
   constructor(config = {}) {
-    if (!config.command) throw new Error("script backend requires command");
-    if (config.args && !Array.isArray(config.args))
+    if (!config.command) {
+      throw new Error("script backend requires command");
+    }
+    if (config.args && !Array.isArray(config.args)) {
       throw new Error("script backend args must be an array");
+    }
     this.name = config.name || "script";
     this.kind = "script";
     this.config = {
@@ -114,12 +122,13 @@ export class ScriptBackend {
         .replaceAll("{query}", request.text)
         .replaceAll("{normalizedQuery}", request.normalizedText),
     );
-    if (this.config.queryMode === "arg")
+    if (this.config.queryMode === "arg") {
       args.push(
         String(this.config.queryArg)
           .replaceAll("{query}", request.text)
           .replaceAll("{normalizedQuery}", request.normalizedText),
       );
+    }
 
     if (request.signal?.aborted) {
       return {
@@ -143,14 +152,16 @@ export class ScriptBackend {
       });
 
       const finish = (result) => {
-        if (done) return;
+        if (done) {
+          return;
+        }
         done = true;
         clearTimeout(timer);
         request.signal?.removeEventListener?.("abort", onAbort);
         resolve({
           ...result,
           diagnostics: {
-            ...(result.diagnostics || {}),
+            ...result.diagnostics,
             stderr: stderr.toString("utf8").slice(0, this.config.maxStderrBytes),
             latencyMs: Date.now() - started,
           },
@@ -206,14 +217,17 @@ export class ScriptBackend {
         }),
       );
       child.on("close", (code, signal) => {
-        if (done) return;
-        if (code !== 0)
+        if (done) {
+          return;
+        }
+        if (code !== 0) {
           return finish({
             status: "error",
             confidence: 0,
             diagnostics: { reason: "exit", code, signal },
             cache: { cacheable: false },
           });
+        }
         const parsed = parseScriptOutput(stdout.toString("utf8"), this.config.protocol);
         finish(parsed);
       });
@@ -221,8 +235,11 @@ export class ScriptBackend {
         onAbort();
         return;
       }
-      if (this.config.queryMode === "stdin") child.stdin.end(request.text);
-      else child.stdin.end();
+      if (this.config.queryMode === "stdin") {
+        child.stdin.end(request.text);
+      } else {
+        child.stdin.end();
+      }
     });
   }
 }

--- a/extensions/auto-recall/src/backends/script.js
+++ b/extensions/auto-recall/src/backends/script.js
@@ -1,0 +1,223 @@
+import { spawn } from "node:child_process";
+import { configHash } from "../cache.js";
+
+function toSources(value) {
+  if (!value) return [];
+  if (Array.isArray(value))
+    return value.map((item) => (typeof item === "string" ? { title: item } : item)).filter(Boolean);
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^\s*-\s*/, "").trim())
+    .filter(Boolean)
+    .map((title) => ({ title }));
+}
+
+function object(value, fallback = {}) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : fallback;
+}
+
+function int(value, fallback, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.min(max, Math.max(min, Math.trunc(n))) : fallback;
+}
+
+/**
+ * Parse stdout from a script backend into the normalized recall result shape.
+ * @param {unknown} stdout Script stdout.
+ * @param {"json"|"text"} [protocol="json"] Output protocol.
+ * @returns {object} Normalized recall result.
+ */
+export function parseScriptOutput(stdout, protocol = "json") {
+  const text = String(stdout || "").trim();
+  if (!text) return { status: "not_found", confidence: 0 };
+  if (protocol === "json") {
+    try {
+      const obj = JSON.parse(text);
+      return {
+        status: obj.status || (obj.degraded ? "degraded" : obj.answer ? "ok" : "not_found"),
+        answer: obj.answer == null ? undefined : String(obj.answer),
+        confidence: Number.isFinite(Number(obj.confidence))
+          ? Number(obj.confidence)
+          : obj.answer
+            ? 1
+            : 0,
+        sources: toSources(obj.sources),
+        diagnostics: obj.diagnostics,
+        cache: obj.cache,
+      };
+    } catch (error) {
+      return {
+        status: "error",
+        confidence: 0,
+        diagnostics: {
+          reason: "malformed_json",
+          error: error.message,
+          stdout: text.slice(0, 1000),
+        },
+        cache: { cacheable: false },
+      };
+    }
+  }
+
+  const answerMatch = text.match(/^ANSWER:\s*([\s\S]*?)(?=^CONFIDENCE:|^SOURCES:|$)/im);
+  const confidenceMatch = text.match(/^CONFIDENCE:\s*([0-9]*\.?[0-9]+)/im);
+  const sourcesMatch = text.match(/^SOURCES:\s*([\s\S]*)$/im);
+  const answer = answerMatch?.[1]?.trim();
+  const confidence = confidenceMatch ? Number(confidenceMatch[1]) : NaN;
+  if (!answer || !Number.isFinite(confidence)) {
+    return {
+      status: "error",
+      confidence: 0,
+      diagnostics: { reason: "malformed_text_protocol", stdout: text.slice(0, 1000) },
+      cache: { cacheable: false },
+    };
+  }
+  return { status: "ok", answer, confidence, sources: toSources(sourcesMatch?.[1]) };
+}
+
+function appendLimited(target, chunk, maxBytes) {
+  const next = Buffer.concat([target, Buffer.from(chunk)]);
+  return next.length > maxBytes ? next.subarray(0, maxBytes) : next;
+}
+
+/**
+ * Recall backend that executes a configured command without a shell.
+ */
+export class ScriptBackend {
+  constructor(config = {}) {
+    if (!config.command) throw new Error("script backend requires command");
+    if (config.args && !Array.isArray(config.args))
+      throw new Error("script backend args must be an array");
+    this.name = config.name || "script";
+    this.kind = "script";
+    this.config = {
+      command: config.command,
+      args: config.args || [],
+      queryMode: config.queryMode || "stdin",
+      queryArg: config.queryArg || "{query}",
+      timeoutMs:
+        config.timeoutMs == null ? undefined : int(config.timeoutMs, undefined, 100, 60_000),
+      maxStdoutBytes: int(config.maxStdoutBytes, 256_000, 1024, 10_000_000),
+      maxStderrBytes: int(config.maxStderrBytes, 32_000, 1024, 1_000_000),
+      protocol: config.protocol || "json",
+      cwd: config.cwd,
+      env: object(config.env),
+    };
+    this.configHash = configHash(this.config);
+  }
+
+  async query(request) {
+    const started = Date.now();
+    const timeoutMs = this.config.timeoutMs || request.timeoutMs;
+    const args = this.config.args.map((arg) =>
+      String(arg)
+        .replaceAll("{query}", request.text)
+        .replaceAll("{normalizedQuery}", request.normalizedText),
+    );
+    if (this.config.queryMode === "arg")
+      args.push(
+        String(this.config.queryArg)
+          .replaceAll("{query}", request.text)
+          .replaceAll("{normalizedQuery}", request.normalizedText),
+      );
+
+    if (request.signal?.aborted) {
+      return {
+        status: "error",
+        confidence: 0,
+        diagnostics: { reason: "aborted", latencyMs: Date.now() - started },
+        cache: { cacheable: false },
+      };
+    }
+
+    return await new Promise((resolve) => {
+      let done = false;
+      let stdout = Buffer.alloc(0);
+      let stderr = Buffer.alloc(0);
+      const child = spawn(this.config.command, args, {
+        shell: false,
+        detached: true,
+        cwd: this.config.cwd,
+        env: { ...process.env, ...this.config.env },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      const finish = (result) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        request.signal?.removeEventListener?.("abort", onAbort);
+        resolve({
+          ...result,
+          diagnostics: {
+            ...(result.diagnostics || {}),
+            stderr: stderr.toString("utf8").slice(0, this.config.maxStderrBytes),
+            latencyMs: Date.now() - started,
+          },
+        });
+      };
+
+      const killGroup = () => {
+        try {
+          process.kill(-child.pid, "SIGKILL");
+        } catch {
+          try {
+            child.kill("SIGKILL");
+          } catch {}
+        }
+      };
+      const onAbort = () => {
+        killGroup();
+        finish({
+          status: "error",
+          confidence: 0,
+          diagnostics: { reason: "aborted" },
+          cache: { cacheable: false },
+        });
+      };
+      const timer = setTimeout(() => {
+        killGroup();
+        finish({
+          status: "error",
+          confidence: 0,
+          diagnostics: { reason: "timeout" },
+          cache: { cacheable: false },
+        });
+      }, timeoutMs).unref?.();
+      request.signal?.addEventListener?.("abort", onAbort, { once: true });
+
+      child.stdout.on("data", (chunk) => {
+        stdout = appendLimited(stdout, chunk, this.config.maxStdoutBytes);
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr = appendLimited(stderr, chunk, this.config.maxStderrBytes);
+      });
+      child.on("error", (error) =>
+        finish({
+          status: "error",
+          confidence: 0,
+          diagnostics: { reason: error.message },
+          cache: { cacheable: false },
+        }),
+      );
+      child.on("close", (code, signal) => {
+        if (done) return;
+        if (code !== 0)
+          return finish({
+            status: "error",
+            confidence: 0,
+            diagnostics: { reason: "exit", code, signal },
+            cache: { cacheable: false },
+          });
+        const parsed = parseScriptOutput(stdout.toString("utf8"), this.config.protocol);
+        finish(parsed);
+      });
+      if (request.signal?.aborted) {
+        onAbort();
+        return;
+      }
+      if (this.config.queryMode === "stdin") child.stdin.end(request.text);
+      else child.stdin.end();
+    });
+  }
+}

--- a/extensions/auto-recall/src/cache.js
+++ b/extensions/auto-recall/src/cache.js
@@ -6,10 +6,14 @@ import { createHash } from "node:crypto";
  * @returns {string} Stable JSON representation.
  */
 export function stableJson(value) {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
   return `{${Object.keys(value)
-    .sort()
+    .toSorted()
     .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
     .join(",")}}`;
 }
@@ -39,7 +43,7 @@ export function configHash(value) {
  * @returns {string} Normalized cache key text.
  */
 export function normalizeCacheText(text) {
-  return String(text || "")
+  return (text == null ? "" : String(text))
     .toLowerCase()
     .replace(/```json[\s\S]*?```/gi, " ")
     .replace(/\[(mon|tue|wed|thu|fri|sat|sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} utc\]/gi, " ")
@@ -85,14 +89,20 @@ export class RecallCache {
   }
 
   ttlFor(status, override) {
-    if (Number.isFinite(override)) return Math.max(0, Number(override));
+    if (Number.isFinite(override)) {
+      return Math.max(0, Number(override));
+    }
     return Math.max(0, Number(this.ttls[status] ?? 0));
   }
 
   get(key, now = Date.now()) {
-    if (!this.enabled) return undefined;
+    if (!this.enabled) {
+      return undefined;
+    }
     const entry = this.map.get(key);
-    if (!entry) return undefined;
+    if (!entry) {
+      return undefined;
+    }
     if (entry.expiresAt <= now) {
       this.map.delete(key);
       return undefined;
@@ -102,7 +112,9 @@ export class RecallCache {
   }
 
   set(key, value, ttlMs, now = Date.now()) {
-    if (!this.enabled || !key || ttlMs <= 0) return false;
+    if (!this.enabled || !key || ttlMs <= 0) {
+      return false;
+    }
     this.map.set(key, { value, expiresAt: now + ttlMs, lastAccess: now });
     this.sweep(now);
     return true;
@@ -110,7 +122,9 @@ export class RecallCache {
 
   sweep(now = Date.now()) {
     for (const [key, entry] of this.map) {
-      if (entry.expiresAt <= now) this.map.delete(key);
+      if (entry.expiresAt <= now) {
+        this.map.delete(key);
+      }
     }
     while (this.map.size > this.maxEntries) {
       let oldestKey;
@@ -121,7 +135,9 @@ export class RecallCache {
           oldestKey = key;
         }
       }
-      if (!oldestKey) break;
+      if (!oldestKey) {
+        break;
+      }
       this.map.delete(oldestKey);
     }
   }

--- a/extensions/auto-recall/src/cache.js
+++ b/extensions/auto-recall/src/cache.js
@@ -1,0 +1,128 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Serialize a JSON-like value with stable object key ordering.
+ * @param {unknown} value Value to serialize.
+ * @returns {string} Stable JSON representation.
+ */
+export function stableJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+    .join(",")}}`;
+}
+
+/**
+ * Build a short SHA-256 based hex hash.
+ * @param {unknown} value Value to hash.
+ * @param {number} [length=16] Number of hex characters to return.
+ * @returns {string} Short hash.
+ */
+export function hash(value, length = 16) {
+  return createHash("sha256").update(String(value)).digest("hex").slice(0, length);
+}
+
+/**
+ * Hash backend configuration with stable key ordering.
+ * @param {unknown} value Backend configuration object.
+ * @returns {string} Stable configuration hash.
+ */
+export function configHash(value) {
+  return hash(stableJson(value), 16);
+}
+
+/**
+ * Normalize user text for cache lookups without keeping metadata envelopes.
+ * @param {unknown} text Raw user text.
+ * @returns {string} Normalized cache key text.
+ */
+export function normalizeCacheText(text) {
+  return String(text || "")
+    .toLowerCase()
+    .replace(/```json[\s\S]*?```/gi, " ")
+    .replace(/\[(mon|tue|wed|thu|fri|sat|sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} utc\]/gi, " ")
+    .replace(/\b(?:conversation info|sender|replied message|forwarded message)\b.*$/gim, " ")
+    .replace(/[{}[\]",:]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1000);
+}
+
+/**
+ * Build an isolated cache key for backend, session, text, and optional suffix.
+ * @param {{backend: {kind: string, name: string, configHash?: string}, text: string, session?: unknown, suffix?: string}} params Cache key parts.
+ * @returns {string} Cache key.
+ */
+export function cacheKeyFor({ backend, text, session, suffix = "" }) {
+  const sessionHash = session ? hash(stableJson(session), 16) : "no-session";
+  const namespace = `${backend.kind}:${backend.name}:${backend.configHash || "no-config"}:${sessionHash}:${suffix || ""}`;
+  return `${hash(namespace)}:${hash(normalizeCacheText(text))}`;
+}
+
+/**
+ * Small in-memory TTL cache with expired-entry and LRU eviction.
+ */
+export class RecallCache {
+  constructor({
+    enabled = true,
+    okTtlMs = 30 * 60_000,
+    notFoundTtlMs = 10 * 60_000,
+    degradedTtlMs = okTtlMs,
+    errorTtlMs = 0,
+    maxEntries = 500,
+  } = {}) {
+    this.enabled = Boolean(enabled);
+    this.ttls = {
+      ok: okTtlMs,
+      not_found: notFoundTtlMs,
+      degraded: degradedTtlMs,
+      error: errorTtlMs,
+    };
+    this.maxEntries = Math.max(1, Number(maxEntries) || 500);
+    this.map = new Map();
+  }
+
+  ttlFor(status, override) {
+    if (Number.isFinite(override)) return Math.max(0, Number(override));
+    return Math.max(0, Number(this.ttls[status] ?? 0));
+  }
+
+  get(key, now = Date.now()) {
+    if (!this.enabled) return undefined;
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= now) {
+      this.map.delete(key);
+      return undefined;
+    }
+    entry.lastAccess = now;
+    return entry.value;
+  }
+
+  set(key, value, ttlMs, now = Date.now()) {
+    if (!this.enabled || !key || ttlMs <= 0) return false;
+    this.map.set(key, { value, expiresAt: now + ttlMs, lastAccess: now });
+    this.sweep(now);
+    return true;
+  }
+
+  sweep(now = Date.now()) {
+    for (const [key, entry] of this.map) {
+      if (entry.expiresAt <= now) this.map.delete(key);
+    }
+    while (this.map.size > this.maxEntries) {
+      let oldestKey;
+      let oldest = Infinity;
+      for (const [key, entry] of this.map) {
+        if (entry.lastAccess < oldest) {
+          oldest = entry.lastAccess;
+          oldestKey = key;
+        }
+      }
+      if (!oldestKey) break;
+      this.map.delete(oldestKey);
+    }
+  }
+}

--- a/extensions/auto-recall/src/config.js
+++ b/extensions/auto-recall/src/config.js
@@ -1,0 +1,153 @@
+import path from "node:path";
+import { HttpBackend } from "./backends/http.js";
+import { ScriptBackend } from "./backends/script.js";
+
+/** Default auto-recall plugin configuration. */
+export const DEFAULT_CONFIG = Object.freeze({
+  enabled: true,
+  agents: [],
+  allowedChatTypes: ["direct", "group"],
+  timeoutMs: 7000,
+  maxResults: 5,
+  minConfidence: 0.4,
+  allowDegraded: false,
+  logPath: undefined,
+  recallMinChars: 8,
+  recallMaxChars: 8000,
+  triggers: { customPath: undefined, reloadSignal: "SIGUSR2" },
+  cache: {
+    enabled: true,
+    okTtlMs: 30 * 60_000,
+    notFoundTtlMs: 10 * 60_000,
+    degradedTtlMs: 30 * 60_000,
+    errorTtlMs: 0,
+    maxEntries: 500,
+  },
+  injection: { maxLength: 2000, tag: "active_memory", includeSources: true },
+  backends: [],
+});
+
+function int(value, fallback, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.min(max, Math.max(min, Math.trunc(n))) : fallback;
+}
+
+function num(value, fallback, min = 0, max = 1) {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : fallback;
+}
+
+function strArray(value, fallback = []) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === "string" && item.trim()).map((item) => item.trim())
+    : fallback;
+}
+
+function object(value, fallback = {}) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : fallback;
+}
+
+/**
+ * Normalize user-provided plugin configuration into bounded runtime settings.
+ * @param {unknown} raw Raw plugin configuration.
+ * @returns {object} Normalized configuration.
+ */
+export function normalizeConfig(raw = {}) {
+  const c = raw && typeof raw === "object" ? raw : {};
+  const cache = { ...DEFAULT_CONFIG.cache, ...object(c.cache) };
+  const injection = { ...DEFAULT_CONFIG.injection, ...object(c.injection) };
+  const triggers = { ...DEFAULT_CONFIG.triggers, ...object(c.triggers) };
+  const reloadSignal =
+    triggers.reloadSignal === false
+      ? false
+      : typeof triggers.reloadSignal === "string" && triggers.reloadSignal.trim()
+        ? triggers.reloadSignal.trim()
+        : DEFAULT_CONFIG.triggers.reloadSignal;
+  return {
+    enabled: c.enabled !== false,
+    agents: strArray(c.agents, DEFAULT_CONFIG.agents),
+    allowedChatTypes: strArray(c.allowedChatTypes, DEFAULT_CONFIG.allowedChatTypes),
+    timeoutMs: int(c.timeoutMs, DEFAULT_CONFIG.timeoutMs, 100, 60_000),
+    maxResults: int(c.maxResults, DEFAULT_CONFIG.maxResults, 1, 50),
+    minConfidence: num(c.minConfidence, DEFAULT_CONFIG.minConfidence),
+    allowDegraded: Boolean(c.allowDegraded),
+    logPath:
+      typeof c.logPath === "string" && c.logPath.trim() ? path.resolve(c.logPath) : undefined,
+    recallMinChars: int(c.recallMinChars, DEFAULT_CONFIG.recallMinChars, 1, 50_000),
+    recallMaxChars: int(c.recallMaxChars, DEFAULT_CONFIG.recallMaxChars, 100, 100_000),
+    triggers: {
+      customPath:
+        typeof triggers.customPath === "string" && triggers.customPath.trim()
+          ? path.resolve(triggers.customPath)
+          : undefined,
+      reloadSignal,
+    },
+    cache: {
+      enabled: cache.enabled !== false,
+      okTtlMs: int(cache.okTtlMs ?? cache.successTtlMs, DEFAULT_CONFIG.cache.okTtlMs, 0),
+      notFoundTtlMs: int(
+        cache.notFoundTtlMs ?? cache.negativeTtlMs,
+        DEFAULT_CONFIG.cache.notFoundTtlMs,
+        0,
+      ),
+      degradedTtlMs: int(
+        cache.degradedTtlMs,
+        cache.okTtlMs ?? cache.successTtlMs ?? DEFAULT_CONFIG.cache.degradedTtlMs,
+        0,
+      ),
+      errorTtlMs: int(cache.errorTtlMs, DEFAULT_CONFIG.cache.errorTtlMs, 0),
+      maxEntries: int(cache.maxEntries, DEFAULT_CONFIG.cache.maxEntries, 1, 50_000),
+    },
+    injection: {
+      maxLength: int(injection.maxLength, DEFAULT_CONFIG.injection.maxLength, 100, 50_000),
+      tag:
+        typeof injection.tag === "string" && /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(injection.tag)
+          ? injection.tag
+          : DEFAULT_CONFIG.injection.tag,
+      includeSources: injection.includeSources !== false,
+    },
+    backends: Array.isArray(c.backends) ? c.backends : [],
+  };
+}
+
+/**
+ * Instantiate configured backends while skipping malformed entries.
+ * @param {{backends: Array<object>}} config Normalized plugin configuration.
+ * @param {{warn?: Function}} [logger] Logger used for backend configuration failures.
+ * @returns {Array<object>} Backend instances.
+ */
+export function createBackends(config, logger) {
+  const backends = [];
+  for (const [index, backend] of config.backends.entries()) {
+    try {
+      if (!backend || typeof backend !== "object")
+        throw new Error(`backend ${index} must be an object`);
+      if (backend.type === "http") backends.push(new HttpBackend(backend));
+      else if (backend.type === "script") backends.push(new ScriptBackend(backend));
+      else throw new Error(`unsupported backend type: ${backend.type}`);
+    } catch (error) {
+      logger?.warn?.({
+        event: "backend_config_failed",
+        index,
+        error: error?.message || String(error),
+      });
+    }
+  }
+  return backends;
+}
+
+/**
+ * Infer OpenClaw chat type from hook context or event metadata.
+ * @param {object} [ctx={}] Hook context.
+ * @param {object} [event={}] Hook event.
+ * @returns {string|null} `direct`, `group`, or null when unknown/unsupported.
+ */
+export function deriveChatType(ctx = {}, event = {}) {
+  if (typeof ctx.chatType === "string") return ctx.chatType;
+  if (typeof event.chatType === "string") return event.chatType;
+  const key = ctx.sessionKey || event.sessionKey || event?.metadata?.sessionKey || "";
+  if (/:group:/i.test(key)) return "group";
+  if (/:direct:/i.test(key)) return "direct";
+  if (ctx.messageProvider && ctx.messageProvider !== "telegram") return null;
+  return null;
+}

--- a/extensions/auto-recall/src/config.js
+++ b/extensions/auto-recall/src/config.js
@@ -120,11 +120,16 @@ export function createBackends(config, logger) {
   const backends = [];
   for (const [index, backend] of config.backends.entries()) {
     try {
-      if (!backend || typeof backend !== "object")
+      if (!backend || typeof backend !== "object") {
         throw new Error(`backend ${index} must be an object`);
-      if (backend.type === "http") backends.push(new HttpBackend(backend));
-      else if (backend.type === "script") backends.push(new ScriptBackend(backend));
-      else throw new Error(`unsupported backend type: ${backend.type}`);
+      }
+      if (backend.type === "http") {
+        backends.push(new HttpBackend(backend));
+      } else if (backend.type === "script") {
+        backends.push(new ScriptBackend(backend));
+      } else {
+        throw new Error(`unsupported backend type: ${backend.type}`);
+      }
     } catch (error) {
       logger?.warn?.({
         event: "backend_config_failed",
@@ -143,11 +148,21 @@ export function createBackends(config, logger) {
  * @returns {string|null} `direct`, `group`, or null when unknown/unsupported.
  */
 export function deriveChatType(ctx = {}, event = {}) {
-  if (typeof ctx.chatType === "string") return ctx.chatType;
-  if (typeof event.chatType === "string") return event.chatType;
+  if (typeof ctx.chatType === "string") {
+    return ctx.chatType;
+  }
+  if (typeof event.chatType === "string") {
+    return event.chatType;
+  }
   const key = ctx.sessionKey || event.sessionKey || event?.metadata?.sessionKey || "";
-  if (/:group:/i.test(key)) return "group";
-  if (/:direct:/i.test(key)) return "direct";
-  if (ctx.messageProvider && ctx.messageProvider !== "telegram") return null;
+  if (/:group:/i.test(key)) {
+    return "group";
+  }
+  if (/:direct:/i.test(key)) {
+    return "direct";
+  }
+  if (ctx.messageProvider && ctx.messageProvider !== "telegram") {
+    return null;
+  }
   return null;
 }

--- a/extensions/auto-recall/src/inflight.js
+++ b/extensions/auto-recall/src/inflight.js
@@ -1,0 +1,23 @@
+/**
+ * De-duplicate concurrent async work by key and clean up after settlement.
+ */
+export class InflightDeduper {
+  constructor() {
+    this.map = new Map();
+  }
+
+  run(key, fn) {
+    if (this.map.has(key)) return { promise: this.map.get(key), hit: true };
+    const promise = Promise.resolve()
+      .then(fn)
+      .finally(() => {
+        this.map.delete(key);
+      });
+    this.map.set(key, promise);
+    return { promise, hit: false };
+  }
+
+  size() {
+    return this.map.size;
+  }
+}

--- a/extensions/auto-recall/src/inflight.js
+++ b/extensions/auto-recall/src/inflight.js
@@ -7,7 +7,9 @@ export class InflightDeduper {
   }
 
   run(key, fn) {
-    if (this.map.has(key)) return { promise: this.map.get(key), hit: true };
+    if (this.map.has(key)) {
+      return { promise: this.map.get(key), hit: true };
+    }
     const promise = Promise.resolve()
       .then(fn)
       .finally(() => {

--- a/extensions/auto-recall/src/injection.js
+++ b/extensions/auto-recall/src/injection.js
@@ -5,15 +5,16 @@
  */
 export function hasActiveMemoryMarker(text) {
   return /<active_memory(?:_plugin)?>[\s\S]*?<\/active_memory(?:_plugin)?>/i.test(
-    String(text || ""),
+    text == null ? "" : String(text),
   );
 }
 
 function formatSources(sources = []) {
   const lines = [];
   for (const source of sources.slice(0, 8)) {
-    if (typeof source === "string") lines.push(`- ${escapeMemoryText(source)}`);
-    else if (source?.title || source?.uri || source?.id || source?.excerpt) {
+    if (typeof source === "string") {
+      lines.push(`- ${escapeMemoryText(source)}`);
+    } else if (source?.title || source?.uri || source?.id || source?.excerpt) {
       const label = escapeMemoryText(source.title || source.uri || source.id || "source");
       const suffix = source.score !== undefined ? ` (${Number(source.score).toFixed(3)})` : "";
       lines.push(
@@ -25,9 +26,7 @@ function formatSources(sources = []) {
 }
 
 function escapeMemoryText(value) {
-  return String(value || "")
-    .replaceAll("<", "‹")
-    .replaceAll(">", "›");
+  return (value == null ? "" : String(value)).replaceAll("<", "‹").replaceAll(">", "›");
 }
 
 /**
@@ -41,14 +40,19 @@ export function buildInjection(
   { maxLength = 2000, tag = "active_memory", includeSources = true } = {},
 ) {
   const answer = escapeMemoryText(result?.answer).trim();
-  if (!answer) return "";
+  if (!answer) {
+    return "";
+  }
   const confidence = Number.isFinite(Number(result.confidence))
     ? Number(result.confidence).toFixed(2)
     : "0.00";
   const sourceLines = includeSources ? formatSources(result.sources) : [];
   let body = `Recall confidence: ${confidence}\n\n${answer}`;
-  if (sourceLines.length) body += `\n\nSources:\n${sourceLines.join("\n")}`;
-  if (body.length > maxLength)
+  if (sourceLines.length) {
+    body += `\n\nSources:\n${sourceLines.join("\n")}`;
+  }
+  if (body.length > maxLength) {
     body = `${body.slice(0, Math.max(0, maxLength - 30)).trimEnd()}\n…[recall truncated]`;
+  }
   return `<${tag}>\n${body}\n</${tag}>`;
 }

--- a/extensions/auto-recall/src/injection.js
+++ b/extensions/auto-recall/src/injection.js
@@ -1,0 +1,54 @@
+/**
+ * Detect whether prompt text already contains an active memory block.
+ * @param {unknown} text Prompt text.
+ * @returns {boolean} True when an active memory marker is present.
+ */
+export function hasActiveMemoryMarker(text) {
+  return /<active_memory(?:_plugin)?>[\s\S]*?<\/active_memory(?:_plugin)?>/i.test(
+    String(text || ""),
+  );
+}
+
+function formatSources(sources = []) {
+  const lines = [];
+  for (const source of sources.slice(0, 8)) {
+    if (typeof source === "string") lines.push(`- ${escapeMemoryText(source)}`);
+    else if (source?.title || source?.uri || source?.id || source?.excerpt) {
+      const label = escapeMemoryText(source.title || source.uri || source.id || "source");
+      const suffix = source.score !== undefined ? ` (${Number(source.score).toFixed(3)})` : "";
+      lines.push(
+        `- ${label}${suffix}${source.excerpt ? ` — ${escapeMemoryText(source.excerpt)}` : ""}`,
+      );
+    }
+  }
+  return lines;
+}
+
+function escapeMemoryText(value) {
+  return String(value || "")
+    .replaceAll("<", "‹")
+    .replaceAll(">", "›");
+}
+
+/**
+ * Build bounded XML-like recall context for prompt prepending.
+ * @param {{answer?: string, confidence?: number, sources?: Array<object|string>}} result Recall result.
+ * @param {{maxLength?: number, tag?: string, includeSources?: boolean}} [options={}] Injection options.
+ * @returns {string|undefined} Injection text, or undefined when no answer exists.
+ */
+export function buildInjection(
+  result,
+  { maxLength = 2000, tag = "active_memory", includeSources = true } = {},
+) {
+  const answer = escapeMemoryText(result?.answer).trim();
+  if (!answer) return "";
+  const confidence = Number.isFinite(Number(result.confidence))
+    ? Number(result.confidence).toFixed(2)
+    : "0.00";
+  const sourceLines = includeSources ? formatSources(result.sources) : [];
+  let body = `Recall confidence: ${confidence}\n\n${answer}`;
+  if (sourceLines.length) body += `\n\nSources:\n${sourceLines.join("\n")}`;
+  if (body.length > maxLength)
+    body = `${body.slice(0, Math.max(0, maxLength - 30)).trimEnd()}\n…[recall truncated]`;
+  return `<${tag}>\n${body}\n</${tag}>`;
+}

--- a/extensions/auto-recall/src/logging.js
+++ b/extensions/auto-recall/src/logging.js
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function bounded(value, max = 1000) {
+  if (typeof value !== "string") return value;
+  return value.length > max
+    ? `${value.slice(0, max)}…[truncated ${value.length - max} chars]`
+    : value;
+}
+
+const DIAGNOSTIC_LOG_FIELDS = new Set(["code", "httpStatus", "latencyMs", "reason", "signal"]);
+
+function sanitizeDiagnostics(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => DIAGNOSTIC_LOG_FIELDS.has(String(key)))
+      .map(([key, item]) => [key, bounded(item)]),
+  );
+}
+
+function sanitize(value) {
+  if (!value || typeof value !== "object") return bounded(value);
+  if (Array.isArray(value)) return value.slice(0, 20).map(sanitize);
+  return Object.fromEntries(
+    Object.entries(value).map(([key, item]) => {
+      if (String(key) === "diagnostics") return [key, sanitizeDiagnostics(item)];
+      return [key, sanitize(item)];
+    }),
+  );
+}
+
+/**
+ * Create an allowlisted diagnostics logger with optional JSONL output.
+ * @param {{logPath?: string, consoleLogger?: {info?: Function, warn?: Function}}} [options={}] Logger options.
+ * @returns {{info: Function, warn: Function}} Logger facade.
+ */
+export function createLogger({ logPath, consoleLogger = console } = {}) {
+  let warned = false;
+  const filePath = logPath ? path.resolve(logPath) : null;
+
+  async function write(level, obj) {
+    const entry = sanitize({ ts: new Date().toISOString(), level, ...obj });
+    if (filePath) {
+      try {
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.appendFile(filePath, JSON.stringify(entry) + "\n", "utf8");
+      } catch (error) {
+        if (!warned) {
+          warned = true;
+          consoleLogger?.warn?.(
+            "auto-recall: log path unwritable; continuing",
+            error?.message || error,
+          );
+        }
+      }
+    }
+    if (level === "warn") consoleLogger?.warn?.(entry);
+    else consoleLogger?.info?.(entry);
+  }
+
+  return {
+    info(obj) {
+      void write("info", typeof obj === "string" ? { message: obj } : obj);
+    },
+    warn(obj) {
+      void write("warn", typeof obj === "string" ? { message: obj } : obj);
+    },
+  };
+}

--- a/extensions/auto-recall/src/logging.js
+++ b/extensions/auto-recall/src/logging.js
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 function bounded(value, max = 1000) {
-  if (typeof value !== "string") return value;
+  if (typeof value !== "string") {
+    return value;
+  }
   return value.length > max
     ? `${value.slice(0, max)}…[truncated ${value.length - max} chars]`
     : value;
@@ -11,7 +13,9 @@ function bounded(value, max = 1000) {
 const DIAGNOSTIC_LOG_FIELDS = new Set(["code", "httpStatus", "latencyMs", "reason", "signal"]);
 
 function sanitizeDiagnostics(value) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
   return Object.fromEntries(
     Object.entries(value)
       .filter(([key]) => DIAGNOSTIC_LOG_FIELDS.has(String(key)))
@@ -20,11 +24,17 @@ function sanitizeDiagnostics(value) {
 }
 
 function sanitize(value) {
-  if (!value || typeof value !== "object") return bounded(value);
-  if (Array.isArray(value)) return value.slice(0, 20).map(sanitize);
+  if (!value || typeof value !== "object") {
+    return bounded(value);
+  }
+  if (Array.isArray(value)) {
+    return value.slice(0, 20).map(sanitize);
+  }
   return Object.fromEntries(
     Object.entries(value).map(([key, item]) => {
-      if (String(key) === "diagnostics") return [key, sanitizeDiagnostics(item)];
+      if (String(key) === "diagnostics") {
+        return [key, sanitizeDiagnostics(item)];
+      }
       return [key, sanitize(item)];
     }),
   );
@@ -55,8 +65,11 @@ export function createLogger({ logPath, consoleLogger = console } = {}) {
         }
       }
     }
-    if (level === "warn") consoleLogger?.warn?.(entry);
-    else consoleLogger?.info?.(entry);
+    if (level === "warn") {
+      consoleLogger?.warn?.(entry);
+    } else {
+      consoleLogger?.info?.(entry);
+    }
   }
 
   return {

--- a/extensions/auto-recall/src/plugin.js
+++ b/extensions/auto-recall/src/plugin.js
@@ -1,0 +1,284 @@
+import { RecallCache, cacheKeyFor, normalizeCacheText } from "./cache.js";
+import { createBackends, deriveChatType, normalizeConfig } from "./config.js";
+import { InflightDeduper } from "./inflight.js";
+import { buildInjection, hasActiveMemoryMarker } from "./injection.js";
+import { createLogger } from "./logging.js";
+import { isSyntheticOrInternalEnvelope, stripEnvelope } from "./strip-envelope.js";
+import { createTriggerManager, getRecallTrigger, isInternalPrompt } from "./triggers.js";
+
+let currentRuntime;
+
+function sessionKeyFor(ctx = {}, event = {}) {
+  return (
+    ctx.sessionKey ||
+    event.sessionKey ||
+    event?.metadata?.sessionKey ||
+    ctx.conversationId ||
+    event.conversationId ||
+    event?.metadata?.conversationId
+  );
+}
+
+function providerFor(ctx = {}, event = {}) {
+  return (
+    ctx.messageProvider ||
+    event.messageProvider ||
+    event?.metadata?.messageProvider ||
+    event?.metadata?.provider
+  );
+}
+
+function eligible(ctx, event, cfg) {
+  const agentId = ctx?.agentId || event?.agentId || event?.metadata?.agentId;
+  if (cfg.agents.length && (!agentId || !cfg.agents.includes(agentId)))
+    return { ok: false, reason: "agent" };
+  if (ctx?.trigger && ctx.trigger !== "user") return { ok: false, reason: "trigger" };
+  const chatType = deriveChatType(ctx, event);
+  if (!chatType || !cfg.allowedChatTypes.includes(chatType))
+    return { ok: false, reason: "chat_type", chatType };
+  return {
+    ok: true,
+    agentId,
+    chatType,
+    provider: providerFor(ctx, event),
+    sessionKey: sessionKeyFor(ctx, event),
+  };
+}
+
+function timeoutController(parents, ms) {
+  const controller = new AbortController();
+  const signals = (Array.isArray(parents) ? parents : [parents]).filter(Boolean);
+  const abort = (event) => {
+    const signal = event?.target;
+    controller.abort(signal?.reason || new Error("aborted"));
+  };
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason || new Error("aborted"));
+      break;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  }
+  const timer = setTimeout(() => controller.abort(new Error("timeout")), ms).unref?.();
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      signals.forEach((signal) => signal.removeEventListener?.("abort", abort));
+    },
+  };
+}
+
+function shouldCache(result) {
+  if (result?.cache?.cacheable === false) return false;
+  if (result?.diagnostics?.reason === "timeout" || result?.diagnostics?.reason === "aborted")
+    return false;
+  return ["ok", "not_found", "degraded", "error"].includes(result?.status);
+}
+
+async function runBackendChain({ backends, request, cache, inflight, logger }) {
+  const degradedCandidates = [];
+  for (const backend of backends) {
+    const cacheProbeKey = cacheKeyFor({
+      backend,
+      text: request.normalizedText,
+      session: request.session,
+    });
+    const cached = cache.get(cacheProbeKey);
+    if (cached) {
+      logger.info({
+        event: "cache_hit",
+        backend: backend.name,
+        status: cached.status,
+        confidence: cached.confidence,
+      });
+      if (cached.status === "ok" && Number(cached.confidence) >= request.minConfidence)
+        return { result: cached, backend, cached: true };
+      if (
+        cached.status === "degraded" &&
+        request.allowDegraded &&
+        Number(cached.confidence) >= request.minConfidence
+      )
+        return { result: cached, backend, cached: true };
+      continue;
+    }
+
+    const { promise, hit } = inflight.run(cacheProbeKey, async () => backend.query(request));
+    if (hit) logger.info({ event: "inflight_hit", backend: backend.name });
+    const result = await promise;
+    const fullCacheKey = cacheKeyFor({
+      backend,
+      text: request.normalizedText,
+      session: request.session,
+      suffix: result?.cache?.keySuffix || "",
+    });
+
+    logger.info({
+      event: "backend_result",
+      backend: backend.name,
+      kind: backend.kind,
+      status: result.status,
+      confidence: result.confidence,
+      diagnostics: result.diagnostics,
+    });
+
+    if (shouldCache(result)) {
+      const ttl = cache.ttlFor(result.status, result.cache?.ttlMs);
+      if (cache.set(fullCacheKey, result, ttl))
+        logger.info({
+          event: "cache_set",
+          backend: backend.name,
+          status: result.status,
+          ttlMs: ttl,
+        });
+      if (fullCacheKey !== cacheProbeKey) cache.set(cacheProbeKey, result, ttl);
+    }
+
+    if (result.status === "ok" && Number(result.confidence) >= request.minConfidence)
+      return { result, backend };
+    if (result.status === "degraded" && Number(result.confidence) >= request.minConfidence)
+      degradedCandidates.push({ result, backend });
+  }
+  if (request.allowDegraded && degradedCandidates.length) return degradedCandidates[0];
+  return {
+    result: degradedCandidates[0]?.result || { status: "not_found", confidence: 0 },
+    backend: degradedCandidates[0]?.backend,
+  };
+}
+
+/**
+ * Create the OpenClaw `before_prompt_build` hook handler for a runtime.
+ * @param {object} runtime Auto-recall runtime from `createRuntime`.
+ * @returns {Function} Async OpenClaw hook handler.
+ */
+export function createBeforePromptBuildHandler(runtime) {
+  return async function beforePromptBuild(event = {}, ctx = {}) {
+    const { cfg, backends, triggers, cache, inflight, logger } = runtime;
+    if (runtime.disposed || runtime.signal?.aborted) return undefined;
+    if (!cfg.enabled || !backends.length) return undefined;
+    const ok = eligible(ctx, event, cfg);
+    if (!ok.ok) return undefined;
+
+    const original = event.prompt || event.text || event.message || "";
+    if (!original || hasActiveMemoryMarker(original) || isSyntheticOrInternalEnvelope(original))
+      return undefined;
+    const text = stripEnvelope(original).slice(0, cfg.recallMaxChars);
+    if (text.length < cfg.recallMinChars || isInternalPrompt(text, triggers.getSnapshot()))
+      return undefined;
+
+    const triggerSnapshot = triggers.getSnapshot();
+    const trigger = getRecallTrigger(text, triggerSnapshot);
+    if (!trigger.match) return undefined;
+
+    const parentSignal = ctx?.signal || event?.signal;
+    const { signal, cleanup } = timeoutController([runtime.signal, parentSignal], cfg.timeoutMs);
+    try {
+      const request = {
+        text,
+        normalizedText: normalizeCacheText(text),
+        trigger: { patternId: trigger.patternId, matchedText: trigger.matchedText },
+        maxResults: cfg.maxResults,
+        minConfidence: cfg.minConfidence,
+        allowDegraded: cfg.allowDegraded,
+        timeoutMs: cfg.timeoutMs,
+        signal,
+        locale: undefined,
+        session: {
+          agentId: ok.agentId,
+          provider: ok.provider,
+          chatType: ok.chatType,
+          sessionKey: ok.sessionKey,
+        },
+      };
+      const { result, backend, cached } = await runBackendChain({
+        backends,
+        request,
+        cache,
+        inflight,
+        logger,
+      });
+      if (!result || result.status === "not_found" || result.status === "error") return undefined;
+      if (result.status === "degraded" && !cfg.allowDegraded) return undefined;
+      if (Number(result.confidence) < cfg.minConfidence) return undefined;
+      const injection = buildInjection(result, cfg.injection);
+      if (!injection) return undefined;
+      logger.info({
+        event: "injected",
+        backend: backend?.name,
+        cached: Boolean(cached),
+        confidence: result.confidence,
+        status: result.status,
+        trigger: trigger.patternId,
+      });
+      return { prependContext: injection };
+    } catch (error) {
+      logger.warn({ event: "exception", error: error?.message || String(error) });
+      return undefined;
+    } finally {
+      cleanup();
+    }
+  };
+}
+
+/**
+ * Create plugin runtime state, including config, backends, cache, and triggers.
+ * @param {object} [pluginConfig={}] Raw plugin configuration.
+ * @param {{info?: Function, warn?: Function}} [apiLogger=console] Host logger.
+ * @returns {object} Runtime with `dispose`.
+ */
+export function createRuntime(pluginConfig = {}, apiLogger = console) {
+  const cfg = normalizeConfig(pluginConfig);
+  const logger = createLogger({ logPath: cfg.logPath, consoleLogger: apiLogger });
+  const triggers = createTriggerManager({
+    customPath: cfg.triggers.customPath,
+    reloadSignal: cfg.triggers.reloadSignal,
+    logger,
+  });
+  const controller = new AbortController();
+  let backends = [];
+  backends = createBackends(cfg, logger);
+  const runtime = {
+    cfg,
+    logger,
+    triggers,
+    backends,
+    cache: new RecallCache(cfg.cache),
+    inflight: new InflightDeduper(),
+    signal: controller.signal,
+    disposed: false,
+    dispose: async () => {
+      runtime.disposed = true;
+      controller.abort(new Error("disposed"));
+      triggers.dispose();
+      await Promise.allSettled(backends.map((backend) => backend.dispose?.()));
+    },
+  };
+  return runtime;
+}
+
+/** OpenClaw plugin entry point. */
+export const plugin = {
+  id: "auto-recall",
+  name: "Auto Recall",
+  description:
+    "Triggers recall backends from user questions and injects relevant memory into the prompt.",
+  register(api) {
+    if (currentRuntime) void currentRuntime.dispose();
+    currentRuntime = createRuntime(api.pluginConfig || {}, api.logger || console);
+    if (!currentRuntime.cfg.enabled) {
+      api.logger?.info?.("auto-recall: disabled");
+      return;
+    }
+    api.on("before_prompt_build", createBeforePromptBuildHandler(currentRuntime));
+  },
+};
+
+export {
+  deriveChatType,
+  getRecallTrigger,
+  hasActiveMemoryMarker,
+  isInternalPrompt,
+  isSyntheticOrInternalEnvelope,
+  normalizeCacheText,
+  stripEnvelope,
+};

--- a/extensions/auto-recall/src/plugin.js
+++ b/extensions/auto-recall/src/plugin.js
@@ -6,8 +6,6 @@ import { createLogger } from "./logging.js";
 import { isSyntheticOrInternalEnvelope, stripEnvelope } from "./strip-envelope.js";
 import { createTriggerManager, getRecallTrigger, isInternalPrompt } from "./triggers.js";
 
-let currentRuntime;
-
 function sessionKeyFor(ctx = {}, event = {}) {
   return (
     ctx.sessionKey ||
@@ -263,13 +261,18 @@ export const plugin = {
   description:
     "Triggers recall backends from user questions and injects relevant memory into the prompt.",
   register(api) {
-    if (currentRuntime) void currentRuntime.dispose();
-    currentRuntime = createRuntime(api.pluginConfig || {}, api.logger || console);
-    if (!currentRuntime.cfg.enabled) {
+    const runtime = createRuntime(api.pluginConfig || {}, api.logger || console);
+    if (!runtime.cfg.enabled) {
       api.logger?.info?.("auto-recall: disabled");
-      return;
+      return () => {
+        void runtime.dispose();
+      };
     }
-    api.on("before_prompt_build", createBeforePromptBuildHandler(currentRuntime));
+    const unsubscribe = api.on("before_prompt_build", createBeforePromptBuildHandler(runtime));
+    return () => {
+      if (typeof unsubscribe === "function") unsubscribe();
+      void runtime.dispose();
+    };
   },
 };
 

--- a/extensions/auto-recall/src/plugin.js
+++ b/extensions/auto-recall/src/plugin.js
@@ -28,12 +28,16 @@ function providerFor(ctx = {}, event = {}) {
 
 function eligible(ctx, event, cfg) {
   const agentId = ctx?.agentId || event?.agentId || event?.metadata?.agentId;
-  if (cfg.agents.length && (!agentId || !cfg.agents.includes(agentId)))
+  if (cfg.agents.length && (!agentId || !cfg.agents.includes(agentId))) {
     return { ok: false, reason: "agent" };
-  if (ctx?.trigger && ctx.trigger !== "user") return { ok: false, reason: "trigger" };
+  }
+  if (ctx?.trigger && ctx.trigger !== "user") {
+    return { ok: false, reason: "trigger" };
+  }
   const chatType = deriveChatType(ctx, event);
-  if (!chatType || !cfg.allowedChatTypes.includes(chatType))
+  if (!chatType || !cfg.allowedChatTypes.includes(chatType)) {
     return { ok: false, reason: "chat_type", chatType };
+  }
   return {
     ok: true,
     agentId,
@@ -68,9 +72,12 @@ function timeoutController(parents, ms) {
 }
 
 function shouldCache(result) {
-  if (result?.cache?.cacheable === false) return false;
-  if (result?.diagnostics?.reason === "timeout" || result?.diagnostics?.reason === "aborted")
+  if (result?.cache?.cacheable === false) {
     return false;
+  }
+  if (result?.diagnostics?.reason === "timeout" || result?.diagnostics?.reason === "aborted") {
+    return false;
+  }
   return ["ok", "not_found", "degraded", "error"].includes(result?.status);
 }
 
@@ -90,19 +97,23 @@ async function runBackendChain({ backends, request, cache, inflight, logger }) {
         status: cached.status,
         confidence: cached.confidence,
       });
-      if (cached.status === "ok" && Number(cached.confidence) >= request.minConfidence)
+      if (cached.status === "ok" && Number(cached.confidence) >= request.minConfidence) {
         return { result: cached, backend, cached: true };
+      }
       if (
         cached.status === "degraded" &&
         request.allowDegraded &&
         Number(cached.confidence) >= request.minConfidence
-      )
+      ) {
         return { result: cached, backend, cached: true };
+      }
       continue;
     }
 
     const { promise, hit } = inflight.run(cacheProbeKey, async () => backend.query(request));
-    if (hit) logger.info({ event: "inflight_hit", backend: backend.name });
+    if (hit) {
+      logger.info({ event: "inflight_hit", backend: backend.name });
+    }
     const result = await promise;
     const fullCacheKey = cacheKeyFor({
       backend,
@@ -122,22 +133,29 @@ async function runBackendChain({ backends, request, cache, inflight, logger }) {
 
     if (shouldCache(result)) {
       const ttl = cache.ttlFor(result.status, result.cache?.ttlMs);
-      if (cache.set(fullCacheKey, result, ttl))
+      if (cache.set(fullCacheKey, result, ttl)) {
         logger.info({
           event: "cache_set",
           backend: backend.name,
           status: result.status,
           ttlMs: ttl,
         });
-      if (fullCacheKey !== cacheProbeKey) cache.set(cacheProbeKey, result, ttl);
+      }
+      if (fullCacheKey !== cacheProbeKey) {
+        cache.set(cacheProbeKey, result, ttl);
+      }
     }
 
-    if (result.status === "ok" && Number(result.confidence) >= request.minConfidence)
+    if (result.status === "ok" && Number(result.confidence) >= request.minConfidence) {
       return { result, backend };
-    if (result.status === "degraded" && Number(result.confidence) >= request.minConfidence)
+    }
+    if (result.status === "degraded" && Number(result.confidence) >= request.minConfidence) {
       degradedCandidates.push({ result, backend });
+    }
   }
-  if (request.allowDegraded && degradedCandidates.length) return degradedCandidates[0];
+  if (request.allowDegraded && degradedCandidates.length) {
+    return degradedCandidates[0];
+  }
   return {
     result: degradedCandidates[0]?.result || { status: "not_found", confidence: 0 },
     backend: degradedCandidates[0]?.backend,
@@ -152,21 +170,31 @@ async function runBackendChain({ backends, request, cache, inflight, logger }) {
 export function createBeforePromptBuildHandler(runtime) {
   return async function beforePromptBuild(event = {}, ctx = {}) {
     const { cfg, backends, triggers, cache, inflight, logger } = runtime;
-    if (runtime.disposed || runtime.signal?.aborted) return undefined;
-    if (!cfg.enabled || !backends.length) return undefined;
+    if (runtime.disposed || runtime.signal?.aborted) {
+      return undefined;
+    }
+    if (!cfg.enabled || !backends.length) {
+      return undefined;
+    }
     const ok = eligible(ctx, event, cfg);
-    if (!ok.ok) return undefined;
+    if (!ok.ok) {
+      return undefined;
+    }
 
     const original = event.prompt || event.text || event.message || "";
-    if (!original || hasActiveMemoryMarker(original) || isSyntheticOrInternalEnvelope(original))
+    if (!original || hasActiveMemoryMarker(original) || isSyntheticOrInternalEnvelope(original)) {
       return undefined;
+    }
     const text = stripEnvelope(original).slice(0, cfg.recallMaxChars);
-    if (text.length < cfg.recallMinChars || isInternalPrompt(text, triggers.getSnapshot()))
+    if (text.length < cfg.recallMinChars || isInternalPrompt(text, triggers.getSnapshot())) {
       return undefined;
+    }
 
     const triggerSnapshot = triggers.getSnapshot();
     const trigger = getRecallTrigger(text, triggerSnapshot);
-    if (!trigger.match) return undefined;
+    if (!trigger.match) {
+      return undefined;
+    }
 
     const parentSignal = ctx?.signal || event?.signal;
     const { signal, cleanup } = timeoutController([runtime.signal, parentSignal], cfg.timeoutMs);
@@ -195,11 +223,19 @@ export function createBeforePromptBuildHandler(runtime) {
         inflight,
         logger,
       });
-      if (!result || result.status === "not_found" || result.status === "error") return undefined;
-      if (result.status === "degraded" && !cfg.allowDegraded) return undefined;
-      if (Number(result.confidence) < cfg.minConfidence) return undefined;
+      if (!result || result.status === "not_found" || result.status === "error") {
+        return undefined;
+      }
+      if (result.status === "degraded" && !cfg.allowDegraded) {
+        return undefined;
+      }
+      if (Number(result.confidence) < cfg.minConfidence) {
+        return undefined;
+      }
       const injection = buildInjection(result, cfg.injection);
-      if (!injection) return undefined;
+      if (!injection) {
+        return undefined;
+      }
       logger.info({
         event: "injected",
         backend: backend?.name,
@@ -270,7 +306,9 @@ export const plugin = {
     }
     const unsubscribe = api.on("before_prompt_build", createBeforePromptBuildHandler(runtime));
     return () => {
-      if (typeof unsubscribe === "function") unsubscribe();
+      if (typeof unsubscribe === "function") {
+        unsubscribe();
+      }
       void runtime.dispose();
     };
   },

--- a/extensions/auto-recall/src/strip-envelope.js
+++ b/extensions/auto-recall/src/strip-envelope.js
@@ -1,0 +1,99 @@
+/**
+ * Check for OpenClaw timestamp envelope lines.
+ * @param {unknown} line Candidate line.
+ * @returns {boolean} True when the line is a timestamp envelope.
+ */
+export function isEnvelopeDateLine(line) {
+  return /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\]/i.test(
+    String(line || "").trim(),
+  );
+}
+
+/**
+ * Remove transport/runtime metadata envelopes before trigger matching.
+ * @param {unknown} text Raw event text.
+ * @returns {string} User-visible text.
+ */
+export function stripEnvelope(text) {
+  if (!text) return "";
+  const lines = String(text).split("\n");
+  const body = [];
+  let state = "normal";
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    if (state === "json_fence") {
+      if (trimmed === "```") state = "normal";
+      continue;
+    }
+
+    if (state === "metadata_header") {
+      if (trimmed.startsWith("```json")) {
+        state = "json_fence";
+        continue;
+      }
+      if (!trimmed) {
+        state = "normal";
+        continue;
+      }
+      state = "normal";
+      continue;
+    }
+
+    if (state === "queued_header") {
+      if (!trimmed || trimmed === "---" || /^Queued #\d+/i.test(trimmed)) continue;
+      state = "normal";
+      i -= 1;
+      continue;
+    }
+
+    if (
+      /^(Conversation info|Sender\b|Replied message|Forwarded message)/i.test(trimmed) ||
+      (/^[A-Za-z][\w -]{0,80}:\s*(?:\(untrusted metadata\))?$/i.test(trimmed) &&
+        lines[i + 1]?.trim().startsWith("```json"))
+    ) {
+      state = "metadata_header";
+      continue;
+    }
+    if (/^\[media attached/i.test(trimmed)) continue;
+    if (/^\[Queued (?:announce )?messages while agent was busy\]/i.test(trimmed)) {
+      state = "queued_header";
+      continue;
+    }
+    if (/^\[(?:Subagent Context|Internal task completion event)\]/i.test(trimmed)) continue;
+    if (/^System:\s*\[.*\]\s*Telegram reaction added:/i.test(trimmed)) continue;
+
+    if (isEnvelopeDateLine(trimmed)) {
+      const rest = trimmed.replace(
+        /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\]\s*/i,
+        "",
+      );
+      if (/^\[(Subagent Context|Internal task completion event)\]/i.test(rest)) continue;
+    }
+
+    body.push(line);
+  }
+
+  return body.join("\n").replace(/^\s+|\s+$/g, "");
+}
+
+/**
+ * Detect envelopes that should never trigger recall.
+ * @param {unknown} text Raw event text.
+ * @returns {boolean} True for synthetic/internal envelopes.
+ */
+export function isSyntheticOrInternalEnvelope(text) {
+  const value = String(text || "").trim();
+  return (
+    /^\[Queued announce messages while agent was busy\]/i.test(value) ||
+    /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\] \[Subagent Context\]/i.test(
+      value,
+    ) ||
+    /^\[Internal task completion event\]/i.test(value) ||
+    /^System:\s*\[.*\]\s*Telegram reaction added:/i.test(value) ||
+    /^runtime context \(internal\)/i.test(value) ||
+    /^<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>/i.test(value)
+  );
+}

--- a/extensions/auto-recall/src/strip-envelope.js
+++ b/extensions/auto-recall/src/strip-envelope.js
@@ -5,7 +5,7 @@
  */
 export function isEnvelopeDateLine(line) {
   return /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\]/i.test(
-    String(line || "").trim(),
+    (line == null ? "" : String(line)).trim(),
   );
 }
 
@@ -15,7 +15,9 @@ export function isEnvelopeDateLine(line) {
  * @returns {string} User-visible text.
  */
 export function stripEnvelope(text) {
-  if (!text) return "";
+  if (!text) {
+    return "";
+  }
   const lines = String(text).split("\n");
   const body = [];
   let state = "normal";
@@ -25,7 +27,9 @@ export function stripEnvelope(text) {
     const trimmed = line.trim();
 
     if (state === "json_fence") {
-      if (trimmed === "```") state = "normal";
+      if (trimmed === "```") {
+        state = "normal";
+      }
       continue;
     }
 
@@ -43,7 +47,9 @@ export function stripEnvelope(text) {
     }
 
     if (state === "queued_header") {
-      if (!trimmed || trimmed === "---" || /^Queued #\d+/i.test(trimmed)) continue;
+      if (!trimmed || trimmed === "---" || /^Queued #\d+/i.test(trimmed)) {
+        continue;
+      }
       state = "normal";
       i -= 1;
       continue;
@@ -57,20 +63,28 @@ export function stripEnvelope(text) {
       state = "metadata_header";
       continue;
     }
-    if (/^\[media attached/i.test(trimmed)) continue;
+    if (/^\[media attached/i.test(trimmed)) {
+      continue;
+    }
     if (/^\[Queued (?:announce )?messages while agent was busy\]/i.test(trimmed)) {
       state = "queued_header";
       continue;
     }
-    if (/^\[(?:Subagent Context|Internal task completion event)\]/i.test(trimmed)) continue;
-    if (/^System:\s*\[.*\]\s*Telegram reaction added:/i.test(trimmed)) continue;
+    if (/^\[(?:Subagent Context|Internal task completion event)\]/i.test(trimmed)) {
+      continue;
+    }
+    if (/^System:\s*\[.*\]\s*Telegram reaction added:/i.test(trimmed)) {
+      continue;
+    }
 
     if (isEnvelopeDateLine(trimmed)) {
       const rest = trimmed.replace(
         /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\]\s*/i,
         "",
       );
-      if (/^\[(Subagent Context|Internal task completion event)\]/i.test(rest)) continue;
+      if (/^\[(Subagent Context|Internal task completion event)\]/i.test(rest)) {
+        continue;
+      }
     }
 
     body.push(line);
@@ -85,7 +99,7 @@ export function stripEnvelope(text) {
  * @returns {boolean} True for synthetic/internal envelopes.
  */
 export function isSyntheticOrInternalEnvelope(text) {
-  const value = String(text || "").trim();
+  const value = (text == null ? "" : String(text)).trim();
   return (
     /^\[Queued announce messages while agent was busy\]/i.test(value) ||
     /^\[(Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\] \[Subagent Context\]/i.test(

--- a/extensions/auto-recall/src/triggers.js
+++ b/extensions/auto-recall/src/triggers.js
@@ -153,22 +153,20 @@ export function normalizeTriggers(raw = {}) {
 }
 
 function compileWordRegex(items) {
-  if (!items.length) return null;
+  if (!items.length) {
+    return null;
+  }
   return new RegExp(
     `(^|\\P{L})(${items
       .map(escapeRegex)
-      .sort((a, b) => b.length - a.length)
+      .toSorted((a, b) => b.length - a.length)
       .join("|")})(?=\\P{L}|$)`,
     "iu",
   );
 }
 
 function tokenize(text) {
-  return (
-    String(text || "")
-      .toLowerCase()
-      .match(/[\p{L}]+/gu) || []
-  );
+  return (text == null ? "" : String(text)).toLowerCase().match(/[\p{L}]+/gu) || [];
 }
 
 /**
@@ -211,7 +209,9 @@ export function defaultTriggerSnapshot() {
 }
 
 export async function loadTriggerSnapshot(customPath, previousRaw = null) {
-  if (!customPath) return defaultTriggerSnapshot();
+  if (!customPath) {
+    return defaultTriggerSnapshot();
+  }
   const raw = JSON.parse(await fs.readFile(customPath, "utf8"));
   const compiled = compileTriggers(raw);
   const stat = await fs.stat(customPath);
@@ -232,7 +232,9 @@ export async function loadTriggerSnapshot(customPath, previousRaw = null) {
  * @returns {object} Per-category count deltas.
  */
 export function diffTriggers(oldRaw, newRaw) {
-  if (!oldRaw) return {};
+  if (!oldRaw) {
+    return {};
+  }
   const added = {};
   const removed = {};
   for (const key of Object.keys(DEFAULT_TRIGGERS)) {
@@ -240,8 +242,12 @@ export function diffTriggers(oldRaw, newRaw) {
     const newSet = new Set(newRaw[key] || []);
     const add = [...newSet].filter((item) => !oldSet.has(item));
     const rem = [...oldSet].filter((item) => !newSet.has(item));
-    if (add.length) added[key] = add;
-    if (rem.length) removed[key] = rem;
+    if (add.length) {
+      added[key] = add;
+    }
+    if (rem.length) {
+      removed[key] = rem;
+    }
   }
   return {
     ...(Object.keys(added).length ? { added } : {}),
@@ -256,7 +262,7 @@ export function diffTriggers(oldRaw, newRaw) {
  * @returns {boolean} True when text is internal prompt content.
  */
 export function isInternalPrompt(text, snapshot = defaultTriggerSnapshot()) {
-  const value = String(text || "").trim();
+  const value = (text == null ? "" : String(text)).trim();
   return snapshot.internalPromptPatterns.some((pattern) => pattern.test(value));
 }
 
@@ -267,26 +273,38 @@ export function isInternalPrompt(text, snapshot = defaultTriggerSnapshot()) {
  * @returns {{match: boolean, patternId?: string, matchedText?: string, reason?: string}} Trigger decision.
  */
 export function getRecallTrigger(text, snapshot = defaultTriggerSnapshot()) {
-  const value = String(text || "");
-  if (!value.trim()) return { match: false };
-  if (isInternalPrompt(value, snapshot)) return { match: false, reason: "internal_prompt" };
+  const value = text == null ? "" : String(text);
+  if (!value.trim()) {
+    return { match: false };
+  }
+  if (isInternalPrompt(value, snapshot)) {
+    return { match: false, reason: "internal_prompt" };
+  }
 
   for (const [patternId, re] of [
     ["memory_keyword", snapshot.memoryKeywordRe],
     ["past_reference", snapshot.pastReferenceRe],
     ["named_entity", snapshot.namedEntityRe],
   ]) {
-    if (!re) continue;
+    if (!re) {
+      continue;
+    }
     const matched = value.match(re);
-    if (matched) return { match: true, patternId, matchedText: matched[2] || matched[0] };
+    if (matched) {
+      return { match: true, patternId, matchedText: matched[2] || matched[0] };
+    }
   }
 
   const words = tokenize(value);
   const hasQuestion = words.some((word) => snapshot.questionWords.has(word));
   const hasPastVerb = words.some((word) => snapshot.pastVerbs.has(word));
-  if (hasQuestion && hasPastVerb) return { match: true, patternId: "past_tense_question" };
+  if (hasQuestion && hasPastVerb) {
+    return { match: true, patternId: "past_tense_question" };
+  }
 
-  if (snapshot.whitelistRe?.test(value)) return { match: false, reason: "whitelisted_term" };
+  if (snapshot.whitelistRe?.test(value)) {
+    return { match: false, reason: "whitelisted_term" };
+  }
   return { match: false };
 }
 
@@ -301,7 +319,9 @@ export function createTriggerManager({ customPath, reloadSignal = "SIGUSR2", log
   let reloading = Promise.resolve();
 
   async function reload(reason = "manual") {
-    if (!customPath || disposed) return snapshot;
+    if (!customPath || disposed) {
+      return snapshot;
+    }
     reloading = reloading.then(async () => {
       try {
         const next = await loadTriggerSnapshot(customPath, snapshot.raw);
@@ -342,14 +362,18 @@ export function createTriggerManager({ customPath, reloadSignal = "SIGUSR2", log
       });
     }
   }
-  if (customPath) void reload("startup");
+  if (customPath) {
+    void reload("startup");
+  }
 
   return {
     getSnapshot: () => snapshot,
     reload,
     dispose() {
       disposed = true;
-      if (signalRegistered && typeof process?.off === "function") process.off(signalName, onSignal);
+      if (signalRegistered && typeof process?.off === "function") {
+        process.off(signalName, onSignal);
+      }
     },
   };
 }

--- a/extensions/auto-recall/src/triggers.js
+++ b/extensions/auto-recall/src/triggers.js
@@ -1,0 +1,355 @@
+import fs from "node:fs/promises";
+
+/** Built-in English/Russian trigger lists and internal prompt filters. */
+export const DEFAULT_TRIGGERS = Object.freeze({
+  past_tense_questions: [
+    "what",
+    "when",
+    "where",
+    "why",
+    "who",
+    "which",
+    "how",
+    "что",
+    "когда",
+    "где",
+    "почему",
+    "кто",
+    "какой",
+    "какая",
+    "какое",
+    "какие",
+    "как",
+  ],
+  past_tense_verbs: [
+    "did",
+    "decided",
+    "said",
+    "discussed",
+    "wrote",
+    "planned",
+    "agreed",
+    "built",
+    "fixed",
+    "closed",
+    "bought",
+    "sold",
+    "was",
+    "were",
+    "было",
+    "были",
+    "был",
+    "была",
+    "делал",
+    "делала",
+    "делали",
+    "решил",
+    "решила",
+    "решили",
+    "обсуждал",
+    "обсуждала",
+    "обсуждали",
+    "писал",
+    "писала",
+    "писали",
+    "говорил",
+    "говорила",
+    "говорили",
+    "планировал",
+    "планировали",
+    "закрыл",
+    "закрыли",
+    "купил",
+    "продал",
+  ],
+  memory_keywords: [
+    "remember",
+    "recall",
+    "remind me",
+    "do you remember",
+    "what did we",
+    "what was",
+    "помнишь",
+    "вспомни",
+    "напомни",
+    "что мы",
+    "что было",
+    "как мы",
+  ],
+  past_references: [
+    "last time",
+    "earlier",
+    "previously",
+    "before",
+    "we discussed",
+    "we decided",
+    "our plan",
+    "в прошлый раз",
+    "раньше",
+    "до этого",
+    "мы обсуждали",
+    "мы решили",
+    "наш план",
+  ],
+  named_entities: [],
+  internal_prompt_denylist: [
+    "You are a memory search agent",
+    "System (untrusted):",
+    "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+    "[Subagent Context]",
+    "Runtime context (internal)",
+  ],
+  term_whitelist: [
+    "OpenClaw",
+    "Mnemostack",
+    "Qdrant",
+    "Memgraph",
+    "Gemini",
+    "Hetzner",
+    "Selectel",
+    "Yandex",
+    "Tailscale",
+    "SearXNG",
+    "API",
+    "JSON",
+    "CLI",
+    "HTTP",
+    "PR",
+    "CI",
+  ],
+});
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stringArray(name, value) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string" || !item.trim())) {
+    throw new Error(`${name} must be an array of non-empty strings`);
+  }
+  return [...new Set(value.map((item) => item.trim()))];
+}
+
+/**
+ * Normalize a triggers file into arrays of non-empty strings.
+ * @param {unknown} raw Raw triggers configuration.
+ * @returns {object} Normalized triggers.
+ */
+export function normalizeTriggers(raw = {}) {
+  const merged = { ...DEFAULT_TRIGGERS, ...(raw && typeof raw === "object" ? raw : {}) };
+  return Object.freeze({
+    past_tense_questions: Object.freeze(
+      stringArray("past_tense_questions", merged.past_tense_questions),
+    ),
+    past_tense_verbs: Object.freeze(stringArray("past_tense_verbs", merged.past_tense_verbs)),
+    memory_keywords: Object.freeze(stringArray("memory_keywords", merged.memory_keywords)),
+    past_references: Object.freeze(stringArray("past_references", merged.past_references)),
+    named_entities: Object.freeze(stringArray("named_entities", merged.named_entities)),
+    internal_prompt_denylist: Object.freeze(
+      stringArray("internal_prompt_denylist", merged.internal_prompt_denylist),
+    ),
+    term_whitelist: Object.freeze(stringArray("term_whitelist", merged.term_whitelist || [])),
+  });
+}
+
+function compileWordRegex(items) {
+  if (!items.length) return null;
+  return new RegExp(
+    `(^|\\P{L})(${items
+      .map(escapeRegex)
+      .sort((a, b) => b.length - a.length)
+      .join("|")})(?=\\P{L}|$)`,
+    "iu",
+  );
+}
+
+function tokenize(text) {
+  return (
+    String(text || "")
+      .toLowerCase()
+      .match(/[\p{L}]+/gu) || []
+  );
+}
+
+/**
+ * Compile normalized triggers into runtime regexes and lookup sets.
+ * @param {object} raw Normalized triggers.
+ * @returns {object} Compiled trigger snapshot.
+ */
+export function compileTriggers(raw) {
+  const cfg = normalizeTriggers(raw);
+  const compiled = Object.freeze({
+    raw: cfg,
+    memoryKeywordRe: compileWordRegex(cfg.memory_keywords),
+    pastReferenceRe: compileWordRegex(cfg.past_references),
+    namedEntityRe: compileWordRegex(cfg.named_entities),
+    whitelistRe: compileWordRegex(cfg.term_whitelist),
+    internalPromptPatterns: Object.freeze(
+      cfg.internal_prompt_denylist.map((item) => new RegExp(`^${escapeRegex(item)}`, "i")),
+    ),
+    questionWords: new Set(cfg.past_tense_questions.map((item) => item.toLowerCase())),
+    pastVerbs: new Set(cfg.past_tense_verbs.map((item) => item.toLowerCase())),
+    counts: Object.freeze(
+      Object.fromEntries(Object.entries(cfg).map(([key, value]) => [key, value.length])),
+    ),
+  });
+  return compiled;
+}
+
+/**
+ * Build the default immutable trigger snapshot.
+ * @returns {object} Default trigger snapshot.
+ */
+export function defaultTriggerSnapshot() {
+  const compiled = compileTriggers(DEFAULT_TRIGGERS);
+  return Object.freeze({
+    ...compiled,
+    sourcePath: "defaults",
+    version: `defaults-${JSON.stringify(compiled.counts)}`,
+    loadedAt: new Date().toISOString(),
+  });
+}
+
+export async function loadTriggerSnapshot(customPath, previousRaw = null) {
+  if (!customPath) return defaultTriggerSnapshot();
+  const raw = JSON.parse(await fs.readFile(customPath, "utf8"));
+  const compiled = compileTriggers(raw);
+  const stat = await fs.stat(customPath);
+  return Object.freeze({
+    ...compiled,
+    sourcePath: customPath,
+    version: `${Math.trunc(stat.mtimeMs)}-${JSON.stringify(compiled.counts)}`,
+    loadedAt: new Date().toISOString(),
+    mtimeMs: stat.mtimeMs,
+    delta: diffTriggers(previousRaw, compiled.raw),
+  });
+}
+
+/**
+ * Summarize trigger category size changes.
+ * @param {object} oldRaw Previous raw trigger config.
+ * @param {object} newRaw Next raw trigger config.
+ * @returns {object} Per-category count deltas.
+ */
+export function diffTriggers(oldRaw, newRaw) {
+  if (!oldRaw) return {};
+  const added = {};
+  const removed = {};
+  for (const key of Object.keys(DEFAULT_TRIGGERS)) {
+    const oldSet = new Set(oldRaw[key] || []);
+    const newSet = new Set(newRaw[key] || []);
+    const add = [...newSet].filter((item) => !oldSet.has(item));
+    const rem = [...oldSet].filter((item) => !newSet.has(item));
+    if (add.length) added[key] = add;
+    if (rem.length) removed[key] = rem;
+  }
+  return {
+    ...(Object.keys(added).length ? { added } : {}),
+    ...(Object.keys(removed).length ? { removed } : {}),
+  };
+}
+
+/**
+ * Check whether text matches the internal prompt denylist.
+ * @param {unknown} text Text to inspect.
+ * @param {object} [snapshot=defaultTriggerSnapshot()] Compiled trigger snapshot.
+ * @returns {boolean} True when text is internal prompt content.
+ */
+export function isInternalPrompt(text, snapshot = defaultTriggerSnapshot()) {
+  const value = String(text || "").trim();
+  return snapshot.internalPromptPatterns.some((pattern) => pattern.test(value));
+}
+
+/**
+ * Match user text against recall trigger patterns.
+ * @param {unknown} text User-visible text.
+ * @param {object} [snapshot=defaultTriggerSnapshot()] Compiled trigger snapshot.
+ * @returns {{match: boolean, patternId?: string, matchedText?: string, reason?: string}} Trigger decision.
+ */
+export function getRecallTrigger(text, snapshot = defaultTriggerSnapshot()) {
+  const value = String(text || "");
+  if (!value.trim()) return { match: false };
+  if (isInternalPrompt(value, snapshot)) return { match: false, reason: "internal_prompt" };
+
+  for (const [patternId, re] of [
+    ["memory_keyword", snapshot.memoryKeywordRe],
+    ["past_reference", snapshot.pastReferenceRe],
+    ["named_entity", snapshot.namedEntityRe],
+  ]) {
+    if (!re) continue;
+    const matched = value.match(re);
+    if (matched) return { match: true, patternId, matchedText: matched[2] || matched[0] };
+  }
+
+  const words = tokenize(value);
+  const hasQuestion = words.some((word) => snapshot.questionWords.has(word));
+  const hasPastVerb = words.some((word) => snapshot.pastVerbs.has(word));
+  if (hasQuestion && hasPastVerb) return { match: true, patternId: "past_tense_question" };
+
+  if (snapshot.whitelistRe?.test(value)) return { match: false, reason: "whitelisted_term" };
+  return { match: false };
+}
+
+/**
+ * Create a hot-reloadable trigger snapshot manager.
+ * @param {{customPath?: string, reloadSignal?: string|false, logger?: {info?: Function, warn?: Function}}} [options={}] Trigger manager options.
+ * @returns {{getSnapshot: Function, reload: Function, dispose: Function}} Trigger manager.
+ */
+export function createTriggerManager({ customPath, reloadSignal = "SIGUSR2", logger } = {}) {
+  let snapshot = defaultTriggerSnapshot();
+  let disposed = false;
+  let reloading = Promise.resolve();
+
+  async function reload(reason = "manual") {
+    if (!customPath || disposed) return snapshot;
+    reloading = reloading.then(async () => {
+      try {
+        const next = await loadTriggerSnapshot(customPath, snapshot.raw);
+        snapshot = next;
+        logger?.info?.({
+          event: "triggers_reloaded",
+          reason,
+          sourcePath: next.sourcePath,
+          version: next.version,
+          delta: next.delta,
+        });
+      } catch (error) {
+        logger?.warn?.({
+          event: "triggers_reload_failed",
+          reason,
+          error: error?.message || String(error),
+        });
+      }
+      return snapshot;
+    });
+    return reloading;
+  }
+
+  const signalName = reloadSignal === false ? undefined : reloadSignal;
+  const onSignal = () => {
+    void reload(signalName);
+  };
+  let signalRegistered = false;
+  if (customPath && signalName && typeof process?.on === "function") {
+    try {
+      process.on(signalName, onSignal);
+      signalRegistered = true;
+    } catch (error) {
+      logger?.warn?.({
+        event: "triggers_signal_failed",
+        signal: signalName,
+        error: error?.message || String(error),
+      });
+    }
+  }
+  if (customPath) void reload("startup");
+
+  return {
+    getSnapshot: () => snapshot,
+    reload,
+    dispose() {
+      disposed = true;
+      if (signalRegistered && typeof process?.off === "function") process.off(signalName, onSignal);
+    },
+  };
+}

--- a/extensions/auto-recall/test/auto-recall.test.js
+++ b/extensions/auto-recall/test/auto-recall.test.js
@@ -423,6 +423,43 @@ test("ScriptBackend uses argv/stdin protocols and does not invoke a shell", asyn
   assert.ok(abortedResult.diagnostics.latencyMs < 100);
 });
 
+test("ScriptBackend handles missing timeout and fast-exit stdin safely", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-script-edge-"));
+  const okScript = path.join(tmp, "ok.mjs");
+  await fs.writeFile(okScript, "console.log(JSON.stringify({answer:'no timeout',confidence:.9}))\n");
+  const noTimeoutBackend = new ScriptBackend({
+    command: process.execPath,
+    args: [okScript],
+    queryMode: "arg",
+    protocol: "json",
+  });
+  const noTimeout = await noTimeoutBackend.query({
+    text: "hello",
+    normalizedText: "hello",
+    trigger: {},
+    signal: new AbortController().signal,
+  });
+  assert.equal(noTimeout.status, "ok");
+  assert.equal(noTimeout.answer, "no timeout");
+
+  const fastExitScript = path.join(tmp, "fast-exit.mjs");
+  await fs.writeFile(fastExitScript, "process.exit(0)\n");
+  const fastExitBackend = new ScriptBackend({
+    command: process.execPath,
+    args: [fastExitScript],
+    queryMode: "stdin",
+    protocol: "json",
+    timeoutMs: 1000,
+  });
+  const fastExit = await fastExitBackend.query({
+    text: "x".repeat(1024 * 1024),
+    normalizedText: "x",
+    trigger: {},
+    signal: new AbortController().signal,
+  });
+  assert.ok(["not_found", "error"].includes(fastExit.status));
+});
+
 test("cache isolation uses sessionKey from event metadata when ctx omits it", async () => {
   const seen = [];
   const server = http.createServer((req, res) => {
@@ -754,6 +791,22 @@ test("hot reload keeps last-known-good trigger snapshot on malformed config", as
 
 test("plugin entry registers and helpers work", () => {
   assert.equal(typeof plugin.register, "function");
+  const handlers = [];
+  const cleanup = plugin.register({
+    pluginConfig: { backends: [{ type: "http", url: "http://127.0.0.1:1" }] },
+    logger: { info() {}, warn() {} },
+    on(name, handler) {
+      handlers.push({ name, handler });
+      return () => {
+        handlers.length = 0;
+      };
+    },
+  });
+  assert.equal(handlers.length, 1);
+  assert.equal(handlers[0].name, "before_prompt_build");
+  assert.equal(typeof cleanup, "function");
+  cleanup();
+  assert.equal(handlers.length, 0);
   assert.equal(
     deriveChatType({ messageProvider: "telegram", sessionKey: "agent:main:telegram:group:-100" }),
     "group",

--- a/extensions/auto-recall/test/auto-recall.test.js
+++ b/extensions/auto-recall/test/auto-recall.test.js
@@ -426,7 +426,10 @@ test("ScriptBackend uses argv/stdin protocols and does not invoke a shell", asyn
 test("ScriptBackend handles missing timeout and fast-exit stdin safely", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-script-edge-"));
   const okScript = path.join(tmp, "ok.mjs");
-  await fs.writeFile(okScript, "console.log(JSON.stringify({answer:'no timeout',confidence:.9}))\n");
+  await fs.writeFile(
+    okScript,
+    "console.log(JSON.stringify({answer:'no timeout',confidence:.9}))\n",
+  );
   const noTimeoutBackend = new ScriptBackend({
     command: process.execPath,
     args: [okScript],

--- a/extensions/auto-recall/test/auto-recall.test.js
+++ b/extensions/auto-recall/test/auto-recall.test.js
@@ -1,0 +1,767 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import plugin, {
+  RecallCache,
+  InflightDeduper,
+  HttpBackend,
+  ScriptBackend,
+  buildInjection,
+  cacheKeyFor,
+  compileTriggers,
+  createBeforePromptBuildHandler,
+  createLogger,
+  createRuntime,
+  deriveChatType,
+  getRecallTrigger,
+  hasActiveMemoryMarker,
+  mapJsonToResult,
+  normalizeConfig,
+  normalizeCacheText,
+  parseScriptOutput,
+  stripEnvelope,
+} from "../index.js";
+
+test("trigger defaults catch recall questions and avoid whitelisted tech false positives", () => {
+  for (const text of [
+    "what did we decide?",
+    "что было",
+    "кто был?",
+    "какой был план?",
+    "помнишь что решили",
+  ]) {
+    assert.equal(getRecallTrigger(text).match, true, text);
+  }
+  for (const term of [
+    "OpenClaw",
+    "Mnemostack",
+    "Qdrant",
+    "Memgraph",
+    "Gemini",
+    "Hetzner",
+    "Selectel",
+    "Yandex",
+    "Tailscale",
+    "SearXNG",
+  ]) {
+    assert.equal(getRecallTrigger(`status ${term}`).match, false, term);
+  }
+  const snapshot = compileTriggers({
+    named_entities: ["Ada Lovelace"],
+    memory_keywords: ["remember"],
+    past_references: ["last time"],
+    past_tense_questions: ["what"],
+    past_tense_verbs: ["did"],
+    internal_prompt_denylist: ["Internal"],
+    term_whitelist: [],
+  });
+  assert.deepEqual(getRecallTrigger("what about Ada Lovelace", snapshot), {
+    match: true,
+    patternId: "named_entity",
+    matchedText: "Ada Lovelace",
+  });
+});
+
+test("stripEnvelope handles metadata and queued wrappers without dropping real date text", () => {
+  assert.equal(
+    stripEnvelope("Conversation info (untrusted metadata):\n```json\n{}\n```\nчто было"),
+    "что было",
+  );
+  assert.equal(
+    stripEnvelope('Sender (untrusted metadata):\n```json\n{"id":1}\n```\nhello'),
+    "hello",
+  );
+  assert.equal(stripEnvelope('Runtime metadata:\n```json\n{"provider":"x"}\n```\nhello'), "hello");
+  assert.equal(
+    stripEnvelope("[Queued messages while agent was busy]\n\n---\nQueued #1\nactual question"),
+    "actual question",
+  );
+  assert.equal(stripEnvelope("[media attached: /tmp/a.png]\ncaption"), "caption");
+  assert.equal(
+    stripEnvelope("[Sat 2026-04-25 16:01 UTC] keep this\nbody"),
+    "[Sat 2026-04-25 16:01 UTC] keep this\nbody",
+  );
+});
+
+test("config and backend numeric limits normalize malformed nested values", () => {
+  const cfg = normalizeConfig({
+    cache: "bad",
+    injection: "bad",
+    triggers: { reloadSignal: false },
+    timeoutMs: "999999",
+  });
+  assert.equal(cfg.cache.maxEntries, 500);
+  assert.equal(cfg.injection.maxLength, 2000);
+  assert.equal(cfg.triggers.reloadSignal, false);
+  assert.equal(cfg.timeoutMs, 60000);
+
+  const httpBackend = new HttpBackend({
+    url: "http://127.0.0.1:1",
+    headers: "bad",
+    timeoutMs: -1,
+    maxResponseBytes: 12,
+    bodyTemplate: "bad",
+    responseMapping: "bad",
+  });
+  assert.equal(httpBackend.config.timeoutMs, 100);
+  assert.equal(httpBackend.config.maxResponseBytes, 1024);
+  assert.deepEqual(httpBackend.config.headers, {});
+  assert.deepEqual(httpBackend.config.bodyTemplate, {});
+
+  const scriptBackend = new ScriptBackend({
+    command: process.execPath,
+    env: "bad",
+    timeoutMs: 999999,
+    maxStdoutBytes: 12,
+    maxStderrBytes: 12,
+  });
+  assert.equal(scriptBackend.config.timeoutMs, 60000);
+  assert.equal(scriptBackend.config.maxStdoutBytes, 1024);
+  assert.equal(scriptBackend.config.maxStderrBytes, 1024);
+  assert.deepEqual(scriptBackend.config.env, {});
+});
+
+test("cache keys include backend config hash and in-flight cleanup runs on rejection", async () => {
+  const a = { kind: "http", name: "a", configHash: "1" };
+  const b = { kind: "http", name: "a", configHash: "2" };
+  assert.notEqual(
+    cacheKeyFor({ backend: a, text: "same" }),
+    cacheKeyFor({ backend: b, text: "same" }),
+  );
+  assert.notEqual(
+    cacheKeyFor({ backend: a, text: "same", session: { sessionKey: "chat-a" } }),
+    cacheKeyFor({ backend: a, text: "same", session: { sessionKey: "chat-b" } }),
+  );
+  assert.equal(normalizeCacheText("  WHAT   was? "), "what was?");
+
+  const cache = new RecallCache({ okTtlMs: 5, notFoundTtlMs: 50, maxEntries: 1 });
+  cache.set("a", { status: "ok" }, cache.ttlFor("ok"));
+  assert.equal(cache.get("a").status, "ok");
+  await new Promise((resolve) => setTimeout(resolve, 8));
+  assert.equal(cache.get("a"), undefined);
+  cache.set("b", { status: "not_found" }, 1000);
+  cache.set("c", { status: "ok" }, 1000);
+  assert.equal(cache.get("b"), undefined);
+  assert.equal(cache.get("c").status, "ok");
+
+  const inflight = new InflightDeduper();
+  await assert.rejects(
+    inflight.run("x", async () => {
+      throw new Error("boom");
+    }).promise,
+  );
+  assert.equal(inflight.size(), 0);
+});
+
+test("HttpBackend maps JSON, bounds malformed responses, and plugin integrates with mock server", async () => {
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    hits += 1;
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      assert.match(body, /MockEntity/);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          answer: "mock answer",
+          confidence: 0.82,
+          sources: [{ title: "doc", score: 0.9 }],
+        }),
+      );
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const url = `http://127.0.0.1:${server.address().port}/recall`;
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-http-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["MockEntity"] }));
+  const runtime = createRuntime(
+    {
+      enabled: true,
+      allowedChatTypes: ["direct"],
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url }],
+      cache: { okTtlMs: 60000 },
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  const handler = createBeforePromptBuildHandler(runtime);
+  const ctx = {
+    agentId: "main",
+    trigger: "user",
+    messageProvider: "telegram",
+    sessionKey: "agent:main:telegram:direct:1",
+  };
+  const r1 = await handler({ prompt: "MockEntity" }, ctx);
+  assert.match(r1.prependContext, /mock answer/);
+  const r2 = await handler({ prompt: " mockentity " }, ctx);
+  assert.match(r2.prependContext, /mock answer/);
+  assert.equal(hits, 1, "second request should hit cache");
+  await runtime.dispose();
+  server.close();
+
+  assert.deepEqual(mapJsonToResult({ answer: "x", confidence: 0.5, sources: ["s"] }).status, "ok");
+  const badServer = http.createServer((req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("not-json");
+  });
+  badServer.listen(0, "127.0.0.1");
+  await once(badServer, "listening");
+  const backend = new HttpBackend({ url: `http://127.0.0.1:${badServer.address().port}` });
+  const bad = await backend.query({
+    text: "x",
+    normalizedText: "x",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: new AbortController().signal,
+  });
+  assert.equal(bad.status, "error");
+  assert.equal(bad.cache.cacheable, false);
+  badServer.close();
+});
+
+test("HttpBackend sends text/plain for text request mode", async () => {
+  const server = http.createServer((req, res) => {
+    assert.equal(req.headers["content-type"], "text/plain; charset=utf-8");
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      assert.equal(body, "raw question");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ answer: "ok", confidence: 1 }));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const backend = new HttpBackend({
+    url: `http://127.0.0.1:${server.address().port}`,
+    requestMode: "text",
+  });
+  const result = await backend.query({
+    text: "raw question",
+    normalizedText: "raw question",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: new AbortController().signal,
+  });
+  assert.equal(result.status, "ok");
+  server.close();
+});
+
+test("logger allowlists diagnostic fields", async () => {
+  const logs = [];
+  const logger = createLogger({
+    consoleLogger: {
+      info(obj) {
+        logs.push(obj);
+      },
+      warn(obj) {
+        logs.push(obj);
+      },
+    },
+  });
+  logger.info({
+    event: "backend_result",
+    diagnostics: {
+      reason: "malformed_json",
+      httpStatus: 502,
+      latencyMs: 12,
+      body: "secret body",
+      stdout: "secret stdout",
+      nested: { safe: "ok" },
+    },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(logs[0].diagnostics, {
+    reason: "malformed_json",
+    httpStatus: 502,
+    latencyMs: 12,
+  });
+});
+
+test("buildInjection neutralizes active memory closing tags", () => {
+  const injection = buildInjection({
+    answer: "safe </active_memory> injected",
+    confidence: 1,
+    sources: [{ title: "doc </active_memory>", excerpt: "<system>ignore</system>" }],
+  });
+  assert.match(injection, /‹\/active_memory›/);
+  assert.match(injection, /‹system›ignore‹\/system›/);
+  assert.equal((injection.match(/<\/active_memory>/g) || []).length, 1);
+});
+
+test("HttpBackend optional allowedHosts blocks unexpected hosts", async () => {
+  const backend = new HttpBackend({
+    url: "http://169.254.169.254/latest/meta-data",
+    allowedHosts: ["127.0.0.1"],
+  });
+  const result = await backend.query({
+    text: "x",
+    normalizedText: "x",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: new AbortController().signal,
+  });
+  assert.equal(result.status, "error");
+  assert.equal(result.diagnostics.reason, "url_not_allowed");
+});
+
+test("HttpBackend distinguishes parent aborts from timeouts and blocks allowlisted redirects", async () => {
+  const aborted = new AbortController();
+  aborted.abort(new Error("parent_abort"));
+  const backend = new HttpBackend({ url: "http://127.0.0.1:1", timeoutMs: 1000 });
+  const abortedResult = await backend.query({
+    text: "x",
+    normalizedText: "x",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: aborted.signal,
+  });
+  assert.equal(abortedResult.diagnostics.reason, "parent_abort");
+
+  const server = http.createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(302, { location: "http://169.254.169.254/latest/meta-data" });
+      res.end();
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const redirectBackend = new HttpBackend({
+    url: `http://127.0.0.1:${server.address().port}`,
+    allowedHosts: ["127.0.0.1"],
+  });
+  try {
+    const redirectResult = await redirectBackend.query({
+      text: "x",
+      normalizedText: "x",
+      trigger: {},
+      timeoutMs: 1000,
+      signal: new AbortController().signal,
+    });
+    assert.equal(redirectResult.status, "error");
+    assert.equal(redirectResult.diagnostics.reason, "redirect_blocked");
+  } finally {
+    server.close();
+  }
+});
+
+test("ScriptBackend uses argv/stdin protocols and does not invoke a shell", async () => {
+  const parsed = parseScriptOutput("ANSWER: ok\nCONFIDENCE: 0.7\nSOURCES:\n- one", "text");
+  assert.equal(parsed.status, "ok");
+  assert.equal(parsed.sources[0].title, "one");
+  assert.equal(parseScriptOutput("ANSWER:\nCONFIDENCE: .", "text").status, "error");
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-script-"));
+  const script = path.join(tmp, "recall.mjs");
+  await fs.writeFile(
+    script,
+    "process.stdin.on('data',d=>{console.log(JSON.stringify({answer:'stdin '+String(d).trim(),confidence:.9,sources:['s']}))})\n",
+  );
+  const backend = new ScriptBackend({
+    command: process.execPath,
+    args: [script],
+    queryMode: "stdin",
+    protocol: "json",
+    timeoutMs: 1000,
+  });
+  const result = await backend.query({
+    text: "hello",
+    normalizedText: "hello",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: new AbortController().signal,
+  });
+  assert.equal(result.status, "ok");
+  assert.equal(result.answer, "stdin hello");
+
+  const argScript = path.join(tmp, "arg.mjs");
+  await fs.writeFile(
+    argScript,
+    "console.log(JSON.stringify({answer:process.argv.at(-1),confidence:.8}))\n",
+  );
+  const argBackend = new ScriptBackend({
+    command: process.execPath,
+    args: [argScript],
+    queryMode: "arg",
+    queryArg: "{query}",
+    protocol: "json",
+    timeoutMs: 1000,
+  });
+  const argResult = await argBackend.query({
+    text: "a; echo hacked",
+    normalizedText: "a",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: new AbortController().signal,
+  });
+  assert.equal(argResult.answer, "a; echo hacked");
+
+  const aborted = new AbortController();
+  aborted.abort(new Error("cancelled"));
+  const abortedResult = await argBackend.query({
+    text: "late",
+    normalizedText: "late",
+    trigger: {},
+    timeoutMs: 1000,
+    signal: aborted.signal,
+  });
+  assert.equal(abortedResult.status, "error");
+  assert.equal(abortedResult.diagnostics.reason, "aborted");
+  assert.ok(abortedResult.diagnostics.latencyMs < 100);
+});
+
+test("cache isolation uses sessionKey from event metadata when ctx omits it", async () => {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      const payload = JSON.parse(body);
+      seen.push(payload.session?.sessionKey);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          status: "ok",
+          answer: `answer for ${payload.session?.sessionKey}`,
+          confidence: 0.9,
+        }),
+      );
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-session-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["SessionEntity"] }));
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url: `http://127.0.0.1:${server.address().port}` }],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  const handler = createBeforePromptBuildHandler(runtime);
+  const ctx = { trigger: "user" };
+
+  const chatA = "agent:main:telegram:direct:chat-a";
+  const chatB = "agent:main:telegram:direct:chat-b";
+  const first = await handler(
+    { prompt: "SessionEntity", metadata: { sessionKey: chatA, messageProvider: "telegram" } },
+    ctx,
+  );
+  const second = await handler(
+    { prompt: "SessionEntity", metadata: { sessionKey: chatB, messageProvider: "telegram" } },
+    ctx,
+  );
+  const third = await handler(
+    { prompt: "SessionEntity", metadata: { sessionKey: chatA, messageProvider: "telegram" } },
+    ctx,
+  );
+
+  assert.match(first.prependContext, /answer for agent:main:telegram:direct:chat-a/);
+  assert.match(second.prependContext, /answer for agent:main:telegram:direct:chat-b/);
+  assert.match(third.prependContext, /answer for agent:main:telegram:direct:chat-a/);
+  assert.deepEqual(seen, [chatA, chatB]);
+  await runtime.dispose();
+  server.close();
+});
+
+test("cache isolation falls back to conversationId when sessionKey is absent", async () => {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      const payload = JSON.parse(body);
+      seen.push(payload.session?.sessionKey);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          status: "ok",
+          answer: `answer for ${payload.session?.sessionKey}`,
+          confidence: 0.9,
+        }),
+      );
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-conversation-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["ConversationEntity"] }));
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url: `http://127.0.0.1:${server.address().port}` }],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  const handler = createBeforePromptBuildHandler(runtime);
+  const ctx = { trigger: "user", chatType: "direct", messageProvider: "telegram" };
+
+  await handler({ prompt: "ConversationEntity", conversationId: "conversation-a" }, ctx);
+  await handler({ prompt: "ConversationEntity", conversationId: "conversation-b" }, ctx);
+  await handler({ prompt: "ConversationEntity", conversationId: "conversation-a" }, ctx);
+
+  assert.deepEqual(seen, ["conversation-a", "conversation-b"]);
+  await runtime.dispose();
+  server.close();
+});
+
+test("runtime can opt out of process-wide reload signals", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-signal-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["SignalEntity"] }));
+  const before = process.listenerCount("SIGUSR2");
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath, reloadSignal: false },
+      backends: [{ type: "http", url: "http://127.0.0.1:1" }],
+    },
+    { info() {}, warn() {} },
+  );
+  assert.equal(process.listenerCount("SIGUSR2"), before);
+  await runtime.dispose();
+});
+
+test("runtime skips invalid backends and keeps valid fallbacks", async () => {
+  const server = http.createServer((req, res) => {
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", answer: "valid fallback", confidence: 0.9 }));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-invalid-backend-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["FallbackEntity"] }));
+  const warnings = [];
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [
+        { type: "script", args: ["missing-command"] },
+        { type: "http", url: `http://127.0.0.1:${server.address().port}` },
+      ],
+    },
+    {
+      info() {},
+      warn(obj) {
+        warnings.push(obj);
+      },
+    },
+  );
+  await runtime.triggers.reload("test");
+  assert.equal(runtime.backends.length, 1);
+  assert.ok(warnings.some((entry) => entry.event === "backend_config_failed"));
+  const result = await createBeforePromptBuildHandler(runtime)(
+    { prompt: "FallbackEntity" },
+    { trigger: "user", sessionKey: "agent:main:telegram:direct:1" },
+  );
+  assert.match(result.prependContext, /valid fallback/);
+  await runtime.dispose();
+  server.close();
+});
+
+test("runtime dispose aborts in-flight work and makes old handlers inert", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-dispose-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["DisposeEntity"] }));
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url: "http://127.0.0.1:1" }],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  let abortReason;
+  runtime.backends = [
+    {
+      name: "slow",
+      kind: "test",
+      configHash: "slow",
+      query(request) {
+        return new Promise((resolve) => {
+          request.signal.addEventListener(
+            "abort",
+            () => {
+              abortReason = request.signal.reason?.message || String(request.signal.reason);
+              resolve({
+                status: "error",
+                confidence: 0,
+                diagnostics: { reason: "aborted" },
+                cache: { cacheable: false },
+              });
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+  ];
+  const handler = createBeforePromptBuildHandler(runtime);
+  const pending = handler(
+    { prompt: "DisposeEntity" },
+    { trigger: "user", chatType: "direct", sessionKey: "agent:main:telegram:direct:1" },
+  );
+  await new Promise((resolve) => setImmediate(resolve));
+  await runtime.dispose();
+
+  assert.equal(await pending, undefined);
+  assert.equal(abortReason, "disposed");
+  assert.equal(
+    await handler(
+      { prompt: "DisposeEntity" },
+      { trigger: "user", chatType: "direct", sessionKey: "agent:main:telegram:direct:1" },
+    ),
+    undefined,
+  );
+});
+
+test("backend chain continues after not_found and low confidence cache", async () => {
+  let firstHits = 0;
+  let secondHits = 0;
+  const first = http.createServer((req, res) => {
+    firstHits += 1;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ status: "not_found", confidence: 0 }));
+  });
+  const second = http.createServer((req, res) => {
+    secondHits += 1;
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", answer: "fallback answer", confidence: 0.9 }));
+  });
+  first.listen(0, "127.0.0.1");
+  second.listen(0, "127.0.0.1");
+  await Promise.all([once(first, "listening"), once(second, "listening")]);
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-chain-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["ChainEntity"] }));
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [
+        { type: "http", url: `http://127.0.0.1:${first.address().port}` },
+        { type: "http", url: `http://127.0.0.1:${second.address().port}` },
+      ],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  const handler = createBeforePromptBuildHandler(runtime);
+  const ctx = {
+    trigger: "user",
+    messageProvider: "telegram",
+    sessionKey: "agent:main:telegram:direct:1",
+  };
+  const result = await handler({ prompt: "ChainEntity" }, ctx);
+  assert.match(result.prependContext, /fallback answer/);
+  const result2 = await handler({ prompt: "ChainEntity" }, ctx);
+  assert.match(result2.prependContext, /fallback answer/);
+  assert.equal(firstHits, 1, "not_found should be negative-cached per backend");
+  assert.equal(secondHits, 1, "successful fallback should be cached");
+  await runtime.dispose();
+  first.close();
+  second.close();
+});
+
+test("degraded results are cached when degraded injection is enabled", async () => {
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    hits += 1;
+    req.resume();
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "degraded", answer: "degraded answer", confidence: 0.9 }));
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-degraded-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["DegradedEntity"] }));
+  const runtime = createRuntime(
+    {
+      allowDegraded: true,
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url: `http://127.0.0.1:${server.address().port}` }],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  const handler = createBeforePromptBuildHandler(runtime);
+  const ctx = { trigger: "user", chatType: "direct", sessionKey: "agent:main:telegram:direct:1" };
+
+  try {
+    assert.match(
+      (await handler({ prompt: "DegradedEntity" }, ctx)).prependContext,
+      /degraded answer/,
+    );
+    assert.match(
+      (await handler({ prompt: "DegradedEntity" }, ctx)).prependContext,
+      /degraded answer/,
+    );
+    assert.equal(hits, 1);
+  } finally {
+    await runtime.dispose();
+    server.close();
+  }
+});
+
+test("hot reload keeps last-known-good trigger snapshot on malformed config", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "auto-recall-triggers-"));
+  const triggersPath = path.join(tmp, "triggers.json");
+  await fs.writeFile(triggersPath, JSON.stringify({ named_entities: ["OldName"] }));
+  const runtime = createRuntime(
+    {
+      triggers: { customPath: triggersPath },
+      backends: [{ type: "http", url: "http://127.0.0.1:1" }],
+    },
+    { info() {}, warn() {} },
+  );
+  await runtime.triggers.reload("test");
+  assert.equal(getRecallTrigger("OldName", runtime.triggers.getSnapshot()).match, true);
+  await fs.writeFile(triggersPath, "{ nope");
+  await runtime.triggers.reload("test");
+  assert.equal(getRecallTrigger("OldName", runtime.triggers.getSnapshot()).match, true);
+  await runtime.dispose();
+});
+
+test("plugin entry registers and helpers work", () => {
+  assert.equal(typeof plugin.register, "function");
+  assert.equal(
+    deriveChatType({ messageProvider: "telegram", sessionKey: "agent:main:telegram:group:-100" }),
+    "group",
+  );
+  assert.equal(
+    deriveChatType({ messageProvider: "webchat", sessionKey: "agent:main:webchat:1" }),
+    null,
+  );
+  assert.equal(hasActiveMemoryMarker("<active_memory>x</active_memory>"), true);
+  assert.match(buildInjection({ answer: "abc", confidence: 0.5, sources: ["s"] }), /abc/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/auto-recall:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/azure-speech:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## What this does

This PR adds `extensions/auto-recall`, a bundled OpenClaw plugin that automatically detects when a user question needs memory retrieval, queries one or more configured recall backends, and injects relevant bounded context into the prompt before the model sees it.

The plugin closes a practical behavioral gap: agents may have access to `memory_search`, but they do not always remember to call it when a conversation depends on prior context. Auto-recall makes recall automatic, transparent, and configurable while keeping the actual memory store outside the plugin.

The implementation was extracted from real production use and hardened as a universal plugin. It is intended to work with local RAG services, existing memory APIs, shell-script adapters, or any other backend that can answer a recall query.

## Why this matters

Memory only helps if it is used at the right time. In long-running assistants, the recurring failure mode is not lack of a recall tool; it is recall discipline. Models often answer from the visible transcript even when older user preferences, decisions, project context, or todos are available through memory.

Auto-recall moves that discipline into the runtime. It detects recall-style questions, runs retrieval against configured backends, and injects the result as prompt context. This plugin was born from months of production use across thousands of conversations, where automatic recall materially reduced forgotten-context failures.

## How it works

- Trigger detection using bilingual English/Russian defaults, with extension to any language via `triggers.json`.
- Backend chain with structured fallback across HTTP and Script backends.
- Result caching with chat-level isolation.
- In-flight de-duplication for identical concurrent recall requests.
- Prompt injection through a bounded, escaped envelope.
- Observability logging with redacted, allowlist-based diagnostics.

The plugin registers a `before_prompt_build` hook. When a user prompt matches recall triggers and passes eligibility checks, it builds a normalized recall request, tries the configured backends in order, validates confidence/status, and returns `prependContext` containing the safe recall envelope.

## Key features

- Pluggable backend chain: HTTP APIs and shell scripts.
- Language-agnostic trigger system with hot-reload support.
- Per-chat cache isolation using session/conversation metadata.
- AbortSignal propagation throughout runtime, HTTP, and script backends.
- SSRF protection through optional HTTP `allowedHosts` and blocked redirects.
- Diagnostics redaction using an allowlist-based logger.
- Prompt injection protection through envelope escaping and bounded output.
- 20 tests covering security, correctness, caching, backend fallback, isolation, and edge cases.

## Security

This plugin has been independently audited three times before upstreaming. All CRITICAL, HIGH, MEDIUM, and LOW findings from those reviews have been resolved.

Key hardening included in this PR:

- Script backends never use `shell: true`; commands and args are executed directly.
- Script timeouts terminate the process group to avoid orphaned child processes.
- HTTP backends support `allowedHosts` SSRF guards and block redirects when host allowlisting is enabled.
- Diagnostics logging is allowlist-based and avoids dumping arbitrary backend payloads or secrets.
- Prompt injection content is wrapped in an escaped, bounded envelope before insertion.
- AbortSignal handling is propagated through hook timeout, backend timeout, runtime disposal, HTTP fetch, and script execution.

See `extensions/auto-recall/README.md` for the full security notes and configuration reference.

## Configuration example

Minimal HTTP backend:

```json
{
  "enabled": true,
  "allowedChatTypes": ["direct", "group"],
  "minConfidence": 0.4,
  "backends": [
    {
      "type": "http",
      "url": "http://127.0.0.1:18793/recall",
      "timeoutMs": 7000
    }
  ]
}
```

Fuller configuration using HTTP host allowlisting, caching, injection bounds, diagnostics, and script fallback:

```json
{
  "enabled": true,
  "agents": ["main"],
  "allowedChatTypes": ["direct", "group"],
  "timeoutMs": 7000,
  "maxResults": 5,
  "minConfidence": 0.4,
  "allowDegraded": false,
  "logPath": "/var/log/openclaw/auto-recall.jsonl",
  "recallMinChars": 8,
  "recallMaxChars": 8000,
  "triggers": {
    "customPath": "/etc/openclaw/auto-recall-triggers.json",
    "reloadSignal": "SIGUSR2"
  },
  "cache": {
    "enabled": true,
    "okTtlMs": 1800000,
    "notFoundTtlMs": 600000,
    "degradedTtlMs": 1800000,
    "errorTtlMs": 0,
    "maxEntries": 500
  },
  "injection": {
    "maxLength": 2000,
    "tag": "active_memory"
  },
  "backends": [
    {
      "type": "http",
      "name": "local-rag",
      "url": "http://127.0.0.1:18793/recall",
      "method": "POST",
      "timeoutMs": 7000,
      "maxResponseBytes": 262144,
      "allowedHosts": ["127.0.0.1"],
      "requestMode": "default"
    },
    {
      "type": "script",
      "name": "local-script",
      "command": "/usr/local/bin/recall-answer",
      "args": ["--json"],
      "queryMode": "stdin",
      "protocol": "json",
      "timeoutMs": 7000,
      "maxStdoutBytes": 262144,
      "maxStderrBytes": 32768
    }
  ]
}
```

## Testing

`npm test` in `extensions/auto-recall` runs 20 tests covering:

- Trigger detection and false-positive avoidance.
- Config normalization and numeric bounds.
- HTTP backend mapping, response size limits, allowed hosts, and redirect blocking.
- Script backend stdin/argv protocols and no-shell execution.
- Cache isolation by session/conversation metadata.
- In-flight cleanup and backend fallback behavior.
- Prompt envelope escaping.
- Hot reload last-known-good trigger handling.
- Runtime disposal and abort behavior.

Validation run for this PR:

```text
cd extensions/auto-recall && npm test
# tests 20
# pass 20

pnpm run lint:plugins:no-extension-imports
pnpm run lint:plugins:no-register-http-handler
pnpm run lint:extensions:no-plugin-sdk-internal
```

## Migration

`extensions/auto-recall/MIGRATION.md` is included for users who already have custom recall wrappers, prompt hooks, or shell-based memory lookup. It documents how to move those setups behind an HTTP or Script backend while preserving existing retrieval logic.

## Future work

- Add a first-class `MemorySearchBackend` if/when the OpenClaw SDK exposes a stable programmatic memory API for plugins.
- Add optional language trigger packs beyond the built-in English/Russian defaults.
- Expand backend adapters if common production integrations emerge.
