### PR TITLE
fix: gate startup context for sandboxed spawned sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ Docs: https://docs.openclaw.ai
 - Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
 - Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
+- Gateway/startup: skip inherited workspace startup memory for sandboxed spawned sessions without real-workspace write access, so `/new` no longer preloads host workspace memory into isolated child runs. (#73611) Thanks @drobison00.
 
 ## 2026.4.27
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2288,7 +2288,9 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("does not preload startup memory from inherited workspaces for spawned sandboxed sessions", async () => {
+  it.each(["all", "non-main"] as const)(
+    "does not preload startup memory from inherited workspaces for spawned sandboxed sessions in %s mode",
+    async (sandboxMode) => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
     try {
@@ -2316,7 +2318,7 @@ describe("gateway agent handler", () => {
                       dailyMemoryDays: 1,
                     },
                     sandbox: {
-                      mode: "all",
+                      mode: sandboxMode,
                       scope: "session",
                       workspaceAccess: "none",
                     },
@@ -2348,10 +2350,10 @@ describe("gateway agent handler", () => {
                 {
                   message: "/new",
                   sessionKey: "agent:main:subagent:sandbox-child",
-                  idempotencyKey: "test-idem-new-spawned-sandbox-memory",
+                  idempotencyKey: `test-idem-new-spawned-sandbox-memory-${sandboxMode}`,
                 },
                 {
-                  reqId: "4-startup-spawned-sandbox-memory",
+                  reqId: `4-startup-spawned-sandbox-memory-${sandboxMode}`,
                   client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
                 },
               );
@@ -2368,7 +2370,8 @@ describe("gateway agent handler", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
+    },
+  );
 
   it("uses /reset suffix as the post-reset message and still injects timestamp", async () => {
     setupNewYorkTimeConfig("2026-01-29T01:30:00.000Z");

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2291,85 +2291,87 @@ describe("gateway agent handler", () => {
   it.each(["all", "non-main"] as const)(
     "does not preload startup memory from inherited workspaces for spawned sandboxed sessions in %s mode",
     async (sandboxMode) => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
-    try {
-      await withTempDir(
-        { prefix: "openclaw-gateway-startup-canonical-" },
-        async (canonicalWorkspaceDir) => {
-          await withTempDir(
-            { prefix: "openclaw-gateway-startup-inherited-" },
-            async (inheritedWorkspaceDir) => {
-              await fs.mkdir(`${inheritedWorkspaceDir}/memory`, { recursive: true });
-              const inheritedMarker = "OC_INHERITED_WORKSPACE_MEMORY_MARKER";
-              await fs.writeFile(
-                `${inheritedWorkspaceDir}/memory/2026-04-27.md`,
-                inheritedMarker,
-                "utf-8",
-              );
-              mocks.loadConfigReturn = {
-                agents: {
-                  defaults: {
-                    workspace: canonicalWorkspaceDir,
-                    userTimezone: "UTC",
-                    startupContext: {
-                      enabled: true,
-                      applyOn: ["new"],
-                      dailyMemoryDays: 1,
-                    },
-                    sandbox: {
-                      mode: sandboxMode,
-                      scope: "session",
-                      workspaceAccess: "none",
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
+      try {
+        await withTempDir(
+          { prefix: "openclaw-gateway-startup-canonical-" },
+          async (canonicalWorkspaceDir) => {
+            await withTempDir(
+              { prefix: "openclaw-gateway-startup-inherited-" },
+              async (inheritedWorkspaceDir) => {
+                await fs.mkdir(`${inheritedWorkspaceDir}/memory`, { recursive: true });
+                const inheritedMarker = "OC_INHERITED_WORKSPACE_MEMORY_MARKER";
+                await fs.writeFile(
+                  `${inheritedWorkspaceDir}/memory/2026-04-27.md`,
+                  inheritedMarker,
+                  "utf-8",
+                );
+                mocks.loadConfigReturn = {
+                  agents: {
+                    defaults: {
+                      workspace: canonicalWorkspaceDir,
+                      userTimezone: "UTC",
+                      startupContext: {
+                        enabled: true,
+                        applyOn: ["new"],
+                        dailyMemoryDays: 1,
+                      },
+                      sandbox: {
+                        mode: sandboxMode,
+                        scope: "session",
+                        workspaceAccess: "none",
+                      },
                     },
                   },
-                },
-              };
-              mockSessionResetSuccess({
-                reason: "new",
-                key: "agent:main:subagent:sandbox-child",
-              });
-              mocks.loadSessionEntry.mockReturnValue({
-                cfg: mocks.loadConfigReturn,
-                storePath: "/tmp/sessions.json",
-                entry: {
-                  sessionId: "existing-child-session",
-                  updatedAt: Date.now(),
-                  spawnedBy: "agent:main:main",
-                  spawnedWorkspaceDir: inheritedWorkspaceDir,
-                },
-                canonicalKey: "agent:main:subagent:sandbox-child",
-              });
-              mocks.updateSessionStore.mockResolvedValue(undefined);
-              mocks.agentCommand.mockResolvedValue({
-                payloads: [{ text: "ok" }],
-                meta: { durationMs: 100 },
-              });
+                };
+                mockSessionResetSuccess({
+                  reason: "new",
+                  key: "agent:main:subagent:sandbox-child",
+                });
+                mocks.loadSessionEntry.mockReturnValue({
+                  cfg: mocks.loadConfigReturn,
+                  storePath: "/tmp/sessions.json",
+                  entry: {
+                    sessionId: "existing-child-session",
+                    updatedAt: Date.now(),
+                    spawnedBy: "agent:main:main",
+                    spawnedWorkspaceDir: inheritedWorkspaceDir,
+                  },
+                  canonicalKey: "agent:main:subagent:sandbox-child",
+                });
+                mocks.updateSessionStore.mockResolvedValue(undefined);
+                mocks.agentCommand.mockResolvedValue({
+                  payloads: [{ text: "ok" }],
+                  meta: { durationMs: 100 },
+                });
 
-              await invokeAgent(
-                {
-                  message: "/new",
-                  sessionKey: "agent:main:subagent:sandbox-child",
-                  idempotencyKey: `test-idem-new-spawned-sandbox-memory-${sandboxMode}`,
-                },
-                {
-                  reqId: `4-startup-spawned-sandbox-memory-${sandboxMode}`,
-                  client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
-                },
-              );
+                await invokeAgent(
+                  {
+                    message: "/new",
+                    sessionKey: "agent:main:subagent:sandbox-child",
+                    idempotencyKey: `test-idem-new-spawned-sandbox-memory-${sandboxMode}`,
+                  },
+                  {
+                    reqId: `4-startup-spawned-sandbox-memory-${sandboxMode}`,
+                    client: {
+                      connect: { scopes: ["operator.admin"] },
+                    } as AgentHandlerArgs["client"],
+                  },
+                );
 
-              await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
-              const call = readLastAgentCommandCall();
-              expect(call?.message).toContain("Execute your Session Startup sequence now");
-              expect(call?.message).not.toContain("[Startup context loaded by runtime]");
-              expect(call?.message).not.toContain(inheritedMarker);
-            },
-          );
-        },
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+                await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+                const call = readLastAgentCommandCall();
+                expect(call?.message).toContain("Execute your Session Startup sequence now");
+                expect(call?.message).not.toContain("[Startup context loaded by runtime]");
+                expect(call?.message).not.toContain(inheritedMarker);
+              },
+            );
+          },
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     },
   );
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2288,6 +2288,88 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("does not preload startup memory from inherited workspaces for spawned sandboxed sessions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00.000Z"));
+    try {
+      await withTempDir(
+        { prefix: "openclaw-gateway-startup-canonical-" },
+        async (canonicalWorkspaceDir) => {
+          await withTempDir(
+            { prefix: "openclaw-gateway-startup-inherited-" },
+            async (inheritedWorkspaceDir) => {
+              await fs.mkdir(`${inheritedWorkspaceDir}/memory`, { recursive: true });
+              const inheritedMarker = "OC_INHERITED_WORKSPACE_MEMORY_MARKER";
+              await fs.writeFile(
+                `${inheritedWorkspaceDir}/memory/2026-04-27.md`,
+                inheritedMarker,
+                "utf-8",
+              );
+              mocks.loadConfigReturn = {
+                agents: {
+                  defaults: {
+                    workspace: canonicalWorkspaceDir,
+                    userTimezone: "UTC",
+                    startupContext: {
+                      enabled: true,
+                      applyOn: ["new"],
+                      dailyMemoryDays: 1,
+                    },
+                    sandbox: {
+                      mode: "all",
+                      scope: "session",
+                      workspaceAccess: "none",
+                    },
+                  },
+                },
+              };
+              mockSessionResetSuccess({
+                reason: "new",
+                key: "agent:main:subagent:sandbox-child",
+              });
+              mocks.loadSessionEntry.mockReturnValue({
+                cfg: mocks.loadConfigReturn,
+                storePath: "/tmp/sessions.json",
+                entry: {
+                  sessionId: "existing-child-session",
+                  updatedAt: Date.now(),
+                  spawnedBy: "agent:main:main",
+                  spawnedWorkspaceDir: inheritedWorkspaceDir,
+                },
+                canonicalKey: "agent:main:subagent:sandbox-child",
+              });
+              mocks.updateSessionStore.mockResolvedValue(undefined);
+              mocks.agentCommand.mockResolvedValue({
+                payloads: [{ text: "ok" }],
+                meta: { durationMs: 100 },
+              });
+
+              await invokeAgent(
+                {
+                  message: "/new",
+                  sessionKey: "agent:main:subagent:sandbox-child",
+                  idempotencyKey: "test-idem-new-spawned-sandbox-memory",
+                },
+                {
+                  reqId: "4-startup-spawned-sandbox-memory",
+                  client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+                },
+              );
+
+              await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+              const call = readLastAgentCommandCall();
+              expect(call?.message).toContain("Execute your Session Startup sequence now");
+              expect(call?.message).not.toContain("[Startup context loaded by runtime]");
+              expect(call?.message).not.toContain(inheritedMarker);
+            },
+          );
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses /reset suffix as the post-reset message and still injects timestamp", async () => {
     setupNewYorkTimeConfig("2026-01-29T01:30:00.000Z");
     mockSessionResetSuccess({ reason: "reset" });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -204,9 +204,7 @@ function shouldSkipStartupContextForSpawnedSandbox(params: {
       return false;
     }
   }
-  return sandboxCfg.mode === "all" || sandboxCfg.mode === "non-main"
-    ? sandboxCfg.workspaceAccess !== "rw"
-    : false;
+  return sandboxCfg.workspaceAccess !== "rw";
 }
 
 function emitSessionsChanged(

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -10,6 +10,7 @@ import {
   resolvePublicAgentAvatarSource,
 } from "../../agents/identity-avatar.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
+import { resolveSandboxConfigForAgent } from "../../agents/sandbox/config.js";
 import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
@@ -179,6 +180,33 @@ function resolveSessionRuntimeWorkspace(params: {
     runtimeWorkspaceDir: workspaceOverride ?? resolveAgentWorkspaceDir(params.cfg, sessionAgentId),
     isCanonicalWorkspace: !workspaceOverride,
   };
+}
+
+function shouldSkipStartupContextForSpawnedSandbox(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  spawnedBy?: string;
+}): boolean {
+  if (!params.spawnedBy) {
+    return false;
+  }
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  const sandboxCfg = resolveSandboxConfigForAgent(params.cfg, agentId);
+  if (sandboxCfg.mode === "off") {
+    return false;
+  }
+  if (sandboxCfg.mode === "non-main") {
+    const mainSessionKey = resolveAgentMainSessionKey({
+      cfg: params.cfg,
+      agentId,
+    });
+    if (params.sessionKey.trim() === mainSessionKey.trim()) {
+      return false;
+    }
+  }
+  return sandboxCfg.mode === "all" || sandboxCfg.mode === "non-main"
+    ? sandboxCfg.workspaceAccess !== "rw"
+    : false;
 }
 
 function emitSessionsChanged(
@@ -1152,18 +1180,27 @@ export const agentHandlers: GatewayRequestHandlers = {
         }
 
         if (shouldPrependStartupContext && resolvedSessionKey) {
-          const { runtimeWorkspaceDir } = resolveSessionRuntimeWorkspace({
-            cfg: cfgForAgent ?? cfg,
-            sessionKey: resolvedSessionKey,
-            sessionEntry,
-            spawnedBy: spawnedByValue,
-          });
-          const startupContextPrelude = await buildSessionStartupContextPrelude({
-            workspaceDir: runtimeWorkspaceDir,
-            cfg: cfgForAgent ?? cfg,
-          });
-          if (startupContextPrelude) {
-            message = `${startupContextPrelude}\n\n${message}`;
+          const startupCfg = cfgForAgent ?? cfg;
+          if (
+            !shouldSkipStartupContextForSpawnedSandbox({
+              cfg: startupCfg,
+              sessionKey: resolvedSessionKey,
+              spawnedBy: spawnedByValue,
+            })
+          ) {
+            const { runtimeWorkspaceDir } = resolveSessionRuntimeWorkspace({
+              cfg: startupCfg,
+              sessionKey: resolvedSessionKey,
+              sessionEntry,
+              spawnedBy: spawnedByValue,
+            });
+            const startupContextPrelude = await buildSessionStartupContextPrelude({
+              workspaceDir: runtimeWorkspaceDir,
+              cfg: startupCfg,
+            });
+            if (startupContextPrelude) {
+              message = `${startupContextPrelude}\n\n${message}`;
+            }
           }
         }
         if (!isRawModelRun) {


### PR DESCRIPTION
# fix: gate startup context for sandboxed spawned sessions

## Summary

- Problem: spawned sandboxed sessions could apply gateway startup context from an inherited real workspace during `/new`.
- Why it matters: `workspaceAccess: "none"` or read-only sandbox settings should not allow gateway-side memory preloads from the host workspace.
- What changed: startup context preload is skipped for spawned sessions whose effective sandbox config is enabled and does not allow real-workspace writes.
- What did NOT change (scope boundary): spawned workspace inheritance and agent dispatch workspace overrides are unchanged outside this startup-context preload path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the gateway used a spawned session's inherited workspace override when building startup-context memory, even when the child session's effective sandbox configuration did not grant real-workspace access.
- Missing detection / guardrail: there was no unit coverage for `/new` on a spawned sandboxed subagent with startup context enabled and memory present only in the inherited workspace.
- Contributing context (if known): the gateway-side preload runs before the child agent process starts, so the child runtime sandbox cannot prevent that read.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/agent.test.ts`
- Scenario the test should lock in: a spawned subagent with sandbox `mode: "all"` and `workspaceAccess: "none"` does not receive startup memory from `spawnedWorkspaceDir` on `/new`.
- Why this is the smallest reliable guardrail: it exercises the gateway handler path that resolves the session workspace and prepends startup context.
- Existing test that already covers this (if any): None before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Sandboxed spawned sessions whose effective sandbox config does not allow real-workspace writes no longer preload startup memory from inherited real workspaces during startup-context-triggering sends such as `/new`.

## Diagram (if applicable)

```text
Before:
spawned sandboxed /new -> inherited real workspace -> startup memory prepended

After:
spawned sandboxed /new -> startup context preload skipped -> no inherited memory injected
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: data access is narrowed for spawned sandboxed sessions by skipping gateway startup-context reads from inherited real workspaces when sandbox settings do not grant real-workspace write access.

## Repro + Verification

### Environment

- OS: Linux container
- Runtime/container: Node v22.14.0, pnpm 10.33.0, Vitest 4.1.5
- Model/provider: N/A
- Integration/channel (if any): Gateway agent RPC handler
- Relevant config (redacted): `agents.defaults.sandbox.mode="all"`, `workspaceAccess="none"`, startup context enabled for `/new`

### Steps

1. Configure a spawned child session with `spawnedBy`, `spawnedWorkspaceDir`, sandbox `mode: "all"`, and `workspaceAccess: "none"`.
2. Put daily startup memory only in the inherited workspace.
3. Send `/new` to the spawned child session through `agentHandlers.agent`.

### Expected

- The child run receives the normal session startup prompt without inherited workspace startup memory.

### Actual

- Before this fix, inherited workspace memory could be prepended. After this fix, the inherited marker is absent and the startup-context preload block is not injected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/agent.test.ts --reporter=verbose`

Result: 1 test file passed, 61 tests passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: rebased branch on current `upstream/main`; confirmed the branch diff only touches `src/gateway/server-methods/agent.ts` and `src/gateway/server-methods/agent.test.ts`; ran the targeted gateway-methods Vitest file successfully.
- Edge cases checked: sandbox mode `all` with `workspaceAccess: "none"`; spawned child session with an inherited workspace marker; non-empty inherited daily memory file.
- What you did **not** verify: full repository test suite, live gateway flows, or packaged release artifacts.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: spawned sandboxed sessions may no longer receive startup memory that operators expected from an inherited real workspace.
  - Mitigation: the behavior is limited to spawned sessions with sandboxing enabled and `workspaceAccess` other than `"rw"`, matching the isolation boundary implied by that config.