### PR TITLE
feat(slack): wake on configured subteam mentions

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -61,6 +61,10 @@ import { sendMessageSlack } from "../send.runtime.js";
 import { resolveSlackThreadStarter } from "../thread.js";
 import { resolveSlackMessageContent } from "./prepare-content.js";
 import { resolveSlackRoutingContext } from "./prepare-routing.js";
+import {
+  extractSlackSubteamMentionIds,
+  matchesConfiguredSubteamMention,
+} from "./subteam-mentions.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import type { PreparedSlackMessage } from "./types.js";
 
@@ -284,9 +288,17 @@ export async function prepareSlackMessage(params: {
   }
   const { senderId, allowFromLower } = authorization;
   const hasAnyMention = /<@[^>]+>/.test(message.text ?? "");
-  const explicitlyMentioned = Boolean(
+  const explicitlyMentionedByBotId = Boolean(
     ctx.botUserId && message.text?.includes(`<@${ctx.botUserId}>`),
   );
+  const messageSubteamIds = extractSlackSubteamMentionIds(message.text ?? "");
+  const isExplicitlyMentionedForAgent = (agentId: string | undefined): boolean =>
+    explicitlyMentionedByBotId ||
+    matchesConfiguredSubteamMention(messageSubteamIds, ctx.cfg, agentId);
+  // Pre-routing seed only relies on the bot-id check. Per-agent subteam
+  // resolution happens after routing so an agent only wakes for subteams
+  // listed in its own (or the global) groupChat.subteamMentions.
+  const explicitlyMentioned = explicitlyMentionedByBotId;
   const seedTopLevelRoomThreadBySource =
     opts.source === "app_mention" || opts.wasMentioned === true || explicitlyMentioned;
   let routing = resolveSlackRoutingContext({
@@ -300,7 +312,7 @@ export async function prepareSlackMessage(params: {
     seedTopLevelRoomThread: seedTopLevelRoomThreadBySource,
   });
 
-  const resolveWasMentioned = (mentionRegexes: RegExp[]) =>
+  const resolveWasMentioned = (mentionRegexes: RegExp[], agentId: string | undefined) =>
     opts.wasMentioned ??
     (!isDirectMessage &&
       matchesMentionWithExplicit({
@@ -308,12 +320,12 @@ export async function prepareSlackMessage(params: {
         mentionRegexes,
         explicit: {
           hasAnyMention,
-          isExplicitlyMentioned: explicitlyMentioned,
-          canResolveExplicit: Boolean(ctx.botUserId),
+          isExplicitlyMentioned: isExplicitlyMentionedForAgent(agentId),
+          canResolveExplicit: Boolean(ctx.botUserId) || messageSubteamIds.length > 0,
         },
       }));
   let mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
-  let wasMentioned = resolveWasMentioned(mentionRegexes);
+  let wasMentioned = resolveWasMentioned(mentionRegexes, routing.route.agentId);
   const hasRuntimeBoundSession = Boolean(routing.runtimeBoundSessionKey);
   // Runtime bindings already pin the root and later thread replies to the same
   // target session, so only unbound regex mentions need a seeded thread reroute.
@@ -335,7 +347,7 @@ export async function prepareSlackMessage(params: {
       seedTopLevelRoomThread: true,
     });
     mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
-    wasMentioned = resolveWasMentioned(mentionRegexes);
+    wasMentioned = resolveWasMentioned(mentionRegexes, routing.route.agentId);
   }
   const {
     route,

--- a/extensions/slack/src/monitor/message-handler/subteam-mentions.test.ts
+++ b/extensions/slack/src/monitor/message-handler/subteam-mentions.test.ts
@@ -1,0 +1,112 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { describe, expect, it } from "vitest";
+import {
+  extractSlackSubteamMentionIds,
+  matchesConfiguredSubteamMention,
+} from "./subteam-mentions.js";
+
+describe("extractSlackSubteamMentionIds", () => {
+  it("returns empty for empty/no-match text", () => {
+    expect(extractSlackSubteamMentionIds("")).toEqual([]);
+    expect(extractSlackSubteamMentionIds("hello @everyone")).toEqual([]);
+  });
+
+  it("extracts a single subteam token", () => {
+    expect(
+      extractSlackSubteamMentionIds("hi <!subteam^S0B07LS458B|cg-agents> there"),
+    ).toEqual(["S0B07LS458B"]);
+  });
+
+  it("extracts and dedupes multiple subteam tokens", () => {
+    expect(
+      extractSlackSubteamMentionIds(
+        "<!subteam^SAAA> and <!subteam^SBBB|x> and <!subteam^SAAA|x>",
+      ).sort(),
+    ).toEqual(["SAAA", "SBBB"]);
+  });
+
+  it("uppercases extracted ids", () => {
+    expect(extractSlackSubteamMentionIds("<!subteam^sabc>")).toEqual(["SABC"]);
+  });
+});
+
+describe("matchesConfiguredSubteamMention", () => {
+  const cfgWith = (params: {
+    global?: string[];
+    agents?: Record<string, string[]>;
+  }): OpenClawConfig =>
+    ({
+      messages: params.global
+        ? { groupChat: { subteamMentions: params.global } }
+        : undefined,
+      agents: {
+        list: Object.entries(params.agents ?? {}).map(([id, list]) => ({
+          id,
+          groupChat: { subteamMentions: list },
+        })),
+      },
+    }) as unknown as OpenClawConfig;
+
+  it("returns false when no subteam ids in message", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        [],
+        cfgWith({ global: ["S0B07LS458B"] }),
+        undefined,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches against global list when no agent override", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        ["S0B07LS458B"],
+        cfgWith({ global: ["S0B07LS458B"] }),
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches against agent-specific list", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        ["S0B07LS458B"],
+        cfgWith({ agents: { jack: ["S0B07LS458B"] } }),
+        "jack",
+      ),
+    ).toBe(true);
+  });
+
+  it("agent override shadows global list (no match if agent list omits id)", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        ["S0B07LS458B"],
+        cfgWith({
+          global: ["S0B07LS458B"],
+          agents: { jack: ["SOTHER"] },
+        }),
+        "jack",
+      ),
+    ).toBe(false);
+  });
+
+  it("empty agent list explicitly opts out (does not fall back to global)", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        ["S0B07LS458B"],
+        cfgWith({ global: ["S0B07LS458B"], agents: { jack: [] } }),
+        "jack",
+      ),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive on configured ids", () => {
+    expect(
+      matchesConfiguredSubteamMention(
+        ["S0B07LS458B"],
+        cfgWith({ global: ["s0b07ls458b"] }),
+        undefined,
+      ),
+    ).toBe(true);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/subteam-mentions.ts
+++ b/extensions/slack/src/monitor/message-handler/subteam-mentions.ts
@@ -1,0 +1,59 @@
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+
+const SUBTEAM_TOKEN_RE = /<!subteam\^([A-Z0-9]+)(?:\|[^>]*)?>/g;
+
+/**
+ * Extracts Slack subteam (user-group) IDs referenced in `<!subteam^SXXX>`
+ * tokens within a message body. Returns an array of unique uppercase IDs.
+ */
+export function extractSlackSubteamMentionIds(text: string): string[] {
+  if (!text) return [];
+  const out = new Set<string>();
+  for (const m of text.matchAll(SUBTEAM_TOKEN_RE)) {
+    const id = m[1]?.toUpperCase();
+    if (id) out.add(id);
+  }
+  return [...out];
+}
+
+function normalizeSubteamIdList(list: readonly string[] | undefined): string[] {
+  if (!list || list.length === 0) return [];
+  const out: string[] = [];
+  for (const raw of list) {
+    const v = normalizeOptionalString(raw);
+    if (v) out.push(v.toUpperCase());
+  }
+  return out;
+}
+
+function resolveConfiguredSubteamIds(
+  cfg: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): string[] {
+  if (!cfg) return [];
+  const agentGroupChat = agentId ? resolveAgentConfig(cfg, agentId)?.groupChat : undefined;
+  // Mirror `mentionPatterns` semantics: presence (even empty) is an explicit
+  // override that shadows the global list.
+  if (agentGroupChat && Object.hasOwn(agentGroupChat, "subteamMentions")) {
+    return normalizeSubteamIdList(agentGroupChat.subteamMentions);
+  }
+  return normalizeSubteamIdList(cfg.messages?.groupChat?.subteamMentions);
+}
+
+/**
+ * Returns true if any subteam ID extracted from message text matches one
+ * configured for the given agent (or the global fallback).
+ */
+export function matchesConfiguredSubteamMention(
+  messageSubteamIds: readonly string[],
+  cfg: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): boolean {
+  if (messageSubteamIds.length === 0) return false;
+  const configured = resolveConfiguredSubteamIds(cfg, agentId);
+  if (configured.length === 0) return false;
+  const set = new Set(configured);
+  return messageSubteamIds.some((id) => set.has(id.toUpperCase()));
+}

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -3,6 +3,16 @@ import type { TtsConfig } from "./types.tts.js";
 
 export type GroupChatConfig = {
   mentionPatterns?: string[];
+  /**
+   * Channel-native group/subteam IDs whose mention should wake this agent
+   * the same way an explicit `@bot` mention would. Adapters that have a
+   * group-mention concept (currently Slack `<!subteam^SXXX>`) honor this
+   * list; others ignore it.
+   *
+   * Example (Slack): `["S0B07LS458B"]` — any `<!subteam^S0B07LS458B>`
+   * token in a room message is treated as an explicit mention.
+   */
+  subteamMentions?: string[];
   historyLimit?: number;
   /**
    * Controls how group/channel turns produce visible room replies.


### PR DESCRIPTION
Closes #73827.

## What

Adds `GroupChatConfig.subteamMentions: string[]` and teaches the Slack adapter's mention preflight to treat `<!subteam^SXXX>` tokens as an explicit @-mention for the routed agent when `SXXX` is in the agent's configured list (or the global fallback).

## Why

Mentioning a Slack user-group containing multiple OpenClaw agents currently wakes none of them — the adapter only checks for direct `<@UXXX>` tokens. Full context, options considered, and config example in #73827.

This is the "option 3" config-only path: no new Slack scopes, no API cache, no event subscriptions. Composes cleanly with a future API-expansion implementation (option 2).

## Diff highlights

- `src/config/types.messages.ts` — schema field on `GroupChatConfig` (auto-inherited by global `messages.groupChat` and per-agent `agents.list[].groupChat`).
- `extensions/slack/src/monitor/message-handler/subteam-mentions.ts` — pure helper:
  - `extractSlackSubteamMentionIds(text)`
  - `matchesConfiguredSubteamMention(ids, cfg, agentId)` — agent override beats global, presence-as-override mirrors existing `mentionPatterns` semantics.
- `extensions/slack/src/monitor/message-handler/prepare.ts` — passes `routing.route.agentId` into `resolveWasMentioned` and folds the per-agent subteam check into the explicit-mention signal. Pre-routing seed kept at bot-id only; the existing `wasMentioned && !seedTopLevelRoomThreadBySource` re-route handles thread reseed when subteam path is what triggers the wake.
- `extensions/slack/src/monitor/message-handler/subteam-mentions.test.ts` — covers extraction, dedupe, case-insensitivity, agent override, opt-out via empty list.

## Test

Local unit tests added; not run in this branch (no `node_modules` in clone). Maintainers' CI will exercise them. Manually traced the prepare.ts mention path and confirmed:

- `wasMentioned` flips true when `<!subteam^SXXX>` is in text and `SXXX` is in the routed agent's allowlist.
- Empty allowlist on agent shadows global (opt-out works).
- Pre-routing seeding behavior unchanged for non-subteam paths.

## Out of scope

API-driven subteam-membership expansion (option 2 in #73827). Happy to follow up with that as a separate PR if maintainers want it.
