### PR TITLE
fix(auth): scope external CLI credential overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/model auth: scope external CLI credential overlays to configured refreshable providers, avoiding unrelated Claude CLI Keychain reads in api-key-only setups. Fixes #73908. Thanks @Ailuras.
 - Security/audit: recognize dangerous node command IDs as valid `gateway.nodes.denyCommands` entries, so audit only warns on real typos or unsupported patterns. (#56923) Thanks @chziyue.
 - Telegram/exec approvals: stop treating general Telegram chat allowlists and `defaultTo` routes as native exec approvers; Telegram now uses explicit `execApprovals.approvers` or owner identity from `commands.ownerAllowFrom`, matching the first-pairing owner bootstrap path. Thanks @pashpashpash.
 - Chat commands: route sensitive group `/diagnostics` and `/export-trajectory` approvals and results to a private owner route, preferring same-surface DMs before falling back to the first configured owner route, so Discord group invocations can land in Telegram when that is the primary owner interface. Thanks @pashpashpash.

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -3,7 +3,9 @@ import type { AuthProfileStore, OAuthCredential } from "./auth-profiles/types.js
 import type { ClaudeCliCredential } from "./cli-credentials.js";
 
 const mocks = vi.hoisted(() => ({
-  readClaudeCliCredentialsCached: vi.fn<() => ClaudeCliCredential | null>(() => null),
+  readClaudeCliCredentialsCached: vi.fn<
+    (options?: { allowKeychainPrompt?: boolean }) => ClaudeCliCredential | null
+  >(() => null),
   readCodexCliCredentialsCached: vi.fn<() => OAuthCredential | null>(() => null),
   readMiniMaxCliCredentialsCached: vi.fn<() => OAuthCredential | null>(() => null),
 }));
@@ -329,6 +331,36 @@ describe("external cli oauth resolution", () => {
         }),
       },
     ]);
+  });
+
+  it("scopes external CLI readers and forwards keychain prompt policy", () => {
+    mocks.readCodexCliCredentialsCached.mockReturnValue(
+      makeOAuthCredential({ provider: "openai-codex" }),
+    );
+    mocks.readClaudeCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "anthropic",
+      access: "claude-cli-access",
+      refresh: "claude-cli-refresh",
+      expires: Date.now() + 5 * 24 * 60 * 60_000,
+    });
+
+    const profiles = resolveExternalCliAuthProfiles(makeStore(), {
+      allowKeychainPrompt: false,
+      providerIds: ["claude-cli"],
+    });
+
+    expect(profiles).toEqual([
+      {
+        profileId: CLAUDE_CLI_PROFILE_ID,
+        credential: expect.objectContaining({ access: "claude-cli-access" }),
+      },
+    ]);
+    expect(mocks.readCodexCliCredentialsCached).not.toHaveBeenCalled();
+    expect(mocks.readClaudeCliCredentialsCached).toHaveBeenCalledWith(
+      expect.objectContaining({ allowKeychainPrompt: false }),
+    );
+    expect(mocks.readMiniMaxCliCredentialsCached).not.toHaveBeenCalled();
   });
 
   it("ignores Claude CLI token credentials", () => {

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -38,6 +38,8 @@ function resolveExternalAuthProfileMap(params: {
   store: AuthProfileStore;
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
+  allowKeychainPrompt?: boolean;
+  externalCliProviderIds?: readonly string[];
 }): ExternalAuthProfileMap {
   const env = params.env ?? process.env;
   const resolveProfiles =
@@ -54,7 +56,11 @@ function resolveExternalAuthProfileMap(params: {
   });
 
   const resolved: ExternalAuthProfileMap = new Map();
-  const cliProfiles = externalCliSync.resolveExternalCliAuthProfiles?.(params.store) ?? [];
+  const cliProfiles =
+    externalCliSync.resolveExternalCliAuthProfiles?.(params.store, {
+      allowKeychainPrompt: params.allowKeychainPrompt,
+      providerIds: params.externalCliProviderIds,
+    }) ?? [];
   for (const profile of cliProfiles) {
     resolved.set(profile.profileId, {
       profileId: profile.profileId,
@@ -76,24 +82,35 @@ function listRuntimeExternalAuthProfiles(params: {
   store: AuthProfileStore;
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
+  allowKeychainPrompt?: boolean;
+  externalCliProviderIds?: readonly string[];
 }): RuntimeExternalOAuthProfile[] {
   return Array.from(
     resolveExternalAuthProfileMap({
       store: params.store,
       agentDir: params.agentDir,
       env: params.env,
+      allowKeychainPrompt: params.allowKeychainPrompt,
+      externalCliProviderIds: params.externalCliProviderIds,
     }).values(),
   );
 }
 
 export function overlayExternalAuthProfiles(
   store: AuthProfileStore,
-  params?: { agentDir?: string; env?: NodeJS.ProcessEnv },
+  params?: {
+    agentDir?: string;
+    env?: NodeJS.ProcessEnv;
+    allowKeychainPrompt?: boolean;
+    externalCliProviderIds?: readonly string[];
+  },
 ): AuthProfileStore {
   const profiles = listRuntimeExternalAuthProfiles({
     store,
     agentDir: params?.agentDir,
     env: params?.env,
+    allowKeychainPrompt: params?.allowKeychainPrompt,
+    externalCliProviderIds: params?.externalCliProviderIds,
   });
   return overlayRuntimeExternalOAuthProfiles(store, profiles);
 }

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -34,10 +34,15 @@ export type ExternalCliResolvedProfile = {
   credential: OAuthCredential;
 };
 
+type ExternalCliAuthProfileOptions = {
+  allowKeychainPrompt?: boolean;
+  providerIds?: readonly string[];
+};
+
 type ExternalCliSyncProvider = {
   profileId: string;
   provider: string;
-  readCredentials: () => OAuthCredential | null;
+  readCredentials: (options?: { allowKeychainPrompt?: boolean }) => OAuthCredential | null;
   // bootstrapOnly providers adopt the external CLI credential only to
   // seed an empty slot; once a local OAuth credential exists for the
   // profile, the local refresh token is treated as canonical and the
@@ -96,8 +101,11 @@ const EXTERNAL_CLI_SYNC_PROVIDERS: ExternalCliSyncProvider[] = [
   {
     profileId: CLAUDE_CLI_PROFILE_ID,
     provider: "claude-cli",
-    readCredentials: () => {
-      const credential = readClaudeCliCredentialsCached({ ttlMs: EXTERNAL_CLI_SYNC_TTL_MS });
+    readCredentials: (options) => {
+      const credential = readClaudeCliCredentialsCached({
+        allowKeychainPrompt: options?.allowKeychainPrompt,
+        ttlMs: EXTERNAL_CLI_SYNC_TTL_MS,
+      });
       if (credential?.type !== "oauth") {
         return null;
       }
@@ -147,13 +155,29 @@ export function readExternalCliBootstrapCredential(params: {
 
 export const readManagedExternalCliCredential = readExternalCliBootstrapCredential;
 
+function normalizeProviderIdToken(providerId: string): string {
+  return providerId.trim().toLowerCase();
+}
+
 export function resolveExternalCliAuthProfiles(
   store: AuthProfileStore,
+  options?: ExternalCliAuthProfileOptions,
 ): ExternalCliResolvedProfile[] {
   const profiles: ExternalCliResolvedProfile[] = [];
   const now = Date.now();
+  const eligibleProviderIds = options?.providerIds
+    ? new Set(options.providerIds.map(normalizeProviderIdToken).filter(Boolean))
+    : undefined;
   for (const providerConfig of EXTERNAL_CLI_SYNC_PROVIDERS) {
-    const creds = providerConfig.readCredentials();
+    if (
+      eligibleProviderIds &&
+      !eligibleProviderIds.has(normalizeProviderIdToken(providerConfig.provider))
+    ) {
+      continue;
+    }
+    const creds = providerConfig.readCredentials({
+      allowKeychainPrompt: options?.allowKeychainPrompt,
+    });
     if (!creds) {
       continue;
     }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -34,6 +34,7 @@ import type { AuthProfileStore } from "./types.js";
 
 type LoadAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
+  externalCliProviderIds?: readonly string[];
   readOnly?: boolean;
   syncExternalCli?: boolean;
 };
@@ -269,12 +270,18 @@ export function loadAuthProfileStoreForRuntime(
   const authPath = resolveAuthStorePath(agentDir);
   const mainAuthPath = resolveAuthStorePath();
   if (!agentDir || authPath === mainAuthPath) {
-    return overlayExternalAuthProfiles(store, { agentDir });
+    return overlayExternalAuthProfiles(store, {
+      agentDir,
+      allowKeychainPrompt: options?.allowKeychainPrompt,
+      externalCliProviderIds: options?.externalCliProviderIds,
+    });
   }
 
   const mainStore = loadAuthProfileStoreForAgent(undefined, options);
   return overlayExternalAuthProfiles(mergeAuthProfileStores(mainStore, store), {
     agentDir,
+    allowKeychainPrompt: options?.allowKeychainPrompt,
+    externalCliProviderIds: options?.externalCliProviderIds,
   });
 }
 
@@ -297,11 +304,18 @@ export function loadAuthProfileStoreWithoutExternalProfiles(agentDir?: string): 
 
 export function ensureAuthProfileStore(
   agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean },
+  options?: {
+    allowKeychainPrompt?: boolean;
+    externalCliProviderIds?: readonly string[];
+  },
 ): AuthProfileStore {
   return overlayExternalAuthProfiles(
     ensureAuthProfileStoreWithoutExternalProfiles(agentDir, options),
-    { agentDir },
+    {
+      agentDir,
+      allowKeychainPrompt: options?.allowKeychainPrompt,
+      externalCliProviderIds: options?.externalCliProviderIds,
+    },
   );
 }
 

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -131,7 +131,6 @@ describe("models.authStatus", () => {
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/agent", {
       externalCliProviderIds: [],
     });
-    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledTimes(1);
   });
 
   it("serves cached response within TTL and marks it as cached", async () => {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -121,6 +121,19 @@ describe("models.authStatus", () => {
     expect(result.providers[0].profiles[0].type).toBe("oauth");
   });
 
+  it("disables external CLI auth overlays for api-key-only configured providers", async () => {
+    mocks.getRuntimeConfig.mockReturnValue({
+      auth: { profiles: { "opencode-go:default": { provider: "opencode-go", mode: "api_key" } } },
+    });
+
+    await handler(createOptions());
+
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/agent", {
+      externalCliProviderIds: [],
+    });
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledTimes(1);
+  });
+
   it("serves cached response within TTL and marks it as cached", async () => {
     const opts1 = createOptions();
     await handler(opts1);

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -292,8 +292,10 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
     try {
       const cfg = context.getRuntimeConfig();
       const agentDir = resolveOpenClawAgentDir();
-      const store = ensureAuthProfileStore(agentDir);
       const configured = resolveConfiguredProviders(cfg);
+      const store = ensureAuthProfileStore(agentDir, {
+        externalCliProviderIds: configured.providers,
+      });
       const authHealth: AuthHealthSummary = buildAuthHealthSummary({
         store,
         cfg,


### PR DESCRIPTION
## Summary
- Root cause: runtime auth-store overlays always evaluated every external CLI credential source before checking whether that provider was relevant to the current model auth status request.
- Fixes #73908 by threading provider eligibility and keychain prompt policy through external CLI auth overlay resolution, then scoping `models.authStatus` to configured refreshable providers.
- Adds regression coverage for api-key-only model auth status and scoped external CLI readers.

## Why This Is Safe
- Existing unrestricted callers keep the same behavior because the new provider scope is optional.
- `models.authStatus` already computes the refreshable provider set; the change reuses that existing view to avoid unrelated runtime-only overlays.
- Security/runtime controls are unchanged: credential parsing, identity checks, persistence filtering, token health rollups, and OAuth bootstrap safety rules are not relaxed.

## Tests
- `pnpm test src/agents/auth-profiles.store-cache.test.ts src/agents/auth-profiles.external-cli-sync.test.ts src/gateway/server-methods/models-auth-status.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/auth-profiles/external-cli-sync.ts src/agents/auth-profiles/external-auth.ts src/agents/auth-profiles/store.ts src/gateway/server-methods/models-auth-status.ts src/agents/auth-profiles.external-cli-sync.test.ts src/gateway/server-methods/models-auth-status.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Out Of Scope
- Startup model prewarm behavior; current main already scopes and backgrounds that path.
- Changing supported CLI credential formats or external CLI auth persistence rules.
- Broad plugin-owner discovery changes beyond this provider-scoped overlay guard.

Made with [Cursor](https://cursor.com)