### PR TITLE
fix(gateway): align dedupe eviction with entry timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
 - Discord: preserve username target resolution for Discord outbound sends. (#79076) Thanks @vincentkoc.
 - Gateway/sessions: rotate generated transcript paths when gateway sessions reset, complementing the daily-rollover transcript persistence. (#79076) Thanks @vincentkoc.
 - Dependencies: pin the transitive `fast-uri` production dependency to `3.1.2` so the production dependency audit no longer resolves the vulnerable `<=3.1.1` range. Thanks @shakkernerd.

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HealthSummary } from "../commands/health.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
-import { DEDUPE_MAX } from "./server-constants.js";
+import { DEDUPE_MAX, DEDUPE_TTL_MS } from "./server-constants.js";
 
 const cleanOldMediaMock = vi.fn(async () => {});
 
@@ -16,7 +16,10 @@ vi.mock("../media/store.js", async () => {
 const MEDIA_CLEANUP_TTL_MS = 24 * 60 * 60_000;
 const ABORTED_RUN_TTL_MS = 60 * 60_000;
 
-function createActiveRun(sessionKey: string): ChatAbortControllerEntry {
+function createActiveRun(
+  sessionKey: string,
+  kind?: ChatAbortControllerEntry["kind"],
+): ChatAbortControllerEntry {
   const now = Date.now();
   return {
     controller: new AbortController(),
@@ -24,6 +27,7 @@ function createActiveRun(sessionKey: string): ChatAbortControllerEntry {
     sessionKey,
     startedAtMs: now,
     expiresAtMs: now + ABORTED_RUN_TTL_MS,
+    kind,
   };
 }
 
@@ -224,6 +228,34 @@ describe("startGatewayMaintenanceTimers", () => {
     stopMaintenanceTimers(timers);
   });
 
+  it("keeps active agent dedupe entries past the normal ttl", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const now = Date.now();
+    deps.chatAbortControllers.set("active-agent", createActiveRun("agent:main:main", "agent"));
+    deps.dedupe.set("agent:active-agent", {
+      ts: now - DEDUPE_TTL_MS - 1,
+      ok: true,
+      payload: { runId: "active-agent", status: "accepted" },
+    });
+    deps.dedupe.set("agent:stale-agent", {
+      ts: now - DEDUPE_TTL_MS - 1,
+      ok: true,
+      payload: { runId: "stale-agent", status: "accepted" },
+    });
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.dedupe.has("agent:active-agent")).toBe(true);
+    expect(deps.dedupe.has("agent:stale-agent")).toBe(false);
+
+    stopMaintenanceTimers(timers);
+  });
+
   it("evicts dedupe overflow by oldest timestamp even after reinsertion", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
@@ -303,6 +335,37 @@ describe("startGatewayMaintenanceTimers", () => {
 
     // item-1 (now - 10k + 1) should remain as it is now one of the oldest but not evicted
     expect(deps.dedupe.has("item-1")).toBe(true);
+
+    stopMaintenanceTimers(timers);
+  });
+
+  it("does not evict active agent dedupe entries while trimming overflow", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const now = Date.now();
+
+    for (let index = 0; index < DEDUPE_MAX; index += 1) {
+      deps.dedupe.set(`stable-${index}`, { ts: now - 1_000 + index, ok: true });
+    }
+    deps.chatAbortControllers.set("active-oldest", createActiveRun("agent:main:main", "agent"));
+    deps.dedupe.set("agent:active-oldest", {
+      ts: now - 10_000,
+      ok: true,
+      payload: { runId: "active-oldest", status: "accepted" },
+    });
+    deps.dedupe.set("overflow-newest", { ts: now, ok: true });
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.dedupe.size).toBe(DEDUPE_MAX);
+    expect(deps.dedupe.has("agent:active-oldest")).toBe(true);
+    expect(deps.dedupe.has("stable-0")).toBe(false);
+    expect(deps.dedupe.has("stable-1")).toBe(false);
+    expect(deps.dedupe.has("overflow-newest")).toBe(true);
 
     stopMaintenanceTimers(timers);
   });

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -250,4 +250,60 @@ describe("startGatewayMaintenanceTimers", () => {
 
     stopMaintenanceTimers(timers);
   });
+
+  it("evicts multiple dedupe overflows by oldest timestamp with interleaved reinsertions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const now = Date.now();
+
+    // Fill to max with sequential timestamps
+    for (let index = 0; index < DEDUPE_MAX; index += 1) {
+      deps.dedupe.set(`item-${index}`, { ts: now - 10_000 + index, ok: true });
+    }
+
+    // Interleave updates and overflows:
+    // 1. Move item-0 to be the newest (was oldest)
+    deps.dedupe.delete("item-0");
+    deps.dedupe.set("item-0", { ts: now, ok: true });
+
+    // 2. Add multiple overflows
+    deps.dedupe.set("overflow-1", { ts: now - 5_000, ok: true }); // Should survive (middle age)
+    deps.dedupe.set("overflow-2", { ts: now - 20_000, ok: true }); // Should be evicted (oldest)
+
+    // 3. Move item-500 to be very old
+    deps.dedupe.delete("item-500");
+    deps.dedupe.set("item-500", { ts: now - 30_000, ok: true }); // Should be evicted (new oldest)
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    // Initial size is DEDUPE_MAX + 2 (item-0 and item-500 were re-added, overflow-1 and overflow-2 added)
+    // Actually:
+    // item-1 to item-499 (499)
+    // item-501 to item-999 (499)
+    // item-0 (1)
+    // item-500 (1)
+    // overflow-1 (1)
+    // overflow-2 (1)
+    // Total: 499 + 499 + 1 + 1 + 1 + 1 = 1002
+    expect(deps.dedupe.size).toBe(DEDUPE_MAX + 2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.dedupe.size).toBe(DEDUPE_MAX);
+
+    // item-500 (now - 30k) and overflow-2 (now - 20k) should be gone
+    expect(deps.dedupe.has("item-500")).toBe(false);
+    expect(deps.dedupe.has("overflow-2")).toBe(false);
+
+    // item-0 (now) and overflow-1 (now - 5k) should remain
+    expect(deps.dedupe.has("item-0")).toBe(true);
+    expect(deps.dedupe.has("overflow-1")).toBe(true);
+
+    // item-1 (now - 10k + 1) should remain as it is now one of the oldest but not evicted
+    expect(deps.dedupe.has("item-1")).toBe(true);
+
+    stopMaintenanceTimers(timers);
+  });
 });

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HealthSummary } from "../commands/health.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import { DEDUPE_MAX } from "./server-constants.js";
 
 const cleanOldMediaMock = vi.fn(async () => {});
 
@@ -219,6 +220,33 @@ describe("startGatewayMaintenanceTimers", () => {
     expect(deps.chatRunBuffers.has(runId)).toBe(false);
     expect(deps.chatDeltaSentAt.has(runId)).toBe(false);
     expect(deps.chatDeltaLastBroadcastLen.has(runId)).toBe(false);
+
+    stopMaintenanceTimers(timers);
+  });
+
+  it("evicts dedupe overflow by oldest timestamp even after reinsertion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-22T00:00:00Z"));
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+    const deps = createMaintenanceTimerDeps();
+    const now = Date.now();
+
+    for (let index = 0; index < DEDUPE_MAX; index += 1) {
+      deps.dedupe.set(`stable-${index}`, { ts: now - 1_000 + index, ok: true });
+    }
+
+    deps.dedupe.delete("stable-10");
+    deps.dedupe.set("stable-10", { ts: now - 2_000, ok: true });
+    deps.dedupe.set("overflow-newest", { ts: now - 100, ok: true });
+
+    const timers = startGatewayMaintenanceTimers(deps);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deps.dedupe.size).toBe(DEDUPE_MAX);
+    expect(deps.dedupe.has("stable-10")).toBe(false);
+    expect(deps.dedupe.has("stable-0")).toBe(true);
+    expect(deps.dedupe.has("overflow-newest")).toBe(true);
 
     stopMaintenanceTimers(timers);
   });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -84,16 +84,29 @@ export function startGatewayMaintenanceTimers(params: {
   const dedupeCleanup = setInterval(() => {
     const AGENT_RUN_SEQ_MAX = 10_000;
     const now = Date.now();
+    const isActiveRunDedupeKey = (key: string) => {
+      if (!key.startsWith("agent:") && !key.startsWith("chat:")) {
+        return false;
+      }
+      const runId = key.slice(key.indexOf(":") + 1);
+      const entry = runId ? params.chatAbortControllers.get(runId) : undefined;
+      if (!entry) {
+        return false;
+      }
+      return key.startsWith("agent:") ? entry.kind === "agent" : entry.kind !== "agent";
+    };
     for (const [k, v] of params.dedupe) {
+      if (isActiveRunDedupeKey(k)) {
+        continue;
+      }
       if (now - v.ts > DEDUPE_TTL_MS) {
         params.dedupe.delete(k);
       }
     }
     if (params.dedupe.size > DEDUPE_MAX) {
       const excess = params.dedupe.size - DEDUPE_MAX;
-      // Keep overflow eviction aligned with the entry timestamp, not Map
-      // insertion order, so refresh/reinsert paths still prune the oldest data.
       const oldestKeys = [...params.dedupe.entries()]
+        .filter(([key]) => !isActiveRunDedupeKey(key))
         .toSorted(([, left], [, right]) => left.ts - right.ts)
         .slice(0, excess)
         .map(([key]) => key);

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -90,9 +90,15 @@ export function startGatewayMaintenanceTimers(params: {
       }
     }
     if (params.dedupe.size > DEDUPE_MAX) {
-      const entries = [...params.dedupe.entries()].toSorted((a, b) => a[1].ts - b[1].ts);
-      for (let i = 0; i < params.dedupe.size - DEDUPE_MAX; i++) {
-        params.dedupe.delete(entries[i][0]);
+      const excess = params.dedupe.size - DEDUPE_MAX;
+      // Keep overflow eviction aligned with the entry timestamp, not Map
+      // insertion order, so refresh/reinsert paths still prune the oldest data.
+      const oldestKeys = [...params.dedupe.entries()]
+        .toSorted(([, left], [, right]) => left.ts - right.ts)
+        .slice(0, excess)
+        .map(([key]) => key);
+      for (const key of oldestKeys) {
+        params.dedupe.delete(key);
       }
     }
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -3321,7 +3321,7 @@ describe("gateway agent handler chat.abort integration", () => {
     );
   });
 
-  it("does not overwrite or evict a pre-existing chatAbortControllers entry with the same runId", async () => {
+  it("does not dispatch a duplicate agent run when dedupe was evicted but the run is active", async () => {
     prime();
     mocks.agentCommand.mockResolvedValueOnce({
       payloads: [{ text: "ok" }],
@@ -3340,6 +3340,8 @@ describe("gateway agent handler chat.abort integration", () => {
       ownerDeviceId: undefined,
     };
     context.chatAbortControllers.set(runId, preExisting);
+    context.dedupe.delete(`agent:${runId}`);
+    const respond = vi.fn();
 
     await invokeAgent(
       {
@@ -3348,16 +3350,14 @@ describe("gateway agent handler chat.abort integration", () => {
         sessionKey: "agent:main:main",
         idempotencyKey: runId,
       },
-      { context, reqId: runId },
+      { context, reqId: runId, respond },
     );
 
     expect(context.chatAbortControllers.get(runId)).toBe(preExisting);
-    // Cleanup after the agent run completes must not evict the pre-existing
-    // entry owned by a concurrent chat.send.
-    await waitForAssertion(() => {
-      expect(mocks.agentCommand).toHaveBeenCalled();
+    expect(mocks.agentCommand).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(true, { runId, status: "in_flight" }, undefined, {
+      cached: true,
+      runId,
     });
-    await new Promise((resolve) => setImmediate(resolve));
-    expect(context.chatAbortControllers.get(runId)).toBe(preExisting);
   });
 });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1284,6 +1284,13 @@ export const agentHandlers: GatewayRequestHandlers = {
         typeof client?.connect?.device?.id === "string" ? client.connect.device.id : undefined,
       kind: "agent",
     });
+    if (!activeRunAbort.registered && context.chatAbortControllers.has(runId)) {
+      respond(true, { runId, status: "in_flight" as const }, undefined, {
+        cached: true,
+        runId,
+      });
+      return;
+    }
 
     const accepted = {
       runId,


### PR DESCRIPTION
Fixes a bug where the dedupe eviction loop under-evicted because the loop condition shrank during deletions. Also keeps eviction deterministic by using each entry timestamp.

This also fixes an adjacent retry bug: active `agent:<runId>` dedupe entries are now protected from maintenance TTL/cap eviction while the matching abort controller is still active, and if an agent retry arrives after dedupe was already evicted, the gateway returns the active `in_flight` run instead of dispatching a duplicate run.

## Real behavior proof

- Behavior or issue addressed: Gateway maintenance dedupe overflow could remain above `DEDUPE_MAX`; active agent idempotency entries could also be evicted while the run was still active, allowing a retry to dispatch a duplicate agent command.
- Real environment tested: OpenClaw repo checkout on macOS with Node 22 locally, plus Blacksmith Testbox Linux `tbx_01kr59qks6wzeb1twhdcqg2rnd` for full changed and full-suite validation.
- Exact steps or command run after this patch: Ran a terminal reproduction of the cleanup math against `DEDUPE_MAX + 2` entries, then ran gateway regression tests and Testbox gates against commit `2bc2cc09068f71e229c243dd63f591a005efeced`.
- Evidence after fix: Terminal capture from the overflow repro:

```text
$ node --input-type=module <dedupe-overflow-repro>
{"oldAfterCleanup":1001,"fixedAfterCleanup":1000,"expectedMax":1000}
```

  Additional terminal proof: `pnpm test src/gateway/server-maintenance.test.ts src/gateway/server-methods/agent.test.ts` passed locally; `pnpm check:changed`, `pnpm check`, and full `pnpm test` passed on Testbox `tbx_01kr59qks6wzeb1twhdcqg2rnd`.
- Observed result after fix: The fixed cleanup returns the dedupe map to 1000 entries for the reproduced overflow case, active agent dedupe entries survive maintenance while their run is active, and retries after dedupe eviction return the existing `in_flight` run without dispatching a second agent command.
- What was not tested: No browser/mobile UI path; this is gateway server maintenance and agent-run idempotency behavior.

Proof policy local evaluation: passed.
