### PR TITLE
fix(failover): improve internal server error classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config: log config health-state write failures instead of silently hiding config observe-recovery write errors. Thanks @sallyom.
 - Diagnostics: reset stuck-session timers on reply, tool, status, block, and ACP progress events, and back off repeated `session.stuck` diagnostics while a session remains unchanged. Supersedes #72010. Thanks @rubencu.
 - Gateway/agents: avoid rebuilding core tools for plugin-only allowlists and keep the full plugin registry cache warm across scoped plugin loads, reducing per-turn latency spikes. Fixes #75882, #75907, #75906, #75887, and #75851. (#75922) Thanks @obviyus.
+- Agents/failover: classify bare `status: internal server error` provider messages as retryable server errors so model fallback can rotate instead of stopping. (#73844) Thanks @thesomewhatyou.
 
 ## 2026.4.30
 

--- a/src/agents/pi-embedded-helpers/failover-matches.test.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.test.ts
@@ -4,6 +4,7 @@ import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
+  isServerErrorMessage,
 } from "./failover-matches.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
@@ -90,5 +91,15 @@ describe("Z.ai vendor error codes (#48988)", () => {
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
     });
+  });
+});
+
+describe("server error status classification", () => {
+  it("classifies a bare internal server error status as server error", () => {
+    expect(isServerErrorMessage("status: internal server error")).toBe(true);
+  });
+
+  it("does not classify prefixed plain internal server error status prose", () => {
+    expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -309,5 +309,8 @@ export function isServerErrorMessage(raw: string): boolean {
     return true;
   }
   const scrubbed = value.replace(STATUS_INTERNAL_SERVER_ERROR_RE, "").trim();
-  return scrubbed.length > 0 && matchesErrorPatterns(scrubbed, ERROR_PATTERNS.serverError);
+  if (scrubbed === "") {
+    return true;
+  }
+  return matchesErrorPatterns(scrubbed, ERROR_PATTERNS.serverError);
 }


### PR DESCRIPTION
Improves the failover classification to treat a pure 'status: internal server error' message as a server error, following reviewer feedback to avoid re-running patterns on un-scrubbed input.