### PR TITLE
fix(cli): clarify infer media provider config errors

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -623,6 +623,21 @@ describe("capability cli", () => {
   });
 
   it("fails image describe when no description text is returned", async () => {
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "openai",
+          {
+            id: "openai",
+            capabilities: ["image"],
+            describeImage: vi.fn(),
+          },
+        ],
+      ]),
+    );
+    mocks.loadConfig.mockReturnValueOnce({
+      models: { providers: { openai: { apiKey: "sk-test" } } },
+    });
     mocks.describeImageFile.mockResolvedValueOnce({
       text: undefined,
       provider: undefined,
@@ -636,6 +651,31 @@ describe("capability cli", () => {
       }),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringMatching(/No description returned for image/),
+    );
+  });
+
+  it("reports missing image-understanding provider config for image describe", async () => {
+    mocks.describeImageFile.mockResolvedValueOnce({
+      text: undefined,
+      provider: undefined,
+      model: undefined,
+    } as never);
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "image", "describe", "--file", "photo.jpg", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("No image-understanding provider configured."),
+    );
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("agents.defaults.imageModel.primary"),
+    );
+    expect(mocks.runtime.error).not.toHaveBeenCalledWith(
       expect.stringMatching(/No description returned for image/),
     );
   });
@@ -1123,6 +1163,21 @@ describe("capability cli", () => {
   });
 
   it("fails audio transcribe when no transcript text is returned", async () => {
+    mocks.buildMediaUnderstandingRegistry.mockReturnValueOnce(
+      new Map([
+        [
+          "openai",
+          {
+            id: "openai",
+            capabilities: ["audio"],
+            transcribeAudio: vi.fn(),
+          },
+        ],
+      ]),
+    );
+    mocks.loadConfig.mockReturnValueOnce({
+      models: { providers: { openai: { apiKey: "sk-test" } } },
+    });
     mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
 
     await expect(
@@ -1132,6 +1187,27 @@ describe("capability cli", () => {
       }),
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringMatching(/No transcript returned for audio/),
+    );
+  });
+
+  it("reports missing audio transcription provider config for audio transcribe", async () => {
+    mocks.transcribeAudioFile.mockResolvedValueOnce({ text: undefined } as never);
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "audio", "transcribe", "--file", "memo.m4a", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("No audio transcription provider configured."),
+    );
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("tools.media.audio.models"),
+    );
+    expect(mocks.runtime.error).not.toHaveBeenCalledWith(
       expect.stringMatching(/No transcript returned for audio/),
     );
   });

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -29,6 +29,7 @@ import type {
   ImageGenerationOutputFormat,
 } from "../image-generation/types.js";
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
+import { providerSupportsCapability } from "../media-understanding/provider-supports.js";
 import {
   describeImageFile,
   describeImageFileWithModel,
@@ -482,6 +483,38 @@ function providerHasGenericConfig(params: {
   );
 }
 
+function hasConfiguredMediaUnderstandingProvider(params: {
+  cfg: OpenClawConfig;
+  capability: "audio" | "image";
+}): boolean {
+  const providers = [...buildMediaUnderstandingRegistry(undefined, params.cfg).values()].filter(
+    (provider) => providerSupportsCapability(provider, params.capability),
+  );
+  return providers.some((provider) =>
+    providerHasGenericConfig({
+      cfg: params.cfg,
+      providerId: provider.id,
+      envVars: getProviderEnvVars(provider.id, {
+        config: params.cfg,
+        includeUntrustedWorkspacePlugins: false,
+      }),
+    }),
+  );
+}
+
+function throwNoMediaUnderstandingProviderConfigured(capability: "audio" | "image"): never {
+  if (capability === "audio") {
+    throw new Error(
+      'No audio transcription provider configured. Configure tools.media.audio.models with a provider/model like "openai/gpt-4o-mini-transcribe", ' +
+        "or configure a supported provider API key first.",
+    );
+  }
+  throw new Error(
+    'No image-understanding provider configured. Set agents.defaults.imageModel.primary to a vision provider/model like "openai/gpt-4.1-mini", ' +
+      "or configure tools.media.image.models. If you want a specific provider, also configure that provider's auth/API key first.",
+  );
+}
+
 async function writeOutputAsset(params: {
   buffer: Buffer;
   mimeType?: string;
@@ -883,6 +916,12 @@ async function runImageDescribe(params: {
             timeoutMs: params.timeoutMs,
           });
       if (!result.text) {
+        if (
+          !activeModel &&
+          !hasConfiguredMediaUnderstandingProvider({ cfg, capability: "image" })
+        ) {
+          throwNoMediaUnderstandingProviderConfigured("image");
+        }
         throw new Error(`No description returned for image: ${resolvedPath}`);
       }
       return {
@@ -921,6 +960,9 @@ async function runAudioTranscribe(params: {
     prompt: params.prompt,
   });
   if (!result.text) {
+    if (!activeModel && !hasConfiguredMediaUnderstandingProvider({ cfg, capability: "audio" })) {
+      throwNoMediaUnderstandingProviderConfigured("audio");
+    }
     throw new Error(`No transcript returned for audio: ${path.resolve(params.file)}`);
   }
   return {


### PR DESCRIPTION
## Summary

- Problem: `infer audio transcribe` and `infer image describe` reported `No transcript/description returned for ... <path>` when no provider was configured.
- Why it matters: The old message made users debug the input file even though the real fix was provider configuration.
- What changed: The CLI now emits capability-specific missing-provider configuration errors for audio transcription and image understanding.
- What did NOT change (scope boundary): The existing `No transcript/description returned...` errors still apply when a configured provider is called but returns empty text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73569
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The CLI treated an empty media-understanding result the same whether no provider was configured or a configured provider returned empty text.
- Missing detection / guardrail: Tests covered empty provider output but not the no-provider-configured branch.
- Contributing context (if known): `infer image generate` already had clearer no-provider wording; audio/image describe lacked parity.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/capability-cli.test.ts`
- Scenario the test should lock in: no configured audio/image-understanding provider emits a config-focused error, while configured empty output preserves the existing empty-result error.
- Why this is the smallest reliable guardrail: The bug is in CLI error selection, so command-level unit tests directly cover the branch.
- Existing test that already covers this (if any): Existing tests covered configured-provider empty output only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`infer audio transcribe` and `infer image describe` now report missing provider configuration when no suitable provider is configured, instead of blaming the input path.
