### PR TITLE
fix(discord): deduplicate accounts sharing the same bot token

### DIFF
--- a/extensions/discord/src/accounts.test.ts
+++ b/extensions/discord/src/accounts.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createDiscordActionGate,
+  deduplicateDiscordAccountsByToken,
   resolveDiscordAccount,
   resolveDiscordMaxLinesPerMessage,
+  type ResolvedDiscordAccount,
 } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
@@ -159,5 +161,58 @@ describe("resolveDiscordMaxLinesPerMessage", () => {
     });
 
     expect(resolved).toBe(80);
+  });
+});
+
+describe("deduplicateDiscordAccountsByToken", () => {
+  function makeAccount(
+    accountId: string,
+    token: string,
+    tokenSource: "env" | "config" | "none",
+  ): ResolvedDiscordAccount {
+    return {
+      accountId,
+      enabled: true,
+      token,
+      tokenSource,
+      config: {} as ResolvedDiscordAccount["config"],
+    };
+  }
+
+  it("keeps config-sourced account over env-sourced when tokens match", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const accounts = [
+      makeAccount("default", "same-token", "env"),
+      makeAccount("work", "same-token", "config"),
+    ];
+    const result = deduplicateDiscordAccountsByToken(accounts);
+    expect(result).toHaveLength(1);
+    expect(result[0].accountId).toBe("work");
+    expect(warnSpy).toHaveBeenCalledOnce();
+    warnSpy.mockRestore();
+  });
+
+  it("keeps both accounts when tokens differ", () => {
+    const accounts = [makeAccount("a", "token-a", "config"), makeAccount("b", "token-b", "config")];
+    const result = deduplicateDiscordAccountsByToken(accounts);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps only the first when same token and same source", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const accounts = [
+      makeAccount("first", "same-token", "env"),
+      makeAccount("second", "same-token", "env"),
+    ];
+    const result = deduplicateDiscordAccountsByToken(accounts);
+    expect(result).toHaveLength(1);
+    expect(result[0].accountId).toBe("first");
+    warnSpy.mockRestore();
+  });
+
+  it("keeps accounts with empty tokens without deduplication", () => {
+    const accounts = [makeAccount("a", "", "none"), makeAccount("b", "", "none")];
+    const result = deduplicateDiscordAccountsByToken(accounts);
+    expect(result).toHaveLength(2);
   });
 });

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -91,8 +91,46 @@ export function resolveDiscordMaxLinesPerMessage(params: {
   }).config.maxLinesPerMessage;
 }
 
+export function deduplicateDiscordAccountsByToken(
+  accounts: ResolvedDiscordAccount[],
+): ResolvedDiscordAccount[] {
+  const tokenGroups = new Map<string, ResolvedDiscordAccount[]>();
+  const result: ResolvedDiscordAccount[] = [];
+
+  for (const account of accounts) {
+    const token = account.token.trim();
+    if (!token) {
+      result.push(account);
+      continue;
+    }
+    let group = tokenGroups.get(token);
+    if (!group) {
+      group = [];
+      tokenGroups.set(token, group);
+    }
+    group.push(account);
+  }
+
+  for (const [, group] of tokenGroups) {
+    if (group.length === 1) {
+      result.push(group[0]);
+      continue;
+    }
+    const configAccounts = group.filter((a) => a.tokenSource === "config");
+    const kept = configAccounts.length > 0 ? configAccounts[0] : group[0];
+    const dropped = group.filter((a) => a !== kept);
+    console.warn(
+      `[discord] duplicate bot token detected: keeping account "${kept.accountId}" (source: ${kept.tokenSource}), dropping ${dropped.map((a) => `"${a.accountId}"`).join(", ")}`,
+    );
+    result.push(kept);
+  }
+
+  return result;
+}
+
 export function listEnabledDiscordAccounts(cfg: OpenClawConfig): ResolvedDiscordAccount[] {
-  return listDiscordAccountIds(cfg)
+  const enabled = listDiscordAccountIds(cfg)
     .map((accountId) => resolveDiscordAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
+  return deduplicateDiscordAccountsByToken(enabled);
 }

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -27,6 +27,7 @@ import {
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/text-runtime";
 import {
+  deduplicateDiscordAccountsByToken,
   listDiscordAccountIds,
   resolveDiscordAccount,
   type ResolvedDiscordAccount,
@@ -166,14 +167,16 @@ const discordMessageActions = {
 };
 
 function resolveDiscordStartupDelayMs(cfg: OpenClawConfig, accountId: string): number {
-  const startupAccountIds = listDiscordAccountIds(cfg).filter((candidateId) => {
-    const candidate = resolveDiscordAccount({ cfg, accountId: candidateId });
-    return (
-      candidate.enabled &&
-      (resolveConfiguredFromCredentialStatuses(candidate) ??
-        Boolean(normalizeOptionalString(candidate.token)))
+  const allStartupAccounts = listDiscordAccountIds(cfg)
+    .map((candidateId) => resolveDiscordAccount({ cfg, accountId: candidateId }))
+    .filter(
+      (candidate) =>
+        candidate.enabled &&
+        (resolveConfiguredFromCredentialStatuses(candidate) ??
+          Boolean(normalizeOptionalString(candidate.token))),
     );
-  });
+  const startupAccounts = deduplicateDiscordAccountsByToken(allStartupAccounts);
+  const startupAccountIds = startupAccounts.map((a) => a.accountId);
   const startupIndex = startupAccountIds.findIndex((candidateId) => candidateId === accountId);
   return startupIndex <= 0 ? 0 : startupIndex * DISCORD_ACCOUNT_STARTUP_STAGGER_MS;
 }


### PR DESCRIPTION
## Bug

Fixes #73441

Discord DM messages are processed twice when two accounts resolve to the same bot token. The user sends one message but receives two responses.

## Root Cause

`resolveDiscordToken()` has a fallback chain: account-level token → top-level `channels.discord.token` → `DISCORD_BOT_TOKEN` env var (for the `default` account only).

The OpenClaw service manager injects `DISCORD_BOT_TOKEN` as a managed env var. If a user has a named account (e.g. `work`) with an explicit token **and** a `default` account entry with no configured token, the `default` account silently picks up the same bot token via the env var fallback.

Both accounts pass the startup filter (`enabled && hasToken`), so **two independent monitors connect to Discord with the same bot credentials**. Each monitor has its own replay guard, so both claim the same inbound message:

1. Monitor A processes the message normally → agent replies
2. Monitor B also receives it, but the agent is now busy → message gets enqueued as `[Queued messages while agent was busy]`
3. Agent finishes → followup queue drains → agent replies again

## Fix

Add `deduplicateDiscordAccountsByToken()` that groups resolved accounts by token value and keeps only one per unique token. When duplicates exist, the account with `source: "config"` (explicit config) is preferred over `source: "env"` (env var fallback). A warning is logged when deduplication occurs.

Applied in two places:
- `listEnabledDiscordAccounts()` — affects monitor startup
- `resolveDiscordStartupDelayMs()` — affects staggered startup timing

## Workaround

Users hitting this today can remove the redundant account entry:
```
openclaw config unset channels.discord.accounts.default
openclaw gateway restart
```

## Tests

4 new tests covering:
- Config-sourced account kept over env-sourced when tokens match
- Both accounts kept when tokens differ
- First account kept when same token and same source
- Empty-token accounts not deduplicated