### PR TITLE
fix(cli/agents add): pre-fill peer-level workspace path in wizard (#71889)

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -176,6 +176,34 @@ export function resolveAgentWorkspaceDir(
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }
 
+/**
+ * Suggest a workspace directory for a *new* non-default agent that follows
+ * the documented peer-level layout from `docs/concepts/multi-agent.md`
+ * ("Paths quick map"): a sibling of the main agent's workspace named
+ * `<base>-<agentId>` rather than a child of it. This is the value the
+ * `agents add` wizard pre-fills; runtime resolution still falls back through
+ * `resolveAgentWorkspaceDir` for any agent that already has a configured or
+ * legacy nested workspace, so existing layouts are never silently rewritten.
+ */
+export function suggestPeerAgentWorkspaceDir(
+  cfg: OpenClawConfig,
+  agentId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const id = normalizeAgentId(agentId);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  if (id === defaultAgentId) {
+    return resolveAgentWorkspaceDir(cfg, id, env);
+  }
+  const mainWorkspace = resolveAgentWorkspaceDir(cfg, defaultAgentId, env);
+  const parent = path.dirname(mainWorkspace);
+  const base = path.basename(mainWorkspace);
+  if (!base) {
+    return stripNullBytes(path.join(mainWorkspace, `workspace-${id}`));
+  }
+  return stripNullBytes(path.join(parent, `${base}-${id}`));
+}
+
 export function resolveAgentDir(
   cfg: OpenClawConfig,
   agentId: string,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentModelPrimary,
   resolveRunModelFallbacksOverride,
   resolveAgentWorkspaceDir,
+  suggestPeerAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
   setAgentEffectiveModelPrimary,
@@ -627,6 +628,48 @@ describe("resolveAgentConfig", () => {
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
     expect(workspace).toBe(path.join(stateDir, "workspace-main"));
+  });
+});
+
+describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
+  it("returns a sibling of the main agent's default workspace", () => {
+    const home = path.join(path.sep, "home", "u");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
+
+    const result = suggestPeerAgentWorkspaceDir({} as OpenClawConfig, "testbug");
+    expect(result).toBe(path.join(path.resolve(home), ".openclaw", "workspace-testbug"));
+  });
+
+  it("returns a sibling of the configured defaults.workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/projects/main" },
+        list: [{ id: "main", default: true }],
+      },
+    };
+    const result = suggestPeerAgentWorkspaceDir(cfg, "tutor");
+    expect(result).toBe(path.resolve("/projects/main-tutor"));
+  });
+
+  it("returns a sibling of an explicitly configured main agent workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: "/work-ws" }],
+      },
+    };
+    const result = suggestPeerAgentWorkspaceDir(cfg, "study");
+    expect(result).toBe(path.resolve("/work-ws-study"));
+  });
+
+  it("returns the main agent's workspace itself for the default agent id", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: "/work-ws" }],
+      },
+    };
+    const result = suggestPeerAgentWorkspaceDir(cfg, "main");
+    expect(result).toBe(path.resolve("/work-ws"));
   });
 });
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -36,6 +36,7 @@ export {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
+  suggestPeerAgentWorkspaceDir,
   type ResolvedAgentConfig,
 } from "./agent-scope-config.js";
 

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -4,6 +4,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
+  suggestPeerAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
@@ -224,7 +225,13 @@ export async function agentsAddCommand(
       }
     }
 
-    const workspaceDefault = resolveAgentWorkspaceDir(cfg, agentId);
+    // For new non-default agents, pre-fill the documented peer-level form
+    // (`workspace-<id>` next to the main agent's workspace) instead of the
+    // legacy nested fallback. Existing agents that already have an explicit
+    // workspace configured keep their resolved value via `resolveAgentConfig`.
+    const workspaceDefault = existingAgent
+      ? resolveAgentWorkspaceDir(cfg, agentId)
+      : suggestPeerAgentWorkspaceDir(cfg, agentId);
     const workspaceInput = await prompter.text({
       message: "Workspace directory",
       initialValue: workspaceDefault,


### PR DESCRIPTION
## Summary

Fixes #71889. The interactive `openclaw agents add <id>` wizard pre-filled the **Workspace directory** prompt with `~/.openclaw/workspace/<id>` (a child of the main agent's workspace) instead of the documented peer-level form `~/.openclaw/workspace-<id>` from `docs/concepts/multi-agent.md` ("Paths quick map"). Users who hit Enter to accept the default ended up with a layout where the main agent's recursive operations leaked into peer agents and `rm -rf ~/.openclaw/workspace` could nuke every other agent's data.

The fix is scoped to the wizard pre-fill; runtime resolution stays compatible.

## Changes

- `src/agents/agent-scope-config.ts`: add `suggestPeerAgentWorkspaceDir(cfg, agentId, env)`. For the default agent it forwards to `resolveAgentWorkspaceDir`. For non-default agents it returns a sibling of the main agent's resolved workspace, named `<base>-<agentId>`. Works for the implicit default `~/.openclaw/workspace` (→ `~/.openclaw/workspace-<id>`), explicit `agents.list[].workspace` (`/work-ws` → `/work-ws-<id>`), and configured `agents.defaults.workspace` (`/projects/main` → `/projects/main-<id>`).
- `src/agents/agent-scope.ts`: re-export the new helper.
- `src/commands/agents.commands.add.ts`: use `suggestPeerAgentWorkspaceDir` for new agents; existing-agent updates keep the current `resolveAgentWorkspaceDir` behavior.
- `src/agents/agent-scope.test.ts`: add 4 cases covering implicit default, configured `defaults.workspace`, explicit main-agent workspace, and the default-agent passthrough.

## Why scope to the wizard, not runtime resolution

`resolveAgentWorkspaceDir`'s nested fallback (`<defaults.workspace>/<id>`) is the resolution path for any existing agent that was added before this fix, or that has `workspace` removed from config. Changing that branch would silently move those agents' workspaces. The wizard pre-fill is the only place users blindly hit Enter, so that's the only behavior that needs to change. New agents created via the wizard write the chosen `workspaceDir` explicitly into config, so the runtime fallback is bypassed for them anyway.

## Test plan

- [x] `pnpm test src/agents/agent-scope.test.ts` — 32/32 pass (4 new cases for `suggestPeerAgentWorkspaceDir`)
- [x] `pnpm tsgo:core` clean
- [x] `pnpm run lint:core` clean
- [x] `pnpm exec oxfmt --check` clean
- [ ] Manual: run `pnpm openclaw agents add testbug` against a fresh `~/.openclaw/`, verify the prompt pre-fills `~/.openclaw/workspace-testbug`

## Suggested CHANGELOG entry

This PR intentionally does not touch `CHANGELOG.md` to avoid hot-file rebase conflicts that have been closing rebased fix PRs. Maintainers can drop the following line under `## Unreleased > ### Fixes` at merge time:

- CLI/agents add: pre-fill the wizard `Workspace directory` prompt with the documented peer-level form (`<base>-<id>` next to the main agent's workspace) instead of the legacy nested `<workspace>/<id>` so users who hit Enter no longer end up with a layout that lets main agent recursive operations leak into peer agents; runtime resolution still honors any existing nested or explicit workspace path. Fixes #71889. Thanks @juan-flores077.