### PR TITLE
fix(cron): keep system events on session route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: keep main-session systemEvent heartbeat wakes on the bound session route by dropping inherited explicit heartbeat destinations when forcing `target: "last"`. Fixes #73900. Thanks @richardmqq.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.
 - Gateway/reload: bound default restart deferral and SIGUSR1 restart drain to five minutes while preserving explicit `deferralTimeoutMs: 0` indefinite waits, so stale active work accounting cannot block config reloads forever. Thanks @vincentkoc.

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -316,6 +316,79 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("does not inherit explicit heartbeat destinations when cron forces target last", async () => {
+    const cfg = {
+      ...createCronConfig("server-cron-heartbeat-last-destination"),
+      agents: {
+        defaults: {
+          heartbeat: {
+            every: "1h",
+            prompt: "Default heartbeat prompt",
+            target: "none",
+            to: "telegram:dm",
+            accountId: "default",
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            heartbeat: {
+              directPolicy: "block",
+              to: "telegram:ops-dm",
+              accountId: "ops",
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const cronDeps = (
+        state.cron as unknown as {
+          state?: {
+            deps?: {
+              runHeartbeatOnce?: (opts?: {
+                agentId?: string;
+                sessionKey?: string | null;
+                reason?: string;
+                heartbeat?: { target?: string };
+              }) => Promise<unknown>;
+            };
+          };
+        }
+      ).state?.deps;
+
+      await cronDeps?.runHeartbeatOnce?.({
+        reason: "cron:test",
+        agentId: "ops",
+        sessionKey: "telegram:group:123:topic:456",
+        heartbeat: { target: "last" },
+      });
+
+      expect(runHeartbeatOnceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "cron:test",
+          agentId: "ops",
+          sessionKey: "agent:ops:telegram:group:123:topic:456",
+          heartbeat: {
+            every: "1h",
+            prompt: "Default heartbeat prompt",
+            target: "last",
+            directPolicy: "block",
+          },
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("preserves trust downgrades when cron enqueues system events", () => {
     const cfg = createCronConfig("server-cron-untrusted");
     loadConfigMock.mockReturnValue(cfg);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import {
@@ -56,6 +57,18 @@ function pickDefined<T extends Record<string, unknown>>(
     }
   }
   return result;
+}
+
+function omitExplicitHeartbeatDestination(
+  heartbeat: AgentDefaultsConfig["heartbeat"] | undefined,
+): AgentDefaultsConfig["heartbeat"] | undefined {
+  if (!heartbeat) {
+    return undefined;
+  }
+  const next = { ...heartbeat };
+  delete next.to;
+  delete next.accountId;
+  return next;
 }
 
 /** Map internal CronJob to the public plugin SDK shape. */
@@ -276,16 +289,15 @@ export function buildGatewayCronService(params: {
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }
         : undefined;
-      if (opts?.heartbeat?.target === "last" && heartbeatOverride) {
-        delete heartbeatOverride.to;
-        delete heartbeatOverride.accountId;
-      }
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
         agentId,
         sessionKey,
-        heartbeat: heartbeatOverride,
+        heartbeat:
+          opts?.heartbeat?.target === "last"
+            ? omitExplicitHeartbeatDestination(heartbeatOverride)
+            : heartbeatOverride,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -276,6 +276,10 @@ export function buildGatewayCronService(params: {
       const heartbeatOverride = opts?.heartbeat
         ? { ...baseHeartbeat, ...opts.heartbeat }
         : undefined;
+      if (opts?.heartbeat?.target === "last" && heartbeatOverride) {
+        delete heartbeatOverride.to;
+        delete heartbeatOverride.accountId;
+      }
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,


### PR DESCRIPTION
## Summary
- Fixes #73900.
- Keeps cron `sessionTarget: "main"` systemEvent heartbeat wakes on the bound session route when cron forces `heartbeat.target = "last"`.
- Adds a gateway cron regression test and changelog entry.

## Root cause
The cron wake adapter merged the cron override `{ target: "last" }` over the resolved heartbeat defaults, but kept inherited explicit destination fields like `heartbeat.to` and `heartbeat.accountId`. Downstream heartbeat delivery treats those fields as explicit routing inputs, so a global DM destination could override the session-bound group/topic route.

## Why This Is Safe
The change is limited to cron-supplied `target: "last"` overrides. It preserves non-routing heartbeat settings such as cadence, prompt, and direct-message policy, while removing inherited explicit destination fields so the existing session delivery context remains authoritative for the wake.

## Security / Runtime Controls
Runtime delivery resolution, allowlist checks, account validation, direct-message blocking policy, systemEvent queuing, and heartbeat execution controls are unchanged. The fix does not rely on prompt text; it removes the conflicting inherited routing inputs before runtime delivery is resolved.

## Tests
- `pnpm test src/gateway/server-cron.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm check:changed`

## Out Of Scope
- No changes to general heartbeat delivery semantics outside cron-forced `target: "last"` wakes.
- No changes to Telegram-specific routing, plugin target parsing, or cron payload handoff behavior.
- No broad refactors of heartbeat config typing or cron service internals.

Made with [Cursor](https://cursor.com)