### PR TITLE
fix(config): allow per-agent verbose and elevated defaults

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -65,6 +65,40 @@ describe("plugins.slots.contextEngine", () => {
   });
 });
 
+describe("agents.list per-agent defaults", () => {
+  it("accepts per-agent verbose and elevated defaults", () => {
+    const result = OpenClawSchema.safeParse({
+      agents: {
+        list: [
+          {
+            id: "main",
+            verboseDefault: "full",
+            elevatedDefault: "ask",
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid per-agent verbose and elevated defaults", () => {
+    const result = OpenClawSchema.safeParse({
+      agents: {
+        list: [
+          {
+            id: "main",
+            verboseDefault: "verbose",
+            elevatedDefault: "always",
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("models.pricing", () => {
   it("accepts the model pricing bootstrap toggle", () => {
     for (const enabled of [true, false]) {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -6194,6 +6194,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   description:
                     "Optional per-agent default thinking level. Overrides agents.defaults.thinkingDefault for this agent when no per-message or session override is set.",
                 },
+                verboseDefault: {
+                  type: "string",
+                  enum: ["off", "on", "full"],
+                },
+                elevatedDefault: {
+                  type: "string",
+                  enum: ["off", "on", "ask", "full"],
+                },
                 reasoningDefault: {
                   type: "string",
                   enum: ["on", "off", "stream"],

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -90,6 +90,8 @@ export type AgentConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "max";
   /** Optional per-agent default verbosity level. */
   verboseDefault?: "off" | "on" | "full";
+  /** Optional per-agent default elevated tools level. */
+  elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Optional per-agent default reasoning visibility. */
   reasoningDefault?: "on" | "off" | "stream";
   /** Optional per-agent default for fast mode. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -838,6 +838,8 @@ export const AgentEntrySchema = z
     thinkingDefault: z
       .enum(["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"])
       .optional(),
+    verboseDefault: z.enum(["off", "on", "full"]).optional(),
+    elevatedDefault: z.enum(["off", "on", "ask", "full"]).optional(),
     reasoningDefault: z.enum(["on", "off", "stream"]).optional(),
     fastModeDefault: z.boolean().optional(),
     skills: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- allow `verboseDefault` and `elevatedDefault` on `agents.list[]` entries
- keep the generated base config schema in sync
- add schema coverage for accepted and rejected per-agent default values

Fixes #73680

## Tests
- `pnpm exec vitest run src/config/config-misc.test.ts src/agents/agent-scope.test.ts`
- `pnpm config:schema:check`
- `pnpm check:changed`