### PR TITLE
feat(diagnostics): add stuckSessionAbortMs threshold to auto-recover stuck sessions

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -151,6 +151,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
           },
+          stuckSessionAbortMs: {
+            type: "integer",
+            exclusiveMinimum: 0,
+            maximum: 9007199254740991,
+            title: "Stuck Session Abort Threshold (ms)",
+            description:
+              "Age threshold in milliseconds after which a stuck processing session is force-aborted: the command lane queue is cleared and the session state is reset to idle, allowing subsequent messages to be processed. Default 600s (10 min). Set higher than stuckSessionWarnMs.",
+          },
           otel: {
             type: "object",
             properties: {
@@ -24215,6 +24223,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "diagnostics.stuckSessionWarnMs": {
       label: "Stuck Session Warning Threshold (ms)",
       help: "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
+      tags: ["observability", "storage"],
+    },
+    "diagnostics.stuckSessionAbortMs": {
+      label: "Stuck Session Abort Threshold (ms)",
+      help: "Age threshold in milliseconds after which a stuck processing session is force-aborted: the command lane queue is cleared and the session state is reset to idle, allowing subsequent messages to be processed. Default 600s (10 min). Set higher than stuckSessionWarnMs.",
       tags: ["observability", "storage"],
     },
     "diagnostics.otel.enabled": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -566,6 +566,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Master toggle for diagnostics instrumentation output in logs and telemetry wiring paths. Defaults to enabled; set false only in tightly constrained environments.",
   "diagnostics.stuckSessionWarnMs":
     "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
+  "diagnostics.stuckSessionAbortMs":
+    "Age threshold in milliseconds after which a stuck processing session is force-aborted: the command lane queue is cleared and the session state is reset to idle, allowing subsequent messages to be processed. Default 600s (10 min). Set higher than stuckSessionWarnMs.",
   "diagnostics.otel.enabled":
     "Enables OpenTelemetry export pipeline for traces, metrics, and logs based on configured endpoint/protocol settings. Keep disabled unless your collector endpoint and auth are fully configured.",
   "diagnostics.otel.endpoint":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -38,6 +38,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "diagnostics.enabled": "Diagnostics Enabled",
   "diagnostics.flags": "Diagnostics Flags",
   "diagnostics.stuckSessionWarnMs": "Stuck Session Warning Threshold (ms)",
+  "diagnostics.stuckSessionAbortMs": "Stuck Session Abort Threshold (ms)",
   "diagnostics.otel.enabled": "OpenTelemetry Enabled",
   "diagnostics.otel.endpoint": "OpenTelemetry Endpoint",
   "diagnostics.otel.tracesEndpoint": "OpenTelemetry Traces Endpoint",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -278,6 +278,8 @@ export type DiagnosticsConfig = {
   flags?: string[];
   /** Threshold in ms before a processing session logs "stuck session" diagnostics. */
   stuckSessionWarnMs?: number;
+  /** Threshold in ms before a stuck processing session is force-aborted (clears lane, resets state). */
+  stuckSessionAbortMs?: number;
   otel?: DiagnosticsOtelConfig;
   cacheTrace?: DiagnosticsCacheTraceConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -304,6 +304,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         flags: z.array(z.string()).optional(),
         stuckSessionWarnMs: z.number().int().positive().optional(),
+        stuckSessionAbortMs: z.number().int().positive().optional(),
         otel: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -61,8 +61,9 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-health-monitor"],
   },
-  // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
+  // Stuck-session thresholds are read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
+  { prefix: "diagnostics.stuckSessionAbortMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -355,6 +355,12 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
   });
 
+  it("treats diagnostics.stuckSessionAbortMs as no-op for gateway restart planning", () => {
+    const plan = buildGatewayReloadPlan(["diagnostics.stuckSessionAbortMs"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("diagnostics.stuckSessionAbortMs");
+  });
+
   it("restarts for gateway.auth.token changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.auth.token"]);
     expect(plan.restartGateway).toBe(true);

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   logSessionStateChange,
   resetDiagnosticStateForTest,
+  resolveStuckSessionAbortMs,
   resolveStuckSessionWarnMs,
   startDiagnosticHeartbeat,
 } from "./diagnostic.js";
@@ -326,6 +327,26 @@ describe("stuck session diagnostics threshold", () => {
     expect(resolveStuckSessionWarnMs({ diagnostics: { stuckSessionWarnMs: -1 } })).toBe(120_000);
     expect(resolveStuckSessionWarnMs({ diagnostics: { stuckSessionWarnMs: 0 } })).toBe(120_000);
     expect(resolveStuckSessionWarnMs()).toBe(120_000);
+  });
+});
+
+describe("resolveStuckSessionAbortMs", () => {
+  it("uses configured abort threshold", () => {
+    expect(
+      resolveStuckSessionAbortMs({
+        diagnostics: { stuckSessionAbortMs: 300_000 },
+      }),
+    ).toBe(300_000);
+  });
+
+  it("uses default 600s when not configured", () => {
+    expect(resolveStuckSessionAbortMs({})).toBe(600_000);
+    expect(resolveStuckSessionAbortMs()).toBe(600_000);
+  });
+
+  it("clamps to valid range", () => {
+    expect(resolveStuckSessionAbortMs({ diagnostics: { stuckSessionAbortMs: 1_000 } })).toBe(600_000);
+    expect(resolveStuckSessionAbortMs({ diagnostics: { stuckSessionAbortMs: 0 } })).toBe(600_000);
   });
 });
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1,3 +1,4 @@
+import { clearCommandLane } from "../process/command-queue.js";
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -45,6 +46,9 @@ const webhookStats = {
 const DEFAULT_STUCK_SESSION_WARN_MS = 120_000;
 const MIN_STUCK_SESSION_WARN_MS = 1_000;
 const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_STUCK_SESSION_ABORT_MS = 600_000;
+const MIN_STUCK_SESSION_ABORT_MS = 60_000;
+const MAX_STUCK_SESSION_ABORT_MS = 24 * 60 * 60 * 1000;
 const RECENT_DIAGNOSTIC_ACTIVITY_MS = 120_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const DEFAULT_LIVENESS_EVENT_LOOP_UTILIZATION_WARN = 0.95;
@@ -286,6 +290,18 @@ export function resolveStuckSessionWarnMs(config?: OpenClawConfig): number {
   const rounded = Math.floor(raw);
   if (rounded < MIN_STUCK_SESSION_WARN_MS || rounded > MAX_STUCK_SESSION_WARN_MS) {
     return DEFAULT_STUCK_SESSION_WARN_MS;
+  }
+  return rounded;
+}
+
+export function resolveStuckSessionAbortMs(config?: OpenClawConfig): number {
+  const raw = config?.diagnostics?.stuckSessionAbortMs;
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    return DEFAULT_STUCK_SESSION_ABORT_MS;
+  }
+  const rounded = Math.floor(raw);
+  if (rounded < MIN_STUCK_SESSION_ABORT_MS || rounded > MAX_STUCK_SESSION_ABORT_MS) {
+    return DEFAULT_STUCK_SESSION_ABORT_MS;
   }
   return rounded;
 }
@@ -650,6 +666,7 @@ export function startDiagnosticHeartbeat(
         diag.debug(`command-poll-backoff prune failed: ${String(err)}`);
       });
 
+    const stuckSessionAbortMs = resolveStuckSessionAbortMs(heartbeatConfig);
     for (const [, state] of diagnosticSessionStates) {
       const ageMs = now - state.lastActivity;
       if (state.state === "processing" && ageMs > stuckSessionWarnMs) {
@@ -659,6 +676,23 @@ export function startDiagnosticHeartbeat(
           state: state.state,
           ageMs,
         });
+        if (ageMs > stuckSessionAbortMs && state.sessionKey) {
+          const laneKey = `session:${state.sessionKey}`;
+          const cleared = clearCommandLane(laneKey);
+          state.state = "idle";
+          state.queueDepth = 0;
+          state.lastActivity = now;
+          diag.error(
+            `stuck session aborted: sessionKey=${state.sessionKey} age=${Math.round(ageMs / 1000)}s laneCleared=${cleared} laneKey=${laneKey}`,
+          );
+          emitDiagnosticEvent({
+            type: "session.aborted",
+            sessionId: state.sessionId,
+            sessionKey: state.sessionKey,
+            ageMs,
+            laneCleared: cleared,
+          });
+        }
       }
     }
   }, 30_000);


### PR DESCRIPTION
## Summary

When a session remains stuck in "processing" state beyond the abort threshold (default 10 min), the command lane queue is cleared and the session state is reset to idle. This prevents a single stuck session from blocking all subsequent messages that share the same lane.

Previously the stuck-session diagnostic only logged warnings without any recovery action — sessions could remain blocked for **up to an hour** (observed max: 3,563s).

## Problem

Each command lane has `maxConcurrent=1`. When a session gets stuck (e.g., subagent LLM call hangs, context overflow), the lane is locked for all subsequent messages. The diagnostic heartbeat detects this every 30s but takes **no corrective action**.

In production, this caused:
- Feishu messages queued for **34+ minutes** behind a stuck session
- **2,587 stuck session warnings** over 4 days  
- Context overflow cascading into quota-exceeded and LLM timeouts
- Gateway CPU at 99.6% from stuck processing loops

## Change

New optional config: `diagnostics.stuckSessionAbortMs` (default `600000` = 10 min)

When a session's `ageMs > stuckSessionAbortMs`:
1. Clears the command lane queue for `session:{sessionKey}`
2. Resets diagnostic session state to idle (`queueDepth=0`, `lastActivity=now`)
3. Logs error-level diagnostic and emits `session.aborted` event

This frees the lane so subsequent messages can be processed immediately.

## Files changed

- `src/logging/diagnostic.ts` — core abort logic in heartbeat  
- `src/process/command-queue.ts` — added `clearCommandLane` import  
- `src/config/types.base.ts` — new config type  
- `src/config/zod-schema.ts` — new config validation  
- `src/config/schema.base.generated.ts` — generated schema  
- `src/config/schema.help.ts` / `schema.labels.ts` — help text  
- `src/gateway/config-reload-plan.ts` — noop reload path  
- Tests updated

## Test plan

- [x] `resolveStuckSessionAbortMs` returns configured value
- [x] `resolveStuckSessionAbortMs` uses default 600s when unset
- [x] `resolveStuckSessionAbortMs` clamps invalid values
- [x] `diagnostics.stuckSessionAbortMs` is treated as noop reload path
- [ ] Manual verification: session stuck > abort threshold triggers lane clear + state reset