### PR TITLE
docs: align 'behaviour' to American 'behavior' (3 occurrences, 2 files)

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -160,7 +160,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
     - `skipSignatureVerification` is for local testing only.
     - On ngrok free tier, set `publicUrl` to the exact ngrok URL; signature verification is always enforced.
     - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Local dev only.
-    - Ngrok free-tier URLs can change or add interstitial behaviour; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
+    - Ngrok free-tier URLs can change or add interstitial behavior; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
 
   </Accordion>
   <Accordion title="Streaming connection caps">
@@ -199,7 +199,7 @@ realtime transcription providers.
 audio mode per call.
 </Warning>
 
-Current runtime behaviour:
+Current runtime behavior:
 
 - `realtime.enabled` is supported for Twilio Media Streams.
 - `realtime.provider` is optional. If unset, Voice Call uses the first registered realtime voice provider.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -517,7 +517,7 @@ Two ways to start an ACP session:
 </ParamField>
 <ParamField path="mode" type='"run" | "session"' default="run">
   `"run"` is one-shot; `"session"` is persistent. If `thread: true` and
-  `mode` is omitted, OpenClaw may default to persistent behaviour per
+  `mode` is omitted, OpenClaw may default to persistent behavior per
   runtime path. `mode: "session"` requires `thread: true`.
 </ParamField>
 <ParamField path="cwd" type="string">


### PR DESCRIPTION
## Summary

- Problem: three `behaviour` (British) occurrences remained in `docs/` against an otherwise consistent American-English convention. The current `docs:spellcheck` script uses codespell, which does not flag British/American variants — these are not "typos" in the codespell sense, just inconsistencies, so they slipped through.
- Why it matters: the public docs site is the canonical OpenClaw reference. Mixed-language spelling reads as a small but visible quality gap, especially for non-native English readers who learn from the docs.
- What changed: switched the three `behaviour` occurrences to `behavior` in `docs/tools/acp-agents.md` and `docs/plugins/voice-call.md`.
- What did NOT change (scope boundary): no other docs touched, no code touched, no spellcheck script changes. Other words with British/American variants were checked (`colour`, `centre`, `licence`, `summarise`, etc.) and none were present in `docs/`, so this PR is the full fix for `docs/`-side language consistency.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

(No tracking issue — surfaced while doing a docs consistency sweep.)

## Root Cause (if applicable)

- Root cause: codespell does not check British/American spelling variance, so the three `behaviour` occurrences passed `npm run docs:spellcheck` without warning.
- Missing detection / guardrail: optional follow-up — add the BrE-variant words OpenClaw consistently avoids (`behaviour`, `colour`, `centre`, `licence`, `summarise`, etc.) to `scripts/codespell-dictionary.txt` so the spellcheck would catch future regressions. Out of scope for this PR.
- Contributing context (if known): N/A.

## Regression Test Plan (if applicable)

N/A — pure spelling change. Verified by `grep -rn 'behaviour' docs/` returning no results after the change.

## User-visible / Behavior Changes

None. Spelling-only.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `grep -rln 'behaviour' docs/` on `main` returns two files (`docs/tools/acp-agents.md`, `docs/plugins/voice-call.md`) with three total occurrences.
2. After this PR: `grep -rn 'behaviour' docs/` returns no results.
3. `grep -rln 'behavior' docs/ | wc -l` — pre-PR: 256, post-PR: 256 (the changes are word-for-word, so `behavior` count stays the same).

### Expected

`docs/` is internally consistent on `behavior` after the sweep.

### Actual

Same as expected.

## Evidence

- [x] Failing test/log before + passing after — N/A (spelling)

## Human Verification (required)

- Verified scenarios: ran `grep -rn 'behaviour' docs/` before and after; confirmed each replacement reads naturally in surrounding paragraph context.
- Edge cases checked: also swept `colour`, `centre`, `fibre`, `theatre`, `licence`, `defence`, `programme`, `grey`, `moulting`, and the common `-ise` verbs (`summarise`, `organise`, `realise`, `recognise`, `specialise`, `prioritise`, `analyse`, `categorise`, `standardise`, `customise`) — none present in `docs/`. So this PR closes the full BrE→AmE gap on the doc surface.
- What you did not verify: the live docs-site rebuild (assumed maintainer-side process).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None. Spelling-only consistency fix.
