### PR TITLE
fix: use context-aware reserveTokensFloor in overflow recovery hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/exec: show plain numeric `reserveTokensFloor` value in context-overflow recovery hint instead of locale-formatted number (e.g. 50000 instead of 50,000). Thanks @XuXuClassMate.
+- Agents/exec: show context-window-aware `reserveTokensFloor` recommendations in context-overflow recovery hint (100k/50k/35k/20k tiers) instead of a static 20000 floor. Thanks @XuXuClassMate.
 - Gateway/hooks: route non-delivered hook completion and error summaries to the target agent's main session instead of the default agent session, preserving multi-agent hook isolation. Fixes #24693; carries forward #68667. Thanks @abersonFAC and @bluesky6868.
 - Discord: own the Carbon interaction listener and hand off Discord slash/component handling asynchronously, so compaction or long session locks no longer trip `InteractionEventListener` listener timeouts. Fixes #73204. Thanks @slideshow-dingo.
 - Gateway/startup: keep value-option foreground starts on the gateway fast path and skip proxy bootstrap unless proxy env is configured, reducing normal gateway startup RSS and avoiding full CLI graph loading. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/exec: show plain numeric `reserveTokensFloor` value in context-overflow recovery hint instead of locale-formatted number (e.g. 50000 instead of 50,000). Thanks @XuXuClassMate.
 - Gateway/hooks: route non-delivered hook completion and error summaries to the target agent's main session instead of the default agent session, preserving multi-agent hook isolation. Fixes #24693; carries forward #68667. Thanks @abersonFAC and @bluesky6868.
 - Discord: own the Carbon interaction listener and hand off Discord slash/component handling asynchronously, so compaction or long session locks no longer trip `InteractionEventListener` listener timeouts. Fixes #73204. Thanks @slideshow-dingo.
 - Gateway/startup: keep value-option foreground starts on the gateway fast path and skip proxy bootstrap unless proxy env is configured, reducing normal gateway startup RSS and avoiding full CLI graph loading. Thanks @vincentkoc.

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -8,6 +8,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildContextOverflowRecoveryText,
+  computeContextAwareReserveTokensFloor,
   MAX_LIVE_SWITCH_RETRIES,
 } from "./agent-runner-execution.js";
 import type { FollowupRun } from "./queue.js";
@@ -384,6 +385,56 @@ describe("buildContextOverflowRecoveryText", () => {
 
     expect(text).toContain("reserveTokensFloor");
     expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("uses session contextTokens as fallback when model metadata is unavailable", () => {
+    // When the primary model is not in context cache (undefined from resolveContextTokensForModel),
+    // but activeSessionEntry.contextTokens is 200000, the hint should recommend 50k (the 200k tier),
+    // not 20k (the default).
+    const text = buildContextOverflowRecoveryText({
+      cfg: {}, // no model metadata, so resolveContextTokensForModel returns undefined
+      primaryProvider: "openrouter",
+      primaryModel: "unknown-model-without-cache-entry",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "some-known-model",
+        contextTokens: 200_000, // 200k session context should map to 50k tier
+      },
+    });
+
+    // Should contain "50000" (50k tier) not "20000" (default tier)
+    expect(text).toContain("50000");
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
+});
+
+describe("computeContextAwareReserveTokensFloor", () => {
+  it("returns 100_000 for context window >= 1M", () => {
+    expect(computeContextAwareReserveTokensFloor(1_000_000)).toBe(100_000);
+    expect(computeContextAwareReserveTokensFloor(2_000_000)).toBe(100_000);
+  });
+
+  it("returns 50_000 for context window >= 200k and < 1M", () => {
+    expect(computeContextAwareReserveTokensFloor(200_000)).toBe(50_000);
+    expect(computeContextAwareReserveTokensFloor(500_000)).toBe(50_000);
+    expect(computeContextAwareReserveTokensFloor(999_999)).toBe(50_000);
+  });
+
+  it("returns 35_000 for context window >= 100k and < 200k", () => {
+    expect(computeContextAwareReserveTokensFloor(100_000)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(150_000)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(199_999)).toBe(35_000);
+  });
+
+  it("returns DEFAULT_RESERVE_TOKENS_FLOOR (20_000) for context window < 100k or undefined", () => {
+    expect(computeContextAwareReserveTokensFloor(99_999)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(50_000)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(undefined)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(0)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(-1)).toBe(20_000);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -404,8 +404,8 @@ describe("buildContextOverflowRecoveryText", () => {
       },
     });
 
-    // Should contain "50000" (50k tier) not "20000" (default tier)
-    expect(text).toContain("50000");
+    // Should contain "50k" (50k tier) not "20k" (default tier)
+    expect(text).toContain("50k");
     expect(text).toContain("reserveTokensFloor");
     expect(text).not.toContain("heartbeat model bleed");
   });
@@ -427,9 +427,9 @@ describe("buildContextOverflowRecoveryText", () => {
       },
     });
 
-    // Should contain "50000" (50k tier from DEFAULT_CONTEXT_TOKENS 200k fallback)
-    // not "20000" (DEFAULT_RESERVE_TOKENS_FLOOR)
-    expect(text).toContain("50000");
+    // Should contain "50k" (50k tier from DEFAULT_CONTEXT_TOKENS 200k fallback)
+    // not "20k" (DEFAULT_RESERVE_TOKENS_FLOOR)
+    expect(text).toContain("50k");
     expect(text).toContain("reserveTokensFloor");
     expect(text).not.toContain("heartbeat model bleed");
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -409,6 +409,30 @@ describe("buildContextOverflowRecoveryText", () => {
     expect(text).toContain("reserveTokensFloor");
     expect(text).not.toContain("heartbeat model bleed");
   });
+
+  it("uses DEFAULT_CONTEXT_TOKENS fallback when both model metadata and session context are unavailable", () => {
+    // After resetReplyRunSession clears activeSessionEntry.contextTokens, and the model
+    // is unknown (not in cache), the hint should use DEFAULT_CONTEXT_TOKENS (200k)
+    // as the fallback and recommend 50k tier, not 20k default.
+    const text = buildContextOverflowRecoveryText({
+      cfg: {}, // no model metadata
+      primaryProvider: "openrouter",
+      primaryModel: "unknown-model-without-cache-entry",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "some-known-model",
+        contextTokens: 0, // cleared by resetReplyRunSession
+      },
+    });
+
+    // Should contain "50000" (50k tier from DEFAULT_CONTEXT_TOKENS 200k fallback)
+    // not "20000" (DEFAULT_RESERVE_TOKENS_FLOOR)
+    expect(text).toContain("50000");
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).not.toContain("heartbeat model bleed");
+  });
 });
 
 describe("computeContextAwareReserveTokensFloor", () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -482,7 +482,7 @@ function buildContextOverflowResetHint(contextWindow: number | undefined): strin
   const reserveFloor = computeContextAwareReserveTokensFloor(effectiveContextWindow);
   return (
     "\n\nTo prevent this, increase your compaction buffer by setting " +
-    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor} or higher in your config.`
+    `\`agents.defaults.compaction.reserveTokensFloor\` to ${(reserveFloor / 1000).toFixed(0)}k or higher in your config.`
   );
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -460,7 +460,7 @@ function buildExternalRunFailureReply(
 
 const DEFAULT_RESERVE_TOKENS_FLOOR = 20_000;
 
-function computeContextAwareReserveTokensFloor(contextWindow: number | undefined): number {
+export function computeContextAwareReserveTokensFloor(contextWindow: number | undefined): number {
   if (!contextWindow || contextWindow <= 0) {
     return DEFAULT_RESERVE_TOKENS_FLOOR;
   }
@@ -648,11 +648,10 @@ export function buildContextOverflowRecoveryText(params: {
   if (heartbeatHint) {
     return prefix + heartbeatHint;
   }
-  const primaryContextWindow = resolveContextTokensForModel({
+  const primaryContextWindow = resolveContextWindowForHint({
     cfg: params.cfg,
-    provider: params.primaryProvider,
-    model: params.primaryModel,
-    allowAsyncLoad: false,
+    ref: { provider: params.primaryProvider ?? "", model: params.primaryModel ?? "" },
+    activeSessionEntry: params.activeSessionEntry,
   });
   return prefix + buildContextOverflowResetHint(primaryContextWindow);
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -480,7 +480,7 @@ function buildContextOverflowResetHint(contextWindow: number | undefined): strin
   const reserveFloor = computeContextAwareReserveTokensFloor(contextWindow);
   return (
     "\n\nTo prevent this, increase your compaction buffer by setting " +
-    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor.toLocaleString()} or higher in your config.`
+    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor} or higher in your config.`
   );
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import {
@@ -477,7 +478,8 @@ export function computeContextAwareReserveTokensFloor(contextWindow: number | un
 }
 
 function buildContextOverflowResetHint(contextWindow: number | undefined): string {
-  const reserveFloor = computeContextAwareReserveTokensFloor(contextWindow);
+  const effectiveContextWindow = contextWindow ?? DEFAULT_CONTEXT_TOKENS;
+  const reserveFloor = computeContextAwareReserveTokensFloor(effectiveContextWindow);
   return (
     "\n\nTo prevent this, increase your compaction buffer by setting " +
     `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor} or higher in your config.`
@@ -551,6 +553,7 @@ function resolveContextWindowForHint(params: {
       provider: params.ref.provider,
       model: params.ref.model,
       allowAsyncLoad: false,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     })
   );
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -458,9 +458,31 @@ function buildExternalRunFailureReply(
   };
 }
 
-const CONTEXT_OVERFLOW_RESET_HINT =
-  "\n\nTo prevent this, increase your compaction buffer by setting " +
-  "`agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.";
+const DEFAULT_RESERVE_TOKENS_FLOOR = 20_000;
+
+function computeContextAwareReserveTokensFloor(contextWindow: number | undefined): number {
+  if (!contextWindow || contextWindow <= 0) {
+    return DEFAULT_RESERVE_TOKENS_FLOOR;
+  }
+  if (contextWindow >= 1_000_000) {
+    return 100_000;
+  }
+  if (contextWindow >= 200_000) {
+    return 50_000;
+  }
+  if (contextWindow >= 100_000) {
+    return 35_000;
+  }
+  return DEFAULT_RESERVE_TOKENS_FLOOR;
+}
+
+function buildContextOverflowResetHint(contextWindow: number | undefined): string {
+  const reserveFloor = computeContextAwareReserveTokensFloor(contextWindow);
+  return (
+    "\n\nTo prevent this, increase your compaction buffer by setting " +
+    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor.toLocaleString()} or higher in your config.`
+  );
+}
 
 type ModelRefLike = {
   provider: string;
@@ -616,16 +638,23 @@ export function buildContextOverflowRecoveryText(params: {
   const prefix = params.duringCompaction
     ? "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again."
     : "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.";
-  return (
-    prefix +
-    (resolveHeartbeatBleedHint({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      primaryProvider: params.primaryProvider,
-      primaryModel: params.primaryModel,
-      activeSessionEntry: params.activeSessionEntry,
-    }) ?? CONTEXT_OVERFLOW_RESET_HINT)
-  );
+  const heartbeatHint = resolveHeartbeatBleedHint({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    primaryProvider: params.primaryProvider,
+    primaryModel: params.primaryModel,
+    activeSessionEntry: params.activeSessionEntry,
+  });
+  if (heartbeatHint) {
+    return prefix + heartbeatHint;
+  }
+  const primaryContextWindow = resolveContextTokensForModel({
+    cfg: params.cfg,
+    provider: params.primaryProvider,
+    model: params.primaryModel,
+    allowAsyncLoad: false,
+  });
+  return prefix + buildContextOverflowResetHint(primaryContextWindow);
 }
 
 function shouldApplyOpenAIGptChatGuard(params: { provider?: string; model?: string }): boolean {


### PR DESCRIPTION
## Summary

Replace hardcoded '20000' in `CONTEXT_OVERFLOW_RESET_HINT` with a dynamic value based on the model's context window size.

### Problem

When context limit is exceeded, the error message suggests setting `agents.defaults.compaction.reserveTokensFloor` to 20000. However, 20000 is too low for models with larger context windows (200k, 1M tokens), causing users to still experience context overflow errors even after applying the recommended config.

### Solution

Use context-aware values for the recommended `reserveTokensFloor`:
- **100k** for context windows >= 1M tokens
- **50k** for context windows >= 200k tokens  
- **35k** for context windows >= 100k tokens
- **20k** for smaller context windows (default)

### Changes

- Add `DEFAULT_RESERVE_TOKENS_FLOOR` constant (20000)
- Add `computeContextAwareReserveTokensFloor()` function with tiered values
- Add `buildContextOverflowResetHint()` helper function
- Update `buildContextOverflowRecoveryText()` to use dynamic hint

### Test Plan

- [ ] Run `pnpm test src/auto-reply/reply/agent-runner-execution.test.ts` to verify existing tests pass
- [ ] Verify the hint now shows context-appropriate values for different model sizes

### Related Issues

Fixes #65839
Fixes #72106