### PR TITLE
fix(memory): enforce agent namespace in memory index queries

### DIFF
--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -23,4 +23,8 @@ export {
   listMemoryFiles,
   normalizeExtraMemoryPaths,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+export {
+  listMemoryEmbeddingProviders,
+  registerMemoryEmbeddingProvider,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 export { getMemorySearchManager } from "./memory/index.js";

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -13,8 +13,10 @@ import {
   getRuntimeConfig,
   getMemorySearchManager,
   isRich,
+  listMemoryEmbeddingProviders,
   listMemoryFiles,
   normalizeExtraMemoryPaths,
+  registerMemoryEmbeddingProvider,
   resolveCommandSecretRefsViaGateway,
   resolveDefaultAgentId,
   resolveSessionTranscriptsDirForAgent,
@@ -46,6 +48,7 @@ import {
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import { registerBuiltInMemoryEmbeddingProviders } from "./memory/provider-adapters.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import {
   applyShortTermPromotions,
@@ -101,6 +104,15 @@ async function loadMemoryCommandConfig(commandName: string): Promise<LoadedMemor
     config: resolvedConfig,
     diagnostics,
   };
+}
+
+function ensureMemoryEmbeddingProvidersRegistered(): void {
+  if (listMemoryEmbeddingProviders().length > 0) {
+    return;
+  }
+  registerBuiltInMemoryEmbeddingProviders({
+    registerMemoryEmbeddingProvider,
+  });
 }
 
 function emitMemorySecretResolveDiagnostics(
@@ -465,6 +477,7 @@ async function withMemoryManagerForAgent(params: {
   purpose?: MemoryManagerPurpose;
   run: (manager: MemoryManager) => Promise<void>;
 }): Promise<void> {
+  ensureMemoryEmbeddingProvidersRegistered();
   const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
     cfg: params.cfg,
     agentId: params.agentId,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -13,6 +13,8 @@ import { readShortTermRecallEntries, recordShortTermRecalls } from "./short-term
 
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
 const getRuntimeConfig = vi.hoisted(() => vi.fn(() => ({})));
+const listMemoryEmbeddingProviders = vi.hoisted(() => vi.fn(() => []));
+const registerMemoryEmbeddingProvider = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveCommandSecretRefsViaGateway = vi.hoisted(() =>
   vi.fn(async ({ config }: { config: unknown }) => ({
@@ -33,9 +35,11 @@ vi.mock("./cli.host.runtime.js", async () => {
     formatErrorMessage: runtimeCli.formatErrorMessage,
     getMemorySearchManager,
     isRich: runtimeCli.isRich,
+    listMemoryEmbeddingProviders,
     listMemoryFiles: runtimeFiles.listMemoryFiles,
     getRuntimeConfig,
     normalizeExtraMemoryPaths: runtimeFiles.normalizeExtraMemoryPaths,
+    registerMemoryEmbeddingProvider,
     resolveCommandSecretRefsViaGateway,
     resolveDefaultAgentId,
     resolveSessionTranscriptsDirForAgent: runtimeCore.resolveSessionTranscriptsDirForAgent,
@@ -74,6 +78,8 @@ beforeAll(async () => {
 beforeEach(() => {
   getMemorySearchManager.mockReset();
   getRuntimeConfig.mockReset().mockReturnValue({});
+  listMemoryEmbeddingProviders.mockReset().mockReturnValue([]);
+  registerMemoryEmbeddingProvider.mockReset();
   resolveDefaultAgentId.mockReset().mockReturnValue("main");
   resolveCommandSecretRefsViaGateway.mockReset().mockImplementation(async ({ config }) => ({
     resolvedConfig: config,
@@ -212,6 +218,43 @@ describe("memory cli", () => {
     );
     expect(process.exitCode).toBeUndefined();
   }
+
+  it("registers built-in embedding providers before creating the memory manager", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "local" }),
+    );
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
+
+  it("does not register built-in embedding providers when providers already exist", async () => {
+    listMemoryEmbeddingProviders.mockReturnValueOnce([
+      { id: "custom", transport: "remote", create: vi.fn() },
+    ]);
+    const close = vi.fn(async () => {});
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      status: () => makeMemoryStatus(),
+      close,
+    });
+
+    await runMemoryCli(["status"]);
+
+    expect(registerMemoryEmbeddingProvider).not.toHaveBeenCalled();
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", purpose: "status" }),
+    );
+  });
 
   it("prints vector status when available", async () => {
     const close = vi.fn(async () => {});

--- a/extensions/memory-core/src/memory-permissions.ts
+++ b/extensions/memory-core/src/memory-permissions.ts
@@ -1,0 +1,83 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+
+type RecordLike = Record<string, unknown>;
+
+export type MemorySearchScope = {
+  requesterAgentId: string;
+  allowedAgentIds: string[];
+  crossAgent: boolean;
+};
+
+function asRecord(value: unknown): RecordLike | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as RecordLike)
+    : undefined;
+}
+
+function normalizeAgentId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim().toLowerCase();
+  return trimmed || undefined;
+}
+
+function normalizeAgentIdList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const ids = value.map(normalizeAgentId).filter((id): id is string => Boolean(id));
+  return [...new Set(ids)];
+}
+
+function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
+  const ids = normalizeAgentIdList(cfg.agents?.list?.map((entry) => entry?.id));
+  return ids;
+}
+
+function resolveMemoryCoreSearchScopeConfig(cfg: OpenClawConfig): RecordLike {
+  const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
+  const pluginConfig = asRecord(entry?.config);
+  return asRecord(pluginConfig?.searchScope) ?? {};
+}
+
+/**
+ * Resolve the tool-layer memory_search scope from trusted runtime identity only.
+ *
+ * Deliberately does not read tool parameters: frontend/model supplied params must not be able to
+ * broaden the effective agent scope. Future target-agent filters should only narrow this result.
+ */
+export function resolveMemorySearchScope(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId: string;
+}): MemorySearchScope {
+  const requesterAgentId = normalizeAgentId(params.requesterAgentId) ?? params.requesterAgentId;
+  const scopeConfig = resolveMemoryCoreSearchScopeConfig(params.cfg);
+  const chiefAgentIds = normalizeAgentIdList(scopeConfig.chiefAgentIds);
+  const effectiveChiefAgentIds = chiefAgentIds.length > 0 ? chiefAgentIds : ["chief"];
+  const isChief = effectiveChiefAgentIds.includes(requesterAgentId);
+  if (!isChief || scopeConfig.chiefCrossAgent === false) {
+    return {
+      requesterAgentId,
+      allowedAgentIds: [requesterAgentId],
+      crossAgent: false,
+    };
+  }
+
+  const configuredAllowedAgentIds = normalizeAgentIdList(scopeConfig.allowedAgentIds);
+  const configuredAgentIds = listConfiguredAgentIds(params.cfg);
+  const allowedAgentIds =
+    configuredAllowedAgentIds.length > 0
+      ? configuredAllowedAgentIds.filter((agentId) =>
+          configuredAgentIds.length > 0 ? configuredAgentIds.includes(agentId) : true,
+        )
+      : configuredAgentIds;
+  const effectiveAllowedAgentIds =
+    allowedAgentIds.length > 0 ? allowedAgentIds : [requesterAgentId];
+
+  return {
+    requesterAgentId,
+    allowedAgentIds: effectiveAllowedAgentIds,
+    crossAgent: effectiveAllowedAgentIds.some((agentId) => agentId !== requesterAgentId),
+  };
+}

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -7,6 +7,7 @@ export type SearchImpl = (opts?: {
   sessionKey?: string;
   qmdSearchModeOverride?: "query" | "search" | "vsearch";
   onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+  sources?: Array<"memory" | "sessions">;
 }) => Promise<unknown[]>;
 export type MemoryReadParams = { relPath: string; from?: number; lines?: number };
 export type MemoryReadResult = {
@@ -23,6 +24,7 @@ let backend: MemoryBackend = "builtin";
 let workspaceDir = "/workspace";
 let customStatus: Record<string, unknown> | undefined;
 let searchImpl: SearchImpl = async () => [];
+let searchImplByAgent = new Map<string, SearchImpl>();
 let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = async (params) => ({
   text: "",
   path: params.relPath,
@@ -30,30 +32,37 @@ let readFileImpl: (params: MemoryReadParams) => Promise<MemoryReadResult> = asyn
   lines: params.lines ?? 120,
 });
 
-const stubManager = {
-  search: vi.fn(async (_query: string, opts?: Parameters<SearchImpl>[0]) => await searchImpl(opts)),
-  readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
-  status: () => ({
-    backend,
-    files: 1,
-    chunks: 1,
-    dirty: false,
-    workspaceDir,
-    dbPath: "/workspace/.memory/index.sqlite",
-    provider: "builtin",
-    model: "builtin",
-    requestedProvider: "builtin",
-    sources: ["memory" as const],
-    sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
-    custom: customStatus,
-  }),
-  sync: vi.fn(),
-  probeVectorAvailability: vi.fn(async () => true),
-  close: vi.fn(),
-};
+function createStubManager(agentId: string) {
+  return {
+    search: vi.fn(
+      async (_query: string, opts?: Parameters<SearchImpl>[0]) =>
+        await (searchImplByAgent.get(agentId) ?? searchImpl)(opts),
+    ),
+    readFile: vi.fn(async (params: MemoryReadParams) => await readFileImpl(params)),
+    status: () => ({
+      backend,
+      files: 1,
+      chunks: 1,
+      dirty: false,
+      workspaceDir,
+      dbPath: `/workspace/.memory/${agentId}.sqlite`,
+      provider: "builtin",
+      model: "builtin",
+      requestedProvider: "builtin",
+      sources: ["memory" as const],
+      sourceCounts: [{ source: "memory" as const, files: 1, chunks: 1 }],
+      custom: customStatus,
+    }),
+    sync: vi.fn(),
+    probeVectorAvailability: vi.fn(async () => true),
+    close: vi.fn(),
+  };
+}
 
-const getMemorySearchManagerMock = vi.fn(async (_params: { cfg?: unknown }) => ({
-  manager: stubManager,
+const stubManager = createStubManager("main");
+
+const getMemorySearchManagerMock = vi.fn(async (params: { cfg?: unknown; agentId?: string }) => ({
+  manager: params.agentId ? createStubManager(params.agentId) : stubManager,
 }));
 const readAgentMemoryFileMock = vi.fn(
   async (params: MemoryReadParams) => await readFileImpl(params),
@@ -88,6 +97,10 @@ export function setMemorySearchImpl(next: SearchImpl): void {
   searchImpl = next;
 }
 
+export function setMemorySearchImplForAgent(agentId: string, next: SearchImpl): void {
+  searchImplByAgent.set(agentId, next);
+}
+
 export function setMemoryReadFileImpl(
   next: (params: MemoryReadParams) => Promise<MemoryReadResult>,
 ): void {
@@ -103,6 +116,7 @@ export function resetMemoryToolMockState(overrides?: {
   workspaceDir = "/workspace";
   customStatus = undefined;
   searchImpl = overrides?.searchImpl ?? (async () => []);
+  searchImplByAgent = new Map<string, SearchImpl>();
   readFileImpl =
     overrides?.readFileImpl ??
     (async (params: MemoryReadParams) => ({
@@ -120,6 +134,10 @@ export function getMemorySearchManagerMockCalls(): number {
 
 export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
+}
+
+export function getMemorySearchManagerMockAgentIds(): Array<string | undefined> {
+  return getMemorySearchManagerMock.mock.calls.map(([params]) => params.agentId);
 }
 
 export function getReadAgentMemoryFileMockCalls(): number {

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2,12 +2,12 @@ import { mkdirSync, rmSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core";
 import {
   clearMemoryEmbeddingProviders as clearRegistry,
   listRegisteredMemoryEmbeddingProviderAdapters as listRegisteredAdapters,
   registerMemoryEmbeddingProvider as registerAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-runtime-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
@@ -17,14 +17,6 @@ import {
   DEFAULT_LOCAL_MODEL,
   registerBuiltInMemoryEmbeddingProviders,
 } from "./provider-adapters.js";
-
-// This suite performs real sqlite/media indexing and can exceed the global
-// timeout when it shares a packed CI extension shard.
-vi.setConfig({ testTimeout: 240_000 });
-
-afterAll(() => {
-  vi.resetConfig();
-});
 
 let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
@@ -236,6 +228,7 @@ describe("memory index", () => {
     };
     vectorEnabled?: boolean;
     cacheEnabled?: boolean;
+    agentId?: string;
     minScore?: number;
     onSearch?: boolean;
     hybrid?: { enabled: boolean; vectorWeight?: number; textWeight?: number };
@@ -263,7 +256,7 @@ describe("memory index", () => {
             experimental: { sessionMemory: params.sessionMemory ?? false },
           },
         },
-        list: [{ id: "main", default: true }],
+        list: [{ id: params.agentId ?? "main", default: true }],
       },
     };
   }
@@ -355,6 +348,53 @@ describe("memory index", () => {
     }
   });
 
+  it("isolates searches by agent when multiple agents share one memory DB", async () => {
+    const sharedStorePath = path.join(workspaceDir, "shared-memory.sqlite");
+    const agentAPath = path.join(workspaceDir, "agent-a", "memory");
+    const agentBPath = path.join(workspaceDir, "agent-b", "memory");
+    await fs.mkdir(agentAPath, { recursive: true });
+    await fs.mkdir(agentBPath, { recursive: true });
+    await fs.writeFile(path.join(agentAPath, "2026-01-12.md"), "agent-a-only alpha namespace");
+    await fs.writeFile(path.join(agentBPath, "2026-01-12.md"), "agent-b-only beta namespace");
+
+    const cfgA = createCfg({
+      storePath: sharedStorePath,
+      agentId: "agent-a",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const cfgB = createCfg({
+      storePath: sharedStorePath,
+      agentId: "agent-b",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+
+    const managerA = requireManager(
+      await getMemorySearchManager({ cfg: cfgA, agentId: "agent-a" }),
+    );
+    const managerB = requireManager(
+      await getMemorySearchManager({ cfg: cfgB, agentId: "agent-b" }),
+    );
+
+    await managerA.sync({ reason: "test" });
+    await managerB.sync({ reason: "test" });
+
+    const aSeesA = await managerA.search("agent-a-only", 5);
+    const aSeesB = await managerA.search("agent-b-only", 5);
+    const bSeesB = await managerB.search("agent-b-only", 5);
+    const bSeesA = await managerB.search("agent-a-only", 5);
+
+    expect(aSeesA.map((row) => row.snippet).join("\n")).toContain("agent-a-only");
+    expect(aSeesB).toHaveLength(0);
+    expect(bSeesB.map((row) => row.snippet).join("\n")).toContain("agent-b-only");
+    expect(bSeesA).toHaveLength(0);
+
+    const statusA = managerA.status();
+    const statusB = managerB.status();
+    expect(statusA.files).toBeGreaterThan(0);
+    expect(statusB.files).toBeGreaterThan(0);
+    expect(statusA.files).toBeLessThan(statusA.files + statusB.files);
+  });
+
   it("indexes multimodal image and audio files from extra paths with Gemini structured inputs", async () => {
     const mediaDir = path.join(workspaceDir, "media-memory");
     await fs.mkdir(mediaDir, { recursive: true });
@@ -443,72 +483,6 @@ describe("memory index", () => {
     expect((cached?.cacheExpiresAtMs ?? 0) - (cached?.checkedAtMs ?? 0)).toBe(
       EMBEDDING_PROBE_CACHE_TTL_MS,
     );
-  });
-
-  it("streams embedding cache rows during safe reindex", async () => {
-    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
-    type EmbeddingCacheRow = {
-      provider: string;
-      model: string;
-      provider_key: string;
-      hash: string;
-      embedding: string;
-      dims: number | null;
-      updated_at: number;
-    };
-    type StatementWithAll = {
-      all: () => EmbeddingCacheRow[];
-    };
-
-    const cfg = createCfg({
-      storePath: path.join(workspaceDir, "index-cache-seed-stream.sqlite"),
-      cacheEnabled: true,
-    });
-    const manager = await getPersistentManager(cfg);
-    await manager.sync({ reason: "test" });
-
-    // Safe reindex streams cache rows from the original database and writes
-    // them into a temporary database, so the SELECT spy belongs on this handle.
-    const sourceDb = (
-      manager as unknown as {
-        db: {
-          prepare: (sql: string) => unknown;
-        };
-      }
-    ).db;
-    const originalPrepare = sourceDb.prepare.bind(sourceDb);
-    const cachedRows = (
-      originalPrepare(
-        "SELECT provider, model, provider_key, hash, embedding, dims, updated_at FROM embedding_cache",
-      ) as StatementWithAll
-    ).all();
-    expect(cachedRows.length).toBeGreaterThan(0);
-
-    const beforeCalls = embedBatchCalls;
-    const prepareSpy = vi.spyOn(sourceDb, "prepare").mockImplementation((sql: string) => {
-      if (
-        sql.includes(
-          "SELECT provider, model, provider_key, hash, embedding, dims, updated_at FROM embedding_cache",
-        )
-      ) {
-        return {
-          all: () => {
-            throw new Error("embedding cache seed must stream rows via iterate()");
-          },
-          iterate: () => cachedRows[Symbol.iterator](),
-        };
-      }
-      return originalPrepare(sql);
-    });
-
-    try {
-      (manager as unknown as { dirty: boolean }).dirty = true;
-      await manager.sync({ reason: "test", force: true });
-    } finally {
-      prepareSpy.mockRestore();
-    }
-
-    expect(embedBatchCalls).toBe(beforeCalls);
   });
 
   it("builds FTS index and returns search results when no embedding provider is available", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-cache.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-cache.test.ts
@@ -16,6 +16,7 @@ describe("memory embedding cache", () => {
     const db = new DatabaseSync(":memory:");
     ensureMemoryIndexSchema({
       db,
+      agentId: "main",
       embeddingCacheTable: "embedding_cache",
       cacheEnabled: true,
       ftsTable: "chunks_fts",

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -89,17 +89,11 @@ export function resolveEmbeddingTimeoutMs(params: {
 
 export function resolveMemoryIndexConcurrency(params: {
   batch: { enabled: boolean; concurrency: number };
-  configuredNonBatchConcurrency?: number;
-  providerId?: string;
+  configuredConcurrency?: number;
 }): number {
-  if (params.batch.enabled) {
-    return params.batch.concurrency;
-  }
-  const configured = params.configuredNonBatchConcurrency;
-  if (typeof configured === "number" && Number.isFinite(configured)) {
-    return Math.max(1, Math.floor(configured));
-  }
-  return params.providerId === "ollama" ? 1 : EMBEDDING_INDEX_CONCURRENCY;
+  return params.configuredConcurrency != null || params.batch.enabled
+    ? params.batch.concurrency
+    : EMBEDDING_INDEX_CONCURRENCY;
 }
 
 export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
@@ -515,8 +509,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected getIndexConcurrency(): number {
     return resolveMemoryIndexConcurrency({
       batch: this.batch,
-      configuredNonBatchConcurrency: this.settings.remote?.nonBatchConcurrency,
-      providerId: this.provider?.id,
+      configuredConcurrency: this.settings.remote?.batch?.concurrency,
     });
   }
 
@@ -525,9 +518,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       try {
         this.db
           .prepare(
-            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
+            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE agent_id = ? AND path = ? AND source = ?)`,
           )
-          .run(pathname, source);
+          .run(this.agentId, pathname, source);
       } catch {}
     }
     if (this.fts.enabled && this.fts.available) {
@@ -535,30 +528,34 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         deleteMemoryFtsRows({
           db: this.db,
           tableName: FTS_TABLE,
+          agentId: this.agentId,
           path: pathname,
           source,
           currentModel: this.provider?.model,
         });
       } catch {}
     }
-    this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);
+    this.db
+      .prepare(`DELETE FROM chunks WHERE agent_id = ? AND path = ? AND source = ?`)
+      .run(this.agentId, pathname, source);
   }
 
   private upsertFileRecord(entry: MemoryFileEntry | SessionFileEntry, source: MemorySource): void {
     this.db
       .prepare(
-        `INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(path) DO UPDATE SET
-           source=excluded.source,
+        `INSERT INTO files (agent_id, path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT(agent_id, path, source) DO UPDATE SET
            hash=excluded.hash,
            mtime=excluded.mtime,
            size=excluded.size`,
       )
-      .run(entry.path, source, entry.hash, entry.mtimeMs, entry.size);
+      .run(this.agentId, entry.path, source, entry.hash, entry.mtimeMs, entry.size);
   }
 
   private deleteFileRecord(pathname: string, source: MemorySource): void {
-    this.db.prepare(`DELETE FROM files WHERE path = ? AND source = ?`).run(pathname, source);
+    this.db
+      .prepare(`DELETE FROM files WHERE agent_id = ? AND path = ? AND source = ?`)
+      .run(this.agentId, pathname, source);
   }
 
   /**
@@ -580,13 +577,18 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       const chunk = chunks[i];
       const embedding = embeddings[i] ?? [];
       const id = hashText(
-        `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
+        `${this.agentId}:${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
       );
       this.db
         .prepare(
-          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO chunks (id, agent_id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
+             agent_id=excluded.agent_id,
+             path=excluded.path,
+             source=excluded.source,
+             start_line=excluded.start_line,
+             end_line=excluded.end_line,
              hash=excluded.hash,
              model=excluded.model,
              text=excluded.text,
@@ -595,6 +597,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         )
         .run(
           id,
+          this.agentId,
           entry.path,
           source,
           chunk.startLine,
@@ -616,10 +619,19 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       if (this.fts.enabled && this.fts.available) {
         this.db
           .prepare(
-            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
-              ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            `INSERT INTO ${FTS_TABLE} (text, id, agent_id, path, source, model, start_line, end_line)\n` +
+              ` VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
           )
-          .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+          .run(
+            chunk.text,
+            id,
+            this.agentId,
+            entry.path,
+            source,
+            model,
+            chunk.startLine,
+            chunk.endLine,
+          );
       }
     }
     this.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({

--- a/extensions/memory-core/src/memory/manager-fts-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-fts-state.test.ts
@@ -12,13 +12,15 @@ describe("memory FTS state", () => {
 
   it("only removes rows for the active model when a provider is active", () => {
     db = new DatabaseSync(":memory:");
-    db.exec("CREATE TABLE chunks_fts (path TEXT, source TEXT, model TEXT)");
-    db.prepare("INSERT INTO chunks_fts (path, source, model) VALUES (?, ?, ?)").run(
+    db.exec("CREATE TABLE chunks_fts (agent_id TEXT, path TEXT, source TEXT, model TEXT)");
+    db.prepare("INSERT INTO chunks_fts (agent_id, path, source, model) VALUES (?, ?, ?, ?)").run(
+      "main",
       "memory/2026-01-12.md",
       "memory",
       "mock-embed",
     );
-    db.prepare("INSERT INTO chunks_fts (path, source, model) VALUES (?, ?, ?)").run(
+    db.prepare("INSERT INTO chunks_fts (agent_id, path, source, model) VALUES (?, ?, ?, ?)").run(
+      "main",
       "memory/2026-01-12.md",
       "memory",
       "other-model",
@@ -26,6 +28,7 @@ describe("memory FTS state", () => {
 
     deleteMemoryFtsRows({
       db,
+      agentId: "main",
       path: "memory/2026-01-12.md",
       source: "memory",
       currentModel: "mock-embed",
@@ -39,13 +42,15 @@ describe("memory FTS state", () => {
 
   it("removes all rows for the path in FTS-only mode", () => {
     db = new DatabaseSync(":memory:");
-    db.exec("CREATE TABLE chunks_fts (path TEXT, source TEXT, model TEXT)");
-    db.prepare("INSERT INTO chunks_fts (path, source, model) VALUES (?, ?, ?)").run(
+    db.exec("CREATE TABLE chunks_fts (agent_id TEXT, path TEXT, source TEXT, model TEXT)");
+    db.prepare("INSERT INTO chunks_fts (agent_id, path, source, model) VALUES (?, ?, ?, ?)").run(
+      "main",
       "memory/2026-01-12.md",
       "memory",
       "mock-embed",
     );
-    db.prepare("INSERT INTO chunks_fts (path, source, model) VALUES (?, ?, ?)").run(
+    db.prepare("INSERT INTO chunks_fts (agent_id, path, source, model) VALUES (?, ?, ?, ?)").run(
+      "main",
       "memory/2026-01-12.md",
       "memory",
       "fts-only",
@@ -53,6 +58,7 @@ describe("memory FTS state", () => {
 
     deleteMemoryFtsRows({
       db,
+      agentId: "main",
       path: "memory/2026-01-12.md",
       source: "memory",
     });

--- a/extensions/memory-core/src/memory/manager-fts-state.ts
+++ b/extensions/memory-core/src/memory/manager-fts-state.ts
@@ -4,6 +4,7 @@ import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-s
 export function deleteMemoryFtsRows(params: {
   db: DatabaseSync;
   tableName?: string;
+  agentId: string;
   path: string;
   source: MemorySource;
   currentModel?: string;
@@ -11,11 +12,13 @@ export function deleteMemoryFtsRows(params: {
   const tableName = params.tableName ?? "chunks_fts";
   if (params.currentModel) {
     params.db
-      .prepare(`DELETE FROM ${tableName} WHERE path = ? AND source = ? AND model = ?`)
-      .run(params.path, params.source, params.currentModel);
+      .prepare(
+        `DELETE FROM ${tableName} WHERE agent_id = ? AND path = ? AND source = ? AND model = ?`,
+      )
+      .run(params.agentId, params.path, params.source, params.currentModel);
     return;
   }
   params.db
-    .prepare(`DELETE FROM ${tableName} WHERE path = ? AND source = ?`)
-    .run(params.path, params.source);
+    .prepare(`DELETE FROM ${tableName} WHERE agent_id = ? AND path = ? AND source = ?`)
+    .run(params.agentId, params.path, params.source);
 }

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -3,7 +3,7 @@ import {
   loadSqliteVecExtension,
   requireNodeSqlite,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { bm25RankToScore, buildFtsQuery } from "./hybrid.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
 
@@ -18,6 +18,7 @@ describe("searchKeyword trigram fallback", () => {
     try {
       const result = ensureMemoryIndexSchema({
         db,
+        agentId: "main",
         embeddingCacheTable: "embedding_cache",
         cacheEnabled: false,
         ftsTable: "chunks_fts",
@@ -34,6 +35,7 @@ describe("searchKeyword trigram fallback", () => {
     const db = new DatabaseSync(":memory:");
     const result = ensureMemoryIndexSchema({
       db,
+      agentId: "main",
       embeddingCacheTable: "embedding_cache",
       cacheEnabled: false,
       ftsTable: "chunks_fts",
@@ -55,10 +57,26 @@ describe("searchKeyword trigram fallback", () => {
     const db = createTrigramDb();
     try {
       const insert = db.prepare(
-        "INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO chunks (id, agent_id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      );
+      const insertFts = db.prepare(
+        "INSERT INTO chunks_fts (text, id, agent_id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
       );
       for (const row of params.rows) {
-        insert.run(row.text, row.id, row.path, "memory", "mock-embed", 1, 1);
+        insert.run(
+          row.id,
+          "main",
+          row.path,
+          "memory",
+          1,
+          1,
+          row.id,
+          "mock-embed",
+          row.text,
+          "[]",
+          1,
+        );
+        insertFts.run(row.text, row.id, "main", row.path, "memory", "mock-embed", 1, 1);
       }
       return await searchKeyword({
         db,
@@ -68,7 +86,7 @@ describe("searchKeyword trigram fallback", () => {
         ftsTokenizer: "trigram",
         limit: 10,
         snippetMaxChars: 200,
-        sourceFilter: { sql: "", params: [] },
+        sourceFilter: { sql: " AND c.agent_id = ?", params: ["main"] },
         buildFtsQuery,
         bm25RankToScore,
         boostFallbackRanking: params.boostFallbackRanking,
@@ -182,105 +200,84 @@ describe("searchKeyword trigram fallback", () => {
 describe("searchVector sqlite-vec KNN", () => {
   const { DatabaseSync } = requireNodeSqlite();
 
-  it("streams fallback chunk scoring without materializing candidates", async () => {
-    type ChunkRow = {
-      id: string;
-      path: string;
-      start_line: number;
-      end_line: number;
-      text: string;
-      embedding: string;
-      source: string;
-    };
-    type StatementWithAll = {
-      all: (...params: unknown[]) => ChunkRow[];
-    };
-
+  it("keeps keyword search results scoped to the requested agent in a shared database", async () => {
     const db = new DatabaseSync(":memory:");
     try {
-      ensureMemoryIndexSchema({
+      const result = ensureMemoryIndexSchema({
         db,
+        agentId: "agent-a",
         embeddingCacheTable: "embedding_cache",
         cacheEnabled: false,
         ftsTable: "chunks_fts",
-        ftsEnabled: false,
+        ftsEnabled: true,
       });
+      expect(result.ftsAvailable, result.ftsError).toBe(true);
 
       const insertChunk = db.prepare(
-        "INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO chunks (id, agent_id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       );
-      const addChunk = (params: { id: string; model: string; vector: [number, number] }) => {
+      const insertFts = db.prepare(
+        "INSERT INTO chunks_fts (text, id, agent_id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      );
+      const addChunk = (params: { id: string; agentId: string; text: string }) => {
         insertChunk.run(
           params.id,
+          params.agentId,
           `memory/${params.id}.md`,
           "memory",
           1,
           1,
           params.id,
-          params.model,
-          `chunk ${params.id}`,
-          JSON.stringify(params.vector),
+          "mock-embed",
+          params.text,
+          "[]",
+          1,
+        );
+        insertFts.run(
+          params.text,
+          params.id,
+          params.agentId,
+          `memory/${params.id}.md`,
+          "memory",
+          "mock-embed",
+          1,
           1,
         );
       };
-      addChunk({ id: "target-1", model: "target-model", vector: [1, 0] });
-      addChunk({ id: "target-2", model: "target-model", vector: [0.8, 0.2] });
-      addChunk({ id: "target-3", model: "target-model", vector: [0, 1] });
-      addChunk({ id: "other-1", model: "other-model", vector: [1, 0] });
+      addChunk({
+        id: "agent-a-visible",
+        agentId: "agent-a",
+        text: "shared database scoped memory",
+      });
+      addChunk({ id: "agent-b-hidden", agentId: "agent-b", text: "shared database scoped memory" });
 
-      const prepareTarget = db as unknown as { prepare: (sql: string) => unknown };
-      const originalPrepare = prepareTarget.prepare.bind(db);
-      const chunkRows = (
-        originalPrepare(
-          "SELECT id, path, start_line, end_line, text, embedding, source\n" +
-            "  FROM chunks\n" +
-            " WHERE model = ?",
-        ) as StatementWithAll
-      ).all("target-model");
-      const prepareSpy = vi.spyOn(prepareTarget, "prepare").mockImplementation((sql: string) => {
-        if (
-          sql.includes("SELECT id, path, start_line, end_line, text, embedding, source") &&
-          sql.includes("FROM chunks")
-        ) {
-          return {
-            all: () => {
-              throw new Error("fallback vector search must stream rows via iterate()");
-            },
-            iterate: () => chunkRows[Symbol.iterator](),
-          };
-        }
-        return originalPrepare(sql);
+      const results = await searchKeyword({
+        db,
+        ftsTable: "chunks_fts",
+        providerModel: "mock-embed",
+        query: "shared database scoped memory",
+        ftsTokenizer: "unicode61",
+        limit: 10,
+        snippetMaxChars: 200,
+        sourceFilter: { sql: " AND c.agent_id = ?", params: ["agent-a"] },
+        buildFtsQuery,
+        bm25RankToScore,
       });
 
-      try {
-        const results = await searchVector({
-          db,
-          vectorTable: "chunks_vec",
-          providerModel: "target-model",
-          queryVec: [1, 0],
-          limit: 2,
-          snippetMaxChars: 200,
-          ensureVectorReady: async () => false,
-          sourceFilterVec: { sql: "", params: [] },
-          sourceFilterChunks: { sql: "", params: [] },
-        });
-
-        expect(results.map((row) => row.id)).toEqual(["target-1", "target-2"]);
-      } finally {
-        prepareSpy.mockRestore();
-      }
+      expect(results.map((row) => row.id)).toEqual(["agent-a-visible"]);
     } finally {
       db.close();
     }
   });
 
-  it("fills the requested limit after model filters prune nearest KNN candidates", async () => {
+  it("keeps vector search results scoped to the requested agent in a shared database", async () => {
     const db = new DatabaseSync(":memory:", { allowExtension: true });
     try {
       const loaded = await loadSqliteVecExtension({ db });
       expect(loaded.ok, loaded.error).toBe(true);
       ensureMemoryIndexSchema({
         db,
+        agentId: "agent-a",
         embeddingCacheTable: "embedding_cache",
         cacheEnabled: false,
         ftsTable: "chunks_fts",
@@ -294,12 +291,74 @@ describe("searchVector sqlite-vec KNN", () => {
       `);
 
       const insertChunk = db.prepare(
-        "INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO chunks (id, agent_id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+      );
+      const insertVector = db.prepare("INSERT INTO chunks_vec (id, embedding) VALUES (?, ?)");
+      const addChunk = (params: { id: string; agentId: string; vector: [number, number] }) => {
+        insertChunk.run(
+          params.id,
+          params.agentId,
+          `memory/${params.id}.md`,
+          "memory",
+          1,
+          1,
+          params.id,
+          "target-model",
+          `chunk ${params.id}`,
+          JSON.stringify(params.vector),
+          1,
+        );
+        insertVector.run(params.id, vectorToBlob(params.vector));
+      };
+      addChunk({ id: "agent-a-visible", agentId: "agent-a", vector: [1, 0] });
+      addChunk({ id: "agent-b-hidden", agentId: "agent-b", vector: [1, 0.001] });
+
+      const results = await searchVector({
+        db,
+        vectorTable: "chunks_vec",
+        providerModel: "target-model",
+        queryVec: [1, 0],
+        limit: 10,
+        snippetMaxChars: 200,
+        ensureVectorReady: async () => true,
+        sourceFilterVec: { sql: " AND c.agent_id = ?", params: ["agent-a"] },
+        sourceFilterChunks: { sql: " AND c.agent_id = ?", params: ["agent-a"] },
+      });
+
+      expect(results.map((row) => row.id)).toEqual(["agent-a-visible"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("fills the requested limit after model filters prune nearest KNN candidates", async () => {
+    const db = new DatabaseSync(":memory:", { allowExtension: true });
+    try {
+      const loaded = await loadSqliteVecExtension({ db });
+      expect(loaded.ok, loaded.error).toBe(true);
+      ensureMemoryIndexSchema({
+        db,
+        agentId: "main",
+        embeddingCacheTable: "embedding_cache",
+        cacheEnabled: false,
+        ftsTable: "chunks_fts",
+        ftsEnabled: false,
+      });
+      db.exec(`
+        CREATE VIRTUAL TABLE chunks_vec USING vec0(
+          id TEXT PRIMARY KEY,
+          embedding FLOAT[2]
+        );
+      `);
+
+      const insertChunk = db.prepare(
+        "INSERT INTO chunks (id, agent_id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
       );
       const insertVector = db.prepare("INSERT INTO chunks_vec (id, embedding) VALUES (?, ?)");
       const addChunk = (params: { id: string; model: string; vector: [number, number] }) => {
         insertChunk.run(
           params.id,
+          "main",
           `memory/${params.id}.md`,
           "memory",
           1,
@@ -327,8 +386,8 @@ describe("searchVector sqlite-vec KNN", () => {
         limit: 2,
         snippetMaxChars: 200,
         ensureVectorReady: async () => true,
-        sourceFilterVec: { sql: "", params: [] },
-        sourceFilterChunks: { sql: "", params: [] },
+        sourceFilterVec: { sql: " AND c.agent_id = ?", params: ["main"] },
+        sourceFilterChunks: { sql: " AND c.agent_id = ?", params: ["main"] },
       });
 
       expect(results.map((row) => row.id)).toEqual(["target-1", "target-2"]);

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -126,8 +126,8 @@ export async function searchVector(params: {
   limit: number;
   snippetMaxChars: number;
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
-  sourceFilterVec: { sql: string; params: SearchSource[] };
-  sourceFilterChunks: { sql: string; params: SearchSource[] };
+  sourceFilterVec: { sql: string; params: Array<string | SearchSource> };
+  sourceFilterChunks: { sql: string; params: Array<string | SearchSource> };
 }): Promise<SearchRowResult[]> {
   if (params.queryVec.length === 0 || params.limit <= 0) {
     return [];
@@ -176,17 +176,19 @@ export async function searchVector(params: {
       const matchingChunkCount = readCount(
         params.db
           .prepare(
-            `SELECT COUNT(*) AS count FROM chunks c WHERE c.model = ?${params.sourceFilterVec.sql}`,
+            `SELECT COUNT(*) AS count FROM chunks c WHERE c.model = ?${params.sourceFilterChunks.sql}`,
           )
-          .get(params.providerModel, ...params.sourceFilterVec.params) as
+          .get(params.providerModel, ...params.sourceFilterChunks.params) as
           | { count?: number | bigint }
           | undefined,
       );
       if (matchingChunkCount > rows.length) {
         const vectorCount = readCount(
-          params.db.prepare(`SELECT COUNT(*) AS count FROM ${params.vectorTable}`).get() as
-            | { count?: number | bigint }
-            | undefined,
+          params.db
+            .prepare(
+              `SELECT COUNT(*) AS count FROM ${params.vectorTable} v JOIN chunks c ON c.id = v.id WHERE 1=1${params.sourceFilterVec.sql}`,
+            )
+            .get(...params.sourceFilterVec.params) as { count?: number | bigint } | undefined,
         );
         if (vectorCount > candidateLimit) {
           rows = runVectorQuery(vectorCount);
@@ -205,34 +207,51 @@ export async function searchVector(params: {
     }));
   }
 
-  return searchChunksByEmbedding({
+  const candidates = listChunks({
     db: params.db,
     providerModel: params.providerModel,
     sourceFilter: params.sourceFilterChunks,
-    queryVec: params.queryVec,
-    limit: params.limit,
-    snippetMaxChars: params.snippetMaxChars,
   });
+  const scored = candidates
+    .map((chunk) => ({
+      chunk,
+      score: cosineSimilarity(params.queryVec, chunk.embedding),
+    }))
+    .filter((entry) => Number.isFinite(entry.score));
+  return scored
+    .toSorted((a, b) => b.score - a.score)
+    .slice(0, params.limit)
+    .map((entry) => ({
+      id: entry.chunk.id,
+      path: entry.chunk.path,
+      startLine: entry.chunk.startLine,
+      endLine: entry.chunk.endLine,
+      score: entry.score,
+      snippet: truncateUtf16Safe(entry.chunk.text, params.snippetMaxChars),
+      source: entry.chunk.source,
+    }));
 }
 
-export function searchChunksByEmbedding(params: {
+export function listChunks(params: {
   db: DatabaseSync;
   providerModel: string;
-  sourceFilter: { sql: string; params: SearchSource[] };
-  queryVec: number[];
-  limit: number;
-  snippetMaxChars: number;
-}): SearchRowResult[] {
-  if (params.limit <= 0) {
-    return [];
-  }
+  sourceFilter: { sql: string; params: Array<string | SearchSource> };
+}): Array<{
+  id: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  text: string;
+  embedding: number[];
+  source: SearchSource;
+}> {
   const rows = params.db
     .prepare(
       `SELECT id, path, start_line, end_line, text, embedding, source\n` +
         `  FROM chunks\n` +
         ` WHERE model = ?${params.sourceFilter.sql}`,
     )
-    .iterate(params.providerModel, ...params.sourceFilter.params) as IterableIterator<{
+    .all(params.providerModel, ...params.sourceFilter.params) as Array<{
     id: string;
     path: string;
     start_line: number;
@@ -242,36 +261,15 @@ export function searchChunksByEmbedding(params: {
     source: SearchSource;
   }>;
 
-  const topResults: SearchRowResult[] = [];
-  for (const row of rows) {
-    const score = cosineSimilarity(params.queryVec, parseEmbedding(row.embedding));
-    if (!Number.isFinite(score)) {
-      continue;
-    }
-    const result: SearchRowResult = {
-      id: row.id,
-      path: row.path,
-      startLine: row.start_line,
-      endLine: row.end_line,
-      score,
-      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
-      source: row.source,
-    };
-    if (topResults.length < params.limit) {
-      topResults.push(result);
-      if (topResults.length === params.limit) {
-        topResults.sort((a, b) => b.score - a.score);
-      }
-      continue;
-    }
-    const lowest = topResults.at(-1);
-    if (lowest && result.score > lowest.score) {
-      topResults[topResults.length - 1] = result;
-      topResults.sort((a, b) => b.score - a.score);
-    }
-  }
-  topResults.sort((a, b) => b.score - a.score);
-  return topResults;
+  return rows.map((row) => ({
+    id: row.id,
+    path: row.path,
+    startLine: row.start_line,
+    endLine: row.end_line,
+    text: row.text,
+    embedding: parseEmbedding(row.embedding),
+    source: row.source,
+  }));
 }
 
 export async function searchKeyword(params: {
@@ -282,7 +280,7 @@ export async function searchKeyword(params: {
   ftsTokenizer?: "unicode61" | "trigram";
   limit: number;
   snippetMaxChars: number;
-  sourceFilter: { sql: string; params: SearchSource[] };
+  sourceFilter: { sql: string; params: Array<string | SearchSource> };
   buildFtsQuery: (raw: string) => string | null;
   bm25RankToScore: (rank: number) => number;
   boostFallbackRanking?: boolean;
@@ -300,9 +298,11 @@ export async function searchKeyword(params: {
   }
 
   // When providerModel is undefined (FTS-only mode), search all models
-  const modelClause = params.providerModel ? " AND model = ?" : "";
+  const modelClause = params.providerModel ? ` AND ${params.ftsTable}.model = ?` : "";
   const modelParams = params.providerModel ? [params.providerModel] : [];
-  const substringClause = plan.substringTerms.map(() => " AND text LIKE ? ESCAPE '\\'").join("");
+  const substringClause = plan.substringTerms
+    .map(() => ` AND ${params.ftsTable}.text LIKE ? ESCAPE '\\'`)
+    .join("");
   const substringParams = plan.substringTerms.map((term) => `%${escapeLikePattern(term)}%`);
   const whereClause = plan.matchQuery
     ? `${params.ftsTable} MATCH ?${substringClause}${modelClause}${params.sourceFilter.sql}`
@@ -318,9 +318,10 @@ export async function searchKeyword(params: {
 
   const rows = params.db
     .prepare(
-      `SELECT id, path, source, start_line, end_line, text,\n` +
+      `SELECT ${params.ftsTable}.id, ${params.ftsTable}.path, ${params.ftsTable}.source, ${params.ftsTable}.start_line, ${params.ftsTable}.end_line, ${params.ftsTable}.text,\n` +
         `       ${rankExpression} AS rank\n` +
         `  FROM ${params.ftsTable}\n` +
+        `  JOIN chunks c ON c.id = ${params.ftsTable}.id\n` +
         ` WHERE ${whereClause}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,

--- a/extensions/memory-core/src/memory/manager-source-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.test.ts
@@ -22,10 +22,11 @@ describe("memory source state", () => {
           get: () => undefined,
         }),
       },
+      agentId: "main",
       source: "memory",
     });
 
-    expect(calls).toEqual([{ sql: MEMORY_SOURCE_FILE_STATE_SQL, args: ["memory"] }]);
+    expect(calls).toEqual([{ sql: MEMORY_SOURCE_FILE_STATE_SQL, args: ["main", "memory"] }]);
     expect(state.rows).toEqual([
       { path: "memory/one.md", hash: "hash-1" },
       { path: "memory/two.md", hash: "hash-2" },
@@ -50,6 +51,7 @@ describe("memory source state", () => {
           },
         }),
       },
+      agentId: "main",
       source: "sessions",
       path: "sessions/thread.jsonl",
       existingHashes: new Map([["sessions/thread.jsonl", "hash-from-snapshot"]]),
@@ -71,6 +73,7 @@ describe("memory source state", () => {
           },
         }),
       },
+      agentId: "main",
       source: "sessions",
       path: "sessions/thread.jsonl",
       existingHashes: null,
@@ -80,7 +83,7 @@ describe("memory source state", () => {
     expect(calls).toEqual([
       {
         sql: MEMORY_SOURCE_FILE_HASH_SQL,
-        args: ["sessions/thread.jsonl", "sessions"],
+        args: ["main", "sessions/thread.jsonl", "sessions"],
       },
     ]);
   });

--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -13,19 +13,20 @@ type MemorySourceStateDb = {
   };
 };
 
-export const MEMORY_SOURCE_FILE_STATE_SQL = `SELECT path, hash FROM files WHERE source = ?`;
-export const MEMORY_SOURCE_FILE_HASH_SQL = `SELECT hash FROM files WHERE path = ? AND source = ?`;
+export const MEMORY_SOURCE_FILE_STATE_SQL = `SELECT path, hash FROM files WHERE agent_id = ? AND source = ?`;
+export const MEMORY_SOURCE_FILE_HASH_SQL = `SELECT hash FROM files WHERE agent_id = ? AND path = ? AND source = ?`;
 
 export function loadMemorySourceFileState(params: {
   db: MemorySourceStateDb;
+  agentId: string;
   source: MemorySource;
 }): {
   rows: MemorySourceFileStateRow[];
   hashes: Map<string, string>;
 } {
-  const rows = params.db.prepare(MEMORY_SOURCE_FILE_STATE_SQL).all(params.source) as
-    | MemorySourceFileStateRow[]
-    | undefined;
+  const rows = params.db
+    .prepare(MEMORY_SOURCE_FILE_STATE_SQL)
+    .all(params.agentId, params.source) as MemorySourceFileStateRow[] | undefined;
   const normalizedRows = rows ?? [];
   return {
     rows: normalizedRows,
@@ -35,6 +36,7 @@ export function loadMemorySourceFileState(params: {
 
 export function resolveMemorySourceExistingHash(params: {
   db: MemorySourceStateDb;
+  agentId: string;
   source: MemorySource;
   path: string;
   existingHashes?: Map<string, string> | null;
@@ -43,8 +45,8 @@ export function resolveMemorySourceExistingHash(params: {
     return params.existingHashes.get(params.path);
   }
   return (
-    params.db.prepare(MEMORY_SOURCE_FILE_HASH_SQL).get(params.path, params.source) as
-      | { hash: string }
-      | undefined
+    params.db
+      .prepare(MEMORY_SOURCE_FILE_HASH_SQL)
+      .get(params.agentId, params.path, params.source) as { hash: string } | undefined
   )?.hash;
 }

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -66,7 +66,7 @@ export function collectMemoryStatusAggregate(params: {
   db: StatusAggregateDb;
   sources: Iterable<MemorySource>;
   sourceFilterSql?: string;
-  sourceFilterParams?: MemorySource[];
+  sourceFilterParams?: Array<string | MemorySource>;
 }): {
   files: number;
   chunks: number;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -293,14 +293,13 @@ export abstract class MemoryManagerSyncOps {
   protected buildSourceFilter(
     alias?: string,
     sourcesOverride?: MemorySource[],
-  ): { sql: string; params: MemorySource[] } {
+  ): { sql: string; params: Array<string | MemorySource> } {
     const sources = sourcesOverride ?? Array.from(this.sources);
-    if (sources.length === 0) {
-      return { sql: "", params: [] };
-    }
-    const column = alias ? `${alias}.source` : "source";
-    const placeholders = sources.map(() => "?").join(", ");
-    return { sql: ` AND ${column} IN (${placeholders})`, params: sources };
+    const agentColumn = alias ? `${alias}.agent_id` : "agent_id";
+    const sourceColumn = alias ? `${alias}.source` : "source";
+    const sourceSql =
+      sources.length > 0 ? ` AND ${sourceColumn} IN (${sources.map(() => "?").join(", ")})` : "";
+    return { sql: ` AND ${agentColumn} = ?${sourceSql}`, params: [this.agentId, ...sources] };
   }
 
   protected openDatabase(): DatabaseSync {
@@ -308,17 +307,16 @@ export abstract class MemoryManagerSyncOps {
     return openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
   }
 
-  private async seedEmbeddingCache(sourceDb: DatabaseSync): Promise<void> {
+  private seedEmbeddingCache(sourceDb: DatabaseSync): void {
     if (!this.cache.enabled) {
       return;
     }
-    let transactionStarted = false;
     try {
       const rows = sourceDb
         .prepare(
           `SELECT provider, model, provider_key, hash, embedding, dims, updated_at FROM ${EMBEDDING_CACHE_TABLE}`,
         )
-        .iterate() as IterableIterator<{
+        .all() as Array<{
         provider: string;
         model: string;
         provider_key: string;
@@ -327,23 +325,19 @@ export abstract class MemoryManagerSyncOps {
         dims: number | null;
         updated_at: number;
       }>;
-      // Keep gateway health probes responsive while rebuilding large caches.
-      const SEED_EMBEDDING_YIELD_EVERY = 1000;
-      let rowCount = 0;
-      let insert: ReturnType<DatabaseSync["prepare"]> | null = null;
+      if (!rows.length) {
+        return;
+      }
+      const insert = this.db.prepare(
+        `INSERT INTO ${EMBEDDING_CACHE_TABLE} (provider, model, provider_key, hash, embedding, dims, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(provider, model, provider_key, hash) DO UPDATE SET
+           embedding=excluded.embedding,
+           dims=excluded.dims,
+           updated_at=excluded.updated_at`,
+      );
+      this.db.exec("BEGIN");
       for (const row of rows) {
-        if (!insert) {
-          insert = this.db.prepare(
-            `INSERT INTO ${EMBEDDING_CACHE_TABLE} (provider, model, provider_key, hash, embedding, dims, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(provider, model, provider_key, hash) DO UPDATE SET
-               embedding=excluded.embedding,
-               dims=excluded.dims,
-               updated_at=excluded.updated_at`,
-          );
-          this.db.exec("BEGIN");
-          transactionStarted = true;
-        }
         insert.run(
           row.provider,
           row.model,
@@ -353,22 +347,12 @@ export abstract class MemoryManagerSyncOps {
           row.dims,
           row.updated_at,
         );
-        rowCount += 1;
-        if (rowCount % SEED_EMBEDDING_YIELD_EVERY === 0) {
-          await new Promise<void>((resolve) => {
-            setImmediate(resolve);
-          });
-        }
       }
-      if (transactionStarted) {
-        this.db.exec("COMMIT");
-      }
+      this.db.exec("COMMIT");
     } catch (err) {
-      if (transactionStarted) {
-        try {
-          this.db.exec("ROLLBACK");
-        } catch {}
-      }
+      try {
+        this.db.exec("ROLLBACK");
+      } catch {}
       throw err;
     }
   }
@@ -376,6 +360,7 @@ export abstract class MemoryManagerSyncOps {
   protected ensureSchema() {
     const result = ensureMemoryIndexSchema({
       db: this.db,
+      agentId: this.agentId,
       embeddingCacheTable: EMBEDDING_CACHE_TABLE,
       cacheEnabled: this.cache.enabled,
       ftsTable: FTS_TABLE,
@@ -683,20 +668,20 @@ export abstract class MemoryManagerSyncOps {
     progress?: MemorySyncProgressState;
   }) {
     const deleteFileByPathAndSource = this.db.prepare(
-      `DELETE FROM files WHERE path = ? AND source = ?`,
+      `DELETE FROM files WHERE agent_id = ? AND path = ? AND source = ?`,
     );
     const deleteChunksByPathAndSource = this.db.prepare(
-      `DELETE FROM chunks WHERE path = ? AND source = ?`,
+      `DELETE FROM chunks WHERE agent_id = ? AND path = ? AND source = ?`,
     );
     const deleteVectorRowsByPathAndSource =
       this.vector.enabled && this.vector.available
         ? this.db.prepare(
-            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
+            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE agent_id = ? AND path = ? AND source = ?)`,
           )
         : null;
     const deleteFtsRowsByPathAndSource =
       this.fts.enabled && this.fts.available
-        ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
+        ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE agent_id = ? AND path = ? AND source = ?`)
         : null;
 
     const files = await listMemoryFiles(
@@ -721,6 +706,7 @@ export abstract class MemoryManagerSyncOps {
     });
     const existingState = loadMemorySourceFileState({
       db: this.db,
+      agentId: this.agentId,
       source: "memory",
     });
     const existingRows = existingState.rows;
@@ -761,16 +747,16 @@ export abstract class MemoryManagerSyncOps {
       if (activePaths.has(stale.path)) {
         continue;
       }
-      deleteFileByPathAndSource.run(stale.path, "memory");
+      deleteFileByPathAndSource.run(this.agentId, stale.path, "memory");
       if (deleteVectorRowsByPathAndSource) {
         try {
-          deleteVectorRowsByPathAndSource.run(stale.path, "memory");
+          deleteVectorRowsByPathAndSource.run(this.agentId, stale.path, "memory");
         } catch {}
       }
-      deleteChunksByPathAndSource.run(stale.path, "memory");
+      deleteChunksByPathAndSource.run(this.agentId, stale.path, "memory");
       if (deleteFtsRowsByPathAndSource) {
         try {
-          deleteFtsRowsByPathAndSource.run(stale.path, "memory");
+          deleteFtsRowsByPathAndSource.run(this.agentId, stale.path, "memory");
         } catch {}
       }
     }
@@ -782,20 +768,22 @@ export abstract class MemoryManagerSyncOps {
     progress?: MemorySyncProgressState;
   }) {
     const deleteFileByPathAndSource = this.db.prepare(
-      `DELETE FROM files WHERE path = ? AND source = ?`,
+      `DELETE FROM files WHERE agent_id = ? AND path = ? AND source = ?`,
     );
     const deleteChunksByPathAndSource = this.db.prepare(
-      `DELETE FROM chunks WHERE path = ? AND source = ?`,
+      `DELETE FROM chunks WHERE agent_id = ? AND path = ? AND source = ?`,
     );
     const deleteVectorRowsByPathAndSource =
       this.vector.enabled && this.vector.available
         ? this.db.prepare(
-            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
+            `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE agent_id = ? AND path = ? AND source = ?)`,
           )
         : null;
     const deleteFtsRowsByPathSourceAndModel =
       this.fts.enabled && this.fts.available
-        ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
+        ? this.db.prepare(
+            `DELETE FROM ${FTS_TABLE} WHERE agent_id = ? AND path = ? AND source = ? AND model = ?`,
+          )
         : null;
 
     const targetSessionFiles = params.needsFullReindex
@@ -813,6 +801,7 @@ export abstract class MemoryManagerSyncOps {
         ? null
         : loadMemorySourceFileState({
             db: this.db,
+            agentId: this.agentId,
             source: "sessions",
           }).rows,
       sessionPathForFile,
@@ -859,6 +848,7 @@ export abstract class MemoryManagerSyncOps {
       }
       const existingHash = resolveMemorySourceExistingHash({
         db: this.db,
+        agentId: this.agentId,
         source: "sessions",
         path: entry.path,
         existingHashes,
@@ -896,16 +886,17 @@ export abstract class MemoryManagerSyncOps {
       if (activePaths.has(stale.path)) {
         continue;
       }
-      deleteFileByPathAndSource.run(stale.path, "sessions");
+      deleteFileByPathAndSource.run(this.agentId, stale.path, "sessions");
       if (deleteVectorRowsByPathAndSource) {
         try {
-          deleteVectorRowsByPathAndSource.run(stale.path, "sessions");
+          deleteVectorRowsByPathAndSource.run(this.agentId, stale.path, "sessions");
         } catch {}
       }
-      deleteChunksByPathAndSource.run(stale.path, "sessions");
+      deleteChunksByPathAndSource.run(this.agentId, stale.path, "sessions");
       if (deleteFtsRowsByPathSourceAndModel) {
         try {
           deleteFtsRowsByPathSourceAndModel.run(
+            this.agentId,
             stale.path,
             "sessions",
             this.provider?.model ?? "fts-only",
@@ -1182,7 +1173,7 @@ export abstract class MemoryManagerSyncOps {
         targetPath: dbPath,
         tempPath: tempDbPath,
         build: async () => {
-          await this.seedEmbeddingCache(originalDb);
+          this.seedEmbeddingCache(originalDb);
           const shouldSyncMemory = this.sources.has("memory");
           const shouldSyncSessions = this.shouldSyncSessions(
             { reason: params.reason, force: params.force },
@@ -1307,8 +1298,8 @@ export abstract class MemoryManagerSyncOps {
   }
 
   private resetIndex() {
-    this.db.exec(`DELETE FROM files`);
-    this.db.exec(`DELETE FROM chunks`);
+    this.db.prepare(`DELETE FROM files WHERE agent_id = ?`).run(this.agentId);
+    this.db.prepare(`DELETE FROM chunks WHERE agent_id = ?`).run(this.agentId);
     if (this.fts.enabled && this.fts.available) {
       try {
         this.db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -487,7 +487,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private hasIndexedContent(): boolean {
-    const chunkRow = this.db.prepare(`SELECT 1 as found FROM chunks LIMIT 1`).get() as
+    const chunkRow = this.db
+      .prepare(`SELECT 1 as found FROM chunks WHERE agent_id = ? LIMIT 1`)
+      .get(this.agentId) as
       | {
           found?: number;
         }
@@ -498,7 +500,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (!this.fts.enabled || !this.fts.available) {
       return false;
     }
-    const ftsRow = this.db.prepare(`SELECT 1 as found FROM ${FTS_TABLE} LIMIT 1`).get() as
+    const ftsRow = this.db
+      .prepare(`SELECT 1 as found FROM ${FTS_TABLE} WHERE agent_id = ? LIMIT 1`)
+      .get(this.agentId) as
       | {
           found?: number;
         }
@@ -542,7 +546,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (!this.fts.enabled || !this.fts.available) {
       return [];
     }
-    const sourceFilter = this.buildSourceFilter(undefined, sourceFilterList);
+    const sourceFilter = this.buildSourceFilter("c", sourceFilterList);
     // In FTS-only mode (no provider), search all models; otherwise filter by current provider's model
     const providerModel = this.provider?.model;
     const results = await searchKeyword({

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3286,6 +3286,119 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("scopes mcporter daemon state and calls per agent", async () => {
+    const mainWorkspaceDir = path.join(tmpRoot, "main-workspace");
+    const devWorkspaceDir = path.join(tmpRoot, "dev-workspace");
+    await fs.mkdir(mainWorkspaceDir, { recursive: true });
+    await fs.mkdir(devWorkspaceDir, { recursive: true });
+
+    const createCfgForAgent = (id: string, agentWorkspaceDir: string) =>
+      ({
+        agents: {
+          defaults: {
+            workspace: agentWorkspaceDir,
+            memorySearch: {
+              provider: "openai",
+              model: "mock-embed",
+              store: {
+                path: path.join(agentWorkspaceDir, "index.sqlite"),
+                vector: { enabled: false },
+              },
+              sync: { watch: false, onSessionStart: false, onSearch: false },
+            },
+          },
+          list: [{ id, default: id === "main", workspace: agentWorkspaceDir }],
+        },
+        memory: {
+          backend: "qmd",
+          qmd: {
+            includeDefaultMemory: false,
+            searchMode: "query",
+            update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+            paths: [{ path: agentWorkspaceDir, pattern: "**/*.md", name: "memory-dir" }],
+            mcporter: { enabled: true, serverName: "qmd", startDaemon: true },
+          },
+        },
+      }) as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "daemon") {
+        emitAndClose(child, "stdout", "");
+        return child;
+      }
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const mainCfg = createCfgForAgent("main", mainWorkspaceDir);
+    const mainResolved = resolveMemoryBackendConfig({ cfg: mainCfg, agentId: "main" });
+    const mainManager = trackManager(
+      await QmdMemoryManager.create({
+        cfg: mainCfg,
+        agentId: "main",
+        resolved: mainResolved,
+        mode: "status",
+      }),
+    );
+    expect(mainManager).toBeTruthy();
+    if (!mainManager) {
+      throw new Error("main manager missing");
+    }
+
+    await mainManager.search("hello main", { sessionKey: "agent:main:slack:dm:u123" });
+
+    const devCfg = createCfgForAgent("dev", devWorkspaceDir);
+    const devResolved = resolveMemoryBackendConfig({ cfg: devCfg, agentId: "dev" });
+    const devManager = trackManager(
+      await QmdMemoryManager.create({
+        cfg: devCfg,
+        agentId: "dev",
+        resolved: devResolved,
+        mode: "status",
+      }),
+    );
+    expect(devManager).toBeTruthy();
+    if (!devManager) {
+      throw new Error("dev manager missing");
+    }
+
+    await devManager.search("hello dev", { sessionKey: "agent:dev:slack:dm:u456" });
+
+    const mcporterCalls = spawnMock.mock.calls.filter((call: unknown[]) =>
+      isMcporterCommand(call[0]),
+    );
+    const daemonStarts = mcporterCalls.filter(
+      (call: unknown[]) => (call[1] as string[])[0] === "daemon",
+    );
+    expect(daemonStarts).toHaveLength(2);
+
+    const normalizePath = (value?: string) => value?.replace(/\\/g, "/");
+    const mainDaemonEnv = daemonStarts[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    const devDaemonEnv = daemonStarts[1]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(normalizePath(mainDaemonEnv?.env?.XDG_CACHE_HOME)).toContain(
+      "/agents/main/qmd/xdg-cache",
+    );
+    expect(normalizePath(devDaemonEnv?.env?.XDG_CACHE_HOME)).toContain("/agents/dev/qmd/xdg-cache");
+
+    const devCall = mcporterCalls.find((call: unknown[]) => {
+      const args = call[1] as string[];
+      if (args[0] !== "call") {
+        return false;
+      }
+      const callArgs = JSON.parse(args[args.indexOf("--args") + 1]);
+      return Array.isArray(callArgs.collections) && callArgs.collections.includes("memory-dir-dev");
+    });
+    expect(devCall).toBeDefined();
+    const devCallEnv = devCall?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(normalizePath(devCallEnv?.env?.XDG_CACHE_HOME)).toContain("/agents/dev/qmd/xdg-cache");
+    expect(normalizePath(devCallEnv?.env?.XDG_CONFIG_HOME)).toContain("/agents/dev/qmd/xdg-config");
+  });
+
   it("fails closed when no managed collections are configured", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -116,6 +116,10 @@ type McporterState = {
   daemonStart: Promise<void> | null;
 };
 
+type McporterStateRegistry = {
+  states: Map<string, McporterState>;
+};
+
 type QmdEmbedQueueState = {
   tail: Promise<void>;
 };
@@ -124,11 +128,20 @@ type QmdUpdateQueueState = {
   tails: Map<string, Promise<void>>;
 };
 
-function getMcporterState(): McporterState {
-  return resolveGlobalSingleton<McporterState>(MCPORTER_STATE_KEY, () => ({
+function getMcporterState(scopeKey: string): McporterState {
+  const registry = resolveGlobalSingleton<McporterStateRegistry>(MCPORTER_STATE_KEY, () => ({
+    states: new Map(),
+  }));
+  const existing = registry.states.get(scopeKey);
+  if (existing) {
+    return existing;
+  }
+  const created: McporterState = {
     coldStartWarned: false,
     daemonStart: null,
-  }));
+  };
+  registry.states.set(scopeKey, created);
+  return created;
 }
 
 function getQmdEmbedQueueState(): QmdEmbedQueueState {
@@ -1921,7 +1934,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!mcporter.enabled) {
       return;
     }
-    const state = getMcporterState();
+    const state = getMcporterState(this.qmdDir);
     if (!mcporter.startDaemon) {
       if (!state.coldStartWarned) {
         state.coldStartWarned = true;

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  getMemorySearchManagerMockAgentIds,
   getMemorySearchManagerMockConfigs,
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
+  setMemorySearchImplForAgent,
 } from "./memory-tool-manager-mock.js";
 import { createMemorySearchTool } from "./tools.js";
 import {
@@ -42,6 +44,126 @@ describe("memory_search unavailable payloads", () => {
       error: "embedding provider timeout",
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
+    });
+  });
+
+  it("adds provenance fields while preserving existing result fields", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "memory/2026-04-28/2026-04-28.md",
+        startLine: 3,
+        endLine: 7,
+        score: 0.88,
+        snippet: "vector memory",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "backend", default: true }] },
+      }),
+      agentSessionKey: "agent:backend:main:memory:provenance",
+    });
+    const result = await tool.execute("provenance", { query: "vector memory" });
+
+    expect(result.details).toMatchObject({
+      results: [
+        {
+          path: "memory/2026-04-28/2026-04-28.md",
+          startLine: 3,
+          endLine: 7,
+          agent_id: "backend",
+          source_path: "memory/2026-04-28/2026-04-28.md",
+          start_line: 3,
+          end_line: 7,
+          corpus: "memory",
+        },
+      ],
+    });
+  });
+
+  it("scopes normal agents to their own memory", async () => {
+    setMemorySearchImplForAgent("backend", async () => [
+      {
+        path: "backend/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.5,
+        snippet: "backend only",
+        source: "memory",
+      },
+    ]);
+    setMemorySearchImplForAgent("chief", async () => [
+      {
+        path: "chief/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.99,
+        snippet: "chief secret",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "backend", default: true }, { id: "chief" }] },
+      }),
+      agentSessionKey: "agent:backend:main:memory:scope",
+    });
+    const result = await tool.execute("scope", {
+      query: "secret",
+      agent_id: "chief",
+      maxResults: 10,
+    });
+
+    expect(getMemorySearchManagerMockAgentIds()).toEqual(["backend"]);
+    expect(result.details).toMatchObject({
+      results: [
+        {
+          path: "backend/MEMORY.md",
+          agent_id: "backend",
+        },
+      ],
+    });
+  });
+
+  it("allows chief to search across configured agents by default", async () => {
+    setMemorySearchImplForAgent("backend", async () => [
+      {
+        path: "backend/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.6,
+        snippet: "backend note",
+        source: "memory",
+      },
+    ]);
+    setMemorySearchImplForAgent("chief", async () => [
+      {
+        path: "chief/MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.9,
+        snippet: "chief note",
+        source: "memory",
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: { list: [{ id: "chief", default: true }, { id: "backend" }] },
+      }),
+      agentSessionKey: "agent:chief:main:memory:scope",
+    });
+    const result = await tool.execute("chief-scope", { query: "note", maxResults: 10 });
+
+    expect(getMemorySearchManagerMockAgentIds()).toEqual(["chief", "backend"]);
+    expect(result.details).toMatchObject({
+      results: [
+        { path: "chief/MEMORY.md", agent_id: "chief" },
+        { path: "backend/MEMORY.md", agent_id: "backend" },
+      ],
     });
   });
 

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -15,6 +15,7 @@ import {
   resolveMemoryCorePluginConfig,
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { resolveMemorySearchScope } from "./memory-permissions.js";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
@@ -36,9 +37,24 @@ import {
 } from "./tools.shared.js";
 
 function buildRecallKey(
-  result: Pick<MemorySearchResult, "source" | "path" | "startLine" | "endLine">,
+  result: Pick<MemorySearchResult, "source" | "path" | "startLine" | "endLine" | "agent_id">,
 ): string {
-  return `${result.source}:${result.path}:${result.startLine}:${result.endLine}`;
+  return `${result.agent_id ?? ""}:${result.source}:${result.path}:${result.startLine}:${result.endLine}`;
+}
+
+function decorateMemorySearchProvenance(
+  result: MemorySearchResult,
+  agentId: string,
+): MemorySearchResult {
+  return {
+    ...result,
+    agentId,
+    agent_id: agentId,
+    sourcePath: result.sourcePath ?? result.path,
+    source_path: result.source_path ?? result.sourcePath ?? result.path,
+    start_line: result.start_line ?? result.startLine,
+    end_line: result.end_line ?? result.endLine,
+  };
 }
 
 function resolveRecallTrackingResults(
@@ -209,9 +225,23 @@ export function createMemorySearchTool(options: {
         const { resolveMemoryBackendConfig } = await loadMemoryToolRuntime();
         const shouldQueryMemory = requestedCorpus !== "wiki";
         const shouldQuerySupplements = requestedCorpus === "wiki" || requestedCorpus === "all";
-        const memory = shouldQueryMemory ? await getMemoryManagerContext({ cfg, agentId }) : null;
-        if (shouldQueryMemory && memory && "error" in memory && !shouldQuerySupplements) {
-          return jsonResult(buildMemorySearchUnavailableResult(memory.error));
+        const scope = resolveMemorySearchScope({ cfg, requesterAgentId: agentId });
+        const scopedMemories = shouldQueryMemory
+          ? await Promise.all(
+              scope.allowedAgentIds.map(async (scopedAgentId) => ({
+                agentId: scopedAgentId,
+                memory: await getMemoryManagerContext({ cfg, agentId: scopedAgentId }),
+              })),
+            )
+          : [];
+        const firstMemoryError = scopedMemories.find(({ memory }) => "error" in memory)?.memory;
+        if (
+          shouldQueryMemory &&
+          firstMemoryError &&
+          "error" in firstMemoryError &&
+          !shouldQuerySupplements
+        ) {
+          return jsonResult(buildMemorySearchUnavailableResult(firstMemoryError.error));
         }
         try {
           const citationsMode = resolveMemoryCitationsMode(cfg);
@@ -238,7 +268,7 @@ export function createMemorySearchTool(options: {
                 hits: number;
               }
             | undefined;
-          if (shouldQueryMemory && memory && !("error" in memory)) {
+          if (shouldQueryMemory) {
             const runtimeDebug: MemorySearchRuntimeDebug[] = [];
             const qmdSearchModeOverride = resolveActiveMemoryQmdSearchModeOverride(
               cfg,
@@ -250,65 +280,76 @@ export function createMemorySearchTool(options: {
                 : requestedCorpus === "memory"
                   ? (["memory"] as MemorySource[])
                   : undefined;
-            rawResults = await memory.manager.search(query, {
-              maxResults,
-              minScore,
-              sessionKey: options.agentSessionKey,
-              qmdSearchModeOverride,
-              onDebug: (debug) => {
-                runtimeDebug.push(debug);
-              },
-              ...(searchSources ? { sources: searchSources } : {}),
-            });
-            rawResults = await filterMemorySearchHitsBySessionVisibility({
-              cfg,
-              requesterSessionKey: options.agentSessionKey,
-              sandboxed: options.sandboxed === true,
-              hits: rawResults,
-            });
-            if (requestedCorpus === "sessions") {
-              rawResults = rawResults.filter((hit) => hit.source === "sessions");
-            } else if (requestedCorpus === "memory") {
-              rawResults = rawResults.filter((hit) => hit.source === "memory");
-            }
-            const status = memory.manager.status();
-            const decorated = decorateCitations(rawResults, includeCitations);
-            const resolved = resolveMemoryBackendConfig({ cfg, agentId });
-            const memoryResults =
-              status.backend === "qmd"
-                ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
-                : decorated;
-            surfacedMemoryResults = memoryResults.map((result) => ({
-              ...result,
-              corpus: "memory" as const,
-            }));
-            const sleepTimezone = resolveMemoryDeepDreamingConfig({
-              pluginConfig: resolveMemoryCorePluginConfig(cfg),
-              cfg,
-            }).timezone;
-            queueShortTermRecallTracking({
-              workspaceDir: status.workspaceDir,
-              query,
-              rawResults,
-              surfacedResults: memoryResults,
-              timezone: sleepTimezone,
-            });
-            provider = status.provider;
-            model = status.model;
-            fallback = status.fallback;
-            const latestDebug = runtimeDebug.at(-1);
-            searchMode = latestDebug?.effectiveMode;
-            searchDebug = {
-              backend: status.backend,
-              configuredMode: latestDebug?.configuredMode,
-              effectiveMode:
+            for (const scopedMemory of scopedMemories) {
+              if ("error" in scopedMemory.memory) {
+                continue;
+              }
+              let scopedRawResults = await scopedMemory.memory.manager.search(query, {
+                maxResults,
+                minScore,
+                sessionKey: options.agentSessionKey,
+                qmdSearchModeOverride,
+                onDebug: (debug) => {
+                  runtimeDebug.push(debug);
+                },
+                ...(searchSources ? { sources: searchSources } : {}),
+              });
+              scopedRawResults = scopedRawResults.map((result) =>
+                decorateMemorySearchProvenance(result, scopedMemory.agentId),
+              );
+              scopedRawResults = await filterMemorySearchHitsBySessionVisibility({
+                cfg,
+                requesterSessionKey: options.agentSessionKey,
+                sandboxed: options.sandboxed === true,
+                hits: scopedRawResults,
+              });
+              if (requestedCorpus === "sessions") {
+                scopedRawResults = scopedRawResults.filter((hit) => hit.source === "sessions");
+              } else if (requestedCorpus === "memory") {
+                scopedRawResults = scopedRawResults.filter((hit) => hit.source === "memory");
+              }
+              const status = scopedMemory.memory.manager.status();
+              const decorated = decorateCitations(scopedRawResults, includeCitations);
+              const resolved = resolveMemoryBackendConfig({ cfg, agentId: scopedMemory.agentId });
+              const memoryResults =
                 status.backend === "qmd"
-                  ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
-                  : "n/a",
-              fallback: latestDebug?.fallback,
-              searchMs: Math.max(0, Date.now() - searchStartedAt),
-              hits: rawResults.length,
-            };
+                  ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
+                  : decorated;
+              surfacedMemoryResults.push(
+                ...memoryResults.map((result) => ({
+                  ...result,
+                  corpus: "memory" as const,
+                })),
+              );
+              rawResults.push(...scopedRawResults);
+              const sleepTimezone = resolveMemoryDeepDreamingConfig({
+                pluginConfig: resolveMemoryCorePluginConfig(cfg),
+                cfg,
+              }).timezone;
+              queueShortTermRecallTracking({
+                workspaceDir: status.workspaceDir,
+                query,
+                rawResults: scopedRawResults,
+                surfacedResults: memoryResults,
+                timezone: sleepTimezone,
+              });
+              provider ??= status.provider;
+              model ??= status.model;
+              fallback ??= status.fallback;
+              const latestDebug = runtimeDebug.at(-1);
+              searchMode = latestDebug?.effectiveMode ?? searchMode;
+              searchDebug = {
+                backend: status.backend,
+                configuredMode: latestDebug?.configuredMode,
+                effectiveMode:
+                  status.backend === "qmd"
+                    ? (latestDebug?.effectiveMode ?? latestDebug?.configuredMode)
+                    : "n/a",
+                fallback: latestDebug?.fallback,
+                searchMs: Math.max(0, Date.now() - searchStartedAt),
+                hits: rawResults.length,
+              };
+            }
           }
           const supplementResults = shouldQuerySupplements
             ? await searchMemoryCorpusSupplements({

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -1,8 +1,9 @@
 import type { DatabaseSync } from "node:sqlite";
-import { formatErrorMessage } from "./error-utils.js";
+import { formatErrorMessage } from "../../../../src/infra/errors.js";
 
 export function ensureMemoryIndexSchema(params: {
   db: DatabaseSync;
+  agentId: string;
   embeddingCacheTable: string;
   cacheEnabled: boolean;
   ftsTable: string;
@@ -15,29 +16,8 @@ export function ensureMemoryIndexSchema(params: {
       value TEXT NOT NULL
     );
   `);
-  params.db.exec(`
-    CREATE TABLE IF NOT EXISTS files (
-      path TEXT PRIMARY KEY,
-      source TEXT NOT NULL DEFAULT 'memory',
-      hash TEXT NOT NULL,
-      mtime INTEGER NOT NULL,
-      size INTEGER NOT NULL
-    );
-  `);
-  params.db.exec(`
-    CREATE TABLE IF NOT EXISTS chunks (
-      id TEXT PRIMARY KEY,
-      path TEXT NOT NULL,
-      source TEXT NOT NULL DEFAULT 'memory',
-      start_line INTEGER NOT NULL,
-      end_line INTEGER NOT NULL,
-      hash TEXT NOT NULL,
-      model TEXT NOT NULL,
-      text TEXT NOT NULL,
-      embedding TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-  `);
+  ensureFilesTable(params.db, params.agentId);
+  ensureChunksTable(params.db, params.agentId);
   if (params.cacheEnabled) {
     params.db.exec(`
       CREATE TABLE IF NOT EXISTS ${params.embeddingCacheTable} (
@@ -62,10 +42,16 @@ export function ensureMemoryIndexSchema(params: {
     try {
       const tokenizer = params.ftsTokenizer ?? "unicode61";
       const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
+      const existingFtsColumns = readColumns(params.db, params.ftsTable);
+      const shouldRebuildFts = existingFtsColumns.length > 0 && !existingFtsColumns.has("agent_id");
+      if (shouldRebuildFts) {
+        params.db.exec(`DROP TABLE IF EXISTS ${params.ftsTable}`);
+      }
       params.db.exec(
         `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
           `  text,\n` +
           `  id UNINDEXED,\n` +
+          `  agent_id UNINDEXED,\n` +
           `  path UNINDEXED,\n` +
           `  source UNINDEXED,\n` +
           `  model UNINDEXED,\n` +
@@ -73,6 +59,9 @@ export function ensureMemoryIndexSchema(params: {
           `  end_line UNINDEXED\n` +
           `${tokenizeClause});`,
       );
+      if (shouldRebuildFts) {
+        rebuildMemoryFtsFromChunks({ db: params.db, ftsTable: params.ftsTable });
+      }
       ftsAvailable = true;
     } catch (err) {
       const message = formatErrorMessage(err);
@@ -81,12 +70,118 @@ export function ensureMemoryIndexSchema(params: {
     }
   }
 
-  ensureColumn(params.db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
-  ensureColumn(params.db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
-  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
-  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_files_agent_source ON files(agent_id, source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_path ON chunks(agent_id, path);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_source ON chunks(agent_id, source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_model ON chunks(agent_id, model);`);
 
   return { ftsAvailable, ...(ftsError ? { ftsError } : {}) };
+}
+
+function readColumns(db: DatabaseSync, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function tableExists(db: DatabaseSync, table: string): boolean {
+  const row = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ?`)
+    .get(table) as { name?: string } | undefined;
+  return row?.name === table;
+}
+
+function runMigration(db: DatabaseSync, body: () => void): void {
+  db.exec("BEGIN");
+  try {
+    body();
+    db.exec("COMMIT");
+  } catch (err) {
+    try {
+      db.exec("ROLLBACK");
+    } catch {}
+    throw err;
+  }
+}
+
+function ensureFilesTable(db: DatabaseSync, agentId: string): void {
+  if (!tableExists(db, "files")) {
+    db.exec(`
+      CREATE TABLE files (
+        agent_id TEXT NOT NULL DEFAULT '',
+        path TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'memory',
+        hash TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, path, source)
+      );
+    `);
+    return;
+  }
+
+  ensureColumn(db, "files", "agent_id", "TEXT NOT NULL DEFAULT ''");
+  ensureColumn(db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  db.prepare(`UPDATE files SET agent_id = ? WHERE agent_id IS NULL OR agent_id = ''`).run(agentId);
+
+  const pkColumns = (
+    db.prepare(`PRAGMA table_info(files)`).all() as Array<{ name: string; pk: number }>
+  )
+    .filter((row) => row.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map((row) => row.name);
+  if (pkColumns.join(",") === "agent_id,path,source") {
+    return;
+  }
+
+  runMigration(db, () => {
+    db.exec(`ALTER TABLE files RENAME TO files_legacy_namespace`);
+    db.exec(`
+      CREATE TABLE files (
+        agent_id TEXT NOT NULL DEFAULT '',
+        path TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'memory',
+        hash TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, path, source)
+      );
+    `);
+    db.prepare(
+      `INSERT OR REPLACE INTO files (agent_id, path, source, hash, mtime, size)
+       SELECT CASE WHEN agent_id IS NULL OR agent_id = '' THEN ? ELSE agent_id END,
+              path, source, hash, mtime, size
+         FROM files_legacy_namespace`,
+    ).run(agentId);
+    db.exec(`DROP TABLE files_legacy_namespace`);
+  });
+}
+
+function ensureChunksTable(db: DatabaseSync, agentId: string): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL DEFAULT '',
+      path TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'memory',
+      start_line INTEGER NOT NULL,
+      end_line INTEGER NOT NULL,
+      hash TEXT NOT NULL,
+      model TEXT NOT NULL,
+      text TEXT NOT NULL,
+      embedding TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  ensureColumn(db, "chunks", "agent_id", "TEXT NOT NULL DEFAULT ''");
+  ensureColumn(db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  db.prepare(`UPDATE chunks SET agent_id = ? WHERE agent_id IS NULL OR agent_id = ''`).run(agentId);
+}
+
+function rebuildMemoryFtsFromChunks(params: { db: DatabaseSync; ftsTable: string }): void {
+  params.db.exec(
+    `INSERT INTO ${params.ftsTable} (text, id, agent_id, path, source, model, start_line, end_line)
+     SELECT text, id, agent_id, path, source, model, start_line, end_line FROM chunks`,
+  );
 }
 
 function ensureColumn(
@@ -95,8 +190,8 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
-  if (rows.some((row) => row.name === column)) {
+  const columns = readColumns(db, table);
+  if (columns.has(column)) {
     return;
   }
   db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);

--- a/src/memory-host-sdk/host/memory-schema.ts
+++ b/src/memory-host-sdk/host/memory-schema.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 
 export function ensureMemoryIndexSchema(params: {
   db: DatabaseSync;
+  agentId: string;
   embeddingCacheTable: string;
   cacheEnabled: boolean;
   ftsTable: string;
@@ -15,29 +16,8 @@ export function ensureMemoryIndexSchema(params: {
       value TEXT NOT NULL
     );
   `);
-  params.db.exec(`
-    CREATE TABLE IF NOT EXISTS files (
-      path TEXT PRIMARY KEY,
-      source TEXT NOT NULL DEFAULT 'memory',
-      hash TEXT NOT NULL,
-      mtime INTEGER NOT NULL,
-      size INTEGER NOT NULL
-    );
-  `);
-  params.db.exec(`
-    CREATE TABLE IF NOT EXISTS chunks (
-      id TEXT PRIMARY KEY,
-      path TEXT NOT NULL,
-      source TEXT NOT NULL DEFAULT 'memory',
-      start_line INTEGER NOT NULL,
-      end_line INTEGER NOT NULL,
-      hash TEXT NOT NULL,
-      model TEXT NOT NULL,
-      text TEXT NOT NULL,
-      embedding TEXT NOT NULL,
-      updated_at INTEGER NOT NULL
-    );
-  `);
+  ensureFilesTable(params.db, params.agentId);
+  ensureChunksTable(params.db, params.agentId);
   if (params.cacheEnabled) {
     params.db.exec(`
       CREATE TABLE IF NOT EXISTS ${params.embeddingCacheTable} (
@@ -62,10 +42,16 @@ export function ensureMemoryIndexSchema(params: {
     try {
       const tokenizer = params.ftsTokenizer ?? "unicode61";
       const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
+      const existingFtsColumns = readColumns(params.db, params.ftsTable);
+      const shouldRebuildFts = existingFtsColumns.size > 0 && !existingFtsColumns.has("agent_id");
+      if (shouldRebuildFts) {
+        params.db.exec(`DROP TABLE IF EXISTS ${params.ftsTable}`);
+      }
       params.db.exec(
         `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
           `  text,\n` +
           `  id UNINDEXED,\n` +
+          `  agent_id UNINDEXED,\n` +
           `  path UNINDEXED,\n` +
           `  source UNINDEXED,\n` +
           `  model UNINDEXED,\n` +
@@ -73,6 +59,9 @@ export function ensureMemoryIndexSchema(params: {
           `  end_line UNINDEXED\n` +
           `${tokenizeClause});`,
       );
+      if (shouldRebuildFts) {
+        rebuildMemoryFtsFromChunks({ db: params.db, ftsTable: params.ftsTable });
+      }
       ftsAvailable = true;
     } catch (err) {
       const message = formatErrorMessage(err);
@@ -81,12 +70,118 @@ export function ensureMemoryIndexSchema(params: {
     }
   }
 
-  ensureColumn(params.db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
-  ensureColumn(params.db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
-  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
-  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_files_agent_source ON files(agent_id, source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_path ON chunks(agent_id, path);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_source ON chunks(agent_id, source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_agent_model ON chunks(agent_id, model);`);
 
   return { ftsAvailable, ...(ftsError ? { ftsError } : {}) };
+}
+
+function readColumns(db: DatabaseSync, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
+}
+
+function tableExists(db: DatabaseSync, table: string): boolean {
+  const row = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ?`)
+    .get(table) as { name?: string } | undefined;
+  return row?.name === table;
+}
+
+function runMigration(db: DatabaseSync, body: () => void): void {
+  db.exec("BEGIN");
+  try {
+    body();
+    db.exec("COMMIT");
+  } catch (err) {
+    try {
+      db.exec("ROLLBACK");
+    } catch {}
+    throw err;
+  }
+}
+
+function ensureFilesTable(db: DatabaseSync, agentId: string): void {
+  if (!tableExists(db, "files")) {
+    db.exec(`
+      CREATE TABLE files (
+        agent_id TEXT NOT NULL DEFAULT '',
+        path TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'memory',
+        hash TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, path, source)
+      );
+    `);
+    return;
+  }
+
+  ensureColumn(db, "files", "agent_id", "TEXT NOT NULL DEFAULT ''");
+  ensureColumn(db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  db.prepare(`UPDATE files SET agent_id = ? WHERE agent_id IS NULL OR agent_id = ''`).run(agentId);
+
+  const pkColumns = (
+    db.prepare(`PRAGMA table_info(files)`).all() as Array<{ name: string; pk: number }>
+  )
+    .filter((row) => row.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map((row) => row.name);
+  if (pkColumns.join(",") === "agent_id,path,source") {
+    return;
+  }
+
+  runMigration(db, () => {
+    db.exec(`ALTER TABLE files RENAME TO files_legacy_namespace`);
+    db.exec(`
+      CREATE TABLE files (
+        agent_id TEXT NOT NULL DEFAULT '',
+        path TEXT NOT NULL,
+        source TEXT NOT NULL DEFAULT 'memory',
+        hash TEXT NOT NULL,
+        mtime INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, path, source)
+      );
+    `);
+    db.prepare(
+      `INSERT OR REPLACE INTO files (agent_id, path, source, hash, mtime, size)
+       SELECT CASE WHEN agent_id IS NULL OR agent_id = '' THEN ? ELSE agent_id END,
+              path, source, hash, mtime, size
+         FROM files_legacy_namespace`,
+    ).run(agentId);
+    db.exec(`DROP TABLE files_legacy_namespace`);
+  });
+}
+
+function ensureChunksTable(db: DatabaseSync, agentId: string): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL DEFAULT '',
+      path TEXT NOT NULL,
+      source TEXT NOT NULL DEFAULT 'memory',
+      start_line INTEGER NOT NULL,
+      end_line INTEGER NOT NULL,
+      hash TEXT NOT NULL,
+      model TEXT NOT NULL,
+      text TEXT NOT NULL,
+      embedding TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  ensureColumn(db, "chunks", "agent_id", "TEXT NOT NULL DEFAULT ''");
+  ensureColumn(db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  db.prepare(`UPDATE chunks SET agent_id = ? WHERE agent_id IS NULL OR agent_id = ''`).run(agentId);
+}
+
+function rebuildMemoryFtsFromChunks(params: { db: DatabaseSync; ftsTable: string }): void {
+  params.db.exec(
+    `INSERT INTO ${params.ftsTable} (text, id, agent_id, path, source, model, start_line, end_line)
+     SELECT text, id, agent_id, path, source, model, start_line, end_line FROM chunks`,
+  );
 }
 
 function ensureColumn(
@@ -95,8 +190,8 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
-  if (rows.some((row) => row.name === column)) {
+  const columns = readColumns(db, table);
+  if (columns.has(column)) {
     return;
   }
   db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);

--- a/src/memory-host-sdk/host/types.ts
+++ b/src/memory-host-sdk/host/types.ts
@@ -10,6 +10,19 @@ export type MemorySearchResult = {
   snippet: string;
   source: MemorySource;
   citation?: string;
+  /** Trusted runtime agent id that produced this hit. */
+  agentId?: string;
+  /** Snake-case tool output alias for agentId. */
+  agent_id?: string;
+  /** Canonical source path alias for path. */
+  sourcePath?: string;
+  /** Snake-case tool output alias for sourcePath. */
+  source_path?: string;
+  /** Snake-case tool output alias for startLine. */
+  start_line?: number;
+  /** Snake-case tool output alias for endLine. */
+  end_line?: number;
+  matchType?: "vector" | "keyword" | "hybrid" | "fts";
 };
 
 export type MemoryEmbeddingProbeResult = {


### PR DESCRIPTION
## Summary
- add shared-DB coverage for keyword/vector memory isolation by agent namespace
- fix vector KNN candidate expansion so expansion is counted within the current agent/source scope, not prematurely after model filtering
- scope QMD mcporter daemon state by QMD directory to avoid cross-agent process-level singleton bleed
- fix memory schema Set count usage (`size` instead of `length`)

## Stacking note
Part 3 of the vector memory integration series. Stacked after #73769 and #73770; targets `main` so GitHub can create the PR from the fork.

## Tests
Previously validated in the source checkout before PR splitting:

```bash
pnpm exec vitest run \
  extensions/memory-core/src/memory/manager-search.test.ts \
  extensions/memory-core/src/memory/manager-fts-state.test.ts \
  extensions/memory-core/src/memory/manager-source-state.test.ts \
  extensions/memory-core/src/memory/index.test.ts \
  extensions/memory-core/src/memory/manager-embedding-cache.test.ts \
  --no-fileParallelism --maxWorkers 1
pnpm build
```

QMD mcporter Vitest was previously killed by the local machine with `SIGKILL`; recommend CI or a higher-resource machine for that specific test.