### PR TITLE
fix(sandbox): gracefully handle Docker daemon unavailability when sandbox mode is off

### DIFF
--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -18,7 +18,7 @@ export {
   requireSandboxBackendFactory,
 } from "./sandbox/backend.js";
 
-export { buildSandboxCreateArgs } from "./sandbox/docker.js";
+export { buildSandboxCreateArgs, isDockerDaemonUnavailable } from "./sandbox/docker.js";
 export {
   listSandboxBrowsers,
   listSandboxContainers,

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -126,10 +126,6 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "../../shared/string-coerce.js";
 import type { SandboxBrowserConfig, SandboxConfig } from "./types.js";
 
 async function ensureSandboxBrowserImage(image: string) {

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -26,12 +26,15 @@ import {
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
+  execDockerRaw,
+  isDockerDaemonUnavailable,
   readDockerContainerEnvVar,
   readDockerContainerLabel,
   readDockerNetworkDriver,
   readDockerNetworkGateway,
   readDockerPort,
 } from "./docker.js";
+import type { ExecDockerRawOptions } from "./docker.js";
 import {
   buildNoVncObserverTokenUrl,
   consumeNoVncObserverToken,
@@ -123,16 +126,11 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-function isDockerDaemonUnavailableBrowser(stderr: string): boolean {
-  const lower = stderr.toLowerCase();
-  return (
-    lower.includes("cannot connect to the docker daemon") ||
-    lower.includes("no such file or directory") ||
-    lower.includes("dial unix") ||
-    lower.includes("docker daemon is not running") ||
-    lower.includes("connection refused")
-  );
-}
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../../shared/string-coerce.js";
+import type { SandboxBrowserConfig, SandboxConfig } from "./types.js";
 
 async function ensureSandboxBrowserImage(image: string) {
   const result = await execDocker(["image", "inspect", image], {
@@ -144,7 +142,7 @@ async function ensureSandboxBrowserImage(image: string) {
   const stderr = result.stderr.trim();
   // When Docker daemon is unavailable, silently return instead of throwing.
   // This allows sandbox.mode="off" sessions to start without Docker errors.
-  if (isDockerDaemonUnavailableBrowser(stderr)) {
+  if (isDockerDaemonUnavailable(stderr)) {
     return;
   }
   throw new Error(

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -126,8 +126,6 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-import type { SandboxBrowserConfig, SandboxConfig } from "./types.js";
-
 async function ensureSandboxBrowserImage(image: string) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -26,7 +26,6 @@ import {
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
-  execDockerRaw,
   isDockerDaemonUnavailable,
   readDockerContainerEnvVar,
   readDockerContainerLabel,
@@ -34,7 +33,6 @@ import {
   readDockerNetworkGateway,
   readDockerPort,
 } from "./docker.js";
-import type { ExecDockerRawOptions } from "./docker.js";
 import {
   buildNoVncObserverTokenUrl,
   consumeNoVncObserverToken,
@@ -46,7 +44,7 @@ import {
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
 import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
-import type { SandboxBrowserConfig, SandboxBrowserContext, SandboxConfig } from "./types.js";
+import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
 import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
@@ -126,6 +124,7 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
+async function ensureSandboxBrowserImage(image: string) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
   });

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -123,11 +123,28 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
+function isDockerDaemonUnavailableBrowser(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return (
+    lower.includes("cannot connect to the docker daemon") ||
+    lower.includes("no such file or directory") ||
+    lower.includes("dial unix") ||
+    lower.includes("docker daemon is not running") ||
+    lower.includes("connection refused")
+  );
+}
+
 async function ensureSandboxBrowserImage(image: string) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
   });
   if (result.code === 0) {
+    return;
+  }
+  const stderr = result.stderr.trim();
+  // When Docker daemon is unavailable, silently return instead of throwing.
+  // This allows sandbox.mode="off" sessions to start without Docker errors.
+  if (isDockerDaemonUnavailableBrowser(stderr)) {
     return;
   }
   throw new Error(

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -46,7 +46,7 @@ import {
 import { readBrowserRegistry, updateBrowserRegistry } from "./registry.js";
 import { resolveSandboxAgentId, slugifySessionKey } from "./shared.js";
 import { isToolAllowed } from "./tool-policy.js";
-import type { SandboxBrowserContext, SandboxConfig } from "./types.js";
+import type { SandboxBrowserConfig, SandboxBrowserContext, SandboxConfig } from "./types.js";
 import { validateNetworkMode } from "./validate-sandbox-security.js";
 import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
@@ -126,7 +126,6 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-async function ensureSandboxBrowserImage(image: string) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
   });

--- a/src/agents/sandbox/docker.test.ts
+++ b/src/agents/sandbox/docker.test.ts
@@ -18,6 +18,7 @@ type MockDockerChild = EventEmitter & {
 const spawnState = vi.hoisted(() => ({
   calls: [] as SpawnCall[],
   imageExists: true,
+  inspectError: "",
 }));
 
 function createMockDockerChild(): MockDockerChild {
@@ -40,7 +41,9 @@ function spawnDockerProcess(command: string, args: string[]) {
     stderr = `unexpected command: ${command}`;
   } else if (args[0] === "image" && args[1] === "inspect") {
     code = spawnState.imageExists ? 0 : 1;
-    stderr = spawnState.imageExists ? "" : `Error response from daemon: No such image: ${args[2]}`;
+    stderr = spawnState.imageExists
+      ? ""
+      : spawnState.inspectError || `Error response from daemon: No such image: ${args[2]}`;
   } else if (args[0] === "pull" || args[0] === "tag") {
     code = 0;
   } else {
@@ -79,6 +82,7 @@ describe("ensureDockerImage", () => {
   beforeEach(async () => {
     spawnState.calls.length = 0;
     spawnState.imageExists = true;
+    spawnState.inspectError = "";
     await loadFreshDockerModuleForTest();
   });
 
@@ -106,6 +110,21 @@ describe("ensureDockerImage", () => {
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain("scripts/sandbox-setup.sh");
     expect((err as Error).message).toContain("python3");
+    expect(spawnState.calls).toEqual([
+      {
+        command: "docker",
+        args: ["image", "inspect", DEFAULT_SANDBOX_IMAGE],
+      },
+    ]);
+  });
+
+  it("returns when the Docker daemon is unavailable during image inspection", async () => {
+    spawnState.imageExists = false;
+    spawnState.inspectError =
+      "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?";
+
+    await ensureDockerImage(DEFAULT_SANDBOX_IMAGE);
+
     expect(spawnState.calls).toEqual([
       {
         command: "docker",

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -308,33 +308,15 @@ export async function ensureDockerImage(image: string) {
   if (exists) {
     return;
   }
-  // If the image doesn't exist, try to build/pull it.
   // When Docker daemon is unavailable, silently return — the caller will
   // fail later if it actually needs Docker, but for sandbox.mode="off"
   // sessions this prevents unnecessary probe errors.
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    const pullResult = await execDocker(["pull", "debian:bookworm-slim"], { allowFailure: true });
-    if (pullResult.code !== 0) {
-      const stderr = pullResult.stderr.trim();
-      if (isDockerDaemonUnavailable(stderr)) {
-        return;
-      }
-      throw new Error(
-        `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim. Failed to pull fallback: ${stderr}`,
-      );
-    }
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
-    return;
+    throw new Error(
+      `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim.`,
+    );
   }
-  // For custom images, try pulling once. If daemon is down, silently return.
-  const pullResult = await execDocker(["pull", image], { allowFailure: true });
-  if (pullResult.code !== 0) {
-    const stderr = pullResult.stderr.trim();
-    if (isDockerDaemonUnavailable(stderr)) {
-      return;
-    }
-    throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
-  }
+  throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
 }
 
 export async function dockerContainerState(name: string) {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -272,6 +272,17 @@ export async function readDockerPort(containerName: string, port: number) {
   return Number.isFinite(mapped) ? mapped : null;
 }
 
+function isDockerDaemonUnavailable(stderr: string): boolean {
+  const lower = stderr.toLowerCase();
+  return (
+    lower.includes("cannot connect to the docker daemon") ||
+    lower.includes("no such file or directory") ||
+    lower.includes("dial unix") ||
+    lower.includes("docker daemon is not running") ||
+    lower.includes("connection refused")
+  );
+}
+
 async function dockerImageExists(image: string) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
@@ -283,6 +294,12 @@ async function dockerImageExists(image: string) {
   if (stderr.includes("No such image")) {
     return false;
   }
+  // When Docker daemon is unavailable, treat the image as non-existent
+  // rather than throwing. This allows sandbox.mode="off" sessions to
+  // start without a running Docker daemon.
+  if (isDockerDaemonUnavailable(stderr)) {
+    return false;
+  }
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
@@ -291,10 +308,23 @@ export async function ensureDockerImage(image: string) {
   if (exists) {
     return;
   }
+  // If the image doesn't exist, try to build/pull it.
+  // When Docker daemon is unavailable, silently return — the caller will
+  // fail later if it actually needs Docker, but for sandbox.mode="off"
+  // sessions this prevents unnecessary probe errors.
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    throw new Error(
-      `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim.`,
-    );
+    const pullResult = await execDocker(["pull", "debian:bookworm-slim"], { allowFailure: true });
+    if (pullResult.code !== 0) {
+      const stderr = pullResult.stderr.trim();
+      if (isDockerDaemonUnavailable(stderr)) {
+        return;
+      }
+      throw new Error(
+        `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim. Failed to pull fallback: ${stderr}`,
+      );
+    }
+    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
+    return;
   }
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
 }

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -326,7 +326,15 @@ export async function ensureDockerImage(image: string) {
     await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
     return;
   }
-  throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
+  // For custom images, try pulling once. If daemon is down, silently return.
+  const pullResult = await execDocker(["pull", image], { allowFailure: true });
+  if (pullResult.code !== 0) {
+    const stderr = pullResult.stderr.trim();
+    if (isDockerDaemonUnavailable(stderr)) {
+      return;
+    }
+    throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
+  }
 }
 
 export async function dockerContainerState(name: string) {

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -276,10 +276,12 @@ export function isDockerDaemonUnavailable(stderr: string): boolean {
   const lower = stderr.toLowerCase();
   return (
     lower.includes("cannot connect to the docker daemon") ||
-    lower.includes("no such file or directory") ||
     lower.includes("dial unix") ||
     lower.includes("docker daemon is not running") ||
-    lower.includes("connection refused")
+    lower.includes("connection refused") ||
+    // Docker socket path errors — narrow enough to avoid false positives
+    lower.includes("no such file or directory") &&
+      (lower.includes("/var/run/docker") || lower.includes("docker.sock"))
   );
 }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -272,7 +272,7 @@ export async function readDockerPort(containerName: string, port: number) {
   return Number.isFinite(mapped) ? mapped : null;
 }
 
-function isDockerDaemonUnavailable(stderr: string): boolean {
+export function isDockerDaemonUnavailable(stderr: string): boolean {
   const lower = stderr.toLowerCase();
   return (
     lower.includes("cannot connect to the docker daemon") ||

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -272,44 +272,42 @@ export async function readDockerPort(containerName: string, port: number) {
   return Number.isFinite(mapped) ? mapped : null;
 }
 
+const DOCKER_DAEMON_UNAVAILABLE_MARKERS = [
+  "cannot connect to the docker daemon",
+  "dial unix",
+  "docker daemon is not running",
+  "connection refused",
+];
+
 export function isDockerDaemonUnavailable(stderr: string): boolean {
-  const lower = stderr.toLowerCase();
-  return (
-    lower.includes("cannot connect to the docker daemon") ||
-    lower.includes("dial unix") ||
-    lower.includes("docker daemon is not running") ||
-    lower.includes("connection refused")
-  );
+  return DOCKER_DAEMON_UNAVAILABLE_MARKERS.some((marker) => stderr.toLowerCase().includes(marker));
 }
 
-async function dockerImageExists(image: string) {
+async function inspectDockerImage(image: string): Promise<"exists" | "missing" | "unavailable"> {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
   });
   if (result.code === 0) {
-    return true;
+    return "exists";
   }
   const stderr = result.stderr.trim();
-  if (stderr.includes("No such image")) {
-    return false;
+  if (stderr.toLowerCase().includes("no such image")) {
+    return "missing";
   }
-  // When Docker daemon is unavailable, treat the image as non-existent
+  // When Docker daemon is unavailable, treat the image as unavailable
   // rather than throwing. This allows sandbox.mode="off" sessions to
   // start without a running Docker daemon.
   if (isDockerDaemonUnavailable(stderr)) {
-    return false;
+    return "unavailable";
   }
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
 export async function ensureDockerImage(image: string) {
-  const exists = await dockerImageExists(image);
-  if (exists) {
+  const imageState = await inspectDockerImage(image);
+  if (imageState === "exists" || imageState === "unavailable") {
     return;
   }
-  // When Docker daemon is unavailable, silently return — the caller will
-  // fail later if it actually needs Docker, but for sandbox.mode="off"
-  // sessions this prevents unnecessary probe errors.
   if (image === DEFAULT_SANDBOX_IMAGE) {
     throw new Error(
       `Sandbox image not found: ${image}. Build it with scripts/sandbox-setup.sh before enabling Docker sandboxing. The default image includes python3 for sandbox write/edit helpers; OpenClaw will not substitute plain debian:bookworm-slim.`,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -278,10 +278,7 @@ export function isDockerDaemonUnavailable(stderr: string): boolean {
     lower.includes("cannot connect to the docker daemon") ||
     lower.includes("dial unix") ||
     lower.includes("docker daemon is not running") ||
-    lower.includes("connection refused") ||
-    // Docker socket path errors — narrow enough to avoid false positives
-    lower.includes("no such file or directory") &&
-      (lower.includes("/var/run/docker") || lower.includes("docker.sock"))
+    lower.includes("connection refused")
   );
 }
 

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_SANDBOX_BROWSER_IMAGE,
   DEFAULT_SANDBOX_COMMON_IMAGE,
   DEFAULT_SANDBOX_IMAGE,
+  isDockerDaemonUnavailable,
   resolveSandboxScope,
 } from "../agents/sandbox.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -86,13 +87,7 @@ async function dockerImageExists(image: string): Promise<boolean> {
       return false;
     }
     const lower = stderr.toLowerCase();
-    if (
-      lower.includes("cannot connect to the docker daemon") ||
-      lower.includes("no such file or directory") ||
-      lower.includes("dial unix") ||
-      lower.includes("docker daemon is not running") ||
-      lower.includes("connection refused")
-    ) {
+    if (isDockerDaemonUnavailable(stderr)) {
       return false;
     }
     throw error;

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -85,6 +85,16 @@ async function dockerImageExists(image: string): Promise<boolean> {
     if (stderr.includes("No such image")) {
       return false;
     }
+    const lower = stderr.toLowerCase();
+    if (
+      lower.includes("cannot connect to the docker daemon") ||
+      lower.includes("no such file or directory") ||
+      lower.includes("dial unix") ||
+      lower.includes("docker daemon is not running") ||
+      lower.includes("connection refused")
+    ) {
+      return false;
+    }
     throw error;
   }
 }

--- a/src/commands/doctor-sandbox.ts
+++ b/src/commands/doctor-sandbox.ts
@@ -86,7 +86,6 @@ async function dockerImageExists(image: string): Promise<boolean> {
     if (stderr.includes("No such image")) {
       return false;
     }
-    const lower = stderr.toLowerCase();
     if (isDockerDaemonUnavailable(stderr)) {
       return false;
     }


### PR DESCRIPTION
## Bug #73586

When `sandbox.mode: "off"` is configured, session startup still triggers a Docker capability probe (`docker image inspect`) that fails when the Docker daemon is unavailable:

```
Error: Failed to inspect sandbox image: failed to connect to the docker API
at unix:///Users/macmini/.orbstack/run/docker.sock: dial unix
/Users/macmini/.orbstack/run/docker.sock: connect: no such file or directory
```

## Root Cause

`dockerImageExists()` in `src/agents/sandbox/docker.ts` threw when Docker daemon was unavailable, even though `resolveSandboxContext` correctly returns `null` for `sandbox.mode="off"`. The probe error bubbled up during session startup.

## Fix

Added `isDockerDaemonUnavailable()` helper to detect Docker connectivity errors (missing socket, connection refused, etc.) and return `false` gracefully instead of throwing. Applied to:

- `dockerImageExists()` — returns false when daemon is down
- `ensureDockerImage()` — skips pull when daemon is unavailable
- `ensureSandboxBrowserImage()` in browser.ts — same graceful handling
- `dockerImageExists()` in doctor-sandbox.ts — same graceful handling

## Files Changed

- `src/agents/sandbox/docker.ts` (+17 lines)
- `src/agents/sandbox/browser.ts` (+17 lines)
- `src/commands/doctor-sandbox.ts` (+10 lines)

## Testing

- Fix is defensive: catches Docker daemon error patterns and returns false
- Does not change behavior when Docker is available
- No behavior change for sandbox.mode="all" or sandbox.mode="non-main"
- Committed and pushed from fork for CI validation