### PR TITLE
fix(discord): gate GuildVoiceStates intent on voice.enabled (#73709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Discord: gate the `GuildVoiceStates` gateway intent on `channels.discord.voice.enabled` instead of subscribing unconditionally, so operators who set `voice.enabled: false` no longer pin the gateway process at ~100% CPU on Linux (~20-33% on macOS) from voice-state events that nothing consumes. Default behavior is unchanged (voice on → voice-state intent on). Fixes #73709. Thanks @sanchezm86.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.

--- a/extensions/discord/src/monitor/gateway-intents.test.ts
+++ b/extensions/discord/src/monitor/gateway-intents.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { resolveDiscordGatewayIntents } from "./gateway-plugin.js";
+
+// Discord gateway intent bit values from the Discord API. We assert against
+// the bitmask result rather than importing the SDK enum so the test does not
+// need the carbon-gateway runtime — the values are public protocol constants.
+const GUILDS = 1 << 0;
+const GUILD_MEMBERS = 1 << 1;
+const GUILD_VOICE_STATES = 1 << 7;
+const GUILD_PRESENCES = 1 << 8;
+const GUILD_MESSAGES = 1 << 9;
+const GUILD_MESSAGE_REACTIONS = 1 << 10;
+const DIRECT_MESSAGES = 1 << 12;
+const DIRECT_MESSAGE_REACTIONS = 1 << 13;
+const MESSAGE_CONTENT = 1 << 15;
+
+const BASE_TEXT_INTENTS =
+  GUILDS |
+  GUILD_MESSAGES |
+  MESSAGE_CONTENT |
+  DIRECT_MESSAGES |
+  GUILD_MESSAGE_REACTIONS |
+  DIRECT_MESSAGE_REACTIONS;
+
+describe("resolveDiscordGatewayIntents", () => {
+  it("includes GuildVoiceStates by default (no voice config provided)", () => {
+    const intents = resolveDiscordGatewayIntents();
+    expect(intents & GUILD_VOICE_STATES).toBe(GUILD_VOICE_STATES);
+    expect(intents & BASE_TEXT_INTENTS).toBe(BASE_TEXT_INTENTS);
+  });
+
+  it("includes GuildVoiceStates when voice.enabled is explicitly true", () => {
+    const intents = resolveDiscordGatewayIntents(undefined, { enabled: true });
+    expect(intents & GUILD_VOICE_STATES).toBe(GUILD_VOICE_STATES);
+  });
+
+  it("omits GuildVoiceStates when voice.enabled is explicitly false (#73709)", () => {
+    // Regression for #73709: subscribing to the GuildVoiceStates gateway
+    // intent when the operator has set `channels.discord.voice.enabled =
+    // false` produced a sustained ~100% CPU spin in the gateway process
+    // on Linux (~20-33% on macOS Apple Silicon) at idle. The intent must
+    // follow the voice-config opt-out so a text-only Discord channel
+    // really is text-only.
+    const intents = resolveDiscordGatewayIntents(undefined, { enabled: false });
+    expect(intents & GUILD_VOICE_STATES).toBe(0);
+    // Base text-channel intents stay on so chat keeps working.
+    expect(intents & BASE_TEXT_INTENTS).toBe(BASE_TEXT_INTENTS);
+  });
+
+  it("layers privileged intents (presence, guildMembers) independently of voice", () => {
+    const intents = resolveDiscordGatewayIntents(
+      { presence: true, guildMembers: true },
+      { enabled: false },
+    );
+    expect(intents & GUILD_PRESENCES).toBe(GUILD_PRESENCES);
+    expect(intents & GUILD_MEMBERS).toBe(GUILD_MEMBERS);
+    expect(intents & GUILD_VOICE_STATES).toBe(0);
+  });
+});

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -74,6 +74,7 @@ function hasCarbonGatewaySocketStarted(plugin: carbonGateway.GatewayPlugin): boo
 
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("openclaw/plugin-sdk/config-types").DiscordIntentsConfig,
+  voiceConfig?: { enabled?: boolean },
 ): number {
   let intents =
     carbonGateway.GatewayIntents.Guilds |
@@ -81,8 +82,14 @@ export function resolveDiscordGatewayIntents(
     carbonGateway.GatewayIntents.MessageContent |
     carbonGateway.GatewayIntents.DirectMessages |
     carbonGateway.GatewayIntents.GuildMessageReactions |
-    carbonGateway.GatewayIntents.DirectMessageReactions |
-    carbonGateway.GatewayIntents.GuildVoiceStates;
+    carbonGateway.GatewayIntents.DirectMessageReactions;
+  // Only subscribe to GuildVoiceStates when voice is actually enabled
+  // (default `true` preserves prior behavior). Subscribing to this intent
+  // when `channels.discord.voice.enabled === false` was the source of a
+  // sustained ~100% CPU spin in the gateway process on Linux. See #73709.
+  if (voiceConfig?.enabled !== false) {
+    intents |= carbonGateway.GatewayIntents.GuildVoiceStates;
+  }
   if (intentsConfig?.presence) {
     intents |= carbonGateway.GatewayIntents.GuildPresences;
   }
@@ -479,7 +486,10 @@ export function createDiscordGatewayPlugin(params: {
     ) => Promise<void>;
   };
 }): carbonGateway.GatewayPlugin {
-  const intents = resolveDiscordGatewayIntents(params.discordConfig?.intents);
+  const intents = resolveDiscordGatewayIntents(
+    params.discordConfig?.intents,
+    params.discordConfig?.voice,
+  );
   const proxy = resolveEffectiveDebugProxyUrl(params.discordConfig?.proxy);
   const debugProxySettings = resolveDebugProxySettings();
   const options = {


### PR DESCRIPTION
## What

Fixes #73709. `resolveDiscordGatewayIntents` unconditionally OR'd `GatewayIntents.GuildVoiceStates` into the requested intent bitmask regardless of `channels.discord.voice.enabled`. The result: a sustained ~100% CPU spin in the gateway process on Linux (Hetzner CPX31, 4 vCPU AMD confirmed) and ~20-33% on macOS (Apple Silicon Mac Studio) at idle, because the Discord gateway kept dispatching voice-state events that nothing consumed when voice was meant to be off.

## Fix

Pass the existing `discordConfig.voice` config through to the intent resolver and gate `GuildVoiceStates` on `voice.enabled !== false`:

```ts
if (voiceConfig?.enabled !== false) {
  intents |= carbonGateway.GatewayIntents.GuildVoiceStates;
}
```

Default behavior is unchanged — `channels.discord.voice.enabled` defaults to `true`, so the intent stays on for the common case. Operators who explicitly set `voice.enabled: false` (text-only Discord channel) now get a true text-only gateway connection without the CPU spin.

## Why this shape rather than a new `intents.voiceStates` opt-in

The issuer's suggested local patch (in #73709) introduces a new `channels.discord.intents.voiceStates` opt-in field. That works, but:

- Adding a new field requires a corresponding `zod-schema.providers-core.ts` strict-schema update.
- It splits the user's intent across two config knobs (`voice.enabled: false` AND `intents.voiceStates: false` to actually go quiet).
- Reusing the existing `voice.enabled` config the user already sets keeps the contract minimal and matches the user's actual mental model (turn off voice → no voice traffic).

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341).** Chose to reuse the existing `voice.enabled` config rather than introduce a new helper / config field. Saves a schema change. ✅
2. **Shared-helper caller check (steipete #60623).** `resolveDiscordGatewayIntents` is exported from `runtime-api.ts` but only called from one in-tree site (`gateway-plugin.ts:489`); adding an optional second parameter is backward-compatible — external callers that pass only the first arg get the same default behavior (voice on). ✅
3. **Broader-fix rival scan (steipete #68270).** Zero rival PRs reference #73709. ✅

## Verified locally

```
npx oxlint extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/gateway-intents.test.ts
# Found 0 warnings and 0 errors.

npx vitest run extensions/discord/src/monitor/gateway-intents.test.ts
# Tests  4 passed (4)
```

Tests cover:
- Default (no args) → `GuildVoiceStates` set
- `voice.enabled: true` → `GuildVoiceStates` set
- `voice.enabled: false` → `GuildVoiceStates` cleared, base text intents preserved
- Privileged intents (`presence`, `guildMembers`) layer independently of voice

lobster-biscuit: 73709-discord-voice-states-intent-gate

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
