### PR TITLE
feat: add local AlpaCore MCP bridge

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,16 @@
+{
+  "servers": {
+    "alpacore-local": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "${workspaceFolder}/scripts/alpacore-mcp-bridge.mjs"
+      ],
+      "env": {
+        "ALPACORE_URL": "http://127.0.0.1:5143",
+        "ALPACORE_TIMEOUT_MS": "240000",
+        "OLLAMA_URL": "http://127.0.0.1:11434"
+      }
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,8 +8,7 @@
       ],
       "env": {
         "ALPACORE_URL": "http://127.0.0.1:5143",
-        "ALPACORE_TIMEOUT_MS": "240000",
-        "OLLAMA_URL": "http://127.0.0.1:11434"
+        "ALPACORE_TIMEOUT_MS": "240000"
       }
     }
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
   "typescript.reportStyleChecksAsWarnings": false,
   "typescript.updateImportsOnFileMove.enabled": "always",
   "typescript.tsdk": "node_modules/typescript/lib",
+  "chat.mcp.autoStart": true,
   "makefile.configureOnOpen": false
 }

--- a/scripts/alpacore-mcp-bridge.mjs
+++ b/scripts/alpacore-mcp-bridge.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const ALPACORE_URL = normalizeBaseUrl(process.env.ALPACORE_URL ?? "http://127.0.0.1:5143");
+const REQUEST_TIMEOUT_MS = normalizeTimeout(process.env.ALPACORE_TIMEOUT_MS, 240_000);
+
+function normalizeBaseUrl(value) {
+  return String(value).replace(/\/+$/, "");
+}
+
+function normalizeTimeout(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function formatError(error) {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function formatResult(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+async function fetchAlpaCore(path, init = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${ALPACORE_URL}${path}`, {
+      ...init,
+      headers: {
+        Accept: "application/json",
+        ...(init.headers ?? {}),
+      },
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `AlpaCore request failed (${response.status} ${response.statusText})${bodyText ? `: ${bodyText}` : ""}`,
+      );
+    }
+    if (!bodyText) {
+      return null;
+    }
+    try {
+      return JSON.parse(bodyText);
+    } catch {
+      return bodyText;
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function toToolResult(action) {
+  try {
+    const value = await action();
+    return {
+      content: [
+        {
+          type: "text",
+          text: formatResult(value),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: formatError(error),
+        },
+      ],
+    };
+  }
+}
+
+const server = new McpServer({
+  name: "alpacore-local",
+  version: "1.0.0",
+});
+
+server.registerTool(
+  "arni_ask",
+  {
+    description: "Send a plain-text prompt to the live Arni endpoint.",
+    inputSchema: {
+      prompt: z.string().min(1).describe("The message to send to Arni."),
+    },
+  },
+  ({ prompt }) =>
+    toToolResult(async () => {
+      const result = await fetchAlpaCore("/api/arni/ask", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(prompt),
+      });
+      if (result && typeof result === "object" && "response" in result) {
+        return result.response;
+      }
+      return result;
+    }),
+);
+
+server.registerTool(
+  "alpacore_health",
+  {
+    description: "Return the live AlpaCore health payload.",
+  },
+  () => toToolResult(() => fetchAlpaCore("/api/health")),
+);
+
+server.registerTool(
+  "alpacore_ready",
+  {
+    description: "Return the live AlpaCore readiness payload.",
+  },
+  () => toToolResult(() => fetchAlpaCore("/api/ready")),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+
+  let shuttingDown = false;
+  let resolveClosed;
+  const closed = new Promise((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    process.stdin.off("end", shutdown);
+    process.stdin.off("close", shutdown);
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+    transport.onclose = undefined;
+    server.close().then(resolveClosed, resolveClosed);
+  };
+
+  transport.onclose = shutdown;
+  process.stdin.once("end", shutdown);
+  process.stdin.once("close", shutdown);
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+
+  try {
+    await server.connect(transport);
+    await closed;
+  } finally {
+    shutdown();
+    await closed;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${formatError(error)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Problem: the repo had no workspace-local MCP bridge for a running AlpaCore instance, so using local AlpaCore tools from VS Code required manual external wiring.
- Why it matters: this makes local MCP setup reproducible inside the repo and keeps the bridge definition close to the code it depends on.
- What changed: add a stdio MCP bridge script at `scripts/alpacore-mcp-bridge.mjs`, add `.vscode/mcp.json` for an `alpacore-local` server, and enable workspace MCP auto-start in `.vscode/settings.json`.
- What did NOT change (scope boundary): no gateway/runtime changes in core OpenClaw, no new remote service dependency, and no changes to production config outside workspace-local VS Code files.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: no test was added; this is workspace-local dev tooling.
- Scenario the test should lock in: MCP stdio startup plus proxying `arni_ask`, `alpacore_health`, and `alpacore_ready` to the local AlpaCore HTTP endpoints.
- Why this is the smallest reliable guardrail: the meaningful guardrail is a live MCP handshake against a running local AlpaCore instance rather than a pure unit test.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: there is no existing repo harness for this VS Code workspace MCP bridge, and no live AlpaCore service was available in this session.

## User-visible / Behavior Changes

- The workspace now defines an `alpacore-local` MCP server in `.vscode/mcp.json`.
- VS Code workspace MCP auto-start is enabled.
- The local bridge exposes `arni_ask`, `alpacore_health`, and `alpacore_ready` through stdio and forwards them to `ALPACORE_URL`.

## Diagram (if applicable)

```text
Before:
VS Code chat -> no repo-local MCP bridge -> manual external setup required

After:
VS Code chat -> alpacore-local MCP stdio bridge -> local AlpaCore HTTP endpoint
```

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: the workspace now exposes a small local MCP tool surface and forwards requests to a local HTTP service.
  - Mitigation: the tool set is explicit and narrow, default endpoints are loopback URLs, and requests are bounded by `ALPACORE_TIMEOUT_MS`.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): VS Code MCP / local AlpaCore
- Relevant config (redacted): `ALPACORE_URL=http://127.0.0.1:5143`, `ALPACORE_TIMEOUT_MS=240000`, `OLLAMA_URL=http://127.0.0.1:11434`

### Steps

1. Start a local AlpaCore instance on `http://127.0.0.1:5143`.
2. Open this repo in VS Code with workspace MCP enabled.
3. Start the `alpacore-local` MCP server and invoke `alpacore_health` or `arni_ask`.

### Expected

- The MCP server starts from `scripts/alpacore-mcp-bridge.mjs` and returns the proxied AlpaCore response.

### Actual

- In this session I verified syntax and branch contents only; no live AlpaCore instance was available for end-to-end MCP execution.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippet used here:

```text
node --check scripts/alpacore-mcp-bridge.mjs
# passed with no output
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `feat/mcp-bridge` was rebased onto current `main`; the PR diff contains only `.vscode/mcp.json`, `.vscode/settings.json`, and `scripts/alpacore-mcp-bridge.mjs`; `node --check scripts/alpacore-mcp-bridge.mjs` passed.
- Edge cases checked: reviewed timeout handling, JSON/text result formatting, and error propagation paths in the bridge script.
- What you did **not** verify: no live MCP handshake, no end-to-end VS Code invocation, and no live AlpaCore HTTP call.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: enabling workspace MCP auto-start may surprise contributors who open the repo without intending to run local MCP tooling.
  - Mitigation: the configuration is workspace-local, the bridge is explicit in `.vscode/mcp.json`, and the endpoint defaults to loopback rather than a remote host.
- Risk: the bridge can fail noisily if AlpaCore is not running.
  - Mitigation: the tool returns explicit error text and uses bounded request timeouts rather than hanging indefinitely.
