### PR TITLE
fix(cli): canonicalize infer model run refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
+- CLI/infer: canonicalize mixed-case model refs in `infer model run` to lowercase provider/model before dispatch so pasted refs like `Anthropic/CLAUDE-OPUS-4-7` resolve through the catalog instead of failing with an empty-output provider error. (#73717) Thanks @ai-hpc.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.
 - PDF/Codex: include extraction-fallback instructions for `openai-codex/*` PDF tool requests so Codex Responses receives its required system prompt. Fixes #77872. Thanks @anyech.
 - Onboard/channels: recover externalized channel plugins from stale `channels.<id>` config by falling back to `ensureChannelSetupPluginInstalled` via the trusted catalog when the plugin is missing on disk, so leftover `appId`/token entries no longer dead-end onboard with "<channel> plugin not available." (#78328) Thanks @sliverp.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -363,6 +363,42 @@ describe("capability cli", () => {
     }) as never);
   });
 
+  async function runModelRunWithModel(model: string, transport: "local" | "gateway") {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--model",
+        model,
+        "--prompt",
+        "hello",
+        ...(transport === "gateway" ? ["--gateway"] : []),
+        "--json",
+      ],
+    });
+  }
+
+  function expectModelRunDispatch(transport: "local" | "gateway", modelRef: string) {
+    if (transport === "gateway") {
+      const slash = modelRef.indexOf("/");
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "agent",
+          params: expect.objectContaining({
+            provider: modelRef.slice(0, slash),
+            model: modelRef.slice(slash + 1),
+          }),
+        }),
+      );
+      return;
+    }
+    expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ modelRef }),
+    );
+  }
+
   it("lists canonical capabilities", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
@@ -778,6 +814,30 @@ describe("capability cli", () => {
       }),
     );
   });
+
+  it.each(["local", "gateway"] as const)(
+    "canonicalizes case-mismatched model refs before %s dispatch",
+    async (transport) => {
+      mocks.loadModelCatalog.mockResolvedValueOnce([
+        { id: "claude-opus-4-7", provider: "anthropic", name: "Claude Opus 4.7" },
+      ] as never);
+
+      await runModelRunWithModel("Anthropic/CLAUDE-OPUS-4-7", transport);
+
+      expectModelRunDispatch(transport, "anthropic/claude-opus-4-7");
+    },
+  );
+
+  it.each(["local", "gateway"] as const)(
+    "keeps custom mixed-case model refs before %s dispatch when the catalog has no match",
+    async (transport) => {
+      mocks.loadModelCatalog.mockResolvedValueOnce([] as never);
+
+      await runModelRunWithModel("custom/MyModel", transport);
+
+      expectModelRunDispatch(transport, "custom/MyModel");
+    },
+  );
 
   it("rejects empty model run prompts before gateway dispatch", async () => {
     await expect(

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -11,6 +11,7 @@ import {
 } from "../agents/auth-profiles.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import { findModelInCatalog } from "../agents/model-catalog-lookup.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import {
   completeWithPreparedSimpleCompletionModel,
@@ -558,6 +559,24 @@ function resolveModelRefOverride(raw: string | undefined): { provider?: string; 
   };
 }
 
+function shouldCanonicalizeModelRunRef(
+  model: string | undefined,
+  ref: { provider?: string; model?: string },
+): ref is { provider: string; model: string } {
+  return Boolean(model && model !== model.toLowerCase() && ref.provider && ref.model);
+}
+
+async function canonicalizeModelRunRef(raw: string | undefined, cfg: OpenClawConfig) {
+  const model = normalizeStringifiedOptionalString(raw);
+  const ref = resolveModelRefOverride(model);
+  if (!shouldCanonicalizeModelRunRef(model, ref)) {
+    return model;
+  }
+  const catalog = await loadModelCatalog({ config: cfg });
+  const entry = findModelInCatalog(catalog, ref.provider, ref.model);
+  return entry ? `${entry.provider}/${entry.id}` : model;
+}
+
 function requireProviderModelOverride(
   raw: string | undefined,
 ): { provider: string; model: string } | undefined {
@@ -644,11 +663,12 @@ async function runModelRun(params: {
           })),
         ]
       : params.prompt;
+  const model = await canonicalizeModelRunRef(params.model, cfg);
   if (params.transport === "local") {
     const prepared = await prepareSimpleCompletionModelForAgent({
       cfg,
       agentId,
-      modelRef: params.model,
+      modelRef: model,
       allowMissingApiKeyModes: ["aws-sdk"],
       skipPiDiscovery: true,
     });
@@ -721,10 +741,10 @@ async function runModelRun(params: {
     } satisfies CapabilityEnvelope;
   }
 
-  const { provider, model } = resolveModelRefOverride(params.model);
+  const { provider, model: modelId } = resolveModelRefOverride(model);
   // Provider/model overrides require trusted-operator scope. Use the backend
   // shared-secret lane so local gateway smokes do not depend on paired CLI device scopes.
-  const hasModelOverride = Boolean(provider || model);
+  const hasModelOverride = Boolean(provider || modelId);
   const response: {
     result?: {
       payloads?: Array<{ text?: string; mediaUrl?: string | null; mediaUrls?: string[] }>;
@@ -751,7 +771,7 @@ async function runModelRun(params: {
             }))
           : undefined,
       provider,
-      model,
+      model: modelId,
       modelRun: true,
       promptMode: "none",
       cleanupBundleMcpOnRunEnd: true,


### PR DESCRIPTION
## Summary

- Problem: `infer model run --model` forwarded case-mismatched catalog model ids such as `Anthropic/CLAUDE-OPUS-4-7` to the model runtime, which could surface as a misleading empty-output provider error.
- Why it matters: users can paste natural mixed-case model refs and get a provider-looking failure instead of the canonical known model behavior.
- What changed: explicit model-run overrides now resolve through the model catalog when there is a unique case-insensitive provider/model match, then dispatch the canonical provider/model ref for both local and gateway transports.
- What did NOT change (scope boundary): custom mixed-case refs are preserved when no unique catalog match exists; this does not change model catalog listing, provider auth, or non-`infer model run` commands.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73715
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `infer model run` parsed and forwarded explicit model overrides without canonicalizing case-only matches against the known model catalog.
- Missing detection / guardrail: no regression test covered case-mismatched explicit model refs before local or gateway dispatch.
- Contributing context (if known): provider ids are normalized case-insensitively, while model ids were forwarded with user-supplied casing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/capability-cli.test.ts`
- Scenario the test should lock in: `Anthropic/CLAUDE-OPUS-4-7` is canonicalized to `anthropic/claude-opus-4-7` before local and gateway model-run dispatch.
- Why this is the smallest reliable guardrail: the bug is in the CLI override-to-dispatch seam, so mocked dispatch tests catch the raw value before any provider call.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw infer model run --model <provider/model>` now accepts case-only mismatches for catalog models when the match is unique, dispatching the canonical model id instead of the raw casing.

## Diagram (if applicable)

```text
Before:
--model Anthropic/CLAUDE-OPUS-4-7 -> raw runtime dispatch -> misleading provider/no-output error

After:
--model Anthropic/CLAUDE-OPUS-4-7 -> unique catalog match -> anthropic/claude-opus-4-7 -> normal dispatch
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.4 LTS
- Runtime/container: Node 22, pnpm dev checkout
- Model/provider: Anthropic catalog model refs
- Integration/channel (if any): CLI `infer model run`
- Relevant config (redacted): default source-checkout runtime config; no secrets included

### Steps

1. Run `openclaw infer model run --model Anthropic/CLAUDE-OPUS-4-7 --prompt "hello" --json`.
2. Observe the model-run dispatch receives the canonical ref.
3. Run the same path with a custom mixed-case ref that has no catalog match.

### Expected

- Known catalog model refs with case-only mismatches dispatch as their canonical provider/model id.
- Custom mixed-case refs without a unique catalog match remain unchanged.

### Actual

- Before this PR, the raw mixed-case catalog model id was forwarded.
- After this PR, the CLI canonicalizes only unique catalog matches before dispatch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm test src/cli/capability-cli.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests  47 passed (47)

pnpm check:changed
passed

git diff --check
passed
```

## Human Verification (required)

- Verified scenarios: local dispatch canonicalization, gateway dispatch canonicalization, custom mixed-case ref preservation.
- Edge cases checked: no catalog match leaves the explicit model override unchanged.
- What you did not verify: live Anthropic provider call.

- `pnpm test src/cli/capability-cli.test.ts -- --reporter=verbose` passed: 51 tests.
- `pnpm build` passed after refreshing the local install with `pnpm install`.
- Live CLI smoke with existing local OpenRouter auth profile passed:
  - Command shape: `pnpm --silent openclaw infer model run --model OpenRouter/OPENROUTER/AUTO --prompt 'Reply with OK only.' --json`
  - Result: exit 0, parseable JSON, `ok=true`, `provider=openrouter`, `model=openrouter/auto`, output text `OK`.
- Additional live smoke with `OpenRouter/ANTHROPIC/CLAUDE-3-HAIKU` exited 1 because the provider returned no text, but the error reported canonicalized `provider "openrouter" model "anthropic/claude-3-haiku"`, not the uppercase input.


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A custom provider intentionally using mixed-case ids could be changed unexpectedly.
  - Mitigation: canonicalization only happens when the loaded model catalog has exactly one case-insensitive provider/model match; otherwise the raw ref is preserved.


## Real behavior proof

**Behavior or issue addressed:** `openclaw infer model run --model <ref>` previously forwarded the user-supplied model ref to the simple-completion transport without case canonicalization. A user typing `DeepSeek/DeepSeek-V4-Flash` (matching the docs / catalog display name) hit a "model not found" / wrong-routing path because catalog ids are stored lowercased. After this patch, mixed-case refs are looked up against the model catalog and rewritten to the canonical `provider/id` before transport setup, so case-insensitive references just work.

**Real environment tested:** macOS Darwin 25.2.0 (arm64), Node 24.15.0 (Homebrew `node@24`), local OpenClaw source checkout at `/Users/a1111/openclaw/` running directly via `node --import tsx` against the patched `src/cli/capability-cli.ts` and the production `findModelInCatalog` / `loadModelCatalog` helpers. Real configured providers (DeepSeek native + OpenAI catalog entries) loaded from `~/.openclaw/openclaw.json` — no mocked catalog.

**Exact steps or command run after this patch:**

1. Checked out the patched branch `fix/infer-model-case-canonicalization` (HEAD `2d491c11f6`, rebased onto upstream `b8f9137d31`).
2. Ran a small node script that loads the user's real config snapshot, loads the model catalog, and exercises `findModelInCatalog` with several mixed-case `provider/id` inputs — the same lookup path that the patched `canonicalizeModelRunRef` calls.
3. Captured the canonical output for each input.

**Evidence after fix:**

Live terminal capture from the patched source running on my Mac, exercising the canonical lookup with mixed-case inputs (the exact code path that `runModelRun` now uses before transport setup):

```
$ node --import tsx --input-type=module -e "
import { loadModelCatalog } from './src/agents/model-catalog.ts';
import { findModelInCatalog } from './src/agents/model-catalog-lookup.ts';
import { readConfigFileSnapshot } from './src/config/io.ts';
const snap = await readConfigFileSnapshot();
const catalog = await loadModelCatalog({ config: snap.config });
for (const r of [
  { provider: 'DeepSeek', model: 'DeepSeek-V4-Flash' },
  { provider: 'DEEPSEEK', model: 'DEEPSEEK-V4-PRO' },
  { provider: 'deepseek', model: 'deepseek-v4-flash' },
  { provider: 'OpenAI', model: 'GPT-4o-mini' },
]) {
  const e = findModelInCatalog(catalog, r.provider, r.model);
  console.log(JSON.stringify(r) + ' => ' + (e ? e.provider + '/' + e.id : 'NOT FOUND'));
}
"
{"provider":"DeepSeek","model":"DeepSeek-V4-Flash"} => deepseek/deepseek-v4-flash
{"provider":"DEEPSEEK","model":"DEEPSEEK-V4-PRO"} => deepseek/deepseek-v4-pro
{"provider":"deepseek","model":"deepseek-v4-flash"} => deepseek/deepseek-v4-flash
{"provider":"OpenAI","model":"GPT-4o-mini"} => openai/gpt-4o-mini
```

The patched `canonicalizeModelRunRef` in `src/cli/capability-cli.ts` runs only when the input has uppercase characters and a parsable `provider/id` shape, then reuses the catalog lookup above and substitutes the canonical pair before invoking transport setup. Already-canonical lowercase inputs short-circuit and are returned untouched.

**Observed result after fix:**

Mixed-case `--model` inputs (e.g., `DeepSeek/DeepSeek-V4-Flash`, `OpenAI/GPT-4o-mini`) resolve to the lowercased catalog id (`deepseek/deepseek-v4-flash`, `openai/gpt-4o-mini`) before the local simple-completion transport or the gateway lane is invoked. Already-canonical lowercase refs are returned unchanged, so this patch is a no-op for the dominant call shape and only changes behavior for previously-failing mixed-case input.

**What was not tested:**

- Live one-shot inference round-trip (i.e., actually completing a model turn with a mixed-case ref) — exercise here was scoped to the canonicalization step that immediately precedes transport setup, since that is where the case bug lives.
- Refs containing non-ASCII characters or unicode case folding edge cases — the helper compares `model !== model.toLowerCase()` against ASCII catalog ids and was not exercised against non-ASCII names.
- Gateway transport lane (only the local simple-completion branch was followed in code; the patch wires the canonicalized ref through both branches but the gateway path was not separately exercised live).
