### PR TITLE
[AI-assisted] fix(telegram): soft-fail benign delete errors

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -801,6 +801,31 @@ describe("handleTelegramAction", () => {
     );
   });
 
+  it("surfaces non-fatal delete warnings", async () => {
+    deleteMessageTelegram.mockResolvedValueOnce({
+      ok: false,
+      warning: "Telegram message 456 was not deleted: already gone",
+    });
+    const cfg = {
+      channels: { telegram: { botToken: "tok" } },
+    } as OpenClawConfig;
+
+    const result = await handleTelegramAction(
+      {
+        action: "deleteMessage",
+        chatId: "123",
+        messageId: 456,
+      },
+      cfg,
+    );
+
+    expect(result.details).toMatchObject({
+      ok: false,
+      deleted: false,
+      warning: "Telegram message 456 was not deleted: already gone",
+    });
+  });
+
   it("respects deleteMessage gating", async () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -18,7 +18,9 @@ const sendStickerTelegram = vi.fn(async () => ({
   messageId: "456",
   chatId: "123",
 }));
-const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const deleteMessageTelegram = vi.fn<typeof telegramActionRuntime.deleteMessageTelegram>(
+  async () => ({ ok: true }),
+);
 const editMessageTelegram = vi.fn(async () => ({
   ok: true,
   messageId: "456",

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -478,11 +478,23 @@ export async function handleTelegramAction(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
       );
     }
-    await telegramActionRuntime.deleteMessageTelegram(chatId ?? "", messageId ?? 0, {
-      cfg,
-      token,
-      accountId: accountId ?? undefined,
-    });
+    const deleteResult = await telegramActionRuntime.deleteMessageTelegram(
+      chatId ?? "",
+      messageId ?? 0,
+      {
+        cfg,
+        token,
+        accountId: accountId ?? undefined,
+      },
+    );
+    if (!deleteResult.ok) {
+      return jsonResult({
+        ok: false,
+        deleted: false,
+        warning: deleteResult.warning,
+        hint: "Delete failed. Do not retry.",
+      });
+    }
     return jsonResult({ ok: true, deleted: true });
   }
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -27,6 +27,7 @@ const {
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
+  deleteMessageTelegram,
   editForumTopicTelegram,
   editMessageTelegram,
   pinMessageTelegram,
@@ -1912,6 +1913,47 @@ describe("sendMessageTelegram", () => {
     expect(sendMessage.mock.calls.every((call) => call[2]?.parse_mode === undefined)).toBe(true);
     expect(sendMessage.mock.calls.map((call) => String(call[1] ?? "")).join("")).toBe(plainText);
     expect(res.messageId).toBe("96");
+  });
+});
+
+describe("deleteMessageTelegram", () => {
+  it.each([
+    "400: Bad Request: message to delete not found",
+    "400: Bad Request: message can't be deleted",
+    "MESSAGE_ID_INVALID",
+    "MESSAGE_DELETE_FORBIDDEN",
+  ])("soft-fails benign delete error: %s", async (errorText) => {
+    const deleteMessage = vi.fn().mockRejectedValue(new Error(errorText));
+    const api = { deleteMessage } as unknown as {
+      deleteMessage: typeof deleteMessage;
+    };
+
+    await expect(
+      deleteMessageTelegram("123", 456, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      warning: expect.stringContaining(errorText),
+    });
+    expect(deleteMessage).toHaveBeenCalledWith("123", 456);
+  });
+
+  it("keeps non-benign delete errors hard", async () => {
+    const deleteMessage = vi.fn().mockRejectedValue(new Error("403: Forbidden: bot was blocked"));
+    const api = { deleteMessage } as unknown as {
+      deleteMessage: typeof deleteMessage;
+    };
+
+    await expect(
+      deleteMessageTelegram("123", 456, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+      }),
+    ).rejects.toThrow(/bot was blocked/i);
   });
 });
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -177,6 +177,8 @@ const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity
 const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+const MESSAGE_DELETE_SOFT_FAILURE_RE =
+  /message to delete not found|message can't be deleted|MESSAGE_ID_INVALID|MESSAGE_DELETE_FORBIDDEN/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
 const sendLogger = createSubsystemLogger("telegram/send");
 const diagLogger = createSubsystemLogger("telegram/diagnostic");
@@ -1068,7 +1070,7 @@ export async function deleteMessageTelegram(
   chatIdInput: string | number,
   messageIdInput: string | number,
   opts: TelegramDeleteOpts,
-): Promise<{ ok: true }> {
+): Promise<{ ok: true } | { ok: false; warning: string }> {
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const rawTarget = String(chatIdInput);
   const chatId = await resolveAndPersistChatId({
@@ -1086,7 +1088,19 @@ export async function deleteMessageTelegram(
     verbose: opts.verbose,
     shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
   });
-  await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
+  try {
+    await requestWithDiag(() => api.deleteMessage(chatId, messageId), "deleteMessage");
+  } catch (err: unknown) {
+    const message = formatErrorMessage(err);
+    if (MESSAGE_DELETE_SOFT_FAILURE_RE.test(message)) {
+      const warning = `Telegram message ${messageId} was not deleted: ${message}`;
+      if (opts.verbose) {
+        sendLogger.warn(warning);
+      }
+      return { ok: false, warning };
+    }
+    throw err;
+  }
   logVerbose(`[telegram] Deleted message ${messageId} from chat ${chatId}`);
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- Treat benign Telegram delete 400s as non-fatal delete results instead of hard tool errors.
- Surface soft delete warnings through the Telegram action runtime so agents do not retry no-op deletes.
- Add regression coverage for benign delete failures and non-benign hard failures.

Fixes #73726.

## Testing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.test.ts` — 144 passed
- `node_modules/.bin/oxfmt.CMD --check extensions/telegram/src/send.ts extensions/telegram/src/action-runtime.ts extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.test.ts`
- `git diff --check -- extensions/telegram/src/send.ts extensions/telegram/src/action-runtime.ts extensions/telegram/src/send.test.ts extensions/telegram/src/action-runtime.test.ts`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`

AI-assisted by OpenAI Codex.