### PR TITLE
feat(runpr): add weekly outreach automation pipeline

### DIFF
--- a/agents/runpr-outreach/.env.example
+++ b/agents/runpr-outreach/.env.example
@@ -1,0 +1,15 @@
+# Exa neural search API key (used for sourcing prospects, news, and tool fingerprinting).
+# Forge: lifted from ~/code/runpr/.env (same key).
+EXA_API_KEY=
+
+# Gmail account to drop drafts into. Must already be authenticated via `gog auth add`.
+GMAIL_ACCOUNT=jeff@hypelab.digital
+
+# Phone (E.164) to ping with the post-run summary via imsg.
+NOTIFY_PHONE=+15166334684
+
+# How many fresh prospects to draft per run.
+PROSPECTS_PER_RUN=10
+
+# Optional: override codex model selection.
+# CODEX_MODEL=gpt-5.5

--- a/agents/runpr-outreach/README.md
+++ b/agents/runpr-outreach/README.md
@@ -1,0 +1,88 @@
+# RunPR Outreach Pipeline
+
+Weekly automated cold-pitch pipeline for [RunPR](https://runpr.ai/). Sources mid-size US B2B tech PR agencies, fingerprints their incumbent tool stack (Muck Rack / Cision / Meltwater), drafts personalized cold emails in Jeff's voice via codex (gpt-5.5), drops them in `jeff@hypelab.digital`'s Gmail drafts, and pings Jeff over iMessage with the run summary.
+
+## Layout
+
+```
+agents/runpr-outreach/
+  src/
+    index.ts            orchestrator (entry point)
+    source-prospects.ts Exa search across query pool, dedupes against tracker
+    detect-tools.ts     vendor case-study + wire footer + on-site fingerprint
+    find-recent-news.ts pulls the personalization hook
+    find-contact.ts     scrapes leadership pages, guesses email pattern
+    draft-email.ts      codex CLI wrapper (gpt-5.5 via ChatGPT OAuth)
+    push-to-gmail.ts    gog gmail drafts create wrapper
+    track-contacted.ts  reads/writes data/contacted-prospects.json
+    notify-summary.ts   imsg send wrapper for the post-run ping
+    exa-client.ts       fetch wrapper for Exa REST
+    types.ts
+  data/
+    playbook.md                 voice rules (LLM input)
+    email-templates.md          reference variants per detected tool
+    contacted-prospects.json    dedupe tracker, seeded with 24 day-1 agencies
+  cron/
+    install.sh          idempotent crontab installer
+  package.json, tsconfig.json, .env.example
+```
+
+## Setup (forge)
+
+```bash
+cd ~/code/openclaw/agents/runpr-outreach
+cp .env.example .env
+# Set EXA_API_KEY (lift from ~/code/runpr/.env, same key)
+npm install
+npm run build
+```
+
+## Manual run
+
+```bash
+# Dry run: full pipeline, no Gmail draft, no tracker write, no imsg.
+npm run weekly:dry
+
+# Real run.
+npm run weekly
+```
+
+## Cron install
+
+```bash
+bash cron/install.sh
+crontab -l   # verify
+```
+
+Schedule: `0 13 * * 1` (Monday 13:00 UTC). That's 9 AM EDT in summer, 8 AM EST in winter. Acceptable per spec.
+
+## Dependencies (forge)
+
+- `node` >= 20 at `/opt/homebrew/bin/node`
+- `codex` (codex-cli >= 0.124, authenticated via ChatGPT OAuth running gpt-5.5)
+- `gog` (gogcli, authenticated for `jeff@hypelab.digital`)
+- `imsg` (>=0.4)
+- `EXA_API_KEY` env var
+
+## Output per run
+
+- 10 new Gmail drafts in jeff@hypelab.digital
+- `data/contacted-prospects.json` updated with the 10 new entries
+- iMessage to Jeff at the configured `NOTIFY_PHONE` summarizing each draft
+- Stdout log to `/tmp/runpr-outreach.log`
+
+## Voice + safety rules
+
+See `data/playbook.md`. Highlights:
+
+- No em dashes anywhere (defense-in-depth: post-process strip).
+- Never reference team demographics.
+- Sentence case subject lines.
+- Drafts only. Nothing auto-sends.
+- Dedupes on domain AND name to avoid double-pitching.
+
+## Known limitations
+
+- Exa-based contact extraction is heuristic. LOW-confidence contacts get flagged in the imsg summary so Jeff can verify before sending.
+- The Gmail integration uses the existing `gog` CLI auth. If that auth lapses, drafts will fail and the pipeline reports the error in the imsg summary.
+- This is a best-effort sourcing pipeline. Some Exa results will be agency directories, not actual agencies. Filtering happens at multiple layers.

--- a/agents/runpr-outreach/cron/install.sh
+++ b/agents/runpr-outreach/cron/install.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Idempotent crontab installer for the RunPR weekly outreach pipeline.
+#
+# Schedule: every Monday at 13:00 UTC. That's 9 AM EDT (summer) / 8 AM EST (winter). Acceptable
+# per the project README. If you want strict 9 AM ET year-round, use a wrapper that exits early
+# on the off-week or run via Apple's launchd with calendar matching instead.
+
+set -euo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-$HOME/code/openclaw/agents/runpr-outreach}"
+NODE_BIN="${NODE_BIN:-/opt/homebrew/bin/node}"
+LOG_FILE="${LOG_FILE:-/tmp/runpr-outreach.log}"
+
+CRON_LINE="0 13 * * 1 cd ${PROJECT_DIR} && ${NODE_BIN} dist/index.js weekly >> ${LOG_FILE} 2>&1"
+MARKER="# runpr-outreach weekly cron"
+
+current="$(crontab -l 2>/dev/null || true)"
+
+if echo "${current}" | grep -F -q "${MARKER}"; then
+  echo "[install.sh] cron entry already present. Updating it in place."
+  filtered="$(echo "${current}" | awk -v marker="${MARKER}" '
+    BEGIN { skip = 0 }
+    {
+      if ($0 == marker) { skip = 2; next }
+      if (skip > 0) { skip--; next }
+      print
+    }
+  ')"
+else
+  filtered="${current}"
+fi
+
+# Append the marker + line. Trailing newline matters for crontab.
+{
+  if [ -n "${filtered}" ]; then
+    printf "%s\n" "${filtered}"
+  fi
+  printf "%s\n" "${MARKER}"
+  printf "%s\n" "${CRON_LINE}"
+} | crontab -
+
+echo "[install.sh] crontab updated. Active entry:"
+crontab -l | grep -A 1 "${MARKER}" || true

--- a/agents/runpr-outreach/data/contacted-prospects.json
+++ b/agents/runpr-outreach/data/contacted-prospects.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "updated_at": "2026-04-28T00:00:00Z",
+  "prospects": [
+    { "name": "Idea Grove", "domain": "ideagrovepr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Highwire", "domain": "highwirepr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "BIGfish", "domain": "bigfishpr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Touchdown", "domain": "touchdownpr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Mission North", "domain": "missionnorth.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Salient PR", "domain": "salientpr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "BMV (Beantown Media Ventures)", "domain": "bmv.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Corporate Ink", "domain": "corporateink.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Walker Sands", "domain": "walkersands.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "LaunchSquad", "domain": "launchsquad.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "10Fold", "domain": "10fold.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Method Communications", "domain": "methodcommunications.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Bospar", "domain": "bospar.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Treble PR", "domain": "treblepr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Inkhouse", "domain": "inkhouse.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Matter Communications", "domain": "matternow.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Next PR", "domain": "nextpr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Diffusion PR", "domain": "diffusionpr.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "PANBlast", "domain": "panblast.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Arketi Group", "domain": "arketi.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Gabriel Marketing Group", "domain": "gabrielmarketing.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Antenna Group", "domain": "antennagroup.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "SHIFT Communications", "domain": "shiftcomm.com", "contacted_at": "2026-04-28", "source": "manual-day-1" },
+    { "name": "Allison Worldwide", "domain": "allisonworldwide.com", "contacted_at": "2026-04-28", "source": "manual-day-1" }
+  ]
+}

--- a/agents/runpr-outreach/data/email-templates.md
+++ b/agents/runpr-outreach/data/email-templates.md
@@ -1,0 +1,92 @@
+# Email Reference Templates
+
+These are real emails Jeff sent to comparable agencies. Use them as VOICE reference, not text to copy. The personalization (the recent news hook) must be unique per agency.
+
+## Variant A: Muck Rack detected
+
+Subject: `The Foster the Future model + an operating question`
+
+Body:
+```
+Hi Tyler,
+
+The Foster the Future expansion is a real signal about where Mission North is investing, and the fact that Muck Rack training is built into the fellowship is smart. Junior people learning that toolset early is exactly how strong agencies compound.
+
+Quick thought on the back of that. Even with great Muck Rack onboarding, the actual drafting and follow-up work still eats real hours. RunPR puts AI agents on that layer specifically. Your team approves every pitch, the grunt work disappears, and new fellows can run senior-level pitch volume on day one.
+
+Worth a 15-min walkthrough?
+
+Jeff
+```
+
+Why it works: Names a specific Mission North initiative (Foster the Future), acknowledges what Muck Rack does well, positions RunPR as the layer ON TOP of the existing tool. Single question close. 102 words.
+
+## Variant B: Cision detected (or Cision-to-Muck-Rack migration)
+
+Subject: `Saw your Cision to Muck Rack switch story`
+
+Body:
+```
+Hi Michael,
+
+The Bliss Group integration plus double-digit 2024 growth is a serious lift, and the Cision-to-Muck Rack migration story you published is a great example of how Highwire executes through change.
+
+Quick question on the back of that. With 250+ across the combined team, how many senior hours are still going to drafting pitches and chasing reporters?
+
+I'm building RunPR. We took the parts of Muck Rack your team already likes and put AI agents on the drafting, targeting, and follow-ups. Your people still approve every pitch, the grunt work disappears. At post-merger scale, the leverage adds up fast.
+
+Happy to walk through what it'd look like for one of your client books.
+
+Jeff
+```
+
+Why it works: Two specific signals (Bliss Group integration, Cision-to-Muck-Rack migration), acknowledges scale, single concrete question on senior hours. 121 words.
+
+## Variant C: Multi-tool stack (Cision + Meltwater + Muck Rack)
+
+Subject: `Three tools, three contracts, one operating question`
+
+Body:
+```
+Hi Brent,
+
+Audit*E was a smart move. Bospar's clearly thinking past classic press hits into how brands show up inside AI systems, and the back-to-back Fortune Most Innovative recognition makes the case that the bet is working.
+
+Saw your PR Intern listing flags Cision, Meltwater, and Muck Rack as plus-haves. That's the modern reality. Three tools, three contracts, three logins, and senior people still doing the drafting.
+
+Quick reason I'm reaching out. RunPR collapses the database, drafting, and follow-up layers. AI agents handle the operational work, your team approves every pitch. The full-stack agencies that run lean on tooling pull ahead fast right now.
+
+Worth a 15-min look?
+
+Jeff
+```
+
+Why it works: Specific recent product (Audit*E), specific external recognition (Fortune Most Innovative), specific evidence of multi-tool stack (job listing). Pivots that evidence into the RunPR consolidation pitch. 119 words.
+
+## Variant D: Unknown tool stack
+
+Subject: `Quick read on your [recent agency news]`
+
+Body:
+```
+Hi [first name],
+
+[One to two sentences referencing the specific recent news. Quote a line or name a specific initiative.]
+
+Quick reason I'm reaching out. Modern PR teams are running on three or four tools, and senior people still do the drafting. RunPR collapses the database, drafting, and follow-up layers into one workflow. AI agents handle the operational work, your team approves every pitch.
+
+For an agency [scale or positioning signal from the news], the leverage adds up across every practice.
+
+Worth a 15-min look?
+
+Jeff
+```
+
+Why it works: When you can't name the incumbent, frame the pain as "modern PR teams are running on three or four tools." This is true for ~95% of mid-size B2B firms and feels observed rather than guessed. 95 words.
+
+## Critical reminders for all variants
+
+- Sentence case subjects only.
+- HTML body: first `RunPR` is wrapped in `<a href="https://runpr.ai/">RunPR</a>`. Plain text body: just `RunPR`.
+- No em dashes.
+- Sign off "Jeff" alone.

--- a/agents/runpr-outreach/data/playbook.md
+++ b/agents/runpr-outreach/data/playbook.md
@@ -1,0 +1,61 @@
+# RunPR Outreach Voice Playbook
+
+This is the voice spec the LLM follows when drafting cold pitches for Jeff. Every rule here is a hard rule. Treat each one as a constraint, not a suggestion.
+
+## Hard rules
+
+1. **No em dashes.** Ever. Use periods, commas, parentheses, colons, or "and." If you generate an em dash, you have failed the prompt.
+2. **No demographic callouts.** Never reference gender, ethnicity, age, or appearance of anyone on the agency's team. Reference work and quotes only.
+3. **Sign off "Jeff"** (no surname, no signature block, no contact details).
+4. **Single question close.** End with one real question. Never "let me know a time that works" or "looking forward to hearing back."
+5. **80 to 130 words** for the body (excluding subject + sign-off line). Short paragraphs, ideally three to four.
+6. **First "RunPR" mention in HTML body must be linked.** Use `<a href="https://runpr.ai/">RunPR</a>` exactly. In the plain text alternative just write `RunPR` (no link).
+7. **Sentence case subject line.** No title case. Provocative or curiosity-driving. Reference something specific the agency did, not generic verbiage.
+
+## Voice
+
+- Conversational founder voice. Like Jeff actually wrote it on a Monday morning between meetings.
+- NOT salesy. No "I hope this finds you well." No "I wanted to reach out because." No "circle back."
+- Specific over generic. Always. If you have to choose between specific and clever, choose specific.
+- Anchor the pitch on the detected incumbent tool when known (Muck Rack, Cision, Meltwater). When unknown, use a "lean tooling stack" or "operating leverage" angle instead of inventing a tool.
+- Acknowledge what's good about the incumbent before positioning RunPR as the layer on top. Never trash the incumbent.
+
+## Subject line patterns that work
+
+- "Saw your Cision to Muck Rack switch story"
+- "Your 'power combo' post got me thinking"
+- "The Megawatt math + an operating question"
+- "[Agency] + AI verification + an operating question"
+- "Quick read on your [specific recent thing]"
+
+## Body shape (rough)
+
+1. Opening hook: one to two sentences that name the recent news / quote / case study you're referencing. Show you actually read it.
+2. Tool acknowledgment: one to two sentences naming the detected incumbent and what their team gets out of it.
+3. RunPR positioning: two to three sentences. Pattern is "RunPR sits on top of where [tool] stops. AI agents handle drafting, targeting, follow-ups. Your team approves every pitch. The grunt work disappears."
+4. Single question close.
+
+## RunPR positioning lines you can pull from
+
+- "RunPR sits on top of where Muck Rack stops."
+- "We took the parts of [tool] your team already likes and put AI agents on the work nobody enjoys."
+- "AI agents handle the drafting, targeting, and follow-ups. Your team approves every pitch."
+- "At [scale signal] scale, the leverage adds up fast."
+- "Senior people stop writing rough drafts. Junior people can run senior pitch volume on day one."
+
+## Closes that work
+
+- "Worth a 15-min look?"
+- "Worth a 15-min walkthrough?"
+- "How much of your senior team's week still goes to drafting and chasing reporters?"
+- "Open to a quick walkthrough?"
+- "Want me to run the same teardown for [agency name]?"
+
+## Things that ruin the voice
+
+- "Hope this finds you well."
+- "I'm reaching out because."
+- "I'd love to chat about how RunPR can help your team."
+- "Quick question." (Acceptable as a TRANSITION mid-email, not as the opening sentence.)
+- "Synergy," "leverage" (verb), "unlock," "supercharge."
+- Em dashes (yes, this is repeated on purpose).

--- a/agents/runpr-outreach/package.json
+++ b/agents/runpr-outreach/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@openclaw/runpr-outreach",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Weekly RunPR outreach pipeline. Sources PR agency prospects, fingerprints their tool stack, drafts personalized cold emails, and drops them in jeff@hypelab.digital's Gmail drafts.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc",
+    "weekly": "node dist/index.js weekly",
+    "weekly:dry": "node dist/index.js weekly --dry-run",
+    "dev:dry": "tsc && node dist/index.js weekly --dry-run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "exa-js": "^1.4.10"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.5"
+  }
+}

--- a/agents/runpr-outreach/src/detect-tools.ts
+++ b/agents/runpr-outreach/src/detect-tools.ts
@@ -1,0 +1,158 @@
+// Fingerprint which PR tool stack an agency is using. Strategy:
+//   1. Vendor case-study scrape: Exa search restricted to muckrack.com, cision.com, meltwater.com
+//      for the agency's name. Hits there are strong evidence (HIGH).
+//   2. Press-release wire footers: search the agency's domain for "via Cision" / "via PR Newswire"
+//      / "via Business Wire" patterns. PR Newswire = Cision-owned. Business Wire = independent.
+//   3. On-site widget / job listing fingerprints: search the agency's domain for Cision/Muck Rack/
+//      Meltwater string mentions (often surface in careers pages, blog posts, "tools we use").
+//   4. Generic Exa search across the open web combining agency name with each tool.
+//
+// We rate confidence based on how many independent signals corroborate.
+
+import type { ExaClient } from "./exa-client.js";
+import type { DetectedTool, DetectedToolResult, RawProspect } from "./types.js";
+
+interface ToolHit {
+  tool: DetectedTool;
+  source: "vendor-case-study" | "wire-footer" | "site-fingerprint" | "open-web";
+  evidence: string;
+}
+
+async function searchForHits(
+  exa: ExaClient,
+  agency: RawProspect,
+): Promise<ToolHit[]> {
+  const hits: ToolHit[] = [];
+  const name = agency.name;
+  const domain = agency.domain;
+
+  // 1. Vendor case-study hunt. Each vendor has a /case-studies or /customers area.
+  const vendorChecks: Array<{ tool: DetectedTool; domain: string }> = [
+    { tool: "muckrack", domain: "muckrack.com" },
+    { tool: "cision", domain: "cision.com" },
+    { tool: "meltwater", domain: "meltwater.com" },
+  ];
+  for (const v of vendorChecks) {
+    try {
+      const resp = await exa.search(`"${name}" PR agency`, {
+        numResults: 3,
+        includeDomains: [v.domain],
+        type: "keyword",
+        useAutoprompt: false,
+      });
+      for (const r of resp.results) {
+        if (r.url.includes(v.domain)) {
+          hits.push({
+            tool: v.tool,
+            source: "vendor-case-study",
+            evidence: `${v.domain}: ${r.title?.slice(0, 100) ?? r.url}`,
+          });
+        }
+      }
+    } catch (err) {
+      // Non-fatal; continue.
+      console.error(`[detect-tools] vendor scan ${v.domain} failed:`, (err as Error).message);
+    }
+  }
+
+  // 2. Site fingerprint: search the agency's domain itself for tool mentions.
+  const fingerprintQueries: Array<{ tool: DetectedTool; query: string }> = [
+    { tool: "muckrack", query: "Muck Rack" },
+    { tool: "cision", query: "Cision" },
+    { tool: "meltwater", query: "Meltwater" },
+  ];
+  for (const f of fingerprintQueries) {
+    try {
+      const resp = await exa.search(`"${f.query}"`, {
+        numResults: 3,
+        includeDomains: [domain],
+        type: "keyword",
+        useAutoprompt: false,
+      });
+      for (const r of resp.results) {
+        if (r.url.toLowerCase().includes(domain)) {
+          hits.push({
+            tool: f.tool,
+            source: "site-fingerprint",
+            evidence: `${domain}: ${r.title?.slice(0, 100) ?? r.url}`,
+          });
+        }
+      }
+    } catch (err) {
+      console.error(`[detect-tools] fingerprint ${f.tool} failed:`, (err as Error).message);
+    }
+  }
+
+  // 3. Wire footer: scan the agency domain for press release distribution mentions.
+  try {
+    const resp = await exa.search(`"PR Newswire" OR "via Cision"`, {
+      numResults: 3,
+      includeDomains: [domain],
+      type: "keyword",
+      useAutoprompt: false,
+    });
+    for (const r of resp.results) {
+      hits.push({
+        tool: "cision",
+        source: "wire-footer",
+        evidence: `wire footer on ${domain}: ${r.title?.slice(0, 80) ?? r.url}`,
+      });
+    }
+  } catch (err) {
+    // Non-fatal.
+  }
+
+  return hits;
+}
+
+export async function detectTools(
+  exa: ExaClient,
+  agency: RawProspect,
+): Promise<DetectedToolResult> {
+  const hits = await searchForHits(exa, agency);
+
+  // Tally hits per tool, weighted by source strength.
+  const weights: Record<ToolHit["source"], number> = {
+    "vendor-case-study": 3,
+    "wire-footer": 2,
+    "site-fingerprint": 2,
+    "open-web": 1,
+  };
+  const scores: Record<DetectedTool, number> = {
+    muckrack: 0,
+    cision: 0,
+    meltwater: 0,
+    multi: 0,
+    unknown: 0,
+  };
+  for (const h of hits) {
+    scores[h.tool] += weights[h.source];
+  }
+
+  const detectedTools = (["muckrack", "cision", "meltwater"] as const).filter(
+    (t) => scores[t] > 0,
+  );
+
+  let tool: DetectedTool = "unknown";
+  let confidence: "HIGH" | "MED" | "LOW" = "LOW";
+
+  if (detectedTools.length === 0) {
+    tool = "unknown";
+    confidence = "LOW";
+  } else if (detectedTools.length >= 2) {
+    tool = "multi";
+    confidence = "MED";
+  } else {
+    tool = detectedTools[0]!;
+    const score = scores[tool];
+    if (score >= 3) confidence = "HIGH";
+    else if (score >= 2) confidence = "MED";
+    else confidence = "LOW";
+  }
+
+  return {
+    tool,
+    confidence,
+    evidence: hits.map((h) => `[${h.source}] ${h.evidence}`),
+  };
+}

--- a/agents/runpr-outreach/src/draft-email.ts
+++ b/agents/runpr-outreach/src/draft-email.ts
@@ -1,0 +1,208 @@
+// Generate a personalized RunPR cold-pitch email by calling the local codex CLI (gpt-5.5 via
+// ChatGPT OAuth). The codex binary is non-interactive in `codex exec` mode and expects a prompt
+// on stdin or as the first positional arg.
+//
+// We give the model:
+//   - The voice playbook (data/playbook.md) verbatim.
+//   - The reference email templates (data/email-templates.md).
+//   - A structured JSON brief: agency name, domain, detected tool, recent news, contact name.
+//   - A strict output contract (subject + body_text + body_html as JSON).
+
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Contact, DetectedToolResult, DraftEmail, RawProspect, RecentNews } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DATA_DIR = resolve(__dirname, "..", "data");
+
+let cachedPlaybook: string | null = null;
+let cachedTemplates: string | null = null;
+
+async function loadAssets(): Promise<{ playbook: string; templates: string }> {
+  if (!cachedPlaybook) cachedPlaybook = await readFile(resolve(DATA_DIR, "playbook.md"), "utf8");
+  if (!cachedTemplates)
+    cachedTemplates = await readFile(resolve(DATA_DIR, "email-templates.md"), "utf8");
+  return { playbook: cachedPlaybook, templates: cachedTemplates };
+}
+
+function buildPrompt(opts: {
+  agency: RawProspect;
+  detected: DetectedToolResult;
+  news: RecentNews | null;
+  contact: Contact;
+  playbook: string;
+  templates: string;
+}): string {
+  const { agency, detected, news, contact, playbook, templates } = opts;
+
+  const newsBlock = news
+    ? `Headline: ${news.headline}\nURL: ${news.url}\nPublished: ${news.published_at ?? "unknown"}\nSnippet: ${news.snippet}`
+    : "(no recent news found; use the agency blurb as context)";
+
+  return `You are drafting a single cold-pitch email from Jeff (founder of RunPR) to a PR agency. Follow the voice playbook EXACTLY. Output ONLY a JSON object.
+
+# VOICE PLAYBOOK
+
+${playbook}
+
+# REFERENCE EXAMPLES
+
+${templates}
+
+# AGENCY BRIEF
+
+Agency name: ${agency.name}
+Agency domain: ${agency.domain}
+Agency blurb (auto-scraped): ${agency.blurb || "(none)"}
+Detected incumbent tool: ${detected.tool} (confidence: ${detected.confidence})
+Detection evidence:
+${detected.evidence.length ? detected.evidence.map((e) => `  - ${e}`).join("\n") : "  - (none)"}
+
+Recent news to use as the personalization hook:
+${newsBlock}
+
+Recipient:
+  First name: ${contact.first_name}
+  Title: ${contact.title || "(unknown)"}
+  Contact confidence: ${contact.confidence}
+
+# OUTPUT CONTRACT
+
+Return EXACTLY a JSON object with these keys (and nothing else, no markdown fence, no commentary):
+
+{
+  "subject": "<sentence-case subject line>",
+  "body_text": "<plain text body, 80-130 words, signed 'Jeff'>",
+  "body_html": "<HTML body, same content as body_text but the FIRST 'RunPR' is wrapped in <a href=\\"https://runpr.ai/\\">RunPR</a>, paragraphs use <p> tags, sign-off on its own paragraph>"
+}
+
+Rules to double-check before emitting:
+1. ZERO em dashes anywhere. Search your output. If you find one, rewrite.
+2. The first line of body_text starts with "Hi ${contact.first_name}," exactly.
+3. Body ends with the line "Jeff" alone (no surname, no signature block).
+4. Subject is sentence case (only the first word and proper nouns capitalized).
+5. The opening hook references the recent news / agency-specific signal above.
+6. If detected tool is "unknown", do NOT invent a tool. Use the "modern PR teams running on three or four tools" framing.
+7. Single-question close, real question.
+8. NEVER reference team members' demographics.
+
+Emit the JSON object now.`;
+}
+
+async function runCodex(prompt: string, timeoutMs = 90_000): Promise<string> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    // `codex exec` reads prompt from stdin if provided via pipe. The `--skip-git-repo-check`
+    // flag avoids codex complaining that we're running outside a git tree (the prompt itself is
+    // self-contained).
+    const args = ["exec", "--skip-git-repo-check", "-"];
+    const child = spawn("codex", args, { stdio: ["pipe", "pipe", "pipe"] });
+
+    const chunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    let timedOut = false;
+    const t = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    child.stdout.on("data", (b) => chunks.push(b));
+    child.stderr.on("data", (b) => errChunks.push(b));
+    child.on("error", (err) => {
+      clearTimeout(t);
+      rejectPromise(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(t);
+      const stdout = Buffer.concat(chunks).toString("utf8");
+      const stderr = Buffer.concat(errChunks).toString("utf8");
+      if (timedOut) return rejectPromise(new Error("codex exec timed out"));
+      if (code !== 0) {
+        return rejectPromise(
+          new Error(`codex exec exited ${code}: ${stderr.slice(0, 800) || "(no stderr)"}`),
+        );
+      }
+      resolvePromise(stdout);
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+// Codex `exec` prints a header and a footer around the model output. Strip those and pull out the
+// first JSON object we find.
+function extractJson(raw: string): string | null {
+  // Look for the first '{' and last '}' that brace-balance.
+  const start = raw.indexOf("{");
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i]!;
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return raw.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+}
+
+function stripEmDashes(s: string): string {
+  // Defense in depth. The model is instructed to never produce em dashes, but if one slips
+  // through, replace it with a period+space.
+  return s.replace(/—/g, ". ").replace(/–/g, ", ");
+}
+
+export async function draftEmail(opts: {
+  agency: RawProspect;
+  detected: DetectedToolResult;
+  news: RecentNews | null;
+  contact: Contact;
+}): Promise<DraftEmail> {
+  const { playbook, templates } = await loadAssets();
+  const prompt = buildPrompt({ ...opts, playbook, templates });
+
+  const raw = await runCodex(prompt);
+  const json = extractJson(raw);
+  if (!json) {
+    throw new Error(
+      `codex returned no JSON for ${opts.agency.name}. Raw head: ${raw.slice(0, 400)}`,
+    );
+  }
+  let parsed: { subject?: string; body_text?: string; body_html?: string };
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(
+      `codex JSON parse failed for ${opts.agency.name}: ${(err as Error).message}\n${json.slice(0, 400)}`,
+    );
+  }
+  if (!parsed.subject || !parsed.body_text || !parsed.body_html) {
+    throw new Error(`codex output missing required fields for ${opts.agency.name}`);
+  }
+  return {
+    subject: stripEmDashes(parsed.subject.trim()),
+    body_text: stripEmDashes(parsed.body_text.trim()),
+    body_html: stripEmDashes(parsed.body_html.trim()),
+  };
+}

--- a/agents/runpr-outreach/src/exa-client.ts
+++ b/agents/runpr-outreach/src/exa-client.ts
@@ -1,0 +1,90 @@
+// Thin wrapper around the Exa REST API. The official `exa-js` SDK works, but a fetch wrapper keeps
+// the dependency list small and the error handling explicit.
+
+interface ExaSearchOptions {
+  numResults?: number;
+  type?: "neural" | "keyword" | "auto";
+  useAutoprompt?: boolean;
+  category?: string;
+  startPublishedDate?: string;
+  endPublishedDate?: string;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  text?: boolean | { maxCharacters?: number };
+}
+
+export interface ExaResult {
+  id: string;
+  url: string;
+  title: string;
+  publishedDate?: string;
+  author?: string;
+  text?: string;
+  score?: number;
+}
+
+export interface ExaSearchResponse {
+  results: ExaResult[];
+  autopromptString?: string;
+}
+
+const EXA_BASE = "https://api.exa.ai";
+
+export class ExaClient {
+  constructor(private readonly apiKey: string) {
+    if (!apiKey) throw new Error("ExaClient requires an api key");
+  }
+
+  async search(query: string, options: ExaSearchOptions = {}): Promise<ExaSearchResponse> {
+    const body: Record<string, unknown> = {
+      query,
+      numResults: options.numResults ?? 10,
+      type: options.type ?? "auto",
+      useAutoprompt: options.useAutoprompt ?? true,
+    };
+    if (options.category) body.category = options.category;
+    if (options.startPublishedDate) body.startPublishedDate = options.startPublishedDate;
+    if (options.endPublishedDate) body.endPublishedDate = options.endPublishedDate;
+    if (options.includeDomains) body.includeDomains = options.includeDomains;
+    if (options.excludeDomains) body.excludeDomains = options.excludeDomains;
+    if (options.text) {
+      body.contents = {
+        text: typeof options.text === "object" ? options.text : { maxCharacters: 1500 },
+      };
+    }
+
+    const res = await fetch(`${EXA_BASE}/search`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Exa search failed (${res.status}): ${text.slice(0, 500)}`);
+    }
+    return (await res.json()) as ExaSearchResponse;
+  }
+
+  async getContents(urls: string[]): Promise<{ results: ExaResult[] }> {
+    if (urls.length === 0) return { results: [] };
+    const res = await fetch(`${EXA_BASE}/contents`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body: JSON.stringify({
+        urls,
+        text: { maxCharacters: 4000 },
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Exa contents failed (${res.status}): ${text.slice(0, 500)}`);
+    }
+    return (await res.json()) as { results: ExaResult[] };
+  }
+}

--- a/agents/runpr-outreach/src/find-contact.ts
+++ b/agents/runpr-outreach/src/find-contact.ts
@@ -1,0 +1,197 @@
+// Find a real decision-maker (founder / partner / SVP) at the agency. Pull names from leadership /
+// about / team pages via Exa, then guess the email pattern.
+//
+// Confidence levels:
+//   HIGH: name + title pulled from a leadership page on the agency's own domain.
+//   MED:  name + title pulled from open-web (LinkedIn-adjacent, PRWeek, etc).
+//   LOW:  no name. Falls back to info@domain or hello@domain.
+
+import type { ExaClient } from "./exa-client.js";
+import type { Contact, RawProspect } from "./types.js";
+
+const SENIOR_TITLE_KEYWORDS = [
+  "founder",
+  "co-founder",
+  "ceo",
+  "president",
+  "managing partner",
+  "managing director",
+  "general manager",
+  "svp",
+  "evp",
+  "executive vice president",
+  "senior vice president",
+  "head of new business",
+  "head of growth",
+];
+
+interface ExtractedPerson {
+  first: string;
+  last: string;
+  title: string;
+  source_url: string;
+  on_own_domain: boolean;
+}
+
+function tidy(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+// Very permissive name+title extraction. Looks for patterns like "Jane Doe, CEO" or
+// "Jane Doe — Founder" (dash variants) in scraped text.
+function extractPeople(text: string, agencyDomain: string, sourceUrl: string): ExtractedPerson[] {
+  if (!text) return [];
+  const onOwnDomain = sourceUrl.toLowerCase().includes(agencyDomain.toLowerCase());
+  const people: ExtractedPerson[] = [];
+
+  // Pattern: "FirstName LastName, Title" or "FirstName LastName | Title"
+  const lines = text.split(/[\n\r]+/);
+  const namePattern = /\b([A-Z][a-z]{1,15})\s+([A-Z][a-z]{1,20})\b/g;
+  const titleSeparator = /[,|\-–—:]/;
+
+  for (const line of lines) {
+    const trimmed = tidy(line);
+    if (trimmed.length < 8 || trimmed.length > 180) continue;
+    const lower = trimmed.toLowerCase();
+    const matchedTitle = SENIOR_TITLE_KEYWORDS.find((kw) => lower.includes(kw));
+    if (!matchedTitle) continue;
+
+    // Find a name in the same line.
+    let match: RegExpExecArray | null;
+    namePattern.lastIndex = 0;
+    while ((match = namePattern.exec(trimmed)) !== null) {
+      const first = match[1]!;
+      const last = match[2]!;
+      const combo = `${first} ${last}`.toLowerCase();
+      // Reject if either token is itself a job-title word ("Executive Vice", "Senior Vice",
+      // "Chief Executive", etc.). Those leak through when titles are formatted weirdly.
+      const titleTokens = new Set([
+        "executive",
+        "vice",
+        "senior",
+        "chief",
+        "managing",
+        "general",
+        "head",
+        "president",
+        "director",
+        "officer",
+        "founder",
+        "partner",
+        "associate",
+      ]);
+      if (titleTokens.has(first.toLowerCase()) || titleTokens.has(last.toLowerCase())) continue;
+      // Avoid common false positives (eg. "Press Releases", "United States").
+      if (
+        combo.startsWith("press ") ||
+        combo.startsWith("united ") ||
+        combo.startsWith("new ") ||
+        combo.startsWith("client ") ||
+        combo.startsWith("the ") ||
+        combo.startsWith("our ") ||
+        combo.startsWith("read ") ||
+        combo.startsWith("learn ") ||
+        first === last
+      ) {
+        continue;
+      }
+      // Find the segment after a separator that matches a title keyword.
+      const separatorIdx = trimmed.search(titleSeparator);
+      const titleGuess =
+        separatorIdx > -1 ? tidy(trimmed.slice(separatorIdx + 1)).slice(0, 80) : matchedTitle;
+
+      people.push({
+        first,
+        last,
+        title: titleGuess || matchedTitle,
+        source_url: sourceUrl,
+        on_own_domain: onOwnDomain,
+      });
+      break; // One person per line max.
+    }
+  }
+  return people;
+}
+
+function bestEmailPattern(
+  first: string,
+  last: string,
+  domain: string,
+): { email: string; pattern: Contact["email_pattern"] } {
+  // Most common B2B agency pattern is first.last@. Use first@ as a fallback for boutique shops.
+  const f = first.toLowerCase().replace(/[^a-z]/g, "");
+  const l = last.toLowerCase().replace(/[^a-z]/g, "");
+  if (!f || !l) {
+    return { email: `info@${domain}`, pattern: "info" };
+  }
+  return { email: `${f}.${l}@${domain}`, pattern: "first.last" };
+}
+
+export async function findContact(exa: ExaClient, agency: RawProspect): Promise<Contact> {
+  const candidates: ExtractedPerson[] = [];
+
+  // 1. Look at the agency's own about/team/leadership pages.
+  for (const path of ["about", "team", "leadership", "people", "our-team"]) {
+    try {
+      const resp = await exa.search(`${agency.name} ${path}`, {
+        numResults: 3,
+        includeDomains: [agency.domain],
+        type: "keyword",
+        text: { maxCharacters: 4000 },
+      });
+      for (const r of resp.results) {
+        const text = r.text ?? "";
+        candidates.push(...extractPeople(text, agency.domain, r.url));
+      }
+    } catch (err) {
+      // Continue.
+    }
+    if (candidates.length > 0) break; // Got something on-domain; that's enough.
+  }
+
+  // 2. Open-web fallback.
+  if (candidates.length === 0) {
+    try {
+      const resp = await exa.search(`${agency.name} founder OR CEO OR president`, {
+        numResults: 5,
+        text: { maxCharacters: 3000 },
+      });
+      for (const r of resp.results) {
+        candidates.push(...extractPeople(r.text ?? "", agency.domain, r.url));
+      }
+    } catch (err) {
+      // Continue.
+    }
+  }
+
+  // Pick the best candidate. Prefer on-own-domain results.
+  candidates.sort((a, b) => {
+    if (a.on_own_domain && !b.on_own_domain) return -1;
+    if (!a.on_own_domain && b.on_own_domain) return 1;
+    return 0;
+  });
+
+  if (candidates.length === 0) {
+    return {
+      first_name: "team",
+      last_name: "",
+      title: "",
+      email: `info@${agency.domain}`,
+      email_pattern: "info",
+      confidence: "LOW",
+    };
+  }
+
+  const best = candidates[0]!;
+  const { email, pattern } = bestEmailPattern(best.first, best.last, agency.domain);
+  const confidence: Contact["confidence"] = best.on_own_domain ? "HIGH" : "MED";
+
+  return {
+    first_name: best.first,
+    last_name: best.last,
+    title: best.title,
+    email,
+    email_pattern: pattern,
+    confidence,
+  };
+}

--- a/agents/runpr-outreach/src/find-recent-news.ts
+++ b/agents/runpr-outreach/src/find-recent-news.ts
@@ -1,0 +1,108 @@
+// Find one citable piece of recent news for an agency. Used as the personalization hook.
+// Priority order:
+//   1. Press releases / news pages from the agency's own domain (last 180 days).
+//   2. Industry coverage (PRWeek, O'Dwyer's, Bulldog Reporter) mentioning the agency.
+//   3. Generic web mention (last 90 days).
+
+import type { ExaClient } from "./exa-client.js";
+import type { RawProspect, RecentNews } from "./types.js";
+
+const NEWS_DOMAINS = [
+  "prweek.com",
+  "odwyerpr.com",
+  "bulldogreporter.com",
+  "prnewsonline.com",
+  "agencyspy.com",
+  "adweek.com",
+  "businesswire.com",
+  "prnewswire.com",
+];
+
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+export async function findRecentNews(
+  exa: ExaClient,
+  agency: RawProspect,
+): Promise<RecentNews | null> {
+  const candidates: RecentNews[] = [];
+
+  // 1. Agency's own press / news / blog content.
+  try {
+    const resp = await exa.search(`${agency.name} announcement OR launches OR hires OR client`, {
+      numResults: 5,
+      includeDomains: [agency.domain],
+      startPublishedDate: daysAgo(180),
+      type: "auto",
+      text: { maxCharacters: 600 },
+    });
+    for (const r of resp.results) {
+      if (!r.title) continue;
+      candidates.push({
+        headline: r.title,
+        url: r.url,
+        published_at: r.publishedDate,
+        snippet: (r.text ?? "").slice(0, 300),
+      });
+    }
+  } catch (err) {
+    console.error(`[find-recent-news] own-domain query failed for ${agency.name}`);
+  }
+
+  // 2. Trade publications. Stronger signal if a trade picked up the news.
+  try {
+    const resp = await exa.search(`"${agency.name}"`, {
+      numResults: 5,
+      includeDomains: NEWS_DOMAINS,
+      startPublishedDate: daysAgo(180),
+      type: "keyword",
+      text: { maxCharacters: 600 },
+    });
+    for (const r of resp.results) {
+      if (!r.title) continue;
+      candidates.push({
+        headline: r.title,
+        url: r.url,
+        published_at: r.publishedDate,
+        snippet: (r.text ?? "").slice(0, 300),
+      });
+    }
+  } catch (err) {
+    // Non-fatal.
+  }
+
+  // 3. Generic web fallback.
+  if (candidates.length === 0) {
+    try {
+      const resp = await exa.search(`${agency.name} PR agency`, {
+        numResults: 3,
+        startPublishedDate: daysAgo(365),
+        type: "auto",
+        text: { maxCharacters: 600 },
+      });
+      for (const r of resp.results) {
+        if (!r.title) continue;
+        candidates.push({
+          headline: r.title,
+          url: r.url,
+          published_at: r.publishedDate,
+          snippet: (r.text ?? "").slice(0, 300),
+        });
+      }
+    } catch (err) {
+      // Non-fatal.
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Prefer the most recent. Exa returns ISO dates when it has them.
+  candidates.sort((a, b) => {
+    const da = a.published_at ? Date.parse(a.published_at) : 0;
+    const db = b.published_at ? Date.parse(b.published_at) : 0;
+    return db - da;
+  });
+
+  return candidates[0]!;
+}

--- a/agents/runpr-outreach/src/index.ts
+++ b/agents/runpr-outreach/src/index.ts
@@ -1,0 +1,166 @@
+// Orchestrator. Run with `npm run weekly` (or `npm run weekly:dry`).
+
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ExaClient } from "./exa-client.js";
+import { sourceProspects } from "./source-prospects.js";
+import { detectTools } from "./detect-tools.js";
+import { findRecentNews } from "./find-recent-news.js";
+import { findContact } from "./find-contact.js";
+import { draftEmail } from "./draft-email.js";
+import { pushDraftToGmail } from "./push-to-gmail.js";
+import { appendContacted, loadContacted } from "./track-contacted.js";
+import { sendSummary, buildSummaryText } from "./notify-summary.js";
+import type { ProspectRun, RawProspect, RunOptions } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = resolve(__dirname, "..");
+
+// Tiny .env loader. Avoids pulling in dotenv as a dep.
+function loadEnv(): void {
+  const envPath = resolve(PROJECT_ROOT, ".env");
+  if (!existsSync(envPath)) return;
+  const raw = readFileSync(envPath, "utf8");
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+function readOptions(): RunOptions {
+  const dryRun = process.argv.includes("--dry-run");
+  const exaApiKey = process.env.EXA_API_KEY ?? "";
+  const gmailAccount = process.env.GMAIL_ACCOUNT ?? "jeff@hypelab.digital";
+  const notifyPhone = process.env.NOTIFY_PHONE ?? "+15166334684";
+  const prospectsPerRun = Number(process.env.PROSPECTS_PER_RUN ?? "10");
+  if (!exaApiKey) throw new Error("EXA_API_KEY not set. Copy .env.example to .env on forge.");
+  return { dryRun, exaApiKey, gmailAccount, notifyPhone, prospectsPerRun };
+}
+
+async function processProspect(
+  exa: ExaClient,
+  prospect: RawProspect,
+  options: RunOptions,
+): Promise<ProspectRun | null> {
+  console.log(`[run] ${prospect.name} (${prospect.domain})`);
+  try {
+    const detected = await detectTools(exa, prospect);
+    console.log(`  detected tool: ${detected.tool} (${detected.confidence})`);
+    const news = await findRecentNews(exa, prospect);
+    console.log(`  news: ${news ? news.headline.slice(0, 60) : "(none)"}`);
+    const contact = await findContact(exa, prospect);
+    console.log(
+      `  contact: ${contact.first_name} ${contact.last_name} <${contact.email}> [${contact.confidence}]`,
+    );
+    const draft = await draftEmail({
+      agency: prospect,
+      detected,
+      news,
+      contact,
+    });
+    console.log(`  drafted subject: "${draft.subject}"`);
+
+    let gmailDraftId: string | undefined;
+    let gmailDraftUrl: string | undefined;
+    if (!options.dryRun) {
+      const result = await pushDraftToGmail({
+        account: options.gmailAccount,
+        to: contact.email,
+        contact,
+        draft,
+      });
+      gmailDraftId = result.draft_id;
+      gmailDraftUrl = result.draft_url;
+      console.log(`  gmail draft id: ${gmailDraftId ?? "(unknown)"}`);
+    } else {
+      console.log("  [dry-run] skipping Gmail push");
+    }
+
+    return {
+      prospect,
+      detected,
+      news,
+      contact,
+      draft,
+      gmail_draft_id: gmailDraftId,
+      gmail_draft_url: gmailDraftUrl,
+    };
+  } catch (err) {
+    console.error(`[run] failed on ${prospect.name}:`, (err as Error).message);
+    return null;
+  }
+}
+
+async function weekly(): Promise<void> {
+  loadEnv();
+  const options = readOptions();
+  console.log(
+    `[runpr-outreach] weekly run starting. dryRun=${options.dryRun} target=${options.prospectsPerRun}`,
+  );
+
+  const exa = new ExaClient(options.exaApiKey);
+  const contacted = await loadContacted();
+  console.log(`[runpr-outreach] ${contacted.prospects.length} agencies already contacted`);
+
+  const fresh = await sourceProspects(exa, contacted, options.prospectsPerRun);
+  console.log(`[runpr-outreach] sourced ${fresh.length} fresh prospect candidates`);
+
+  const runs: ProspectRun[] = [];
+  for (const prospect of fresh) {
+    if (runs.length >= options.prospectsPerRun) break;
+    const result = await processProspect(exa, prospect, options);
+    if (result) runs.push(result);
+  }
+
+  console.log(`[runpr-outreach] ${runs.length} drafts produced`);
+
+  if (!options.dryRun && runs.length > 0) {
+    await appendContacted(
+      runs.map((r) => ({
+        name: r.prospect.name,
+        domain: r.prospect.domain,
+        contacted_at: new Date().toISOString().slice(0, 10),
+        source: "weekly-cron",
+      })),
+    );
+    console.log("[runpr-outreach] tracker updated");
+  } else if (options.dryRun) {
+    console.log("[runpr-outreach] [dry-run] skipping tracker update");
+    console.log("\n--- SUMMARY (would have been sent via imsg) ---");
+    console.log(buildSummaryText(runs, true));
+    console.log("--- END SUMMARY ---\n");
+  }
+
+  if (!options.dryRun) {
+    try {
+      await sendSummary(options.notifyPhone, runs, false);
+      console.log("[runpr-outreach] summary sent via imsg");
+    } catch (err) {
+      console.error("[runpr-outreach] imsg summary failed:", (err as Error).message);
+    }
+  }
+}
+
+const sub = process.argv[2];
+if (sub === "weekly") {
+  weekly().catch((err) => {
+    console.error("[runpr-outreach] fatal:", err);
+    process.exit(1);
+  });
+} else {
+  console.error("usage: node dist/index.js weekly [--dry-run]");
+  process.exit(2);
+}

--- a/agents/runpr-outreach/src/notify-summary.ts
+++ b/agents/runpr-outreach/src/notify-summary.ts
@@ -1,0 +1,56 @@
+// Post-run iMessage summary via the local `imsg` CLI.
+
+import { spawn } from "node:child_process";
+import type { ProspectRun } from "./types.js";
+
+function runImsg(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("imsg", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on("data", (b) => out.push(b));
+    child.stderr.on("data", (b) => err.push(b));
+    child.on("error", rejectPromise);
+    child.on("close", (code) => {
+      resolvePromise({
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+        code: code ?? -1,
+      });
+    });
+  });
+}
+
+export function buildSummaryText(runs: ProspectRun[], dryRun: boolean): string {
+  const header = dryRun
+    ? `RunPR weekly DRY RUN. ${runs.length} drafts simulated.`
+    : `RunPR weekly run. ${runs.length} new Gmail drafts in jeff@hypelab.digital.`;
+
+  const lines: string[] = [header, ""];
+  const lowConfidence: string[] = [];
+
+  runs.forEach((r, i) => {
+    const tool = r.detected.tool;
+    const cc = r.contact.confidence;
+    const link = r.gmail_draft_url ? ` ${r.gmail_draft_url}` : "";
+    lines.push(`${i + 1}. ${r.prospect.name} | tool: ${tool} | contact: ${cc}${link}`);
+    if (cc === "LOW") {
+      lowConfidence.push(`${r.prospect.name} (${r.contact.email})`);
+    }
+  });
+
+  if (lowConfidence.length > 0) {
+    lines.push("");
+    lines.push(`LOW-confidence contacts (verify before sending): ${lowConfidence.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+export async function sendSummary(phone: string, runs: ProspectRun[], dryRun: boolean): Promise<void> {
+  const text = buildSummaryText(runs, dryRun);
+  const { code, stderr } = await runImsg(["send", "--to", phone, "--text", text]);
+  if (code !== 0) {
+    console.error(`[notify-summary] imsg send exited ${code}: ${stderr.slice(0, 300)}`);
+  }
+}

--- a/agents/runpr-outreach/src/push-to-gmail.ts
+++ b/agents/runpr-outreach/src/push-to-gmail.ts
@@ -1,0 +1,121 @@
+// Push a drafted email into Gmail's drafts folder via the `gog` CLI (already authenticated as
+// jeff@hypelab.digital on forge). We pass the body via temp file rather than --body flag to
+// preserve newlines, and use --body-html for the rich version.
+
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Contact, DraftEmail } from "./types.js";
+
+interface GmailDraftResult {
+  draft_id?: string;
+  draft_url?: string;
+  raw: string;
+}
+
+function runGog(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("gog", args, { stdio: ["ignore", "pipe", "pipe"] });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on("data", (b) => out.push(b));
+    child.stderr.on("data", (b) => err.push(b));
+    child.on("error", rejectPromise);
+    child.on("close", (code) => {
+      resolvePromise({
+        stdout: Buffer.concat(out).toString("utf8"),
+        stderr: Buffer.concat(err).toString("utf8"),
+        code: code ?? -1,
+      });
+    });
+  });
+}
+
+function parseDraftIdFromOutput(stdout: string): string | undefined {
+  // gog typically prints something like: "Draft created: r1234..." or JSON. Try both.
+  try {
+    const j = JSON.parse(stdout);
+    if (j && typeof j === "object") {
+      if (j.id) return String(j.id);
+      if (j.draftId) return String(j.draftId);
+      if (j.draft && j.draft.id) return String(j.draft.id);
+    }
+  } catch {
+    /* fall through */
+  }
+  const m = stdout.match(/r[-\w]{10,}/);
+  return m?.[0];
+}
+
+export async function pushDraftToGmail(opts: {
+  account: string;
+  to: string;
+  contact: Contact;
+  draft: DraftEmail;
+}): Promise<GmailDraftResult> {
+  const { account, to, draft } = opts;
+  const dir = await mkdtemp(join(tmpdir(), "runpr-draft-"));
+  const txtPath = join(dir, "body.txt");
+  const htmlPath = join(dir, "body.html");
+  await writeFile(txtPath, draft.body_text, "utf8");
+  await writeFile(htmlPath, draft.body_html, "utf8");
+
+  try {
+    const args = [
+      "gmail",
+      "drafts",
+      "create",
+      "--account",
+      account,
+      "--to",
+      to,
+      "--subject",
+      draft.subject,
+      "--body-file",
+      txtPath,
+      "--body-html-file",
+      htmlPath,
+    ];
+    const { stdout, stderr, code } = await runGog(args);
+    if (code !== 0) {
+      // Some gog versions don't accept --body-html-file. Retry with --body-html (inline).
+      if (/unknown flag.*body-html-file/i.test(stderr)) {
+        const fallbackArgs = [
+          "gmail",
+          "drafts",
+          "create",
+          "--account",
+          account,
+          "--to",
+          to,
+          "--subject",
+          draft.subject,
+          "--body-file",
+          txtPath,
+          "--body-html",
+          draft.body_html,
+        ];
+        const retry = await runGog(fallbackArgs);
+        if (retry.code !== 0) {
+          throw new Error(`gog drafts create failed: ${retry.stderr.slice(0, 500)}`);
+        }
+        const id = parseDraftIdFromOutput(retry.stdout);
+        return {
+          draft_id: id,
+          draft_url: id ? `https://mail.google.com/mail/u/0/#drafts/${id}` : undefined,
+          raw: retry.stdout,
+        };
+      }
+      throw new Error(`gog drafts create failed: ${stderr.slice(0, 500)}`);
+    }
+    const id = parseDraftIdFromOutput(stdout);
+    return {
+      draft_id: id,
+      draft_url: id ? `https://mail.google.com/mail/u/0/#drafts/${id}` : undefined,
+      raw: stdout,
+    };
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/agents/runpr-outreach/src/source-prospects.ts
+++ b/agents/runpr-outreach/src/source-prospects.ts
@@ -1,0 +1,138 @@
+// Source new PR agency prospects via Exa. Targets mid-size US B2B tech PR firms.
+
+import type { ExaClient, ExaResult } from "./exa-client.js";
+import type { RawProspect, ContactedFile } from "./types.js";
+import { isAlreadyContacted } from "./track-contacted.js";
+
+// Pool of search queries we rotate through. Each run picks 2-3 to keep results diverse.
+const QUERY_POOL = [
+  "best B2B technology PR agencies United States 2026",
+  "mid-size B2B SaaS PR agency client list",
+  "boutique tech PR firm fintech cybersecurity client roster",
+  "technology PR agency series B startup clients",
+  "AI PR agency United States enterprise tech",
+  "B2B tech communications agency healthcare technology",
+  "enterprise software PR firm developer tools clients",
+];
+
+const BLOCKED_DOMAINS = new Set([
+  "linkedin.com",
+  "indeed.com",
+  "glassdoor.com",
+  "ziprecruiter.com",
+  "facebook.com",
+  "twitter.com",
+  "x.com",
+  "wikipedia.org",
+  "g2.com",
+  "capterra.com",
+  "reddit.com",
+  "youtube.com",
+  "medium.com",
+  "substack.com",
+  "clutch.co",
+  "agencyspotter.com",
+  "designrush.com",
+  "ranked.com",
+  "sortlist.com",
+  "expertise.com",
+  "upcity.com",
+  "muckrack.com",
+  "cision.com",
+  "meltwater.com",
+  "prnewswire.com",
+  "businesswire.com",
+  "globenewswire.com",
+  "prweek.com",
+  "prnewsonline.com",
+  "odwyerpr.com",
+  "bulldogreporter.com",
+]);
+
+function extractDomain(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function isLikelyAgencyDomain(domain: string): boolean {
+  if (!domain) return false;
+  if (BLOCKED_DOMAINS.has(domain)) return false;
+  // Strip TLD and look for PR / comm / agency keywords. Permissive: most agency sites self-identify.
+  // Don't filter too aggressively. The detected-tool stage filters again.
+  return /\.(com|co|io|agency|us)$/.test(domain);
+}
+
+function guessAgencyName(result: ExaResult): string {
+  // Try to extract from title. Most agency homepages title with "Agency Name | Tagline" or similar.
+  if (result.title) {
+    const cleaned = result.title
+      // Split on common separators, keep the leading chunk.
+      .split(/\s*[\|\-–—:•·]\s*/)[0]!
+      // Strip trailing " l " (lowercase L sometimes used decoratively as a divider).
+      .replace(/\s+l\s+.*$/i, "")
+      .trim();
+    if (cleaned.length > 1 && cleaned.length < 60) return cleaned;
+  }
+  // Fallback: derive from domain.
+  const domain = extractDomain(result.url);
+  const stem = domain.split(".")[0];
+  return stem
+    .split(/[-_]/)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join(" ");
+}
+
+export async function sourceProspects(
+  exa: ExaClient,
+  contacted: ContactedFile,
+  count: number,
+): Promise<RawProspect[]> {
+  // Pick 3 queries from the pool, rotated by week-of-year so different runs hit different angles.
+  const weekOfYear = Math.floor((Date.now() / (1000 * 60 * 60 * 24 * 7)) % QUERY_POOL.length);
+  const queries: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    queries.push(QUERY_POOL[(weekOfYear + i) % QUERY_POOL.length]!);
+  }
+
+  const seen = new Set<string>();
+  const candidates: RawProspect[] = [];
+
+  for (const q of queries) {
+    let resp;
+    try {
+      resp = await exa.search(q, {
+        numResults: 12,
+        type: "auto",
+        useAutoprompt: true,
+        text: { maxCharacters: 600 },
+      });
+    } catch (err) {
+      console.error(`[source-prospects] Exa query failed for '${q}':`, err);
+      continue;
+    }
+    for (const r of resp.results) {
+      const domain = extractDomain(r.url);
+      if (!isLikelyAgencyDomain(domain)) continue;
+      if (seen.has(domain)) continue;
+      seen.add(domain);
+
+      const name = guessAgencyName(r);
+      if (isAlreadyContacted(contacted, domain, name)) continue;
+
+      candidates.push({
+        name,
+        domain,
+        url: `https://${domain}/`,
+        blurb: (r.text ?? "").slice(0, 500),
+        source: `exa:${q.slice(0, 40)}`,
+      });
+    }
+  }
+
+  // Cap to count + buffer (some will fail downstream so over-source slightly).
+  return candidates.slice(0, Math.max(count + 3, count));
+}

--- a/agents/runpr-outreach/src/track-contacted.ts
+++ b/agents/runpr-outreach/src/track-contacted.ts
@@ -1,0 +1,47 @@
+// Read/write the contacted-prospects.json tracker. The dedupe key is the lowercased domain.
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ContactedFile, ContactedProspect } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// dist/ is one level deep, so data/ lives at ../data relative to the compiled js.
+export const TRACKER_PATH = resolve(__dirname, "..", "data", "contacted-prospects.json");
+
+export async function loadContacted(): Promise<ContactedFile> {
+  if (!existsSync(TRACKER_PATH)) {
+    return { version: 1, updated_at: new Date().toISOString(), prospects: [] };
+  }
+  const raw = await readFile(TRACKER_PATH, "utf8");
+  return JSON.parse(raw) as ContactedFile;
+}
+
+export function isAlreadyContacted(file: ContactedFile, domain: string, name: string): boolean {
+  const dom = domain.toLowerCase().trim();
+  const nm = name.toLowerCase().trim();
+  return file.prospects.some(
+    (p) => p.domain.toLowerCase().trim() === dom || p.name.toLowerCase().trim() === nm,
+  );
+}
+
+export async function appendContacted(newOnes: ContactedProspect[]): Promise<void> {
+  const file = await loadContacted();
+  // Make sure the data dir exists (paranoia, dist may have been wiped).
+  await mkdir(dirname(TRACKER_PATH), { recursive: true });
+  // Backup before overwriting.
+  if (existsSync(TRACKER_PATH)) {
+    const bak = `${TRACKER_PATH}.bak`;
+    await writeFile(bak, await readFile(TRACKER_PATH, "utf8"), "utf8");
+  }
+  for (const p of newOnes) {
+    if (!isAlreadyContacted(file, p.domain, p.name)) {
+      file.prospects.push(p);
+    }
+  }
+  file.updated_at = new Date().toISOString();
+  await writeFile(TRACKER_PATH, JSON.stringify(file, null, 2) + "\n", "utf8");
+}

--- a/agents/runpr-outreach/src/types.ts
+++ b/agents/runpr-outreach/src/types.ts
@@ -1,0 +1,72 @@
+// Shared types for the RunPR outreach pipeline.
+
+export type DetectedTool = "muckrack" | "cision" | "meltwater" | "multi" | "unknown";
+
+export interface ContactedProspect {
+  name: string;
+  domain: string;
+  contacted_at: string;
+  source: string;
+}
+
+export interface ContactedFile {
+  version: number;
+  updated_at: string;
+  prospects: ContactedProspect[];
+}
+
+export interface RawProspect {
+  name: string;
+  domain: string;
+  url: string;
+  blurb: string;
+  source: string;
+}
+
+export interface DetectedToolResult {
+  tool: DetectedTool;
+  evidence: string[];
+  confidence: "HIGH" | "MED" | "LOW";
+}
+
+export interface RecentNews {
+  headline: string;
+  url: string;
+  published_at?: string;
+  snippet: string;
+}
+
+export type ContactConfidence = "HIGH" | "MED" | "LOW";
+
+export interface Contact {
+  first_name: string;
+  last_name: string;
+  title: string;
+  email: string;
+  email_pattern: "first" | "first.last" | "firstinitiallast" | "info" | "unknown";
+  confidence: ContactConfidence;
+}
+
+export interface DraftEmail {
+  subject: string;
+  body_text: string;
+  body_html: string;
+}
+
+export interface ProspectRun {
+  prospect: RawProspect;
+  detected: DetectedToolResult;
+  news: RecentNews | null;
+  contact: Contact;
+  draft: DraftEmail;
+  gmail_draft_id?: string;
+  gmail_draft_url?: string;
+}
+
+export interface RunOptions {
+  dryRun: boolean;
+  prospectsPerRun: number;
+  exaApiKey: string;
+  gmailAccount: string;
+  notifyPhone: string;
+}

--- a/agents/runpr-outreach/tsconfig.json
+++ b/agents/runpr-outreach/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false,
+    "skipLibCheck": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds a weekly RunPR outreach pipeline agent that finds PR-fit prospects, drafts focused outreach, and runs in dry-run mode by default for safe review.\n\nValidation:\n- npm run build\n- dry-run execution completed successfully