### PR TITLE
fix(cli): validate plugin ID before enabling

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -40,6 +40,11 @@ import { resolvePluginUninstallId } from "./plugins-uninstall-selection.js";
 import { runPluginUpdateCommand } from "./plugins-update-command.js";
 import { promptYesNo } from "./prompt.js";
 
+/** Sanitize untrusted input before writing to terminal (strip ANSI + control chars) */
+function sanitizeForTerminal(value: string): string {
+  return value.replace(/[\u0000-\u001F\u007F-\u009F]/g, "").replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
 export type PluginsListOptions = {
   json?: boolean;
   enabled?: boolean;
@@ -493,8 +498,9 @@ export function registerPluginsCli(program: Command) {
       const report = buildPluginDiagnosticsReport({ config: cfg });
       const availableIds = report.plugins.map((p) => p.id);
       if (!availableIds.includes(resolvedId)) {
+        const safeId = sanitizeForTerminal(id);
         defaultRuntime.log(
-          theme.error(`Plugin "${id}" not found. Run 'openclaw plugins list' to see available plugins.`),
+          theme.error(`Plugin "${safeId}" not found. Run 'openclaw plugins list' to see available plugins.`),
         );
         process.exitCode = 1;
         return;
@@ -508,14 +514,13 @@ export function registerPluginsCli(program: Command) {
         ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
       });
       logSlotWarnings(slotResult.warnings);
+      const safeId = sanitizeForTerminal(id);
       if (enableResult.enabled) {
-        defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
+        defaultRuntime.log(`Enabled plugin "${safeId}". Restart the gateway to apply.`);
         return;
       }
       defaultRuntime.log(
-        theme.warn(
-          `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
-        ),
+        theme.warn(`Plugin "${safeId}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`),
       );
     });
 

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -486,6 +486,16 @@ export function registerPluginsCli(program: Command) {
     .action(async (id: string) => {
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
+      // Validate plugin ID exists in discovered plugins
+      const report = buildPluginDiagnosticsReport({ config: cfg });
+      const availableIds = report.plugins.map((p) => p.id);
+      if (!availableIds.includes(id)) {
+        defaultRuntime.log(
+          theme.error(`Plugin "${id}" not found. Run 'openclaw plugins list' to see available plugins.`),
+        );
+        process.exitCode = 1;
+        return;
+      }
       const enableResult = enablePluginInConfig(cfg, id);
       let next: OpenClawConfig = enableResult.config;
       const slotResult = applySlotSelectionForPlugin(next, id);

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -5,6 +5,7 @@ import { loadConfig, readConfigFileSnapshot, replaceConfigFile } from "../config
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { normalizeChatChannelId } from "../channels/ids.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { listMarketplacePlugins } from "../plugins/marketplace.js";
 import { formatPluginSourceForTable, resolvePluginSourceRoots } from "../plugins/source-display.js";
@@ -486,19 +487,21 @@ export function registerPluginsCli(program: Command) {
     .action(async (id: string) => {
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
+      // Normalize alias (e.g., "tg" → "telegram") before validation
+      const resolvedId = normalizeChatChannelId(id) ?? id;
       // Validate plugin ID exists in discovered plugins
       const report = buildPluginDiagnosticsReport({ config: cfg });
       const availableIds = report.plugins.map((p) => p.id);
-      if (!availableIds.includes(id)) {
+      if (!availableIds.includes(resolvedId)) {
         defaultRuntime.log(
           theme.error(`Plugin "${id}" not found. Run 'openclaw plugins list' to see available plugins.`),
         );
         process.exitCode = 1;
         return;
       }
-      const enableResult = enablePluginInConfig(cfg, id);
+      const enableResult = enablePluginInConfig(cfg, resolvedId);
       let next: OpenClawConfig = enableResult.config;
-      const slotResult = applySlotSelectionForPlugin(next, id);
+      const slotResult = applySlotSelectionForPlugin(next, resolvedId);
       next = slotResult.config;
       await replaceConfigFile({
         nextConfig: next,


### PR DESCRIPTION
## Summary

Fixes #73551

The `plugins enable` command now validates the plugin ID against discovered plugins before modifying config.

## Problem

Previously, `openclaw plugins enable <invalid-id>` would silently write invalid plugin entry to config, causing potential gateway startup failures.

## Solution

Added validation using `buildPluginDiagnosticsReport` to check if plugin ID exists before enabling.

## Changes

```diff
+ const report = buildPluginDiagnosticsReport({ config: cfg });
+ const availableIds = report.plugins.map((p) => p.id);
+ if (!availableIds.includes(id)) {
+   defaultRuntime.log(theme.error(`Plugin "${id}" not found.`));
+   process.exitCode = 1;
+   return;
+ }
```

## Test Plan

1. `openclaw plugins enable nonexistent-plugin` → Error + exit 1
2. `openclaw plugins list` shows available plugins
3. `openclaw plugins enable telegram` → Success

## Security

No security implications - purely CLI input validation.