### PR TITLE
fix: reject unknown plugin ids in plugins enable/disable

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  buildPluginSnapshotReport,
   enablePluginInConfig,
   loadConfig,
+  runtimeErrors,
   refreshPluginRegistry,
   resetPluginsCliTestState,
   runPluginsCommand,
@@ -23,6 +25,10 @@ describe("plugins cli policy mutations", () => {
       },
     } as OpenClawConfig;
     loadConfig.mockReturnValue({} as OpenClawConfig);
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [{ id: "alpha", name: "Alpha" }],
+      diagnostics: [],
+    });
     enablePluginInConfig.mockReturnValue({
       config: enabledConfig,
       enabled: true,
@@ -46,6 +52,10 @@ describe("plugins cli policy mutations", () => {
         },
       },
     } as OpenClawConfig);
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [{ id: "alpha", name: "Alpha" }],
+      diagnostics: [],
+    });
 
     await runPluginsCommand(["plugins", "disable", "alpha"]);
 
@@ -56,5 +66,40 @@ describe("plugins cli policy mutations", () => {
       installRecords: {},
       reason: "policy-changed",
     });
+  });
+
+  it("fails without mutating config when enabling an unknown plugin id", async () => {
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [{ id: "alpha", name: "Alpha" }],
+      diagnostics: [],
+    });
+
+    await expect(runPluginsCommand(["plugins", "enable", "missing-plugin"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+    expect(enablePluginInConfig).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(
+      "Plugin not found: missing-plugin. Run `openclaw plugins list` to see installed plugins.",
+    );
+  });
+
+  it("fails without mutating config when disabling an unknown plugin id", async () => {
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [{ id: "alpha", name: "Alpha" }],
+      diagnostics: [],
+    });
+
+    await expect(runPluginsCommand(["plugins", "disable", "missing-plugin"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(
+      "Plugin not found: missing-plugin. Run `openclaw plugins list` to see installed plugins.",
+    );
   });
 });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -120,6 +120,14 @@ function formatInstallLines(install: PluginInstallRecord | undefined): string[] 
   return lines;
 }
 
+function resolveKnownPluginId(
+  rawId: string,
+  plugins: Array<{ id: string; name?: string | null }>,
+): string | null {
+  const plugin = plugins.find((entry) => entry.id === rawId || entry.name === rawId);
+  return plugin?.id ?? null;
+}
+
 function countEnabledPlugins(plugins: readonly { enabled: boolean }[]): number {
   return plugins.filter((plugin) => plugin.enabled).length;
 }
@@ -540,15 +548,23 @@ export function registerPluginsCli(program: Command) {
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
       const { enablePluginInConfig } = await import("../plugins/enable.js");
+      const { buildPluginSnapshotReport } = await import("../plugins/status.js");
       const { applySlotSelectionForPlugin, logSlotWarnings } =
         await import("./plugins-command-helpers.js");
       const { refreshPluginRegistryAfterConfigMutation } =
         await import("./plugins-registry-refresh.js");
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-      const enableResult = enablePluginInConfig(cfg, id);
+      const pluginId = resolveKnownPluginId(id, buildPluginSnapshotReport({ config: cfg }).plugins);
+      if (!pluginId) {
+        defaultRuntime.error(
+          `Plugin not found: ${id}. Run \`openclaw plugins list\` to see installed plugins.`,
+        );
+        return defaultRuntime.exit(1);
+      }
+      const enableResult = enablePluginInConfig(cfg, pluginId);
       let next: OpenClawConfig = enableResult.config;
-      const slotResult = applySlotSelectionForPlugin(next, id);
+      const slotResult = applySlotSelectionForPlugin(next, pluginId);
       next = slotResult.config;
       await replaceConfigFile({
         nextConfig: next,
@@ -563,12 +579,12 @@ export function registerPluginsCli(program: Command) {
       });
       logSlotWarnings(slotResult.warnings);
       if (enableResult.enabled) {
-        defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
+        defaultRuntime.log(`Enabled plugin "${pluginId}". Restart the gateway to apply.`);
         return;
       }
       defaultRuntime.log(
         theme.warn(
-          `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
+          `Plugin "${pluginId}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
         ),
       );
     });
@@ -578,12 +594,20 @@ export function registerPluginsCli(program: Command) {
     .description("Disable a plugin in config")
     .argument("<id>", "Plugin id")
     .action(async (id: string) => {
+      const { buildPluginSnapshotReport } = await import("../plugins/status.js");
       const { setPluginEnabledInConfig } = await import("./plugins-config.js");
       const { refreshPluginRegistryAfterConfigMutation } =
         await import("./plugins-registry-refresh.js");
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-      const next = setPluginEnabledInConfig(cfg, id, false);
+      const pluginId = resolveKnownPluginId(id, buildPluginSnapshotReport({ config: cfg }).plugins);
+      if (!pluginId) {
+        defaultRuntime.error(
+          `Plugin not found: ${id}. Run \`openclaw plugins list\` to see installed plugins.`,
+        );
+        return defaultRuntime.exit(1);
+      }
+      const next = setPluginEnabledInConfig(cfg, pluginId, false);
       await replaceConfigFile({
         nextConfig: next,
         ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
@@ -595,7 +619,7 @@ export function registerPluginsCli(program: Command) {
           warn: (message) => defaultRuntime.log(theme.warn(message)),
         },
       });
-      defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
+      defaultRuntime.log(`Disabled plugin "${pluginId}". Restart the gateway to apply.`);
     });
 
   plugins


### PR DESCRIPTION
## Background

`openclaw plugins enable <id>` and `openclaw plugins disable <id>` currently mutate `plugins.entries.<id>` even when the requested plugin was never discovered. That leaves a stale config entry behind, prints a contradictory success message, and exits 0 on typos.

## Changes

- validate the requested plugin id against the discovered plugin snapshot before mutating config
- reuse the resolved canonical plugin id for enable/disable logging and slot selection
- return a clear `Plugin not found: <id>. Run \`openclaw plugins list\` to see installed plugins.` error and exit 1 when the plugin is unknown
- add CLI regression coverage that asserts unknown enable/disable requests do not write config or refresh the registry

## Validation

- `pnpm test src/cli/plugins-cli.policy.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/plugins-cli.ts src/cli/plugins-cli.policy.test.ts`
- `OPENCLAW_STATE_DIR=$(mktemp -d) pnpm openclaw plugins enable totally-fake-plugin-xyz` → exits 1 and leaves config unchanged

## Impact

- typoed or nonexistent plugin ids stop failing open
- operators no longer get stale `plugins.entries.*` warnings carried into later plugin commands
- shell scripts can reliably branch on a non-zero exit when a requested plugin id does not exist

Fixes #73551.
