### PR TITLE
fix: skip external CLI credential reads when no profile exists

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -153,11 +153,17 @@ export function resolveExternalCliAuthProfiles(
   const profiles: ExternalCliResolvedProfile[] = [];
   const now = Date.now();
   for (const providerConfig of EXTERNAL_CLI_SYNC_PROVIDERS) {
+    // Skip providers that have no existing profile in the store.
+    // Reading credentials (e.g., from macOS keychain) is expensive and should
+    // only happen when there's a profile that could use them.
+    const existing = store.profiles[providerConfig.profileId];
+    if (!existing) {
+      continue;
+    }
     const creds = providerConfig.readCredentials();
     if (!creds) {
       continue;
     }
-    const existing = store.profiles[providerConfig.profileId];
     const existingOAuth =
       existing?.type === "oauth" && existing.provider === providerConfig.provider
         ? existing


### PR DESCRIPTION
## Summary

Fixes #74006 - Gateway disconnects and slow startup after v2026.4.26 update.

Root cause: `resolveExternalCliAuthProfiles` unconditionally reads credentials for ALL external CLI providers (Claude CLI, Codex, MiniMax) during startup, even when no profiles for those providers are configured. This causes expensive macOS keychain queries that block gateway startup.

**User config (from issue):**
- `auth.profiles: only opencode-go:default (api_key)`
- No Anthropic/Claude configured
- But startup still queries macOS keychain for Claude CLI credentials, causing 5-10s blocking calls

## Changes

- In `resolveExternalCliAuthProfiles`, check if a profile exists before reading credentials
- If no profile exists in the store for a provider, skip reading credentials for that provider
- This avoids expensive keychain lookups when no profile would use them

## Testing

- Verified fix logic: no longer reads credentials for providers without existing profiles
- Existing tests cover the oauth adoption flow; fix only affects the early-continue path

Fixes openclaw/openclaw#74006