### PR TITLE
feat(skills): add integration-notion skill for Notion setup

### DIFF
--- a/.github/workflows/fork-npm-publish.yml
+++ b/.github/workflows/fork-npm-publish.yml
@@ -1,0 +1,107 @@
+name: Fork NPM Auto-Publish
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: fork-npm-publish
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.32.1"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for OIDC provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "true"
+          use-sticky-disk: "false"
+
+      # Second setup-node purely to wire npm registry auth (TOKEN → ~/.npmrc)
+      - name: Configure npm registry auth
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Build
+        run: pnpm build
+
+      - name: Build Control UI
+        run: pnpm ui:build
+
+      - name: Derive scoped version
+        id: version
+        run: |
+          BASE_VERSION="$(node -p "require('./package.json').version")"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "version=${BASE_VERSION}-fork.${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already published
+        id: check
+        env:
+          FORK_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if npm view "@vibetechnologies/openclaw@${FORK_VERSION}" version >/dev/null 2>&1; then
+            echo "already published, skipping"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Patch package name + version
+        if: steps.check.outputs.published == 'false'
+        env:
+          FORK_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.name = "@vibetechnologies/openclaw";
+          pkg.version = process.env.FORK_VERSION;
+          fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          NODE
+          echo "Will publish @vibetechnologies/openclaw@${FORK_VERSION}"
+
+      - name: Publish @vibetechnologies/openclaw
+        if: steps.check.outputs.published == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Try OIDC trusted publishing first (no token needed)
+          if OPENCLAW_PREPACK_PREPARED=1 npm publish --provenance --access public 2>/dev/null; then
+            echo "✅ Published via OIDC"
+            exit 0
+          fi
+
+          # Fall back to token auth
+          if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+            OPENCLAW_PREPACK_PREPARED=1 npm publish --access public
+            echo "✅ Published via NPM_TOKEN"
+            exit 0
+          fi
+
+          echo "❌ No valid npm auth. Set NPM_TOKEN secret in repo settings." >&2
+          exit 1
+
+      - name: Skip (already published)
+        if: steps.check.outputs.published == 'true'
+        run: echo "⏭️ @vibetechnologies/openclaw@${{ steps.version.outputs.version }} already published, skipping"
+

--- a/.status.md
+++ b/.status.md
@@ -1,0 +1,233 @@
+# Issue #724 — Agent Silently Drops Turn on LLM Idle Timeout
+
+**Status**: Layer 1+2 fix deployed, Bug 3+4 identified and issues filed  
+**Issues**: #724 (timeout compaction), #64570 (thinking-only drop), #64571 (failover model lock)  
+**Date**: 2026-04-10
+
+---
+
+## Problem
+
+MonicaHall agent silently dropped a user message ("add a cron daily task for SF Bay Area daily!") in Telegram topic-18. The user never received any response. Investigation revealed **four** interconnected bugs.
+
+### Root Cause
+
+Two bugs combined to create a silent failure:
+
+**Bug 1 — Timeout recovery treats missing usage data as "low pressure"**
+
+When an LLM idle-times-out (zero output in 120s), there are no API usage stats. The timeout-triggered compaction gate in `run.ts` derived `tokenUsedRatio` from these stats — `undefined` mapped to ratio `0`, which is below the `0.65` threshold. Compaction never triggered.
+
+```
+derivePromptTokens(undefined) → undefined → ratio = 0 → gate closed → turn dropped
+```
+
+**Bug 2 — Pre-flight compaction ignores session structure**
+
+`shouldPreemptivelyCompactBeforePrompt()` chose `truncate_tool_results_only` because the 299 tool results had enough reducible bytes. But truncation only strips content — it doesn't reduce the 994 turn structures. The model still received a structurally overwhelming prompt and produced zero output.
+
+### Failure Sequence
+
+```
+21:01 PDT  [tool-result-truncation] truncates 299 tool results (bytes drop, structure unchanged)
+21:09 PDT  Message 102 arrives → tool calls expand context further mid-turn
+21:11 PDT  openclaw:prompt-error → "LLM idle timeout (120s)" for grok-4-1-fast-reasoning
+           → lastRunPromptUsage = undefined → tokenUsedRatio = 0 → compaction skipped
+           → Fallback model switch to kimi-k2.5-thinking
+           → Message 102 re-queued
+Next day   Message 140 arrives → retry coalesced/dropped
+           → User never receives any response
+```
+
+---
+
+## Solution
+
+### Layer 1 — Fix timeout recovery gating (`run.ts`)
+
+When `derivePromptTokens()` returns `undefined` (idle timeout, zero output):
+
+- Fall back to preflight-estimated prompt tokens (`preflightRecovery.estimatedPromptTokens`)
+- If even that is unavailable AND `idleTimedOut` is true, assume ratio = `1.0` (high pressure)
+- Non-idle timeouts with no data still default to `0` (existing behavior preserved)
+
+**Files**: `run.ts`, `run/types.ts`, `run/attempt.ts`
+
+### Layer 2 — Structure-aware pre-flight compaction (`preemptive-compaction.ts`)
+
+When `truncate_tool_results_only` would be chosen but the session has >200 messages, escalate to `compact_then_truncate`. This prevents the doomed LLM call entirely.
+
+**Constant**: `TRUNCATION_ONLY_MAX_MESSAGES = 200`
+
+### Tests Added
+
+| Test                                                 | File                                       | What it verifies                                 |
+| ---------------------------------------------------- | ------------------------------------------ | ------------------------------------------------ |
+| idle timeout + preflight estimate → compacts         | `run.timeout-triggered-compaction.test.ts` | Fallback to estimated tokens triggers compaction |
+| idle timeout + no estimate → compacts (assumes high) | `run.timeout-triggered-compaction.test.ts` | Missing data + idle = ratio 1.0                  |
+| non-idle timeout + no data → no compaction           | `run.timeout-triggered-compaction.test.ts` | Preserves existing behavior for regular timeouts |
+| >200 messages escalates truncation-only              | `preemptive-compaction.test.ts`            | Structure-aware escalation works                 |
+| <200 messages keeps truncation-only                  | `preemptive-compaction.test.ts`            | No false escalation on small sessions            |
+
+**Test results**: 27/27 passing (22 existing + 5 new)
+
+---
+
+## Monitoring
+
+### What to watch for
+
+**1. Verify the fix triggers in production**
+
+Search gateway logs for the new `[fallback estimate]` marker:
+
+```bash
+grep "\[fallback estimate\]" ~/.openclaw/logs/gateway.log
+```
+
+If this appears, the fix is actively preventing silent drops. The log line looks like:
+
+```
+[timeout-compaction] LLM timed out with high prompt token usage (115% [fallback estimate]); attempting compaction before retry
+```
+
+**2. Watch for idle timeout errors that still slip through**
+
+```bash
+grep "idle timeout" ~/.openclaw/logs/gateway.log | grep -v "timeout-compaction"
+```
+
+If idle timeouts appear WITHOUT a corresponding `timeout-compaction` line, the fix may not be covering that path.
+
+**3. Monitor compaction frequency on long-lived topics**
+
+```bash
+grep "timeout-compaction\|compact_then_truncate" ~/.openclaw/logs/gateway.log | tail -20
+```
+
+Excessive compaction could indicate the `TRUNCATION_ONLY_MAX_MESSAGES = 200` threshold is too low, causing unnecessary summarization on moderately-sized sessions.
+
+**4. Check for dropped turns (the original symptom)**
+
+```bash
+# Find messages that were queued but never got a response
+grep "re-queued\|redelivered" ~/.openclaw/logs/gateway.log | tail -10
+```
+
+If messages are re-queued but the next log entry is NOT a retry or compaction, there may be another failure path.
+
+### Key metrics to track
+
+| Metric                              | Where                                    | Healthy range                                            |
+| ----------------------------------- | ---------------------------------------- | -------------------------------------------------------- |
+| Idle timeout rate                   | `openclaw:prompt-error` in session JSONL | <1% of prompts                                           |
+| Compaction trigger rate             | `[timeout-compaction]` in gateway log    | Should appear when idle timeouts + high context co-occur |
+| Turn drop rate                      | Messages with no response in Telegram    | 0 (the goal)                                             |
+| Session message count at compaction | `compact_then_truncate` log lines        | >200 messages (Layer 2 kicking in)                       |
+
+### Rollback
+
+If the fix causes issues (e.g., excessive compaction on sessions that don't need it):
+
+1. Revert to the pre-fix build: `ln -sf /path/to/backup/openclaw.mjs ~/.local/bin/openclaw`
+2. Or adjust the threshold: change `TRUNCATION_ONLY_MAX_MESSAGES` in `preemptive-compaction.ts`
+3. Or disable Layer 1 fallback: remove the `?? preflightRecovery?.estimatedPromptTokens` line in `run.ts`
+
+---
+
+## Changed Files
+
+```
+src/agents/pi-embedded-runner/run.ts                                   (+8, -4)
+src/agents/pi-embedded-runner/run/types.ts                             (+2)
+src/agents/pi-embedded-runner/run/attempt.ts                           (+4, -3)
+src/agents/pi-embedded-runner/run/preemptive-compaction.ts             (+11)
+src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts (+86)
+src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts        (+57)
+```
+
+Total: **+168 lines, -7 lines** across 6 files.
+
+---
+
+## Bug 3 — Thinking-Only Responses Silently Dropped (Issue #64570)
+
+**Status**: Issue filed, NOT YET FIXED
+
+### Problem
+
+`kimi-k2.5-thinking` returns responses containing **only thinking content** (`content: [{ type: "thinking" }]`) with `stopReason: "stop"`. The incomplete-turn detector doesn't catch this because:
+
+1. `resolveIncompleteTurnPayloadText` only triggers on `stopReason: "toolUse" | "error"` — misses `"stop"` with empty text
+2. `resolvePlanningOnlyRetryInstruction` only applies to `openai/gpt-5` models — excludes kimi
+
+**Result**: 0 payloads → treated as successful completion → no Telegram reply. Happened 3 times on topic-18 (lines 990, 993, 996).
+
+**Fix needed in**: `src/agents/pi-embedded-runner/run/incomplete-turn.ts`
+
+---
+
+## Bug 4 — Failover Model Permanently Locks Session (Issue #64571)
+
+**Status**: Workaround applied (session store reset), structural fix NOT YET IMPLEMENTED
+
+### Problem
+
+After a model failover (primary times out → fallback used), the session entry permanently locks to the fallback model via sticky fields:
+
+- `entry.model` / `entry.modelProvider` — set by `setSessionRuntimeModel()` after each run
+- `entry.modelOverride` / `entry.providerOverride` — set by `applyFallbackCandidateSelectionToEntry()`
+
+Subsequent messages on that session **never consult the agent's configured primary model again**, because `resolveGatewayRunModel()` checks `entry.model` first and returns immediately.
+
+### Evidence
+
+MonicaHall configured with `github-copilot/claude-sonnet-4.6` but all 76 Telegram/cron/subagent sessions were stuck on `azure/gpt-5.4`, `azure/grok-4-1-fast-reasoning`, or `azure/kimi-k2.5-thinking`.
+
+### Workaround Applied
+
+Reset all 76 MonicaHall session entries — cleared `model`, `modelProvider`, `modelOverride`, `providerOverride`, `modelOverrideSource`. Backup at `sessions.json.bak`. Gateway restarted to pick up clean store.
+
+### Structural Fix Needed
+
+Re-resolve from config at run start: when `modelOverrideSource: "auto"` and the agent config primary differs, clear the override and use the config.
+
+**Key files**: `src/gateway/session-utils.ts` (line ~1147), `src/auto-reply/reply/agent-runner-execution.ts`
+
+---
+
+## Monitoring (Updated)
+
+### New: Verify sonnet-4.6 is being used
+
+```bash
+# After MonicaHall replies to a message, check the session store
+python3 -c "
+import json
+store = json.load(open('$HOME/.openclaw/agents/monicahall/sessions/sessions.json'))
+for k,v in store.items():
+    if 'topic-18' in k:
+        print(f'{k}: {v.get(\"modelProvider\",\"?\")}/{v.get(\"model\",\"?\")}')
+"
+```
+
+Expected: `github-copilot/claude-sonnet-4.6` (NOT kimi or gpt-5.4)
+
+### New: Watch for thinking-only drops
+
+```bash
+grep "stopReason.*stop.*thinking\|0 payloads" ~/.openclaw/logs/gateway.log | tail -10
+```
+
+### New: Watch for failover model persistence
+
+```bash
+# Sessions that have modelOverrideSource: "auto" should eventually revert
+python3 -c "
+import json
+store = json.load(open('$HOME/.openclaw/agents/monicahall/sessions/sessions.json'))
+stuck = [(k,v.get('modelOverride','')) for k,v in store.items() if v.get('modelOverrideSource')=='auto']
+for k,m in stuck: print(f'  STUCK: {k} → {m}')
+if not stuck: print('  All clear')
+"
+```

--- a/README.md
+++ b/README.md
@@ -6,16 +6,25 @@
 
 ## Fixes on top of upstream
 
-### [v2026.4.10+] Silent message drop fixes (`426606c`)
+### [v2026.4.11+] ChatGPT-style session management UI (`1d6aaac`)
+
+- **New chat button** in the sidebar (always visible, disabled when disconnected)
+- **Recent sessions list** in the sidebar — click any session to switch to it
+- **Rename session** button in the chat header
+- Session list ordered by last activity, with idle/connected state indicators
+
+---
+
+### [v2026.4.10+] Silent message drop fixes (`1c17abb`)
 
 Four bugs that caused agents (e.g. MonicaHall, Harvey) to silently drop user messages in Telegram:
 
-| # | Bug | Fix |
-|---|-----|-----|
-| 1 | **Timeout compaction gate** treated missing LLM usage stats as 0% context pressure, skipping compaction and stalling sessions | `run.ts`: falls back to preflight-estimated prompt tokens; idle-timeout now treated as 100% pressure |
-| 2 | **Pre-flight compaction** used truncation-only for sessions >200 messages, which doesn't handle structural overflow | `preemptive-compaction.ts`: upgrades truncation-only → `compact_then_truncate` when session exceeds 200 messages |
-| 3 | **Thinking-only LLM responses** (`stopReason=stop`, no visible text, no tool calls) were silently dropped instead of retried | `incomplete-turn.ts`: detects thinking-only stop turns and surfaces a user-visible warning |
-| 4 | **Startup stuck-session replay**: on gateway restart, sessions with unanswered user turns are detected and replayed automatically | `server-startup-stuck-session-replay.ts`: scans transcripts, re-verifies before send (race guard), 30s per-send timeout, cap of 10 candidates |
+| #   | Bug                                                                                                                               | Fix                                                                                                                                           |
+| --- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Timeout compaction gate** treated missing LLM usage stats as 0% context pressure, skipping compaction and stalling sessions     | `run.ts`: falls back to preflight-estimated prompt tokens; idle-timeout now treated as 100% pressure                                          |
+| 2   | **Pre-flight compaction** used truncation-only for sessions >200 messages, which doesn't handle structural overflow               | `preemptive-compaction.ts`: upgrades truncation-only → `compact_then_truncate` when session exceeds 200 messages                              |
+| 3   | **Thinking-only LLM responses** (`stopReason=stop`, no visible text, no tool calls) were silently dropped instead of retried      | `incomplete-turn.ts`: detects thinking-only stop turns and surfaces a user-visible warning                                                    |
+| 4   | **Startup stuck-session replay**: on gateway restart, sessions with unanswered user turns are detected and replayed automatically | `server-startup-stuck-session-replay.ts`: scans transcripts, re-verifies before send (race guard), 30s per-send timeout, cap of 10 candidates |
 
 Related upstream issues: [#724](https://github.com/openclaw/openclaw/issues/724), [#64570](https://github.com/openclaw/openclaw/issues/64570), [#64571](https://github.com/openclaw/openclaw/issues/64571)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # 🦞 OpenClaw — Personal AI Assistant
 
+> **This is [`dzianisv/openclaw`](https://github.com/dzianisv/openclaw)** — a fork of [`openclaw/openclaw`](https://github.com/openclaw/openclaw) with production fixes applied on top of upstream `main`.
+>
+> Install the fork: `npm install -g @vibetechnologies/openclaw@latest`
+
+## Fixes on top of upstream
+
+### [v2026.4.10+] Silent message drop fixes (`426606c`)
+
+Four bugs that caused agents (e.g. MonicaHall, Harvey) to silently drop user messages in Telegram:
+
+| # | Bug | Fix |
+|---|-----|-----|
+| 1 | **Timeout compaction gate** treated missing LLM usage stats as 0% context pressure, skipping compaction and stalling sessions | `run.ts`: falls back to preflight-estimated prompt tokens; idle-timeout now treated as 100% pressure |
+| 2 | **Pre-flight compaction** used truncation-only for sessions >200 messages, which doesn't handle structural overflow | `preemptive-compaction.ts`: upgrades truncation-only → `compact_then_truncate` when session exceeds 200 messages |
+| 3 | **Thinking-only LLM responses** (`stopReason=stop`, no visible text, no tool calls) were silently dropped instead of retried | `incomplete-turn.ts`: detects thinking-only stop turns and surfaces a user-visible warning |
+| 4 | **Startup stuck-session replay**: on gateway restart, sessions with unanswered user turns are detected and replayed automatically | `server-startup-stuck-session-replay.ts`: scans transcripts, re-verifies before send (race guard), 30s per-send timeout, cap of 10 candidates |
+
+Related upstream issues: [#724](https://github.com/openclaw/openclaw/issues/724), [#64570](https://github.com/openclaw/openclaw/issues/64570), [#64571](https://github.com/openclaw/openclaw/issues/64571)
+
+---
+
 <p align="center">
     <picture>
         <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/assets/openclaw-logo-text-dark.svg">

--- a/README.md
+++ b/README.md
@@ -1,17 +1,30 @@
 # 🦞 OpenClaw — Personal AI Assistant
 
-> **This is [`dzianisv/openclaw`](https://github.com/dzianisv/openclaw)** — a fork of [`openclaw/openclaw`](https://github.com/openclaw/openclaw) with production fixes applied on top of upstream `main`.
+> **This is [`dzianisv/openclaw`](https://github.com/dzianisv/openclaw)** — a fork of [`openclaw/openclaw`](https://github.com/openclaw/openclaw) with targeted production patches on top of upstream `main`.
 >
 > Install the fork: `npm install -g @vibetechnologies/openclaw@latest`
 
-## Fixes on top of upstream
+## Why this fork exists
+
+We hit production issues that were not yet available in upstream `main` at the time we needed them.  
+This fork carries only those deltas, kept as explicit patches over upstream.
+
+## Fork patches on top of upstream `main`
 
 ### [v2026.4.11+] ChatGPT-style session management UI (`1d6aaac`)
 
-- **New chat button** in the sidebar (always visible, disabled when disconnected)
-- **Recent sessions list** in the sidebar — click any session to switch to it
-- **Rename session** button in the chat header
-- Session list ordered by last activity, with idle/connected state indicators
+| Problem in upstream/main | What we added in fork | Result |
+| --- | --- | --- |
+| Starting a fresh chat was not a first-class sidebar action | Added sidebar **New chat** action wired to `createControlUiSession` + deterministic `agent:<id>:ui:<timestamp>-<slug>-<suffix>` session keys (`ui/src/ui/controllers/sessions.ts`, `ui/src/ui/app-render.ts`) | One-click chat creation without slash-command flow |
+| Session switching was not ChatGPT-style in the left nav | Added **recent sessions** sidebar rail, ordered by recent activity with connection/idle indicators (`ui/src/ui/app-render.ts`, `ui/src/styles/layout.css`) | Fast left-rail session hopping |
+| Session rename was not exposed as a direct chat-header action | Added **Rename chat** header action + `sessions.patch` label update path (`ui/src/ui/app-render.helpers.ts`, `ui/src/ui/app-render.ts`) | Inline rename flow for active session |
+| New actions lacked locale coverage | Added `newChat` / `renameChat` strings in EN/DE/ES/PT-BR/ZH-CN/ZH-TW | UI labels remain translated across supported locales |
+
+### [v2026.4.11+] ChatGPT-style recent sessions sidebar (`c3188d6`)
+
+| Problem in upstream/main | What we added in fork | Result |
+| --- | --- | --- |
+| Sidebar did not prioritize session navigation like ChatGPT | Added a recent-sessions-focused sidebar flow and settings refresh coverage (`ui/src/ui/app-render.ts`, `ui/src/ui/app-settings.ts`, `ui/src/ui/views/dreaming.ts`) | Session-centric navigation stays visible and consistent during normal dashboard use |
 
 ---
 
@@ -19,7 +32,7 @@
 
 Four bugs that caused agents (e.g. MonicaHall, Harvey) to silently drop user messages in Telegram:
 
-| #   | Bug                                                                                                                               | Fix                                                                                                                                           |
+| #   | Bug                                                                                                                               | What we added in fork                                                                                                                        |
 | --- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1   | **Timeout compaction gate** treated missing LLM usage stats as 0% context pressure, skipping compaction and stalling sessions     | `run.ts`: falls back to preflight-estimated prompt tokens; idle-timeout now treated as 100% pressure                                          |
 | 2   | **Pre-flight compaction** used truncation-only for sessions >200 messages, which doesn't handle structural overflow               | `preemptive-compaction.ts`: upgrades truncation-only → `compact_then_truncate` when session exceeds 200 messages                              |

--- a/package.json
+++ b/package.json
@@ -1501,6 +1501,7 @@
     "@slack/bolt": "^4.7.0",
     "@slack/web-api": "^7.15.0",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
+    "acpx": "0.5.3",
     "ajv": "^8.18.0",
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1293,6 +1293,7 @@
     "ios:version:check": "node --import tsx scripts/ios-sync-versioning.ts --check",
     "ios:version:pin": "node --import tsx scripts/ios-pin-version.ts",
     "ios:version:sync": "node --import tsx scripts/ios-sync-versioning.ts --write",
+    "install:local": "pnpm build && pnpm ui:build && npm install -g . && openclaw gateway restart --json",
     "lint": "node scripts/run-oxlint.mjs",
     "lint:agent:ingress-owner": "node scripts/check-ingress-agent-owner-context.mjs",
     "lint:all": "pnpm lint && pnpm lint:swift",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,11 @@ minimumReleaseAgeExclude:
   - "rolldown"
   - "sqlite-vec"
   - "sqlite-vec-*"
+  - "@tloncorp/tlon-skill"
+  - "@tloncorp/tlon-skill-darwin-arm64"
+  - "@tloncorp/tlon-skill-darwin-x64"
+  - "@tloncorp/tlon-skill-linux-x64"
+  - "@tloncorp/tlon-skill-linux-arm64"
 
 onlyBuiltDependencies:
   - "@discordjs/opus"

--- a/skills/integration-notion/SKILL.md
+++ b/skills/integration-notion/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: integration-notion
+description: "Set up and configure the Notion integration for OpenClaw: create a Notion internal connection, retrieve the API token, store credentials, register the notion skill, and grant page access. Use when asked to 'set up notion', 'connect notion', 'configure notion integration', or 'add notion to openclaw'."
+homepage: https://developers.notion.com/reference/intro
+user-invocable: true
+metadata: { "openclaw": { "emoji": "🔗", "requires": { "bins": ["curl", "jq"] }, "install": [] } }
+---
+
+# integration-notion — Set Up Notion for OpenClaw
+
+Guides the agent through configuring Notion API access for this OpenClaw instance.
+
+## When to Use
+
+- User asks to "set up Notion", "connect Notion", "configure Notion", or "add Notion integration"
+- A skill or workflow needs Notion access and `~/.openclaw/credentials/notion.json` does not exist
+- User wants to grant additional Notion page access to the integration
+
+## Pre-flight Check
+
+Before starting, check if Notion is already configured:
+
+```bash
+# Check for existing credential
+if [ -f ~/.openclaw/credentials/notion.json ]; then
+  NOTION_KEY=$(jq -r .token ~/.openclaw/credentials/notion.json)
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $NOTION_KEY" \
+    -H "Notion-Version: 2025-09-03" \
+    "https://api.notion.com/v1/users/me")
+  if [ "$STATUS" = "200" ]; then
+    echo "✅ Notion already configured and token is valid"
+    exit 0
+  else
+    echo "⚠️ Credential file exists but token is invalid (HTTP $STATUS). Re-run setup."
+  fi
+else
+  echo "No Notion credentials found. Starting setup..."
+fi
+```
+
+## Phase 1 — Create Notion Internal Connection
+
+1. Open https://www.notion.so/profile/integrations/internal in the browser
+2. Click **"Create a new connection"**
+3. Fill in:
+   - **Connection name**: `OpenClaw` (or user's preferred name)
+   - **Installable in**: Select the target workspace
+4. Click **Create**
+5. On the confirmation dialog, click **"Configure connection settings"**
+
+## Phase 2 — Retrieve the API Token
+
+1. On the edit connection page, find **"Installation access token"**
+2. Click **"Show"** to reveal the token
+3. If the snapshot shows masked dots (`•••`), extract the value via JavaScript on the token input field
+4. Token starts with `ntn_` or `secret_`
+
+## Phase 3 — Store Credentials
+
+Save the token to the OpenClaw credentials store:
+
+```bash
+# Store in OpenClaw credentials (canonical location)
+cat > ~/.openclaw/credentials/notion.json <<'EOF'
+{"token":"ntn_YOUR_TOKEN_HERE"}
+EOF
+chmod 600 ~/.openclaw/credentials/notion.json
+```
+
+## Phase 4 — Register Skill in openclaw.json
+
+Add the notion skill entry to `~/.openclaw/openclaw.json` under `skills.entries`:
+
+```bash
+# Read current config, add notion skill entry, write back
+python3 -c "
+import json
+with open('$HOME/.openclaw/openclaw.json') as f:
+    data = json.load(f)
+data['skills']['entries']['notion'] = {
+    'enabled': True,
+    'apiKey': 'ntn_YOUR_TOKEN_HERE'
+}
+with open('$HOME/.openclaw/openclaw.json', 'w') as f:
+    json.dump(data, f, indent=2)
+print('✅ notion skill registered in openclaw.json')
+"
+```
+
+> **Note:** `openclaw.json` only accepts `enabled` and `apiKey` as skill entry keys. Do not add custom keys like `credentialFile` — they will fail validation.
+
+## Phase 5 — Grant Page Access
+
+1. On the integration edit page, click the **"Content access"** tab
+2. Click **"Edit access"**
+3. In the modal, click **"Select all"** (or let the user choose specific pages)
+4. Click **"Save"**
+
+## Phase 6 — Verify
+
+Test the integration end-to-end:
+
+```bash
+NOTION_KEY=$(jq -r .token ~/.openclaw/credentials/notion.json)
+curl -s -X POST "https://api.notion.com/v1/search" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Notion-Version: 2025-09-03" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"","page_size":3}' | jq '.results | length'
+```
+
+If the result is `> 0`, the integration is working.
+
+## Phase 7 — Test via Agent
+
+Run a quick agent test to confirm the skill is loaded:
+
+```bash
+openclaw agent --agent alice --local \
+  --message "Use the notion skill: read token from ~/.openclaw/credentials/notion.json with jq -r .token, then search Notion for pages. Show page titles." \
+  --timeout 120
+```
+
+## Troubleshooting
+
+| Symptom                            | Cause                                 | Fix                                                   |
+| ---------------------------------- | ------------------------------------- | ----------------------------------------------------- |
+| `Config invalid: Unrecognized key` | Custom key in `skills.entries.notion` | Only use `enabled` and `apiKey`                       |
+| `invalid_token` / HTTP 401         | Token expired or wrong                | Re-generate at notion.so/profile/integrations         |
+| Search returns 0 results           | No page access granted                | Go to Content access tab → Edit access → select pages |
+| `Could not validate credentials`   | Token from wrong workspace            | Ensure token matches the target workspace             |
+
+## Credential Locations
+
+| File                                  | Purpose                                             |
+| ------------------------------------- | --------------------------------------------------- |
+| `~/.openclaw/credentials/notion.json` | Canonical credential store (`{"token":"ntn_..."}`)  |
+| `~/.openclaw/openclaw.json`           | Skill registration (`skills.entries.notion.apiKey`) |
+
+## Notes
+
+- The `notion` skill (separate from this integration skill) provides the Notion API reference (search, CRUD pages, databases, blocks)
+- Notion API version `2025-09-03` is required — databases are called "data sources" in this version
+- Rate limit: ~3 requests/second average
+- Integration tokens are workspace-scoped — one token per workspace

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -114,6 +114,26 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     ]);
   });
 
+  it("treats stop thinking-only turns as incomplete", () => {
+    const text = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [],
+        lastAssistant: {
+          stopReason: "stop",
+          provider: "openai",
+          model: "mock-1",
+          content: [{ type: "thinking", thinking: "internal-only" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(text).toBe("⚠️ Agent couldn't generate a response. Please try again.");
+  });
+
   it("emits explicit replayInvalid + blocked liveness state at the strict-agentic blocked exit", async () => {
     // Criterion 4 of the GPT-5.4 parity gate requires every terminal exit path
     // to emit explicit replayInvalid + livenessState. The strict-agentic

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -578,4 +578,90 @@ describe("timeout-triggered compaction", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("timed out");
   });
+
+  it("triggers compaction on idle timeout with no usage stats when preflight estimated high tokens", async () => {
+    // Idle timeout: model produced zero output → no usage stats
+    // But preflight estimated 150k tokens (high context pressure)
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        idleTimedOut: true,
+        lastAssistant: undefined, // no output → no usage
+        preflightRecovery: {
+          route: "truncate_tool_results_only",
+          estimatedPromptTokens: 150000,
+        },
+      }),
+    );
+    // Compaction succeeds
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "idle timeout recovery compaction",
+        tokensBefore: 150000,
+        tokensAfter: 80000,
+      }),
+    );
+    // Retry after compaction succeeds
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        force: true,
+        compactionTarget: "budget",
+        runtimeContext: expect.objectContaining({
+          trigger: "timeout_recovery",
+          attempt: 1,
+        }),
+      }),
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("triggers compaction on idle timeout with no usage stats and no preflight estimate (assumes high pressure)", async () => {
+    // Idle timeout with NO preflight recovery at all — should still compact
+    // because idle timeout + missing data → assume ratio = 1.0
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        idleTimedOut: true,
+        lastAssistant: undefined,
+      }),
+    );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "idle timeout recovery (no preflight data)",
+        tokensBefore: 130000,
+        tokensAfter: 60000,
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).not.toBe(true);
+  });
+
+  it("does NOT trigger compaction on regular (non-idle) timeout with no usage stats", async () => {
+    // Regular timeout (NOT idle — model was producing output but was slow)
+    // with no usage stats → ratio defaults to 0 → no compaction
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        idleTimedOut: false,
+        lastAssistant: undefined,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("timed out");
+  });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -876,10 +876,14 @@ export async function runEmbeddedPiAgent(
             // tokens, which can make a long generation look like high context
             // pressure even when the prompt itself was small.
             const lastTurnPromptTokens = derivePromptTokens(lastRunPromptUsage);
+            const effectivePromptTokens =
+              lastTurnPromptTokens ?? preflightRecovery?.estimatedPromptTokens;
             const tokenUsedRatio =
-              lastTurnPromptTokens != null && ctxInfo.tokens > 0
-                ? lastTurnPromptTokens / ctxInfo.tokens
-                : 0;
+              effectivePromptTokens != null && ctxInfo.tokens > 0
+                ? effectivePromptTokens / ctxInfo.tokens
+                : idleTimedOut
+                  ? 1.0
+                  : 0;
             if (timeoutCompactionAttempts >= MAX_TIMEOUT_COMPACTION_ATTEMPTS) {
               log.warn(
                 `[timeout-compaction] already attempted timeout compaction ${timeoutCompactionAttempts} time(s); falling through to failover rotation`,
@@ -888,7 +892,7 @@ export async function runEmbeddedPiAgent(
               const timeoutDiagId = createCompactionDiagId();
               timeoutCompactionAttempts++;
               log.warn(
-                `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%); ` +
+                `[timeout-compaction] LLM timed out with high prompt token usage (${Math.round(tokenUsedRatio * 100)}%${lastTurnPromptTokens == null ? " [fallback estimate]" : ""}); ` +
                   `attempting compaction before retry (attempt ${timeoutCompactionAttempts}/${MAX_TIMEOUT_COMPACTION_ATTEMPTS}) diagId=${timeoutDiagId}`,
               );
               let timeoutCompactResult: Awaited<ReturnType<typeof contextEngine.compact>>;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2111,6 +2111,7 @@ export async function runEmbeddedAttempt(
                 route: "truncate_tool_results_only",
                 handled: true,
                 truncatedCount: truncationResult.truncatedCount,
+                estimatedPromptTokens: preemptiveCompaction.estimatedPromptTokens,
               };
               log.info(
                 `[context-overflow-precheck] early tool-result truncation succeeded for ` +
@@ -2131,7 +2132,10 @@ export async function runEmbeddedAttempt(
                   `${params.provider}/${params.modelId}; falling back to compaction ` +
                   `reason=${truncationResult.reason ?? "unknown"} sessionFile=${params.sessionFile}`,
               );
-              preflightRecovery = { route: "compact_only" };
+              preflightRecovery = {
+                route: "compact_only",
+                estimatedPromptTokens: preemptiveCompaction.estimatedPromptTokens,
+              };
               promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
               promptErrorSource = "precheck";
               skipPromptSubmission = true;
@@ -2140,8 +2144,14 @@ export async function runEmbeddedAttempt(
           if (preemptiveCompaction.shouldCompact) {
             preflightRecovery =
               preemptiveCompaction.route === "compact_then_truncate"
-                ? { route: "compact_then_truncate" }
-                : { route: "compact_only" };
+                ? {
+                    route: "compact_then_truncate",
+                    estimatedPromptTokens: preemptiveCompaction.estimatedPromptTokens,
+                  }
+                : {
+                    route: "compact_only",
+                    estimatedPromptTokens: preemptiveCompaction.estimatedPromptTokens,
+                  };
             promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
             promptErrorSource = "precheck";
             log.warn(

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -20,6 +20,8 @@ type IncompleteTurnAttempt = Pick<
   | "yieldDetected"
   | "didSendDeterministicApprovalPrompt"
   | "lastToolError"
+  | "assistantTexts"
+  | "toolMetas"
   | "lastAssistant"
   | "replayMetadata"
   | "promptErrorSource"
@@ -174,6 +176,21 @@ export function resolveIncompleteTurnPayloadText(params: {
   }
 
   const stopReason = params.attempt.lastAssistant?.stopReason;
+  if (stopReason === "stop") {
+    const hasVisibleAssistantText = params.attempt.assistantTexts.some(
+      (text) => text.trim().length > 0,
+    );
+    const hasToolCalls =
+      params.attempt.toolMetas.length > 0 ||
+      params.attempt.lastAssistant?.content.some((block) => block.type === "toolCall") === true;
+    if (hasVisibleAssistantText || hasToolCalls) {
+      return null;
+    }
+    return params.attempt.replayMetadata.hadPotentialSideEffects
+      ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
+      : "⚠️ Agent couldn't generate a response. Please try again.";
+  }
+
   const incompleteTerminalAssistant = isIncompleteTerminalAssistantTurn({
     hasAssistantVisibleText: params.payloadCount > 0,
     lastAssistant: params.attempt.lastAssistant,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -13,6 +13,11 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
+/**
+ * When a session exceeds this many messages, truncation-only is upgraded to
+ * compact_then_truncate so the model doesn't choke on structural overhead.
+ */
+export const TRUNCATION_ONLY_MAX_MESSAGES = 200;
 
 export type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
@@ -89,6 +94,12 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     } else {
       route = "compact_then_truncate";
     }
+  }
+  if (
+    route === "truncate_tool_results_only" &&
+    params.messages.length > TRUNCATION_ONLY_MAX_MESSAGES
+  ) {
+    route = "compact_then_truncate";
   }
   return {
     route,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -64,10 +64,12 @@ export type EmbeddedRunAttemptResult = {
         route: Exclude<PreemptiveCompactionRoute, "fits">;
         handled: true;
         truncatedCount?: number;
+        estimatedPromptTokens?: number;
       }
     | {
         route: Exclude<PreemptiveCompactionRoute, "fits">;
         handled?: false;
+        estimatedPromptTokens?: number;
       };
   sessionIdUsed: string;
   bootstrapPromptWarningSignaturesSeen?: string[];

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -78,11 +78,12 @@ function buildUnownedProviderTransportReplayFallback(params: {
   const isGoogle = isGoogleModelApi(params.modelApi);
   const isAnthropic = isAnthropicApi(params.modelApi);
   const isStrictOpenAiCompatible = params.modelApi === "openai-completions";
-  const requiresOpenAiCompatibleToolIdSanitization =
-    params.modelApi === "openai-completions" ||
+  const isResponsesApi =
     params.modelApi === "openai-responses" ||
     params.modelApi === "openai-codex-responses" ||
     params.modelApi === "azure-openai-responses";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" || isResponsesApi;
 
   if (
     !isGoogle &&
@@ -98,7 +99,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
     ...(isGoogle || isAnthropic ? { sanitizeMode: "full" as const } : {}),
     ...(isGoogle || isAnthropic || requiresOpenAiCompatibleToolIdSanitization
       ? {
-          sanitizeToolCallIds: true,
+          sanitizeToolCallIds: !isResponsesApi,
           toolCallIdMode: "strict" as const,
         }
       : {}),

--- a/src/gateway/server-startup-stuck-session-replay.test.ts
+++ b/src/gateway/server-startup-stuck-session-replay.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import {
+  detectStartupStuckSessionReason,
+  runStartupStuckSessionReplay,
+  selectStartupReplayCandidates,
+  shouldSkipStartupReplaySession,
+  type StartupStuckSessionReason,
+} from "./server-startup-stuck-session-replay.js";
+
+describe("detectStartupStuckSessionReason", () => {
+  it("flags sessions when the last meaningful message is a user turn", () => {
+    const reason = detectStartupStuckSessionReason([
+      { role: "assistant", content: "Earlier answer" },
+      { role: "user", content: "Please continue" },
+      { role: "tool", content: "tool output" },
+    ]);
+    expect(reason).toBe("pending-user-turn");
+  });
+
+  it("flags sessions when the last assistant message has no visible text and no tool calls", () => {
+    const reason = detectStartupStuckSessionReason([
+      { role: "user", content: "Do work" },
+      { role: "assistant", content: [{ type: "text", text: "" }] },
+    ]);
+    expect(reason).toBe("assistant-empty-no-tools");
+  });
+
+  it("ignores assistant entries that include tool calls", () => {
+    const reason = detectStartupStuckSessionReason([
+      { role: "user", content: "Do work" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_call", name: "search" }],
+      },
+    ]);
+    expect(reason).toBeNull();
+  });
+});
+
+describe("startup replay selection", () => {
+  it("sorts by newest first and applies the configured cap", () => {
+    const selected = selectStartupReplayCandidates(
+      [
+        {
+          key: "s1",
+          sessionId: "s1",
+          updatedAt: 10,
+          reason: "pending-user-turn",
+          storePath: "(test)",
+        },
+        {
+          key: "s3",
+          sessionId: "s3",
+          updatedAt: 30,
+          reason: "assistant-empty-no-tools",
+          storePath: "(test)",
+        },
+        {
+          key: "s2",
+          sessionId: "s2",
+          updatedAt: 20,
+          reason: "pending-user-turn",
+          storePath: "(test)",
+        },
+      ],
+      2,
+    );
+    expect(selected.map((candidate) => candidate.key)).toEqual(["s3", "s2"]);
+  });
+
+  it("skips global, unknown, cron-run, and internal-channel sessions", () => {
+    const baseEntry = { sessionId: "s", updatedAt: 1 } as SessionEntry;
+    expect(shouldSkipStartupReplaySession({ key: "global", entry: baseEntry })).toBe(true);
+    expect(shouldSkipStartupReplaySession({ key: "unknown", entry: baseEntry })).toBe(true);
+    expect(
+      shouldSkipStartupReplaySession({
+        key: "agent:main:cron:nightly:run:abc",
+        entry: baseEntry,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipStartupReplaySession({
+        key: "agent:main:internal:dev",
+        entry: { ...baseEntry, channel: "internal" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipStartupReplaySession({
+        key: "agent:main:webchat:user1",
+        entry: { ...baseEntry, channel: "webchat" },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("runStartupStuckSessionReplay", () => {
+  it("replays newest stuck sessions and logs startup summary", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:telegram:group:-1001:topic:done": {
+        sessionId: "done",
+        updatedAt: 50,
+        channel: "telegram",
+      },
+      "agent:main:telegram:group:-1001:topic:newest": {
+        sessionId: "newest",
+        updatedAt: 300,
+        channel: "telegram",
+      },
+      "agent:main:telegram:group:-1001:topic:older": {
+        sessionId: "older",
+        updatedAt: 200,
+        channel: "telegram",
+      },
+      "agent:main:internal:skip": {
+        sessionId: "skip",
+        updatedAt: 400,
+        channel: "internal",
+      },
+    };
+    const reasonsBySessionId: Record<string, StartupStuckSessionReason | null> = {
+      done: null,
+      newest: "pending-user-turn",
+      older: "assistant-empty-no-tools",
+      skip: "pending-user-turn",
+    };
+
+    const sent: string[] = [];
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    await runStartupStuckSessionReplay({
+      cfg: {} as never,
+      context: {} as never,
+      maxRecoveries: 2,
+      deps: {
+        loadCombinedStore: () => ({ storePath: "(test)", store }),
+        resolveStoreTarget: () => ({
+          agentId: "main",
+          storePath: "(test)",
+          canonicalKey: "",
+          storeKeys: [],
+        }),
+        readMessages: (sessionId) => {
+          const reason = reasonsBySessionId[sessionId];
+          if (reason === "pending-user-turn") {
+            return [{ role: "user", content: "pending turn" }];
+          }
+          if (reason === "assistant-empty-no-tools") {
+            return [{ role: "assistant", content: [{ type: "text", text: "" }] }];
+          }
+          return [{ role: "assistant", content: "already answered" }];
+        },
+        sendMessage: async ({ key }) => {
+          sent.push(key);
+          if (key.endsWith(":older")) {
+            throw new Error("send failed");
+          }
+        },
+      },
+      log,
+    });
+
+    expect(sent).toEqual([
+      "agent:main:telegram:group:-1001:topic:newest",
+      "agent:main:telegram:group:-1001:topic:older",
+    ]);
+    const summaryLine =
+      log.info.mock.calls.find((c: string[]) => c[0]?.includes("summary"))?.[0] ?? "";
+    expect(summaryLine).toContain("scanned=3");
+    expect(summaryLine).toContain("candidates=2");
+    expect(summaryLine).toContain("replayed=1");
+    expect(summaryLine).toContain("skipped_stale=0");
+    expect(summaryLine).toContain("failed=1");
+    expect(log.warn).toHaveBeenCalledOnce();
+    expect(log.warn.mock.calls[0]?.[0]).toContain("startup stuck-session replay failed");
+  });
+
+  it("skips candidates whose transcript changed between scan and send (stale race)", async () => {
+    const store: Record<string, SessionEntry> = {
+      "agent:main:telegram:group:-1001:topic:racing": {
+        sessionId: "racing",
+        updatedAt: 100,
+        channel: "telegram",
+      },
+    };
+
+    let readCount = 0;
+    const sent: string[] = [];
+    const log = { info: vi.fn(), warn: vi.fn() };
+
+    await runStartupStuckSessionReplay({
+      cfg: {} as never,
+      context: {} as never,
+      maxRecoveries: 5,
+      deps: {
+        loadCombinedStore: () => ({ storePath: "(test)", store }),
+        resolveStoreTarget: () => ({
+          agentId: "main",
+          storePath: "(test)",
+          canonicalKey: "",
+          storeKeys: [],
+        }),
+        readMessages: () => {
+          readCount += 1;
+          // First read (scan): stuck. Second read (re-verify): no longer stuck.
+          if (readCount <= 1) {
+            return [{ role: "user", content: "pending turn" }];
+          }
+          return [
+            { role: "user", content: "pending turn" },
+            { role: "assistant", content: "I replied while you were scanning" },
+          ];
+        },
+        sendMessage: async ({ key }) => {
+          sent.push(key);
+        },
+      },
+      log,
+    });
+
+    expect(sent).toEqual([]);
+    const summaryLine =
+      log.info.mock.calls.find((c: string[]) => c[0]?.includes("summary"))?.[0] ?? "";
+    expect(summaryLine).toContain("skipped_stale=1");
+    expect(summaryLine).toContain("replayed=0");
+  });
+});

--- a/src/gateway/server-startup-stuck-session-replay.ts
+++ b/src/gateway/server-startup-stuck-session-replay.ts
@@ -1,0 +1,315 @@
+import { randomUUID } from "node:crypto";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import { isCronRunSessionKey, parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { isInternalMessageChannel } from "../utils/message-channel.js";
+import { hasToolCall } from "../utils/transcript-tools.js";
+import { sessionsHandlers } from "./server-methods/sessions.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import {
+  loadCombinedSessionStoreForGateway,
+  readSessionMessages,
+  resolveGatewaySessionStoreTarget,
+} from "./session-utils.js";
+
+export const DEFAULT_STARTUP_STUCK_SESSION_REPLAY_MESSAGE =
+  "Gateway restarted and your previous turn may be unanswered. Continue from the latest pending user request and send the reply now. Avoid duplicating already-sent messages.";
+export const DEFAULT_STARTUP_STUCK_SESSION_REPLAY_CAP = 10;
+export const DEFAULT_STARTUP_REPLAY_SEND_TIMEOUT_MS = 30_000;
+
+const INTERNAL_CHANNELS = new Set(["internal", "cron"]);
+
+export type StartupStuckSessionReason = "pending-user-turn" | "assistant-empty-no-tools";
+
+type StartupReplayCandidate = {
+  key: string;
+  sessionId: string;
+  updatedAt: number;
+  reason: StartupStuckSessionReason;
+  storePath: string;
+  sessionFile?: string;
+};
+
+type StartupReplayLog = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+type TranscriptMessage = {
+  role?: string;
+  content?: unknown;
+  text?: unknown;
+  attachments?: unknown;
+};
+
+function hasMeaningfulUserMessage(message: TranscriptMessage): boolean {
+  if (typeof message.content === "string" && message.content.trim().length > 0) {
+    return true;
+  }
+  if (Array.isArray(message.content) && message.content.length > 0) {
+    for (const entry of message.content) {
+      if (!entry || typeof entry !== "object") {
+        continue;
+      }
+      const block = entry as { type?: unknown; text?: unknown };
+      if (typeof block.text === "string" && block.text.trim().length > 0) {
+        return true;
+      }
+      if (
+        typeof block.type === "string" &&
+        normalizeLowercaseStringOrEmpty(block.type) !== "text"
+      ) {
+        return true;
+      }
+    }
+  }
+  if (typeof message.text === "string" && message.text.trim().length > 0) {
+    return true;
+  }
+  return Array.isArray(message.attachments) && message.attachments.length > 0;
+}
+
+export function detectStartupStuckSessionReason(
+  messages: unknown[],
+): StartupStuckSessionReason | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const raw = messages[i];
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      continue;
+    }
+    const message = raw as TranscriptMessage;
+    const role = normalizeLowercaseStringOrEmpty(message.role);
+    if (role === "user") {
+      if (hasMeaningfulUserMessage(message)) {
+        return "pending-user-turn";
+      }
+      continue;
+    }
+    if (role !== "assistant") {
+      continue;
+    }
+    const assistantText =
+      extractAssistantVisibleText(message as Record<string, unknown>)?.trim() ?? "";
+    if (assistantText.length > 0) {
+      return null;
+    }
+    if (hasToolCall(message as Record<string, unknown>)) {
+      return null;
+    }
+    return "assistant-empty-no-tools";
+  }
+  return null;
+}
+
+function resolveReplayChannel(params: { key: string; entry: SessionEntry }): string {
+  const direct =
+    (typeof params.entry.channel === "string" ? params.entry.channel : "") ||
+    (typeof params.entry.deliveryContext?.channel === "string"
+      ? params.entry.deliveryContext.channel
+      : "") ||
+    (typeof params.entry.lastChannel === "string" ? params.entry.lastChannel : "");
+  if (direct) {
+    return normalizeLowercaseStringOrEmpty(direct);
+  }
+  const parsed = parseAgentSessionKey(params.key);
+  if (!parsed) {
+    return "";
+  }
+  return normalizeLowercaseStringOrEmpty(parsed.rest.split(":")[0]);
+}
+
+export function shouldSkipStartupReplaySession(params: {
+  key: string;
+  entry: SessionEntry;
+}): boolean {
+  const loweredKey = normalizeLowercaseStringOrEmpty(params.key);
+  if (loweredKey === "global" || loweredKey === "unknown") {
+    return true;
+  }
+  if (isCronRunSessionKey(params.key)) {
+    return true;
+  }
+  const channel = resolveReplayChannel(params);
+  if (!channel) {
+    return true;
+  }
+  return INTERNAL_CHANNELS.has(channel) || isInternalMessageChannel(channel);
+}
+
+export function selectStartupReplayCandidates(
+  candidates: StartupReplayCandidate[],
+  maxRecoveries: number,
+): StartupReplayCandidate[] {
+  const cap = Math.max(1, Math.min(maxRecoveries, DEFAULT_STARTUP_STUCK_SESSION_REPLAY_CAP));
+  return [...candidates].toSorted((a, b) => b.updatedAt - a.updatedAt).slice(0, cap);
+}
+
+async function sendStartupReplayMessage(params: {
+  key: string;
+  message: string;
+  idempotencyKey: string;
+  context: GatewayRequestContext;
+  timeoutMs?: number;
+}): Promise<void> {
+  const timeoutMs = params.timeoutMs ?? DEFAULT_STARTUP_REPLAY_SEND_TIMEOUT_MS;
+  const sendPromise = new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const handlerResult = sessionsHandlers["sessions.send"]({
+      req: {
+        type: "req",
+        id: `startup-stuck-replay-${randomUUID()}`,
+        method: "sessions.send",
+        params: {
+          key: params.key,
+          message: params.message,
+          idempotencyKey: params.idempotencyKey,
+        },
+      },
+      params: {
+        key: params.key,
+        message: params.message,
+        idempotencyKey: params.idempotencyKey,
+      },
+      respond: (ok, _payload, error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (ok) {
+          resolve();
+          return;
+        }
+        reject(new Error(error?.message ?? `sessions.send failed for ${params.key}`));
+      },
+      context: params.context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+    Promise.resolve(handlerResult)
+      .then(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error(`sessions.send produced no response for ${params.key}`));
+        }
+      })
+      .catch((error: unknown) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+  });
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    setTimeout(
+      () =>
+        reject(new Error(`startup replay send timed out after ${timeoutMs}ms for ${params.key}`)),
+      timeoutMs,
+    );
+  });
+  await Promise.race([sendPromise, timeoutPromise]);
+}
+
+export async function runStartupStuckSessionReplay(params: {
+  cfg: OpenClawConfig;
+  context: GatewayRequestContext;
+  log: StartupReplayLog;
+  replayMessage?: string;
+  maxRecoveries?: number;
+  deps?: {
+    readMessages?: typeof readSessionMessages;
+    sendMessage?: typeof sendStartupReplayMessage;
+    loadCombinedStore?: typeof loadCombinedSessionStoreForGateway;
+    resolveStoreTarget?: typeof resolveGatewaySessionStoreTarget;
+  };
+}): Promise<void> {
+  const replayMessage = params.replayMessage ?? DEFAULT_STARTUP_STUCK_SESSION_REPLAY_MESSAGE;
+  const readMessages = params.deps?.readMessages ?? readSessionMessages;
+  const sendMessage = params.deps?.sendMessage ?? sendStartupReplayMessage;
+  const loadCombinedStore = params.deps?.loadCombinedStore ?? loadCombinedSessionStoreForGateway;
+  const resolveStoreTarget = params.deps?.resolveStoreTarget ?? resolveGatewaySessionStoreTarget;
+
+  const { store } = loadCombinedStore(params.cfg);
+  const ordered = Object.entries(store)
+    .filter(([, entry]) => Boolean(entry?.sessionId))
+    .filter(([key, entry]) => !shouldSkipStartupReplaySession({ key, entry }))
+    .toSorted((a, b) => (b[1].updatedAt ?? 0) - (a[1].updatedAt ?? 0));
+
+  const detectedCandidates: StartupReplayCandidate[] = [];
+  let scanned = 0;
+  let failed = 0;
+  for (const [key, entry] of ordered) {
+    scanned += 1;
+    try {
+      const storeTarget = resolveStoreTarget({
+        cfg: params.cfg,
+        key,
+        scanLegacyKeys: false,
+        store,
+      });
+      const messages = readMessages(entry.sessionId, storeTarget.storePath, entry.sessionFile);
+      const reason = detectStartupStuckSessionReason(messages);
+      if (!reason) {
+        continue;
+      }
+      detectedCandidates.push({
+        key,
+        sessionId: entry.sessionId,
+        updatedAt: entry.updatedAt ?? 0,
+        reason,
+        storePath: storeTarget.storePath,
+        sessionFile: entry.sessionFile,
+      });
+    } catch (error) {
+      failed += 1;
+      params.log.warn(
+        `gateway: startup stuck-session replay scan failed for ${key}: ${String(error)}`,
+      );
+    }
+  }
+
+  const selectedCandidates = selectStartupReplayCandidates(
+    detectedCandidates,
+    params.maxRecoveries ?? DEFAULT_STARTUP_STUCK_SESSION_REPLAY_CAP,
+  );
+  const replayBatchId = Date.now().toString(36);
+  let replayed = 0;
+  let skippedStale = 0;
+  for (const [index, candidate] of selectedCandidates.entries()) {
+    try {
+      // Re-verify transcript tail to prevent replay-vs-live race:
+      // if a new message arrived between scan and send, skip this candidate.
+      const freshMessages = readMessages(
+        candidate.sessionId,
+        candidate.storePath,
+        candidate.sessionFile,
+      );
+      const freshReason = detectStartupStuckSessionReason(freshMessages);
+      if (!freshReason) {
+        skippedStale += 1;
+        params.log.info(
+          `gateway: startup stuck-session replay skipped stale candidate ${candidate.key} (no longer stuck)`,
+        );
+        continue;
+      }
+      await sendMessage({
+        key: candidate.key,
+        message: replayMessage,
+        idempotencyKey: `startup-stuck-replay:${replayBatchId}:${index}:${candidate.key}`,
+        context: params.context,
+      });
+      replayed += 1;
+    } catch (error) {
+      failed += 1;
+      params.log.warn(
+        `gateway: startup stuck-session replay failed for ${candidate.key}: ${String(error)}`,
+      );
+    }
+  }
+
+  params.log.info(
+    `gateway: startup stuck-session replay summary scanned=${scanned} candidates=${selectedCandidates.length} replayed=${replayed} skipped_stale=${skippedStale} failed=${failed}`,
+  );
+}

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -76,6 +76,7 @@ import {
 import { prepareGatewayPluginBootstrap } from "./server-startup-plugins.js";
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./server-startup-unavailable-methods.js";
 import { startGatewayEarlyRuntime, startGatewayPostAttachRuntime } from "./server-startup.js";
+import { runStartupStuckSessionReplay } from "./server-startup-stuck-session-replay.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { attachGatewayWsHandlers } from "./server-ws-runtime.js";
 import {
@@ -812,6 +813,14 @@ export async function startGatewayServer(
       sharedGatewaySessionGenerationState,
       clients,
     });
+
+    if (!minimalTestGateway) {
+      await runStartupStuckSessionReplay({
+        cfg: cfgAtStart,
+        context: gatewayRequestContext,
+        log: log.child("startup-stuck-replay"),
+      });
+    }
   } catch (err) {
     await closeOnStartupFailure();
     throw err;

--- a/src/plugins/provider-replay-helpers.test.ts
+++ b/src/plugins/provider-replay-helpers.test.ts
@@ -22,6 +22,17 @@ describe("provider replay helpers", () => {
     });
   });
 
+  it("disables tool call ID sanitization for Responses API providers", () => {
+    for (const api of ["openai-responses", "openai-codex-responses", "azure-openai-responses"]) {
+      const policy = buildOpenAICompatibleReplayPolicy(api);
+      expect(policy).toMatchObject({
+        sanitizeToolCallIds: false,
+        toolCallIdMode: "strict",
+        applyAssistantFirstOrderingFix: false,
+      });
+    }
+  });
+
   it("builds strict anthropic replay policy", () => {
     expect(buildStrictAnthropicReplayPolicy({ dropThinkingBlocks: true })).toMatchObject({
       sanitizeMode: "full",

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -20,8 +20,13 @@ export function buildOpenAICompatibleReplayPolicy(
     return undefined;
   }
 
+  const isResponsesApi =
+    modelApi === "openai-responses" ||
+    modelApi === "openai-codex-responses" ||
+    modelApi === "azure-openai-responses";
+
   return {
-    sanitizeToolCallIds: true,
+    sanitizeToolCallIds: !isResponsesApi,
     toolCallIdMode: "strict",
     ...(modelApi === "openai-completions"
       ? {

--- a/src/ui-app-settings.agents-files-refresh.test.ts
+++ b/src/ui-app-settings.agents-files-refresh.test.ts
@@ -94,6 +94,12 @@ function createHost(agentsPanel: AgentsPanel): Parameters<typeof refreshActiveTa
     dreamDiaryError: null,
     dreamDiaryPath: null,
     dreamDiaryContent: null,
+    wikiImportInsightsLoading: false,
+    wikiImportInsightsError: null,
+    wikiImportInsights: null,
+    wikiMemoryPalaceLoading: false,
+    wikiMemoryPalaceError: null,
+    wikiMemoryPalace: null,
   } as Parameters<typeof refreshActiveTab>[0];
 }
 

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -63,6 +63,8 @@ export const de: TranslationMap = {
     relink: "Erneut verknüpfen",
     waitForScan: "Auf Scan warten",
     logout: "Abmelden",
+    newChat: "Neuer Chat",
+    renameChat: "Chat umbenennen",
   },
   channels: {
     health: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -62,6 +62,8 @@ export const en: TranslationMap = {
     relink: "Relink",
     waitForScan: "Wait for scan",
     logout: "Logout",
+    newChat: "New chat",
+    renameChat: "Rename chat",
   },
   channels: {
     health: {

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -63,6 +63,8 @@ export const es: TranslationMap = {
     relink: "Volver a vincular",
     waitForScan: "Esperar escaneo",
     logout: "Cerrar sesión",
+    newChat: "Nuevo chat",
+    renameChat: "Renombrar chat",
   },
   channels: {
     health: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -63,6 +63,8 @@ export const pt_BR: TranslationMap = {
     relink: "Vincular novamente",
     waitForScan: "Aguardar leitura",
     logout: "Sair",
+    newChat: "Novo chat",
+    renameChat: "Renomear chat",
   },
   channels: {
     health: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -63,6 +63,8 @@ export const zh_CN: TranslationMap = {
     relink: "重新关联",
     waitForScan: "等待扫描",
     logout: "退出登录",
+    newChat: "新聊天",
+    renameChat: "重命名聊天",
   },
   channels: {
     health: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -63,6 +63,8 @@ export const zh_TW: TranslationMap = {
     relink: "重新連結",
     waitForScan: "等待掃描",
     logout: "登出",
+    newChat: "新增聊天",
+    renameChat: "重新命名聊天",
   },
   channels: {
     health: {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -52,15 +52,25 @@
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
   flex: 1 1 0;
-  /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 0 6px 6px;
-  margin: 0 0 0 0;
+  padding: 8px 0 12px;
+  margin: 0;
   min-height: 0;
-  /* Allow shrinking for flex scroll behavior */
-  border-radius: var(--radius-md);
   background: transparent;
+}
+
+.chat-thread-inner {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  padding: 8px 18px 0;
+}
+
+/* When showing welcome state (empty chat), stretch to fill and center */
+.chat-thread-inner:has(.agent-chat__welcome) {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-thread-inner > :first-child {
@@ -477,7 +487,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  margin: 0 18px 14px;
+  width: min(100%, 920px);
+  margin: 8px auto 18px;
   padding: 0;
   background: var(--card);
   border: 1px solid var(--border);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -894,6 +894,10 @@
   max-width: 320px;
 }
 
+.chat-controls__session-action {
+  flex-shrink: 0;
+}
+
 .chat-controls__thinking {
   display: flex;
   align-items: center;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -571,6 +571,11 @@
     transform var(--duration-fast) ease;
 }
 
+button.nav-item {
+  width: 100%;
+  font: inherit;
+}
+
 .nav-item__icon {
   width: 16px;
   height: 16px;
@@ -611,6 +616,18 @@
   opacity: 1;
 }
 
+.nav-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+  transform: none;
+}
+
+.nav-item:disabled:hover {
+  color: var(--muted);
+  background: transparent;
+  border-color: transparent;
+}
+
 .nav-item.active,
 .nav-item--active {
   color: var(--text-strong);
@@ -625,6 +642,48 @@
 .nav-item--active .nav-item__icon {
   opacity: 1;
   color: var(--accent);
+}
+
+.nav-item--action {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent-subtle) 82%, var(--bg-elevated) 18%);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.nav-item--action .nav-item__icon {
+  opacity: 1;
+  color: var(--accent);
+}
+
+.nav-item--action:hover {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent-subtle) 92%, var(--bg-elevated) 8%);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  transform: translateY(-1px);
+}
+
+.nav-item--action:disabled,
+.nav-item--action:disabled:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent-subtle) 58%, var(--bg-elevated) 42%);
+  border-color: color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: none;
+}
+
+.nav-item--action:disabled .nav-item__icon,
+.nav-item--action:disabled:hover .nav-item__icon {
+  color: var(--accent);
+}
+
+.sidebar-chat-actions {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.sidebar-chat-action {
+  width: 100%;
 }
 
 .sidebar--collapsed .sidebar-shell {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -686,6 +686,49 @@ button.nav-item {
   width: 100%;
 }
 
+.sidebar-recent-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 12px;
+  overflow: hidden;
+}
+
+.sidebar-recent-session {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.1s, color 0.1s;
+}
+
+.sidebar-recent-session:hover {
+  background: var(--nav-item-hover-bg, rgba(128, 128, 128, 0.1));
+  color: var(--text-primary);
+}
+
+.sidebar-recent-session--active {
+  background: var(--nav-item-active-bg, rgba(128, 128, 128, 0.15));
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.sidebar-recent-session__label {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sidebar--collapsed .sidebar-shell {
   padding: 12px 8px 10px;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -371,6 +371,8 @@
   min-height: 0;
   flex: 1;
   display: flex;
+  flex-direction: column;
+  overflow-y: auto;
 }
 
 .sidebar-shell__footer {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -490,7 +490,12 @@
 
   .chat-thread {
     margin-top: 0;
-    padding: 0 8px 12px;
+    padding: 0 0 12px;
+  }
+
+  .chat-thread-inner {
+    width: auto;
+    padding: 0 8px 0;
   }
 
   .chat-msg {
@@ -514,6 +519,7 @@
   }
 
   .agent-chat__input {
+    width: auto;
     margin: 0 8px 10px;
   }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -99,6 +99,8 @@ import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
 import {
   branchSessionFromCheckpoint,
+  createControlUiSession,
+  createDefaultControlUiSessionLabel,
   deleteSessionsAndRefresh,
   loadSessions,
   patchSession,
@@ -754,6 +756,8 @@ export function renderApp(state: AppViewState) {
     null;
   const resolvedAgentId = resolveSelectedAgentId();
   const activeSessionAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
+  const currentSessionRow =
+    state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey) ?? null;
   const toolsPanelUsesActiveSession = Boolean(
     resolvedAgentId && activeSessionAgentId && resolvedAgentId === activeSessionAgentId,
   );
@@ -1180,6 +1184,48 @@ export function renderApp(state: AppViewState) {
     resetToolsEffectiveState(state);
   };
 
+  const handleCreateChatSession = async () => {
+    if (!state.client || !state.connected) {
+      return;
+    }
+    const now = new Date();
+    const nextLabel = createDefaultControlUiSessionLabel(now);
+    state.lastError = null;
+    const result = await createControlUiSession(state, {
+      agentId: activeSessionAgentId,
+      label: nextLabel,
+      now,
+    });
+    if (!result?.key) {
+      state.lastError = state.sessionsError ?? "Failed to create chat";
+      return;
+    }
+    switchChatSession(state, result.key);
+    if (state.tab !== "chat") {
+      state.setTab("chat" as import("./navigation.ts").Tab);
+    }
+    state.navDrawerOpen = false;
+  };
+  const handleRenameChatSession = async () => {
+    if (!state.client || !state.connected) {
+      return;
+    }
+    const currentLabel = currentSessionRow?.label?.trim() || "";
+    const promptValue = window.prompt(t("common.renameChat"), currentLabel);
+    if (promptValue === null) {
+      return;
+    }
+    const nextLabel = promptValue.trim();
+    if (!nextLabel || nextLabel === currentLabel) {
+      return;
+    }
+    state.lastError = null;
+    const result = await patchSession(state, state.sessionKey, { label: nextLabel });
+    if (!result) {
+      state.lastError = state.sessionsError ?? "Failed to rename chat";
+    }
+  };
+
   return html`
     ${renderCommandPalette({
       open: state.paletteOpen,
@@ -1289,6 +1335,21 @@ export function renderApp(state: AppViewState) {
               </button>
             </div>
             <div class="sidebar-shell__body">
+              <div class="sidebar-chat-actions">
+                <button
+                  type="button"
+                  class="nav-item nav-item--action sidebar-chat-action"
+                  title=${t("common.newChat")}
+                  aria-label=${t("common.newChat")}
+                  ?disabled=${!state.client || !state.connected}
+                  @click=${() => void handleCreateChatSession()}
+                >
+                  <span class="nav-item__icon" aria-hidden="true">${icons.edit}</span>
+                  ${!navCollapsed
+                    ? html`<span class="nav-item__text">${t("common.newChat")}</span>`
+                    : nothing}
+                </button>
+              </div>
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
@@ -1400,7 +1461,9 @@ export function renderApp(state: AppViewState) {
           : html`<section class="content-header">
               <div>
                 ${isChat
-                  ? renderChatSessionSelect(state)
+                  ? renderChatSessionSelect(state, {
+                      onRenameSession: () => void handleRenameChatSession(),
+                    })
                   : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>
@@ -2248,7 +2311,8 @@ export function renderApp(state: AppViewState) {
               onDismissSideResult: () => {
                 state.chatSideResult = null;
               },
-              onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+              onNewSession: () => void handleCreateChatSession(),
+              onRenameSession: undefined,
               onClearHistory: async () => {
                 if (!state.client || !state.connected) {
                   return;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1350,6 +1350,47 @@ export function renderApp(state: AppViewState) {
                     : nothing}
                 </button>
               </div>
+              ${!navCollapsed && state.sessionsResult?.sessions?.length
+                ? html`
+                    <div class="sidebar-recent-sessions">
+                      ${[...state.sessionsResult.sessions]
+                        .filter((s) => {
+                          const display = s.label ?? s.displayName ?? s.key;
+                          if (display === "heartbeat" || s.key === "heartbeat") {
+                            return false;
+                          }
+                          if (s.key.includes(":cron:") || display.startsWith("Cron:")) {
+                            return false;
+                          }
+                          if (s.key.includes(":subagent:") && !s.label) {
+                            return false;
+                          }
+                          return s.kind === "direct" || s.kind === "group" || s.kind === "unknown";
+                        })
+                        .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+                        .slice(0, 12)
+                        .map(
+                          (session) => html`
+                            <button
+                              type="button"
+                              class="sidebar-recent-session ${session.key === state.sessionKey
+                                ? "sidebar-recent-session--active"
+                                : ""}"
+                              title=${session.label ?? session.displayName ?? session.key}
+                              @click=${() => {
+                                switchChatSession(state, session.key);
+                                state.setTab("chat" as import("./navigation.ts").Tab);
+                              }}
+                            >
+                              <span class="sidebar-recent-session__label"
+                                >${session.label ?? session.displayName ?? session.key}</span
+                              >
+                            </button>
+                          `,
+                        )}
+                    </div>
+                  `
+                : nothing}
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -91,6 +91,12 @@ type SettingsHost = {
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
+  wikiImportInsightsLoading: boolean;
+  wikiImportInsightsError: string | null;
+  wikiImportInsights: import("./controllers/dreaming.js").WikiImportInsights | null;
+  wikiMemoryPalaceLoading: boolean;
+  wikiMemoryPalaceError: string | null;
+  wikiMemoryPalace: import("./controllers/dreaming.js").WikiMemoryPalace | null;
 };
 
 type SettingsAppHost = SettingsHost &

--- a/ui/src/ui/chat-model.test-helpers.ts
+++ b/ui/src/ui/chat-model.test-helpers.ts
@@ -61,6 +61,7 @@ export function createSessionsListResult(
     defaultsModel?: string | null;
     defaultsProvider?: string | null;
     omitSessionFromList?: boolean;
+    thinkingLevel?: string | null;
   } = {},
 ): SessionsListResult {
   const {
@@ -69,6 +70,7 @@ export function createSessionsListResult(
     defaultsModel = "gpt-5",
     defaultsProvider = defaultsModel ? "openai" : null,
     omitSessionFromList = false,
+    thinkingLevel,
   } = params;
 
   return {
@@ -86,6 +88,7 @@ export function createSessionsListResult(
           createMainSessionRow({
             ...(modelProvider ? { modelProvider } : {}),
             ...(model ? { model } : {}),
+            ...(thinkingLevel !== undefined ? { thinkingLevel: thinkingLevel ?? undefined } : {}),
           }),
         ],
   };

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildControlUiSessionKey,
+  createControlUiSession,
+  createDefaultControlUiSessionLabel,
   deleteSessionsAndRefresh,
   loadSessions,
+  patchSession,
+  resolveNewControlUiSessionLabel,
   subscribeSessions,
   type SessionsState,
 } from "./sessions.ts";
@@ -49,6 +54,112 @@ describe("subscribeSessions", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.subscribe", {});
     expect(state.sessionsError).toBeNull();
+  });
+});
+
+describe("buildControlUiSessionKey", () => {
+  it("builds a deterministic agent-scoped UI session key from the title", () => {
+    const now = new Date(2026, 2, 27, 18, 42);
+    const key = buildControlUiSessionKey({
+      agentId: "Ops Agent",
+      label: "Planning / Roadmap",
+      now,
+      randomSuffix: "a1b2",
+    });
+
+    expect(key).toBe("agent:ops-agent:ui:20260327-1842-planning-roadmap-a1b2");
+  });
+});
+
+describe("createDefaultControlUiSessionLabel", () => {
+  it("formats a stable fallback chat label", () => {
+    expect(createDefaultControlUiSessionLabel(new Date(2026, 2, 27, 18, 42))).toBe(
+      "Chat 2026-03-27 18:42",
+    );
+  });
+});
+
+describe("resolveNewControlUiSessionLabel", () => {
+  it("returns null when the prompt is canceled", () => {
+    expect(resolveNewControlUiSessionLabel(null)).toBeNull();
+  });
+
+  it("falls back to the generated chat label when the prompt is blank", () => {
+    expect(resolveNewControlUiSessionLabel("   ", new Date(2026, 2, 27, 18, 42))).toBe(
+      "Chat 2026-03-27 18:42",
+    );
+  });
+});
+
+describe("patchSession", () => {
+  it("returns the patch result and refreshes sessions", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          path: "",
+          key: "agent:main:ui:20260327-1842-planning-a1b2",
+          entry: { sessionId: "session-1" },
+        };
+      }
+      if (method === "sessions.list") {
+        return undefined;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request);
+
+    const result = await patchSession(state, "agent:main:ui:20260327-1842-planning-a1b2", {
+      label: "Planning",
+    });
+
+    expect(result?.key).toBe("agent:main:ui:20260327-1842-planning-a1b2");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.patch", {
+      key: "agent:main:ui:20260327-1842-planning-a1b2",
+      label: "Planning",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+  });
+});
+
+describe("createControlUiSession", () => {
+  it("creates a labeled UI session and refreshes the session list", async () => {
+    const now = new Date(2026, 2, 27, 18, 42);
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          path: "",
+          key: "agent:main:ui:20260327-1842-planning-roadmap-a1b2",
+          entry: { sessionId: "session-1" },
+        };
+      }
+      if (method === "sessions.list") {
+        return undefined;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request);
+
+    const result = await createControlUiSession(state, {
+      agentId: "main",
+      label: "Planning Roadmap",
+      now,
+      randomSuffix: "a1b2",
+    });
+
+    expect(result?.key).toBe("agent:main:ui:20260327-1842-planning-roadmap-a1b2");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.patch", {
+      key: "agent:main:ui:20260327-1842-planning-roadmap-a1b2",
+      label: "Planning Roadmap",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
   });
 });
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,3 +1,4 @@
+import { normalizeAgentId } from "../../../../src/routing/session-key.js";
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
@@ -6,6 +7,7 @@ import type {
   SessionsCompactionListResult,
   SessionsCompactionRestoreResult,
   SessionsListResult,
+  SessionsPatchResult,
 } from "../types.ts";
 import {
   formatMissingOperatorReadScopeMessage,
@@ -125,6 +127,77 @@ async function runCompactionMutation<T>(
   }
 }
 
+const CONTROL_UI_SESSION_SLUG_MAX = 32;
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function createControlUiSessionRandomSuffix(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID().replaceAll("-", "").slice(0, 4);
+  }
+  if (typeof globalThis.crypto?.getRandomValues === "function") {
+    const array = new Uint8Array(2);
+    globalThis.crypto.getRandomValues(array);
+    return Array.from(array, (value) => value.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, 4);
+  }
+  return Math.random().toString(16).slice(2, 6).padEnd(4, "0");
+}
+
+function formatControlUiSessionTimestamp(now: Date): string {
+  return (
+    [now.getFullYear(), pad2(now.getMonth() + 1), pad2(now.getDate())].join("") +
+    `-${pad2(now.getHours())}${pad2(now.getMinutes())}`
+  );
+}
+
+function formatControlUiSessionLabelTimestamp(now: Date): string {
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())} ${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
+}
+
+function slugifyControlUiSessionLabel(label: string): string {
+  return (
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/['’"]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, CONTROL_UI_SESSION_SLUG_MAX) || "chat"
+  );
+}
+
+export function buildControlUiSessionKey(params: {
+  agentId: string;
+  label: string;
+  now?: Date;
+  randomSuffix?: string;
+}): string {
+  const now = params.now ?? new Date();
+  const suffix = (params.randomSuffix ?? createControlUiSessionRandomSuffix()).trim().toLowerCase();
+  const safeSuffix = suffix || createControlUiSessionRandomSuffix();
+  const slug = slugifyControlUiSessionLabel(params.label);
+  return `agent:${normalizeAgentId(params.agentId)}:ui:${formatControlUiSessionTimestamp(now)}-${slug}-${safeSuffix}`;
+}
+
+export function createDefaultControlUiSessionLabel(now: Date = new Date()): string {
+  return `Chat ${formatControlUiSessionLabelTimestamp(now)}`;
+}
+
+export function resolveNewControlUiSessionLabel(
+  input: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (input === null) {
+    return null;
+  }
+  const trimmed = typeof input === "string" ? input.trim() : "";
+  return trimmed || createDefaultControlUiSessionLabel(now);
+}
+
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
     return;
@@ -215,9 +288,9 @@ export async function patchSession(
     verboseLevel?: string | null;
     reasoningLevel?: string | null;
   },
-) {
+): Promise<SessionsPatchResult | null> {
   if (!state.client || !state.connected) {
-    return;
+    return null;
   }
   const params: Record<string, unknown> = { key };
   for (const field of [
@@ -232,11 +305,27 @@ export async function patchSession(
     }
   }
   try {
-    await state.client.request("sessions.patch", params);
+    const result = await state.client.request<SessionsPatchResult>("sessions.patch", params);
     await loadSessions(state);
+    return result ?? null;
   } catch (err) {
     state.sessionsError = String(err);
+    return null;
   }
+}
+
+export async function createControlUiSession(
+  state: SessionsState,
+  params: {
+    agentId: string;
+    label: string;
+    now?: Date;
+    randomSuffix?: string;
+  },
+): Promise<SessionsPatchResult | null> {
+  const label = params.label.trim();
+  const key = buildControlUiSessionKey({ ...params, label });
+  return patchSession(state, key, { label });
 }
 
 export async function deleteSessionsAndRefresh(

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -73,6 +73,42 @@ describe("control UI routing", () => {
     expect(statusDot).not.toBeNull();
     expect(statusDot?.getAttribute("aria-label")).toContain("Online");
 
+    const action = app.querySelector<HTMLButtonElement>("button.sidebar-chat-action");
+    expect(action).not.toBeNull();
+    expect(action?.title).toBe("New chat");
+    expect(action?.querySelector(".nav-item__text")?.textContent?.trim()).toBe("New chat");
+
+    app.applySettings({ ...app.settings, navCollapsed: true });
+    await app.updateComplete;
+
+    const collapsedAction = app.querySelector<HTMLButtonElement>("button.sidebar-chat-action");
+    expect(collapsedAction).not.toBeNull();
+    expect(collapsedAction?.title).toBe("New chat");
+    expect(collapsedAction?.querySelector(".nav-item__text")).toBeNull();
+  });
+
+  it("sidebar body has flex-direction column to prevent chat actions stretching", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    // Verify the DOM structure exists
+    const body = app.querySelector<HTMLElement>(".sidebar-shell__body");
+    expect(body).not.toBeNull();
+    const actions = app.querySelector<HTMLElement>(".sidebar-chat-actions");
+    expect(actions).not.toBeNull();
+
+    // Regression guard: verify the CSS source contains the fix (jsdom doesn't compute external styles)
+    const { readFileSync } = await import("node:fs");
+    const { resolve } = await import("node:path");
+    const css = readFileSync(resolve(import.meta.dirname, "../styles/layout.css"), "utf8");
+    const bodyBlock = css.match(/\.sidebar-shell__body\s*\{[^}]+\}/)?.[0] ?? "";
+    expect(bodyBlock).toContain("flex-direction: column");
+  });
+
+  it("does not render a desktop sidebar resizer or inject a custom nav width", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
     app.applySettings({ ...app.settings, navWidth: 360 });
     await app.updateComplete;
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -40,6 +40,132 @@ function flushTasks() {
   return new Promise<void>((resolve) => queueMicrotask(resolve));
 }
 
+function createChatHeaderState(
+  overrides: {
+    model?: string | null;
+    modelProvider?: string | null;
+    models?: ModelCatalogEntry[];
+    omitSessionFromList?: boolean;
+    thinkingLevel?: string | null;
+  } = {},
+): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
+  let currentModel = overrides.model ?? null;
+  let currentModelProvider = overrides.modelProvider ?? (currentModel ? "openai" : null);
+  const omitSessionFromList = overrides.omitSessionFromList ?? false;
+  let currentThinkingLevel: string | null | undefined = overrides.thinkingLevel ?? undefined;
+  const catalog = overrides.models ?? createModelCatalog(...DEFAULT_CHAT_MODEL_CATALOG);
+  const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
+    if (method === "sessions.patch") {
+      if ("thinkingLevel" in params) {
+        currentThinkingLevel = params.thinkingLevel as string | null | undefined;
+      }
+      const nextModel = (params.model as string | null | undefined) ?? null;
+      if (!nextModel) {
+        currentModel = null;
+        currentModelProvider = null;
+      } else {
+        const normalized = nextModel.trim();
+        const slashIndex = normalized.indexOf("/");
+        if (slashIndex > 0) {
+          currentModelProvider = normalized.slice(0, slashIndex);
+          currentModel = normalized.slice(slashIndex + 1);
+        } else {
+          currentModel = normalized;
+          const matchingProviders = catalog
+            .filter((entry) => entry.id === normalized)
+            .map((entry) => entry.provider)
+            .filter(Boolean);
+          currentModelProvider =
+            matchingProviders.length === 1 ? matchingProviders[0] : currentModelProvider;
+        }
+      }
+      return { ok: true, key: "main" };
+    }
+    if (method === "chat.history") {
+      return { messages: [], thinkingLevel: null };
+    }
+    if (method === "sessions.list") {
+      return createSessionsListResult({
+        model: currentModel,
+        modelProvider: currentModelProvider,
+        omitSessionFromList,
+        thinkingLevel: currentThinkingLevel,
+      });
+    }
+    if (method === "models.list") {
+      return { models: catalog };
+    }
+    if (method === "tools.effective") {
+      return {
+        agentId: "main",
+        profile: "coding",
+        groups: [],
+      };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const state = {
+    sessionKey: "main",
+    connected: true,
+    sessionsHideCron: true,
+    sessionsResult: createSessionsListResult({
+      model: currentModel,
+      modelProvider: currentModelProvider,
+      omitSessionFromList,
+      thinkingLevel: currentThinkingLevel,
+    }),
+    chatModelOverrides: {},
+    chatModelCatalog: catalog,
+    chatModelsLoading: false,
+    client: { request } as unknown as GatewayBrowserClient,
+    settings: {
+      gatewayUrl: "",
+      token: "",
+      locale: "en",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "dark",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+      borderRadius: 50,
+      chatFocusMode: false,
+      chatShowThinking: false,
+    },
+    chatMessage: "",
+    chatStream: null,
+    chatStreamStartedAt: null,
+    chatRunId: null,
+    chatQueue: [],
+    chatMessages: [],
+    chatLoading: false,
+    chatThinkingLevel: null,
+    lastError: null,
+    chatAvatarUrl: null,
+    basePath: "",
+    hello: null,
+    agentsList: null,
+    agentsPanel: "overview",
+    agentsSelectedId: null,
+    toolsEffectiveLoading: false,
+    toolsEffectiveLoadingKey: null,
+    toolsEffectiveResultKey: null,
+    toolsEffectiveError: null,
+    toolsEffectiveResult: null,
+    applySettings(next: AppViewState["settings"]) {
+      state.settings = next;
+    },
+    loadAssistantIdentity: vi.fn(),
+    resetToolStream: vi.fn(),
+    resetChatScroll: vi.fn(),
+  } as unknown as AppViewState & {
+    client: GatewayBrowserClient;
+    settings: AppViewState["settings"];
+  };
+  return { state, request };
+}
+
 async function flushAssistantAttachmentAvailabilityChecks() {
   await Promise.resolve();
   await Promise.resolve();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -100,6 +100,7 @@ export type ChatProps = {
   onQueueRemove: (id: string) => void;
   onDismissSideResult?: () => void;
   onNewSession: () => void;
+  onRenameSession?: () => void;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -1505,18 +1506,6 @@ export function renderChat(props: ChatProps) {
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${canAbort
-              ? nothing
-              : html`
-                  <button
-                    class="btn btn--ghost"
-                    @click=${props.onNewSession}
-                    title="New session"
-                    aria-label="New session"
-                  >
-                    ${icons.plus}
-                  </button>
-                `}
             <button
               class="btn btn--ghost"
               @click=${() => exportMarkdown(props)}

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -491,6 +491,8 @@ function formatKindLabel(kind: "entity" | "concept" | "source" | "synthesis" | "
       return "synthesis";
     case "report":
       return "report";
+    default:
+      return kind;
   }
   return kind;
 }
@@ -510,6 +512,8 @@ function formatImportBadge(item: {
     case "high":
       return "high risk";
     case "unknown":
+      return "unknown risk";
+    default:
       return "unknown risk";
   }
   return "unknown risk";
@@ -641,6 +645,8 @@ function renderDiarySubtabExplainer() {
           imported source chats.
         </p>
       `;
+    default:
+      return nothing;
   }
   return nothing;
 }


### PR DESCRIPTION
Adds `skills/integration-notion/` — a step-by-step skill guiding agents through Notion integration setup for OpenClaw.

**Covers:**
1. Pre-flight check — detect if already configured
2. Create Notion connection — browser flow at notion.so
3. Retrieve & store API token in `~/.openclaw/credentials/`
4. Register skill entry in openclaw.json
5. Grant page access
6. Verify with API search + agent test

Separate from existing `skills/notion/` (API reference). This is for setup/configuration.