### PR TITLE
ci: shard gateway codeql quality

### DIFF
--- a/.github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
@@ -1,0 +1,34 @@
+name: openclaw-codeql-gateway-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/gateway/protocol
+  - src/gateway/server-methods
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -60,6 +60,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/config-boundary"
 
+  gateway-runtime-boundary:
+    name: Critical Quality (gateway-runtime-boundary)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/gateway-runtime-boundary"
+
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -249,6 +249,9 @@ over narrow high-value surfaces. Its baseline job scans the same auth, secrets,
 sandbox, cron, and gateway surface as the security workflow. The config-boundary
 job scans config schema, migration, normalization, and IO contracts under the
 separate `/codeql-critical-quality/config-boundary` category. The
+gateway-runtime-boundary job scans gateway protocol schemas and server method
+contracts under the separate
+`/codeql-critical-quality/gateway-runtime-boundary` category. The
 plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
 entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
 category. Keep the workflow separate from security so quality findings can be


### PR DESCRIPTION
## Summary
- Problem: the non-security CodeQL quality workflow is intentionally narrow, but the next runtime surface needs a separate signal bucket instead of bloating the baseline category.
- Why it matters: gateway protocol schemas and server methods are high-leverage API/runtime contracts, and sharding keeps CodeQL fast and actionable.
- What changed: added a `gateway-runtime-boundary` critical-quality CodeQL config and workflow job for `src/gateway/protocol` + `src/gateway/server-methods`.
- What did NOT change (scope boundary): no runtime behavior, no security profile changes, no broad/default CodeQL expansion.

## Change Type (select all)

- [x] Chore/infra
- [x] Docs

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts
- [x] CI/CD / infra

## Linked Issue/PR

- Related #73498
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A.

## Regression Test Plan (if applicable)

N/A. Workflow/config-only shard expansion.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 repo environment
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Parse CodeQL workflow/config YAML.
2. Run workflow sanity.
3. Dispatch `CodeQL Critical Quality` on this branch.

### Expected

- All four critical-quality categories upload cleanly.

### Actual

- Local YAML parse: passed.
- `git diff --check`: passed.
- `pnpm check:workflows`: passed.
- Branch CodeQL workflow: pending.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: YAML parse, diff check, workflow sanity, shard size check.
- Edge cases checked: kept baseline category unchanged; new shard is separate from security.
- What you did **not** verify: branch CodeQL upload/result counts yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: adds another scheduled CodeQL job.
  - Mitigation: scope is 84 prod TS files after test/generated/test-helper ignores and remains on the small Blacksmith Linux runner.
