### PR TITLE
[AI-assisted] feat(mcp): allow serve operator scope selection

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -117,9 +117,46 @@ describe("mcp cli", () => {
         gatewayUrl: "ws://127.0.0.1:18789",
         gatewayToken: "secret-token",
         gatewayPassword: undefined,
+        operatorScopes: undefined,
         claudeChannelMode: "on",
         verbose: true,
       });
+    });
+  });
+
+  it("starts the channel bridge with explicit operator scopes", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand([
+        "mcp",
+        "serve",
+        "--scope",
+        "operator.read",
+        "--scope",
+        "operator.approvals",
+      ]);
+
+      expect(serveOpenClawChannelMcp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operatorScopes: ["operator.read", "operator.approvals"],
+        }),
+      );
+    });
+  });
+
+  it("rejects unknown operator scopes", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(runMcpCommand(["mcp", "serve", "--scope", "operator.nope"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Invalid --scope value"));
+      expect(serveOpenClawChannelMcp).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -5,6 +5,7 @@ import {
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
 } from "../config/mcp-config.js";
+import { KNOWN_OPERATOR_SCOPES, type OperatorScope } from "../gateway/operator-scopes.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -24,6 +25,30 @@ function printJson(value: unknown): void {
   defaultRuntime.writeJson(value);
 }
 
+function collectScopeOption(value: string | string[], previous: string[] = []): string[] {
+  return [...previous, ...(Array.isArray(value) ? value : [value])];
+}
+
+function parseOperatorScopes(values: unknown): OperatorScope[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  const rawValues = Array.isArray(values) ? values : [values];
+  const scopes: OperatorScope[] = [];
+  for (const raw of rawValues) {
+    const scope = String(raw).trim();
+    if (!KNOWN_OPERATOR_SCOPES.has(scope as OperatorScope)) {
+      throw new Error(
+        `Invalid --scope value "${scope}". Use one of: ${[...KNOWN_OPERATOR_SCOPES].join(", ")}.`,
+      );
+    }
+    if (!scopes.includes(scope as OperatorScope)) {
+      scopes.push(scope as OperatorScope);
+    }
+  }
+  return scopes.length > 0 ? scopes : undefined;
+}
+
 export function registerMcpCli(program: Command) {
   const mcp = program.command("mcp").description("Manage OpenClaw MCP config and channel bridge");
 
@@ -35,6 +60,7 @@ export function registerMcpCli(program: Command) {
     .option("--token-file <path>", "Read gateway token from file")
     .option("--password <password>", "Gateway password (if required)")
     .option("--password-file <path>", "Read gateway password from file")
+    .option("--scope <scope...>", "Operator scope to request (repeatable)", collectScopeOption)
     .option(
       "--claude-channel-mode <mode>",
       "Claude channel notification mode: auto, on, or off",
@@ -58,6 +84,7 @@ export function registerMcpCli(program: Command) {
           gatewayUrl: opts.url as string | undefined,
           gatewayToken,
           gatewayPassword,
+          operatorScopes: parseOperatorScopes(opts.scope),
           claudeChannelMode,
           verbose: Boolean(opts.verbose),
         });

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayClient } from "../gateway/client.js";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import {
@@ -63,6 +64,7 @@ export class OpenClawChannelBridge {
       gatewayUrl?: string;
       gatewayToken?: string;
       gatewayPassword?: string;
+      operatorScopes?: OperatorScope[];
       claudeChannelMode: ClaudeChannelMode;
       verbose: boolean;
     },
@@ -118,7 +120,7 @@ export class OpenClawChannelBridge {
       clientDisplayName: "OpenClaw MCP",
       clientVersion: VERSION,
       mode: GATEWAY_CLIENT_MODES.CLI,
-      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
+      scopes: this.params.operatorScopes ?? [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
       requestTimeoutMs: 180_000,
       onEvent: (event) => {
         void this.handleGatewayEvent(event);

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import { shouldRetryInitialMcpGatewayConnect } from "./channel-bridge.js";
 import { createOpenClawChannelMcpServer, OpenClawChannelBridge } from "./channel-server.js";
 import { extractAttachmentsFromMessage } from "./channel-shared.js";
@@ -81,6 +82,70 @@ function gatewayRequestError(retryable: boolean): Error {
   });
 }
 
+async function captureGatewayClientScopes(operatorScopes?: OperatorScope[]): Promise<unknown> {
+  let capturedScopes: unknown;
+
+  vi.resetModules();
+  vi.doMock("../gateway/client-bootstrap.js", () => ({
+    resolveGatewayClientBootstrap: vi.fn(async () => ({
+      url: "ws://127.0.0.1:18888",
+      auth: {},
+    })),
+  }));
+  vi.doMock("../gateway/client.js", () => ({
+    GatewayClient: class {
+      private readonly opts: {
+        scopes?: unknown;
+        onHelloOk?: () => void;
+      };
+
+      constructor(opts: { scopes?: unknown; onHelloOk?: () => void }) {
+        this.opts = opts;
+        capturedScopes = opts.scopes;
+      }
+
+      start(): void {
+        this.opts.onHelloOk?.();
+      }
+
+      async request(): Promise<Record<string, never>> {
+        return {};
+      }
+
+      async stopAndWait(): Promise<void> {
+        return undefined;
+      }
+    },
+  }));
+  vi.doMock("../gateway/method-scopes.js", () => ({
+    APPROVALS_SCOPE: "operator.approvals",
+    READ_SCOPE: "operator.read",
+    WRITE_SCOPE: "operator.write",
+  }));
+  vi.doMock("../gateway/protocol/client-info.js", () => ({
+    GATEWAY_CLIENT_MODES: { CLI: "cli" },
+    GATEWAY_CLIENT_NAMES: { CLI: "cli" },
+  }));
+
+  const bridge = new OpenClawChannelBridge({} as never, {
+    operatorScopes,
+    claudeChannelMode: "off",
+    verbose: false,
+  });
+  try {
+    await bridge.start();
+  } finally {
+    await bridge.close();
+    vi.doUnmock("../gateway/client-bootstrap.js");
+    vi.doUnmock("../gateway/client.js");
+    vi.doUnmock("../gateway/method-scopes.js");
+    vi.doUnmock("../gateway/protocol/client-info.js");
+    vi.resetModules();
+  }
+
+  return capturedScopes;
+}
+
 describe("openclaw channel mcp server", () => {
   test("keeps initial MCP gateway connection alive through transient connect errors", () => {
     expect(
@@ -88,6 +153,18 @@ describe("openclaw channel mcp server", () => {
     ).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(true))).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(false))).toBe(false);
+  });
+
+  test("passes configured operator scopes to the gateway client", async () => {
+    await expect(captureGatewayClientScopes(["operator.read"])).resolves.toEqual(["operator.read"]);
+  });
+
+  test("defaults gateway client scopes for mcp serve", async () => {
+    await expect(captureGatewayClientScopes()).resolves.toEqual([
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+    ]);
   });
 
   describe("gateway-backed flows", () => {

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import { VERSION } from "../version.js";
 import { OpenClawChannelBridge } from "./channel-bridge.js";
 import { ClaudePermissionRequestSchema, type ClaudeChannelMode } from "./channel-shared.js";
@@ -12,6 +13,7 @@ export type OpenClawMcpServeOptions = {
   gatewayUrl?: string;
   gatewayToken?: string;
   gatewayPassword?: string;
+  operatorScopes?: OperatorScope[];
   config?: OpenClawConfig;
   claudeChannelMode?: ClaudeChannelMode;
   verbose?: boolean;
@@ -42,6 +44,7 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
     gatewayUrl: opts.gatewayUrl,
     gatewayToken: opts.gatewayToken,
     gatewayPassword: opts.gatewayPassword,
+    operatorScopes: opts.operatorScopes,
     claudeChannelMode,
     verbose: opts.verbose ?? false,
   });


### PR DESCRIPTION
## Summary

- Problem: `openclaw mcp serve` always requested the default operator scopes and could not be started with a narrower/explicit scope set.
- Why it matters: operators may need to run the MCP bridge with only the scopes required for their integration.
- What changed: added repeatable `--scope` validation/plumbing and passed configured operator scopes through to the gateway client.
- What did NOT change (scope boundary): default `mcp serve` scope behavior is unchanged when `--scope` is omitted.

AI-assisted: yes, built with Codex. I understand the code changes and verified the focused regressions locally.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73864
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: MCP serve options did not expose operator scope selection, and the channel bridge always supplied the fixed default scope list.
- Missing detection / guardrail: no CLI/server tests covered explicit scope plumbing.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/mcp-cli.test.ts`, `src/mcp/channel-server.test.ts`
- Scenario the test should lock in: CLI accepts repeatable valid scopes, rejects unknown scopes, and the channel bridge passes configured scopes or defaults when omitted.
- Why this is the smallest reliable guardrail: it covers the CLI option and gateway-client construction boundaries without requiring a live gateway.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw mcp serve` now supports repeatable `--scope <operator.scope>` flags.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: Users can explicitly choose the operator scopes requested by the MCP bridge. Values are validated against known operator scopes, and omission preserves the previous default scope set.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node.js / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): MCP CLI/channel bridge
- Relevant config (redacted): N/A

### Steps

1. Start `openclaw mcp serve --scope operator.read --scope operator.approvals`.
2. Confirm requested scopes are passed to the gateway client.
3. Start without `--scope` and confirm existing defaults are preserved.
4. Try an unknown scope and confirm the CLI rejects it.

### Expected

- Explicit valid scopes are honored; invalid scopes fail fast; omitted scopes keep current defaults.

### Actual

- Before this change, scope selection was not configurable.

## Evidence

- [x] Failing test/log before + passing after

Focused local validation:

```text
node scripts/test-projects.mjs src/cli/mcp-cli.test.ts src/mcp/channel-server.test.ts
Test Files  2 passed (2)
Tests       14 passed (14)
```

## Human Verification (required)

- Verified scenarios: focused CLI and channel bridge tests; `git diff --check` before commit.
- Edge cases checked: duplicate/repeatable scope collection, invalid scope rejection, default scope fallback.
- What you did **not** verify: live MCP bridge against a real gateway; full repo `pnpm test` / `pnpm check`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users might request an insufficient scope set for a workflow.
  - Mitigation: default behavior is unchanged unless users opt into explicit scopes, and invalid scope names are rejected.