### PR TITLE
fix(session-memory): sanitize chat-template tokens in persisted trans…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Docs: https://docs.openclaw.ai
 - Docker Compose: default missing config and workspace bind mounts to `${HOME:-/tmp}/.openclaw` so manual compose runs do not create invalid empty-source volume specs. (#64485) Thanks @jlapenna.
 - Agents/context engines: preserve the child agent's configured `agentDir` when subagent cleanup re-resolves a context engine, so `onSubagentEnded` hooks keep operating on the correct per-agent state. (#67243) Thanks @jarimustonen.
 - Channels/WhatsApp: restrict pairing verification replies to real inbound user content, preventing unsolicited prompts from receipts, typing indicators, presence updates, and other non-message Baileys upserts. Fixes #73797. (#73823) Thanks @hclsys.
+- Hooks/session-memory: strip chat-template control tokens (ChatML, Llama 3/4, Mistral, Phi, GPT-OSS, Gemma, reserved-token variants) from persisted session transcripts before they are written under `memory/`, so quantized local-model output cannot re-inject scaffolding tokens on the next /new and trigger a self-poisoning loop. Fixes #69943. Thanks @YB0y.
 - Configure/Ollama: show the configured Ollama model allowlist after Cloud only or Cloud + Local setup and skip slow per-model cloud metadata fetches. (#73995) Thanks @obviyus.
 
 ## 2026.4.27

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRecentSessionContent } from "./transcript.js";
+
+describe("getRecentSessionContent — chat-template token sanitization (regression for #69943)", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-memory-transcript-"));
+    file = path.join(dir, "session.jsonl");
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  async function writeMessage(role: string, content: unknown): Promise<void> {
+    const line = JSON.stringify({ type: "message", message: { role, content } });
+    await fs.writeFile(file, line);
+  }
+
+  it("strips ChatML tokens from string content", async () => {
+    await writeMessage("assistant", "Hello<|im_end|><|endoftext|>");
+    const out = (await getRecentSessionContent(file)) ?? "";
+    expect(out).not.toContain("<|im_end|>");
+    expect(out).not.toContain("<|endoftext|>");
+    expect(out).toContain("Hello");
+  });
+
+  it("strips Llama-family tokens from text-block content", async () => {
+    await writeMessage("user", [{ type: "text", text: "ask<|begin_of_text|><|eot_id|>" }]);
+    const out = (await getRecentSessionContent(file)) ?? "";
+    expect(out).not.toContain("<|begin_of_text|>");
+    expect(out).not.toContain("<|eot_id|>");
+    expect(out).toContain("ask");
+  });
+
+  it("strips reserved-special-token variants", async () => {
+    await writeMessage("assistant", "x<|reserved_special_token_42|>y");
+    const out = (await getRecentSessionContent(file)) ?? "";
+    expect(out).not.toContain("<|reserved_special_token_42|>");
+    expect(out).toContain("x");
+    expect(out).toContain("y");
+  });
+
+  it("preserves clean content unchanged", async () => {
+    await writeMessage("user", "what's the weather?");
+    const out = await getRecentSessionContent(file);
+    expect(out).toBe("user: what's the weather?");
+  });
+});

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { replaceLlmSpecialTokenLiterals } from "../../../security/external-content.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 
 function extractTextMessageContent(content: unknown): string | undefined {
   if (typeof content === "string") {
-    return content;
+    return replaceLlmSpecialTokenLiterals(content);
   }
   if (!Array.isArray(content)) {
     return undefined;
@@ -15,7 +16,7 @@ function extractTextMessageContent(content: unknown): string | undefined {
     }
     const candidate = block as { type?: unknown; text?: unknown };
     if (candidate.type === "text" && typeof candidate.text === "string") {
-      return candidate.text;
+      return replaceLlmSpecialTokenLiterals(candidate.text);
     }
   }
   return undefined;

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -294,7 +294,7 @@ function replaceMarkers(content: string): string {
   return output;
 }
 
-function replaceLlmSpecialTokenLiterals(content: string): string {
+export function replaceLlmSpecialTokenLiterals(content: string): string {
   let output = content;
   for (const literal of LLM_SPECIAL_TOKEN_LITERALS) {
     output = output.split(literal).join(SPECIAL_TOKEN_REPLACEMENT);


### PR DESCRIPTION
fix(session-memory): sanitize chat-template tokens in persisted transcripts (#69943)

The session-memory hook persisted raw model output to memory/<date>-<slug>.md without sanitizing chat-template control tokens. On the next /new the file was re-injected as conversation context, which the model parsed as scaffolding and amplified, producing a self-poisoning loop.

Reuses the existing replaceLlmSpecialTokenLiterals helper in src/security/external-content.ts (already covers ChatML, Llama 3/4, Mistral, Phi, GPT-OSS, Gemma, and reserved-token variants) by exporting it and applying it in extractTextMessageContent so every transcript consumer benefits.

Verified:
- pnpm install --frozen-lockfile
- pnpm test src/hooks/bundled/session-memory/transcript.test.ts src/hooks/bundled/session-memory/handler.test.ts src/security/external-content.test.ts
- pnpm exec oxfmt --check --threads=1 src/security/external-content.ts src/hooks/bundled/session-memory/transcript.ts src/hooks/bundled/session-memory/transcript.test.ts CHANGELOG.md
- pnpm check:changed
- pnpm tsgo:core
- pnpm tsgo:test:src
- git diff --check

Closes #69943

## Summary

- **Problem**: The bundled `session-memory` hook persists raw model output to `memory/<date>-<slug>.md` on `/new` and `/reset` without sanitizing chat-template control tokens (`<|im_end|>`, `<|endoftext|>`, `<|begin_of_text|>`, `[INST]`, `<start_of_turn>`, etc.). On the next `/new` the file is re-injected as `## Conversation Summary` context, where the model parses the embedded template tokens as in-progress chat-template scaffolding and emits more orphaned markers, NO_REPLY-only completions, or raw `<tool_call>` XML — which the hook then saves as the next memory file. Each `/new` degrades the agent further until it is functionally non-responsive.
- **Why it matters**: The poisoning persists across `/new` (which users expect to be a clean reset) and propagates across all subsequent sessions for that agent. The only working workaround is disabling the hook globally and quarantining the existing files. Common with quantized local models that emit chat-template tokens in their text output.
- **What changed**: Apply the existing `replaceLlmSpecialTokenLiterals` sanitizer from `src/security/external-content.ts` inside `extractTextMessageContent` in the session-memory transcript reader, so every transcript consumer (not just this hook) receives cleaned text. Export the helper so it can be reused.
- **What did NOT change (scope boundary)**: The token literal list, the writer path, the slug generator, the LLM prompt, the hook config, or the unicode-homoglyph folding logic. No new sanitization logic is introduced — only an additional call site for the existing helper.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #69943
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: `extractTextMessageContent` in `src/hooks/bundled/session-memory/transcript.ts` returned the raw `text` field from message content blocks unchanged. Any chat-template control tokens emitted by the model in that text were persisted verbatim into the dated memory file by the writer at `handler.ts`, then re-injected as `## Conversation Summary` context on the next session.
- **Missing detection / guardrail**: There was no transcript-level test for the sanitization invariant on the session-memory persistence path. The existing chat-template sanitizer in `src/security/external-content.ts` (covering ChatML, Llama 3/4, Mistral, Phi, GPT-OSS, Gemma, and reserved-token variants) was internal-only and not applied on this code path.
- **Contributing context (if known)**: Common with locally-hosted quantized models that don't fully suppress chat-template tokens in their generated text. Less common with hosted providers, which is why this regression went unnoticed in maintainer testing. Distinct from #42112 (orphaned tool_use blocks rejected by the provider API) — there the corruption is in the session JSONL transcript and the provider returns 400; here the corruption is in the hook-managed memory file, persists across `/new`, and propagates across sessions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/hooks/bundled/session-memory/transcript.test.ts` (new file)
- Scenario the test should lock in: A JSONL session message whose `content` (string OR text-block) contains `<|im_end|>`, `<|endoftext|>`, `<|begin_of_text|>`, `<|eot_id|>`, or `<|reserved_special_token_42|>` must be returned by `getRecentSessionContent` with those tokens replaced. Clean content must round-trip unchanged.
- Why this is the smallest reliable guardrail: A pure-helper unit test on `getRecentSessionContent` directly exercises the sanitization invariant at the seam where it matters (transcript read), is fast and deterministic (no LLM mocks), and protects the contract for every downstream consumer — not just the session-memory writer. Matches the repo's testing guidance: pure helper / contract unit tests at the boundary, not integration coverage of the whole hook.
- Existing test that already covers this (if any): None. `handler.test.ts` covers the writer, slug generation, and reset-fallback paths but not transcript content sanitization. `external-content.test.ts` covers `wrapExternalContent` end-to-end but does not exercise this code path.
- If no new test is added, why not: N/A — a new test file is added.

## User-visible / Behavior Changes

Persisted session memory files (`memory/<date>-<slug>.md`) no longer contain raw chat-template control tokens in the `## Conversation Summary` block. Tokens are replaced with the existing `[REMOVED_SPECIAL_TOKEN]` sentinel from `external-content.ts`, matching how external untrusted content is already neutralized elsewhere in the codebase. No config, no defaults, no schema, no public API changes. Existing on-disk poisoned memory files from prior versions are NOT rewritten (out of scope); users who hit the bug previously must still quarantine those files manually as the issue body recommends.

## Diagram (if applicable)

```text
Before:
session.jsonl  ──→ extractTextMessageContent  ──→ writeFileWithinRoot  ──→ memory/<date>-<slug>.md
  (raw <|im_end|>)            (passthrough)                                   (poisoned)
                                                                                  │
                                                                                  ▼
                                                                       /new re-injects as
                                                                    ## Conversation Summary
                                                                                  │
                                                                                  ▼
                                                                       model parses tokens
                                                                       as scaffolding → loop

After:
session.jsonl  ──→ extractTextMessageContent  ──→ writeFileWithinRoot  ──→ memory/<date>-<slug>.md
  (raw <|im_end|>)        │                                                  (clean)
                          ▼
              replaceLlmSpecialTokenLiterals
                  (returns clean text)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A. This change is defensively neutralizing untrusted content (model output) before persistence and re-injection — strictly tightens the security posture by extending an existing sanitization pattern (`replaceLlmSpecialTokenLiterals`) to the session-memory transcript path. No widened surfaces.

## Repro + Verification

### Environment

- OS: Linux x86_64 (Ubuntu noble)
- Runtime/container: Node 22.22.2 via nvm; pnpm 10.33.0
- Model/provider: any quantized local model that emits chat-template tokens in text output (e.g. self-hosted Qwen / Llama / Mistral / Gemma via Ollama, llama.cpp, or vLLM)
- Integration/channel (if any): any (bug reproduces on any channel that reaches `/new` or `/reset`)
- Relevant config (redacted): default `hooks` includes the bundled `session-memory` hook (default for new agents); no other config required

### Steps

1. Configure an agent with a quantized local model whose responses occasionally include chat-template literals (e.g. `<|im_end|>`, `<|endoftext|>`, or `<|reserved_special_token_42|>`).
2. Hold a normal conversation, then issue `/new` to trigger the `session-memory` hook.
3. Inspect the new file at `~/.openclaw/workspace-<agent>/memory/<YYYY-MM-DD>-<slug>.md`. On a release without this fix, the file's `## Conversation Summary` contains the raw tokens.
4. Issue `/new` again. The agent reads the poisoned summary on the next turn and emits more orphan role markers / NO_REPLY / raw `<tool_call>` XML, which is then saved into the next memory file. Each `/new` degrades further.

### Expected

- The persisted memory file's `## Conversation Summary` contains no raw `<|...|>`, `[INST]`, `<start_of_turn>`, etc. literals.
- The `[REMOVED_SPECIAL_TOKEN]` sentinel appears in their place where they would otherwise have been.
- Subsequent `/new` cycles do not amplify malformed output; the loop is broken at the persistence seam.

### Actual

- With this PR applied, behavior matches expected.
- New unit tests in `transcript.test.ts` exercise this directly without requiring a live local model: synthetic JSONL with poisoned content is read back through `getRecentSessionContent` and asserted clean.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification (Node 22.22.2, pnpm 10.33.0):

```text
$ pnpm test src/hooks/bundled/session-memory/transcript.test.ts \
            src/hooks/bundled/session-memory/handler.test.ts \
            src/security/external-content.test.ts

[test] starting test/vitest/vitest.unit-fast.config.ts
 Test Files  1 passed (1)
      Tests  79 passed (79)        ← external-content.test.ts unchanged

[test] starting test/vitest/vitest.hooks.config.ts
 Test Files  2 passed (2)
      Tests  23 passed (23)        ← 19 handler + 4 new transcript

[test] passed 2 Vitest shards in 19.30s
```

Verbose listing of the 4 new tests, all passing:

```text
✓ getRecentSessionContent — chat-template token sanitization (regression for #69943)
  ✓ strips ChatML tokens from string content
  ✓ strips Llama-family tokens from text-block content
  ✓ strips reserved-special-token variants
  ✓ preserves clean content unchanged
```

Boundary gates:

```text
$ pnpm check:changed
[check:changed] typecheck extensions       OK
[check:changed] typecheck extension tests  OK
[check:changed] lint core                  Found 0 warnings and 0 errors.
[check:changed] lint extensions            Found 0 warnings and 0 errors.
[check:changed] lint scripts               Found 0 warnings and 0 errors.
[check:changed] runtime sidecar guard      OK
[check:changed] runtime import cycles      0 cycles
[check:changed] webhook body guard         OK
[check:changed] pairing store guard        OK
[check:changed] pairing account guard      OK
exit 0

$ pnpm tsgo:core             # exit 0
$ pnpm tsgo:test:src         # exit 0
$ git diff --check           # clean
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: All four new unit cases pass individually and in the full hooks-shard run; `handler.test.ts` (19 tests covering writer / slug / reset-fallback paths) still passes unchanged; `external-content.test.ts` (79 tests) still passes — confirming the export change does not affect existing behavior.
- Edge cases checked:
  - Token in plain string `content` (most common shape).
  - Token in text-block `content` (multi-block messages).
  - `<|reserved_special_token_N|>` regex variant (covers future reserved tokens).
  - Clean content (negative case — exact byte equality preserved: `"user: what's the weather?"`).
- Boundary checks performed locally beyond CI: `pnpm check:changed` exit 0 (full lane list above); direct `pnpm tsgo:core` exit 0; direct `pnpm tsgo:test:src` exit 0; `git diff --check` clean; `pnpm exec oxfmt --check --threads=1` on all touched files clean.
- What you did **not** verify: A live end-to-end run with a real quantized local model emitting chat-template tokens (lab not configured for that locally). The pure-helper unit tests are the right seam for this regression per repo testing guidance and exercise the same code path the hook runs against on disk.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A. Users who already have poisoned memory files from prior versions should still quarantine them manually as recommended in #69943 — this PR does not retroactively rewrite on-disk artifacts (out of scope). Public API note: `replaceLlmSpecialTokenLiterals` becomes an exported function from `src/security/external-content.ts`. The token list, replacement sentinel, and behavior are unchanged. Third-party code reaching into this module will see the new export but no breakage.

## Risks and Mitigations

- Risk: A future change to the token literal list in `external-content.ts` silently affects session-memory transcript output as well.
  - Mitigation: Intentional — there should be one source of truth for chat-template tokens. The new `transcript.test.ts` cases lock in coverage at the call site, so a regression in the literal list will fail both `external-content.test.ts` and `transcript.test.ts`.
- Risk: The `[REMOVED_SPECIAL_TOKEN]` sentinel itself appearing in the persisted memory file might confuse a model on re-injection.
  - Mitigation: This sentinel is already used by `wrapExternalContent` for the same purpose elsewhere in the codebase and is a stable plain-ASCII string with no chat-template significance — strictly safer than the raw tokens it replaces. If desired, a follow-up could replace with empty string in this specific path, but consistency with existing usage is preferred.
- Risk: The hook still re-injects role markers (`assistant:`, `user:`) and `<tool_call>` XML mentioned in the issue body.
  - Mitigation: Out of scope for this PR. Per repo guidance ("One issue per PR", "What did NOT change"), this PR addresses the chat-template *control token* class specifically, which is the dominant cause of the self-poisoning loop and the class for which a tested helper already exists. A follow-up PR can extend sanitization to orphan role markers and unparsed tool-call XML if the maintainer wants.
