### PR TITLE
ci: shard agent runtime codeql quality

### DIFF
--- a/.github/codeql/codeql-agent-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-agent-runtime-boundary-critical-quality.yml
@@ -1,0 +1,53 @@
+name: openclaw-codeql-agent-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/acp/control-plane
+  - src/agents/command
+  - src/agents/cli-runner
+  - src/agents/pi-embedded-runner
+  - src/agents/tools
+  - src/agents/*completion*.ts
+  - src/agents/*transport*.ts
+  - src/agents/model-*.ts
+  - src/agents/openclaw-tools*.ts
+  - src/agents/provider-*.ts
+  - src/agents/session*.ts
+  - src/agents/tool-call*.ts
+  - src/auto-reply/reply/agent-runner*.ts
+  - src/auto-reply/reply/commands*.ts
+  - src/auto-reply/reply/directive-handling*.ts
+  - src/auto-reply/reply/dispatch-*.ts
+  - src/auto-reply/reply/get-reply-run*.ts
+  - src/auto-reply/reply/provider-dispatcher*.ts
+  - src/auto-reply/reply/queue*.ts
+  - src/auto-reply/reply/reply-run-registry*.ts
+  - src/auto-reply/reply/session*.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -102,6 +102,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/channel-runtime-boundary"
 
+  agent-runtime-boundary:
+    name: Critical Quality (agent-runtime-boundary)
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-agent-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/agent-runtime-boundary"
+
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
     runs-on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -259,6 +259,9 @@ contracts under the separate
 `/codeql-critical-quality/gateway-runtime-boundary` category. The
 channel-runtime-boundary job scans core channel implementation contracts under
 the separate `/codeql-critical-quality/channel-runtime-boundary` category. The
+agent-runtime-boundary job scans command execution, model/provider dispatch,
+auto-reply dispatch and queues, and ACP control-plane runtime contracts under
+the separate `/codeql-critical-quality/agent-runtime-boundary` category. The
 plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
 entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
 category. Keep the workflow separate from security so quality findings can be


### PR DESCRIPTION
## Summary
- add an agent-runtime-boundary CodeQL Critical Quality config for high-value runtime control surfaces
- add the matching Blacksmith-backed CodeQL Critical Quality job
- document the new quality shard alongside the existing config/gateway/channel/plugin jobs

## Validation
- ruby YAML parse for the workflow and new CodeQL config
- git diff --check
- pnpm check:workflows