### PR TITLE
fix(media): send echoTranscript for preflight-transcribed audio

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -74,6 +74,7 @@ export type TelegramInboundBodyResult = {
   canDetectMention: boolean;
   shouldBypassMention: boolean;
   audioTranscribedMediaIndex?: number;
+  preflightTranscript?: string;
   stickerCacheHit: boolean;
   locationData?: NormalizedLocation;
 };
@@ -371,6 +372,7 @@ export async function resolveTelegramInboundBody(params: {
     ...(audioTranscribedMediaIndex !== undefined && audioTranscribedMediaIndex >= 0
       ? { audioTranscribedMediaIndex }
       : {}),
+    ...(preflightTranscript ? { preflightTranscript } : {}),
     stickerCacheHit,
     locationData: locationData ?? undefined,
   };

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -112,6 +112,7 @@ export async function buildTelegramInboundContextPayload(params: {
   stickerCacheHit: boolean;
   effectiveWasMentioned: boolean;
   audioTranscribedMediaIndex?: number;
+  preflightTranscript?: string;
   commandAuthorized: boolean;
   locationData?: NormalizedLocation;
   options?: TelegramMessageContextOptions;
@@ -148,6 +149,7 @@ export async function buildTelegramInboundContextPayload(params: {
     stickerCacheHit,
     effectiveWasMentioned,
     audioTranscribedMediaIndex,
+    preflightTranscript,
     commandAuthorized,
     locationData,
     options,
@@ -383,6 +385,7 @@ export async function buildTelegramInboundContextPayload(params: {
     ...(audioTranscribedMediaIndex !== undefined
       ? { MediaTranscribedIndexes: [audioTranscribedMediaIndex] }
       : {}),
+    ...(preflightTranscript ? { Transcript: preflightTranscript } : {}),
     Sticker: allMedia[0]?.stickerMetadata,
     StickerMediaIncluded: allMedia[0]?.stickerMetadata ? !stickerCacheHit : undefined,
     ...(locationData ? toLocationContext(locationData) : undefined),

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -581,6 +581,9 @@ export const buildTelegramMessageContext = async ({
     ...(bodyResult.audioTranscribedMediaIndex !== undefined
       ? { audioTranscribedMediaIndex: bodyResult.audioTranscribedMediaIndex }
       : {}),
+    ...(bodyResult.preflightTranscript
+      ? { preflightTranscript: bodyResult.preflightTranscript }
+      : {}),
     locationData: bodyResult.locationData,
     options,
     dmAllowFrom,

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -27,6 +27,7 @@ const hasAvailableAuthForProviderMock = vi.hoisted(() =>
 const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
+const sendTranscriptEchoMock = vi.hoisted(() => vi.fn());
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
@@ -263,6 +264,10 @@ describe("applyMediaUnderstanding", () => {
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
+    vi.doMock("./echo-transcript.js", () => ({
+      sendTranscriptEcho: sendTranscriptEchoMock,
+      DEFAULT_ECHO_TRANSCRIPT_FORMAT: '“{transcript}"',
+    }));
     vi.doMock("./provider-registry.js", async () => {
       const actual =
         await vi.importActual<typeof import("./provider-registry.js")>("./provider-registry.js");
@@ -312,6 +317,7 @@ describe("applyMediaUnderstanding", () => {
     mockedFetchRemoteMedia.mockClear();
     mockedRunFfmpeg.mockReset();
     mockedRunExec.mockReset();
+    sendTranscriptEchoMock.mockReset();
     mockedFetchRemoteMedia.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
       contentType: "audio/ogg",
@@ -1025,6 +1031,47 @@ describe("applyMediaUnderstanding", () => {
       expect.objectContaining({
         capability: "audio",
         outcome: "no-attachment",
+      }),
+    );
+  });
+
+  it("sends echoTranscript when audio was preflight-transcribed by channel", async () => {
+    const dir = await createTempMediaDir();
+    const audioPath = path.join(dir, "voice.ogg");
+    await fs.writeFile(audioPath, createSafeAudioFixtureBuffer(2048));
+    const ctx: MsgContext = {
+      Body: '[Audio transcript (machine-generated, untrusted)]: "hello world"',
+      Transcript: "hello world",
+      MediaPath: audioPath,
+      MediaType: "audio/ogg",
+      MediaTranscribedIndexes: [0],
+      Provider: "telegram",
+      OriginatingTo: "telegram:123",
+    };
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            echoTranscript: true,
+            models: [{ provider: "groq" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      providers: {},
+    });
+
+    expect(result.appliedAudio).toBe(false);
+    expect(ctx.Transcript).toBe("hello world");
+    expect(sendTranscriptEchoMock).toHaveBeenCalledTimes(1);
+    expect(sendTranscriptEchoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcript: "hello world",
       }),
     );
   });

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -648,6 +648,25 @@ export async function applyMediaUnderstanding(params: {
         ctx.RawBody = originalUserText;
       }
       ctx.MediaUnderstanding = [...(ctx.MediaUnderstanding ?? []), ...outputs];
+    } else if (originalUserText) {
+      ctx.CommandBody = originalUserText;
+      ctx.RawBody = originalUserText;
+    }
+
+    // Handle preflight-transcribed audio: the channel handler (e.g., Telegram
+    // preflight) already transcribed the audio and set ctx.Transcript, but
+    // applyMediaUnderstanding skipped the attachment because it was marked
+    // alreadyTranscribed. Still send the echo if configured.
+    if (!outputs.some((o) => o.kind === "audio.transcription") && ctx.Transcript) {
+      const audioCfg = cfg.tools?.media?.audio;
+      if (audioCfg?.echoTranscript) {
+        await sendTranscriptEcho({
+          ctx,
+          cfg,
+          transcript: ctx.Transcript,
+          format: audioCfg.echoFormat ?? DEFAULT_ECHO_TRANSCRIPT_FORMAT,
+        });
+      }
     }
     // Only skip file extraction for attachments that have a real (non-synthetic)
     // audio transcription. Synthetic placeholders should not prevent file extraction


### PR DESCRIPTION
## Summary

Fixes #73615 — `tools.media.audio.echoTranscript` regression where the transcript echo (`📝 "{transcript}"`) is no longer sent to Telegram after upgrading to v2026.4.25+.

## Root Cause

Commit `8bead989da` (v2026.4.25) moved Telegram audio transcription into a preflight step that runs before the media-understanding pipeline. The preflight path:

1. Transcribes audio via `transcribeFirstAudio`
2. Sets `MediaTranscribedIndexes` on the context (marks attachment as `alreadyTranscribed`)
3. Formats the transcript into the message body

But `applyMediaUnderstanding` then skips already-transcribed audio, produces no `audio.transcription` outputs, and therefore never enters the `sendTranscriptEcho` code path (which only fires when `audioOutputs.length > 0`).

## Fix

**Two-part change:**

1. **Telegram context chain** (`bot-message-context.body.ts` → `bot-message-context.ts` → `bot-message-context.session.ts`): Pass the `preflightTranscript` through the context chain and set `ctx.Transcript` when it exists, so the transcript is available to the media-understanding pipeline.

2. **Media understanding pipeline** (`apply.ts`): After the main outputs processing block, detect the preflight case — `ctx.Transcript` is set but no audio outputs were produced — and call `sendTranscriptEcho` with the pre-existing transcript.

This approach:
- Preserves the preflight architecture (audio transcribed once, no double-processing)
- Reuses the existing `sendTranscriptEcho` function and format config
- Works for any channel that sets `ctx.Transcript` before `applyMediaUnderstanding` runs

## Testing

- **Regression test added** in `apply.test.ts`: verifies `sendTranscriptEcho` fires for preflight-transcribed audio when `echoTranscript: true`
- **All existing tests pass**: 46/46 in `apply.test.ts`, 103 files / 1475 tests in Telegram extension, full `pnpm check` + `pnpm check:test-types` clean

## Files Changed

| File | Change |
|------|--------|
| `extensions/telegram/src/bot-message-context.body.ts` | Return `preflightTranscript` from body resolver |
| `extensions/telegram/src/bot-message-context.ts` | Pass `preflightTranscript` to session builder |
| `extensions/telegram/src/bot-message-context.session.ts` | Set `ctx.Transcript` when `preflightTranscript` exists |
| `src/media-understanding/apply.ts` | Echo preflight transcripts when no new audio outputs |
| `src/media-understanding/apply.test.ts` | Regression test for preflight echo |