### PR TITLE
fix(memory): register built-in embedding providers for memory CLI

### DIFF
--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -23,4 +23,8 @@ export {
   listMemoryFiles,
   normalizeExtraMemoryPaths,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+export {
+  listMemoryEmbeddingProviders,
+  registerMemoryEmbeddingProvider,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 export { getMemorySearchManager } from "./memory/index.js";

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -13,8 +13,10 @@ import {
   getRuntimeConfig,
   getMemorySearchManager,
   isRich,
+  listMemoryEmbeddingProviders,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
+  registerMemoryEmbeddingProvider,
   resolveCommandSecretRefsViaGateway,
   resolveDefaultAgentId,
   resolveSessionTranscriptsDirForAgent,
@@ -46,6 +48,7 @@ import {
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import { registerBuiltInMemoryEmbeddingProviders } from "./memory/provider-adapters.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import {
   applyShortTermPromotions,
@@ -101,6 +104,15 @@ async function loadMemoryCommandConfig(commandName: string): Promise<LoadedMemor
     config: resolvedConfig,
     diagnostics,
   };
+}
+
+function ensureMemoryEmbeddingProvidersRegistered(): void {
+  if (listMemoryEmbeddingProviders().length > 0) {
+    return;
+  }
+  registerBuiltInMemoryEmbeddingProviders({
+    registerMemoryEmbeddingProvider,
+  });
 }
 
 function emitMemorySecretResolveDiagnostics(
@@ -465,6 +477,7 @@ async function withMemoryManagerForAgent(params: {
   purpose?: MemoryManagerPurpose;
   run: (manager: MemoryManager) => Promise<void>;
 }): Promise<void> {
+  ensureMemoryEmbeddingProvidersRegistered();
   const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
     cfg: params.cfg,
     agentId: params.agentId,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -13,6 +13,8 @@ import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({})));
+const listMemoryEmbeddingProviders = vi.hoisted(() => vi.fn(() => []));
+const registerMemoryEmbeddingProvider = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveCommandSecretRefsViaGateway = vi.hoisted(() =>
   vi.fn(async ({ config }: { config: unknown }) => ({
@@ -33,9 +35,11 @@ vi.mock("./cli.host.runtime.js", async () => {
     formatErrorMessage: runtimeCli.formatErrorMessage,
     getMemorySearchManager,
     isRich: runtimeCli.isRich,
+    listMemoryEmbeddingProviders,
     listMemoryFiles: runtimeFiles.listMemoryFiles,
     getRuntimeConfig,
     normalizeExtraMemoryPaths: runtimeFiles.normalizeExtraMemoryPaths,
+    registerMemoryEmbeddingProvider,
     resolveCommandSecretRefsViaGateway,
     resolveDefaultAgentId,
     resolveSessionTranscriptsDirForAgent: runtimeCore.resolveSessionTranscriptsDirForAgent,
@@ -74,6 +78,8 @@ beforeAll(async () => {
 beforeEach(() => {
   getMemorySearchManager.mockReset();
   getRuntimeConfig.mockReset().mockReturnValue({});
+  listMemoryEmbeddingProviders.mockReset().mockReturnValue([]);
+  registerMemoryEmbeddingProvider.mockReset();
   resolveDefaultAgentId.mockReset().mockReturnValue("main");
   resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
     resolvedConfig: config,
@@ -212,6 +218,43 @@ describe("memory cli", () => {
     );
     expect(process.exitCode).toBeUndefined();
   }
+
+  it("registers built-in embedding providers before creating the memory manager", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "local" }),
+    );
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
+
+  it("does not register built-in embedding providers when providers already exist", async () => {
+    listMemoryEmbeddingProviders.mockReturnValueOnce([
+      { id: "custom", transport: "remote", create: vi.fn() },
+    ]);
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).not.toHaveBeenCalled();
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
 
   it("prints vector status when available", async () => {
     const close = vi.fn(async () => {});


### PR DESCRIPTION
## Summary
- register built-in memory embedding providers before memory CLI manager creation
- cover `memory status/index/search` CLI paths through shared initialization
- add regression coverage for the memory CLI provider registration path

## Local verification
Attempted:

```bash
pnpm exec vitest run extensions/memory-core/src/cli.test.ts --no-fileParallelism --maxWorkers 1 --reporter verbose
```

The first local run was blocked before business assertions because dependency resolution reported a missing `global-agent`. After dependency restore was attempted, the local install was killed by the machine with `SIGKILL`; a later quick import check showed `global-agent import ok`. This PR should be validated by CI in a clean install environment.

Part 1 of the vector memory integration series.