### PR TITLE
Add Higgsfield MCP bundled plugin

### DIFF
--- a/docs/plugins/higgsfield.md
+++ b/docs/plugins/higgsfield.md
@@ -1,0 +1,55 @@
+---
+title: Higgsfield MCP
+summary: Use Higgsfield AI image and video generation from OpenClaw via the official remote MCP server.
+---
+
+# Higgsfield MCP
+
+OpenClaw includes a bundled Higgsfield MCP plugin that connects MCP-capable
+agent turns to Higgsfield's official remote MCP server.
+
+The bundle uses Higgsfield's published MCP connector endpoint:
+
+```json
+{
+  "url": "https://mcp.higgsfield.ai/mcp"
+}
+```
+
+## Enable the plugin
+
+Bundled MCP plugins are disabled until explicitly enabled. Enable Higgsfield with:
+
+```bash
+openclaw plugins enable higgsfield
+```
+
+## Requirements
+
+- A Higgsfield account
+- Access to the official Higgsfield MCP connector at
+  [higgsfield.ai/mcp](https://higgsfield.ai/mcp)
+
+No API key is required in OpenClaw. Higgsfield authenticates users through the
+remote MCP connector flow.
+
+## Tools
+
+The official Higgsfield MCP connector provides tools for creative generation and
+asset workflows, including:
+
+- image generation across Higgsfield-supported models
+- video generation from text, references, and images
+- generation history and asset browsing
+- reusable characters and visual references
+- presets and production-oriented campaign workflows
+
+Generation tools may run asynchronously. Poll with the matching status or result
+tool until the job is complete, then use the returned asset URL.
+
+## Security and cost notes
+
+- Higgsfield generations consume the user's Higgsfield credits; confirm before bulk or expensive runs.
+- Image-to-video tools may require publicly reachable input image URLs or uploaded assets.
+- Generated asset URLs can be time-limited. Archive important outputs promptly.
+- Do not paste Higgsfield session tokens or account credentials into prompts, chat messages, or logs.

--- a/extensions/higgsfield/.claude-plugin/plugin.json
+++ b/extensions/higgsfield/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "Higgsfield",
+  "description": "Higgsfield AI image and video generation MCP bundle for OpenClaw.",
+  "mcpServers": [".mcp.json"],
+  "skills": ["skills"]
+}

--- a/extensions/higgsfield/.mcp.json
+++ b/extensions/higgsfield/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "higgsfield": {
+      "url": "https://mcp.higgsfield.ai/mcp"
+    }
+  }
+}

--- a/extensions/higgsfield/skills/SKILL.md
+++ b/extensions/higgsfield/skills/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: higgsfield
+summary: Use the official Higgsfield remote MCP server for AI image and video generation.
+description: Generate Higgsfield images/videos, browse assets, train characters, inspect presets/models/history, and manage generation jobs via the official Higgsfield MCP connector.
+---
+
+# Higgsfield MCP
+
+Use this skill when the user asks for Higgsfield image/video generation or wants to inspect Higgsfield jobs, assets, presets, models, generation history, or character references.
+
+## Requirements
+
+The bundled MCP connector points to Higgsfield's official remote MCP endpoint:
+
+`https://mcp.higgsfield.ai/mcp`
+
+No API keys are configured in OpenClaw. The user authenticates with their Higgsfield account through the MCP connector flow.
+
+## Typical flow
+
+1. Check available models, presets, or history when the request depends on them.
+2. Generate the image or video using the official Higgsfield MCP tools.
+3. Poll asynchronous generations until completion when the tool returns a pending job.
+4. Return downloadable output URLs or attach saved media when the caller asks for delivery.
+
+## Notes
+
+- Higgsfield generations consume the user's Higgsfield credits; confirm before expensive or bulk runs.
+- Image-to-video tools may require accessible input image URLs or uploaded assets.
+- Results can be time-limited on the Higgsfield side; archive important outputs promptly.

--- a/scripts/copy-bundled-plugin-metadata.mjs
+++ b/scripts/copy-bundled-plugin-metadata.mjs
@@ -77,6 +77,42 @@ function isManifestlessBundledRuntimeSupportPackage(params) {
   return params.topLevelPublicSurfaceEntries.length > 0;
 }
 
+function isBundledBundlePluginDir(pluginDir) {
+  return [
+    path.join(pluginDir, ".codex-plugin", "plugin.json"),
+    path.join(pluginDir, ".claude-plugin", "plugin.json"),
+    path.join(pluginDir, ".cursor-plugin", "plugin.json"),
+  ].some((candidate) => fs.existsSync(candidate));
+}
+
+function copyBundlePluginRuntimeMetadata(pluginDir, distPluginDir) {
+  removePathIfExists(distPluginDir);
+  const entries = [
+    ".codex-plugin",
+    ".claude-plugin",
+    ".cursor-plugin",
+    ".mcp.json",
+    ".lsp.json",
+    "commands",
+    "skills",
+    "agents",
+    "hooks",
+    "output-styles",
+    "settings.json",
+  ];
+  for (const entry of entries) {
+    const source = path.join(pluginDir, entry);
+    if (!fs.existsSync(source)) {
+      continue;
+    }
+    fs.cpSync(source, path.join(distPluginDir, entry), {
+      recursive: true,
+      force: true,
+      dereference: false,
+    });
+  }
+}
+
 function rewritePackageEntry(entry) {
   if (typeof entry !== "string" || entry.trim().length === 0) {
     return undefined;
@@ -347,13 +383,19 @@ export function copyBundledPluginMetadata(params = {}) {
         packageJson,
         topLevelPublicSurfaceEntries,
       });
+    const isBundlePlugin = !fs.existsSync(manifestPath) && isBundledBundlePluginDir(pluginDir);
 
     sourcePluginDirs.add(dirent.name);
 
     const distManifestPath = path.join(distPluginDir, "openclaw.plugin.json");
     const distPackageJsonPath = path.join(distPluginDir, "package.json");
-    if (!fs.existsSync(manifestPath) && !isManifestlessSupportPackage) {
+    if (!fs.existsSync(manifestPath) && !isManifestlessSupportPackage && !isBundlePlugin) {
       removePathIfExists(distPluginDir);
+      continue;
+    }
+
+    if (isBundlePlugin) {
+      copyBundlePluginRuntimeMetadata(pluginDir, distPluginDir);
       continue;
     }
 

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -11,6 +11,7 @@ import {
   withBundleHomeEnv,
   writeClaudeBundleManifest,
 } from "./bundle-mcp.test-support.js";
+import { pluginTestRepoRoot } from "./generated-plugin-test-helpers.js";
 
 function getServerArgs(value: unknown): unknown[] | undefined {
   return isRecord(value) && Array.isArray(value.args) ? value.args : undefined;
@@ -217,5 +218,17 @@ describe("loadEnabledBundleMcpConfig", () => {
         });
       },
     );
+  });
+
+  it("loads the bundled Higgsfield MCP plugin", () => {
+    const loaded = loadEnabledBundleMcpConfig({
+      workspaceDir: pluginTestRepoRoot,
+      cfg: createEnabledBundleConfig(["higgsfield"]),
+    });
+
+    expectNoDiagnostics(loaded.diagnostics);
+    expect(loaded.config.mcpServers.higgsfield).toMatchObject({
+      url: "https://mcp.higgsfield.ai/mcp",
+    });
   });
 });

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -437,6 +437,38 @@ describe("copyBundledPluginMetadata", () => {
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", pluginId))).toBe(expectedExists);
   });
 
+  it("copies bundled bundle plugin metadata", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-bundle-plugin-");
+    const pluginDir = path.join(repoRoot, "extensions", "higgsfield");
+    fs.mkdirSync(path.join(pluginDir, ".claude-plugin"), { recursive: true });
+    fs.mkdirSync(path.join(pluginDir, "skills"), { recursive: true });
+    writeJson(path.join(pluginDir, ".claude-plugin", "plugin.json"), {
+      name: "Higgsfield",
+      mcpServers: [".mcp.json"],
+      skills: ["skills"],
+    });
+    writeJson(path.join(pluginDir, ".mcp.json"), {
+      mcpServers: {
+        higgsfield: { url: "https://mcp.higgsfield.ai/mcp" },
+      },
+    });
+    fs.writeFileSync(path.join(pluginDir, "skills", "SKILL.md"), "# Higgsfield\n", "utf8");
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, "dist", "extensions", "higgsfield", ".claude-plugin", "plugin.json"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(repoRoot, "dist", "extensions", "higgsfield", ".mcp.json")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(repoRoot, "dist", "extensions", "higgsfield", "skills", "SKILL.md")),
+    ).toBe(true);
+  });
+
   it("preserves manifest-less runtime support package outputs and copies package metadata", () => {
     const repoRoot = makeRepoRoot("openclaw-bundled-runtime-support-");
     const pluginDir = path.join(repoRoot, "extensions", "image-generation-core");


### PR DESCRIPTION
## Summary

- add a bundled Claude-format Higgsfield MCP plugin pointing at Higgsfield's official remote MCP endpoint: `https://mcp.higgsfield.ai/mcp`
- include a Higgsfield skill and plugin docs with official connector/auth guidance
- teach bundled plugin metadata copying to preserve bundle-only plugins in `dist/extensions`
- add coverage for Higgsfield MCP loading and bundle metadata copying

## Testing

- `pnpm build`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/plugins/bundle-mcp.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts --reporter=dot`
- `pnpm exec oxlint scripts/copy-bundled-plugin-metadata.mjs src/plugins/bundle-mcp.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts`
- `pnpm dlx markdownlint-cli2 docs/plugins/higgsfield.md`

## Notes

Full `pnpm lint` currently reports unrelated pre-existing `typescript-eslint(no-redundant-type-constituents)` errors in embedding/memory extension files; changed files pass targeted oxlint.
