### PR TITLE
fix(agents): move groupId trust check into resolveGroupToolPolicy for all callers [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ Docs: https://docs.openclaw.ai
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
 - Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
 - Gateway/startup: skip inherited workspace startup memory for sandboxed spawned sessions without real-workspace write access, so `/new` no longer preloads host workspace memory into isolated child runs. (#73611) Thanks @drobison00.
+- Agents/tool policy: validate caller group IDs against session or spawned context before applying group-scoped tool policies or persisting gateway group metadata, so forged group IDs cannot unlock more permissive tools. (#73720) Thanks @mmaps.
 
 ## 2026.4.27
 

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -67,6 +67,8 @@ export function applyFinalEffectiveToolPolicy(
     return params.bundledTools;
   }
   const trustedGroup = resolveTrustedGroupId(params);
+  // Resolve here for warnings and to strip caller-only group metadata before
+  // this pass; resolveGroupToolPolicy re-checks internally for all callers.
   if (trustedGroup.dropped) {
     params.warn(
       "effective tool policy: dropping caller-provided groupId that does not match session-derived group context",

--- a/src/agents/pi-embedded-runner/effective-tool-policy.ts
+++ b/src/agents/pi-embedded-runner/effective-tool-policy.ts
@@ -2,8 +2,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getPluginToolMeta } from "../../plugins/tools.js";
 import {
   resolveEffectiveToolPolicy,
-  resolveGroupContextFromSessionKey,
   resolveGroupToolPolicy,
+  resolveTrustedGroupId,
   resolveSubagentToolPolicyForSession,
 } from "../pi-tools.policy.js";
 import {
@@ -59,32 +59,6 @@ type FinalEffectiveToolPolicyParams = {
   ownerOnlyToolAllowlist?: string[];
   warn: (message: string) => void;
 };
-
-function resolveTrustedGroupId(params: FinalEffectiveToolPolicyParams): {
-  groupId: string | null | undefined;
-  dropped: boolean;
-} {
-  const callerGroupId = (params.groupId ?? "").trim();
-  if (!callerGroupId) {
-    return { groupId: params.groupId, dropped: false };
-  }
-  const sessionGroupIds = resolveGroupContextFromSessionKey(params.sessionKey).groupIds ?? [];
-  const spawnedGroupIds = resolveGroupContextFromSessionKey(params.spawnedBy).groupIds ?? [];
-  const trusted = [...sessionGroupIds, ...spawnedGroupIds];
-  // Fail-closed: if the session/spawnedBy keys do not encode a group context,
-  // we have no server-verified ground truth to compare the caller value
-  // against. A non-group session (direct, subagent, cron) should not consult
-  // a group-scoped tool policy at all, and accepting the caller's groupId
-  // here would let an attacker widen bundled-tool availability by sending
-  // an arbitrary group id.
-  if (trusted.length === 0) {
-    return { groupId: null, dropped: true };
-  }
-  if (trusted.includes(callerGroupId)) {
-    return { groupId: params.groupId, dropped: false };
-  }
-  return { groupId: null, dropped: true };
-}
 
 export function applyFinalEffectiveToolPolicy(
   params: FinalEffectiveToolPolicyParams,

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -462,6 +462,36 @@ describe("Agent-specific tool filtering", () => {
     });
   });
 
+  it("should not apply forged caller group tool policy for non-group sessions", () => {
+    const cfg: OpenClawConfig = {
+      tools: { allow: ["read"] },
+      channels: {
+        whatsapp: {
+          groups: {
+            "trusted-group": {
+              tools: { allow: ["exec", "read", "write", "edit"] },
+            },
+          },
+        },
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      messageProvider: "whatsapp",
+      groupId: "trusted-group",
+      workspaceDir: "/tmp/test-forged-group-policy",
+      agentDir: "/tmp/agent-forged-group-policy",
+    });
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("read");
+    expect(names).not.toContain("exec");
+    expect(names).not.toContain("write");
+    expect(names).not.toContain("edit");
+    expect(names).not.toContain("apply_patch");
+  });
+
   it("should resolve feishu group tool policy for sender-scoped session keys", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -145,6 +145,32 @@ describe("resolveGroupToolPolicy group context validation", () => {
       }),
     ).toEqual({ allow: ["read"] });
   });
+
+  it("prefers the session-derived channel over caller-supplied messageProvider", () => {
+    const channelCfg = {
+      channels: {
+        discord: {
+          groups: {
+            C123: { tools: { allow: ["exec"] } },
+          },
+        },
+        slack: {
+          groups: {
+            C123: { tools: { allow: ["read"] } },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const policy = resolveGroupToolPolicy({
+      config: channelCfg,
+      sessionKey: "agent:main:slack:group:C123",
+      messageProvider: "discord",
+      groupId: "C123",
+    });
+
+    expect(policy).toEqual({ allow: ["read"] });
+  });
 });
 
 describe("resolveSubagentToolPolicy depth awareness", () => {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -101,6 +101,25 @@ describe("resolveGroupToolPolicy group context validation", () => {
     ).toEqual({ allow: ["exec", "read", "write", "edit"] });
   });
 
+  it("accepts caller groupId when spawnedBy provides the trusted group context", () => {
+    expect(
+      resolveTrustedGroupId({
+        sessionKey: "agent:main:main",
+        spawnedBy: "agent:main:whatsapp:group:trusted-group",
+        groupId: "trusted-group",
+      }),
+    ).toEqual({ groupId: "trusted-group", dropped: false });
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        spawnedBy: "agent:main:whatsapp:group:trusted-group",
+        messageProvider: "whatsapp",
+        groupId: "trusted-group",
+      }),
+    ).toEqual({ allow: ["exec", "read", "write", "edit"] });
+  });
+
   it("keeps specific session group policy ahead of trusted parent caller groupId", () => {
     const scopedCfg: OpenClawConfig = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -7,8 +7,10 @@ import {
   filterToolsByPolicy,
   isToolAllowedByPolicyName,
   resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
   resolveSubagentToolPolicy,
   resolveSubagentToolPolicyForSession,
+  resolveTrustedGroupId,
 } from "./pi-tools.policy.js";
 import { createStubTool } from "./test-helpers/pi-tool-stubs.js";
 import { providerAliasCases } from "./test-helpers/provider-alias-cases.js";
@@ -37,6 +39,92 @@ describe("pi-tools.policy", () => {
 
   it("blocks apply_patch when write is denylisted", () => {
     expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(false);
+  });
+});
+
+describe("resolveGroupToolPolicy group context validation", () => {
+  const cfg: OpenClawConfig = {
+    channels: {
+      whatsapp: {
+        groups: {
+          "safe-room": {
+            tools: { allow: ["read"] },
+          },
+          "trusted-group": {
+            tools: { allow: ["exec", "read", "write", "edit"] },
+          },
+        },
+      },
+    },
+    tools: { allow: ["read"] },
+  };
+
+  it("rejects forged groupId when the session has no group context", () => {
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:main",
+        messageProvider: "whatsapp",
+        groupId: "trusted-group",
+        groupChannel: "whatsapp",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("uses session-derived group policy when caller groupId disagrees", () => {
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:whatsapp:group:safe-room",
+        messageProvider: "whatsapp",
+        groupId: "trusted-group",
+        groupChannel: "whatsapp",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("accepts caller groupId when it matches session-derived group context", () => {
+    expect(
+      resolveTrustedGroupId({
+        sessionKey: "agent:main:whatsapp:group:trusted-group",
+        groupId: "trusted-group",
+      }),
+    ).toEqual({ groupId: "trusted-group", dropped: false });
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:whatsapp:group:trusted-group",
+        messageProvider: "whatsapp",
+        groupId: "trusted-group",
+        groupChannel: "whatsapp",
+      }),
+    ).toEqual({ allow: ["exec", "read", "write", "edit"] });
+  });
+
+  it("keeps specific session group policy ahead of trusted parent caller groupId", () => {
+    const scopedCfg: OpenClawConfig = {
+      channels: {
+        whatsapp: {
+          groups: {
+            room: {
+              tools: { allow: ["exec", "read"] },
+            },
+            "room:sender:alice": {
+              tools: { allow: ["read"] },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      resolveGroupToolPolicy({
+        config: scopedCfg,
+        sessionKey: "agent:main:whatsapp:group:room:sender:alice",
+        messageProvider: "whatsapp",
+        groupId: "room",
+      }),
+    ).toEqual({ allow: ["read"] });
   });
 });
 

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -481,7 +481,7 @@ export function resolveGroupToolPolicy(params: {
   if (groupIds.length === 0) {
     return undefined;
   }
-  const channelRaw = params.messageProvider ?? sessionContext.channel ?? spawnedContext.channel;
+  const channelRaw = sessionContext.channel ?? spawnedContext.channel ?? params.messageProvider;
   const channel = normalizeMessageChannel(channelRaw);
   if (!channel) {
     return undefined;

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -279,6 +279,51 @@ export function resolveGroupContextFromSessionKey(sessionKey?: string | null): {
   };
 }
 
+type GroupToolPolicyContext = ReturnType<typeof resolveGroupContextFromSessionKey>;
+
+function resolveTrustedGroupIdFromContexts(params: {
+  groupId?: string | null;
+  sessionContext: GroupToolPolicyContext;
+  spawnedContext: GroupToolPolicyContext;
+}): {
+  groupId: string | null | undefined;
+  dropped: boolean;
+} {
+  const callerGroupId = (params.groupId ?? "").trim();
+  if (!callerGroupId) {
+    return { groupId: params.groupId, dropped: false };
+  }
+  const trustedGroupIds = collectUniqueStrings([
+    ...(params.sessionContext.groupIds ?? []),
+    ...(params.spawnedContext.groupIds ?? []),
+  ]);
+  // Fail closed when no server-derived session/spawn context can vouch for the
+  // caller group id. Non-group sessions must not opt into group-scoped tool
+  // policy by supplying an arbitrary groupId.
+  if (trustedGroupIds.length === 0) {
+    return { groupId: null, dropped: true };
+  }
+  if (trustedGroupIds.includes(callerGroupId)) {
+    return { groupId: params.groupId, dropped: false };
+  }
+  return { groupId: null, dropped: true };
+}
+
+export function resolveTrustedGroupId(params: {
+  groupId?: string | null;
+  sessionKey?: string | null;
+  spawnedBy?: string | null;
+}): {
+  groupId: string | null | undefined;
+  dropped: boolean;
+} {
+  return resolveTrustedGroupIdFromContexts({
+    groupId: params.groupId,
+    sessionContext: resolveGroupContextFromSessionKey(params.sessionKey),
+    spawnedContext: resolveGroupContextFromSessionKey(params.spawnedBy),
+  });
+}
+
 function resolveProviderToolPolicy(params: {
   byProvider?: Record<string, ToolPolicyConfig>;
   modelProvider?: string;
@@ -421,10 +466,17 @@ export function resolveGroupToolPolicy(params: {
   }
   const sessionContext = resolveGroupContextFromSessionKey(params.sessionKey);
   const spawnedContext = resolveGroupContextFromSessionKey(params.spawnedBy);
+  const trustedGroup = resolveTrustedGroupIdFromContexts({
+    groupId: params.groupId,
+    sessionContext,
+    spawnedContext,
+  });
+  // Keep server-derived ids first so a caller cannot use a trusted parent
+  // candidate to skip a more-specific session group policy.
   const groupIds = collectUniqueStrings([
-    ...buildScopedGroupIdCandidates(params.groupId),
     ...(sessionContext.groupIds ?? []),
     ...(spawnedContext.groupIds ?? []),
+    ...buildScopedGroupIdCandidates(trustedGroup.groupId),
   ]);
   if (groupIds.length === 0) {
     return undefined;
@@ -444,8 +496,8 @@ export function resolveGroupToolPolicy(params: {
     const toolsConfig = plugin?.groups?.resolveToolPolicy?.({
       cfg: params.config,
       groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
+      groupChannel: trustedGroup.dropped ? null : params.groupChannel,
+      groupSpace: trustedGroup.dropped ? null : params.groupSpace,
       accountId: params.accountId,
       senderId: params.senderId,
       senderName: params.senderName,

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -445,6 +445,66 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.acp).toEqual(existingAcpMeta);
   });
 
+  it("keeps stored group metadata when a trusted group session receives caller-supplied selectors", async () => {
+    const sessionKey = "agent:main:slack:group:C123";
+    const existingEntry = buildExistingMainStoreEntry({
+      channel: "slack",
+      groupId: "C123",
+      groupChannel: "#trusted",
+      space: "TTRUSTED",
+    });
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: existingEntry,
+      canonicalKey: sessionKey,
+    });
+
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        [sessionKey]: { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "trusted group turn",
+        agentId: "main",
+        sessionKey,
+        channel: "slack",
+        groupId: "C123",
+        groupChannel: "#forged-admin",
+        groupSpace: "TFORGED",
+        idempotencyKey: "trusted-group-forged-selectors",
+      },
+      { reqId: "trusted-group-forged-selectors" },
+    );
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedEntry?.groupId).toBe("C123");
+    expect(capturedEntry?.groupChannel).toBe("#trusted");
+    expect(capturedEntry?.space).toBe("TTRUSTED");
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      groupChannel?: string;
+      groupSpace?: string;
+      runContext?: { groupChannel?: string; groupSpace?: string };
+    };
+    expect(callArgs.groupChannel).toBe("#trusted");
+    expect(callArgs.groupSpace).toBe("TTRUSTED");
+    expect(callArgs.runContext?.groupChannel).toBe("#trusted");
+    expect(callArgs.runContext?.groupSpace).toBe("TTRUSTED");
+  });
+
   it("tags newly-created plugin runtime sessions with the plugin owner", async () => {
     const sessionKey = "agent:main:dreaming-narrative-light-workspace-1";
     mocks.loadSessionEntry.mockReturnValue({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -505,6 +505,58 @@ describe("gateway agent handler", () => {
     expect(callArgs.runContext?.groupSpace).toBe("TTRUSTED");
   });
 
+  it("persists first-turn group selectors for a trusted new group session", async () => {
+    const sessionKey = "agent:main:slack:group:C123";
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: undefined,
+      canonicalKey: sessionKey,
+    });
+
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {};
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "first trusted group turn",
+        agentId: "main",
+        sessionKey,
+        channel: "slack",
+        groupId: "C123",
+        groupChannel: "#general",
+        groupSpace: "TWORKSPACE",
+        idempotencyKey: "trusted-group-first-turn-selectors",
+      },
+      { reqId: "trusted-group-first-turn-selectors" },
+    );
+
+    expect(mocks.updateSessionStore).toHaveBeenCalled();
+    expect(capturedEntry?.groupId).toBe("C123");
+    expect(capturedEntry?.groupChannel).toBe("#general");
+    expect(capturedEntry?.space).toBe("TWORKSPACE");
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      groupChannel?: string;
+      groupSpace?: string;
+      runContext?: { groupChannel?: string; groupSpace?: string };
+    };
+    expect(callArgs.groupChannel).toBe("#general");
+    expect(callArgs.groupSpace).toBe("TWORKSPACE");
+    expect(callArgs.runContext?.groupChannel).toBe("#general");
+    expect(callArgs.runContext?.groupSpace).toBe("TWORKSPACE");
+  });
+
   it("tags newly-created plugin runtime sessions with the plugin owner", async () => {
     const sessionKey = "agent:main:dreaming-narrative-light-workspace-1";
     mocks.loadSessionEntry.mockReturnValue({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -2539,6 +2539,71 @@ describe("gateway agent handler", () => {
       undefined,
     );
   });
+
+  describe("groupId session-entry persistence validation", () => {
+    async function captureGroupEntryFields(
+      sessionKey: string,
+      entry: Record<string, unknown>,
+      requestGroupId?: string,
+    ) {
+      mocks.loadSessionEntry.mockReturnValue({
+        cfg: {},
+        storePath: "/tmp/sessions.json",
+        entry: { sessionId: "existing-session-id", updatedAt: Date.now(), ...entry },
+        canonicalKey: sessionKey,
+      });
+      let capturedEntry: Record<string, unknown> | undefined;
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store: Record<string, unknown> = {
+          [sessionKey]: { sessionId: "existing-session-id" },
+        };
+        await updater(store);
+        capturedEntry = store[sessionKey] as Record<string, unknown>;
+      });
+      mocks.agentCommand.mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+      await invokeAgent({
+        message: "hi",
+        agentId: "main",
+        sessionKey,
+        idempotencyKey: `group-persist-${sessionKey}-${requestGroupId ?? "none"}`,
+        ...(requestGroupId !== undefined ? { groupId: requestGroupId } : {}),
+      });
+      return capturedEntry;
+    }
+
+    it("drops forged groupId on non-group session before writing session entry", async () => {
+      const entry = await captureGroupEntryFields("agent:main:main", {}, "trusted-group");
+      expect(entry?.groupId).toBeUndefined();
+    });
+
+    it("preserves groupId when session key encodes matching group membership", async () => {
+      const entry = await captureGroupEntryFields(
+        "agent:main:slack:group:trusted-group",
+        {},
+        "trusted-group",
+      );
+      expect(entry?.groupId).toBe("trusted-group");
+    });
+
+    it("clears a previously forged groupId from the session entry on reconnection", async () => {
+      // Entry carries a forged groupId from a prior request; new request supplies none.
+      const entry = await captureGroupEntryFields(
+        "agent:main:main",
+        { groupId: "trusted-group" },
+        undefined,
+      );
+      expect(entry?.groupId).toBeUndefined();
+    });
+
+    it("trusts groupId when spawnedBy session key encodes the matching group", async () => {
+      const entry = await captureGroupEntryFields(
+        "agent:main:main",
+        { spawnedBy: "agent:main:slack:group:trusted-group" },
+        "trusted-group",
+      );
+      expect(entry?.groupId).toBe("trusted-group");
+    });
+  });
 });
 
 describe("gateway agent handler chat.abort integration", () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -10,6 +10,7 @@ import {
   resolvePublicAgentAvatarSource,
 } from "../../agents/identity-avatar.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
+import { resolveTrustedGroupId } from "../../agents/pi-tools.policy.js";
 import { resolveSandboxConfigForAgent } from "../../agents/sandbox/config.js";
 import {
   normalizeSpawnedRunMetadata,
@@ -882,6 +883,31 @@ export const agentHandlers: GatewayRequestHandlers = {
       resolvedGroupId = resolvedGroupId || inheritedGroup?.groupId;
       resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
       resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
+      // Validate the effective group ID (request value or stored fallback) against
+      // the session key before persisting. Fail-closed: non-group session keys
+      // cannot have a trusted groupId regardless of what the caller or the
+      // existing session entry contains. This prevents a forged groupId from
+      // surviving across reconnections via the session entry.
+      const effectiveGroupId = resolvedGroupId ?? entry?.groupId;
+      if (effectiveGroupId) {
+        const trustedGroup = resolveTrustedGroupId({
+          groupId: effectiveGroupId,
+          sessionKey: canonicalKey,
+          spawnedBy: spawnedByValue,
+        });
+        if (trustedGroup.dropped) {
+          resolvedGroupId = undefined;
+          resolvedGroupChannel = undefined;
+          resolvedGroupSpace = undefined;
+        } else if (!resolvedGroupId) {
+          // Promote the validated stored value into resolvedGroupId so the
+          // session entry write below does not need a ?? fallback that could
+          // re-admit a stale or previously-forged entry value.
+          resolvedGroupId = effectiveGroupId;
+          resolvedGroupChannel = resolvedGroupChannel ?? entry?.groupChannel;
+          resolvedGroupSpace = resolvedGroupSpace ?? entry?.space;
+        }
+      }
       const deliveryFields = normalizeSessionDeliveryFields(entry);
       // When the session has no delivery context yet (e.g. a freshly-spawned subagent
       // with deliver: false), seed it from the request's channel/to/threadId params.
@@ -935,9 +961,9 @@ export const agentHandlers: GatewayRequestHandlers = {
         spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
         spawnDepth: entry?.spawnDepth,
         channel: entry?.channel ?? request.channel?.trim(),
-        groupId: resolvedGroupId ?? entry?.groupId,
-        groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
-        space: resolvedGroupSpace ?? entry?.space,
+        groupId: resolvedGroupId,
+        groupChannel: resolvedGroupChannel,
+        space: resolvedGroupSpace,
         ...(pluginOwnerId ? { pluginOwnerId } : {}),
         cliSessionIds: entry?.cliSessionIds,
         cliSessionBindings: entry?.cliSessionBindings,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -67,6 +67,10 @@ import {
 } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import {
+  parseRawSessionConversationRef,
+  parseThreadSessionSuffix,
+} from "../../sessions/session-key-utils.js";
+import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
@@ -206,6 +210,51 @@ function shouldSkipStartupContextForSpawnedSandbox(params: {
     }
   }
   return sandboxCfg.workspaceAccess !== "rw";
+}
+
+type TrustedGroupMetadata = {
+  groupId?: string;
+  groupChannel?: string;
+  groupSpace?: string;
+};
+
+function normalizeTrustedGroupMetadata(value?: {
+  groupId?: unknown;
+  groupChannel?: unknown;
+  groupSpace?: unknown;
+  space?: unknown;
+}): TrustedGroupMetadata {
+  return {
+    groupId: normalizeOptionalString(value?.groupId),
+    groupChannel: normalizeOptionalString(value?.groupChannel),
+    groupSpace: normalizeOptionalString(value?.groupSpace ?? value?.space),
+  };
+}
+
+function resolveSessionKeyGroupId(sessionKey: string): string | undefined {
+  const { baseSessionKey } = parseThreadSessionSuffix(sessionKey);
+  const conversation = parseRawSessionConversationRef(baseSessionKey ?? sessionKey);
+  if (!conversation || (conversation.kind !== "group" && conversation.kind !== "channel")) {
+    return undefined;
+  }
+  return conversation.rawId;
+}
+
+function resolveTrustedGroupMetadata(params: {
+  sessionKey: string;
+  spawnedBy?: string;
+  stored: TrustedGroupMetadata;
+  inherited?: TrustedGroupMetadata;
+}): TrustedGroupMetadata {
+  return {
+    groupId:
+      params.stored.groupId ??
+      params.inherited?.groupId ??
+      resolveSessionKeyGroupId(params.sessionKey) ??
+      (params.spawnedBy ? resolveSessionKeyGroupId(params.spawnedBy) : undefined),
+    groupChannel: params.stored.groupChannel ?? params.inherited?.groupChannel,
+    groupSpace: params.stored.groupSpace ?? params.inherited?.groupSpace,
+  };
 }
 
 function emitSessionsChanged(
@@ -865,48 +914,44 @@ export const agentHandlers: GatewayRequestHandlers = {
           : normalizeOptionalString(entry.pluginOwnerId);
       const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
       spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, entry?.spawnedBy);
-      let inheritedGroup:
-        | { groupId?: string; groupChannel?: string; groupSpace?: string }
-        | undefined;
-      if (spawnedByValue && (!resolvedGroupId || !resolvedGroupChannel || !resolvedGroupSpace)) {
+      const storedGroup = normalizeTrustedGroupMetadata(entry);
+      let inheritedGroup: TrustedGroupMetadata | undefined;
+      if (
+        spawnedByValue &&
+        (!storedGroup.groupId || !storedGroup.groupChannel || !storedGroup.groupSpace)
+      ) {
         try {
           const parentEntry = loadSessionEntry(spawnedByValue)?.entry;
-          inheritedGroup = {
+          inheritedGroup = normalizeTrustedGroupMetadata({
             groupId: parentEntry?.groupId,
             groupChannel: parentEntry?.groupChannel,
             groupSpace: parentEntry?.space,
-          };
+          });
         } catch {
           inheritedGroup = undefined;
         }
       }
-      resolvedGroupId = resolvedGroupId || inheritedGroup?.groupId;
-      resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
-      resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
-      // Validate the effective group ID (request value or stored fallback) against
-      // the session key before persisting. Fail-closed: non-group session keys
-      // cannot have a trusted groupId regardless of what the caller or the
-      // existing session entry contains. This prevents a forged groupId from
-      // surviving across reconnections via the session entry.
-      const effectiveGroupId = resolvedGroupId ?? entry?.groupId;
-      if (effectiveGroupId) {
-        const trustedGroup = resolveTrustedGroupId({
-          groupId: effectiveGroupId,
-          sessionKey: canonicalKey,
-          spawnedBy: spawnedByValue,
-        });
-        if (trustedGroup.dropped) {
-          resolvedGroupId = undefined;
-          resolvedGroupChannel = undefined;
-          resolvedGroupSpace = undefined;
-        } else if (!resolvedGroupId) {
-          // Promote the validated stored value into resolvedGroupId so the
-          // session entry write below does not need a ?? fallback that could
-          // re-admit a stale or previously-forged entry value.
-          resolvedGroupId = effectiveGroupId;
-          resolvedGroupChannel = resolvedGroupChannel ?? entry?.groupChannel;
-          resolvedGroupSpace = resolvedGroupSpace ?? entry?.space;
-        }
+      const trustedGroup = resolveTrustedGroupMetadata({
+        sessionKey: canonicalKey,
+        spawnedBy: spawnedByValue,
+        stored: storedGroup,
+        inherited: inheritedGroup,
+      });
+      const validatedGroup = trustedGroup.groupId
+        ? resolveTrustedGroupId({
+            groupId: trustedGroup.groupId,
+            sessionKey: canonicalKey,
+            spawnedBy: spawnedByValue,
+          })
+        : undefined;
+      if (validatedGroup?.dropped) {
+        resolvedGroupId = undefined;
+        resolvedGroupChannel = undefined;
+        resolvedGroupSpace = undefined;
+      } else {
+        resolvedGroupId = trustedGroup.groupId;
+        resolvedGroupChannel = trustedGroup.groupChannel;
+        resolvedGroupSpace = trustedGroup.groupSpace;
       }
       const deliveryFields = normalizeSessionDeliveryFields(entry);
       // When the session has no delivery context yet (e.g. a freshly-spawned subagent

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -257,6 +257,17 @@ function resolveTrustedGroupMetadata(params: {
   };
 }
 
+function requestGroupMatchesTrusted(params: {
+  requestGroupId?: string;
+  trustedGroupId?: string;
+}): boolean {
+  const requestGroupId = params.requestGroupId?.trim();
+  if (!requestGroupId) {
+    return true;
+  }
+  return Boolean(params.trustedGroupId && requestGroupId === params.trustedGroupId);
+}
+
 function emitSessionsChanged(
   context: Pick<
     GatewayRequestHandlerOptions["context"],
@@ -949,9 +960,19 @@ export const agentHandlers: GatewayRequestHandlers = {
         resolvedGroupChannel = undefined;
         resolvedGroupSpace = undefined;
       } else {
+        const trustRequestSelectors =
+          Boolean(trustedGroup.groupId) &&
+          requestGroupMatchesTrusted({
+            requestGroupId: normalizedSpawned.groupId,
+            trustedGroupId: trustedGroup.groupId,
+          });
         resolvedGroupId = trustedGroup.groupId;
-        resolvedGroupChannel = trustedGroup.groupChannel;
-        resolvedGroupSpace = trustedGroup.groupSpace;
+        resolvedGroupChannel =
+          trustedGroup.groupChannel ??
+          (trustRequestSelectors ? normalizedSpawned.groupChannel : undefined);
+        resolvedGroupSpace =
+          trustedGroup.groupSpace ??
+          (trustRequestSelectors ? normalizedSpawned.groupSpace : undefined);
       }
       const deliveryFields = normalizeSessionDeliveryFields(entry);
       // When the session has no delivery context yet (e.g. a freshly-spawned subagent


### PR DESCRIPTION
## Summary

- **Problem:** `resolveGroupToolPolicy()` merged a caller-provided `groupId` into the group ID candidate list without cross-checking it against server-verified session context. A scoped gateway caller could supply an arbitrary `groupId` matching a more-permissive group policy and gain access to tools (e.g. `exec`) denied by the global or agent-level policy. The forged value was also persisted to the session entry, making the bypass survive reconnections.
- **Why it matters:** The prior fix for the same invariant (commit `0e7a992d3f`) applied `resolveTrustedGroupId()` only to the bundled MCP/LSP tool filter. The two core tool paths (`createOpenClawCodingTools` and `collectExplicitToolAllowlistSources`) passed the raw caller `groupId` directly to `resolveGroupToolPolicy`, leaving them unprotected. The session entry write in the gateway `agent` handler also accepted the raw value without validation.
- **What changed:**
  - `resolveTrustedGroupId` is extracted from `effective-tool-policy.ts` and moved into `pi-tools.policy.ts` as an exported function. The validation (fail-closed: drop caller `groupId` when it is absent from session/spawn-derived group context) is now applied inside `resolveGroupToolPolicy` itself, protecting all current and future callers.
  - Candidate ordering is fixed so server-derived IDs are resolved before any caller-supplied candidate, preventing a trusted parent ID from skipping a more-specific session-scoped policy. `groupChannel`/`groupSpace` are nulled when the group ID is dropped.
  - The gateway `agent` handler now validates the effective group ID (request value or stored entry fallback) against the session key before writing it to the session entry. A forged `groupId` that survived to the session entry — including one written by a prior request — is now cleared on the next interaction for that session.
- **What did NOT change:** No change to session key format, auth modes, or any behavior for legitimate group-session callers whose `groupId` matches session-derived context.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveGroupToolPolicy` accepted `params.groupId` unconditionally. When `sessionKey` encodes no group context (e.g. `agent:main:main`), `sessionContext.groupIds` is empty, but the caller-supplied ID was still prepended to the candidate list and resolved against config. The gateway session entry write compounded this by persisting the raw value, allowing the bypass to survive reconnections.
- Missing detection / guardrail: The validation introduced for bundled tools was scoped to `applyFinalEffectiveToolPolicy` and not applied to the shared helper all core tool paths call.
- Contributing context: Incomplete fix scope — the prior patch fixed the symptom for one call site rather than fixing the shared helper.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
  - [x] Seam / integration test
- Target tests:
  - `src/agents/pi-tools.policy.test.ts` (new `resolveGroupToolPolicy group context validation` suite)
  - `src/agents/pi-tools-agent-config.test.ts` (new forge-rejection integration case)
  - `src/gateway/server-methods/agent.test.ts` (new `groupId session-entry persistence validation` suite)
- Scenarios locked in:
  1. Forged `groupId` on a non-group session → `resolveGroupToolPolicy` returns `undefined`
  2. Session encodes a different group than the caller claims → session-derived policy wins
  3. Caller `groupId` matches session-derived context → accepted, correct policy returned
  4. `spawnedBy` provides group context when `sessionKey` does not → caller ID accepted
  5. Session-scoped policy is not bypassed by a trusted parent caller ID
  6. Forged `groupId` in request dropped before session entry write
  7. Legitimate `groupId` matching session key preserved in session entry
  8. Stale forged `groupId` in existing entry cleared on reconnection
  9. `spawnedBy` group context trusted for session entry write

## User-visible / Behavior Changes

None for legitimate callers. Callers on group sessions whose `groupId` matches session context are unaffected. Callers whose `groupId` does not match session context now have the forged ID dropped (with a warning log) and fall back to session-derived or global policy — matching the behavior already enforced for bundled MCP/LSP tools.

## Diagram (if applicable)

```text
Before:
[caller: groupId="trusted-group", sessionKey="agent:main:main"]
  -> resolveGroupToolPolicy: groupIds = ["trusted-group", ...session([])]
  -> returns permissive group policy (bypass)
  -> session entry: groupId="trusted-group" (persisted, survives reconnect)

After:
[caller: groupId="trusted-group", sessionKey="agent:main:main"]
  -> resolveTrustedGroupIdFromContexts: session has no group context -> dropped=true
  -> resolveGroupToolPolicy: groupIds = [...session([]), ...candidates(null)] = []
  -> returns undefined (fail-closed)
  -> session entry: groupId=undefined (forged value not written)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — callers that previously exploited the bypass no longer receive escalated tool access, and the forged value is no longer persisted to session state
- Data access scope changed? No
- Risk + mitigation: Tightening existing enforcement. Any caller that relied on the unvalidated path was already in violation of the intended policy. No legitimate caller is affected.

## Repro + Verification

### Environment

- OS: Linux (CI)
- Runtime/container: Node 22
- Integration/channel: whatsapp (unit tests); generic non-group session keys

### Steps

1. Call `resolveGroupToolPolicy` with `sessionKey: "agent:main:main"` (no group context), `groupId: "trusted-group"`, and a config that grants `exec` to `trusted-group`.
2. Before fix: returns `{ allow: ["exec", "read", "write", "edit"] }`.
3. After fix: returns `undefined` (fail-closed).

### Expected

`resolveGroupToolPolicy` returns `undefined` when the caller's `groupId` is not vouched for by session or spawn context. The gateway session entry write omits the group fields when validation fails.

### Actual (after fix)

Both invariants hold. Existing group-session callers unaffected.

## Evidence

- [x] New unit suite `resolveGroupToolPolicy group context validation` (5 cases) — all green
- [x] Integration smoke `should not apply forged caller group tool policy for non-group sessions` — green
- [x] New gateway suite `groupId session-entry persistence validation` (4 cases) — all green

## Human Verification (required)

- Verified scenarios: forge rejection on non-group session; session-derived policy wins when caller claims different group; spawnedBy trust path; ordering (session-scoped policy not skipped by parent caller ID); forged value dropped before session entry write; stale entry value cleared on reconnection
- Edge cases checked: empty `groupId`, whitespace-only `groupId` (short-circuits without drop), `spawnedBy`-only context
- What was NOT verified: live gateway WebSocket replay

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A caller on a legitimate group session might see their `groupId` dropped if the session key does not encode the group ID (e.g. legacy or non-standard key format).
  - Mitigation: `resolveGroupContextFromSessionKey` is the same parser used throughout the existing policy stack. If a session key was valid before this patch for group policy resolution, it continues to be valid. The only callers affected are those passing a `groupId` that was never encoded in the session key — i.e., the exploit path.