### PR TITLE
fix(telegram): fail-soft on benign deleteMessage 400s (#73726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Telegram: fail-soft on benign `deleteMessage` 400s (`message to delete not found`, `message can't be deleted`, `MESSAGE_ID_INVALID`, `MESSAGE_DELETE_FORBIDDEN`) so "delete the previous reminder before sending a new one" idioms stop flooding the runtime log at ERROR level for what is operationally a no-op. Mirrors the existing `reactMessageTelegram` `REACTION_INVALID` pattern. Real failures (auth, network) still propagate. Fixes #73726. Thanks @Avicennasis.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -478,11 +478,22 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    await telegramActionRuntime.deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
-      cfg,
-      token,
-      accountId: accountId ?? undefined,
-    });
+    const deleteResult = await telegramActionRuntime.deleteMessageTelegram(
+      chatId ?? "",
+      messageId ?? 0,
+      {
+        cfg,
+        token,
+        accountId: accountId ?? undefined,
+      },
+    );
+    if (deleteResult.ok === false) {
+      // Treat benign Telegram fail-soft warnings as a successful no-op for
+      // the caller (the message is gone — the desired state is reached) but
+      // surface the warning so dashboards / agents can see what happened
+      // without flooding the runtime log at ERROR level. See #73726.
+      return jsonResult({ ok: true, deleted: false, warning: deleteResult.warning });
+    }
     return jsonResult({ ok: true, deleted: true });
   }
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -27,6 +27,7 @@ const {
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
+  deleteMessageTelegram,
   editForumTopicTelegram,
   editMessageTelegram,
   pinMessageTelegram,
@@ -1981,6 +1982,68 @@ describe("reactMessageTelegram", () => {
         resolvedChatId: "-100123",
       }),
     );
+  });
+});
+
+describe("deleteMessageTelegram (#73726)", () => {
+  it("returns ok when deleteMessage succeeds", async () => {
+    const deleteMessage = vi.fn().mockResolvedValue(true);
+    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+
+    const result = await deleteMessageTelegram("123", 456, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(deleteMessage).toHaveBeenCalledWith("123", 456);
+  });
+
+  it.each([
+    "Bad Request: message to delete not found",
+    "Bad Request: message can't be deleted",
+    "Bad Request: MESSAGE_ID_INVALID",
+    "Bad Request: MESSAGE_DELETE_FORBIDDEN",
+  ])("fail-soft on benign Telegram 400: %s", async (errorMessage) => {
+    // Regression for #73726: these "the thing is already gone" responses
+    // are operationally a no-op for the caller (delete-then-resend
+    // idiom), so they should return `{ ok: false, warning }` instead of
+    // throwing through `createTelegramRequestWithDiag` and logging at
+    // ERROR level. Mirrors the `reactMessageTelegram` REACTION_INVALID
+    // pattern in the same file.
+    const deleteMessage = vi.fn().mockRejectedValue(new Error(errorMessage));
+    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+
+    const result = await deleteMessageTelegram("123", 456, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+    if (result.ok === false) {
+      expect(result.warning).toContain(
+        errorMessage.includes("MESSAGE")
+          ? (errorMessage.split("Bad Request: ")[1] ?? errorMessage)
+          : errorMessage,
+      );
+    }
+  });
+
+  it("rethrows non-benign errors (e.g. unauthorized, network)", async () => {
+    // Anything other than the benign 400s must keep propagating so real
+    // breakage is still visible in error logs.
+    const deleteMessage = vi.fn().mockRejectedValue(new Error("401 Unauthorized: bot token"));
+    const api = { deleteMessage } as unknown as { deleteMessage: typeof deleteMessage };
+
+    await expect(
+      deleteMessageTelegram("123", 456, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+      }),
+    ).rejects.toThrow(/401 Unauthorized/);
   });
 });
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1068,7 +1068,7 @@ export async function deleteMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number,
   opts: TelegramDeleteOpts,
-): Promise<{ ok: true }> {
+): Promise<{ ok: true } | { ok: false; warning: string }> {
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const rawTarget = String(chatIdInput);
   const chatId = await resolveAndPersistChatId({
@@ -1086,7 +1086,28 @@ export async function deleteMessageTelegram(
     verbose: opts.verbose,
     shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
   });
-  await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
+  try {
+    await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
+  } catch (err: unknown) {
+    // Fail-soft on benign Telegram Bot API 400s that occur in normal
+    // operation: the message was already removed by the user, is older
+    // than the 48h bot-delete window, or never existed (e.g. a stale
+    // tracking-file `msg_id`). Mirrors the `reactMessageTelegram`
+    // pattern at the top of this file (#73726).
+    const msg = formatErrorMessage(err);
+    if (
+      /message to delete not found/i.test(msg) ||
+      /message can'?t be deleted/i.test(msg) ||
+      /MESSAGE_ID_INVALID/i.test(msg) ||
+      /MESSAGE_DELETE_FORBIDDEN/i.test(msg)
+    ) {
+      logVerbose(
+        `[telegram] Delete soft-failed for message ${messageId} in chat ${chatId}: ${msg}`,
+      );
+      return { ok: false as const, warning: msg };
+    }
+    throw err;
+  }
   logVerbose(`[telegram] Deleted message ${messageId} from chat ${chatId}`);
   return { ok: true };
 }


### PR DESCRIPTION
## What

Fixes #73726. `deleteMessageTelegram` (in `extensions/telegram/src/send.ts`) let every error from `api.deleteMessage` propagate, including the benign Telegram Bot API 400s that occur in normal operation:

- `Bad Request: message to delete not found` — already removed by user
- `Bad Request: message can't be deleted` — older than the 48h bot-delete window or stale tracking-file `msg_id`
- `MESSAGE_ID_INVALID` / `MESSAGE_DELETE_FORBIDDEN` — analogous edge cases

These propagated through `createTelegramRequestWithDiag` and got logged at ERROR level on every recurring "delete the previous reminder before sending a new one" idiom. Operator dashboards / digest emails were noisy for what is operationally a no-op (the message is gone, which is the desired state).

## Fix

Mirror the established `reactMessageTelegram` `REACTION_INVALID` pattern in the same file (`send.ts:1045-1053`): catch the benign 400s, log at verbose level, and return `{ ok: false, warning }`.

```ts
try {
  await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
} catch (err: unknown) {
  const msg = formatErrorMessage(err);
  if (
    /message to delete not found/i.test(msg) ||
    /message can'?t be deleted/i.test(msg) ||
    /MESSAGE_ID_INVALID/i.test(msg) ||
    /MESSAGE_DELETE_FORBIDDEN/i.test(msg)
  ) {
    logVerbose(...);
    return { ok: false, warning: msg };
  }
  throw err;
}
```

The `message delete` action runtime caller (`action-runtime.ts:481`) is updated to surface the warning in the JSON result while still treating the operation as successful (`{ok: true, deleted: false, warning: ...}` instead of `{ok: true, deleted: true}`). Real failures (auth, network, etc.) still propagate.

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341).** Pattern reused verbatim from `reactMessageTelegram` (lines 1011-1055 in the same file). The shape — try/catch + regex on `formatErrorMessage(err)` + `{ok: false, warning}` return — is the established Telegram fail-soft idiom. ✅
2. **Shared-helper caller check (steipete #60623).** `deleteMessageTelegram` is exported from `runtime-api.ts` and called from `action-runtime.ts:481`. Updated the in-tree caller; the return-type widening from `Promise<{ok: true}>` to `Promise<{ok: true} | {ok: false, warning}>` is backward-compatible because `{ok: true}` is a subset of the union — external callers that only check `ok` keep behaving identically. ✅
3. **Broader-fix rival scan (steipete #68270).** Zero rival PRs reference #73726. ✅

## Verified locally

```
npx oxlint extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.ts
# Found 0 warnings and 0 errors.

npx vitest run extensions/telegram/src/send.test.ts
# Tests  91 passed (91)

npx vitest run extensions/telegram/src/action-runtime.test.ts
# Tests  53 passed (53)
```

Tests cover:
- Happy path (`ok: true` on successful delete)
- All 4 benign 400 messages (parameterized via `it.each`)
- Non-benign error rethrow (e.g. 401 Unauthorized) still bubbles up

lobster-biscuit: 73726-telegram-delete-fail-soft

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
