### PR TITLE
fix: guard against empty prompt race in runEmbeddedPiAgent

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2531,7 +2531,12 @@ export async function runEmbeddedAttempt(
             if (msg.role !== 'user') return false;
             const c = msg.content;
             if (typeof c === 'string') return c.trim().length > 0;
-            if (Array.isArray(c)) return c.some((p) => (p as { type?: string; text?: string })?.type === 'text' && typeof (p as { text?: string }).text === 'string' && (p as { text?: string }).text.trim().length > 0);
+            if (Array.isArray(c)) return c.some((p) => {
+              const part = p as { type?: string; text?: string };
+              if (part.type !== 'text') return false;
+              const text = part.text;
+              return typeof text === 'string' && text.trim().length > 0;
+            });
             return false;
           });
           if (

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2541,6 +2541,7 @@ export async function runEmbeddedAttempt(
             // Replace the empty prompt with a safe greeting so the normal
             // submission flow below dispatches something viable.
             promptSubmission = {
+              ...promptSubmission,
               prompt:
                 "A new session was started. Greet the user briefly in your configured persona and ask what they want to do.",
             };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2472,7 +2472,7 @@ export async function runEmbeddedAttempt(
           }
           prePromptMessageCount = activeSession.messages.length;
 
-          const promptSubmission = resolveRuntimeContextPromptParts({
+          let promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
           });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2525,11 +2525,13 @@ export async function runEmbeddedAttempt(
           // Secondary guard: even if messages.length > 0, verify they have actual content.
           // Empty user messages (from an active-memory mid-rebuild race) pass the length
           // check but contain no text, which still results in an empty API payload → 400.
-          const hasNonEmptyUserMsg = (activeSession.messages ?? []).some((m) => {
-            if (!m || (m as any).role !== 'user') return false;
-            const c = (m as any).content;
+          const hasNonEmptyUserMsg = (activeSession.messages as readonly unknown[]).some((m) => {
+            if (!m) return false;
+            const msg = m as { role?: string; content?: string | unknown[] };
+            if (msg.role !== 'user') return false;
+            const c = msg.content;
             if (typeof c === 'string') return c.trim().length > 0;
-            if (Array.isArray(c)) return c.some((p: any) => p?.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0);
+            if (Array.isArray(c)) return c.some((p) => (p as { type?: string; text?: string })?.type === 'text' && typeof (p as { text?: string }).text === 'string' && (p as { text?: string }).text.trim().length > 0);
             return false;
           });
           if (

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2526,17 +2526,27 @@ export async function runEmbeddedAttempt(
           // Empty user messages (from an active-memory mid-rebuild race) pass the length
           // check but contain no text, which still results in an empty API payload → 400.
           const hasNonEmptyUserMsg = (activeSession.messages as readonly unknown[]).some((m) => {
-            if (!m) return false;
+            if (!m) {
+              return false;
+            }
             const msg = m as { role?: string; content?: string | unknown[] };
-            if (msg.role !== 'user') return false;
+            if (msg.role !== 'user') {
+              return false;
+            }
             const c = msg.content;
-            if (typeof c === 'string') return c.trim().length > 0;
-            if (Array.isArray(c)) return c.some((p) => {
-              const part = p as { type?: string; text?: string };
-              if (part.type !== 'text') return false;
-              const text = part.text;
-              return typeof text === 'string' && text.trim().length > 0;
-            });
+            if (typeof c === 'string') {
+              return c.trim().length > 0;
+            }
+            if (Array.isArray(c)) {
+              return c.some((p) => {
+                const part = p as { type?: string; text?: string };
+                if (part.type !== 'text') {
+                  return false;
+                }
+                const text = part.text;
+                return typeof text === 'string' && text.trim().length > 0;
+              });
+            }
             return false;
           });
           if (

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2522,6 +2522,34 @@ export async function runEmbeddedAttempt(
             transcriptLeafId,
           });
 
+          // Secondary guard: even if messages.length > 0, verify they have actual content.
+          // Empty user messages (from an active-memory mid-rebuild race) pass the length
+          // check but contain no text, which still results in an empty API payload → 400.
+          const hasNonEmptyUserMsg = (activeSession.messages ?? []).some((m) => {
+            if (!m || (m as any).role !== 'user') return false;
+            const c = (m as any).content;
+            if (typeof c === 'string') return c.trim().length > 0;
+            if (Array.isArray(c)) return c.some((p: any) => p?.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0);
+            return false;
+          });
+          if (
+            !skipPromptSubmission &&
+            (!promptSubmission.prompt || !promptSubmission.prompt.trim()) &&
+            imageResult.images.length === 0 &&
+            !hasNonEmptyUserMsg
+          ) {
+            skipPromptSubmission = true;
+            promptSubmission = {
+              prompt:
+                "A new session was started. Greet the user briefly in your configured persona and ask what they want to do.",
+            };
+            log.warn(
+              `[empty-prompt-guard] injected safe greeting for empty prompt race ` +
+                `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger} ` +
+                `provider=${params.provider}/${params.modelId}`,
+            );
+          }
+
           if (
             !skipPromptSubmission &&
             !promptSubmission.runtimeOnly &&

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2538,7 +2538,8 @@ export async function runEmbeddedAttempt(
             imageResult.images.length === 0 &&
             !hasNonEmptyUserMsg
           ) {
-            skipPromptSubmission = true;
+            // Replace the empty prompt with a safe greeting so the normal
+            // submission flow below dispatches something viable.
             promptSubmission = {
               prompt:
                 "A new session was started. Greet the user briefly in your configured persona and ask what they want to do.",


### PR DESCRIPTION
## Fix for #73926

When /new or /reset races with active-memory mid-rebuild, activeSession.messages can contain entries that pass `messages.length > 0` but have no actual text content. The existing `hasPromptSubmissionContent` check only guards on length, not content quality — so an empty prompt plus empty messages still reaches the LLM dispatch, causing a 400 `messages: at least one message is required` error.

### What this fixes

Adds a secondary guard in `src/agents/pi-embedded-runner/run/attempt.ts` that:

- Checks whether any user message in `activeSession.messages` has actual non-empty text content (covering both string and multi-block content arrays)
- When prompt is empty, no images are present, and no non-empty user message exists → injects a safe greeting prompt instead of sending an empty payload to the API

### Root cause

The existing `hasPromptSubmissionContent` check (line 2526) correctly detects `messages.length === 0`, but when active-memory mid-rebuild races with a bare reset, `messages` can have entries that pass the length check while containing only empty-text user messages. This sends an empty body to the LLM API → 400.

### Change

```diff
+          // Secondary guard: even if messages.length > 0, verify they have actual content.
+          const hasNonEmptyUserMsg = (activeSession.messages ?? []).some((m) => {
+            if (!m || (m as any).role !== 'user') return false;
+            const c = (m as any).content;
+            if (typeof c === 'string') return c.trim().length > 0;
+            if (Array.isArray(c)) return c.some((p: any) => p?.type === 'text' && typeof p.text === 'string' && p.text.trim().length > 0);
+            return false;
+          });
+          if (
+            !skipPromptSubmission &&
+            (!promptSubmission.prompt || !promptSubmission.prompt.trim()) &&
+            imageResult.images.length === 0 &&
+            !hasNonEmptyUserMsg
+          ) {
+            skipPromptSubmission = true;
+            promptSubmission = {
+              prompt:
+                "A new session was started. Greet the user briefly in your configured persona and ask what they want to do.",
+            };
+            log.warn(
+              `[empty-prompt-guard] injected safe greeting for empty prompt race ` +
+                `runId=${params.runId} sessionId=${params.sessionId} trigger=${params.trigger} ` +
+                `provider=${params.provider}/${params.modelId}`,
+            );
+          }
```

Fixes #73926.