### PR TITLE
fix(telegram): use agent's own default model for Telegram model list check mark

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -348,14 +348,12 @@ export const registerTelegramHandlers = ({
     });
     const store = loadSessionStore(storePath);
     const entry = resolveSessionStoreEntry({ store, sessionKey }).existing;
+    const defaultModel = resolveDefaultModelForAgent({ cfg: runtimeCfg, agentId: route.agentId });
     const storedOverride = resolveStoredModelOverride({
       sessionEntry: entry,
       sessionStore: store,
       sessionKey,
-      defaultProvider: resolveDefaultModelForAgent({
-        cfg: runtimeCfg,
-        agentId: route.agentId,
-      }).provider,
+      defaultProvider: defaultModel.provider,
     });
     if (storedOverride) {
       return {
@@ -377,12 +375,11 @@ export const registerTelegramHandlers = ({
         model: `${provider}/${model}`,
       };
     }
-    const modelCfg = runtimeCfg.agents?.defaults?.model;
     return {
       agentId: route.agentId,
       sessionEntry: entry,
       sessionKey,
-      model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
+      model: `${defaultModel.provider}/${defaultModel.model}`,
     };
   };
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -689,6 +689,63 @@ describe("createTelegramBot", () => {
     await sendModelCallback(2);
     expect(buildModelsProviderDataMock.mock.calls.at(-1)?.[1]).toBe("agent-b");
   });
+
+  it("uses the bound agent default model in Telegram model lists when no session override exists", async () => {
+    loadConfig.mockImplementation(() => ({
+      agents: {
+        defaults: {
+          model: "github-copilot/gpt-5.4",
+        },
+        list: [
+          {
+            id: "wenwang-agent",
+            model: "google/gemini-3.1-pro-preview",
+          },
+        ],
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+      bindings: [
+        {
+          agentId: "wenwang-agent",
+          match: { channel: "telegram", accountId: "default" },
+        },
+      ],
+    }));
+
+    editMessageTextSpy.mockClear();
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-model-google-1",
+        data: "mdl_list_google_1",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 25,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    const keyboard = (
+      editMessageTextSpy.mock.calls.at(-1)?.[3] as {
+        reply_markup?: { inline_keyboard?: { text?: string }[][] };
+      }
+    )?.reply_markup?.inline_keyboard;
+    const texts = (keyboard ?? []).flat().map((button) => button?.text ?? "");
+
+    expect(texts).toContain("gemini-3.1-pro-preview ✓");
+    expect(texts).not.toContain("gpt-5.4 ✓");
+  });
+
   it("wraps inbound message with Telegram envelope", async () => {
     await withEnvAsync({ TZ: "Europe/Vienna" }, async () => {
       createTelegramBot({ token: "tok" });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -691,6 +691,8 @@ describe("createTelegramBot", () => {
   });
 
   it("uses the bound agent default model in Telegram model lists when no session override exists", async () => {
+    const buildModelsProviderDataMock =
+      telegramBotDepsForTest.buildModelsProviderData as unknown as ReturnType<typeof vi.fn>;
     loadConfig.mockImplementation(() => ({
       agents: {
         defaults: {
@@ -713,6 +715,15 @@ describe("createTelegramBot", () => {
         },
       ],
     }));
+    buildModelsProviderDataMock.mockResolvedValue({
+      byProvider: new Map([
+        ["github-copilot", new Set(["gpt-5.4"])],
+        ["google", new Set(["gemini-3.1-pro-preview"])],
+      ]),
+      providers: ["github-copilot", "google"],
+      resolvedDefault: { provider: "github-copilot", model: "gpt-5.4" },
+      modelNames: new Map(),
+    });
 
     editMessageTextSpy.mockClear();
     createTelegramBot({ token: "tok" });


### PR DESCRIPTION
## Problem

The Telegram model selection callback (`mdl_list_*`) determines which model to mark with ✓ by reading `sessionState.model` from `resolveTelegramSessionState`. When there is **no stored session override**, `resolveTelegramSessionState` fell back to `agents.defaults.model` (the global default), **not** the bound agent's own configured model.

### Example of the bug

- `wenwang-agent` has `model: "google/gemini-3.1-pro-preview"` in `agents.list`
- `main` (the default agent) has `model: "github-copilot/gpt-5.4"` as the global default
- When a user opens `/model` in the WenWang bot, the Telegram UI showed **"gpt-5.4 ✓"** instead of **"gemini-3.1-pro-preview ✓"**

## Root cause

In `extensions/telegram/src/bot-handlers.runtime.ts`, `resolveTelegramSessionState` had a fallback at the end:

```typescript
// BEFORE (bug)
const modelCfg = runtimeCfg.agents?.defaults?.model;
return { ...model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary };
```

This always uses the global default regardless of which agent is bound to the Telegram account.

## Fix

Replace the global-fallback path with `resolveDefaultModelForAgent({ agentId: route.agentId })`, which correctly resolves the per-agent configured model, or falls back to the global default only when no agent-level override exists:

```typescript
// AFTER (correct)
const defaultModel = resolveDefaultModelForAgent({ cfg: runtimeCfg, agentId: route.agentId });
return { ..., model: `${defaultModel.provider}/${defaultModel.model}` };
```

`resolveDefaultModelForAgent` already implements the correct priority: `agent.model` → `agents.defaults.model` → hardcoded default, so this change is a pure improvement with no regressions.

## Regression test

Added a test in `bot.create-telegram-bot.test.ts` that:
1. Binds `wenwang-agent` to a Telegram account with `model: "google/gemini-3.1-pro-preview"`
2. Sets `agents.defaults.model = "github-copilot/gpt-5.4"`
3. Triggers a `mdl_list_google_1` callback
4. Asserts that "gemini-3.1-pro-preview ✓" appears in the keyboard and "gpt-5.4 ✓" does not

## Call site review

No other call site of `resolveTelegramSessionState` is affected by this change:
- The `defaultProvider` call on line 355 is used only by `resolveStoredModelOverride` when a stored override exists (early return) — **not affected**
- The `resolvedDefault` call at line 1717 is for `isDefaultSelection` judgment — **not affected** (same logic)
- Other call sites (`bot-native-commands.ts`, `sticker-cache.ts`, `bot-message-dispatch.ts`) use `resolveDefaultModelForAgent` directly — **not affected**