### PR TITLE
[Slack] fix Slack action thread target normalization

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -515,6 +515,24 @@ describe("handleSlackAction", () => {
     await sendSecondMessageAndExpectNoThread({ cfg, context });
   });
 
+  it("replyToMode=first normalizes channel target when accounting explicit threadTs", async () => {
+    const { cfg, context, hasRepliedRef } = createReplyToFirstScenario();
+
+    await handleSlackAction(
+      {
+        action: "sendMessage",
+        to: "#c123",
+        content: "Explicit",
+        threadTs: "9999999999.999999",
+      },
+      cfg,
+      context,
+    );
+
+    expect(hasRepliedRef.value).toBe(true);
+    await sendSecondMessageAndExpectNoThread({ cfg, context });
+  });
+
   it("replyToMode=first marks hasRepliedRef even when threadTs is explicit", async () => {
     const { cfg, context, hasRepliedRef } = createReplyToFirstScenario();
 

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import {
   createActionGate,
@@ -25,6 +26,19 @@ const messagingActions = new Set([
 
 const reactionsActions = new Set(["react", "reactions"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
+
+function sameSlackChannelTarget(targetChannel: string, currentChannelId: string): boolean {
+  const parsedTarget = parseSlackTarget(targetChannel, {
+    defaultKind: "channel",
+  });
+  if (!parsedTarget || parsedTarget.kind !== "channel") {
+    return false;
+  }
+  return (
+    normalizeLowercaseStringOrEmpty(parsedTarget.id) ===
+    normalizeLowercaseStringOrEmpty(currentChannelId)
+  );
+}
 
 type SlackActionsRuntimeModule = typeof import("./actions.runtime.js");
 type SlackAccountsRuntimeModule = typeof import("./accounts.runtime.js");
@@ -105,16 +119,8 @@ function resolveThreadTsFromContext(
     return undefined;
   }
 
-  const parsedTarget = parseSlackTarget(targetChannel, {
-    defaultKind: "channel",
-  });
-  if (!parsedTarget || parsedTarget.kind !== "channel") {
-    return undefined;
-  }
-  const normalizedTarget = parsedTarget.id;
-
   // Different channel - don't inject
-  if (normalizedTarget !== context.currentChannelId) {
+  if (!sameSlackChannelTarget(targetChannel, context.currentChannelId)) {
     return undefined;
   }
 
@@ -267,8 +273,7 @@ export async function handleSlackAction(
         // threadTs: once we send a message to the current channel, consider the
         // first reply "used" so later tool calls don't auto-thread again.
         if (context?.hasRepliedRef && context.currentChannelId) {
-          const parsedTarget = parseSlackTarget(to, { defaultKind: "channel" });
-          if (parsedTarget?.kind === "channel" && parsedTarget.id === context.currentChannelId) {
+          if (sameSlackChannelTarget(to, context.currentChannelId)) {
             context.hasRepliedRef.value = true;
           }
         }
@@ -310,8 +315,7 @@ export async function handleSlackAction(
         }
 
         if (context?.hasRepliedRef && context.currentChannelId) {
-          const parsedTarget = parseSlackTarget(to, { defaultKind: "channel" });
-          if (parsedTarget?.kind === "channel" && parsedTarget.id === context.currentChannelId) {
+          if (sameSlackChannelTarget(to, context.currentChannelId)) {
             context.hasRepliedRef.value = true;
           }
         }

--- a/extensions/slack/src/action-threading.test.ts
+++ b/extensions/slack/src/action-threading.test.ts
@@ -41,6 +41,21 @@ describe("resolveSlackAutoThreadId", () => {
     ).toBeUndefined();
   });
 
+  it("threads first matching prefixed channel target with bare current channel", () => {
+    const hasRepliedRef = { value: false };
+
+    expect(
+      resolveSlackAutoThreadId({
+        to: "channel:C123",
+        toolContext: createToolContext({
+          replyToMode: "first",
+          hasRepliedRef,
+        }),
+      }),
+    ).toBe("thread-1");
+    expect(hasRepliedRef.value).toBe(false);
+  });
+
   it("skips auto-threading when reply mode or thread context blocks it", () => {
     expect(
       resolveSlackAutoThreadId({


### PR DESCRIPTION
## Summary

Fix Slack message-action auto-threading target comparisons so channel targets are normalized before matching the current Slack channel context.

## Root Cause

Slack action threading compared parsed outbound target IDs directly against the current channel ID. That could miss equivalent targets when one side included Slack target syntax or different casing, such as `#c123` or `channel:C123` matching current channel `C123`, which could break `replyToMode: "first"` accounting.

## Changes

- Add a shared normalized channel-target comparison inside Slack action runtime.
- Use that comparison for auto-injected `threadTs` and `hasRepliedRef` accounting in `sendMessage` and `uploadFile`.
- Add focused tests for prefixed/bare target matching and single-use reply accounting.

## Validation

- `pnpm test:extension slack` - 85 files, 821 tests passed
- `pnpm exec oxfmt --check --threads=1 extensions/slack/src/action-runtime.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/action-threading.test.ts`
- `pnpm check:changed`
- `codex review --base origin/main` - no regression found
- Rebased onto latest `origin/main` and ran `git diff --check origin/main`

## AI Assistance

This PR was prepared with Codex assistance. I reviewed the code, tests, and local validation results before submission.
