### PR TITLE
fix(amazon-bedrock): add modelContextWindowOverrides for per-model context window config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,33 @@
 
 Docs: https://docs.openclaw.ai
 
-## 2026.5.2
-
-### Highlights
-
-- Alpha prerelease support adds the `vYYYY.M.D-alpha.N` tag shape, npm `alpha` dist-tag, release workflow inputs, package acceptance, Telegram package checks, and upgrade-survivor validation paths.
-- ClawHub-first plugin installation now covers diagnostics, onboarding, doctor repair, channel setup, install/update records, and artifact metadata while keeping npm fallback for cutovers. Thanks @vincentkoc.
-- Gateway startup, session listing, task maintenance, prompt prep, plugin loading, and filesystem hot paths get targeted cache and fanout reductions for large or plugin-heavy installs.
-- Control UI and WebChat reliability improves across Sessions, Cron, long-running Gateway WebSockets, grouped-message width, slash-command feedback, iOS PWA bounds, selection contrast, and Talk diagnostics.
-- Channel and provider fixes cover Telegram topic commands and networking, Discord delivery and startup edge cases, OpenAI-compatible TTS/Realtime, OpenRouter/DeepSeek replay, Anthropic-compatible streaming, Brave/SearXNG/Firecrawl web search, and voice-call routing.
+## Unreleased
 
 ### Changes
 
-- Release: add first-class alpha prerelease support across version parsing, release workflows, package specs, published-package validation, plugin publish planning, and release docs.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
-- Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup prefer ClawHub installs while carrying ClawPack metadata through install records and npm fallback paths. Thanks @vincentkoc.
+- Plugins/diagnostics: make diagnostics OpenTelemetry and Prometheus ClawHub-first installs while keeping npm fallback metadata for release cutovers. Thanks @vincentkoc.
+- Plugins/onboarding: carry ClawHub install metadata through channel setup catalogs so missing channel plugins can install from ClawHub before npm/local fallback. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.
+
+### Fixes
+
+- Control UI: allow deployments to configure grouped chat message max-width with a validated `gateway.controlUi.chatMessageMaxWidth` setting instead of patching bundled CSS after upgrades. Fixes #67935. Thanks @xiew4589-lang.
+- Control UI/Cron: ignore malformed persisted cron rows without valid payloads before they enter UI state and guard stale cron render paths, preventing blank Control UI sections after a bad cron snapshot. Fixes #55047 and #54439; supersedes #54550 and #54552.
+- Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
+- Plugins/doctor: repair missing configured provider and channel plugins from ClawHub before npm fallback, preserving ClawPack metadata in the install record. Thanks @vincentkoc.
+- Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.
+- Gateway/sessions: keep `sessions.list` polling responsive on large session stores by reusing list-safe session cache/indexes and returning a lightweight compaction checkpoint preview instead of heavyweight summaries. Thanks @rolandrscheel.
+- Control UI/Gateway: keep long-running dashboard WebSocket sessions alive with protocol pings and keep Stop available after reconnect or reload by recovering session-scoped active-run abort state. Fixes #70991. Thanks @alexandre-leng.
+- CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
+- Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis. Long `process(poll)`, browser, or `exec` tool calls that exceed `agents.defaults.timeoutSeconds` previously rotated auth profiles, switched to a fallback model, and surfaced a misleading "LLM request timed out" error even though the primary model had already responded. Mirrors the existing `timedOutDuringCompaction` precedent (#46889). Fixes #52147. (#75873) Thanks @simonusa.
+- Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
+- Amazon Bedrock: support per-model context window overrides via `modelContextWindowOverrides` config key with compiled regex matching, so models discovered with missing or incorrect context windows can be corrected without hardcoded table changes. Fixes #73328. (#73959) Thanks @zhangguiping-xydt.
+
+## 2026.5.2
+
+### Changes
+
 - Agents/runtime: reuse the startup-loaded plugin registry for request-time providers, tools, channel actions, web/capability/memory/migration helpers, and memoized provider extra-params so stable embedded-run inputs no longer repeat plugin registry resolution while model-specific transport hook patches stay isolated. Thanks @DmitryPogodaev.
 - Agents/runtime: memoize transcript replay-policy resolution for stable config and process-env runs while preserving custom-env provider hook behavior. Thanks @DmitryPogodaev.
 - Infra/path-guards: add a fast path for canonical absolute POSIX containment checks, avoiding repeated `path.resolve` and `path.relative` work in hot filesystem walkers. Refs #75895, #75575, and #68782. Thanks @Enderfga.
@@ -44,23 +55,9 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependency pins, including TypeBox 1.1.37, AWS SDK 3.1041.0, Microsoft Teams 2.0.9, and Marked 18.0.3. Thanks @mariozechner, @aws, and @microsoft.
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
-- Agents/Codex: add committed happy-path prompt snapshots for Codex/message-tool Telegram direct, Discord group, and heartbeat turns so prompt drift can be reviewed. Thanks @pashpashpash.
 
 ### Fixes
 
-- Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.
-- Plugins/source checkout: discover source-only plugins such as Codex from the `extensions/*` workspace while using npm package excludes as the packaged-core boundary, removing the stale core-bundle metadata path.
-- Plugins/ClawHub: install ClawPack artifacts from the explicit npm-pack `.tgz` resolver path and persist artifact kind, npm integrity, shasum, and tarball metadata for update and diagnostics flows. Thanks @vincentkoc.
-- Control UI: allow deployments to configure grouped chat message max-width with a validated `gateway.controlUi.chatMessageMaxWidth` setting instead of patching bundled CSS after upgrades. Fixes #67935. Thanks @xiew4589-lang.
-- Control UI/Cron: ignore malformed persisted cron rows without valid payloads before they enter UI state and guard stale cron render paths, preventing blank Control UI sections after a bad cron snapshot. Fixes #55047 and #54439; supersedes #54550 and #54552.
-- Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
-- Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.
-- Gateway/sessions: keep `sessions.list` polling responsive on large session stores by reusing list-safe session cache/indexes and returning a lightweight compaction checkpoint preview instead of heavyweight summaries. Thanks @rolandrscheel.
-- Control UI/Gateway: keep long-running dashboard WebSocket sessions alive with protocol pings and keep Stop available after reconnect or reload by recovering session-scoped active-run abort state. Fixes #70991. Thanks @alexandre-leng.
-- CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
-- Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis, avoiding misleading "LLM request timed out" errors after the primary model has already responded. Fixes #52147. (#75873) Thanks @simonusa.
-- Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
-- Agents/compaction: keep prior context on consecutive turns against z.ai-style providers (z.ai direct, openrouter z-ai/\*, in-house GLM gateways), avoiding accidental Pi state reset after successful turns. (#76056) Thanks @openperf.
 - Doctor/plugins: run a one-time 2026.5.2 configured-plugin install repair based on `meta.lastTouchedVersion`, installing actively used downloadable OpenClaw plugins from ClawHub with npm fallback before marking the config touched for the release.
 - Sessions/transcripts: use one `session.writeLock.acquireTimeoutMs` policy for session transcript lock acquisitions and raise the default wait to 60 seconds, avoiding user-visible lock timeouts during legitimate slow prep, cleanup, compaction, and mirror work. Fixes #75894. Thanks @shandutta.
 - Control UI: contain the standalone iOS PWA viewport with safe-area-aware document locking, so Add-to-Home-Screen launches cannot scroll past the device bounds. Refs #76072. Thanks @kvncrw.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-dfdecb3918124ec7926ffe17220e498ffeef2fc7a7edfea528cc5a7f284cb8ef  plugin-sdk-api-baseline.json
-079c31016f34256af290f80f3e16d6f8154eb13513d36547ba41d3241d60e0e4  plugin-sdk-api-baseline.jsonl
+8a3eab9d802a53e8f559520022dc0813b01e3bba87bbd5d91f86889067d11238  plugin-sdk-api-baseline.json
+441ee7fa8d1f0eb141aa3323633bddd6b3ee294dcf326e9d41d65647b3e79f9a  plugin-sdk-api-baseline.jsonl

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -171,6 +171,9 @@ For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still re
                 refreshInterval: 3600,
                 defaultContextWindow: 32000,
                 defaultMaxTokens: 4096,
+                modelContextWindowOverrides: {
+                  "claude-sonnet-4-6": 200000,
+                },
               },
             },
           },
@@ -187,6 +190,7 @@ For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still re
     | `refreshInterval` | `3600` | Cache duration in seconds. Set to `0` to disable caching. |
     | `defaultContextWindow` | `32000` | Context window used for discovered models (override if you know your model limits). |
     | `defaultMaxTokens` | `4096` | Max output tokens used for discovered models (override if you know your model limits). |
+    | `modelContextWindowOverrides` | (none) | Per-model context window overrides for Bedrock models not yet covered by the built-in lookup table. Maps regex patterns to context window values (e.g. `{"claude-sonnet-4-6": 200000}`). Patterns are sorted alphabetically by key and the first (lexicographically earliest) matching pattern wins; built-in entries always take precedence. |
 
   </Accordion>
 </AccordionGroup>

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -172,7 +172,7 @@ For explicit `models.providers["amazon-bedrock"]` entries, OpenClaw can still re
                 defaultContextWindow: 32000,
                 defaultMaxTokens: 4096,
                 modelContextWindowOverrides: {
-                  "claude-sonnet-4-6": 200000,
+                  "claude-opus-4-6": 200000,
                 },
               },
             },

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -591,4 +591,150 @@ describe("bedrock discovery", () => {
       input: ["text", "image"],
     });
   });
+
+  // -----------------------------------------------------------------------
+  // modelContextWindowOverrides — regex-based context window overrides
+  // -----------------------------------------------------------------------
+
+  it("applies regex context window overrides to unknown foundation models", async () => {
+    mockSingleActiveSummary({
+      modelId: "example.unknown-text-v1:0",
+      modelName: "Example Unknown Text",
+      providerName: "example",
+    });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: {
+        modelContextWindowOverrides: {
+          "^example\\.": 128_000,
+        },
+      },
+      clientFactory,
+    });
+
+    expect(models[0]).toMatchObject({
+      id: "example.unknown-text-v1:0",
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    });
+  });
+
+  it("applies regex context window overrides to inference profiles", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "jp.example.unknown-text-v1:0",
+            inferenceProfileName: "JP Example Unknown Text",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:ap-northeast-1::foundation-model/example.unknown-text-v1:0",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({
+      region: "ap-northeast-1",
+      config: {
+        modelContextWindowOverrides: {
+          "^example\\.unknown": 256_000,
+        },
+      },
+      clientFactory,
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "jp.example.unknown-text-v1:0",
+      contextWindow: 256_000,
+    });
+  });
+
+  it("built-in KNOWN_CONTEXT_WINDOWS takes precedence over regex overrides", async () => {
+    mockSingleActiveSummary();
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: {
+        modelContextWindowOverrides: {
+          "anthropic.claude-3-7-sonnet": 999_999,
+        },
+      },
+      clientFactory,
+    });
+
+    // Built-in table says 200_000; regex override of 999_999 must not win.
+    expect(models[0]).toMatchObject({
+      id: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+      contextWindow: 200_000,
+    });
+  });
+
+  it("applies the first matching regex override when multiple patterns match", async () => {
+    mockSingleActiveSummary({
+      modelId: "example.unknown-text-v1:0",
+      modelName: "Example Unknown Text",
+      providerName: "example",
+    });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: {
+        modelContextWindowOverrides: {
+          "^example\\.": 100_000,
+          "^example\\.unknown": 200_000,
+        },
+      },
+      clientFactory,
+    });
+
+    // First matching regex wins.
+    expect(models[0]).toMatchObject({
+      id: "example.unknown-text-v1:0",
+      contextWindow: 100_000,
+    });
+  });
+
+  it("regex override matches stripped ID when baseModelId is unavailable", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "us.example.unknown-text-v1:0",
+            inferenceProfileName: "US Example Unknown Text",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: {
+        modelContextWindowOverrides: {
+          "^example\\.": 128_000,
+        },
+      },
+      clientFactory,
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "us.example.unknown-text-v1:0",
+      contextWindow: 128_000,
+    });
+  });
 });

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -112,16 +112,53 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   "qwen.qwen3-vl-235b-a22b": 128_000,
 };
 
+type CompiledCwOverride = { key: string; pattern: RegExp; contextWindow: number };
+
+/**
+ * Compile user-supplied regex → contextWindow overrides into `RegExp` objects.
+ * Invalid patterns are logged and skipped.
+ *
+ * Results are sorted by key so that matching order is deterministic and consistent
+ * with {@link sortedCwOverrides} (which sorts the cache key the same way).
+ *
+ * NOTE: Patterns are compiled directly from admin-controlled config with no
+ * complexity guard. Keep patterns simple and anchored (e.g. `^anthropic\.claude-`)
+ * to avoid catastrophic backtracking in `RegExp.prototype.test`.
+ */
+function compileCwOverrides(overrides?: Record<string, number>): CompiledCwOverride[] {
+  if (!overrides) {
+    return [];
+  }
+  const compiled: CompiledCwOverride[] = [];
+  for (const [key, cw] of Object.entries(overrides)) {
+    if (typeof cw !== "number" || !Number.isInteger(cw) || cw <= 0) {
+      continue;
+    }
+    try {
+      compiled.push({ key, pattern: new RegExp(key), contextWindow: Math.floor(cw) });
+    } catch {
+      log.warn("Skipping invalid modelContextWindowOverrides pattern", { pattern: key });
+    }
+  }
+  return compiled.toSorted((a, b) => a.key.localeCompare(b.key));
+}
+
 /**
  * Resolve the real context window for a Bedrock model ID.
  * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
+ * Built-in known-model entries take precedence; regex overrides are checked
+ * only when no exact match is found.
  */
-function resolveKnownContextWindow(modelId: string): number | undefined {
+function resolveKnownContextWindow(
+  modelId: string,
+  cwOverrides?: CompiledCwOverride[],
+): number | undefined {
   const stripped = modelId.replace(/^(?:us|eu|ap|apac|au|jp|global)\./, "");
   const candidates = [modelId, stripped];
   for (const candidate of candidates) {
-    if (KNOWN_CONTEXT_WINDOWS[candidate] !== undefined) {
-      return KNOWN_CONTEXT_WINDOWS[candidate];
+    const known = KNOWN_CONTEXT_WINDOWS[candidate];
+    if (known !== undefined) {
+      return known;
     }
     const withoutVersionSuffix = candidate.replace(/:0$/, "");
     if (
@@ -129,6 +166,14 @@ function resolveKnownContextWindow(modelId: string): number | undefined {
       KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix] !== undefined
     ) {
       return KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix];
+    }
+  }
+  // Fall back to config-driven regex overrides.
+  if (cwOverrides) {
+    for (const override of cwOverrides) {
+      if (override.pattern.test(modelId)) {
+        return override.contextWindow;
+      }
     }
   }
   return undefined;
@@ -204,14 +249,22 @@ function normalizeProviderFilter(filter?: string[]): string[] {
   return Array.from(normalized).toSorted();
 }
 
+function sortedCwOverrides(overrides: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(overrides).toSorted(([a], [b]) => a.localeCompare(b)));
+}
+
 function buildCacheKey(params: {
   region: string;
   providerFilter: string[];
   refreshIntervalSeconds: number;
   defaultContextWindow: number;
   defaultMaxTokens: number;
+  modelCwOverrides: Record<string, number>;
 }): string {
-  return JSON.stringify(params);
+  return JSON.stringify({
+    ...params,
+    modelCwOverrides: sortedCwOverrides(params.modelCwOverrides),
+  });
 }
 
 function includesTextModalities(modalities?: Array<string>): boolean {
@@ -298,6 +351,7 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
 function toModelDefinition(
   summary: BedrockModelSummary,
   defaults: { contextWindow: number; maxTokens: number },
+  cwOverrides?: CompiledCwOverride[],
 ): ModelDefinitionConfig {
   const id = summary.modelId?.trim() ?? "";
   return {
@@ -306,7 +360,7 @@ function toModelDefinition(
     reasoning: inferReasoningSupport(summary),
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
-    contextWindow: resolveKnownContextWindow(id) ?? defaults.contextWindow,
+    contextWindow: resolveKnownContextWindow(id, cwOverrides) ?? defaults.contextWindow,
     maxTokens: defaults.maxTokens,
   };
 }
@@ -390,6 +444,7 @@ function resolveInferenceProfiles(
   defaults: { contextWindow: number; maxTokens: number },
   providerFilter: string[],
   foundationModels: Map<string, ModelDefinitionConfig>,
+  cwOverrides?: CompiledCwOverride[],
 ): ModelDefinitionConfig[] {
   const discovered: ModelDefinitionConfig[] = [];
   for (const profile of profiles) {
@@ -428,7 +483,7 @@ function resolveInferenceProfiles(
       cost: baseModel?.cost ?? DEFAULT_COST,
       contextWindow:
         baseModel?.contextWindow ??
-        resolveKnownContextWindow(baseModelId ?? profile.inferenceProfileId ?? "") ??
+        resolveKnownContextWindow(baseModelId ?? profile.inferenceProfileId ?? "", cwOverrides) ??
         defaults.contextWindow,
       maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });
@@ -458,12 +513,14 @@ export async function discoverBedrockModels(params: {
   const providerFilter = normalizeProviderFilter(params.config?.providerFilter);
   const defaultContextWindow = resolveDefaultContextWindow(params.config);
   const defaultMaxTokens = resolveDefaultMaxTokens(params.config);
+  const cwOverrides = compileCwOverrides(params.config?.modelContextWindowOverrides);
   const cacheKey = buildCacheKey({
     region: params.region,
     providerFilter,
     refreshIntervalSeconds,
     defaultContextWindow,
     defaultMaxTokens,
+    modelCwOverrides: params.config?.modelContextWindowOverrides ?? {},
   });
   const now = params.now?.() ?? Date.now();
 
@@ -505,10 +562,14 @@ export async function discoverBedrockModels(params: {
       if (!shouldIncludeSummary(summary, providerFilter)) {
         continue;
       }
-      const def = toModelDefinition(summary, {
-        contextWindow: defaultContextWindow,
-        maxTokens: defaultMaxTokens,
-      });
+      const def = toModelDefinition(
+        summary,
+        {
+          contextWindow: defaultContextWindow,
+          maxTokens: defaultMaxTokens,
+        },
+        cwOverrides,
+      );
       discovered.push(def);
       const normalizedId = normalizeLowercaseStringOrEmpty(def.id);
       seenIds.add(normalizedId);
@@ -521,6 +582,7 @@ export async function discoverBedrockModels(params: {
       { contextWindow: defaultContextWindow, maxTokens: defaultMaxTokens },
       providerFilter,
       foundationModels,
+      cwOverrides,
     );
     for (const profile of inferenceProfiles) {
       const normalizedId = normalizeLowercaseStringOrEmpty(profile.id);

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -171,8 +171,10 @@ function resolveKnownContextWindow(
   // Fall back to config-driven regex overrides.
   if (cwOverrides) {
     for (const override of cwOverrides) {
-      if (override.pattern.test(modelId)) {
-        return override.contextWindow;
+      for (const candidate of candidates) {
+        if (override.pattern.test(candidate)) {
+          return override.contextWindow;
+        }
       }
     }
   }

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -24,7 +24,12 @@
           },
           "refreshInterval": { "type": "integer", "minimum": 0 },
           "defaultContextWindow": { "type": "integer", "minimum": 1 },
-          "defaultMaxTokens": { "type": "integer", "minimum": 1 }
+          "defaultMaxTokens": { "type": "integer", "minimum": 1 },
+          "modelContextWindowOverrides": {
+            "type": "object",
+            "additionalProperties": { "type": "integer", "minimum": 1 },
+            "description": "Regex pattern to context window overrides for Bedrock models not covered by the built-in lookup table."
+          }
         }
       },
       "guardrail": {
@@ -71,6 +76,10 @@
     "discovery.defaultMaxTokens": {
       "label": "Default Max Tokens",
       "help": "Fallback max output tokens to assign to discovered Bedrock models."
+    },
+    "discovery.modelContextWindowOverrides": {
+      "label": "Context Window Overrides",
+      "help": "Regex pattern to context window mapping for Bedrock models not yet in the built-in table. First matching pattern wins; built-in entries always take precedence."
     },
     "guardrail": {
       "label": "Guardrail",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -21828,6 +21828,39 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                       ],
                     },
+                    artifactKind: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "legacy-zip",
+                        },
+                        {
+                          type: "string",
+                          const: "npm-pack",
+                        },
+                      ],
+                    },
+                    artifactFormat: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "zip",
+                        },
+                        {
+                          type: "string",
+                          const: "tgz",
+                        },
+                      ],
+                    },
+                    npmIntegrity: {
+                      type: "string",
+                    },
+                    npmShasum: {
+                      type: "string",
+                    },
+                    npmTarballName: {
+                      type: "string",
+                    },
                     clawpackSha256: {
                       type: "string",
                     },

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -147,9 +147,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             type: "integer",
             exclusiveMinimum: 0,
             maximum: 9007199254740991,
-            title: "Session Liveness Threshold (ms)",
+            title: "Stuck Session Warning Threshold (ms)",
             description:
-              "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
+              "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
           },
           otel: {
             type: "object",
@@ -1279,65 +1279,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
         description:
           "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",
       },
-      accessGroups: {
-        type: "object",
-        propertyNames: {
-          type: "string",
-          minLength: 1,
-        },
-        additionalProperties: {
-          oneOf: [
-            {
-              type: "object",
-              properties: {
-                type: {
-                  type: "string",
-                  const: "discord.channelAudience",
-                },
-                guildId: {
-                  type: "string",
-                  minLength: 1,
-                },
-                channelId: {
-                  type: "string",
-                  minLength: 1,
-                },
-                membership: {
-                  type: "string",
-                  const: "canViewChannel",
-                },
-              },
-              required: ["type", "guildId", "channelId"],
-              additionalProperties: false,
-            },
-            {
-              type: "object",
-              properties: {
-                type: {
-                  type: "string",
-                  const: "message.senders",
-                },
-                members: {
-                  type: "object",
-                  propertyNames: {
-                    type: "string",
-                    minLength: 1,
-                  },
-                  additionalProperties: {
-                    type: "array",
-                    items: {
-                      type: "string",
-                      minLength: 1,
-                    },
-                  },
-                },
-              },
-              required: ["type", "members"],
-              additionalProperties: false,
-            },
-          ],
-        },
-      },
       acp: {
         type: "object",
         properties: {
@@ -1687,16 +1628,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   title: "Model Provider Inject num_ctx (OpenAI Compat)",
                   description:
                     "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
-                },
-                params: {
-                  type: "object",
-                  propertyNames: {
-                    type: "string",
-                  },
-                  additionalProperties: {},
-                  title: "Model Provider Runtime Parameters",
-                  description:
-                    "Provider-specific runtime parameters interpreted by provider plugins. Keep keys documented by the provider, and prefer explicit provider docs over ad hoc shared assumptions.",
                 },
                 headers: {
                   type: "object",
@@ -4213,22 +4144,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     reliability: {
                       type: "object",
                       properties: {
-                        outputLimits: {
-                          type: "object",
-                          properties: {
-                            maxTurnRawChars: {
-                              type: "integer",
-                              minimum: 1024,
-                              maximum: 67108864,
-                            },
-                            maxTurnLines: {
-                              type: "integer",
-                              minimum: 100,
-                              maximum: 100000,
-                            },
-                          },
-                          additionalProperties: false,
-                        },
                         watchdog: {
                           type: "object",
                           properties: {
@@ -20708,6 +20623,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
           },
+          parentForkMaxTokens: {
+            type: "integer",
+            minimum: 0,
+            maximum: 9007199254740991,
+            title: "Session Parent Fork Max Tokens",
+            description:
+              "Maximum parent-session token count allowed for thread/session inheritance forking. If the parent exceeds this, OpenClaw starts a fresh thread session instead of forking; set 0 to disable this protection.",
+          },
           mainKey: {
             type: "string",
             title: "Session Main Key",
@@ -20816,23 +20739,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
           },
-          writeLock: {
-            type: "object",
-            properties: {
-              acquireTimeoutMs: {
-                type: "integer",
-                exclusiveMinimum: 0,
-                maximum: 9007199254740991,
-                title: "Session Write Lock Acquire Timeout",
-                description:
-                  "Milliseconds to wait while acquiring a session transcript write lock before reporting the session as busy. Default: 60000; raise for slow disks or long prep/cleanup, lower only when quick failure is preferred.",
-              },
-            },
-            additionalProperties: false,
-            title: "Session Write Lock",
-            description:
-              "Groups session transcript write-lock acquisition controls. Tune only when legitimate transcript prep, cleanup, compaction, or mirror work contends longer than the default wait.",
-          },
           agentToAgent: {
             type: "object",
             properties: {
@@ -20872,19 +20778,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Thread Binding Max Age (hours)",
                 description:
                   "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
-              },
-              spawnSessions: {
-                type: "boolean",
-                title: "Thread-Bound Session Spawns",
-                description:
-                  "Global default gate for creating thread-bound work sessions from sessions_spawn and ACP thread spawns. Default: true when thread bindings are enabled.",
-              },
-              defaultSpawnContext: {
-                type: "string",
-                enum: ["isolated", "fork"],
-                title: "Thread Spawn Context",
-                description:
-                  'Default native subagent context for thread-bound spawns. Use "fork" to start from the requester transcript or "isolated" for a clean child. Default: "fork".',
               },
             },
             additionalProperties: false,
@@ -21828,55 +21721,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                       ],
                     },
-                    artifactKind: {
-                      anyOf: [
-                        {
-                          type: "string",
-                          const: "legacy-zip",
-                        },
-                        {
-                          type: "string",
-                          const: "npm-pack",
-                        },
-                      ],
-                    },
-                    artifactFormat: {
-                      anyOf: [
-                        {
-                          type: "string",
-                          const: "zip",
-                        },
-                        {
-                          type: "string",
-                          const: "tgz",
-                        },
-                      ],
-                    },
-                    npmIntegrity: {
-                      type: "string",
-                    },
-                    npmShasum: {
-                      type: "string",
-                    },
-                    npmTarballName: {
-                      type: "string",
-                    },
-                    clawpackSha256: {
-                      type: "string",
-                    },
-                    clawpackSpecVersion: {
-                      type: "integer",
-                      minimum: 0,
-                      maximum: 9007199254740991,
-                    },
-                    clawpackManifestSha256: {
-                      type: "string",
-                    },
-                    clawpackSize: {
-                      type: "integer",
-                      minimum: 0,
-                      maximum: 9007199254740991,
-                    },
                     gitUrl: {
                       type: "string",
                     },
@@ -22325,11 +22169,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Allow External Control UI Embed URLs",
                 description:
                   "DANGEROUS toggle that allows hosted embeds to load absolute external http(s) URLs. Keep this off unless your Control UI intentionally embeds trusted third-party pages; hosted /__openclaw__/canvas and /__openclaw__/a2ui documents do not need it.",
-              },
-              chatMessageMaxWidth: {
-                title: "Control UI Chat Message Max Width",
-                description:
-                  'Optional CSS max-width for grouped Control UI chat messages, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
               },
               allowedOrigins: {
                 type: "array",
@@ -24586,8 +24425,8 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["observability"],
     },
     "diagnostics.stuckSessionWarnMs": {
-      label: "Session Liveness Threshold (ms)",
-      help: "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
+      label: "Stuck Session Warning Threshold (ms)",
+      help: "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
       tags: ["observability", "storage"],
     },
     "diagnostics.otel.enabled": {
@@ -26026,11 +25865,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "DANGEROUS toggle that allows hosted embeds to load absolute external http(s) URLs. Keep this off unless your Control UI intentionally embeds trusted third-party pages; hosted /__openclaw__/canvas and /__openclaw__/a2ui documents do not need it.",
       tags: ["security", "access", "network", "advanced"],
     },
-    "gateway.controlUi.chatMessageMaxWidth": {
-      label: "Control UI Chat Message Max Width",
-      help: 'Optional CSS max-width for grouped Control UI chat messages, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
-      tags: ["advanced"],
-    },
     "gateway.controlUi.allowedOrigins": {
       label: "Control UI Allowed Origins",
       help: 'Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com). Required for non-loopback Control UI deployments unless dangerous Host-header fallback is explicitly enabled. Setting ["*"] means allow any browser origin and should be avoided outside tightly controlled local testing.',
@@ -27085,11 +26919,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
       tags: ["models"],
     },
-    "models.providers.*.params": {
-      label: "Model Provider Runtime Parameters",
-      help: "Provider-specific runtime parameters interpreted by provider plugins. Keep keys documented by the provider, and prefer explicit provider docs over ad hoc shared assumptions.",
-      tags: ["models"],
-    },
     "models.providers.*.headers": {
       label: "Model Provider Headers",
       help: "Static HTTP headers merged into provider requests for tenant routing, proxy auth, or custom gateway requirements. Use this sparingly and keep sensitive header values in secrets.",
@@ -27909,6 +27738,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: 'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
       tags: ["storage"],
     },
+    "session.parentForkMaxTokens": {
+      label: "Session Parent Fork Max Tokens",
+      help: "Maximum parent-session token count allowed for thread/session inheritance forking. If the parent exceeds this, OpenClaw starts a fresh thread session instead of forking; set 0 to disable this protection.",
+      tags: ["security", "auth", "performance", "storage"],
+    },
     "session.mainKey": {
       label: "Session Main Key",
       help: 'Overrides the canonical main session key used for continuity when dmScope or routing logic points to "main". Use a stable value only if you intentionally need custom session anchoring.',
@@ -27959,16 +27793,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Matches the raw, unnormalized session-key prefix for exact full-key policy targeting. Use this when normalized keyPrefix is too broad and you need agent-prefixed or transport-specific precision.",
       tags: ["access", "storage"],
     },
-    "session.writeLock": {
-      label: "Session Write Lock",
-      help: "Groups session transcript write-lock acquisition controls. Tune only when legitimate transcript prep, cleanup, compaction, or mirror work contends longer than the default wait.",
-      tags: ["storage"],
-    },
-    "session.writeLock.acquireTimeoutMs": {
-      label: "Session Write Lock Acquire Timeout",
-      help: "Milliseconds to wait while acquiring a session transcript write lock before reporting the session as busy. Default: 60000; raise for slow disks or long prep/cleanup, lower only when quick failure is preferred.",
-      tags: ["performance", "storage"],
-    },
     "session.agentToAgent": {
       label: "Session Agent-to-Agent",
       help: "Groups controls for inter-agent session exchanges, including loop prevention limits on reply chaining. Keep defaults unless you run advanced agent-to-agent automation with strict turn caps.",
@@ -27998,16 +27822,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Thread Binding Max Age (hours)",
       help: "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
       tags: ["performance", "storage"],
-    },
-    "session.threadBindings.spawnSessions": {
-      label: "Thread-Bound Session Spawns",
-      help: "Global default gate for creating thread-bound work sessions from sessions_spawn and ACP thread spawns. Default: true when thread bindings are enabled.",
-      tags: ["storage"],
-    },
-    "session.threadBindings.defaultSpawnContext": {
-      label: "Thread Spawn Context",
-      help: 'Default native subagent context for thread-bound spawns. Use "fork" to start from the requester transcript or "isolated" for a clean child. Default: "fork".',
-      tags: ["storage"],
     },
     "session.maintenance": {
       label: "Session Maintenance",
@@ -29341,6 +29155,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["advanced", "url-secret"],
     },
   },
-  version: "2026.5.2",
+  version: "2026.4.30",
   generatedAt: "2026-03-22T21:17:33.302Z",
 };

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -147,9 +147,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             type: "integer",
             exclusiveMinimum: 0,
             maximum: 9007199254740991,
-            title: "Stuck Session Warning Threshold (ms)",
+            title: "Session Liveness Threshold (ms)",
             description:
-              "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
+              "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
           },
           otel: {
             type: "object",
@@ -1279,6 +1279,65 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
         description:
           "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",
       },
+      accessGroups: {
+        type: "object",
+        propertyNames: {
+          type: "string",
+          minLength: 1,
+        },
+        additionalProperties: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "discord.channelAudience",
+                },
+                guildId: {
+                  type: "string",
+                  minLength: 1,
+                },
+                channelId: {
+                  type: "string",
+                  minLength: 1,
+                },
+                membership: {
+                  type: "string",
+                  const: "canViewChannel",
+                },
+              },
+              required: ["type", "guildId", "channelId"],
+              additionalProperties: false,
+            },
+            {
+              type: "object",
+              properties: {
+                type: {
+                  type: "string",
+                  const: "message.senders",
+                },
+                members: {
+                  type: "object",
+                  propertyNames: {
+                    type: "string",
+                    minLength: 1,
+                  },
+                  additionalProperties: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                      minLength: 1,
+                    },
+                  },
+                },
+              },
+              required: ["type", "members"],
+              additionalProperties: false,
+            },
+          ],
+        },
+      },
       acp: {
         type: "object",
         properties: {
@@ -1628,6 +1687,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   title: "Model Provider Inject num_ctx (OpenAI Compat)",
                   description:
                     "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
+                },
+                params: {
+                  type: "object",
+                  propertyNames: {
+                    type: "string",
+                  },
+                  additionalProperties: {},
+                  title: "Model Provider Runtime Parameters",
+                  description:
+                    "Provider-specific runtime parameters interpreted by provider plugins. Keep keys documented by the provider, and prefer explicit provider docs over ad hoc shared assumptions.",
                 },
                 headers: {
                   type: "object",
@@ -4144,6 +4213,22 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     reliability: {
                       type: "object",
                       properties: {
+                        outputLimits: {
+                          type: "object",
+                          properties: {
+                            maxTurnRawChars: {
+                              type: "integer",
+                              minimum: 1024,
+                              maximum: 67108864,
+                            },
+                            maxTurnLines: {
+                              type: "integer",
+                              minimum: 100,
+                              maximum: 100000,
+                            },
+                          },
+                          additionalProperties: false,
+                        },
                         watchdog: {
                           type: "object",
                           properties: {
@@ -20623,14 +20708,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
           },
-          parentForkMaxTokens: {
-            type: "integer",
-            minimum: 0,
-            maximum: 9007199254740991,
-            title: "Session Parent Fork Max Tokens",
-            description:
-              "Maximum parent-session token count allowed for thread/session inheritance forking. If the parent exceeds this, OpenClaw starts a fresh thread session instead of forking; set 0 to disable this protection.",
-          },
           mainKey: {
             type: "string",
             title: "Session Main Key",
@@ -20739,6 +20816,23 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
           },
+          writeLock: {
+            type: "object",
+            properties: {
+              acquireTimeoutMs: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+                title: "Session Write Lock Acquire Timeout",
+                description:
+                  "Milliseconds to wait while acquiring a session transcript write lock before reporting the session as busy. Default: 60000; raise for slow disks or long prep/cleanup, lower only when quick failure is preferred.",
+              },
+            },
+            additionalProperties: false,
+            title: "Session Write Lock",
+            description:
+              "Groups session transcript write-lock acquisition controls. Tune only when legitimate transcript prep, cleanup, compaction, or mirror work contends longer than the default wait.",
+          },
           agentToAgent: {
             type: "object",
             properties: {
@@ -20778,6 +20872,19 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Thread Binding Max Age (hours)",
                 description:
                   "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
+              },
+              spawnSessions: {
+                type: "boolean",
+                title: "Thread-Bound Session Spawns",
+                description:
+                  "Global default gate for creating thread-bound work sessions from sessions_spawn and ACP thread spawns. Default: true when thread bindings are enabled.",
+              },
+              defaultSpawnContext: {
+                type: "string",
+                enum: ["isolated", "fork"],
+                title: "Thread Spawn Context",
+                description:
+                  'Default native subagent context for thread-bound spawns. Use "fork" to start from the requester transcript or "isolated" for a clean child. Default: "fork".',
               },
             },
             additionalProperties: false,
@@ -21721,6 +21828,22 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                       ],
                     },
+                    clawpackSha256: {
+                      type: "string",
+                    },
+                    clawpackSpecVersion: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    clawpackManifestSha256: {
+                      type: "string",
+                    },
+                    clawpackSize: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
                     gitUrl: {
                       type: "string",
                     },
@@ -22169,6 +22292,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Allow External Control UI Embed URLs",
                 description:
                   "DANGEROUS toggle that allows hosted embeds to load absolute external http(s) URLs. Keep this off unless your Control UI intentionally embeds trusted third-party pages; hosted /__openclaw__/canvas and /__openclaw__/a2ui documents do not need it.",
+              },
+              chatMessageMaxWidth: {
+                title: "Control UI Chat Message Max Width",
+                description:
+                  'Optional CSS max-width for grouped Control UI chat messages, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
               },
               allowedOrigins: {
                 type: "array",
@@ -24425,8 +24553,8 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["observability"],
     },
     "diagnostics.stuckSessionWarnMs": {
-      label: "Stuck Session Warning Threshold (ms)",
-      help: "Age threshold in milliseconds for emitting stuck-session warnings while a session remains in processing state. Increase for long multi-tool turns to reduce false positives; decrease for faster hang detection.",
+      label: "Session Liveness Threshold (ms)",
+      help: "No-progress age threshold in milliseconds for classifying long processing sessions as long-running, stalled, or stuck. Reply, tool, status, block, and ACP progress reset the timer; repeated stuck diagnostics back off while unchanged.",
       tags: ["observability", "storage"],
     },
     "diagnostics.otel.enabled": {
@@ -25865,6 +25993,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "DANGEROUS toggle that allows hosted embeds to load absolute external http(s) URLs. Keep this off unless your Control UI intentionally embeds trusted third-party pages; hosted /__openclaw__/canvas and /__openclaw__/a2ui documents do not need it.",
       tags: ["security", "access", "network", "advanced"],
     },
+    "gateway.controlUi.chatMessageMaxWidth": {
+      label: "Control UI Chat Message Max Width",
+      help: 'Optional CSS max-width for grouped Control UI chat messages, for example "960px", "82%", or "min(1280px, 82%)". Values are validated against a constrained width grammar before reaching the browser.',
+      tags: ["advanced"],
+    },
     "gateway.controlUi.allowedOrigins": {
       label: "Control UI Allowed Origins",
       help: 'Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com). Required for non-loopback Control UI deployments unless dangerous Host-header fallback is explicitly enabled. Setting ["*"] means allow any browser origin and should be avoided outside tightly controlled local testing.',
@@ -26919,6 +27052,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
       tags: ["models"],
     },
+    "models.providers.*.params": {
+      label: "Model Provider Runtime Parameters",
+      help: "Provider-specific runtime parameters interpreted by provider plugins. Keep keys documented by the provider, and prefer explicit provider docs over ad hoc shared assumptions.",
+      tags: ["models"],
+    },
     "models.providers.*.headers": {
       label: "Model Provider Headers",
       help: "Static HTTP headers merged into provider requests for tenant routing, proxy auth, or custom gateway requirements. Use this sparingly and keep sensitive header values in secrets.",
@@ -27738,11 +27876,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: 'Controls typing behavior timing: "never", "instant", "thinking", or "message" based emission points. Keep conservative modes in high-volume channels to avoid unnecessary typing noise.',
       tags: ["storage"],
     },
-    "session.parentForkMaxTokens": {
-      label: "Session Parent Fork Max Tokens",
-      help: "Maximum parent-session token count allowed for thread/session inheritance forking. If the parent exceeds this, OpenClaw starts a fresh thread session instead of forking; set 0 to disable this protection.",
-      tags: ["security", "auth", "performance", "storage"],
-    },
     "session.mainKey": {
       label: "Session Main Key",
       help: 'Overrides the canonical main session key used for continuity when dmScope or routing logic points to "main". Use a stable value only if you intentionally need custom session anchoring.',
@@ -27793,6 +27926,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Matches the raw, unnormalized session-key prefix for exact full-key policy targeting. Use this when normalized keyPrefix is too broad and you need agent-prefixed or transport-specific precision.",
       tags: ["access", "storage"],
     },
+    "session.writeLock": {
+      label: "Session Write Lock",
+      help: "Groups session transcript write-lock acquisition controls. Tune only when legitimate transcript prep, cleanup, compaction, or mirror work contends longer than the default wait.",
+      tags: ["storage"],
+    },
+    "session.writeLock.acquireTimeoutMs": {
+      label: "Session Write Lock Acquire Timeout",
+      help: "Milliseconds to wait while acquiring a session transcript write lock before reporting the session as busy. Default: 60000; raise for slow disks or long prep/cleanup, lower only when quick failure is preferred.",
+      tags: ["performance", "storage"],
+    },
     "session.agentToAgent": {
       label: "Session Agent-to-Agent",
       help: "Groups controls for inter-agent session exchanges, including loop prevention limits on reply chaining. Keep defaults unless you run advanced agent-to-agent automation with strict turn caps.",
@@ -27822,6 +27965,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Thread Binding Max Age (hours)",
       help: "Optional hard max age in hours for thread-bound sessions across providers/channels (0 disables hard cap). Default: 0.",
       tags: ["performance", "storage"],
+    },
+    "session.threadBindings.spawnSessions": {
+      label: "Thread-Bound Session Spawns",
+      help: "Global default gate for creating thread-bound work sessions from sessions_spawn and ACP thread spawns. Default: true when thread bindings are enabled.",
+      tags: ["storage"],
+    },
+    "session.threadBindings.defaultSpawnContext": {
+      label: "Thread Spawn Context",
+      help: 'Default native subagent context for thread-bound spawns. Use "fork" to start from the requester transcript or "isolated" for a clean child. Default: "fork".',
+      tags: ["storage"],
     },
     "session.maintenance": {
       label: "Session Maintenance",
@@ -29155,6 +29308,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["advanced", "url-secret"],
     },
   },
-  version: "2026.4.30",
+  version: "2026.5.2",
   generatedAt: "2026-03-22T21:17:33.302Z",
 };

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -139,6 +139,12 @@ export type BedrockDiscoveryConfig = {
   refreshInterval?: number;
   defaultContextWindow?: number;
   defaultMaxTokens?: number;
+  /** Regex pattern → context window overrides for Bedrock models not yet
+   *  covered by the built-in lookup table.  Patterns are tested against
+   *  the full model ID (e.g. "anthropic.claude-sonnet-4-6-v1:0").  The
+   *  first matching pattern wins; built-in known-model entries always take
+   *  precedence. */
+  modelContextWindowOverrides?: Record<string, number>;
 };
 
 export type DiscoveryToggleConfig = {


### PR DESCRIPTION
## Summary

Fixes #73328

### Issue
Amazon Bedrock discovery defaults `contextWindow` to 32000 for all Claude 3.x/4.x models, which is incorrect for newer models with larger context windows.

### Solution
Add `modelContextWindowOverrides` config option that allows users to specify per-model context window overrides via regex patterns. The known-model table takes precedence; regex overrides are checked only when no exact match is found.

### Changes
- `extensions/amazon-bedrock/discovery.ts`: regex overrides with deterministic key-sorted matching, cache key normalisation, stripped-ID lookup, Number.isInteger guard
- `extensions/amazon-bedrock/discovery.test.ts`: tests for override behaviour
- `extensions/amazon-bedrock/openclaw.plugin.json`: config schema + uiHints
- `docs/providers/bedrock.md`: config docs with match ordering clarification
- `src/config/types.models.ts`: type definition