### PR TITLE
fix: cache plugin manifest loads by file signature

### DIFF
--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadPluginManifest, MAX_PLUGIN_MANIFEST_BYTES } from "./manifest.js";
+import {
+  clearPluginManifestLoadCache,
+  loadPluginManifest,
+  MAX_PLUGIN_MANIFEST_BYTES,
+} from "./manifest.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
@@ -13,6 +17,7 @@ function makeTempDir() {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  clearPluginManifestLoadCache();
   cleanupTrackedTempDirs(tempDirs);
 });
 
@@ -51,6 +56,35 @@ describe("loadPluginManifest JSON5 tolerance", () => {
 
     expect(result.ok).toBe(true);
     expect(json5Parse).not.toHaveBeenCalled();
+  });
+
+  it("reuses the normalized manifest while the file signature is unchanged", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "cached-strict-json",
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+    const originalReadFileSync = fs.readFileSync;
+    let manifestFileReads = 0;
+    vi.spyOn(fs, "readFileSync").mockImplementation(
+      (...args: Parameters<typeof fs.readFileSync>) => {
+        if (typeof args[0] === "number") {
+          manifestFileReads += 1;
+        }
+        return originalReadFileSync(...args);
+      },
+    );
+
+    const first = loadPluginManifest(dir, false);
+    const second = loadPluginManifest(dir, false);
+
+    expect(first.ok).toBe(true);
+    expect(second).toBe(first);
+    expect(manifestFileReads).toBe(1);
   });
 
   it("parses a manifest with trailing commas", () => {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -414,6 +414,49 @@ export type PluginManifestLoadResult =
   | { ok: true; manifest: PluginManifest; manifestPath: string }
   | { ok: false; error: string; manifestPath: string };
 
+type PluginManifestLoadCacheEntry = {
+  signature: string;
+  result: PluginManifestLoadResult;
+};
+
+const MAX_PLUGIN_MANIFEST_LOAD_CACHE_ENTRIES = 2048;
+const pluginManifestLoadCache = new Map<string, PluginManifestLoadCacheEntry>();
+
+function buildPluginManifestLoadCacheKey(params: {
+  manifestPath: string;
+  rejectHardlinks: boolean;
+  rootRealPath?: string;
+}): string {
+  return [
+    params.manifestPath,
+    params.rejectHardlinks ? "reject-hardlinks" : "allow-hardlinks",
+    params.rootRealPath ?? "",
+  ].join("\0");
+}
+
+function buildPluginManifestFileSignature(stats: fs.Stats): string {
+  return [stats.dev, stats.ino, stats.size, stats.mtimeMs].join(":");
+}
+
+function rememberPluginManifestLoadResult(
+  cacheKey: string,
+  signature: string | undefined,
+  result: PluginManifestLoadResult,
+): PluginManifestLoadResult {
+  if (!signature) {
+    return result;
+  }
+  if (pluginManifestLoadCache.size >= MAX_PLUGIN_MANIFEST_LOAD_CACHE_ENTRIES) {
+    pluginManifestLoadCache.clear();
+  }
+  pluginManifestLoadCache.set(cacheKey, { signature, result });
+  return result;
+}
+
+export function clearPluginManifestLoadCache(): void {
+  pluginManifestLoadCache.clear();
+}
+
 function normalizeStringListRecord(value: unknown): Record<string, string[]> | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -1164,6 +1207,11 @@ export function loadPluginManifest(
   rootRealPath?: string,
 ): PluginManifestLoadResult {
   const manifestPath = resolvePluginManifestPath(rootDir);
+  const cacheKey = buildPluginManifestLoadCacheKey({
+    manifestPath,
+    rejectHardlinks,
+    rootRealPath,
+  });
   const opened = openBoundaryFileSync({
     absolutePath: manifestPath,
     rootPath: rootDir,
@@ -1186,28 +1234,41 @@ export function loadPluginManifest(
       }),
     });
   }
+  let cacheSignature: string | undefined;
+  try {
+    cacheSignature = buildPluginManifestFileSignature(fs.fstatSync(opened.fd));
+    const cached = pluginManifestLoadCache.get(cacheKey);
+    if (cached?.signature === cacheSignature) {
+      fs.closeSync(opened.fd);
+      return cached.result;
+    }
+  } catch {
+    cacheSignature = undefined;
+  }
+  const remember = (result: PluginManifestLoadResult) =>
+    rememberPluginManifestLoadResult(cacheKey, cacheSignature, result);
   let raw: unknown;
   try {
     raw = parseJsonWithJson5Fallback(fs.readFileSync(opened.fd, "utf-8"));
   } catch (err) {
-    return {
+    return remember({
       ok: false,
       error: `failed to parse plugin manifest: ${String(err)}`,
       manifestPath,
-    };
+    });
   } finally {
     fs.closeSync(opened.fd);
   }
   if (!isRecord(raw)) {
-    return { ok: false, error: "plugin manifest must be an object", manifestPath };
+    return remember({ ok: false, error: "plugin manifest must be an object", manifestPath });
   }
   const id = normalizeOptionalString(raw.id) ?? "";
   if (!id) {
-    return { ok: false, error: "plugin manifest requires id", manifestPath };
+    return remember({ ok: false, error: "plugin manifest requires id", manifestPath });
   }
   const configSchema = isRecord(raw.configSchema) ? raw.configSchema : null;
   if (!configSchema) {
-    return { ok: false, error: "plugin manifest requires configSchema", manifestPath };
+    return remember({ ok: false, error: "plugin manifest requires configSchema", manifestPath });
   }
 
   const kind = parsePluginKind(raw.kind);
@@ -1260,7 +1321,7 @@ export function loadPluginManifest(
     uiHints = raw.uiHints as Record<string, PluginConfigUiHint>;
   }
 
-  return {
+  return remember({
     ok: true,
     manifest: {
       id,
@@ -1302,7 +1363,7 @@ export function loadPluginManifest(
       channelConfigs,
     },
     manifestPath,
-  };
+  });
 }
 
 // package.json "openclaw" metadata (used for setup/catalog)


### PR DESCRIPTION
## Summary

- cache `loadPluginManifest` results by manifest path, hardlink policy, optional real root, and file signature
- reuse the normalized manifest result when the manifest file is unchanged
- add regression coverage for repeated unchanged manifest loads

## Context

This is the smallest upstreamable slice from a `v2026.4.26` CPU investigation on a Docker/Synology deployment. The gateway was repeatedly spending CPU in plugin manifest/runtime discovery during channel startup; caching normalized manifest loads reduced repeated strict JSON/JSON5 parse and normalization work in bursty startup paths.

Related issue: #73647

## Validation

- `node --import tsx <manifest-cache-smoke>` => `manifest cache smoke ok`
- `corepack pnpm exec oxfmt --check --threads=1 src/plugins/manifest.ts src/plugins/manifest.json5-tolerance.test.ts`
- `corepack pnpm run tsgo:test:src`

Note: direct `vitest run src/plugins/manifest.json5-tolerance.test.ts` was not used as final validation on the NAS because the default Vitest invocation spent several minutes in project bundling. The source typecheck and a direct runtime smoke both passed.
