### PR TITLE
ci: shard channel codeql quality

### DIFF
--- a/.github/codeql/codeql-channel-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-channel-runtime-boundary-critical-quality.yml
@@ -1,0 +1,33 @@
+name: openclaw-codeql-channel-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/channels
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -81,6 +81,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/gateway-runtime-boundary"
 
+  channel-runtime-boundary:
+    name: Critical Quality (channel-runtime-boundary)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-channel-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/channel-runtime-boundary"
+
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -252,6 +252,8 @@ separate `/codeql-critical-quality/config-boundary` category. The
 gateway-runtime-boundary job scans gateway protocol schemas and server method
 contracts under the separate
 `/codeql-critical-quality/gateway-runtime-boundary` category. The
+channel-runtime-boundary job scans core channel implementation contracts under
+the separate `/codeql-critical-quality/channel-runtime-boundary` category. The
 plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
 entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
 category. Keep the workflow separate from security so quality findings can be


### PR DESCRIPTION
## Summary
- add a channel-runtime CodeQL critical-quality shard for core channel implementation contracts
- keep the quality workflow on Blacksmith with a separate category
- document the shard in the CI guide

## Verification
- ruby yaml parse for workflow/config
- git diff --check
- pnpm check:workflows