### PR TITLE
docs(plugins): add Camofox Browser community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -36,6 +36,20 @@ Search, e-commerce sites, and more — just by asking.
 openclaw plugins install @apify/apify-openclaw-plugin
 ```
 
+### Camofox Browser
+
+Anti-detection browser automation server for AI agents. Wraps Camoufox
+(Firefox-based) to bypass bot detection on Google, Amazon, LinkedIn, and other
+protected sites. Provides 10 tools for tab management, navigation, clicking,
+typing, screenshots, and cookie import with full session isolation.
+
+- **npm:** `@askjo/camofox-browser`
+- **repo:** [github.com/jo-inc/camofox-browser](https://github.com/jo-inc/camofox-browser)
+
+```bash
+openclaw plugins install @askjo/camofox-browser
+```
+
 ### Codex App Server Bridge
 
 Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to


### PR DESCRIPTION
## Summary

Adds **Camofox Browser** to the community plugins listing — an anti-detection browser automation server for AI agents.

- **npm:** `@askjo/camofox-browser`
- **ClawHub:** [`@askjo/camofox-browser`](https://clawhub.ai/plugins/@askjo/camofox-browser) (scan: clean, verification: source-linked)
- **repo:** [github.com/jo-inc/camofox-browser](https://github.com/jo-inc/camofox-browser) (3.4K ⭐)
- **install:** `openclaw plugins install @askjo/camofox-browser`

## Context

@steipete suggested this listing in [#14192](https://github.com/openclaw/openclaw/pull/14192#issuecomment-2665478392):

> "very interesting! This could be a community plugin hosted on your own GitHub repository. We highlight great plugins at https://docs.openclaw.ai/plugins/community in the future."

A previous docs PR ([#23052](https://github.com/openclaw/openclaw/pull/23052)) was submitted per that suggestion and received a 5/5 Greptile confidence score, but was auto-closed by the stale bot without maintainer review.

Since then, the plugin has matured significantly:
- **3.4K GitHub stars**
- **Bundled in [hermes-agent](https://github.com/NousResearch/hermes-agent)** (123K ⭐) as one of its 5 browser backends — listed as a direct npm dependency (`@askjo/camofox-browser`) with dedicated integration files (`browser_camofox.py`, `browser_camofox_state.py`), setup wizard support, and featured in their v0.7.0 and v0.11.0 release notes
- Published on ClawHub with **clean scan** and **source-linked** verification tier
- Full `openclaw.plugin.json` manifest with tools, permissions, runtimeDependencies, and securityModel declarations
- 10 tools: `camofox_create_tab`, `camofox_snapshot`, `camofox_click`, `camofox_type`, `camofox_navigate`, `camofox_scroll`, `camofox_screenshot`, `camofox_close_tab`, `camofox_list_tabs`, `camofox_import_cookies`
- Security Model section in README (11 subsections)

## Quality bar checklist

| Requirement | Status |
|---|---|
| Published on ClawHub or npm | ✅ Both ([ClawHub](https://clawhub.ai/plugins/@askjo/camofox-browser), [npm](https://www.npmjs.com/package/@askjo/camofox-browser)) |
| Public GitHub repo | ✅ [jo-inc/camofox-browser](https://github.com/jo-inc/camofox-browser) (3.4K ⭐) |
| Setup and usage docs | ✅ README + AGENTS.md + Security Model |
| Active maintenance | ✅ 11 versions, latest v1.8.12 (Apr 2026) |
| ClawHub scan | ✅ Clean (0 findings), source-linked verification |

## Changes

Single file: `docs/plugins/community.md` — added Camofox Browser entry between Apify and Codex App Server Bridge (alphabetical order).