### PR TITLE
fix(telegram): show Ollama think levels from catalog [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Telegram: include configured Ollama reasoning metadata when building native `/think` argument menus so reasoning-capable models show `off`, `low`, `medium`, `high`, and `max` instead of only `off`. Fixes #73515. Thanks @danielzinhu99.
 - fix(agents): canonicalize provider aliases in byProvider tool policy lookup [AI]. (#72917) Thanks @pgondhi987.
 - fix(security): block npm_execpath injection from workspace .env [AI-assisted]. (#73262) Thanks @pgondhi987.
 - Tools/web_fetch: decode response bodies from raw bytes using declared HTTP, XML, or HTML meta charsets before extraction, so Shift_JIS and other legacy-charset pages no longer return mojibake. Fixes #72916. Thanks @amknight.

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -714,7 +714,7 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
           name: "level",
           description: "Thinking level",
           type: "string",
-          choices: ({ provider, model }) => listThinkingLevels(provider, model),
+          choices: ({ provider, model, catalog }) => listThinkingLevels(provider, model, catalog),
         },
       ],
       argsMenu: "auto",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -61,6 +61,27 @@ function installSlackNativeCommandOverrides() {
   });
 }
 
+function installOllamaThinkingProvider() {
+  const registry = createTestRegistry();
+  registry.providers.push({
+    pluginId: "ollama",
+    source: "test",
+    provider: {
+      id: "ollama",
+      label: "Ollama",
+      auth: [],
+      resolveThinkingProfile: ({ reasoning }: { reasoning?: boolean }) => ({
+        levels:
+          reasoning === true
+            ? [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }]
+            : [{ id: "off" }],
+        defaultLevel: "off",
+      }),
+    } as never,
+  });
+  setActivePluginRegistry(registry);
+}
+
 beforeEach(() => {
   vi.doUnmock("../channels/plugins/index.js");
   setActivePluginRegistry(createTestRegistry([]));
@@ -498,6 +519,43 @@ describe("commands registry args", () => {
     expect(seenChoice?.argName).toBe("level");
     expect(seenChoice?.provider).toBeTruthy();
     expect(seenChoice?.model).toBeTruthy();
+  });
+
+  it("uses configured model catalog reasoning for /think arg menus", () => {
+    installOllamaThinkingProvider();
+    const command = findCommandByNativeName("think");
+    expect(command).toBeTruthy();
+    if (!command) {
+      return;
+    }
+
+    const menu = resolveCommandArgMenu({
+      command,
+      args: undefined,
+      cfg: {
+        models: {
+          providers: {
+            ollama: {
+              models: [{ id: "glm-5.1:cloud", name: "GLM 5.1 Cloud", reasoning: true }],
+            },
+          },
+        },
+      } as never,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+    });
+
+    expect(menu?.arg.name).toBe("level");
+    expect(menu?.choices.map((choice) => choice.value)).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
+    expect(formatCommandArgMenuTitle({ command, menu: menu! })).toBe(
+      "Choose level for /think.\nOptions: off, low, medium, high, max.",
+    );
   });
 
   it("does not show menus when args were provided as raw text only", () => {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -302,12 +302,20 @@ export function resolveCommandArgMenu(params: {
   if (command.argsParsing === "none") {
     return null;
   }
+  const resolvedCatalog = catalog ?? (cfg ? buildConfiguredModelCatalog({ cfg }) : undefined);
   const argSpec = command.argsMenu;
   const argName =
     argSpec === "auto"
       ? command.args.find(
           (arg) =>
-            resolveCommandArgChoices({ command, arg, cfg, provider, model, catalog }).length > 0,
+            resolveCommandArgChoices({
+              command,
+              arg,
+              cfg,
+              provider,
+              model,
+              catalog: resolvedCatalog,
+            }).length > 0,
         )?.name
       : argSpec.arg;
   if (!argName) {
@@ -323,7 +331,14 @@ export function resolveCommandArgMenu(params: {
   if (!arg) {
     return null;
   }
-  const choices = resolveCommandArgChoices({ command, arg, cfg, provider, model, catalog });
+  const choices = resolveCommandArgChoices({
+    command,
+    arg,
+    cfg,
+    provider,
+    model,
+    catalog: resolvedCatalog,
+  });
   if (choices.length === 0) {
     return null;
   }

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import {
+  buildConfiguredModelCatalog,
+  resolveConfiguredModelRef,
+} from "../agents/model-selection.js";
 import type { SkillCommandSpec } from "../agents/skills.js";
 import { getChannelPlugin, getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -26,6 +29,7 @@ import type {
   NativeCommandSpec,
   ShouldHandleTextCommandsParams,
 } from "./commands-registry.types.js";
+import type { ThinkingCatalogEntry } from "./thinking.shared.js";
 
 export {
   isCommandEnabled,
@@ -257,6 +261,7 @@ export function resolveCommandArgChoices(params: {
   cfg?: OpenClawConfig;
   provider?: string;
   model?: string;
+  catalog?: ThinkingCatalogEntry[];
 }): ResolvedCommandArgChoice[] {
   const { command, arg, cfg } = params;
   if (!arg.choices) {
@@ -271,6 +276,7 @@ export function resolveCommandArgChoices(params: {
           cfg,
           provider: params.provider ?? defaults.provider,
           model: params.model ?? defaults.model,
+          catalog: params.catalog ?? (cfg ? buildConfiguredModelCatalog({ cfg }) : undefined),
           command,
           arg,
         };
@@ -287,8 +293,9 @@ export function resolveCommandArgMenu(params: {
   cfg?: OpenClawConfig;
   provider?: string;
   model?: string;
+  catalog?: ThinkingCatalogEntry[];
 }): { arg: CommandArgDefinition; choices: ResolvedCommandArgChoice[]; title?: string } | null {
-  const { command, args, cfg, provider, model } = params;
+  const { command, args, cfg, provider, model, catalog } = params;
   if (!command.args || !command.argsMenu) {
     return null;
   }
@@ -299,7 +306,8 @@ export function resolveCommandArgMenu(params: {
   const argName =
     argSpec === "auto"
       ? command.args.find(
-          (arg) => resolveCommandArgChoices({ command, arg, cfg, provider, model }).length > 0,
+          (arg) =>
+            resolveCommandArgChoices({ command, arg, cfg, provider, model, catalog }).length > 0,
         )?.name
       : argSpec.arg;
   if (!argName) {
@@ -315,7 +323,7 @@ export function resolveCommandArgMenu(params: {
   if (!arg) {
     return null;
   }
-  const choices = resolveCommandArgChoices({ command, arg, cfg, provider, model });
+  const choices = resolveCommandArgChoices({ command, arg, cfg, provider, model, catalog });
   if (choices.length === 0) {
     return null;
   }

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { CommandArgValues } from "./commands-args.types.js";
+import type { ThinkingCatalogEntry } from "./thinking.shared.js";
 
 export type { CommandArgValue, CommandArgValues, CommandArgs } from "./commands-args.types.js";
 
@@ -28,6 +29,7 @@ export type CommandArgChoiceContext = {
   cfg?: OpenClawConfig;
   provider?: string;
   model?: string;
+  catalog?: ThinkingCatalogEntry[];
   command: ChatCommandDefinition;
   arg: CommandArgDefinition;
 };


### PR DESCRIPTION
## Summary
Fixes the native `/think` argument menu for configured Ollama models whose catalog entry has `reasoning: true`.

## Root Cause
The `/think` command resolved dynamic menu choices with only provider/model context. Ollama's thinking profile depends on catalog `reasoning` metadata, so configured reasoning-capable Ollama models fell back to the provider's non-reasoning profile and exposed only `off`.

## Linked Issue
Fixes #73515.

## Why This Is Safe
The change reuses the existing configured model catalog builder and the existing catalog-aware `listThinkingLevels` path. Static choices and commands without dynamic choices are unchanged, and callers can still pass an explicit catalog when they have one.

## Security And Runtime Controls
No authorization, command gating, provider execution, prompt construction, or runtime policy controls change. This only changes which pre-existing `/think` levels are displayed in the native argument menu.

## Tests
- `git diff --check`
- `pnpm test src/auto-reply/commands-registry.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

## Out Of Scope
- Querying Ollama `/api/show` from the command menu path.
- Changing how thinking levels are applied after a user selects a level.
- Broader native command menu redesigns for channel-specific UX.

## Contributor Notes
- AI-assisted change.

Made with [Cursor](https://cursor.com)