### PR TITLE
fix(acpx): validate runtime session mode at wrapper boundary (#73071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
+- Acpx/runtime: validate the runtime session mode at the `AcpxRuntime.ensureSession` wrapper boundary so callers that pass anything other than `persistent` or `oneshot` get a clear `ACP_INVALID_RUNTIME_OPTION` error instead of silently round-tripping through the encoded handle as a default `persistent` mode and later throwing `SessionResumeRequiredError`. Investigation context: #73071. (#73548) Thanks @amknight.
 
 ## 2026.4.27
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AcpRuntime } from "../runtime-api.js";
+import { AcpRuntimeError, type AcpRuntime } from "../runtime-api.js";
 import { AcpxRuntime, __testing } from "./runtime.js";
 
 type TestSessionStore = {
@@ -83,6 +83,43 @@ function makeRuntime(
 describe("AcpxRuntime fresh reset wrapper", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("rejects unsupported runtime session modes with a clear AcpRuntimeError (issue #73071)", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const ensureSpy = vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude",
+    });
+
+    for (const badMode of ["run", "session", "", undefined, null, 0]) {
+      await expect(
+        runtime.ensureSession({
+          sessionKey: "agent:claude:acp:test",
+          agent: "claude",
+          mode: badMode as never,
+        }),
+      ).rejects.toMatchObject({
+        name: "AcpRuntimeError",
+        code: "ACP_INVALID_RUNTIME_OPTION",
+        message: expect.stringContaining("Unsupported ACP runtime session mode"),
+      });
+    }
+
+    expect(ensureSpy).not.toHaveBeenCalled();
+  });
+
+  it("exposes assertSupportedRuntimeSessionMode as a typed guard", () => {
+    expect(() => __testing.assertSupportedRuntimeSessionMode("persistent")).not.toThrow();
+    expect(() => __testing.assertSupportedRuntimeSessionMode("oneshot")).not.toThrow();
+    expect(() => __testing.assertSupportedRuntimeSessionMode("run" as never)).toThrow(
+      AcpRuntimeError,
+    );
   });
 
   it("normalizes OpenClaw Codex model ids for ACP startup", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -231,6 +231,25 @@ function failUnsupportedCodexAcpModel(rawModel: string, detail?: string): never 
   );
 }
 
+// acpx's `decodeAcpxRuntimeHandleState` only accepts `persistent` and `oneshot`; any other
+// value silently round-trips through the encoded handle as `persistent` and later throws
+// `SessionResumeRequiredError` on agent restart. Fail fast at this boundary instead.
+// See openclaw/openclaw#73071.
+const SUPPORTED_RUNTIME_SESSION_MODES = new Set(["persistent", "oneshot"] as const);
+
+function assertSupportedRuntimeSessionMode(
+  mode: unknown,
+): asserts mode is "persistent" | "oneshot" {
+  if (typeof mode === "string" && SUPPORTED_RUNTIME_SESSION_MODES.has(mode as never)) {
+    return;
+  }
+  const supported = Array.from(SUPPORTED_RUNTIME_SESSION_MODES).join(", ");
+  throw new AcpRuntimeError(
+    "ACP_INVALID_RUNTIME_OPTION",
+    `Unsupported ACP runtime session mode ${JSON.stringify(mode)}. Expected one of: ${supported}.`,
+  );
+}
+
 function failUnsupportedCodexAcpThinking(rawThinking: string): never {
   throw new AcpRuntimeError(
     "ACP_INVALID_RUNTIME_OPTION",
@@ -460,6 +479,7 @@ export class AcpxRuntime implements AcpRuntime {
   async ensureSession(
     input: Parameters<AcpRuntime["ensureSession"]>[0],
   ): Promise<AcpRuntimeHandle> {
+    assertSupportedRuntimeSessionMode(input.mode);
     const command = resolveAgentCommandForName({
       agentName: input.agent,
       agentRegistry: this.agentRegistry,
@@ -584,6 +604,7 @@ export {
 
 export const __testing = {
   appendCodexAcpConfigOverrides,
+  assertSupportedRuntimeSessionMode,
   codexAcpSessionModelId,
   isCodexAcpCommand,
   normalizeCodexAcpModelOverride,


### PR DESCRIPTION
## Summary

Hardens the `extensions/acpx` runtime wrapper so that an out-of-contract `mode` value passed to `AcpxRuntime.ensureSession` fails fast with a clear `AcpRuntimeError("ACP_INVALID_RUNTIME_OPTION", …)` instead of silently being encoded into a handle that decodes back to `"persistent"` + `same-session-only`.

Investigation context: openclaw/openclaw#73071.

## Why

While investigating #73071 I traced the `AcpRuntimeError: Internal error code=ACP_TURN_FAILED` chain end-to-end:

1. `claude-agent-acp@0.26.0` returns the JSON-RPC default `{code:-32603, message:"Internal error", data:{details:"Resource not found"}}` when sent a `session/load` for an unknown sessionId.
2. acpx 0.6.1 surfaces that as a runtime `error` event.
3. OpenClaw's `consumeAcpTurnStream` re-wraps it as `AcpRuntimeError("ACP_TURN_FAILED", "Internal error")`.

Along the way I found a separate **latent footgun** in our wrapper: acpx's `decodeAcpxRuntimeHandleState` only accepts `mode === "persistent" | "oneshot"`. If anything ever passes a different value (for example our own user-facing `"run"` / `"session"` vocabulary), the encoded handle decodes back to default `mode: "persistent"` → `resumePolicy: "same-session-only"` → the next `runTurn` throws the misleading `SessionResumeRequiredError("Persistent ACP session ... could not be resumed: Resource not found")` on a fresh agent process.

Today's production translation in `src/agents/acp-spawn.ts:305` (`resolveAcpSessionMode("session"|"run") → "persistent"|"oneshot"`) and the typed `AcpRuntimeSessionMode` keep this safe at the user-facing boundary — but the silent fallback was hiding type-violations and making future debugging harder. This PR makes the contract enforceable at runtime.

## What changed

- **`extensions/acpx/src/runtime.ts`** — added `assertSupportedRuntimeSessionMode()` helper next to the existing `failUnsupported*` helpers (with a `// See openclaw/openclaw#73071` comment), and called it at the top of `AcpxRuntime.ensureSession()`.
- **`extensions/acpx/src/runtime.test.ts`** — two regression tests:
  - One that drives the wrapper with `"run"`, `"session"`, `""`, `undefined`, `null`, `0`, asserts the `AcpRuntimeError("ACP_INVALID_RUNTIME_OPTION", "Unsupported ACP runtime session mode …")` shape, and verifies the underlying delegate is never called.
  - One direct unit on the helper through `__testing.assertSupportedRuntimeSessionMode`.
- **`scripts/repro/issue-73071/`** — repro harness used to nail down the fault (stub adapter + drivers against the real `extensions/acpx/src/runtime.ts` wrapper and against `claude-agent-acp@0.26.0`). Documented in `README.md`. Runs in ~30s against a fresh checkout.

## Verification

- `pnpm test extensions/acpx/src/runtime.test.ts` — **24/24 passing** (2 new + 22 existing) in 0.66s
- `pnpm check:changed --staged` — `typecheck extensions`, `typecheck extension tests`, `lint extensions`, `oxfmt` all green for touched files
- Targeted `oxfmt --check` on all 7 files — clean
- End-to-end repro against `claude-agent-acp@0.26.0`: `mode:"run"` (typed bypass) reproduces the silent fallback before the patch and now fails with `ACP_INVALID_RUNTIME_OPTION`; `mode:"oneshot"` and `mode:"persistent"` continue to work and return `stopReason:"end_turn"`.

## Scope notes

- This does **not** claim to close #73071. The reporter's specific failure (single `sessions_spawn({mode:"run"})` from a clean boot producing `ACP_TURN_FAILED` in ~2s with 0 tokens) does not reproduce against `acpx@0.6.1` + `claude-agent-acp@0.26.0` in a clean repro environment, so we still need diagnostics from them (lsof on `:18789`, `~/.openclaw/state/acpx/sessions/` listing, verbose gateway log, `openclaw acp doctor --json`). Comment with that ask is going on the issue separately.
- The fix scope is intentionally narrow (`extensions/acpx/`) per AGENTS.md "owner boundary" — no core seam needed.

Thanks @bobtrahan for the detailed report on #73071.
