### PR TITLE
fix(agents): inject resolved OAuth bearer into boundary-aware embedded streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/reliability: publish real transport-liveness into WhatsApp channel status and force earlier reconnects on silent transport stalls, so quiet healthy sessions stay connected while wedged sockets recover before the later remote 408 path. (#72656) Thanks @Sathvik-1007.
 - Core/channels: tighten selected runtime, media, and plugin edge-case handling while preserving existing behavior. Thanks @jesse-merhi.
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and allow `channels.whatsapp.exposeErrorText` to suppress visible error text per channel or account. (#71830) Thanks @rubencu.
+- Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
 
 ## 2026.4.27
 

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -1,10 +1,31 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import * as providerTransportStream from "../provider-transport-stream.js";
 import {
   describeEmbeddedAgentStreamStrategy,
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentStreamFn,
 } from "./stream-resolution.js";
+
+// Wrap createBoundaryAwareStreamFnForModel with a spy that delegates to the
+// real implementation by default so existing routing tests still observe a
+// real transport stream; per-test overrideBoundaryAwareStreamFnOnce() injects
+// a probe stream when a regression test needs to inspect the wrapped
+// transport's options.
+vi.mock("../provider-transport-stream.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof providerTransportStream>();
+  return {
+    ...actual,
+    createBoundaryAwareStreamFnForModel: vi.fn(actual.createBoundaryAwareStreamFnForModel),
+  };
+});
+
+const overrideBoundaryAwareStreamFnOnce = (streamFn: StreamFn): void => {
+  vi.mocked(providerTransportStream.createBoundaryAwareStreamFnForModel).mockReturnValueOnce(
+    streamFn,
+  );
+};
 
 describe("describeEmbeddedAgentStreamStrategy", () => {
   it("describes provider-owned stream paths explicitly", () => {
@@ -202,5 +223,139 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     ).resolves.toMatchObject({
       signal: explicitSignal,
     });
+  });
+
+  it("injects the resolved run api key into the boundary-aware Codex Responses fallback", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      resolvedApiKey: "oauth-bearer-token",
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "oauth-bearer-token" });
+    expect(innerStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to authStorage when no resolved api key is available for boundary-aware fallback", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const authStorage = {
+      getApiKey: vi.fn(async () => "stored-bearer-token"),
+    };
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      authStorage,
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "stored-bearer-token" });
+    expect(authStorage.getApiKey).toHaveBeenCalledWith("openai-codex");
+  });
+
+  it("forwards the run abort signal into the boundary-aware fallback when callers omit one", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const runSignal = new AbortController().signal;
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      signal: runSignal,
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      resolvedApiKey: "oauth-bearer-token",
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ signal: runSignal, apiKey: "oauth-bearer-token" });
+  });
+
+  it("does not overwrite an explicit signal on the boundary-aware fallback path", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const runSignal = new AbortController().signal;
+    const explicitSignal = new AbortController().signal;
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      signal: runSignal,
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      resolvedApiKey: "oauth-bearer-token",
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {
+        signal: explicitSignal,
+      }),
+    ).resolves.toMatchObject({ signal: explicitSignal });
+  });
+
+  it("forwards the run signal on the sync boundary-aware fallback path without auth credentials", async () => {
+    const innerStreamFn = vi.fn(async (_model, _context, options) => options);
+    const runSignal = new AbortController().signal;
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      signal: runSignal,
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ signal: runSignal });
+  });
+
+  it("does not strip cache boundary markers on the boundary-aware fallback path", async () => {
+    const innerStreamFn = vi.fn(async (_model, context, _options) => context);
+    overrideBoundaryAwareStreamFnOnce(innerStreamFn as never);
+    const streamFn = resolveEmbeddedAgentStreamFn({
+      currentStreamFn: undefined,
+      shouldUseWebSocketTransport: false,
+      sessionId: "session-1",
+      model: {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.5",
+      } as never,
+      resolvedApiKey: "oauth-bearer-token",
+    });
+
+    const systemPrompt = "intro<<openclaw-cache-boundary>>tail";
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, { systemPrompt } as never, {}),
+    ).resolves.toMatchObject({ systemPrompt });
   });
 });

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -73,36 +73,19 @@ export function resolveEmbeddedAgentStreamFn(params: {
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
   if (params.providerStreamFn) {
-    const inner = params.providerStreamFn;
-    const normalizeContext = (context: Parameters<StreamFn>[1]) =>
-      context.systemPrompt
-        ? {
-            ...context,
-            systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
-          }
-        : context;
-    const mergeRunSignal = (options: Parameters<StreamFn>[2]) => {
-      const signal = options?.signal ?? params.signal;
-      return signal ? { ...options, signal } : options;
-    };
-    // Provider-owned transports bypass pi-coding-agent's default auth lookup,
-    // so keep injecting the resolved runtime apiKey for streamSimple-compatible
-    // transports that still read credentials from options.apiKey.
-    if (params.authStorage || params.resolvedApiKey) {
-      const { authStorage, model, resolvedApiKey } = params;
-      return async (m, context, options) => {
-        const apiKey = await resolveEmbeddedAgentApiKey({
-          provider: model.provider,
-          resolvedApiKey,
-          authStorage,
-        });
-        return inner(m, normalizeContext(context), {
-          ...mergeRunSignal(options),
-          apiKey: apiKey ?? options?.apiKey,
-        });
-      };
-    }
-    return (m, context, options) => inner(m, normalizeContext(context), mergeRunSignal(options));
+    return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
+      runSignal: params.signal,
+      resolvedApiKey: params.resolvedApiKey,
+      authStorage: params.authStorage,
+      providerId: params.model.provider,
+      transformContext: (context) =>
+        context.systemPrompt
+          ? {
+              ...context,
+              systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
+            }
+          : context,
+    });
   }
 
   const currentStreamFn = params.currentStreamFn ?? streamSimple;
@@ -124,9 +107,52 @@ export function resolveEmbeddedAgentStreamFn(params: {
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
-      return boundaryAwareStreamFn;
+      // Boundary-aware transports read credentials from options.apiKey just
+      // like provider-owned streams, but the embedded run layer never gets to
+      // inject the resolved runtime key for them. Without this wrap, OAuth
+      // providers (e.g. openai-codex/gpt-5.5) hit the Responses API with an
+      // empty bearer and fail with 401 Missing bearer auth header.
+      return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
+        runSignal: params.signal,
+        resolvedApiKey: params.resolvedApiKey,
+        authStorage: params.authStorage,
+        providerId: params.model.provider,
+      });
     }
   }
 
   return currentStreamFn;
+}
+
+function wrapEmbeddedAgentStreamFn(
+  inner: StreamFn,
+  params: {
+    runSignal: AbortSignal | undefined;
+    resolvedApiKey: string | undefined;
+    authStorage: { getApiKey(provider: string): Promise<string | undefined> } | undefined;
+    providerId: string;
+    transformContext?: (context: Parameters<StreamFn>[1]) => Parameters<StreamFn>[1];
+  },
+): StreamFn {
+  const transformContext =
+    params.transformContext ?? ((context: Parameters<StreamFn>[1]) => context);
+  const mergeRunSignal = (options: Parameters<StreamFn>[2]) => {
+    const signal = options?.signal ?? params.runSignal;
+    return signal ? { ...options, signal } : options;
+  };
+  if (!params.authStorage && !params.resolvedApiKey) {
+    return (m, context, options) => inner(m, transformContext(context), mergeRunSignal(options));
+  }
+  const { authStorage, providerId, resolvedApiKey } = params;
+  return async (m, context, options) => {
+    const apiKey = await resolveEmbeddedAgentApiKey({
+      provider: providerId,
+      resolvedApiKey,
+      authStorage,
+    });
+    return inner(m, transformContext(context), {
+      ...mergeRunSignal(options),
+      apiKey: apiKey ?? options?.apiKey,
+    });
+  };
 }


### PR DESCRIPTION
### Summary

- **Problem**: Sending any UI message while the default model is `openai-codex/gpt-5.5` causes the embedded run to fail before reply with `unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses`. Logs show three matching errors at the lane (`lane=main`), session-agent (`lane=session:agent:main:main`) and embedded-agent layers. The resolved Codex OAuth profile is present and validated (`openclaw models status` reports it as healthy), but the OpenAI Responses HTTP request goes out with no bearer header. The defect is in `src/agents/pi-embedded-runner/stream-resolution.ts:124` (pre-fix), inside `resolveEmbeddedAgentStreamFn`.
- **Root Cause**: `resolveEmbeddedAgentStreamFn` injects the resolved runtime `apiKey` (the OAuth bearer that the embedded run layer already resolved at `src/agents/pi-embedded-runner/run.ts:867` and forwarded as `params.resolvedApiKey` from `src/agents/pi-embedded-runner/run/attempt.ts:1611`) only on the **provider-owned** branch. On the boundary-aware fallback branch — taken whenever a model resolves to a transport-aware API like `openai-codex-responses` without a registered provider stream — the function simply `return boundaryAwareStreamFn;` and the resolved key is dropped. `createOpenAIResponsesTransportStreamFn` at `src/agents/openai-transport-stream.ts:738` then constructs the OpenAI client from `options?.apiKey || getEnvApiKey(model.provider) || ""`. For OAuth-only providers like `openai-codex` there is no env var, `options.apiKey` was never injected, so the SDK is created with `apiKey: ""` and OpenAI rejects the request with the 401 above. `gpt-5.5` is the first widely-used Codex model that takes this exact `boundary-aware:openai-codex-responses` lane (the `openai-codex` plugin does not register a provider-owned stream for the Codex Responses API — see `extensions/openai/openai-codex-provider.ts:175`), which is why the regression surfaces specifically on the `openai-codex/gpt-5.5` upgrade and stays present after re-running `OpenAI Codex OAuth login`.
- **Fix**: Extract the existing `resolvedApiKey` + run-signal injection logic from the provider-owned branch into a small private helper `wrapEmbeddedAgentStreamFn`, and apply the same wrapper to the boundary-aware fallback. The provider-owned branch keeps its `stripSystemPromptCacheBoundary` context normalization (passed in as the optional `transformContext` callback). The boundary-aware branch deliberately omits that callback because boundary-aware transports (`createOpenAIResponsesTransportStreamFn`, `createAnthropicMessagesTransportStreamFn`, etc.) already strip the cache boundary internally — see `src/agents/openai-transport-stream.ts:254`, `:870`, `:1755` — so re-stripping would be a behavior change. Auth precedence inside the helper is preserved exactly: `resolvedApiKey?.trim()` wins, then `authStorage.getApiKey(provider)`, then any pre-existing `options.apiKey`. This is the minimal change that closes the credential gap on every boundary-aware transport (Codex Responses, OpenAI Responses, OpenAI Completions, Azure OpenAI Responses, Anthropic Messages, Google Generative AI) without touching provider plugins, transport internals, OAuth refresh, or the Responses URL.
- **What changed**:
  - `src/agents/pi-embedded-runner/stream-resolution.ts`: refactored `resolveEmbeddedAgentStreamFn` to delegate to a new private `wrapEmbeddedAgentStreamFn` helper; the boundary-aware fallback now wraps the resolved transport with the same auth/signal injection that the provider-owned branch already had.
  - `src/agents/pi-embedded-runner/stream-resolution.test.ts`: added four focused regression tests covering resolved-key injection, `authStorage` fallback, run-signal forwarding, and cache-boundary preservation on the boundary-aware fallback path. Existing tests (provider-owned auth/signal, fallback shape labels) are unchanged.
- **What did NOT change (scope boundary)**:
  - No change to `extensions/openai/openai-codex-provider.ts`, the OpenAI Codex OAuth login flow, model registry, or `auth-profiles.json` storage.
  - No change to `createOpenAIResponsesTransportStreamFn` or any of the boundary-aware transports — the `apiKey || getEnvApiKey(model.provider) || ""` chain remains exactly as it was.
  - No change to provider-owned stream behavior, system prompt cache boundary stripping, WebSocket transport, Anthropic Vertex stream, or the run / attempt control flow.
  - No new public API, no new exports, no `any`, no widened types — `wrapEmbeddedAgentStreamFn` is a file-local helper.
  - No change to gateway protocol, channels, plugins SDK, settings schema, or docs/changelog beyond what the regression test asserts.

### Reproduction

1. Configure OpenAI Codex OAuth on `main`.
2. `openclaw models set openai-codex/gpt-5.5`
3. `openclaw models status` — confirms the OAuth profile resolves cleanly.
4. `openclaw gateway --port 18789`
5. Send any message in the Control UI.
6. Observe no assistant reply.
7. Tail the gateway log:
   ```
   grep -Ei 'embedded|lane task|401|unauthorized|responses' /tmp/openclaw/openclaw-2026-04-28.log | tail -n 40
   ```
   Expected (current `main`):
   ```
   lane task error: lane=main durationMs=87316 error="unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses"
   lane task error: lane=session:agent:main:main durationMs=87319 error="unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses"
   Embedded agent failed before reply: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses
   ```
8. Apply this PR. Repeat steps 4–6 — the embedded run completes and the assistant reply renders normally.

The new unit test `injects the resolved run api key into the boundary-aware Codex Responses fallback` reproduces the credential drop deterministically without any network or live OAuth.

### Risk / Mitigation

- **Risk**: The wrapper is now applied to every boundary-aware transport (`openai-responses`, `openai-codex-responses`, `openai-completions`, `azure-openai-responses`, `anthropic-messages`, `google-generative-ai`). For non-OAuth providers that previously relied on `getEnvApiKey(model.provider)` inside the transport, an empty `params.resolvedApiKey` and missing `params.authStorage` would now still produce no `options.apiKey` — exactly as before. For env-keyed providers that *do* have an `authStorage` entry, `authStorage.getApiKey(provider)` returns the same key the transport would have read from env, so behavior is preserved. The auth precedence (`resolvedApiKey` → `authStorage` → existing `options.apiKey`) is bit-identical to the provider-owned branch that has been in production since `d12987d72`.
- **Risk**: The boundary-aware path now also forwards the run abort signal when callers do not pass one explicitly, mirroring the provider-owned branch added in `d12987d72`. Cancellation reaches the OpenAI SDK `AbortSignal` slot the same way; the existing test `does not overwrite an explicit provider-owned stream signal` proves explicit caller signals still win, and the new boundary-aware sibling test asserts the same precedence.
- **Mitigation**: Four new regression tests in `stream-resolution.test.ts` lock the contract: resolved-key injection, `authStorage` fallback, run-signal forwarding, and cache-boundary preservation on the boundary-aware path. The cache-boundary test directly proves the fix did not silently start re-stripping `<<openclaw-cache-boundary>>` markers (which would corrupt prompt-cache hit rates on Codex Responses). Existing provider-owned coverage is untouched and continues to assert the prior behavior end-to-end.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] Integrations

### Linked Issue/PR

Fixes #73559