### PR TITLE
fix: resolve slash-form model aliases before provider parsing

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -450,12 +450,10 @@ export function resolveModelRefFromString(params: {
   if (!model) {
     return null;
   }
-  if (!model.includes("/")) {
-    const aliasKey = normalizeLowercaseStringOrEmpty(model);
-    const aliasMatch = params.aliasIndex?.byAlias.get(aliasKey);
-    if (aliasMatch) {
-      return { ref: aliasMatch.ref, alias: aliasMatch.alias };
-    }
+  const aliasKey = normalizeLowercaseStringOrEmpty(model);
+  const aliasMatch = params.aliasIndex?.byAlias.get(aliasKey);
+  if (aliasMatch) {
+    return { ref: aliasMatch.ref, alias: aliasMatch.alias };
   }
   const parsed = parseModelRefWithCompatAlias({
     cfg: params.cfg,

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -853,6 +853,32 @@ describe("model-selection", () => {
         ref: { provider: "opencode-go", model: "kimi-k2.6" },
       });
     });
+
+    it("resolves slash-form aliases through the allowlist path", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openai/xiaomi/mimo-v2-pro-mit": {
+                alias: "xiaomi/mimo-v2-pro-mit",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "xiaomi/mimo-v2-pro-mit",
+        defaultProvider: "openai",
+      });
+
+      expect(result).toEqual({
+        key: "openai/xiaomi/mimo-v2-pro-mit",
+        ref: { provider: "openai", model: "xiaomi/mimo-v2-pro-mit" },
+      });
+    });
   });
 
   describe("resolveModelRefFromString", () => {
@@ -976,6 +1002,33 @@ describe("model-selection", () => {
         model: "moonshotai/kimi-k2.5",
       });
       expect(resolved?.alias).toBe("kimi");
+    });
+
+    it("resolves slash-form aliases before provider/model parsing", () => {
+      const index = {
+        byAlias: new Map([
+          [
+            "xiaomi/mimo-v2-pro-mit",
+            {
+              alias: "xiaomi/mimo-v2-pro-mit",
+              ref: { provider: "openai", model: "xiaomi/mimo-v2-pro-mit" },
+            },
+          ],
+        ]),
+        byKey: new Map(),
+      };
+
+      const resolved = resolveModelRefFromString({
+        raw: "xiaomi/mimo-v2-pro-mit",
+        defaultProvider: "openai",
+        aliasIndex: index,
+      });
+
+      expect(resolved?.ref).toEqual({
+        provider: "openai",
+        model: "xiaomi/mimo-v2-pro-mit",
+      });
+      expect(resolved?.alias).toBe("xiaomi/mimo-v2-pro-mit");
     });
   });
 


### PR DESCRIPTION
## Summary
- resolve slash-form model aliases before provider/model parsing
- let runtime selection map values like `xiaomi/mimo-v2-pro-mit` back to configured canonical refs such as `openai/xiaomi/mimo-v2-pro-mit`
- add focused regression coverage for both `resolveAllowedModelRef` and `resolveModelRefFromString`

## Problem
OpenClaw currently allows configured aliases that themselves contain `/`, and `openclaw models list` shows them as aliases. But runtime model selection only checked the alias index for inputs without `/`. As a result, values like `xiaomi/mimo-v2-pro-mit` bypassed alias lookup, were parsed as real `provider/model` refs, and could fail at runtime with `Unknown model: xiaomi/mimo-v2-pro-mit`.

Fixes #73573.

## Validation
- `pnpm test src/agents/model-selection.test.ts`
- `pnpm test src/agents/pi-embedded-runner/model.forward-compat.errors-and-overrides.test.ts`