### PR TITLE
[AI-assisted] fix(agents): clarify approval slug guidance

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -792,6 +792,23 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("do not also send plain chat /approve instructions");
   });
 
+  it("keeps approval slug instructions separate from command previews", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain(
+      "include the concrete /approve command copied from the tool output's `Reply with:` line",
+    );
+    expect(prompt).toContain(
+      "never substitute the shell command/script for the approval slug",
+    );
+    expect(prompt).toContain(
+      "as descriptive text or a code block separate from the /approve command",
+    );
+    expect(prompt).toContain("never put the command/script in the /approve slug position");
+  });
+
   it("includes runtime provider capabilities when present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -149,9 +149,9 @@ function buildExecApprovalPromptGuidance(params: {
       ? Boolean(resolveChannelApprovalCapability(getChannelPlugin(runtimeChannel))?.native)
       : false);
   if (usesNativeApprovalUi) {
-    return "When exec returns approval-pending on this channel, rely on native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command if the tool result says chat approvals are unavailable or only manual approval is possible.";
+    return "When exec returns approval-pending on this channel, rely on native approval card/buttons when they appear and do not also send plain chat /approve instructions. Only include the concrete /approve command copied from the tool output's `Reply with:` line if the tool result says chat approvals are unavailable or only manual approval is possible; never substitute the shell command/script for the approval slug.";
   }
-  return "When exec returns approval-pending, include the concrete /approve command from tool output as plain chat text for the user, and do not ask for a different or rotated code.";
+  return "When exec returns approval-pending, include the concrete /approve command copied from the tool output's `Reply with:` line as plain chat text for the user; never substitute the shell command/script for the approval slug, and do not ask for a different or rotated code.";
 }
 
 function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
@@ -769,7 +769,7 @@ export function buildAgentSystemPrompt(params: {
         }),
         "Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.",
         "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
-        "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",
+        "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) as descriptive text or a code block separate from the /approve command; never put the command/script in the /approve slug position.",
         "",
       ],
     }),


### PR DESCRIPTION
## Summary

- Problem: approval guidance could be read as permission to place the shell command/script where the `/approve` slug belongs.
- Why it matters: users need the exact `/approve ...` command from tool output, while still seeing the command being approved separately.
- What changed: clarified system prompt guidance to copy `/approve` only from the tool output `Reply with:` line and keep command previews separate.
- What did NOT change (scope boundary): no approval runtime, policy, or command execution behavior changed.

AI-assisted: yes, built with Codex. I understand the code changes and verified the focused regression locally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73954
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: prompt wording asked the agent to preserve/show the full command near approval instructions but did not explicitly separate command previews from the `/approve` slug.
- Missing detection / guardrail: no regression asserted that approval slug guidance stays distinct from command preview guidance.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/system-prompt.test.ts`
- Scenario the test should lock in: system prompt tells agents to copy `/approve` from `Reply with:` and never substitute shell commands/scripts into the approval slug position.
- Why this is the smallest reliable guardrail: it tests the generated model-facing guidance directly.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Agents should present approval commands more clearly when command approval is needed.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Generate the agent system prompt.
2. Inspect approval-related guidance.
3. Confirm `/approve` slug instructions are explicitly separate from command preview instructions.

### Expected

- Agents are told to use the `/approve` command from the tool output `Reply with:` line and show shell commands separately.

### Actual

- Before this change, the wording was easier to misread.

## Evidence

- [x] Failing test/log before + passing after

Focused local validation:

```text
node scripts/test-projects.mjs src/agents/system-prompt.test.ts
Test Files  1 passed (1)
Tests       67 passed (67)
```

## Human Verification (required)

- Verified scenarios: focused system prompt regression test; `git diff --check` before commit.
- Edge cases checked: native approval UI guidance and plain chat approval guidance both preserve the `Reply with:` source of truth.
- What you did **not** verify: full repo `pnpm test` / `pnpm check`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: prompt wording changes could be too verbose.
  - Mitigation: scoped to the existing approval guidance block and covered by prompt text regression tests.