### PR TITLE
docs(skills): require body files for github text

### DIFF
--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -69,10 +69,42 @@ gitcrawl cluster-detail openclaw/openclaw --id <cluster-id> --member-limit 20 --
 
 ## Handle GitHub text safely
 
-- For issue comments and PR comments, use literal multiline strings or `-F - <<'EOF'` for real newlines. Never embed `\n`.
-- Do not use `gh issue/pr comment -b "..."` when the body contains backticks or shell characters. Prefer a single-quoted heredoc.
+- For issue comments, PR comments, PR bodies, review bodies, and release notes, use real multiline body files or heredocs. Never embed `\n` for line breaks.
+- Do not use `gh issue/pr comment -b "..."` or `gh pr create --body "..."` for multiline text, backticks, markdown lists, or shell-sensitive content.
+- Prefer `--body-file` with a temporary markdown file, then preview the file before posting.
 - Do not wrap issue or PR refs like `#24643` in backticks when you want auto-linking.
 - PR landing comments should include clickable full commit links for landed and source SHAs when present.
+
+Safe PR body pattern:
+
+```bash
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+- What changed
+
+## Verification
+- `pnpm test`
+
+## Notes
+- Risks, follow-ups, or reviewer context
+EOF
+cat /tmp/pr-body.md
+gh pr create --title "chore: update workflow" --body-file /tmp/pr-body.md
+```
+
+Safe PR comment/review pattern:
+
+```bash
+cat > /tmp/pr-comment.md <<'EOF'
+## Review
+- Finding or approval note
+
+## Verification
+- Evidence checked
+EOF
+cat /tmp/pr-comment.md
+gh pr comment 55 --repo openclaw/openclaw --body-file /tmp/pr-comment.md
+```
 
 ## Search broadly before deciding
 

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -77,8 +77,18 @@ gh pr checks 55 --repo owner/repo
 # View PR details
 gh pr view 55 --repo owner/repo
 
-# Create PR
-gh pr create --title "feat: add feature" --body "Description"
+# Create PR with a real multiline body. Do not pass literal \n strings.
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+- Describe the change
+
+## Verification
+- List commands or manual checks
+
+## Notes
+- Optional follow-up or risk notes
+EOF
+gh pr create --title "feat: add feature" --body-file /tmp/pr-body.md
 
 # Merge PR
 gh pr merge 55 --squash --repo owner/repo
@@ -134,6 +144,46 @@ Most commands support `--json` for structured output with `--jq` filtering:
 gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
 gh pr list --json number,title,state,mergeable --jq '.[] | select(.mergeable == "MERGEABLE")'
 ```
+
+## Text Body Safety
+
+GitHub comments, PR bodies, issue bodies, and review bodies must render with real newlines.
+
+Use one of these safe patterns:
+
+```bash
+# PR body
+cat > /tmp/pr-body.md <<'EOF'
+## Summary
+- What changed
+
+## Verification
+- `npm test`
+
+## Notes
+- Anything reviewers should know
+EOF
+gh pr create --title "chore: update workflow" --body-file /tmp/pr-body.md
+
+# PR comment
+cat > /tmp/pr-comment.md <<'EOF'
+## Review
+- Finding or approval note
+
+## Verification
+- Evidence checked
+EOF
+gh pr comment 55 --repo owner/repo --body-file /tmp/pr-comment.md
+```
+
+Do not use escaped newline strings for multiline GitHub text:
+
+```bash
+# Bad: GitHub may render literal \n
+gh pr create --body "## Summary\n- item\n\n## Verification\n- test"
+```
+
+Before posting, preview the exact file/body with `cat /tmp/pr-body.md` or `cat /tmp/pr-comment.md`.
 
 ## Templates
 


### PR DESCRIPTION
## Summary
- Update the GitHub skill to require `--body-file` for multiline PR bodies and comments
- Update the OpenClaw PR maintainer skill with safe PR body/comment templates
- Explicitly ban escaped `\n` strings for multiline GitHub text

## Verification
- `git diff --check`

## Notes
- Fixes the PR/comment rendering issue where GitHub displayed literal `\n` characters instead of real newlines
