### PR TITLE
fix(infra): resolve exec-approvals path under OPENCLAW_STATE_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 - Core/channels: tighten selected runtime, media, and plugin edge-case handling while preserving existing behavior. Thanks @jesse-merhi.
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and allow `channels.whatsapp.exposeErrorText` to suppress visible error text per channel or account. (#71830) Thanks @rubencu.
 - Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
+- Exec approvals: resolve `exec-approvals.json` and `exec-approvals.sock` under `OPENCLAW_STATE_DIR` so the exec tool no longer crashes with `EACCES: permission denied, lstat '/root/.openclaw'` when the gateway runs with `HOME=/root` but `OPENCLAW_STATE_DIR` points at a user-writable directory. Aligns exec-approvals path resolution with `openclaw.json` and `oauth.json`, which already honor the state dir. [AI-assisted] Thanks @maisui99.
 
 ## 2026.4.27
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -29,6 +29,7 @@ let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -58,6 +59,11 @@ afterEach(() => {
     delete process.env.OPENCLAW_HOME;
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
+  }
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
   }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -89,6 +95,25 @@ describe("exec approvals store helpers", () => {
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
     );
+  });
+
+  it("places approvals file under OPENCLAW_STATE_DIR when set, ignoring HOME", () => {
+    const homeDir = createHomeDir();
+    const stateDir = makeTempDir();
+    tempDirs.push(stateDir);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.sock")),
+    );
+
+    const ensured = ensureExecApprovals();
+    expect(fs.existsSync(path.join(stateDir, "exec-approvals.json"))).toBe(true);
+    expect(fs.existsSync(path.join(homeDir, ".openclaw", "exec-approvals.json"))).toBe(false);
+    expect(ensured.socket?.path).toBe(path.join(stateDir, "exec-approvals.sock"));
   });
 
   it("merges socket defaults from normalized, current, and built-in fallback", () => {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 
 const requestJsonlSocketMock = vi.hoisted(() => vi.fn());
@@ -28,8 +29,7 @@ let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSoc
 let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
 
 const tempDirs: string[] = [];
-const originalOpenClawHome = process.env.OPENCLAW_HOME;
-const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
+let envSnapshot: ReturnType<typeof captureEnv>;
 
 beforeAll(async () => {
   ({
@@ -51,20 +51,12 @@ beforeAll(async () => {
 
 beforeEach(() => {
   requestJsonlSocketMock.mockReset();
+  envSnapshot = captureEnv(["OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  if (originalOpenClawHome === undefined) {
-    delete process.env.OPENCLAW_HOME;
-  } else {
-    process.env.OPENCLAW_HOME = originalOpenClawHome;
-  }
-  if (originalOpenClawStateDir === undefined) {
-    delete process.env.OPENCLAW_STATE_DIR;
-  } else {
-    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
-  }
+  envSnapshot.restore();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -97,7 +89,7 @@ describe("exec approvals store helpers", () => {
     );
   });
 
-  it("places approvals file under OPENCLAW_STATE_DIR when set, ignoring HOME", () => {
+  it("places approvals file under OPENCLAW_STATE_DIR, overriding HOME-derived default", () => {
     const homeDir = createHomeDir();
     const stateDir = makeTempDir();
     tempDirs.push(stateDir);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -171,8 +172,8 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const APPROVALS_FILENAME = "exec-approvals.json";
+const APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -181,12 +182,12 @@ function hashExecApprovalsRaw(raw: string | null): string {
     .digest("hex");
 }
 
-export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+export function resolveExecApprovalsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), APPROVALS_FILENAME);
 }
 
-export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+export function resolveExecApprovalsSocketPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), APPROVALS_SOCKET_FILENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
## Summary

- Fix the `exec` tool crashing with `EACCES: permission denied, lstat '/root/.openclaw'` whenever the gateway runs with `HOME=/root` (e.g. systemd unit, `sudo` without `-H`, dropped privileges) but `OPENCLAW_STATE_DIR` points at a user-writable directory.
- Route `resolveExecApprovalsPath` and `resolveExecApprovalsSocketPath` (`src/infra/exec-approvals.ts`) through `resolveStateDir(env)`, matching how `openclaw.json` (`src/config/paths.ts:resolveCanonicalConfigPath`) and `oauth.json` (`resolveOAuthPath`) already resolve their state-dir-aware paths.
- Backwards compatible: when `OPENCLAW_STATE_DIR` is unset, both paths fall back to `${homedir}/.openclaw/...` exactly as before via `resolveStateDir`'s default branch.

## Why

`exec-approvals.ts` was the lone state-dir-aware file still hard-coded as `~/.openclaw/...` and only consulted `HOME` / `OPENCLAW_HOME` via `expandHomePrefix`. The result: every `resolveExecApprovals(agentId)` call hits `ensureExecApprovals → saveExecApprovals → ensureDir → assertNoSymlinkPathComponents`, and that symlink walk's `fs.lstatSync('/root/.openclaw')` fails with EACCES when the running user (e.g. `gem`, uid 1000) cannot traverse `/root` (default 0700). Other state-dir paths (`device-auth-store.ts`, `gateway-lock.ts`, `oauth.json`) already pull from `resolveStateDir(env)`, so this aligns the last outlier.

## Reproduction

```
USER=gem (uid=1000), HOME=/root, OPENCLAW_STATE_DIR=/home/gem/workspace/agent
[tools] exec failed: EACCES: permission denied, lstat '/root/.openclaw'
raw_params={"command":"echo \"test\" && whoami"}
```

After the fix, `resolveExecApprovalsPath()` returns `/home/gem/workspace/agent/exec-approvals.json`; the symlink walk's `trustedRoot=/root` early-returns because the target is outside it, and `mkdirSync` succeeds against the user-writable state dir.

## Test plan

- [x] `pnpm test src/infra/exec-approvals-store.test.ts` — 18/18 passed (added regression test asserting that with `OPENCLAW_STATE_DIR` set, `ensureExecApprovals()` places `exec-approvals.{json,sock}` under the state dir and **not** under HOME).
- [x] Targeted suites (`exec-approvals`, `exec-approvals-cli`, `exec-policy-cli`, `audit-exec-surface`, `invoke-system-run`, `gateway/server-methods/exec-approvals`) — 74 vitest shards passed.
- [x] `pnpm tsgo` — clean.
- [x] `pnpm check:changed` — typecheck / lint / runtime-sidecar / import-cycles all green.

## Notes for reviewers

- The polish commit on top swaps the test's hand-rolled env save/restore for the shared `captureEnv` helper (`src/test-utils/env.ts`) and aligns the changelog wording with neighboring `### Fixes` entries.
- One known follow-up that I deliberately did **not** bundle: `resolveExecApprovals` now invokes `resolveStateDir(env)` ~5× per exec (vs. one pure string-replace before), each potentially adding 1–2 `fs.existsSync` syscalls. The absolute cost is microseconds against millisecond-level exec spawn + IPC, but if you'd like, I can plumb a once-resolved `stateDir` through `ensureExecApprovals` / `load` / `save` (mirroring the `stateDir` default param pattern in `resolveCanonicalConfigPath`) in a follow-up.