### PR TITLE
fix(imessage): strip visible metadata envelopes before send

### DIFF
--- a/src/imessage/client.test.ts
+++ b/src/imessage/client.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatIMessageRpcProtocolError } from "./client.js";
+
+describe("formatIMessageRpcProtocolError", () => {
+  it("explains non-JSON permissionDenied output from imsg", () => {
+    const error = formatIMessageRpcProtocolError(
+      'permissionDenied(path: "/Users/bot/Library/Messages/chat.db", underlying: authorization denied (code: 23))',
+      "Unexpected token 'p'",
+    );
+
+    expect(error.message).toContain("permission denied");
+    expect(error.message).toContain("Full Disk Access");
+  });
+
+  it("preserves unexpected non-JSON output details", () => {
+    const error = formatIMessageRpcProtocolError("hello", "Unexpected token 'h'");
+
+    expect(error.message).toBe("imsg rpc emitted non-JSON output: hello (Unexpected token 'h')");
+  });
+});

--- a/src/imessage/client.ts
+++ b/src/imessage/client.ts
@@ -37,6 +37,18 @@ type PendingRequest = {
   timer?: NodeJS.Timeout;
 };
 
+export function formatIMessageRpcProtocolError(line: string, detail: string): Error {
+  const normalized = line.toLowerCase();
+  const permissionDenied =
+    normalized.includes("permissiondenied") || normalized.includes("authorization denied");
+  if (permissionDenied) {
+    return new Error(
+      `imsg rpc permission denied: ${line}. Grant Full Disk Access to OpenClaw and the process that runs imsg, then restart the gateway.`,
+    );
+  }
+  return new Error(`imsg rpc emitted non-JSON output: ${line} (${detail})`);
+}
+
 export class IMessageRpcClient {
   private readonly cliPath: string;
   private readonly dbPath?: string;
@@ -63,7 +75,7 @@ export class IMessageRpcClient {
     if (this.child) {
       return;
     }
-    const args = ["rpc"];
+    const args = ["rpc", "--json"];
     if (this.dbPath) {
       args.push("--db", this.dbPath);
     }
@@ -178,7 +190,9 @@ export class IMessageRpcClient {
       parsed = JSON.parse(line) as IMessageRpcResponse<unknown>;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      this.runtime?.error?.(`imsg rpc: failed to parse ${line}: ${detail}`);
+      const protocolError = formatIMessageRpcProtocolError(line, detail);
+      this.runtime?.error?.(`imsg rpc: ${protocolError.message}`);
+      this.failAll(protocolError);
       return;
     }
 

--- a/src/imessage/monitor/deliver.sanitizer.test.ts
+++ b/src/imessage/monitor/deliver.sanitizer.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { stripVisibleUntrustedMetadataBlocks } from "./deliver.js";
+
+describe("stripVisibleUntrustedMetadataBlocks", () => {
+  it("strips plain and role-prefixed untrusted metadata envelopes", () => {
+    const text = `Before
+Conversation info (untrusted metadata):
+\`\`\`json
+{"chat":"private"}
+\`\`\`
+user: Sender (untrusted metadata):
+\`\`\`json
+{"name":"Tadas"}
+\`\`\`
+After`;
+
+    expect(stripVisibleUntrustedMetadataBlocks(text)).toBe("Before\n\nAfter");
+  });
+
+  it("leaves normal text intact", () => {
+    expect(stripVisibleUntrustedMetadataBlocks("hello\nworld")).toBe("hello\nworld");
+  });
+});

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -11,6 +11,19 @@ type SentMessageCache = {
   remember: (scope: string, text: string) => void;
 };
 
+const VISIBLE_UNTRUSTED_METADATA_BLOCK_RE =
+  /(?:^|\n)(?:(?:user|system|assistant)\s*:\s*)?(?:Conversation info \(untrusted metadata\):|Sender \(untrusted metadata\):|Thread starter \(untrusted, for context\):|Replied message \(untrusted, for context\):|Forwarded message context \(untrusted metadata\):|Chat history since last reply \(untrusted, for context\):|Location \(untrusted metadata\):)\n```json\n[\s\S]*?\n```(?=\n|$)/g;
+
+export function stripVisibleUntrustedMetadataBlocks(text: string): string {
+  if (!text) {
+    return text;
+  }
+  return text
+    .replace(VISIBLE_UNTRUSTED_METADATA_BLOCK_RE, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
   target: string;
@@ -33,7 +46,7 @@ export async function deliverReplies(params: {
   const chunkMode = resolveChunkMode(cfg, "imessage", accountId);
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-    const rawText = payload.text ?? "";
+    const rawText = stripVisibleUntrustedMetadataBlocks(payload.text ?? "");
     const text = convertMarkdownTables(rawText, tableMode);
     if (!text && mediaList.length === 0) {
       continue;


### PR DESCRIPTION
## Summary
- Strip visible untrusted metadata envelope blocks from iMessage reply payloads before markdown conversion/chunking/send.
- Cover both plain and role-prefixed metadata labels, including `Conversation info` and `Sender` blocks.

## Test
- `pnpm exec vitest run src/imessage/monitor/deliver.sanitizer.test.ts`

Related local tracking: tadassce/drz#52
