### PR TITLE
fix(tts): deliver WhatsApp voice notes from suppressed group replies

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -534,10 +534,10 @@ describe("deliverWebReply", () => {
       undefined,
     );
     expect(expectFirstSendMediaPayload(msg)).not.toHaveProperty("caption");
-    expect(msg.reply).toHaveBeenCalledWith("caption", undefined);
+    expect(msg.reply).not.toHaveBeenCalled();
   });
 
-  it("sends audio media as ptt voice note with visible text separately", async () => {
+  it("sends audio media as ptt voice note without duplicating visible text", async () => {
     const msg = makeMsg();
     (
       loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
@@ -565,7 +565,7 @@ describe("deliverWebReply", () => {
       undefined,
     );
     expect(expectFirstSendMediaPayload(msg)).not.toHaveProperty("caption");
-    expect(msg.reply).toHaveBeenCalledWith("cap", undefined);
+    expect(msg.reply).not.toHaveBeenCalled();
   });
 
   it("transcodes mp3 audio media before sending a ptt voice note", async () => {
@@ -605,7 +605,7 @@ describe("deliverWebReply", () => {
       undefined,
     );
     expect(expectFirstSendMediaPayload(msg)).not.toHaveProperty("caption");
-    expect(msg.reply).toHaveBeenCalledWith("cap", undefined);
+    expect(msg.reply).not.toHaveBeenCalled();
   });
 
   it("sends video media", async () => {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -161,6 +161,7 @@ export async function deliverWebReply(params: {
             ),
           "media:audio",
         );
+        // Voice-note captions are not sent again as text; duplicate text makes TTS replies noisy.
       } else if (media.kind === "video") {
         const quote = getQuote();
         await sendWithRetry(

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -161,9 +161,6 @@ export async function deliverWebReply(params: {
             ),
           "media:audio",
         );
-        if (caption) {
-          await sendWithRetry(() => msg.reply(caption, quote), "media:audio-text");
-        }
       } else if (media.kind === "video") {
         const quote = getQuote();
         await sendWithRetry(

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -100,11 +100,11 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("sends visible text separately from push-to-talk voice notes", async () => {
+  it("does not duplicate visible text for push-to-talk voice notes", async () => {
     const payload = Buffer.from("aud");
     await api.sendMessage("+1555", "voice text", payload, "audio/ogg");
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      1,
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
       "1555@s.whatsapp.net",
       expect.objectContaining({
         audio: payload,
@@ -112,9 +112,6 @@ describe("createWebSendApi", () => {
         mimetype: "audio/ogg",
       }),
     );
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "1555@s.whatsapp.net", {
-      text: "voice text",
-    });
   });
 
   it("supports video media and gifPlayback option", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -85,14 +85,6 @@ export function createWebSendApi(params: {
       const result = quotedOpts
         ? await params.sock.sendMessage(jid, payload, quotedOpts)
         : await params.sock.sendMessage(jid, payload);
-      if (mediaBuffer && mediaType?.startsWith("audio/") && text.trim()) {
-        const textPayload: AnyMessageContent = { text };
-        if (quotedOpts) {
-          await params.sock.sendMessage(jid, textPayload, quotedOpts);
-        } else {
-          await params.sock.sendMessage(jid, textPayload);
-        }
-      }
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
       recordWhatsAppOutbound(accountId);
       const messageId = resolveOutboundMessageId(result);

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -245,8 +245,8 @@ describe("web outbound", () => {
       cfg: WHATSAPP_TEST_CFG,
       mediaUrl: "/tmp/voice.ogg",
     });
-    expect(sendMessage).toHaveBeenNthCalledWith(1, "+1555", "", buf, "audio/ogg; codecs=opus");
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("+1555", "", buf, "audio/ogg; codecs=opus");
   });
 
   it.each([
@@ -270,14 +270,13 @@ describe("web outbound", () => {
     expect(hoisted.runFfmpeg).toHaveBeenCalledWith(
       expect.arrayContaining(["-c:a", "libopus", "-ar", "48000", "-b:a", "64k"]),
     );
-    expect(sendMessage).toHaveBeenNthCalledWith(
-      1,
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
       "+1555",
       "",
       Buffer.from("opus-output"),
       "audio/ogg; codecs=opus",
     );
-    expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
   });
 
   it("maps video with caption", async () => {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -116,7 +116,6 @@ export async function sendMessageWhatsApp(
     let mediaBuffer: Buffer | undefined;
     let mediaType: string | undefined;
     let documentFileName: string | undefined;
-    let visibleTextAfterVoice: string | undefined;
     if (primaryMediaUrl) {
       const media = await prepareWhatsAppOutboundMedia(
         await loadOutboundMediaFromUrl(primaryMediaUrl, {
@@ -131,7 +130,6 @@ export async function sendMessageWhatsApp(
       mediaBuffer = media.buffer;
       mediaType = media.mimetype;
       if (media.kind === "audio" && caption) {
-        visibleTextAfterVoice = caption;
         text = "";
       } else if (media.kind === "document") {
         text = caption ?? "";
@@ -157,13 +155,6 @@ export async function sendMessageWhatsApp(
     const result = sendOptions
       ? await active.sendMessage(to, text, mediaBuffer, mediaType, sendOptions)
       : await active.sendMessage(to, text, mediaBuffer, mediaType);
-    if (visibleTextAfterVoice) {
-      if (sendOptions) {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined, sendOptions);
-      } else {
-        await active.sendMessage(to, visibleTextAfterVoice, undefined, undefined);
-      }
-    }
     const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
     const durationMs = Date.now() - startedAt;
     outboundLog.info(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4364,6 +4364,84 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     );
   });
 
+  it("delivers voice media payloads when group source delivery is message-tool-only", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return {
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/tts-group.wav",
+        audioAsVoice: true,
+      } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "group",
+        WasMentioned: true,
+        SessionKey: "test:whatsapp:group:G1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: undefined,
+        mediaUrl: "https://example.com/tts-group.wav",
+        audioAsVoice: true,
+      }),
+    );
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("delivers pending tool voice media emitted as a block in message-tool-only groups", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      await opts?.onBlockReply?.({
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/tts-tool-group.wav",
+        audioAsVoice: true,
+      });
+      return { text: "NO_REPLY" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "group",
+        WasMentioned: true,
+        SessionKey: "test:whatsapp:group:G1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: undefined,
+        mediaUrl: "https://example.com/tts-tool-group.wav",
+        audioAsVoice: true,
+      }),
+    );
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
   it("allows config to keep group/channel source delivery automatic", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4371,8 +4371,9 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
       return {
         text: "NO_REPLY",
-        mediaUrl: "https://example.com/tts-group.wav",
+        mediaUrl: "/tmp/openclaw/tts-group.wav",
         audioAsVoice: true,
+        trustedLocalMedia: true,
       } satisfies ReplyPayload;
     });
 
@@ -4394,8 +4395,9 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
       expect.objectContaining({
         text: undefined,
-        mediaUrl: "https://example.com/tts-group.wav",
+        mediaUrl: "/tmp/openclaw/tts-group.wav",
         audioAsVoice: true,
+        trustedLocalMedia: true,
       }),
     );
     expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
@@ -4409,8 +4411,9 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
       await opts?.onBlockReply?.({
         text: "NO_REPLY",
-        mediaUrl: "https://example.com/tts-tool-group.wav",
+        mediaUrl: "/tmp/openclaw/tts-tool-group.wav",
         audioAsVoice: true,
+        trustedLocalMedia: true,
       });
       return { text: "NO_REPLY" } satisfies ReplyPayload;
     });
@@ -4434,10 +4437,87 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
       expect.objectContaining({
         text: undefined,
-        mediaUrl: "https://example.com/tts-tool-group.wav",
+        mediaUrl: "/tmp/openclaw/tts-tool-group.wav",
         audioAsVoice: true,
+        trustedLocalMedia: true,
       }),
     );
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver trusted remote voice media in message-tool-only groups", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      await opts?.onBlockReply?.({
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/remote.wav",
+        audioAsVoice: true,
+        trustedLocalMedia: true,
+      });
+      return {
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/final-remote.wav",
+        audioAsVoice: true,
+        trustedLocalMedia: true,
+      } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "group",
+        WasMentioned: true,
+        SessionKey: "test:whatsapp:group:G1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver untrusted voice media in message-tool-only groups", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      await opts?.onBlockReply?.({
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/model-block.wav",
+        audioAsVoice: true,
+      });
+      return {
+        text: "NO_REPLY",
+        mediaUrl: "https://example.com/model-final.wav",
+        audioAsVoice: true,
+      } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        ChatType: "group",
+        WasMentioned: true,
+        SessionKey: "test:whatsapp:group:G1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
     expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -810,6 +810,41 @@ export async function dispatchReplyFromConfig(
         routedFinalCount: 0,
       };
     };
+    const suppressedModeVoiceMediaKeys = new Set<string>();
+    const sendSuppressedModeVoiceMediaPayload = async (
+      payload: ReplyPayload,
+    ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
+      const parts = resolveSendableOutboundReplyParts(payload);
+      if (!payload.audioAsVoice || !parts.hasMedia) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      const mediaKey = parts.mediaUrls.join("\n");
+      if (suppressedModeVoiceMediaKeys.has(mediaKey)) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      suppressedModeVoiceMediaKeys.add(mediaKey);
+      const normalizedPayload = await normalizeReplyMediaPayload({
+        ...payload,
+        text: undefined,
+      });
+      const result = await routeReplyToOriginating(normalizedPayload);
+      if (result) {
+        if (!result.ok) {
+          logVerbose(
+            `dispatch-from-config: route-reply (suppressed-mode voice media) failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+        return {
+          queuedFinal: result.ok,
+          routedFinalCount: result.ok ? 1 : 0,
+        };
+      }
+      markInboundDedupeReplayUnsafe();
+      return {
+        queuedFinal: dispatcher.sendFinalReply(normalizedPayload),
+        routedFinalCount: 0,
+      };
+    };
 
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
@@ -1052,6 +1087,8 @@ export async function dispatchReplyFromConfig(
     const onPlanUpdateFromReplyOptions = params.replyOptions?.onPlanUpdate;
     const onApprovalEventFromReplyOptions = params.replyOptions?.onApprovalEvent;
     const onPatchSummaryFromReplyOptions = params.replyOptions?.onPatchSummary;
+    let suppressedModeQueuedFinal = false;
+    let suppressedModeRoutedFinalCount = 0;
 
     const replyResolver =
       params.replyResolver ?? (await loadGetReplyFromConfigRuntime()).getReplyFromConfig;
@@ -1189,6 +1226,11 @@ export async function dispatchReplyFromConfig(
               markInboundDedupeReplayUnsafe();
             }
             if (suppressDelivery) {
+              if (suppressAutomaticSourceDelivery && !sourceReplyPolicy.sendPolicyDenied) {
+                const finalReply = await sendSuppressedModeVoiceMediaPayload(payload);
+                suppressedModeQueuedFinal = finalReply.queuedFinal || suppressedModeQueuedFinal;
+                suppressedModeRoutedFinalCount += finalReply.routedFinalCount;
+              }
               return;
             }
             // Suppress reasoning payloads — channels using this generic dispatch
@@ -1305,8 +1347,8 @@ export async function dispatchReplyFromConfig(
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
 
-    let queuedFinal = false;
-    let routedFinalCount = 0;
+    let queuedFinal = suppressedModeQueuedFinal;
+    let routedFinalCount = suppressedModeRoutedFinalCount;
     if (!suppressDelivery) {
       for (const reply of replies) {
         // Suppress reasoning payloads from channel delivery — channels using this
@@ -1376,6 +1418,15 @@ export async function dispatchReplyFromConfig(
             `dispatch-from-config: accumulated block TTS failed: ${formatErrorMessage(err)}`,
           );
         }
+      }
+    } else if (suppressAutomaticSourceDelivery && !sourceReplyPolicy.sendPolicyDenied) {
+      for (const reply of replies) {
+        if (reply.isReasoning === true) {
+          continue;
+        }
+        const finalReply = await sendSuppressedModeVoiceMediaPayload(reply);
+        queuedFinal = finalReply.queuedFinal || queuedFinal;
+        routedFinalCount += finalReply.routedFinalCount;
       }
     }
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -91,6 +91,28 @@ let runtimePluginsPromise: Promise<typeof import("./runtime-plugins.runtime.js")
 let replyMediaPathsRuntimePromise: Promise<typeof import("./reply-media-paths.runtime.js")> | null =
   null;
 
+const FILE_URL_RE = /^file:\/\//iu;
+const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/u;
+
+function isLocalTrustedMediaSource(mediaUrl: string): boolean {
+  const value = mediaUrl.trim();
+  if (!value) {
+    return false;
+  }
+  if (value.startsWith("/") || WINDOWS_DRIVE_RE.test(value)) {
+    return true;
+  }
+  if (!FILE_URL_RE.test(value)) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "file:" && !parsed.host && parsed.pathname.startsWith("/");
+  } catch {
+    return false;
+  }
+}
+
 function loadRouteReplyRuntime() {
   routeReplyRuntimePromise ??= import("./route-reply.runtime.js");
   return routeReplyRuntimePromise;
@@ -815,7 +837,10 @@ export async function dispatchReplyFromConfig(
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
       const parts = resolveSendableOutboundReplyParts(payload);
-      if (!payload.audioAsVoice || !parts.hasMedia) {
+      if (!payload.audioAsVoice || payload.trustedLocalMedia !== true || !parts.hasMedia) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
+      if (!parts.mediaUrls.every(isLocalTrustedMediaSource)) {
         return { queuedFinal: false, routedFinalCount: 0 };
       }
       const mediaKey = parts.mediaUrls.join("\n");
@@ -827,6 +852,9 @@ export async function dispatchReplyFromConfig(
         ...payload,
         text: undefined,
       });
+      if (!resolveSendableOutboundReplyParts(normalizedPayload).hasMedia) {
+        return { queuedFinal: false, routedFinalCount: 0 };
+      }
       const result = await routeReplyToOriginating(normalizedPayload);
       if (result) {
         if (!result.ok) {

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -1,17 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenAiCompatibleSpeechProvider } from "./openai-compatible-speech-provider.js";
 
-const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRequestConfigMock } =
-  vi.hoisted(() => ({
-    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-    postJsonRequestMock: vi.fn(),
-    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://example.test/v1",
-      allowPrivateNetwork: false,
-      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-      dispatcherPolicy: undefined,
-    })),
-  }));
+const {
+  assertOkOrThrowHttpErrorMock,
+  logVerboseMock,
+  postJsonRequestMock,
+  resolveProviderHttpRequestConfigMock,
+} = vi.hoisted(() => ({
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  logVerboseMock: vi.fn(),
+  postJsonRequestMock: vi.fn(),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://example.test/v1",
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+    dispatcherPolicy: undefined,
+  })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
@@ -19,9 +24,14 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
 }));
 
+vi.mock("../globals.js", () => ({
+  logVerbose: logVerboseMock,
+}));
+
 describe("createOpenAiCompatibleSpeechProvider", () => {
   afterEach(() => {
     assertOkOrThrowHttpErrorMock.mockClear();
+    logVerboseMock.mockClear();
     postJsonRequestMock.mockReset();
     resolveProviderHttpRequestConfigMock.mockClear();
     vi.unstubAllEnvs();
@@ -176,7 +186,7 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
       envKey: "DEMO_API_KEY",
       responseFormats: ["mp3", "pcm"],
       defaultResponseFormat: "pcm",
-      voiceCompatibleResponseFormats: ["mp3"],
+      voiceCompatibleResponseFormats: ["mp3", "pcm"],
     });
 
     const result = await provider.synthesize({
@@ -195,6 +205,92 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
     expect(result.audioBuffer.readUInt32LE(24)).toBe(24_000);
     expect(result.audioBuffer.readUInt16LE(22)).toBe(1);
     expect(result.audioBuffer.subarray(44)).toEqual(Buffer.from([1, 0, 2, 0]));
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("logs when a requested PCM response has a non-PCM content type", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(new Uint8Array([9, 8, 7]), {
+        status: 200,
+        headers: { "content-type": "application/octet-stream" },
+      }),
+      release,
+    });
+    vi.stubEnv("DEMO_API_KEY", "sk-env");
+
+    const provider = createOpenAiCompatibleSpeechProvider({
+      id: "demo",
+      label: "Demo",
+      autoSelectOrder: 40,
+      models: ["demo-tts"],
+      voices: ["alloy"],
+      defaultModel: "demo-tts",
+      defaultVoice: "alloy",
+      defaultBaseUrl: "https://example.test/v1",
+      envKey: "DEMO_API_KEY",
+      responseFormats: ["mp3", "pcm"],
+      defaultResponseFormat: "pcm",
+      voiceCompatibleResponseFormats: ["mp3"],
+    });
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: { responseFormat: "pcm" },
+      target: "audio-file",
+      timeoutMs: 1234,
+    });
+
+    expect(result.outputFormat).toBe("pcm");
+    expect(result.fileExtension).toBe(".pcm");
+    expect(result.audioBuffer).toEqual(Buffer.from([9, 8, 7]));
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "Demo TTS: requested pcm responseFormat but response content-type was application/octet-stream; leaving raw PCM audio unwrapped.",
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("leaves declared PCM responses unwrapped when PCM parameters are out of range", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(new Uint8Array([6, 5, 4]), {
+        status: 200,
+        headers: { "content-type": "audio/pcm;rate=999999999999;channels=999999" },
+      }),
+      release,
+    });
+    vi.stubEnv("DEMO_API_KEY", "sk-env");
+
+    const provider = createOpenAiCompatibleSpeechProvider({
+      id: "demo",
+      label: "Demo",
+      autoSelectOrder: 40,
+      models: ["demo-tts"],
+      voices: ["alloy"],
+      defaultModel: "demo-tts",
+      defaultVoice: "alloy",
+      defaultBaseUrl: "https://example.test/v1",
+      envKey: "DEMO_API_KEY",
+      responseFormats: ["mp3", "pcm"],
+      defaultResponseFormat: "pcm",
+      voiceCompatibleResponseFormats: ["mp3"],
+    });
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: { responseFormat: "pcm" },
+      target: "audio-file",
+      timeoutMs: 1234,
+    });
+
+    expect(result.outputFormat).toBe("pcm");
+    expect(result.fileExtension).toBe(".pcm");
+    expect(result.audioBuffer).toEqual(Buffer.from([6, 5, 4]));
+    expect(logVerboseMock).toHaveBeenCalledWith(
+      "Demo TTS: requested pcm responseFormat but response content-type was audio/pcm;rate=999999999999;channels=999999; leaving raw PCM audio unwrapped.",
+    );
     expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/src/tts/openai-compatible-speech-provider.test.ts
+++ b/src/tts/openai-compatible-speech-provider.test.ts
@@ -152,4 +152,49 @@ describe("createOpenAiCompatibleSpeechProvider", () => {
     });
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it("wraps declared raw PCM responses as WAV audio", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(new Uint8Array([1, 0, 2, 0]), {
+        status: 200,
+        headers: { "content-type": "audio/pcm;rate=24000;channels=1" },
+      }),
+      release,
+    });
+    vi.stubEnv("DEMO_API_KEY", "sk-env");
+
+    const provider = createOpenAiCompatibleSpeechProvider({
+      id: "demo",
+      label: "Demo",
+      autoSelectOrder: 40,
+      models: ["demo-tts"],
+      voices: ["alloy"],
+      defaultModel: "demo-tts",
+      defaultVoice: "alloy",
+      defaultBaseUrl: "https://example.test/v1",
+      envKey: "DEMO_API_KEY",
+      responseFormats: ["mp3", "pcm"],
+      defaultResponseFormat: "pcm",
+      voiceCompatibleResponseFormats: ["mp3"],
+    });
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: { responseFormat: "pcm" },
+      target: "voice-note",
+      timeoutMs: 1234,
+    });
+
+    expect(result.outputFormat).toBe("wav");
+    expect(result.fileExtension).toBe(".wav");
+    expect(result.voiceCompatible).toBe(false);
+    expect(result.audioBuffer.subarray(0, 4).toString("ascii")).toBe("RIFF");
+    expect(result.audioBuffer.subarray(8, 12).toString("ascii")).toBe("WAVE");
+    expect(result.audioBuffer.readUInt32LE(24)).toBe(24_000);
+    expect(result.audioBuffer.readUInt16LE(22)).toBe(1);
+    expect(result.audioBuffer.subarray(44)).toEqual(Buffer.from([1, 0, 2, 0]));
+    expect(release).toHaveBeenCalledOnce();
+  });
 });

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { asFiniteNumber, asObject, trimToUndefined } from "../agents/provider-http-errors.js";
+import { logVerbose } from "../globals.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import type {
@@ -86,6 +87,11 @@ function responseFormatToFileExtension(format: string): `.${string}` {
   return `.${format}`;
 }
 
+const PCM_MIN_SAMPLE_RATE = 8_000;
+const PCM_MAX_SAMPLE_RATE = 192_000;
+const PCM_MIN_CHANNELS = 1;
+const PCM_MAX_CHANNELS = 8;
+
 function parsePcmAudioContentType(contentType: string | null):
   | {
       sampleRate: number;
@@ -112,6 +118,15 @@ function parsePcmAudioContentType(contentType: string | null):
     } else if (key === "channels") {
       channels = Math.trunc(value);
     }
+  }
+
+  if (
+    sampleRate < PCM_MIN_SAMPLE_RATE ||
+    sampleRate > PCM_MAX_SAMPLE_RATE ||
+    channels < PCM_MIN_CHANNELS ||
+    channels > PCM_MAX_CHANNELS
+  ) {
+    return undefined;
   }
 
   return { sampleRate, channels };
@@ -143,23 +158,27 @@ function wrapPcm16LeToWav(params: { pcm: Buffer; sampleRate: number; channels: n
 
 function normalizeAudioResponse(params: {
   audioBuffer: Buffer;
+  providerLabel: string;
   response: Response;
   responseFormat: string;
 }): { audioBuffer: Buffer; outputFormat: string; fileExtension: `.${string}` } {
-  const pcm =
-    params.responseFormat === "pcm"
-      ? parsePcmAudioContentType(params.response.headers.get("content-type"))
-      : undefined;
-  if (pcm) {
-    return {
-      audioBuffer: wrapPcm16LeToWav({
-        pcm: params.audioBuffer,
-        sampleRate: pcm.sampleRate,
-        channels: pcm.channels,
-      }),
-      outputFormat: "wav",
-      fileExtension: ".wav",
-    };
+  if (params.responseFormat === "pcm") {
+    const contentType = params.response.headers.get("content-type");
+    const pcm = parsePcmAudioContentType(contentType);
+    if (pcm) {
+      return {
+        audioBuffer: wrapPcm16LeToWav({
+          pcm: params.audioBuffer,
+          sampleRate: pcm.sampleRate,
+          channels: pcm.channels,
+        }),
+        outputFormat: "wav",
+        fileExtension: ".wav",
+      };
+    }
+    logVerbose(
+      `${params.providerLabel} TTS: requested pcm responseFormat but response content-type was ${contentType ?? "missing"}; leaving raw PCM audio unwrapped.`,
+    );
   }
   return {
     audioBuffer: params.audioBuffer,
@@ -465,6 +484,7 @@ export function createOpenAiCompatibleSpeechProvider<
         );
         const audio = normalizeAudioResponse({
           audioBuffer: Buffer.from(await response.arrayBuffer()),
+          providerLabel: options.label,
           response,
           responseFormat,
         });
@@ -472,7 +492,7 @@ export function createOpenAiCompatibleSpeechProvider<
           audioBuffer: audio.audioBuffer,
           outputFormat: audio.outputFormat,
           fileExtension: audio.fileExtension,
-          voiceCompatible: options.voiceCompatibleResponseFormats.includes(responseFormat),
+          voiceCompatible: options.voiceCompatibleResponseFormats.includes(audio.outputFormat),
         };
       } finally {
         await release();

--- a/src/tts/openai-compatible-speech-provider.ts
+++ b/src/tts/openai-compatible-speech-provider.ts
@@ -86,6 +86,88 @@ function responseFormatToFileExtension(format: string): `.${string}` {
   return `.${format}`;
 }
 
+function parsePcmAudioContentType(contentType: string | null):
+  | {
+      sampleRate: number;
+      channels: number;
+    }
+  | undefined {
+  const parts = contentType?.split(";").map((part) => part.trim()) ?? [];
+  const mime = parts.shift()?.toLowerCase();
+  if (mime !== "audio/pcm" && mime !== "audio/l16") {
+    return undefined;
+  }
+
+  let sampleRate = 24_000;
+  let channels = 1;
+  for (const part of parts) {
+    const [rawKey, rawValue] = part.split("=", 2);
+    const key = rawKey?.trim().toLowerCase();
+    const value = Number(rawValue?.trim());
+    if (!Number.isFinite(value) || value <= 0) {
+      continue;
+    }
+    if (key === "rate" || key === "samplerate" || key === "sample-rate") {
+      sampleRate = Math.trunc(value);
+    } else if (key === "channels") {
+      channels = Math.trunc(value);
+    }
+  }
+
+  return { sampleRate, channels };
+}
+
+function wrapPcm16LeToWav(params: { pcm: Buffer; sampleRate: number; channels: number }): Buffer {
+  const bitsPerSample = 16;
+  const bytesPerSample = bitsPerSample / 8;
+  const byteRate = params.sampleRate * params.channels * bytesPerSample;
+  const blockAlign = params.channels * bytesPerSample;
+  const header = Buffer.alloc(44);
+
+  header.write("RIFF", 0, "ascii");
+  header.writeUInt32LE(36 + params.pcm.length, 4);
+  header.write("WAVE", 8, "ascii");
+  header.write("fmt ", 12, "ascii");
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(params.channels, 22);
+  header.writeUInt32LE(params.sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write("data", 36, "ascii");
+  header.writeUInt32LE(params.pcm.length, 40);
+
+  return Buffer.concat([header, params.pcm]);
+}
+
+function normalizeAudioResponse(params: {
+  audioBuffer: Buffer;
+  response: Response;
+  responseFormat: string;
+}): { audioBuffer: Buffer; outputFormat: string; fileExtension: `.${string}` } {
+  const pcm =
+    params.responseFormat === "pcm"
+      ? parsePcmAudioContentType(params.response.headers.get("content-type"))
+      : undefined;
+  if (pcm) {
+    return {
+      audioBuffer: wrapPcm16LeToWav({
+        pcm: params.audioBuffer,
+        sampleRate: pcm.sampleRate,
+        channels: pcm.channels,
+      }),
+      outputFormat: "wav",
+      fileExtension: ".wav",
+    };
+  }
+  return {
+    audioBuffer: params.audioBuffer,
+    outputFormat: params.responseFormat,
+    fileExtension: responseFormatToFileExtension(params.responseFormat),
+  };
+}
+
 function trimTrailingBaseUrl(value: unknown, fallback: string): string {
   return (trimToUndefined(value) ?? fallback).replace(/\/+$/u, "");
 }
@@ -381,10 +463,15 @@ export function createOpenAiCompatibleSpeechProvider<
           response,
           options.apiErrorLabel ?? `${options.label} TTS API error`,
         );
-        return {
+        const audio = normalizeAudioResponse({
           audioBuffer: Buffer.from(await response.arrayBuffer()),
-          outputFormat: responseFormat,
-          fileExtension: responseFormatToFileExtension(responseFormat),
+          response,
+          responseFormat,
+        });
+        return {
+          audioBuffer: audio.audioBuffer,
+          outputFormat: audio.outputFormat,
+          fileExtension: audio.fileExtension,
           voiceCompatible: options.voiceCompatibleResponseFormats.includes(responseFormat),
         };
       } finally {


### PR DESCRIPTION
## Summary

- Problem: WhatsApp group replies configured with suppressed automatic source delivery could generate TTS audio successfully but drop internally-generated voice media before channel delivery.
- Why it matters: voice-first WhatsApp group workflows could appear to do nothing even though the TTS tool/provider succeeded; OpenRouter/Gemini PCM responses also needed a container that the media pipeline can persist and send.
- What changed: allow only trusted internal `audioAsVoice` media from local staged/file sources through suppressed delivery modes, including pending tool media flushed through `onBlockReply`; wrap declared raw PCM from OpenAI-compatible speech providers as WAV when PCM parameters are in safe WAV ranges; stop sending duplicate visible text after WhatsApp voice notes; report unexpected PCM content types and calculate voice compatibility after response normalization.
- What did NOT change (scope boundary): this does not enable normal automatic text replies in `message_tool_only` groups, does not allow untrusted/model-emitted or remote media to bypass suppression, does not change TTS provider selection, and does not change channel permissions/allowlists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: TTS generation succeeded, but group `message_tool_only` delivery suppression returned before forwarding internally-generated voice media. In the real path, the TTS tool emitted pending media through the block-reply callback, not only as the final reply payload.
- Missing detection / guardrail: tests covered suppressed text delivery but did not cover trusted `audioAsVoice` media emitted from pending tool/block delivery, untrusted `audioAsVoice` media that must remain suppressed, or remote media that must not be accepted as trusted local media.
- Contributing context (if known): OpenRouter/Gemini TTS can return raw PCM on the OpenAI-compatible path, which needs a WAV container before normal media delivery when rate/channel metadata is valid.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/tts/openai-compatible-speech-provider.test.ts`, `extensions/whatsapp/src/auto-reply/deliver-reply.test.ts`, `extensions/whatsapp/src/inbound/send-api.test.ts`, `extensions/whatsapp/src/send.test.ts`
- Scenario the test should lock in: suppressed group delivery sends trusted internal local `audioAsVoice` media from both final replies and pending tool media; untrusted or remote `audioAsVoice` media remains suppressed; declared raw PCM responses are wrapped as WAV only when PCM content-type parameters are bounded; PCM content-type mismatches are observable; WhatsApp voice-note delivery does not duplicate text.
- Why this is the smallest reliable guardrail: it exercises the dispatch suppression branch, the provider response-normalization branch, and the WhatsApp voice send paths directly without requiring a live WhatsApp session.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A, new tests are included.

## User-visible / Behavior Changes

WhatsApp voice-note replies no longer duplicate the same phrase as both text and audio. Trusted TTS voice media can now be delivered in groups that suppress normal automatic text replies via `message_tool_only`.

## Diagram (if applicable)

```text
Before:
TTS tool -> pending trusted audioAsVoice block -> suppressed group delivery -> dropped media
Model media directive -> audioAsVoice block -> suppressed group delivery -> dropped media
OpenRouter PCM -> raw PCM attachment path -> media delivery cannot reliably send
WhatsApp voice-note send -> audio + separate duplicate text

After:
TTS tool -> pending trusted local audioAsVoice block -> trusted voice-media exception -> WhatsApp voice note
Model/remote media directive -> audioAsVoice block -> suppressed group delivery -> still dropped
OpenRouter PCM with valid metadata -> WAV wrapper -> normal media persistence/delivery
WhatsApp voice-note send -> audio caption only, no duplicate text message
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

The suppressed-delivery exception is gated on `audioAsVoice`, media presence, the internal `trustedLocalMedia` marker, and a local media source requirement. Remote `http(s)` media remains suppressed even if a resolver/plugin sets the trust marker. The payload is normalized with text stripped and rechecked for sendable media before routing.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js / pnpm local gateway build
- Model/provider: OpenRouter OpenAI-compatible TTS using Gemini TTS PCM response, with OpenAI/Microsoft fallback configured
- Integration/channel (if any): WhatsApp group
- Relevant config (redacted): `messages.tts.provider=openrouter`, `messages.tts.auto=inbound`, `messages.tts.mode=final`, OpenAI-compatible provider `responseFormat=pcm`, group source delivery using the default `message_tool_only` behavior

### Steps

1. Configure auto TTS for inbound WhatsApp replies with an OpenAI-compatible provider that returns declared PCM audio.
2. Send a WhatsApp group voice message that triggers the TTS tool while group source delivery suppresses normal automatic replies.
3. Observe whether the generated TTS media is delivered as a WhatsApp voice note and whether duplicate visible text is sent.

### Expected

- The trusted internally-generated local audio is delivered as one WhatsApp voice note.
- The same phrase is not also sent as a duplicate text message.
- Untrusted/model-emitted or remote media does not bypass `message_tool_only` suppression.

### Actual

- Before this PR, the TTS tool could generate audio successfully but the pending voice media was dropped in the suppressed-delivery path, or voice-note sends duplicated the visible caption text.
- After this PR, trusted local voice media is forwarded, untrusted/remote voice media remains suppressed, duplicate text is not sent, and valid declared PCM is wrapped as WAV.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts` — 94 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/tts/openai-compatible-speech-provider.test.ts` — 5 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/send.test.ts` — 57 passed
- `pnpm build`

Live trace after the fix showed OpenRouter TTS generated a WAV attachment and the WhatsApp channel logged a successful media reply send.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live WhatsApp group voice-message loopback generated TTS via OpenRouter/Gemini PCM and sent the resulting audio as media; local dispatch tests cover trusted final and pending tool voice-media paths, plus untrusted and remote suppression.
- Edge cases checked: duplicate suppression for the same media URL, text suppression remains in `message_tool_only`, untrusted `audioAsVoice` media remains suppressed, remote media cannot claim local trust, PCM content-type rate/channel parsing defaults and explicit values, out-of-range PCM parameters are left raw, post-normalization voice compatibility.
- What you did **not** verify: every WhatsApp client rendering variant and all non-OpenRouter speech providers in a live channel.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer, bot re-run, or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: voice media could bypass suppressed source delivery more broadly than intended.
  - Mitigation: the exception requires explicit `audioAsVoice`, media, the internal `trustedLocalMedia` marker, and a local file/path source; normal automatic text delivery plus untrusted or remote media remain suppressed.
- Risk: malformed declared PCM metadata could create invalid WAV headers.
  - Mitigation: WAV wrapping only accepts sample rates from 8000 to 192000 Hz and 1 to 8 channels; out-of-range or malformed values are logged and left as raw PCM instead of being wrapped.
