### PR TITLE
Allow explicit self-hosted Firecrawl endpoints

### DIFF
--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -49,6 +49,9 @@
           },
           "baseUrl": {
             "type": "string"
+          },
+          "allowSelfHosted": {
+            "type": "boolean"
           }
         }
       },
@@ -61,6 +64,9 @@
           },
           "baseUrl": {
             "type": "string"
+          },
+          "allowSelfHosted": {
+            "type": "boolean"
           },
           "onlyMainContent": {
             "type": "boolean"

--- a/extensions/firecrawl/src/config.ts
+++ b/extensions/firecrawl/src/config.ts
@@ -24,6 +24,7 @@ type FirecrawlSearchConfig =
   | {
       apiKey?: unknown;
       baseUrl?: string;
+      allowSelfHosted?: boolean;
     }
   | undefined;
 
@@ -32,10 +33,12 @@ type PluginEntryConfig =
       webSearch?: {
         apiKey?: unknown;
         baseUrl?: string;
+        allowSelfHosted?: boolean;
       };
       webFetch?: {
         apiKey?: unknown;
         baseUrl?: string;
+        allowSelfHosted?: boolean;
         onlyMainContent?: boolean;
         maxAgeMs?: number;
         timeoutSeconds?: number;
@@ -47,6 +50,7 @@ type FirecrawlFetchConfig =
   | {
       apiKey?: unknown;
       baseUrl?: string;
+      allowSelfHosted?: boolean;
       onlyMainContent?: boolean;
       maxAgeMs?: number;
       timeoutSeconds?: number;
@@ -193,6 +197,12 @@ export function resolveFirecrawlBaseUrl(cfg?: OpenClawConfig): string {
     normalizeSecretInput(process.env.FIRECRAWL_BASE_URL) ||
     "";
   return configured || DEFAULT_FIRECRAWL_BASE_URL;
+}
+
+export function resolveFirecrawlAllowSelfHosted(cfg?: OpenClawConfig): boolean {
+  const search = resolveFirecrawlSearchConfig(cfg);
+  const fetch = resolveFirecrawlFetchConfig(cfg);
+  return search?.allowSelfHosted === true || fetch?.allowSelfHosted === true;
 }
 
 export function resolveFirecrawlOnlyMainContent(cfg?: OpenClawConfig, override?: boolean): boolean {

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -13,6 +13,7 @@ import {
 import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { wrapExternalContent, wrapWebContent } from "openclaw/plugin-sdk/security-runtime";
 import {
+  resolveFirecrawlAllowSelfHosted,
   resolveFirecrawlApiKey,
   resolveFirecrawlBaseUrl,
   resolveFirecrawlMaxAgeMs,
@@ -64,12 +65,19 @@ export type FirecrawlScrapeParams = {
   timeoutSeconds?: number;
 };
 
-function resolveEndpoint(baseUrl: string, pathname: "/v2/search" | "/v2/scrape"): string {
+function resolveEndpoint(
+  baseUrl: string,
+  pathname: "/v2/search" | "/v2/scrape",
+  options: { allowSelfHosted?: boolean } = {},
+): string {
   const url = new URL(baseUrl.trim() || "https://api.firecrawl.dev");
-  if (url.protocol !== "https:") {
-    throw new Error("Firecrawl baseUrl must use https.");
+  const allowSelfHosted = options.allowSelfHosted === true;
+  if (url.protocol !== "https:" && !(allowSelfHosted && url.protocol === "http:")) {
+    throw new Error(
+      "Firecrawl baseUrl must use https unless allowSelfHosted is enabled for an explicit http endpoint.",
+    );
   }
-  if (!ALLOWED_FIRECRAWL_HOSTS.has(url.hostname)) {
+  if (!allowSelfHosted && !ALLOWED_FIRECRAWL_HOSTS.has(url.hostname)) {
     throw new Error(`Firecrawl baseUrl host is not allowed: ${url.hostname}`);
   }
   url.username = "";
@@ -271,6 +279,7 @@ export async function runFirecrawlSearch(
   const sources = Array.isArray(params.sources) ? params.sources.filter(Boolean) : [];
   const categories = Array.isArray(params.categories) ? params.categories.filter(Boolean) : [];
   const baseUrl = resolveFirecrawlBaseUrl(params.cfg);
+  const allowSelfHosted = resolveFirecrawlAllowSelfHosted(params.cfg);
   const cacheKey = normalizeCacheKey(
     JSON.stringify({
       type: "firecrawl-search",
@@ -306,7 +315,7 @@ export async function runFirecrawlSearch(
   const start = Date.now();
   const payload = await postFirecrawlJson(
     {
-      url: resolveEndpoint(baseUrl, "/v2/search"),
+      url: resolveEndpoint(baseUrl, "/v2/search", { allowSelfHosted }),
       timeoutSeconds,
       apiKey,
       body,
@@ -421,6 +430,7 @@ export async function runFirecrawlScrape(
     );
   }
   const baseUrl = resolveFirecrawlBaseUrl(params.cfg);
+  const allowSelfHosted = resolveFirecrawlAllowSelfHosted(params.cfg);
   const timeoutSeconds = resolveFirecrawlScrapeTimeoutSeconds(params.cfg, params.timeoutSeconds);
   const onlyMainContent = resolveFirecrawlOnlyMainContent(params.cfg, params.onlyMainContent);
   const maxAgeMs = resolveFirecrawlMaxAgeMs(params.cfg, params.maxAgeMs);
@@ -450,7 +460,7 @@ export async function runFirecrawlScrape(
 
   const payload = await postFirecrawlJson(
     {
-      url: resolveEndpoint(baseUrl, "/v2/scrape"),
+      url: resolveEndpoint(baseUrl, "/v2/scrape", { allowSelfHosted }),
       timeoutSeconds,
       apiKey,
       errorLabel: "Firecrawl",

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -611,13 +611,23 @@ describe("firecrawl tools", () => {
     );
     expect(() =>
       firecrawlClientTesting.resolveEndpoint("http://api.firecrawl.dev", "/v2/scrape"),
-    ).toThrow("Firecrawl baseUrl must use https.");
+    ).toThrow("Firecrawl baseUrl must use https");
     expect(() =>
       firecrawlClientTesting.resolveEndpoint("https://127.0.0.1:8787", "/v2/scrape"),
     ).toThrow("Firecrawl baseUrl host is not allowed");
     expect(() =>
       firecrawlClientTesting.resolveEndpoint("https://attacker.example", "/v2/search"),
     ).toThrow("Firecrawl baseUrl host is not allowed");
+    expect(
+      firecrawlClientTesting.resolveEndpoint("http://127.0.0.1:8787", "/v2/scrape", {
+        allowSelfHosted: true,
+      }),
+    ).toBe("http://127.0.0.1:8787/v2/scrape");
+    expect(
+      firecrawlClientTesting.resolveEndpoint("https://firecrawl.internal", "/v2/search", {
+        allowSelfHosted: true,
+      }),
+    ).toBe("https://firecrawl.internal/v2/search");
   });
 
   it("respects positive numeric overrides for scrape and cache behavior", () => {


### PR DESCRIPTION
Adds an explicit allowSelfHosted config flag for the Firecrawl extension so operators can point web fetch/search tooling at a trusted self-hosted Firecrawl endpoint instead of only api.firecrawl.dev. The default remains cloud-only/HTTPS-only unless allowSelfHosted is true.\n\nValidation:\n- pnpm test:extension firecrawl\n- node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.extensions.json extensions/firecrawl