### PR TITLE
fix(gateway): skip text-only assistant media transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Control UI: skip assistant-media transcript injection when a TTS/media reply no longer has embeddable media content, so stale audio references cannot create duplicate text-only assistant replies. Fixes #73956. Thanks @zachisfine.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.
 - Gateway/reload: bound default restart deferral and SIGUSR1 restart drain to five minutes while preserving explicit `deferralTimeoutMs: 0` indefinite waits, so stale active work accounting cannot block config reloads forever. Thanks @vincentkoc.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -715,6 +715,54 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("does not persist text-only assistant-media fallbacks when TTS media is unavailable", async () => {
+    const transcriptDir = createTranscriptFixture("openclaw-chat-send-agent-tts-missing-");
+    const audioPath = path.join(transcriptDir, "missing.mp3");
+    mockState.config = {
+      agents: {
+        defaults: {
+          workspace: transcriptDir,
+        },
+      },
+    };
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: {
+          text: "Text-only test: one clean reply, no TTS, no media, no tool narration.",
+          spokenText: "Text-only test: one clean reply, no TTS, no media, no tool narration.",
+          mediaUrl: audioPath,
+          mediaUrls: [audioPath],
+          trustedLocalMedia: true,
+          audioAsVoice: true,
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-agent-tts-missing",
+      expectBroadcast: false,
+      waitFor: "dedupe",
+    });
+
+    const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant",
+    );
+    expect(assistantUpdates).toHaveLength(0);
+    expect(JSON.stringify(mockState.emittedTranscriptUpdates)).not.toContain(
+      "idem-agent-tts-missing:assistant-media",
+    );
+    expect(context.dedupe.has("chat:idem-agent-tts-missing")).toBe(true);
+  });
+
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {
     const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2250,16 +2250,16 @@ export const chatHandlers: GatewayRequestHandlers = {
         const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
           ? persistedAssistantContent
           : undefined;
+        if (!persistedContentForAppend) {
+          return;
+        }
         const transcriptReply =
           mediaMessage?.transcriptText ??
           extractAssistantDisplayTextFromContent(assistantContent) ??
           buildTranscriptReplyText([transcriptPayload]);
-        if (!transcriptReply && !persistedAssistantContent?.length && !assistantContent?.length) {
-          return;
-        }
         const appended = appendAssistantTranscriptMessage({
           message: transcriptReply,
-          ...(persistedContentForAppend?.length ? { content: persistedContentForAppend } : {}),
+          content: persistedContentForAppend,
           sessionId,
           storePath: latestStorePath,
           sessionFile: latestEntry?.sessionFile,


### PR DESCRIPTION
## Summary
- Fixes #73956.
- Root cause: the webchat assistant-media transcript path treated any media-bearing reply payload as appendable, then fell back to visible text when stale or unavailable media could not be embedded. That could store a second `gateway-injected` assistant message with the same text as the model answer.
- The fix only appends an assistant-media transcript message after the gateway has built persisted non-text media content, so text-only fallbacks are left to the normal model transcript.

## Why This Is Safe
- Successful audio/image assistant-media replies still append when non-text content is present.
- Non-agent command TTS behavior is unchanged; this guard is only in the agent-run assistant-media supplement path.
- Security and runtime controls are unchanged: local media access policy, trusted media checks, sensitive-media filtering, idempotency keys, auth scopes, and transcript emission boundaries remain the same.

## Tests
- `git diff --check`
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -- --reporter=verbose`
- `pnpm check:changed`

## Out Of Scope
- No changes to TTS enablement/config defaults.
- No changes to assistant-media HTTP serving or Control UI playback.
- No transcript migration or cleanup for already-stored duplicate messages.

Made with [Cursor](https://cursor.com)