### PR TITLE
ci: shard channel codeql security

### DIFF
--- a/.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
+++ b/.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
@@ -1,0 +1,35 @@
+name: openclaw-codeql-channel-runtime-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+  - exclude:
+      problem.severity:
+        - recommendation
+        - warning
+
+paths:
+  - src/channels
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
+++ b/.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
@@ -17,6 +17,21 @@ query-filters:
 
 paths:
   - src/channels
+  - src/config/channel-*.ts
+  - src/config/types.channel*.ts
+  - src/gateway/server-channel*.ts
+  - src/gateway/server-methods/channels.ts
+  - src/gateway/protocol/schema/channels.ts
+  - src/infra/channel-*.ts
+  - src/infra/exec-approval-channel-runtime.ts
+  - src/infra/outbound/channel-*.ts
+  - src/plugin-sdk/channel-*.ts
+  - src/plugins/channel-*.ts
+  - src/plugins/bundled-channel-*.ts
+  - src/plugins/runtime/*channel*.ts
+  - src/secrets/channel-*.ts
+  - src/secrets/runtime-config-collectors-channels.ts
+  - src/security/audit-channel*.ts
 
 paths-ignore:
   - "**/node_modules"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   critical-security:
-    name: Critical Security (${{ matrix.language }})
+    name: Critical Security (${{ matrix.category }})
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'security' }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
@@ -37,10 +37,17 @@ jobs:
       matrix:
         include:
           - language: javascript-typescript
+            category: javascript-typescript
             runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-javascript-typescript-critical-security.yml
+          - language: javascript-typescript
+            category: channel-runtime-boundary
+            runs_on: blacksmith-8vcpu-ubuntu-2404
+            timeout_minutes: 25
+            config_file: ./.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
           - language: actions
+            category: actions
             runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 10
             config_file: ./.github/codeql/codeql-actions-critical-security.yml
@@ -59,4 +66,4 @@ jobs:
       - name: Analyze
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
-          category: "/codeql-critical-security/${{ matrix.language }}"
+          category: "/codeql-critical-security/${{ matrix.category }}"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -230,7 +230,11 @@ or overlapping changed hunks.
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner,
 not the full repository sweep. Daily and manual runs scan Actions workflow code
 plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
-gateway surfaces with high-precision security queries.
+gateway surfaces with high-precision security queries. The
+channel-runtime-boundary job separately scans core channel implementation
+contracts under the `/codeql-critical-security/channel-runtime-boundary`
+category so channel security signal can scale without broadening the baseline
+JS/TS category.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android
 security shard. It builds the Android app manually for CodeQL on the smallest

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -232,7 +232,8 @@ not the full repository sweep. Daily and manual runs scan Actions workflow code
 plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
 gateway surfaces with high-precision security queries. The
 channel-runtime-boundary job separately scans core channel implementation
-contracts under the `/codeql-critical-security/channel-runtime-boundary`
+contracts plus the channel plugin runtime, gateway, Plugin SDK, secrets, and
+audit touchpoints under the `/codeql-critical-security/channel-runtime-boundary`
 category so channel security signal can scale without broadening the baseline
 JS/TS category.
 


### PR DESCRIPTION
## Summary

- add a dedicated CodeQL critical-security config for `src/channels`
- add a separate `/codeql-critical-security/channel-runtime-boundary` upload category while keeping the existing JS/TS and Actions categories stable
- document the channel security shard in the CI guide

## Validation

- `pnpm docs:list`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/codeql.yml .github/codeql/codeql-channel-runtime-boundary-critical-security.yml`
- `git diff --check origin/main..HEAD`
- `pnpm check:workflows`

## Notes

This addresses the channel security coverage gap flagged during PR 73742 without mixing security findings into the non-security quality shard.
