### PR TITLE
fix(plugin-sdk): add missing discord export for external channel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -852,6 +852,10 @@
       "types": "./dist/plugin-sdk/directory-runtime.d.ts",
       "default": "./dist/plugin-sdk/directory-runtime.js"
     },
+    "./plugin-sdk/discord": {
+      "types": "./dist/plugin-sdk/discord.d.ts",
+      "default": "./dist/plugin-sdk/discord.js"
+    },
     "./plugin-sdk/media-generation-runtime-shared": {
       "types": "./dist/plugin-sdk/media-generation-runtime-shared.d.ts",
       "default": "./dist/plugin-sdk/media-generation-runtime-shared.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -196,6 +196,7 @@
   "global-singleton",
   "directory-config-runtime",
   "directory-runtime",
+  "discord",
   "media-generation-runtime-shared",
   "image-generation",
   "image-generation-runtime",

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -1,0 +1,13 @@
+// Narrow plugin-sdk surface for the external Discord channel plugin.
+//
+// @openclaw/discord@2026.3.13 imports `openclaw/plugin-sdk/discord` expecting
+// generic plugin types and the empty config schema helper.  This barrel
+// re-exports exactly those symbols so the external plugin resolves correctly
+// when the package.json `exports` map includes `./plugin-sdk/discord`.
+//
+// See: https://github.com/openclaw/openclaw/issues/73685
+
+export type { OpenClawPluginApi } from "../plugins/types.js";
+export type { OpenClawConfig } from "../config/types.openclaw.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";


### PR DESCRIPTION
## Summary

Add `./plugin-sdk/discord` to the package.json exports map so `@openclaw/discord@2026.3.13` (and future versions) can resolve `openclaw/plugin-sdk/discord`.

## Root cause

`openclaw@2026.4.26`'s `package.json` `exports` map does not include `./plugin-sdk/discord`. When the external Discord plugin does `import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/discord"`, Node's exports-map resolver rejects it. The plugin loader's fallback tries `dist/plugin-sdk/root-alias.cjs/discord` which doesn't exist either, so the Discord plugin never registers and the bot stays offline.

## Changes

1. **`src/plugin-sdk/discord.ts`** — new barrel re-exporting the four symbols the Discord plugin uses: `OpenClawPluginApi`, `OpenClawConfig`, `PluginRuntime`, `emptyPluginConfigSchema`.
2. **`package.json`** — add `./plugin-sdk/discord` export entry pointing to the new barrel's build output.
3. **`scripts/lib/plugin-sdk-entrypoints.json`** — register `discord` so the build pipeline includes it.

## Verification

All source imports resolve to existing files. Build output (`dist/plugin-sdk/discord.js` + `.d.ts`) will be produced by the standard plugin-sdk build pipeline.

Fixes #73685