### PR TITLE
fix(gateway): skip model pricing fetches when mode is replace

### DIFF
--- a/src/gateway/model-pricing-config.ts
+++ b/src/gateway/model-pricing-config.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export function isGatewayModelPricingEnabled(config: OpenClawConfig): boolean {
-  return config.models?.pricing?.enabled !== false;
+  return config.models?.pricing?.enabled !== false && config.models?.mode !== "replace";
 }


### PR DESCRIPTION
When `models.mode` is set to `replace`, all model configurations are provided manually and the built-in pricing catalog from OpenRouter/LiteLLM is not used. However, the gateway still performs pricing fetches during startup, which can take up to 60 seconds to timeout.

This change makes `isGatewayModelPricingEnabled()` return `false` when `models.mode === "replace"`, consistent with the existing `models.pricing.enabled: false` option that already allows skipping these fetches.

Closes #74020