### PR TITLE
fix: enforce focus subagent scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
 - Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
+- Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
 
 ## 2026.4.27
 

--- a/src/auto-reply/reply/commands-subagents-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-focus.test.ts
@@ -15,6 +15,7 @@ const hoisted = vi.hoisted(() => ({
   readAcpSessionEntryMock: vi.fn(),
   resolveConversationBindingContextMock: vi.fn(),
   resolveFocusTargetSessionMock: vi.fn(),
+  resolveStoredSubagentCapabilitiesMock: vi.fn(),
   sessionBindingCapabilitiesMock: vi.fn(),
   sessionBindingBindMock: vi.fn(),
   sessionBindingResolveByConversationMock: vi.fn(),
@@ -100,6 +101,11 @@ vi.mock("../../channels/thread-bindings-policy.js", () => ({
 
 vi.mock("../../infra/outbound/session-binding-service.js", () => ({
   getSessionBindingService: () => buildFocusSessionBindingService(),
+}));
+
+vi.mock("../../agents/subagent-capabilities.js", () => ({
+  resolveStoredSubagentCapabilities: (sessionKey: string, options: unknown) =>
+    hoisted.resolveStoredSubagentCapabilitiesMock(sessionKey, options),
 }));
 
 vi.mock("./conversation-binding-input.js", () => ({
@@ -195,6 +201,7 @@ function buildFocusContext(params?: {
   chatType?: string;
   senderId?: string;
   token?: string;
+  requesterKey?: string;
 }) {
   return {
     params: buildCommandParams({
@@ -203,7 +210,7 @@ function buildFocusContext(params?: {
       senderId: params?.senderId,
     }),
     handledPrefix: "/focus",
-    requesterKey: "agent:main:main",
+    requesterKey: params?.requesterKey ?? "agent:main:main",
     runs: [],
     restTokens: [params?.token ?? "codex-acp"],
   } satisfies Parameters<typeof handleSubagentsFocusAction>[0];
@@ -224,6 +231,9 @@ function buildUnfocusContext(params?: { senderId?: string }) {
 describe("focus actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hoisted.resolveStoredSubagentCapabilitiesMock.mockReturnValue({
+      controlScope: "children",
+    });
     hoisted.sessionBindingCapabilitiesMock.mockReturnValue(createSessionBindingCapabilities());
     hoisted.sessionBindingResolveByConversationMock.mockReturnValue(null);
     hoisted.resolveFocusTargetSessionMock.mockResolvedValue({
@@ -278,6 +288,11 @@ describe("focus actions", () => {
 
     expect(result.reply?.text).toContain("bound this conversation");
     expect(result.reply?.text).toContain("(acp)");
+    expect(hoisted.resolveFocusTargetSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requesterKey: "agent:main:main",
+      }),
+    );
     expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
       expect.objectContaining({
         placement: "current",
@@ -289,6 +304,29 @@ describe("focus actions", () => {
         }),
       }),
     );
+  });
+
+  it("rejects /focus from a leaf subagent", async () => {
+    hoisted.resolveStoredSubagentCapabilitiesMock.mockReturnValue({
+      controlScope: "none",
+    });
+    hoisted.resolveConversationBindingContextMock.mockReturnValue({
+      channel: THREAD_CHANNEL,
+      accountId: "default",
+      conversationId: "thread-1",
+      parentConversationId: "parent-1",
+      threadId: "thread-1",
+    });
+
+    const result = await handleSubagentsFocusAction(
+      buildFocusContext({
+        requesterKey: "agent:main:subagent:leaf-a",
+      }),
+    );
+
+    expect(result.reply?.text).toContain("Leaf subagents cannot control other sessions.");
+    expect(hoisted.resolveFocusTargetSessionMock).not.toHaveBeenCalled();
+    expect(hoisted.sessionBindingBindMock).not.toHaveBeenCalled();
   });
 
   it("binds topic-chat topics as current conversations", async () => {

--- a/src/auto-reply/reply/commands-subagents-shared-focus.test.ts
+++ b/src/auto-reply/reply/commands-subagents-shared-focus.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveFocusTargetSession } from "./commands-subagents/shared.js";
+
+const hoisted = vi.hoisted(() => ({
+  callGatewayMock: vi.fn(),
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (params: unknown) => hoisted.callGatewayMock(params),
+}));
+
+describe("resolveFocusTargetSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restricts gateway fallback resolution to a subagent requester's children", async () => {
+    hoisted.callGatewayMock.mockResolvedValue({
+      key: "agent:main:subagent:child",
+    });
+
+    const result = await resolveFocusTargetSession({
+      runs: [],
+      token: "child",
+      requesterKey: "agent:main:subagent:parent",
+    });
+
+    expect(result?.targetSessionKey).toBe("agent:main:subagent:child");
+    expect(hoisted.callGatewayMock).toHaveBeenCalledWith({
+      method: "sessions.resolve",
+      params: {
+        key: "child",
+        spawnedBy: "agent:main:subagent:parent",
+      },
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-subagents/action-focus.ts
+++ b/src/auto-reply/reply/commands-subagents/action-focus.ts
@@ -21,7 +21,12 @@ import { getSessionBindingService } from "../../../infra/outbound/session-bindin
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import type { CommandHandlerResult } from "../commands-types.js";
 import { resolveConversationBindingContextFromAcpCommand } from "../conversation-binding-input.js";
-import { type SubagentsCommandContext, resolveFocusTargetSession, stopWithText } from "./shared.js";
+import {
+  type SubagentsCommandContext,
+  resolveCommandSubagentController,
+  resolveFocusTargetSession,
+  stopWithText,
+} from "./shared.js";
 
 type FocusBindingContext = {
   channel: string;
@@ -71,6 +76,11 @@ export async function handleSubagentsFocusAction(
     return stopWithText("Usage: /focus <subagent-label|session-key|session-id|session-label>");
   }
 
+  const controller = resolveCommandSubagentController(params, ctx.requesterKey);
+  if (controller.controlScope !== "children") {
+    return stopWithText("⚠️ Leaf subagents cannot control other sessions.");
+  }
+
   const bindingContext = resolveFocusBindingContext(params);
   if (!bindingContext) {
     return stopWithText("⚠️ /focus must be run inside a bindable conversation.");
@@ -85,7 +95,11 @@ export async function handleSubagentsFocusAction(
     return stopWithText("⚠️ Conversation bindings are unavailable for this account.");
   }
 
-  const focusTarget = await resolveFocusTargetSession({ runs, token });
+  const focusTarget = await resolveFocusTargetSession({
+    runs,
+    token,
+    requesterKey: controller.controllerSessionKey,
+  });
   if (!focusTarget) {
     return stopWithText(`⚠️ Unable to resolve focus target: ${token}`);
   }

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -307,6 +307,7 @@ export type FocusTargetResolution = {
 export async function resolveFocusTargetSession(params: {
   runs: SubagentRunRecord[];
   token: string;
+  requesterKey?: string;
 }): Promise<FocusTargetResolution | null> {
   const subagentMatch = resolveSubagentTarget(params.runs, params.token);
   if (subagentMatch.entry) {
@@ -326,6 +327,8 @@ export async function resolveFocusTargetSession(params: {
   }
 
   const attempts: Array<Record<string, string>> = [];
+  const requesterKey = normalizeOptionalString(params.requesterKey);
+  const spawnedBy = requesterKey && isSubagentSessionKey(requesterKey) ? requesterKey : undefined;
   attempts.push({ key: token });
   if (looksLikeSessionId(token)) {
     attempts.push({ sessionId: token });
@@ -336,7 +339,7 @@ export async function resolveFocusTargetSession(params: {
     try {
       const resolved = await callGateway({
         method: "sessions.resolve",
-        params: attempt,
+        params: spawnedBy ? { ...attempt, spawnedBy } : attempt,
       });
       const key = normalizeOptionalString(resolved?.key) ?? "";
       if (!key) {


### PR DESCRIPTION
# fix: enforce focus subagent scope

## Summary

- Problem: `/focus` could resolve and bind a target session before applying the subagent control-scope boundary used by other subagent-control commands.
- Why it matters: A leaf subagent should not be able to persistently redirect a conversation to sessions outside its allowed control boundary.
- What changed: `/focus` now resolves the requester controller, rejects leaf subagent callers, and passes a requester key into fallback target resolution so gateway resolution is restricted to child sessions for subagent callers.
- What did NOT change (scope boundary): No channel binding policy, session binding storage, gateway schema, or CI/automation behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts- Related NVIDIA-dev/openclaw-tracking#525

- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The `/focus` handler did not call `resolveCommandSubagentController` before target resolution and binding, and fallback gateway target resolution omitted the requester's `spawnedBy` visibility filter.
- Missing detection / guardrail: Existing focused-command tests covered binding behavior but not leaf-subagent rejection or gateway fallback scoping.
- Contributing context (if known): Similar subagent-control commands already enforce this boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-subagents-focus.test.ts` and `src/auto-reply/reply/commands-subagents-shared-focus.test.ts`
- Scenario the test should lock in: Leaf subagent `/focus` requests are rejected before binding, and subagent fallback target resolution passes `spawnedBy`.
- Why this is the smallest reliable guardrail: The affected behavior is contained in the focus action and its shared target resolver.
- Existing test that already covers this (if any): Existing focus binding tests covered normal binding paths, not this boundary.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Leaf subagents can no longer use `/focus` to bind conversations to other sessions.

## Diagram (if applicable)

```text
Before:
[leaf subagent /focus] -> [resolve any gateway-visible target] -> [bind conversation]

After:
[leaf subagent /focus] -> [control-scope check] -> [rejected]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The `/focus` command now rejects leaf subagent control attempts and narrows fallback target resolution for subagent callers. This reduces session-control and conversation-routing scope.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node v22.14.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): auto-reply focused conversation bindings
- Relevant config (redacted): default unit-test config

### Steps

1. Run the focused auto-reply tests for `/focus` and shared focus target resolution.
2. Verify leaf-subagent `/focus` rejects before target resolution and binding.
3. Verify subagent fallback target resolution includes `spawnedBy`.

### Expected

- Leaf subagent focus requests are rejected.
- Fallback target resolution for subagent requesters is scoped to the requester's children.

### Actual

- `pnpm exec vitest run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-subagents-focus.test.ts src/auto-reply/reply/commands-subagents-shared-focus.test.ts --reporter=verbose` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused validation after the fix:

```text
Test Files  2 passed (2)
Tests  13 passed (13)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Leaf-subagent focus rejection, normal focus binding tests, and `spawnedBy` propagation in fallback resolution.
- Edge cases checked: Existing current-thread, room-thread, topic-thread, ACP metadata, rebind-owner, unsupported-channel, and unfocus tests still pass.
- What you did **not** verify: Full repository test suite and live channel integrations.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A legitimate subagent caller may no longer focus arbitrary non-child sessions.
  - Mitigation: This matches the existing subagent control-scope boundary and keeps non-subagent callers on the existing path.