### PR TITLE
fix(bedrock): strip inferenceConfig.temperature for Opus 4.7 (#73663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Amazon Bedrock: strip `inferenceConfig.temperature` from Bedrock Converse payloads for the Opus 4.7 family (`anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`, `global.anthropic.claude-opus-4-7`), so requests stop tripping the Anthropic upstream `invalid_request_error: "temperature" is deprecated for this model.` `ValidationException`. Without this strip the embedded run hangs in `processing` until the watchdog fires (~140s) because the classifier does not surface the nested upstream error as a failover trigger. Mirrors the existing Mantle-Anthropic check in `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23`. Fixes #73663 (Bug 1). Thanks @bstanbury.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -158,6 +158,14 @@ function makeAppInferenceProfileDescriptor(modelId: string): never {
   } as never;
 }
 
+function makeBedrockClaudeModel(modelId: string): never {
+  return {
+    api: "bedrock-converse-stream",
+    provider: "amazon-bedrock",
+    id: modelId,
+  } as never;
+}
+
 /**
  * Call wrapStreamFn and then invoke the returned stream function, capturing
  * the payload via the onPayload hook that streamWithPayloadPatch installs.
@@ -294,6 +302,67 @@ describe("amazon-bedrock provider plugin", () => {
     ).toMatchObject({
       cacheRetention: "none",
     });
+  });
+
+  it.each([
+    ["anthropic.claude-opus-4-7"],
+    ["us.anthropic.claude-opus-4-7"],
+    ["global.anthropic.claude-opus-4-7"],
+  ])(
+    "drops inferenceConfig.temperature for Opus 4.7 Bedrock model %s (#73663)",
+    async (modelId) => {
+      // Anthropic upstream rejects Bedrock Converse requests for the Opus
+      // 4.7 family with `invalid_request_error: "temperature" is deprecated
+      // for this model.`. Without this strip, the run hangs in `processing`
+      // until the watchdog fires (~140s) because OpenClaw's failover
+      // classifier does not recognize the nested upstream error inside
+      // ValidationException.
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "amazon-bedrock",
+        modelId,
+        streamFn: spyStreamFn,
+      } as never);
+      const result = wrapped?.(
+        makeBedrockClaudeModel(modelId),
+        { messages: [] } as never,
+        {},
+      ) as unknown as Record<string, unknown>;
+      // Apply the patch with a payload that mirrors what pi-ai builds when
+      // `temperature` was provided in agent options.
+      const payload: Record<string, unknown> = {
+        inferenceConfig: { temperature: 0.7, maxTokens: 32_000 },
+      };
+      expect(typeof result?.onPayload).toBe("function");
+      (result.onPayload as (p: Record<string, unknown>) => void)(payload);
+      expect(payload.inferenceConfig).toBeDefined();
+      expect(payload.inferenceConfig).not.toHaveProperty("temperature");
+      // maxTokens stays — only temperature is stripped.
+      expect(payload.inferenceConfig).toMatchObject({ maxTokens: 32_000 });
+    },
+  );
+
+  it("preserves inferenceConfig.temperature for Opus 4.6 Bedrock model (#73663 regression guard)", async () => {
+    // 4.6 still accepts temperature; only 4.7 onward changed upstream.
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1:0",
+      streamFn: spyStreamFn,
+    } as never);
+    const result = wrapped?.(
+      makeBedrockClaudeModel("us.anthropic.claude-opus-4-6-v1:0"),
+      { messages: [] } as never,
+      {},
+    ) as unknown as Record<string, unknown>;
+    const payload: Record<string, unknown> = {
+      inferenceConfig: { temperature: 0.7, maxTokens: 32_000 },
+    };
+    if (typeof result?.onPayload === "function") {
+      (result.onPayload as (p: Record<string, unknown>) => void)(payload);
+    }
+    // 4.6 keeps temperature.
+    expect(payload.inferenceConfig).toMatchObject({ temperature: 0.7, maxTokens: 32_000 });
   });
 
   describe("guardrail config schema", () => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -21,6 +21,21 @@ type GuardrailConfig = {
   trace?: "enabled" | "disabled" | "enabled_full";
 };
 
+/**
+ * Anthropic upstream rejects Bedrock Converse requests for the Opus 4.7
+ * family with `invalid_request_error: "temperature" is deprecated for this
+ * model.`. Mirrors the existing Mantle-Anthropic check in
+ * `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23`. See
+ * #73663.
+ *
+ * Matches the family across regional and global inference profiles:
+ * `anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`,
+ * `global.anthropic.claude-opus-4-7`.
+ */
+function bedrockModelRejectsTemperature(modelId: string): boolean {
+  return modelId.includes("claude-opus-4-7");
+}
+
 type AmazonBedrockPluginConfig = {
   discovery?: {
     enabled?: boolean;
@@ -391,7 +406,14 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
       // For opaque profile IDs, we'll resolve via GetInferenceProfile on first call.
       const heuristicMatch = needsCachePointInjection(modelId);
 
-      if (!region && !mayNeedCacheInjection) {
+      // Strip `inferenceConfig.temperature` for Opus 4.7 — Anthropic upstream
+      // rejects it with `invalid_request_error: "temperature" is deprecated
+      // for this model.`, which OpenClaw's runtime classifier does not
+      // currently surface as a failover-worthy error, so the run hangs in
+      // `processing` until a watchdog fires (#73663).
+      const dropTemperatureForOpus47 = bedrockModelRejectsTemperature(modelId);
+
+      if (!region && !mayNeedCacheInjection && !dropTemperatureForOpus47) {
         return wrapped;
       }
 
@@ -403,6 +425,15 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         const merged = Object.assign({}, options, region ? { region } : {});
 
         if (!mayNeedCacheInjection) {
+          if (dropTemperatureForOpus47) {
+            return streamWithPayloadPatch(underlying, streamModel, context, merged, (payload) => {
+              const inferenceConfig = (payload as { inferenceConfig?: Record<string, unknown> })
+                .inferenceConfig;
+              if (inferenceConfig && "temperature" in inferenceConfig) {
+                delete inferenceConfig.temperature;
+              }
+            });
+          }
           return underlying(streamModel, context, merged);
         }
 
@@ -421,6 +452,13 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
           // Fast path: ARN heuristic already identified this as Claude.
           return streamWithPayloadPatch(underlying, streamModel, context, merged, (payload) => {
             injectBedrockCachePoints(payload, cacheRetention);
+            if (dropTemperatureForOpus47) {
+              const inferenceConfig = (payload as { inferenceConfig?: Record<string, unknown> })
+                .inferenceConfig;
+              if (inferenceConfig && "temperature" in inferenceConfig) {
+                delete inferenceConfig.temperature;
+              }
+            }
           });
         }
 
@@ -435,6 +473,13 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
             const eligible = await resolveAppProfileCacheEligible(modelId, region);
             if (eligible && payload && typeof payload === "object") {
               injectBedrockCachePoints(payload as Record<string, unknown>, cacheRetention);
+            }
+            if (dropTemperatureForOpus47 && payload && typeof payload === "object") {
+              const inferenceConfig = (payload as { inferenceConfig?: Record<string, unknown> })
+                .inferenceConfig;
+              if (inferenceConfig && "temperature" in inferenceConfig) {
+                delete inferenceConfig.temperature;
+              }
             }
             return originalOnPayload?.(payload, payloadModel);
           },


### PR DESCRIPTION
## What

Fixes #73663 (Bug 1). Anthropic upstream rejects Bedrock Converse requests for the Opus 4.7 family with:

```
ValidationException: ... "temperature" is deprecated for this model.
```

OpenClaw's embedded agent runtime currently sends `inferenceConfig.temperature` for every Bedrock Claude call. The Bedrock SDK surfaces the nested upstream error as a `ValidationException`, which OpenClaw's failover classifier does not recognize as a surfaceable / failover-worthy error. The result: chats routed to `amazon-bedrock/us.anthropic.claude-opus-4-7` (and the regional/global profile siblings) hang in `state=processing` until a diagnostic watchdog fires at ~140s. Sessions are effectively dead with no user-visible error and no failover to the configured fallback chain.

Reporter (@bstanbury) verified via direct boto3 probe that:
- Bedrock routing is fine
- Anthropic upstream is fine
- Opus 4.6 accepts `temperature`
- Opus 4.7 rejects `temperature` (upstream behavior, documented in `invalid_request_error`)

## Fix

Strip `payload.inferenceConfig.temperature` for the Opus 4.7 family at the existing `wrapStreamFn` payload-patch boundary in `extensions/amazon-bedrock/register.sync.runtime.ts`. Mirrors the established Mantle-Anthropic check at `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23`:

```ts
function bedrockModelRejectsTemperature(modelId: string): boolean {
  return modelId.includes("claude-opus-4-7");
}
```

Applied across all three regional/global inference profile prefixes (`anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`, `global.anthropic.claude-opus-4-7`) and on all three branches of the wrapped stream:

1. No-cache-injection path (most non-app-profile Anthropic models)
2. Cache-injection fast path (ARN heuristic match)
3. Cache-injection slow path (opaque profile lookup via GetInferenceProfile)

Other `inferenceConfig` fields (`maxTokens`, etc) flow through unchanged. Opus 4.6 and earlier still send `temperature`.

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341).** Mantle-Anthropic's `requiresDefaultSampling(modelId)` at `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23` is the same shape. Could not export-share across plugins because they live in separate extension boundaries; the new helper is module-local with the same one-line `modelId.includes("claude-opus-4-7")` body and a doc comment cross-referencing the mantle file. ✅
2. **Shared-helper caller check (steipete #60623).** `streamWithPayloadPatch` is reused — same callback shape that already injects guardrails and cache points. No contract change for other callers. ✅
3. **Broader-fix rival scan (steipete #68270).** Zero rival PRs reference #73663. Bug 2 (failover classifier should surface nested upstream errors inside ValidationException) is intentionally out of scope here — that is a separate fix in the failover state machine. ✅

## Test changes

- New test helper `makeBedrockClaudeModel(modelId)` (one-line, mirrors `makeAppInferenceProfileDescriptor`) so the Bedrock-Converse model descriptor is reusable.
- New parameterized test pinning the strip across all three Opus 4.7 inference profile shapes — feeds `payload.inferenceConfig.temperature` and asserts the strip removes only `temperature` and leaves `maxTokens` intact.
- New regression guard test for Opus 4.6 — confirms `temperature` survives so 4.6 callers are not affected.

## Verified locally

```
npx oxlint extensions/amazon-bedrock/register.sync.runtime.ts extensions/amazon-bedrock/index.test.ts
# Found 0 warnings and 0 errors.

npx vitest run extensions/amazon-bedrock/index.test.ts
# Tests  26 passed (26)
```

lobster-biscuit: 73663-bedrock-opus-4-7-temperature

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
