### PR TITLE
fix(agents): skip blank replay history prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/session reset: ignore blank replay-history entries when deciding whether a reset turn has model-visible input, so `/new` and `/reset` no longer dispatch empty requests during active-memory rebuild races. Fixes #73926. Thanks @giangthb.
 - Security/audit: recognize dangerous node command IDs as valid `gateway.nodes.denyCommands` entries, so audit only warns on real typos or unsupported patterns. (#56923) Thanks @chziyue.
 - Telegram/exec approvals: stop treating general Telegram chat allowlists and `defaultTo` routes as native exec approvers; Telegram now uses explicit `execApprovals.approvers` or owner identity from `commands.ownerAllowFrom`, matching the first-pairing owner bootstrap path. Thanks @pashpashpash.
 - Chat commands: route sensitive group `/diagnostics` and `/export-trajectory` approvals and results to a private owner route, preferring same-surface DMs before falling back to the first configured owner route, so Discord group invocations can land in Telegram when that is the primary owner interface. Thanks @pashpashpash.

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -84,11 +84,33 @@ describe("hasPromptSubmissionContent", () => {
     ).toBe(false);
   });
 
+  it("rejects empty prompt submissions with only blank replay history", () => {
+    expect(
+      hasPromptSubmissionContent({
+        prompt: "   ",
+        messages: [
+          { role: "user", content: "   ", timestamp: 1 },
+          { role: "user", content: { type: "text", text: "" }, timestamp: 2 },
+          { role: "user", content: [{ type: "text", text: "\n\t" }], timestamp: 3 },
+          { role: "assistant", content: [], timestamp: 4 },
+        ],
+        imageCount: 0,
+      }),
+    ).toBe(false);
+  });
+
   it("allows blank prompt submissions when replay history has content", () => {
     expect(
       hasPromptSubmissionContent({
         prompt: "   ",
         messages: [{ role: "user", content: "previous turn", timestamp: 1 }],
+        imageCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      hasPromptSubmissionContent({
+        prompt: "   ",
+        messages: [{ role: "user", content: [{ type: "image", data: "abc" }], timestamp: 1 }],
         imageCount: 0,
       }),
     ).toBe(true);

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -241,7 +241,35 @@ export function hasPromptSubmissionContent(params: {
   messages: readonly unknown[];
   imageCount: number;
 }): boolean {
-  return params.prompt.trim().length > 0 || params.messages.length > 0 || params.imageCount > 0;
+  return (
+    params.prompt.trim().length > 0 ||
+    params.messages.some(hasModelVisibleMessageContent) ||
+    params.imageCount > 0
+  );
+}
+
+function hasModelVisibleMessageContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  return hasModelVisibleContent((message as { content?: unknown }).content);
+}
+
+function hasModelVisibleContent(content: unknown): boolean {
+  if (typeof content === "string") {
+    return content.trim().length > 0;
+  }
+  if (Array.isArray(content)) {
+    return content.some(hasModelVisibleContent);
+  }
+  if (!content || typeof content !== "object") {
+    return false;
+  }
+  const block = content as { text?: unknown; type?: unknown };
+  if (typeof block.text === "string") {
+    return block.text.trim().length > 0;
+  }
+  return typeof block.type === "string" && block.type.trim().length > 0;
 }
 
 const QUEUED_USER_MESSAGE_MARKER =


### PR DESCRIPTION
## Summary
- Tighten the embedded-run prompt content guard so blank replay-history entries do not count as model-visible input.
- Add regression coverage for blank string/object/array replay content while preserving structured non-text history such as images.
- Add an Unreleased changelog entry for #73926.

## Root Cause
`hasPromptSubmissionContent` treated any replay-history entry as content by checking only `messages.length`. During `/new` or `/reset` races, stale empty user/assistant entries could therefore bypass the empty prompt/history/images skip path and reach provider dispatch with no model-visible input.

## Linked Issue
Fixes #73926.

## Why This Is Safe
The change keeps the existing dispatch boundary behavior: submissions with prompt text, prompt images, or model-visible replay history still run. It only changes the history side of the guard from array presence to visible content presence, matching the sanitizer behavior that already drops blank user replay content.

## Security And Runtime Controls
No security or authorization controls change. This does not add a prompt-text policy, alter model routing, or relax tool/runtime permissions; it only prevents blank payloads from being submitted.

## Tests Run
- `git diff --check`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts test/scripts/check-changelog-attributions.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

## Out Of Scope
- No reset/startup prompt injection changes.
- No active-memory scheduling or rebuild-order changes.
- No provider adapter changes beyond avoiding empty submissions at the existing guard.

Made with [Cursor](https://cursor.com)