### PR TITLE
fix: clarify infer audio/image errors when no provider configured

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -385,6 +385,25 @@ describe("capability cli", () => {
   });
 
   it("fails image describe when no description text is returned", async () => {
+    mocks.loadConfig.mockReturnValue({
+      models: {
+        providers: {
+          openai: { apiKey: "test-key" },
+        },
+      },
+    });
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "openai",
+          {
+            id: "openai",
+            capabilities: ["image"],
+            defaultModels: { image: "gpt-4.1-mini" },
+          },
+        ],
+      ]),
+    );
     mocks.describeImageFile.mockResolvedValueOnce({
       text: undefined,
       provider: undefined,
@@ -399,6 +418,24 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       expect.stringMatching(/No description returned for image/),
+    );
+  });
+
+  it("fails image describe with a config-focused error when no provider is configured", async () => {
+    mocks.describeImageFile.mockResolvedValueOnce({
+      text: undefined,
+      provider: undefined,
+      model: undefined,
+    } as never);
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "image", "describe", "--file", "photo.jpg", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringMatching(/No image-understanding provider configured/),
     );
   });
 
@@ -545,6 +582,25 @@ describe("capability cli", () => {
   });
 
   it("fails audio transcribe when no transcript text is returned", async () => {
+    mocks.loadConfig.mockReturnValue({
+      models: {
+        providers: {
+          deepgram: { apiKey: "test-key" },
+        },
+      },
+    });
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "deepgram",
+          {
+            id: "deepgram",
+            capabilities: ["audio"],
+            defaultModels: { audio: "nova-3" },
+          },
+        ],
+      ]),
+    );
     mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
 
     await expect(
@@ -555,6 +611,20 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       expect.stringMatching(/No transcript returned for audio/),
+    );
+  });
+
+  it("fails audio transcribe with a config-focused error when no provider is configured", async () => {
+    mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringMatching(/No audio transcription provider configured/),
     );
   });
 

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -423,6 +423,25 @@ function providerHasGenericConfig(params: {
   );
 }
 
+function hasConfiguredMediaUnderstandingProvider(params: {
+  cfg: OpenClawConfig;
+  capability: "audio" | "image";
+}): boolean {
+  const providers = [...buildMediaUnderstandingRegistry(undefined, params.cfg).values()].filter((provider) =>
+    provider.capabilities?.includes(params.capability),
+  );
+  return providers.some((provider) =>
+    providerHasGenericConfig({
+      cfg: params.cfg,
+      providerId: provider.id,
+      envVars: getProviderEnvVars(provider.id, {
+        config: params.cfg,
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    }),
+  );
+}
+
 async function writeOutputAsset(params: {
   buffer: Buffer;
   mimeType?: string;
@@ -755,6 +774,11 @@ async function runImageDescribe(params: {
         activeModel,
       });
       if (!result.text) {
+        if (!activeModel && !hasConfiguredMediaUnderstandingProvider({ cfg, capability: "image" })) {
+          throw new Error(
+            "No image-understanding provider configured. Set agents.defaults.imageModel.primary to a provider/model (for example \"openai/gpt-4.1-mini\") and configure that provider's auth/API key.",
+          );
+        }
         throw new Error(`No description returned for image: ${path.resolve(filePath)}`);
       }
       return {
@@ -793,6 +817,11 @@ async function runAudioTranscribe(params: {
     prompt: params.prompt,
   });
   if (!result.text) {
+    if (!activeModel && !hasConfiguredMediaUnderstandingProvider({ cfg, capability: "audio" })) {
+      throw new Error(
+        "No audio transcription provider configured. Configure an audio provider auth/API key (see `openclaw infer audio providers --json`) or pass --model <provider/model>.",
+      );
+    }
     throw new Error(`No transcript returned for audio: ${path.resolve(params.file)}`);
   }
   return {


### PR DESCRIPTION
## Summary
- Detect the "no configured provider" case for `infer image describe` and `infer audio transcribe` when provider output text is empty.
- Return actionable config-focused errors for that case, while preserving the existing "No transcript/description returned" message when a configured provider returns an empty response.
- Add CLI regression tests for both branches (configured-vs-unconfigured provider behavior).

## Test plan
- [x] `pnpm test src/cli/capability-cli.test.ts`

Closes #73569
