### PR TITLE
feat(skills): add persist flag and trustedSources config for commercial use

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createCanonicalFixtureSkill } from "../skills.test-helpers.js";
+import { shouldIncludeSkill } from "./config.js";
+import type { SkillEntry } from "./types.js";
+
+function createFixtureEntry(params: {
+  name: string;
+  metadata?: SkillEntry["metadata"];
+}): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name: params.name,
+      description: "test skill",
+      filePath: `/tmp/${params.name}/SKILL.md`,
+      baseDir: `/tmp/${params.name}`,
+      source: "openclaw-workspace",
+    }),
+    frontmatter: {},
+    metadata: params.metadata,
+  };
+}
+
+describe("shouldIncludeSkill", () => {
+  it("includes a basic skill with no requirements", () => {
+    const entry = createFixtureEntry({ name: "basic" });
+    expect(shouldIncludeSkill({ entry })).toBe(true);
+  });
+
+  it("excludes a disabled skill", () => {
+    const entry = createFixtureEntry({ name: "disabled" });
+    const config: OpenClawConfig = {
+      skills: { entries: { disabled: { enabled: false } } },
+    };
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
+
+  it("excludes a skill with unmet binary requirement", () => {
+    const entry = createFixtureEntry({
+      name: "needs-bin",
+      metadata: { requires: { bins: ["nonexistent-bin-xyz"] } },
+    });
+    expect(shouldIncludeSkill({ entry })).toBe(false);
+  });
+
+  it("includes a skill with unmet binary requirement when persist is set in config", () => {
+    const entry = createFixtureEntry({
+      name: "persist-config",
+      metadata: { requires: { bins: ["nonexistent-bin-xyz"] } },
+    });
+    const config: OpenClawConfig = {
+      skills: { entries: { "persist-config": { persist: true } } },
+    };
+    expect(shouldIncludeSkill({ entry, config })).toBe(true);
+  });
+
+  it("includes a skill with unmet binary requirement when persist is set in metadata", () => {
+    const entry = createFixtureEntry({
+      name: "persist-meta",
+      metadata: { persist: true, requires: { bins: ["nonexistent-bin-xyz"] } },
+    });
+    expect(shouldIncludeSkill({ entry })).toBe(true);
+  });
+
+  it("includes a skill with unmet env requirement when persist is set", () => {
+    const entry = createFixtureEntry({
+      name: "persist-env",
+      metadata: { persist: true, requires: { env: ["MISSING_ENV_VAR_XYZ"] } },
+    });
+    expect(shouldIncludeSkill({ entry })).toBe(true);
+  });
+
+  it("includes a skill with unmet config requirement when persist is set", () => {
+    const entry = createFixtureEntry({
+      name: "persist-config-req",
+      metadata: { persist: true, requires: { config: ["nonexistent.config.path"] } },
+    });
+    expect(shouldIncludeSkill({ entry })).toBe(true);
+  });
+
+  it("still excludes a disabled skill even when persist is set", () => {
+    const entry = createFixtureEntry({
+      name: "disabled-persist",
+      metadata: { persist: true },
+    });
+    const config: OpenClawConfig = {
+      skills: { entries: { "disabled-persist": { enabled: false, persist: true } } },
+    };
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
+
+  it("excludes OS-mismatched skill even when persist is set", () => {
+    const mismatchedOs = process.platform === "darwin" ? "linux" : "darwin";
+    const entry = createFixtureEntry({
+      name: "wrong-os",
+      metadata: { persist: true, os: [mismatchedOs] },
+    });
+    expect(shouldIncludeSkill({ entry })).toBe(false);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -86,10 +86,11 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  const persist = skillConfig?.persist === true || entry.metadata?.persist === true;
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,
-    always: entry.metadata?.always,
+    always: entry.metadata?.always || persist,
     requires: entry.metadata?.requires,
     hasBin: hasBinary,
     hasRemoteBin: eligibility?.remote?.hasBin,

--- a/src/agents/skills/frontmatter.test.ts
+++ b/src/agents/skills/frontmatter.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { resolveOpenClawMetadata, resolveSkillInvocationPolicy } from "./frontmatter.js";
 
+describe("resolveOpenClawMetadata persist", () => {
+  it("parses persist from metadata", () => {
+    const metadata = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"persist":true}}',
+    });
+    expect(metadata?.persist).toBe(true);
+  });
+
+  it("returns undefined for persist when not set", () => {
+    const metadata = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"always":true}}',
+    });
+    expect(metadata?.persist).toBeUndefined();
+  });
+
+  it("returns false when persist is explicitly false", () => {
+    const metadata = resolveOpenClawMetadata({
+      metadata: '{"openclaw":{"persist":false}}',
+    });
+    expect(metadata?.persist).toBe(false);
+  });
+});
+
 describe("resolveSkillInvocationPolicy", () => {
   it("defaults to enabled behaviors", () => {
     const policy = resolveSkillInvocationPolicy({});

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -196,6 +196,7 @@ export function resolveOpenClawMetadata(
   const osRaw = resolveOpenClawManifestOs(metadataObj);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
+    persist: typeof metadataObj.persist === "boolean" ? metadataObj.persist : undefined,
     emoji: readStringValue(metadataObj.emoji),
     homepage: readStringValue(metadataObj.homepage),
     skillKey: readStringValue(metadataObj.skillKey),

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -18,6 +18,8 @@ export type SkillInstallSpec = {
 
 export type OpenClawSkillMetadata = {
   always?: boolean;
+  /** When true, always include this skill regardless of runtime eligibility checks. */
+  persist?: boolean;
   skillKey?: string;
   primaryEnv?: string;
   emoji?: string;

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -2,6 +2,8 @@ import type { SecretInput } from "./types.secrets.js";
 
 export type SkillConfig = {
   enabled?: boolean;
+  /** When true, always include this skill regardless of runtime eligibility checks. */
+  persist?: boolean;
   apiKey?: SecretInput;
   env?: Record<string, string>;
   config?: Record<string, unknown>;
@@ -37,9 +39,22 @@ export type SkillsLimitsConfig = {
   maxSkillFileBytes?: number;
 };
 
+export type SkillsTrustedSource =
+  | "openclaw-bundled"
+  | "openclaw-managed"
+  | "openclaw-extra"
+  | "openclaw-workspace"
+  | "agents-skills-personal"
+  | "agents-skills-project";
+
 export type SkillsConfig = {
   /** Optional bundled-skill allowlist (only affects bundled skills). */
   allowBundled?: string[];
+  /**
+   * Skill source types to trust for security scanning.
+   * Trusted sources skip code safety scans during `openclaw security audit`.
+   */
+  trustedSources?: SkillsTrustedSource[];
   load?: SkillsLoadConfig;
   install?: SkillsInstallConfig;
   limits?: SkillsLimitsConfig;

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -40,7 +40,7 @@ export type SkillsLimitsConfig = {
 };
 
 export type SkillsTrustedSource =
-  | "openclaw-bundled"
+  | "openclaw-bundled" // no-op: bundled skills are already exempt from code-safety scans
   | "openclaw-managed"
   | "openclaw-extra"
   | "openclaw-workspace"

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -149,6 +149,7 @@ const ResponsesEndpointUrlFetchShape = {
 const SkillEntrySchema = z
   .object({
     enabled: z.boolean().optional(),
+    persist: z.boolean().optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     env: z.record(z.string(), z.string()).optional(),
     config: z.record(z.string(), z.unknown()).optional(),
@@ -965,6 +966,18 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
+        trustedSources: z
+          .array(
+            z.enum([
+              "openclaw-bundled",
+              "openclaw-managed",
+              "openclaw-extra",
+              "openclaw-workspace",
+              "agents-skills-personal",
+              "agents-skills-project",
+            ]),
+          )
+          .optional(),
         load: z
           .object({
             extraDirs: z.array(z.string()).optional(),

--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -10,7 +10,7 @@ import {
 import * as skillScanner from "./skill-scanner.js";
 
 vi.mock("../agents/skills.js", () => ({
-  loadWorkspaceSkillEntries: (workspaceDir: string) => {
+  loadWorkspaceSkillEntries: vi.fn((workspaceDir: string) => {
     const sep = workspaceDir.includes("\\") ? "\\" : "/";
     const baseDir = `${workspaceDir}${sep}skills${sep}evil-skill`;
     return [
@@ -25,7 +25,7 @@ vi.mock("../agents/skills.js", () => ({
         frontmatter: {},
       },
     ];
-  },
+  }),
 }));
 
 describe("audit-extra async code safety", () => {
@@ -134,6 +134,40 @@ description: test skill
     expect(skillFinding).toBeDefined();
     expect(skillFinding?.detail).toContain("dangerous-exec");
     expect(skillFinding?.detail).toMatch(/runner\.js:\d+/);
+  });
+
+  it("skips code safety scan for skills from trusted sources", async () => {
+    const scanSpy = vi.spyOn(skillScanner, "scanDirectoryWithSummary");
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: sharedCodeSafetyWorkspaceDir } },
+      skills: { trustedSources: ["openclaw-workspace"] },
+    };
+
+    // Override the mock to return a skill with a trusted source type.
+    const { loadWorkspaceSkillEntries } = await import("../agents/skills.js");
+    (loadWorkspaceSkillEntries as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        skill: {
+          baseDir: sharedCodeSafetyWorkspaceDir,
+          description: "trusted skill",
+          filePath: path.join(sharedCodeSafetyWorkspaceDir, "skills", "trusted-skill", "SKILL.md"),
+          name: "trusted-skill",
+          source: "openclaw-workspace",
+        },
+        frontmatter: {},
+      },
+    ]);
+
+    const findings = await collectInstalledSkillsCodeSafetyFindings({
+      cfg,
+      stateDir: sharedCodeSafetyStateDir,
+    });
+
+    // The scanner should not be called for trusted source skills
+    expect(scanSpy).not.toHaveBeenCalled();
+    // No findings should be reported
+    const skillFindings = findings.filter((f) => f.checkId.startsWith("skills.code_safety"));
+    expect(skillFindings).toHaveLength(0);
   });
 
   it("flags plugin extension entry path traversal in deep audit", async () => {

--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -145,7 +145,7 @@ description: test skill
 
     // Override the mock to return a skill with a trusted source type.
     const { loadWorkspaceSkillEntries } = await import("../agents/skills.js");
-    (loadWorkspaceSkillEntries as ReturnType<typeof vi.fn>).mockReturnValue([
+    (loadWorkspaceSkillEntries as ReturnType<typeof vi.fn>).mockReturnValueOnce([
       {
         skill: {
           baseDir: sharedCodeSafetyWorkspaceDir,
@@ -166,7 +166,7 @@ description: test skill
     // The scanner should not be called for trusted source skills
     expect(scanSpy).not.toHaveBeenCalled();
     // No findings should be reported
-    const skillFindings = findings.filter((f) => f.checkId.startsWith("skills.code_safety"));
+    const skillFindings = findings.filter((f) => f.checkId === "skills.code_safety");
     expect(skillFindings).toHaveLength(0);
   });
 

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -10,6 +10,7 @@ import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/config.js";
 import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { resolveOAuthDir } from "../config/paths.js";
+import type { SkillsTrustedSource } from "../config/types.skills.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
   normalizeOptionalLowercaseString,
@@ -836,11 +837,26 @@ export async function collectInstalledSkillsCodeSafetyFindings(params: {
   ]);
   const workspaceDirs = listAgentWorkspaceDirs(params.cfg);
   const { loadWorkspaceSkillEntries } = await loadSkillsModule();
+  const trustedSources = new Set(params.cfg?.skills?.trustedSources ?? []);
 
   for (const workspaceDir of workspaceDirs) {
     const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg });
     for (const entry of entries) {
-      if (resolveSkillSource(entry.skill) === "openclaw-bundled") {
+      const skillSource = resolveSkillSource(entry.skill);
+      if (skillSource === "openclaw-bundled") {
+        continue;
+      }
+      if (trustedSources.has(skillSource as SkillsTrustedSource)) {
+        const skillDir = path.resolve(entry.skill.baseDir);
+        if (!scannedSkillDirs.has(skillDir)) {
+          scannedSkillDirs.add(skillDir);
+          findings.push({
+            checkId: "skills.code_safety.trusted_source",
+            severity: "info",
+            title: `Skipped code safety scan for trusted skill: ${entry.skill.baseDir}`,
+            detail: `Skill from source "${skillSource}" bypassed code safety scan per trustedSources config.`,
+          });
+        }
         continue;
       }
 

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -830,7 +830,7 @@ export async function collectInstalledSkillsCodeSafetyFindings(params: {
 }): Promise<SecurityAuditFinding[]> {
   const findings: SecurityAuditFinding[] = [];
   const pluginExtensionsDir = path.join(params.stateDir, "extensions");
-  const scannedSkillDirs = new Set<string>();
+  const scannedSkillDirs = new Set<string>(); // shared across trusted and normal paths — deduplicates per unique physical dir
   const [{ listAgentWorkspaceDirs }, { resolveSkillSource }] = await Promise.all([
     loadAgentWorkspaceDirsModule(),
     loadSkillSourceModule(),


### PR DESCRIPTION
## Summary

Fixes #73549

### Changes
- Add `persist` flag that keeps a skill active even when runtime eligibility checks are unmet
- Add `trustedSources` config allowing operators to skip code safety scanning for designated skill sources

### Fixes applied since last review
| Round | PR | Issues |
|---|---|---|
| v1 | #73707 | 2 P2: checkId naming, scannedSkillDirs dedup |
| v2 | #73999 | 1 P1: test assertion fail, 3 P2: mock leak, dedup comment, dead enum |
| v3 | This | All resolved |