### PR TITLE
Add model route change guard

### DIFF
--- a/src/agents/model-route-change-guard.test.ts
+++ b/src/agents/model-route-change-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelRouteChangeGuardNotice,
+  evaluateModelRouteChangeGuard,
+  resolveModelRouteBillingMode,
+} from "./model-route-change-guard.js";
+
+const base = {
+  selectedProvider: "codex-cli",
+  selectedModel: "gpt-5.4",
+  activeProvider: "openai",
+  activeModel: "gpt-4o",
+  selectedAuthMode: "oauth" as const,
+  activeAuthMode: "api-key" as const,
+};
+
+describe("model-route-change-guard", () => {
+  it("classifies api-key/token/aws-sdk providers as metered", () => {
+    expect(resolveModelRouteBillingMode({ provider: "openai", authMode: "api-key" })).toBe(
+      "metered",
+    );
+    expect(resolveModelRouteBillingMode({ provider: "openrouter", authMode: "token" })).toBe(
+      "metered",
+    );
+    expect(resolveModelRouteBillingMode({ provider: "amazon-bedrock", authMode: "aws-sdk" })).toBe(
+      "metered",
+    );
+  });
+
+  it("treats oauth and local providers as non-metered routes", () => {
+    expect(resolveModelRouteBillingMode({ provider: "codex", authMode: "oauth" })).toBe(
+      "subscription",
+    );
+    expect(resolveModelRouteBillingMode({ provider: "ollama", authMode: "unknown" })).toBe("local");
+  });
+
+  it("escalates a fallback from subscription auth into metered api-key billing in dry-run mode", () => {
+    const result = evaluateModelRouteChangeGuard(base);
+
+    expect(result.changed).toBe(true);
+    expect(result.enforcement).toBe("dry-run");
+    expect(result.action).toBe("escalate");
+    expect(result.escalationRequired).toBe(true);
+    expect(result.reason).toContain("metered billing");
+    expect(result.selected.billingMode).toBe("subscription");
+    expect(result.active.billingMode).toBe("metered");
+    expect(buildModelRouteChangeGuardNotice(result)).toContain("budget cap");
+  });
+
+  it("blocks the same transition when enforcement is enabled", () => {
+    const result = evaluateModelRouteChangeGuard({ ...base, enforcement: "block" });
+
+    expect(result.action).toBe("block");
+  });
+
+  it("allows a metered transition when approval and budget cap metadata are present", () => {
+    const result = evaluateModelRouteChangeGuard({
+      ...base,
+      enforcement: "block",
+      approval: { approved: true, budgetCapUsd: 25, approvalId: "mc-approval-1" },
+    });
+
+    expect(result.action).toBe("allow");
+    expect(result.escalationRequired).toBe(false);
+    expect(result.approval).toEqual({
+      approved: true,
+      hasBudgetCap: true,
+      approvalId: "mc-approval-1",
+    });
+  });
+
+  it("does not escalate model-only changes that stay on non-metered auth", () => {
+    const result = evaluateModelRouteChangeGuard({
+      selectedProvider: "codex-cli",
+      selectedModel: "gpt-5.4",
+      activeProvider: "codex-cli",
+      activeModel: "gpt-5.5",
+      selectedAuthMode: "oauth",
+      activeAuthMode: "oauth",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.action).toBe("allow");
+    expect(result.escalationRequired).toBe(false);
+  });
+});

--- a/src/agents/model-route-change-guard.ts
+++ b/src/agents/model-route-change-guard.ts
@@ -1,0 +1,188 @@
+import type { ModelAuthMode } from "./model-auth.js";
+
+export type ModelRouteBillingMode = "metered" | "subscription" | "local" | "unknown";
+export type ModelRouteGuardEnforcement = "dry-run" | "block";
+export type ModelRouteGuardAction = "allow" | "escalate" | "block";
+
+export type ModelRouteApproval = {
+  approved?: boolean;
+  budgetCapUsd?: number;
+  approvalId?: string;
+};
+
+export type ModelRouteChangeGuardInput = {
+  selectedProvider: string;
+  selectedModel: string;
+  activeProvider: string;
+  activeModel: string;
+  selectedAuthMode?: ModelAuthMode;
+  activeAuthMode?: ModelAuthMode;
+  enforcement?: ModelRouteGuardEnforcement;
+  approval?: ModelRouteApproval;
+};
+
+export type ModelRouteChangeGuardResult = {
+  changed: boolean;
+  action: ModelRouteGuardAction;
+  enforcement: ModelRouteGuardEnforcement;
+  escalationRequired: boolean;
+  selected: {
+    provider: string;
+    model: string;
+    authMode: ModelAuthMode | "unknown";
+    billingMode: ModelRouteBillingMode;
+  };
+  active: {
+    provider: string;
+    model: string;
+    authMode: ModelAuthMode | "unknown";
+    billingMode: ModelRouteBillingMode;
+  };
+  reason?: string;
+  approval?: {
+    approved: boolean;
+    hasBudgetCap: boolean;
+    approvalId?: string;
+  };
+};
+
+function clean(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function resolveModelRouteBillingMode(params: {
+  provider?: string;
+  authMode?: ModelAuthMode;
+}): ModelRouteBillingMode {
+  const provider = clean(params.provider).toLowerCase();
+  if (!provider) {
+    return "unknown";
+  }
+  if (
+    provider === "local" ||
+    provider === "ollama" ||
+    provider.includes("local") ||
+    provider.includes("lmstudio")
+  ) {
+    return "local";
+  }
+  switch (params.authMode) {
+    case "api-key":
+    case "token":
+    case "aws-sdk":
+      return "metered";
+    case "oauth":
+      return "subscription";
+    case "mixed":
+    case "unknown":
+    case undefined:
+      return "unknown";
+  }
+  return "unknown";
+}
+
+function hasApprovalAndBudgetCap(approval: ModelRouteApproval | undefined): boolean {
+  return (
+    approval?.approved === true &&
+    typeof approval.budgetCapUsd === "number" &&
+    approval.budgetCapUsd > 0
+  );
+}
+
+function describeEscalationReason(params: {
+  selectedBilling: ModelRouteBillingMode;
+  activeBilling: ModelRouteBillingMode;
+  selectedProvider: string;
+  activeProvider: string;
+  selectedAuthMode: ModelAuthMode | "unknown";
+  activeAuthMode: ModelAuthMode | "unknown";
+}): string | undefined {
+  if (params.activeBilling === "metered" && params.selectedBilling !== "metered") {
+    return `model route changed into metered billing (${params.selectedProvider} → ${params.activeProvider})`;
+  }
+  if (params.activeBilling === "metered" && params.selectedProvider !== params.activeProvider) {
+    return `provider fallback changed into metered billing (${params.selectedProvider} → ${params.activeProvider})`;
+  }
+  if (params.activeBilling === "metered" && params.selectedAuthMode !== params.activeAuthMode) {
+    return `auth profile changed into metered billing (${params.selectedAuthMode} → ${params.activeAuthMode})`;
+  }
+  return undefined;
+}
+
+export function evaluateModelRouteChangeGuard(
+  input: ModelRouteChangeGuardInput,
+): ModelRouteChangeGuardResult {
+  const selectedProvider = clean(input.selectedProvider);
+  const selectedModel = clean(input.selectedModel);
+  const activeProvider = clean(input.activeProvider);
+  const activeModel = clean(input.activeModel);
+  const selectedAuthMode = input.selectedAuthMode ?? "unknown";
+  const activeAuthMode = input.activeAuthMode ?? "unknown";
+  const selectedBilling = resolveModelRouteBillingMode({
+    provider: selectedProvider,
+    authMode: input.selectedAuthMode,
+  });
+  const activeBilling = resolveModelRouteBillingMode({
+    provider: activeProvider,
+    authMode: input.activeAuthMode,
+  });
+  const changed = selectedProvider !== activeProvider || selectedModel !== activeModel;
+  const enforcement = input.enforcement ?? "dry-run";
+  const reason = changed
+    ? describeEscalationReason({
+        selectedBilling,
+        activeBilling,
+        selectedProvider,
+        activeProvider,
+        selectedAuthMode,
+        activeAuthMode,
+      })
+    : undefined;
+  const approvalSatisfied = hasApprovalAndBudgetCap(input.approval);
+  const escalationRequired = Boolean(reason && !approvalSatisfied);
+  const action: ModelRouteGuardAction = escalationRequired
+    ? enforcement === "block"
+      ? "block"
+      : "escalate"
+    : "allow";
+
+  return {
+    changed,
+    action,
+    enforcement,
+    escalationRequired,
+    selected: {
+      provider: selectedProvider,
+      model: selectedModel,
+      authMode: selectedAuthMode,
+      billingMode: selectedBilling,
+    },
+    active: {
+      provider: activeProvider,
+      model: activeModel,
+      authMode: activeAuthMode,
+      billingMode: activeBilling,
+    },
+    ...(reason ? { reason } : {}),
+    ...(input.approval
+      ? {
+          approval: {
+            approved: input.approval.approved === true,
+            hasBudgetCap:
+              typeof input.approval.budgetCapUsd === "number" && input.approval.budgetCapUsd > 0,
+            ...(input.approval.approvalId ? { approvalId: input.approval.approvalId } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+export function buildModelRouteChangeGuardNotice(
+  result: ModelRouteChangeGuardResult,
+): string | undefined {
+  if (!result.escalationRequired || !result.reason) {
+    return undefined;
+  }
+  const prefix = result.action === "block" ? "⛔" : "⚠️";
+  return `${prefix} Model route guard: ${result.reason}; approval with a budget cap is required before enforcing this transition.`;
+}

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -3,6 +3,10 @@ import { hasConfiguredModelFallbacks, resolveSessionAgentId } from "../../agents
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
+import {
+  buildModelRouteChangeGuardNotice,
+  evaluateModelRouteChangeGuard,
+} from "../../agents/model-route-change-guard.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded-runner/runs.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
@@ -1256,6 +1260,31 @@ export async function runReplyAgent(params: {
       attempts: fallbackAttempts,
       state: fallbackStateEntry,
     });
+    const modelRouteGuard = fallbackTransition.fallbackTransitioned
+      ? evaluateModelRouteChangeGuard({
+          selectedProvider,
+          selectedModel,
+          activeProvider: providerUsed,
+          activeModel: modelUsed,
+          selectedAuthMode: resolveModelAuthMode(selectedProvider, cfg),
+          activeAuthMode: resolveModelAuthMode(providerUsed, cfg),
+          enforcement: "dry-run",
+        })
+      : undefined;
+    if (modelRouteGuard?.escalationRequired && isDiagnosticsEnabled(cfg)) {
+      emitTrustedDiagnosticEvent({
+        type: "model.route_change_guard",
+        sessionKey,
+        sessionId: followupRun.run.sessionId,
+        channel: replyToChannel,
+        agentId: followupRun.run.agentId,
+        action: modelRouteGuard.action,
+        enforcement: modelRouteGuard.enforcement,
+        ...(modelRouteGuard.reason ? { reason: modelRouteGuard.reason } : {}),
+        selected: modelRouteGuard.selected,
+        active: modelRouteGuard.active,
+      });
+    }
     if (fallbackTransition.stateChanged) {
       if (fallbackStateEntry) {
         fallbackStateEntry.fallbackNoticeSelectedModel = fallbackTransition.nextState.selectedModel;
@@ -1502,6 +1531,12 @@ export async function runReplyAgent(params: {
         });
         if (fallbackNotice) {
           verboseNotices.push({ text: fallbackNotice });
+        }
+        const guardNotice = modelRouteGuard
+          ? buildModelRouteChangeGuardNotice(modelRouteGuard)
+          : undefined;
+        if (guardNotice) {
+          verboseNotices.push({ text: guardNotice });
         }
       }
     }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -45,6 +45,29 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   durationMs?: number;
 };
 
+export type DiagnosticModelRouteChangeGuardEvent = DiagnosticBaseEvent & {
+  type: "model.route_change_guard";
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  channel?: string;
+  action: "allow" | "escalate" | "block";
+  enforcement: "dry-run" | "block";
+  reason?: string;
+  selected: {
+    provider: string;
+    model: string;
+    authMode: string;
+    billingMode: string;
+  };
+  active: {
+    provider: string;
+    model: string;
+    authMode: string;
+    billingMode: string;
+  };
+};
+
 export type DiagnosticWebhookReceivedEvent = DiagnosticBaseEvent & {
   type: "webhook.received";
   channel: string;
@@ -445,6 +468,7 @@ export type DiagnosticTelemetryExporterEvent = DiagnosticBaseEvent & {
 
 export type DiagnosticEventPayload =
   | DiagnosticUsageEvent
+  | DiagnosticModelRouteChangeGuardEvent
   | DiagnosticWebhookReceivedEvent
   | DiagnosticWebhookProcessedEvent
   | DiagnosticWebhookErrorEvent

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -193,6 +193,14 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.costUsd = event.costUsd;
       record.durationMs = event.durationMs;
       break;
+    case "model.route_change_guard":
+      record.channel = event.channel;
+      record.provider = event.active.provider;
+      record.model = event.active.model;
+      record.action = event.action;
+      record.mode = event.enforcement;
+      assignReasonCode(record, event.reason);
+      break;
     case "webhook.received":
       record.channel = event.channel;
       break;


### PR DESCRIPTION
## What
Adds a dry-run model route-change guard that records provider/auth/billing transitions when fallback moves a session into metered billing.

## Why
Rex task bb28ee08 requested runtime metadata/audit coverage before any provider/auth/billing transition can become an approval-gated block.

## How
- Classifies model routes by auth mode into metered/subscription/local/unknown
- Emits a diagnostic event and verbose notice when fallback transitions into metered billing without approval + budget cap metadata
- Keeps enforcement in dry-run only; no provider config, billing, or live runtime mutation

## Testing
- node scripts/test-projects.mjs src/agents/model-route-change-guard.test.ts src/infra/diagnostic-events.test.ts src/auto-reply/fallback-state.test.ts
- git diff --check
- PATH=/tmp/openclaw-pnpm-shim:$PATH corepack pnpm check:changed
- vet --base-commit 7120f5b25487f2fc021d7642c663e2cea279e015

## Safety
No gateway restart, provider config mutation, billing change, live smoke, deploy, or destructive action.