### PR TITLE
feat(memory): scope memory_search by agent and add provenance

### DIFF
--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -23,4 +23,8 @@ export {
   listMemoryFiles,
   normalizeExtraMemoryPaths,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+export {
+  listMemoryEmbeddingProviders,
+  registerMemoryEmbeddingProvider,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 export { getMemorySearchManager } from "./memory/index.js";

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -13,8 +13,10 @@ import {
   getRuntimeConfig,
   getMemorySearchManager,
   isRich,
+  listMemoryEmbeddingProviders,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
+  registerMemoryEmbeddingProvider,
   resolveCommandSecretRefsViaGateway,
   resolveDefaultAgentId,
   resolveSessionTranscriptsDirForAgent,
@@ -46,6 +48,7 @@ import {
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import { registerBuiltInMemoryEmbeddingProviders } from "./memory/provider-adapters.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import {
   applyShortTermPromotions,
@@ -101,6 +104,15 @@ async function loadMemoryCommandConfig(commandName: string): Promise<LoadedMemor
     config: resolvedConfig,
     diagnostics,
   };
+}
+
+function ensureMemoryEmbeddingProvidersRegistered(): void {
+  if (listMemoryEmbeddingProviders().length > 0) {
+    return;
+  }
+  registerBuiltInMemoryEmbeddingProviders({
+    registerMemoryEmbeddingProvider,
+  });
 }
 
 function emitMemorySecretResolveDiagnostics(
@@ -465,6 +477,7 @@ async function withMemoryManagerForAgent(params: {
   purpose?: MemoryManagerPurpose;
   run: (manager: MemoryManager) => Promise<void>;
 }): Promise<void> {
+  ensureMemoryEmbeddingProvidersRegistered();
   const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
     cfg: params.cfg,
     agentId: params.agentId,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -13,6 +13,8 @@ import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({})));
+const listMemoryEmbeddingProviders = vi.hoisted(() => vi.fn(() => []));
+const registerMemoryEmbeddingProvider = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveCommandSecretRefsViaGateway = vi.hoisted(() =>
   vi.fn(async ({ config }: { config: unknown }) => ({
@@ -33,9 +35,11 @@ vi.mock("./cli.host.runtime.js", async () => {
     formatErrorMessage: runtimeCli.formatErrorMessage,
     getMemorySearchManager,
     isRich: runtimeCli.isRich,
+    listMemoryEmbeddingProviders,
     listMemoryFiles: runtimeFiles.listMemoryFiles,
     getRuntimeConfig,
     normalizeExtraMemoryPaths: runtimeFiles.normalizeExtraMemoryPaths,
+    registerMemoryEmbeddingProvider,
     resolveCommandSecretRefsViaGateway,
     resolveDefaultAgentId,
     resolveSessionTranscriptsDirForAgent: runtimeCore.resolveSessionTranscriptsDirForAgent,
@@ -74,6 +78,8 @@ beforeAll(async () => {
 beforeEach(() => {
   getMemorySearchManager.mockReset();
   getRuntimeConfig.mockReset().mockReturnValue({});
+  listMemoryEmbeddingProviders.mockReset().mockReturnValue([]);
+  registerMemoryEmbeddingProvider.mockReset();
   resolveDefaultAgentId.mockReset().mockReturnValue("main");
   resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
     resolvedConfig: config,
@@ -212,6 +218,43 @@ describe("memory cli", () => {
     );
     expect(process.exitCode).toBeUndefined();
   }
+
+  it("registers built-in embedding providers before creating the memory manager", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "local" }),
+    );
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
+
+  it("does not register built-in embedding providers when providers already exist", async () => {
+    listMemoryEmbeddingProviders.mockReturnValueOnce([
+      { id: "custom", transport: "remote", create: vi.fn() },
+    ]);
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).not.toHaveBeenCalled();
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
 
   it("prints vector status when available", async () => {
     const close = vi.fn(async () => {});

--- a/extensions/memory-core/src/memory-permissions.ts
+++ b/extensions/memory-core/src/memory-permissions.ts
@@ -1,0 +1,83 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+
+type RecordLike = Record<string, unknown>;
+
+export type MemorySearchScope = {
+  requesterAgentId: string;
+  allowedAgentIds: string[];
+  crossAgent: boolean;
+};
+
+function asRecord(value: unknown): RecordLike | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as RecordLike)
+    : undefined;
+}
+
+function normalizeAgentId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  return trimmed || undefined;
+}
+
+function normalizeAgentIdList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const ids = value.map(normalizeAgentId).filter((id): id is string => Boolean(id));
+  return [...new Set(ids)];
+}
+
+function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
+  const ids = normalizeAgentIdList(cfg.agents?.list?.map((entry) => entry?.id));
+  return ids;
+}
+
+function resolveMemoryCoreSearchScopeConfig(cfg: OpenClawConfig): RecordLike {
+  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
+  const pluginConfig = asRecord(entry?.config);
+  return asRecord(pluginConfig?.searchScope) ?? {};
+}
+
+/**
+ * Resolve the tool-layer memory_search scope from trusted runtime identity only.
+ *
+ * Deliberately does not read tool parameters: frontend/model supplied params must not be able to
+ * broaden the effective agent scope. Future target-agent filters should only narrow this result.
+ */
+export function resolveMemorySearchScope(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId: string;
+}): MemorySearchScope {
+  const requesterAgentId = normalizeAgentId(params.requesterAgentId) ?? params.requesterAgentId;
+  const scopeConfig = resolveMemoryCoreSearchScopeConfig(params.cfg);
+  const chiefAgentIds = normalizeAgentIdList(scopeConfig.chiefAgentIds);
+  const effectiveChiefAgentIds = chiefAgentIds.length > 0 ? chiefAgentIds : ["chief"];
+  const isChief = effectiveChiefAgentIds.includes(requesterAgentId);
+  if (!isChief || scopeConfig.chiefCrossAgent === false) {
+    return {
+      requesterAgentId,
+      allowedAgentIds: [requesterAgentId],
+      crossAgent: false,
+    };
+  }
+
+  const configuredAllowedAgentIds = normalizeAgentIdList(scopeConfig.allowedAgentIds);
+  const configuredAgentIds = listConfiguredAgentIds(params.cfg);
+  const allowedAgentIds =
+    configuredAllowedAgentIds.length > 0
+      ? configuredAllowedAgentIds.filter((agentId) =>
+          configuredAgentIds.length > 0 ? configuredAgentIds.includes(agentId) : true,
+        )
+      : configuredAgentIds;
+  const effectiveAllowedAgentIds =
+    allowedAgentIds.length > 0 ? allowedAgentIds : [requesterAgentId];
+
+  return {
+    requesterAgentId,
+    allowedAgentIds: effectiveAllowedAgentIds,
+    crossAgent: effectiveAllowedAgentIds.some((agentId) => agentId !== requesterAgentId),
+  };
+}

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -7,6 +7,7 @@ export type SearchImpl = (opts?: {
   sessionKey?: string;
   qmdSearchModeOverride?: "query" | "search" | "vsearch";
   onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+  sources?: Array<"memory" | "sessions">;
 }) => Promise<unknown[]>;
 export type MemoryReadParams = { relPath: string; from?: number; lines?: number };
 export type MemoryReadResult = {
@@ -23,6 +24,7 @@ let backend: MemoryBackend = "builtin";
 let workspaceDir = "/workspace";
 let customStatus: Record<string, unknown> | undefined;
 let searchImpl: SearchImpl = async () => [];
+let searchImplByAgent = new Map<string, SearchImpl>();
 let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = async (params) => ({
   text: "",
   path: params.relPath,
@@ -30,30 +32,37 @@ let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = asyn
   lines: params.lines ?? 120,
 });
 
-const stubManager = {
-  search: vi.fn(async (_query: string, opts?: Parameters<SearchImpl>[0]) => await searchImpl(opts)),
-  readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
-  status: () => ({
-    backend,
-    files: 1,
-    chunks: 1,
-    dirty: false,
-    workspaceDir,
-    dbPath: "/workspace/.memory/index.sqlite",
-    provider: "builtin",
-    model: "builtin",
-    requestedProvider: "builtin",
-    sources: ["memory" as const],
-    sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
-    custom: customStatus,
-  }),
-  sync: vi.fn(),
-  probeVectorAvailability: vi.fn(async () => true),
-  close: vi.fn(),
-};
+function createStubManager(agentId: string) {
+  return {
+    search: vi.fn(
+      async (_query: string, opts?: Parameters<SearchImpl>[0]) =>
+        await (searchImplByAgent.get(agentId) ?? searchImpl)(opts),
+    ),
+    readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
+    status: () => ({
+      backend,
+      files: 1,
+      chunks: 1,
+      dirty: false,
+      workspaceDir,
+      dbPath: `/workspace/.memory/${agentId}.sqlite`,
+      provider: "builtin",
+      model: "builtin",
+      requestedProvider: "builtin",
+      sources: ["memory" as const],
+      sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
+      custom: customStatus,
+    }),
+    sync: vi.fn(),
+    probeVectorAvailability: vi.fn(async () => true),
+    close: vi.fn(),
+  };
+}
 
-const getMemorySearchManagerMock = vi.fn(async (_params: { cfg?: unknown }) => ({
-  manager: stubManager,
+const stubManager = createStubManager("main");
+
+const getMemorySearchManagerMock = vi.fn(async (params: { cfg?: unknown; agentId?: string }) => ({
+  manager: params.agentId ? createStubManager(params.agentId) : stubManager,
 }));
 const readAgentMemoryFileMock = vi.fn(
   async (params: MemoryReadParams) => await readFileImpl(params),
@@ -88,6 +97,10 @@ export function setMemorySearchImpl(next: SearchImpl): void {
   searchImpl = next;
 }
 
+export function setMemorySearchImplForAgent(agentId: string, next: SearchImpl): void {
+  searchImplByAgent.set(agentId, next);
+}
+
 export function setMemoryReadFileImpl(
   next: (params: MemoryReadParams) => Promise<MemoryReadResult>,
 ): void {
@@ -103,6 +116,7 @@ export function resetMemoryToolMockState(overrides?: {
   workspaceDir = "/workspace";
   customStatus = undefined;
   searchImpl = overrides?.searchImpl ?? (async () => []);
+  searchImplByAgent = new Map<string, SearchImpl>();
   readFileImpl =
     overrides?.readFileImpl ??
     (async (params: MemoryReadParams) => ({
@@ -120,6 +134,10 @@ export function getMemorySearchManagerMockCalls(): number {
 
 export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
+}
+
+export function getMemorySearchManagerMockAgentIds(): Array<string | undefined> {
+  return getMemorySearchManagerMock.mock.calls.map(([params]) => params.agentId);
 }
 
 export function getReadAgentMemoryFileMockCalls(): number {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  getMemorySearchManagerMockAgentIds,
   getMemorySearchManagerMockConfigs,
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
+  setMemorySearchImplForAgent,
 } from "./memory-tool-manager-mock.js";
 import { createMemorySearchTool } from "./tools.js";
 import {
@@ -42,6 +44,126 @@ describe("memory_search unavailable payloads", () => {
       error: "embedding provider timeout",
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
+    });
+  });
+
+  it("adds provenance fields while preserving existing result fields", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-28/2026-04-28.md",
+        startLine: 3,
+        endLine: 7,
+        score: 0.88,
+        snippet: "vector memory",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "backend", default: true }] },
+      }),
+      agentSessionKey: "agent:backend:main:memory:provenance",
+    });
+    const result = await tool.execute("provenance", { query: "vector memory" });
+
+    expect(result.details).toMatchObject({
+      results: [
+        {
+          path: "memory/2026-04-28/2026-04-28.md",
+          startLine: 3,
+          endLine: 7,
+          agent_id: "backend",
+          source_path: "memory/2026-04-28/2026-04-28.md",
+          start_line: 3,
+          end_line: 7,
+          corpus: "memory",
+        },
+      ],
+    });
+  });
+
+  it("scopes normal agents to their own memory", async () => {
+    setMemorySearchImplForAgent("backend", async () => [
+      {
+        path: "backend/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.5,
+        snippet: "backend only",
+        source: "memory",
+      },
+    ]);
+    setMemorySearchImplForAgent("chief", async () => [
+      {
+        path: "chief/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.99,
+        snippet: "chief secret",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "backend", default: true }, { id: "chief" }] },
+      }),
+      agentSessionKey: "agent:backend:main:memory:scope",
+    });
+    const result = await tool.execute("scope", {
+      query: "secret",
+      agent_id: "chief",
+      maxResults: 10,
+    });
+
+    expect(getMemorySearchManagerMockAgentIds()).toEqual(["backend"]);
+    expect(result.details).toMatchObject({
+      results: [
+        {
+          path: "backend/MEMORY.md",
+          agent_id: "backend",
+        },
+      ],
+    });
+  });
+
+  it("allows chief to search across configured agents by default", async () => {
+    setMemorySearchImplForAgent("backend", async () => [
+      {
+        path: "backend/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.6,
+        snippet: "backend note",
+        source: "memory",
+      },
+    ]);
+    setMemorySearchImplForAgent("chief", async () => [
+      {
+        path: "chief/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.9,
+        snippet: "chief note",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "chief", default: true }, { id: "backend" }] },
+      }),
+      agentSessionKey: "agent:chief:main:memory:scope",
+    });
+    const result = await tool.execute("chief-scope", { query: "note", maxResults: 10 });
+
+    expect(getMemorySearchManagerMockAgentIds()).toEqual(["chief", "backend"]);
+    expect(result.details).toMatchObject({
+      results: [
+        { path: "chief/MEMORY.md", agent_id: "chief" },
+        { path: "backend/MEMORY.md", agent_id: "backend" },
+      ],
     });
   });
 

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -15,6 +15,7 @@ import {
   resolveMemoryCorePluginConfig,
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { resolveMemorySearchScope } from "./memory-permissions.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
@@ -36,9 +37,24 @@ import {
 } from "./tools.shared.js";
 
 function buildRecallKey(
-  result: Pick<MemorySearchResult, "source" | "path" | "startLine" | "endLine">,
+  result: Pick<MemorySearchResult, "source" | "path" | "startLine" | "endLine" | "agent_id">,
 ): string {
-  return `${result.source}:${result.path}:${result.startLine}:${result.endLine}`;
+  return `${result.agent_id ?? ""}:${result.source}:${result.path}:${result.startLine}:${result.endLine}`;
+}
+
+function decorateMemorySearchProvenance(
+  result: MemorySearchResult,
+  agentId: string,
+): MemorySearchResult {
+  return {
+    ...result,
+    agentId,
+    agent_id: agentId,
+    sourcePath: result.sourcePath ?? result.path,
+    source_path: result.source_path ?? result.sourcePath ?? result.path,
+    start_line: result.start_line ?? result.startLine,
+    end_line: result.end_line ?? result.endLine,
+  };
 }
 
 function resolveRecallTrackingResults(
@@ -209,9 +225,23 @@ export function createMemorySearchTool(options: {
         const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
         const shouldQueryMemory = requestedCorpus !== "wiki";
         const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
-        const memory = shouldQueryMemory ? await getMemoryManagerContext({ cfg, agentId }) : null;
-        if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
-          return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+        const scope = resolveMemorySearchScope({ cfg, requesterAgentId: agentId });
+        const scopedMemories = shouldQueryMemory
+          ? await Promise.all(
+              scope.allowedAgentIds.map(async (scopedAgentId) => ({
+                agentId: scopedAgentId,
+                memory: await getMemoryManagerContext({ cfg, agentId: scopedAgentId }),
+              })),
+            )
+          : [];
+        const firstMemoryError = scopedMemories.find(({ memory }) => "error" in memory)?.memory;
+        if (
+          shouldQueryMemory &&
+          firstMemoryError &&
+          "error" in firstMemoryError &&
+          !shouldQuerySupplements
+        ) {
+          return jsonResult(buildMemorySearchUnavailableResult(firstMemoryError.error));
         }
         try {
           const citationsMode = resolveMemoryCitationsMode(cfg);
@@ -238,7 +268,7 @@ export function createMemorySearchTool(options: {
                 hits: number;
               }
             | undefined;
-          if (shouldQueryMemory && memory && !("error" in memory)) {
+          if (shouldQueryMemory) {
             const runtimeDebug: MemorySearchRuntimeDebug[] = [];
             const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
               cfg,
@@ -250,65 +280,76 @@ export function createMemorySearchTool(options: {
                 : requestedCorpus === "memory"
                   ? (["memory"] as MemorySource[])
                   : undefined;
-            rawResults = await memory.manager.search(query, {
-              maxResults,
-              minScore,
-              sessionKey: options.agentSessionKey,
-              qmdSearchModeOverride,
-              onDebug: (debug) => {
-                runtimeDebug.push(debug);
-              },
-              ...(searchSources ? { sources: searchSources } : {}),
-            });
-            rawResults = await filterMemorySearchHitsBySessionVisibility({
-              cfg,
-              requesterSessionKey: options.agentSessionKey,
-              sandboxed: options.sandboxed === true,
-              hits: rawResults,
-            });
-            if (requestedCorpus === "sessions") {
-              rawResults = rawResults.filter((hit) => hit.source === "sessions");
-            } else if (requestedCorpus === "memory") {
-              rawResults = rawResults.filter((hit) => hit.source === "memory");
-            }
-            const status = memory.manager.status();
-            const decorated = decorateCitations(rawResults, includeCitations);
-            const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-            const memoryResults =
-              status.backend === "qmd"
-                ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
-                : decorated;
-            surfacedMemoryResults = memoryResults.map((result) => ({
-              ...result,
-              corpus: "memory" as const,
-            }));
-            const sleepTimezone = resolveMemoryDeepDreamingConfig({
-              pluginConfig: resolveMemoryCorePluginConfig(cfg),
-              cfg,
-            }).timezone;
-            queueShortTermRecallTracking({
-              workspaceDir: status.workspaceDir,
-              query,
-              rawResults,
-              surfacedResults: memoryResults,
-              timezone: sleepTimezone,
-            });
-            provider = status.provider;
-            model = status.model;
-            fallback = status.fallback;
-            const latestDebug = runtimeDebug.at(-1);
-            searchMode = latestDebug?.effectiveMode;
-            searchDebug = {
-              backend: status.backend,
-              configuredMode: latestDebug?.configuredMode,
-              effectiveMode:
+            for (const scopedMemory of scopedMemories) {
+              if ("error" in scopedMemory.memory) {
+                continue;
+              }
+              let scopedRawResults = await scopedMemory.memory.manager.search(query, {
+                maxResults,
+                minScore,
+                sessionKey: options.agentSessionKey,
+                qmdSearchModeOverride,
+                onDebug: (debug) => {
+                  runtimeDebug.push(debug);
+                },
+                ...(searchSources ? { sources: searchSources } : {}),
+              });
+              scopedRawResults = scopedRawResults.map((result) =>
+                decorateMemorySearchProvenance(result, scopedMemory.agentId),
+              );
+              scopedRawResults = await filterMemorySearchHitsBySessionVisibility({
+                cfg,
+                requesterSessionKey: options.agentSessionKey,
+                sandboxed: options.sandboxed === true,
+                hits: scopedRawResults,
+              });
+              if (requestedCorpus === "sessions") {
+                scopedRawResults = scopedRawResults.filter((hit) => hit.source === "sessions");
+              } else if (requestedCorpus === "memory") {
+                scopedRawResults = scopedRawResults.filter((hit) => hit.source === "memory");
+              }
+              const status = scopedMemory.memory.manager.status();
+              const decorated = decorateCitations(scopedRawResults, includeCitations);
+              const resolved = resolveMemoryBackendConfig({ cfg, agentId: scopedMemory.agentId });
+              const memoryResults =
                 status.backend === "qmd"
-                  ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
-                  : "n/a",
-              fallback: latestDebug?.fallback,
-              searchMs: Math.max(0, Date.now() - searchStartedAt),
-              hits: rawResults.length,
-            };
+                  ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+                  : decorated;
+              surfacedMemoryResults.push(
+                ...memoryResults.map((result) => ({
+                  ...result,
+                  corpus: "memory" as const,
+                })),
+              );
+              rawResults.push(...scopedRawResults);
+              const sleepTimezone = resolveMemoryDeepDreamingConfig({
+                pluginConfig: resolveMemoryCorePluginConfig(cfg),
+                cfg,
+              }).timezone;
+              queueShortTermRecallTracking({
+                workspaceDir: status.workspaceDir,
+                query,
+                rawResults: scopedRawResults,
+                surfacedResults: memoryResults,
+                timezone: sleepTimezone,
+              });
+              provider ??= status.provider;
+              model ??= status.model;
+              fallback ??= status.fallback;
+              const latestDebug = runtimeDebug.at(-1);
+              searchMode = latestDebug?.effectiveMode ?? searchMode;
+              searchDebug = {
+                backend: status.backend,
+                configuredMode: latestDebug?.configuredMode,
+                effectiveMode:
+                  status.backend === "qmd"
+                    ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
+                    : "n/a",
+                fallback: latestDebug?.fallback,
+                searchMs: Math.max(0, Date.now() - searchStartedAt),
+                hits: rawResults.length,
+              };
+            }
           }
           const supplementResults = shouldQuerySupplements
             ? await searchMemoryCorpusSupplements({

--- a/src/memory-host-sdk/host/types.ts
+++ b/src/memory-host-sdk/host/types.ts
@@ -10,6 +10,19 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  /** Trusted runtime agent id that produced this hit. */
+  agentId?: string;
+  /** Snake-case tool output alias for agentId. */
+  agent_id?: string;
+  /** Canonical source path alias for path. */
+  sourcePath?: string;
+  /** Snake-case tool output alias for sourcePath. */
+  source_path?: string;
+  /** Snake-case tool output alias for startLine. */
+  start_line?: number;
+  /** Snake-case tool output alias for endLine. */
+  end_line?: number;
+  matchType?: "vector" | "keyword" | "hybrid" | "fts";
 };
 
 export type MemoryEmbeddingProbeResult = {


### PR DESCRIPTION
## Summary
- resolve memory search scope from caller/agent identity
- keep ordinary agents scoped to their own memory while allowing configured coordinator agents such as `chief` to search visible agents
- add provenance fields to memory search results: `agent_id`, `source_path`, `start_line`, `end_line`
- keep `memory_get` exact-read semantics unchanged

## Stacking note
This PR is part 2 of the vector memory integration series and is stacked after #73769. It currently targets `main` because GitHub does not allow an upstream PR base to be a fork-only branch; after #73769 lands, this diff should narrow to this PR's scope.

## Tests
Not run locally in this PR step because the checkout dependency restore was previously killed by the machine with `SIGKILL`. This should be validated by CI in a clean environment.