### PR TITLE
[codex] Bias group chat prompts toward subagent delegation

### DIFF
--- a/src/agents/prompt-composition.test.ts
+++ b/src/agents/prompt-composition.test.ts
@@ -63,10 +63,12 @@ describe("prompt composition invariants", () => {
     const eventTurn = getTurn(groupScenario!, "t3");
 
     expect(first.systemPrompt).toContain("You are in a Slack group chat.");
+    expect(first.systemPrompt).toContain("prefer delegating bounded side investigations early");
     expect(first.systemPrompt).toContain("Activation: trigger-only");
     expect(first.systemPrompt).toContain('reply with exactly "NO_REPLY"');
     expect(first.systemPrompt).not.toContain("## Silent Replies");
     expect(steady.systemPrompt).toContain("You are in a Slack group chat.");
+    expect(steady.systemPrompt).toContain("prefer delegating bounded side investigations early");
     expect(steady.systemPrompt).toContain('reply with exactly "NO_REPLY"');
     expect(steady.systemPrompt).not.toContain("## Silent Replies");
     expect(steady.systemPrompt).not.toContain("Activation: trigger-only");

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -31,6 +31,8 @@ describe("group runtime loading", () => {
       "You are in a WhatsApp group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
     );
     expect(groupChatContext).toContain("Minimize empty lines and use normal chat conventions");
+    expect(groupChatContext).toContain("prefer delegating bounded side investigations early");
+    expect(groupChatContext).toContain("Keep the critical path local");
     expect(groupChatContext).toContain('reply with exactly "NO_REPLY"');
     const toolOnlyContext = groups.buildGroupChatContext({
       sessionCtx: { ChatType: "group", Provider: "discord" },

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -245,6 +245,9 @@ export function buildGroupChatContext(params: {
   lines.push(
     "Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
   );
+  lines.push(
+    "When subagent or session-spawn tools are available and a directly requested group-chat task will require several tool calls, prefer delegating bounded side investigations early so the channel gets a responsive path forward. Keep the critical path local, avoid subagents for simple one-step work, and only surface concise group-visible updates when they add value.",
+  );
   const canUseSilentReply =
     !messageToolOnly &&
     params.silentToken &&


### PR DESCRIPTION
## Summary
- add group-chat prompt guidance to prefer bounded subagent/session-spawn delegation for directly requested multi-tool tasks
- keep the local agent on the critical path and explicitly avoid subagents for simple one-step work
- cover the guidance in group helper and composed prompt tests

## Why
In busy group chats, visible responsiveness matters. For tasks that need several independent lookups or tool calls, the prompt should nudge the agent to delegate side investigations early while preserving concise channel behavior.

## Validation
- `pnpm vitest run src/auto-reply/reply/groups.test.ts src/agents/prompt-composition.test.ts src/agents/system-prompt.test.ts`
- `pnpm format:check src/auto-reply/reply/groups.ts src/auto-reply/reply/groups.test.ts src/agents/prompt-composition.test.ts`
