### PR TITLE
[AI-assisted] fix(cli): honor fully qualified infer model overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
+- CLI/infer: honor fully qualified local model-run provider/model overrides without bypassing slash-form aliases or the Codex app-server guard. Fixes #73921. Thanks @brokemac79.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -37,6 +37,20 @@ const mocks = vi.hoisted(() => ({
   ),
   resolveMemorySearchConfig: vi.fn(() => null),
   loadModelCatalog: vi.fn(async () => []),
+  prepareSimpleCompletionModel: vi.fn(
+    async ({ provider, modelId }: { provider: string; modelId: string }) => ({
+      model: {
+        provider,
+        id: modelId,
+        maxTokens: 128,
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    }),
+  ),
   prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
     selection: {
       provider: "openai",
@@ -161,6 +175,8 @@ vi.mock("../agents/model-catalog.js", () => ({
 }));
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModel:
+    mocks.prepareSimpleCompletionModel as unknown as typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent:
     mocks.prepareSimpleCompletionModelForAgent as unknown as typeof import("../agents/simple-completion-runtime.js").prepareSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel:
@@ -308,6 +324,7 @@ describe("capability cli", () => {
         return store;
       });
     mocks.resolveMemorySearchConfig.mockReset().mockReturnValue(null);
+    mocks.prepareSimpleCompletionModel.mockClear();
     mocks.prepareSimpleCompletionModelForAgent.mockClear();
     mocks.completeWithPreparedSimpleCompletionModel.mockClear();
     mocks.callGateway.mockClear().mockImplementation((async ({ method }: { method: string }) => {
@@ -414,6 +431,82 @@ describe("capability cli", () => {
             }),
           ],
         },
+      }),
+    );
+  });
+
+  it("prepares qualified local model probe overrides directly", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--prompt",
+        "hello",
+        "--model",
+        "github-copilot/gemini-3-flash-preview",
+        "--json",
+      ],
+    });
+
+    expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        modelId: "gemini-3-flash-preview",
+        agentDir: "/tmp/agent",
+        allowMissingApiKeyModes: ["aws-sdk"],
+        skipPiDiscovery: true,
+      }),
+    );
+    expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(mocks.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "github-copilot",
+          id: "gemini-3-flash-preview",
+        }),
+      }),
+    );
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "github-copilot",
+        model: "gemini-3-flash-preview",
+      }),
+    );
+  });
+
+  it("keeps slash-form model aliases on the agent-aware local path", async () => {
+    mocks.loadConfig.mockReturnValueOnce({
+      agents: {
+        defaults: {
+          models: {
+            "openai/xiaomi/mimo-v2-pro-mit": {
+              alias: "xiaomi/mimo-v2-pro-mit",
+            },
+          },
+        },
+      },
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--prompt",
+        "hello",
+        "--model",
+        "xiaomi/mimo-v2-pro-mit",
+        "--json",
+      ],
+    });
+
+    expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
+    expect(mocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelRef: "xiaomi/mimo-v2-pro-mit",
       }),
     );
   });
@@ -693,6 +786,37 @@ describe("capability cli", () => {
         params: expect.objectContaining({
           provider: "anthropic",
           model: "claude-haiku-4-5",
+          modelRun: true,
+          promptMode: "none",
+        }),
+      }),
+    );
+  });
+
+  it("passes github copilot model probe overrides to gateway dispatch", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "model",
+        "run",
+        "--prompt",
+        "hello",
+        "--gateway",
+        "--model",
+        "github-copilot/gpt-5.3-codex",
+        "--json",
+      ],
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientName: "gateway-client",
+        mode: "backend",
+        scopes: ["operator.admin"],
+        params: expect.objectContaining({
+          provider: "github-copilot",
+          model: "gpt-5.3-codex",
           modelRun: true,
           promptMode: "none",
         }),

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -10,10 +10,17 @@ import {
   loadAuthProfileStoreForRuntime,
 } from "../agents/auth-profiles.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
+import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import {
+  buildModelAliasIndex,
+  resolveModelRefFromString,
+} from "../agents/model-selection-shared.js";
 import {
   completeWithPreparedSimpleCompletionModel,
+  prepareSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
 } from "../agents/simple-completion-runtime.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -573,6 +580,37 @@ function requireProviderModelOverride(
   };
 }
 
+function resolveQualifiedModelRunOverride(params: {
+  cfg: OpenClawConfig;
+  raw: string | undefined;
+}): { provider: string; model: string; profileId?: string } | undefined {
+  const trimmed = params.raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const split = splitTrailingAuthProfile(trimmed);
+  if (!split.model.includes("/")) {
+    return undefined;
+  }
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  const resolved = resolveModelRefFromString({
+    raw: split.model,
+    defaultProvider: DEFAULT_PROVIDER,
+    aliasIndex,
+  });
+  if (!resolved || resolved.alias || resolved.ref.provider === "codex") {
+    return undefined;
+  }
+  return {
+    provider: resolved.ref.provider,
+    model: resolved.ref.model,
+    ...(split.profile ? { profileId: split.profile } : {}),
+  };
+}
+
 function collectModelRunText(content: Array<{ type: string; text?: string }>): string {
   return content
     .map((block) => (block.type === "text" && typeof block.text === "string" ? block.text : ""))
@@ -644,17 +682,35 @@ async function runModelRun(params: {
         ]
       : params.prompt;
   if (params.transport === "local") {
-    const prepared = await prepareSimpleCompletionModelForAgent({
+    const override = resolveQualifiedModelRunOverride({
       cfg,
-      agentId,
-      modelRef: params.model,
-      allowMissingApiKeyModes: ["aws-sdk"],
-      skipPiDiscovery: true,
+      raw: params.model,
     });
+    const agentDir = resolveAgentDir(cfg, agentId);
+    const prepared = override
+      ? await prepareSimpleCompletionModel({
+          cfg,
+          provider: override.provider,
+          modelId: override.model,
+          agentDir,
+          ...(override.profileId ? { profileId: override.profileId } : {}),
+          allowMissingApiKeyModes: ["aws-sdk"],
+          skipPiDiscovery: true,
+        })
+      : await prepareSimpleCompletionModelForAgent({
+          cfg,
+          agentId,
+          modelRef: params.model,
+          allowMissingApiKeyModes: ["aws-sdk"],
+          skipPiDiscovery: true,
+        });
     if ("error" in prepared) {
       throw new Error(prepared.error);
     }
-    if (prepared.selection.provider === "codex") {
+    const selectedProvider =
+      "selection" in prepared ? prepared.selection.provider : prepared.model.provider;
+    const selectedModel = "selection" in prepared ? prepared.selection.modelId : prepared.model.id;
+    if (selectedProvider === "codex") {
       throw new Error(
         'The codex provider is served by the Codex app-server agent runtime, not the local simple-completion transport. Use an openai/<model> ref with agents.defaults.agentRuntime.id: "codex", run through the gateway, or use /codex commands.',
       );
@@ -682,15 +738,15 @@ async function runModelRun(params: {
     const text = collectModelRunText(result.content);
     if (!text) {
       throw new Error(
-        `No text output returned for provider "${prepared.selection.provider}" model "${prepared.selection.modelId}".`,
+        `No text output returned for provider "${selectedProvider}" model "${selectedModel}".`,
       );
     }
     return {
       ok: true,
       capability: "model.run",
       transport: "local" as const,
-      provider: prepared.selection.provider,
-      model: prepared.selection.modelId,
+      provider: selectedProvider,
+      model: selectedModel,
       attempts: [],
       ...(imageFiles.length > 0
         ? {


### PR DESCRIPTION
## Summary

- Problem: local `capability model run --model provider/model` could route through agent default selection instead of honoring the fully qualified provider/model override directly.
- Why it matters: explicit probes like `github-copilot/...` should test the requested provider/model, not the agent fallback/default path.
- What changed: qualified local model run overrides are prepared directly with `prepareSimpleCompletionModel`; gateway dispatch forwarding remains explicit.
- What did NOT change (scope boundary): unqualified model refs still use the existing agent default selection path.

AI-assisted: yes, built with Codex. I understand the code changes and verified the focused regression locally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73921
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: local model-run handling always delegated through agent-aware model preparation, even when the CLI supplied a fully qualified provider/model override.
- Missing detection / guardrail: no test asserted direct local preparation for provider-qualified model run overrides.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/capability-cli.test.ts`
- Scenario the test should lock in: local model run with `github-copilot/model` calls direct simple-completion preparation, and gateway mode forwards the explicit provider/model.
- Why this is the smallest reliable guardrail: it exercises the CLI command plumbing without live provider calls.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw capability model run --model provider/model` now honors fully qualified local provider/model overrides more directly.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js / pnpm workspace
- Model/provider: mocked in unit tests
- Integration/channel (if any): CLI
- Relevant config (redacted): N/A

### Steps

1. Run a local model probe with `--model github-copilot/<model>`.
2. Confirm the CLI prepares that explicit provider/model directly.
3. Run gateway mode and confirm explicit provider/model are forwarded.

### Expected

- Fully qualified model overrides select the requested provider/model.

### Actual

- Before this change, local mode could go through agent default resolution first.

## Evidence

- [x] Failing test/log before + passing after

Focused local validation:

```text
node scripts/test-projects.mjs src/cli/capability-cli.test.ts
Test Files  1 passed (1)
Tests       50 passed (50)
```

## Human Verification (required)

- Verified scenarios: focused CLI regression tests; `git diff --check` before commit.
- Edge cases checked: provider-qualified local override and gateway override forwarding.
- What you did **not** verify: live GitHub Copilot provider call; full repo `pnpm test` / `pnpm check`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: changing local model-run path for qualified overrides could miss agent-specific defaults.
  - Mitigation: only provider-qualified refs take the direct path; unqualified refs continue through existing agent selection.