### PR TITLE
perf(capability-provider): reuse active registry on non-memory/non-speech lookups

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -252,6 +252,44 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
   });
 
+  it("uses active non-speech capability providers even when cfg has explicit plugin entries", () => {
+    // Regression: hasExplicitPluginConfig used to bypass the active-registry
+    // cache whenever cfg.plugins.entries was non-empty, which is true for
+    // every user that has installed a plugin. That forced a full
+    // loadOpenClawPlugins cycle on every capability lookup, costing
+    // ~5–6s per call and adding ~25–30s of latency per agent turn.
+    const active = createEmptyPluginRegistry();
+    active.mediaUnderstandingProviders.push({
+      pluginId: "deepgram",
+      pluginName: "Deepgram",
+      source: "test",
+      provider: {
+        id: "deepgram",
+        capabilities: ["audio"],
+      },
+    } as never);
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(active);
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      cfg: {
+        plugins: {
+          entries: {
+            deepgram: { enabled: true },
+            "some-other-plugin": { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["deepgram"]);
+    expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
+    expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalledWith(
+      expect.objectContaining({ activate: false }),
+    );
+  });
+
   it("keeps active speech providers when cfg requests an active provider alias", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -9,7 +9,6 @@ import {
   resolvePluginSnapshotCacheTtlMs,
   shouldUsePluginSnapshotCache,
 } from "./cache-controls.js";
-import { hasExplicitPluginConfig } from "./config-policy.js";
 import { resolveRuntimePluginRegistry } from "./loader.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
 import type { PluginRegistry } from "./registry-types.js";
@@ -323,11 +322,18 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
+  // When the active registry already has providers for this capability, return
+  // them directly. memoryEmbeddingProviders and speechProviders are handled
+  // separately below because their lookup must reconcile against `cfg`-level
+  // provider preferences (memory embedding plugin selection, speech alias
+  // resolution). For every other capability key, the active registry is
+  // already authoritative — the runtime rebuilt it on the last config-affecting
+  // change, so reusing it here is safe regardless of whether `cfg` carries
+  // explicit plugin entries.
   if (
     activeProviders.length > 0 &&
     params.key !== "memoryEmbeddingProviders" &&
-    params.key !== "speechProviders" &&
-    !hasExplicitPluginConfig(params.cfg?.plugins)
+    params.key !== "speechProviders"
   ) {
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }


### PR DESCRIPTION
## Summary

- **Problem:** `resolvePluginCapabilityProviders`'s active-registry early-return is gated on `!hasExplicitPluginConfig(params.cfg?.plugins)`. `hasExplicitPluginConfig` returns `true` for any non-empty `plugins.entries` — i.e., every gateway with at least one installed plugin. The gate fails for effectively every production user, every capability lookup falls through to `loadOpenClawPlugins`, and the full plugin registry is rebuilt (Jiti loader + manifest validation + per-plugin `register()`) on each call.
- **Why it matters:** A single agent turn triggers ~4 capability lookups (`imageGenerationProviders`, `videoGenerationProviders`, `musicGenerationProviders`, `mediaUnderstandingProviders`, `realtimeVoiceProviders`, `realtimeTranscriptionProviders`, etc.). At ~5–6s per re-load, this stacks into ~25–30s of wall-clock latency per turn — even when the LLM call itself completes in <100ms. Repro and instrumented logs in #73793.
- **What changed:** Dropped the `!hasExplicitPluginConfig` clause from the early-return. `memoryEmbeddingProviders` and `speechProviders` continue to fall through (they reconcile against cfg-level provider preferences). For every other capability key, `activeProviders.length > 0` means the active registry is authoritative — the runtime already rebuilds it on config-affecting changes, so reusing it here is safe regardless of `cfg.plugins.entries`. The unused `hasExplicitPluginConfig` import was removed from this file.
- **What did NOT change (scope boundary):** Behavior for `memoryEmbeddingProviders` and `speechProviders`. Behavior when the active registry has zero providers for the requested key (still falls through to load). Behavior of `hasExplicitPluginConfig` itself (still used in `bundle-commands.ts`, `bundled-compat.ts`, etc.). Cache-key construction in `loader.ts`. The capability-provider load path's compat config resolution.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #73793
- [x] This PR fixes a bug or regression

## Root Cause

`hasExplicitPluginConfig` was added to defensively bypass the active-registry cache when callers passed an explicit `cfg`, on the assumption that an explicit cfg might request a different plugin set than the active registry was built with. In practice, however, `hasExplicitPluginConfig` returns `true` for *any* non-empty `plugins.entries` — and every installed plugin populates `plugins.entries` — so the gate fires universally and the cache is effectively never used in production. The runtime already invalidates the active registry on real config changes (the cache key in `resolvePluginLoadCacheContext` includes `plugins`, `installs`, `activationMetadataKey`, etc.), so the defensive bypass is redundant. Removing it lets the cache do its job for capability lookups.

## Tests

- Added `uses active non-speech capability providers even when cfg has explicit plugin entries` in `src/plugins/capability-provider-runtime.test.ts`. Asserts that `mediaUnderstandingProviders` lookup with `cfg.plugins.entries` populated returns the active provider directly without invoking `loadPluginManifestRegistry` or `resolveRuntimePluginRegistry({…, activate: false})`.
- All 19 existing tests in `capability-provider-runtime.test.ts` pass unchanged.

## Verification

```
$ pnpm vitest run src/plugins/capability-provider-runtime.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
   Duration  2.87s
```

Production validation pending — once this lands, scope-openclaw's instrumented timing log will confirm the per-turn `register()` count drops from 4–5 to 1.
