### PR TITLE
fix(cli): set non-zero exit code when crestodian detects non-TTY [AI-assisted]

### DIFF
--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
 import { runCrestodian } from "./crestodian.js";
 import { createCrestodianTestRuntime } from "./crestodian.test-helpers.js";
 import type { CrestodianOverview } from "./overview.js";
@@ -111,5 +112,37 @@ describe("runCrestodian", () => {
     expect(runInteractiveTuiCalls).toBe(1);
     expect(onReadyCalls).toBe(1);
     expect(lines.join("\n")).not.toContain("Say: status");
+  });
+
+  it("exits with code 1 when stdin is not a TTY", async () => {
+    const { runtime } = createCrestodianTestRuntime();
+    const originalExitCode = process.exitCode;
+
+    await runCrestodian(
+      {
+        input: { isTTY: false } as unknown as NodeJS.ReadableStream,
+        output: { isTTY: true } as unknown as NodeJS.WritableStream,
+      },
+      runtime,
+    );
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+
+  it("exits with code 1 when stdout is not a TTY", async () => {
+    const { runtime } = createCrestodianTestRuntime();
+    const originalExitCode = process.exitCode;
+
+    await runCrestodian(
+      {
+        input: { isTTY: true } as unknown as NodeJS.ReadableStream,
+        output: { isTTY: false } as unknown as NodeJS.WritableStream,
+      },
+      runtime,
+    );
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
   });
 });

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -1,4 +1,4 @@
-import { stdin as defaultStdin, stdout as defaultStdout } from "node:process";
+import process, { stdin as defaultStdin, stdout as defaultStdout } from "node:process";
 import { withProgress } from "../cli/progress.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import type { CrestodianAssistantPlanner } from "./assistant.js";
@@ -92,6 +92,7 @@ export async function runCrestodian(
   const outputIsTty = (output as { isTTY?: boolean }).isTTY === true;
   if (!interactive || !inputIsTty || !outputIsTty) {
     runtime.error("Crestodian needs an interactive TTY. Use --message for one command.");
+    process.exitCode = 1;
     return;
   }
 


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `runCrestodian()` detects a non-TTY stdin/stdout and prints an error message, but returns without setting `process.exitCode`. The process exits with code 0, misleading shell scripts and CI flows into thinking Crestodian ran successfully.
- Why it matters: Exit code 0 signals success. Scripts gating on Crestodian's exit code silently proceed despite the error. The two sibling subcommands (`models auth login` and `plugins uninstall`) both exit non-zero for the same condition.
- What changed: Added `process.exitCode = 1` before the early return in `runCrestodian()` (consistent with the parallel TTY guard already present in `run-main.ts`). Added two regression tests covering the stdin-not-TTY and stdout-not-TTY paths.
- What did NOT change (scope boundary): No changes to the interactive TUI path, the one-shot `--message` path, or the `run-main.ts` bare-root TTY guard.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] CLI

## Linked Issue/PR
- Closes #73646
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The `runCrestodian()` function in `src/crestodian/crestodian.ts` called `runtime.error()` and returned early when stdin/stdout was not a TTY, but never set `process.exitCode`. The parallel guard in `src/cli/run-main.ts` (line 403) already sets `process.exitCode = 1` for the same condition on the bare-root path, but the explicit `openclaw crestodian` subcommand path was missed.
- Missing detection / guardrail: No test asserted `process.exitCode` after the non-TTY early return.
- Contributing context: The two code paths (bare root in `run-main.ts` vs explicit subcommand in `crestodian.ts`) were likely written at different times, and the exit code was only added to the former.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/crestodian/crestodian.test.ts`
- Scenario the test should lock in: When `runCrestodian()` is called with `input.isTTY = false` or `output.isTTY = false`, `process.exitCode` must be set to 1.
- Why this is the smallest reliable guardrail: The TTY check is purely a process-level concern — a unit test asserting `process.exitCode` after calling `runCrestodian()` with mock streams covers the exact failure mode without needing integration infrastructure.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — two new tests added.

## User-visible / Behavior Changes
- `openclaw crestodian` (and bare `openclaw` on the explicit subcommand path) now exits with code 1 instead of 0 when stdin or stdout is not a TTY. The error message is unchanged.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only changes the process exit code from 0 to 1 in an error path. No security-sensitive behavior is affected.
