### PR TITLE
Fix restart continuations after explicit restarts

### DIFF
--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -138,6 +138,7 @@ describe("gateway tool restart continuation", () => {
     );
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledWith({
       delayMs: 250,
+      deferralTimeoutMs: 30_000,
       reason: "continue after reboot",
       emitHooks: expect.objectContaining({
         beforeEmit: expect.any(Function),

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -24,6 +24,7 @@ import { isOpenClawOwnerOnlyCoreToolName } from "./owner-only-tools.js";
 const log = createSubsystemLogger("gateway-tool");
 
 const DEFAULT_UPDATE_TIMEOUT_MS = 20 * 60_000;
+const EXPLICIT_RESTART_DEFERRAL_TIMEOUT_MS = 30_000;
 // Security: the agent-facing `gateway` tool is owner-only, but per SECURITY.md the model/agent
 // itself is not a trusted principal. `assertGatewayConfigMutationAllowed` is the explicit
 // model -> operator trust-boundary control on `config.apply`/`config.patch`, so the runtime
@@ -411,6 +412,7 @@ export function createGatewayTool(opts?: {
         let sentinelPath: string | null = null;
         const scheduled = scheduleGatewaySigusr1Restart({
           delayMs,
+          deferralTimeoutMs: EXPLICIT_RESTART_DEFERRAL_TIMEOUT_MS,
           reason,
           emitHooks: {
             beforeEmit: async () => {

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -37,6 +37,8 @@ import { persistSessionEntry } from "./commands-session-store.js";
 import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
 import { resolveConversationBindingContextFromAcpCommand } from "./conversation-binding-input.js";
 
+const EXPLICIT_RESTART_DEFERRAL_TIMEOUT_MS = 30_000;
+
 const SESSION_COMMAND_PREFIX = "/session";
 const SESSION_DURATION_OFF_VALUES = new Set(["off", "disable", "disabled", "none", "0"]);
 const SESSION_ACTION_IDLE = "idle";
@@ -680,6 +682,7 @@ export const handleRestartCommand: CommandHandler = async (params, allowTextComm
   if (hasSigusr1Listener) {
     let sentinelPath: string | null = null;
     scheduleGatewaySigusr1Restart({
+      deferralTimeoutMs: EXPLICIT_RESTART_DEFERRAL_TIMEOUT_MS,
       reason: "/restart",
       emitHooks: sentinelPayload
         ? {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -717,6 +717,61 @@ describe("scheduleRestartSentinelWake", () => {
           OriginatingChannel: "telegram",
           OriginatingTo: "telegram:200482621",
         }),
+        replyOptions: expect.objectContaining({
+          sourceReplyDeliveryMode: "automatic",
+        }),
+      }),
+    );
+  });
+
+  it("keeps restart continuations visible in group topics", async () => {
+    mocks.readRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:telegram:group:-100123:topic:26866",
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-100123",
+          accountId: "default",
+        },
+        threadId: "26866",
+        ts: 123,
+        continuation: {
+          kind: "agentTurn",
+          message: "continue after restart",
+        },
+      },
+    } as Awaited<ReturnType<typeof mocks.readRestartSentinel>>);
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {
+        sessionId: "topic-session",
+        updatedAt: 0,
+        origin: { chatType: "group" },
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:telegram:group:-100123:topic:26866",
+      legacyKey: undefined,
+    } as LoadedSessionEntry);
+    mocks.resolveOutboundTarget.mockReturnValue({
+      ok: true as const,
+      to: "telegram:-100123",
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.recordInboundSessionAndDispatchReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        accountId: "default",
+        ctxPayload: expect.objectContaining({
+          Body: "continue after restart",
+          ChatType: "group",
+          MessageThreadId: "26866",
+        }),
+        replyOptions: expect.objectContaining({
+          sourceReplyDeliveryMode: "automatic",
+        }),
       }),
     );
   });

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -330,6 +330,9 @@ async function deliverQueuedSessionDelivery(params: {
     onDispatchError: (err) => {
       dispatchError ??= err;
     },
+    replyOptions: {
+      sourceReplyDeliveryMode: "automatic",
+    },
   });
   if (dispatchError) {
     throw dispatchError;

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -540,6 +540,24 @@ describe("infra runtime", () => {
       }
     });
 
+    it("emits SIGUSR1 after per-request deferral timeout even without runtime timeout", async () => {
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        setPreRestartDeferralCheck(() => 5);
+        scheduleGatewaySigusr1Restart({ delayMs: 0, deferralTimeoutMs: 1_000 });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(emitSpy).not.toHaveBeenCalledWith("SIGUSR1");
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
     it("emits SIGUSR1 if deferral check throws", async () => {
       const emitSpy = vi.spyOn(process, "emit");
       const handler = () => {};

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -655,6 +655,7 @@ export type ScheduledRestart = {
 
 export function scheduleGatewaySigusr1Restart(opts?: {
   delayMs?: number;
+  deferralTimeoutMs?: number;
   reason?: string;
   audit?: RestartAuditInfo;
   emitHooks?: RestartEmitHooks;
@@ -738,9 +739,15 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         return;
       }
       const cfg = getRuntimeConfig();
+      const deferralTimeoutMs =
+        typeof opts?.deferralTimeoutMs === "number" &&
+        Number.isFinite(opts.deferralTimeoutMs) &&
+        opts.deferralTimeoutMs > 0
+          ? Math.floor(opts.deferralTimeoutMs)
+          : cfg.gateway?.reload?.deferralTimeoutMs;
       deferGatewayRestartUntilIdle({
         getPendingCount: pendingCheck,
-        maxWaitMs: resolveGatewayRestartDeferralTimeoutMs(cfg.gateway?.reload?.deferralTimeoutMs),
+        maxWaitMs: resolveGatewayRestartDeferralTimeoutMs(deferralTimeoutMs),
         reason: scheduledReason,
       });
     },


### PR DESCRIPTION
## Summary

- Force restart-sentinel continuation turns to use automatic source delivery so owed restart replies remain visible in group/topic conversations.
- Bound explicit chat/tool restart deferral so a leaked or long-lived pending counter cannot make `gateway.restart` return ok without ever emitting SIGUSR1.
- Add regression coverage for Telegram-style group topic restart continuations and per-request restart deferral timeouts.

## Root cause

Recent group reply handling defaults normal group/channel turns to message-tool-only delivery. Restart-sentinel continuations use the generic gateway dispatch path, so their final reply could be suppressed in a Telegram topic even though the continuation turn ran.

A second issue showed up in topic 22684: the `gateway.restart` tool wrote a continuation and returned ok, but the scheduler waited indefinitely in the pre-restart deferral layer. With no runtime deferral timeout, any stale pending counter could prevent SIGUSR1 from ever being emitted.

## Validation

- `pnpm exec oxfmt --check --threads=1 src/infra/restart.ts src/infra/infra-runtime.test.ts src/agents/tools/gateway-tool.ts src/agents/tools/gateway-tool.test.ts src/auto-reply/reply/commands-session.ts src/gateway/server-restart-sentinel.ts src/gateway/server-restart-sentinel.test.ts`
- `pnpm test src/infra/infra-runtime.test.ts src/agents/tools/gateway-tool.test.ts src/gateway/server-restart-sentinel.test.ts`