### PR TITLE
docs: add Clownfish replacement smoke typo

### DIFF
--- a/docs/clownfish-replacement-smoke.md
+++ b/docs/clownfish-replacement-smoke.md
@@ -1,0 +1,8 @@
+# Clownfish Replacement Smoke
+
+This temporary smoke PR intentionally contains a typo for Clownfish to replace.
+
+Expected word: replacement
+Mistaken word: replacment
+
+Smoke id: 20260429T032843Z


### PR DESCRIPTION
Temporary Clownfish replacement smoke source PR. This intentionally contains the typo `replacment`; Clownfish should open a replacement PR that fixes it, preserve credit, then close this source PR.\n\nSmoke id: 20260429T032843Z