### PR TITLE
[AI-assisted] fix(outbound): prefer agent account binding for message tool

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -729,9 +729,9 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         ).resolvedConfig;
       }
 
-      const accountId = readStringParam(params, "accountId") ?? agentAccountId;
-      if (accountId) {
-        params.accountId = accountId;
+      const explicitAccountId = readStringParam(params, "accountId");
+      if (explicitAccountId) {
+        params.accountId = explicitAccountId;
       }
 
       const gatewayResolved = resolveGatewayOptions({
@@ -776,7 +776,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         cfg,
         action,
         params,
-        defaultAccountId: accountId ?? undefined,
+        defaultAccountId: agentAccountId ?? undefined,
         requesterSenderId: options?.requesterSenderId,
         senderIsOwner: options?.senderIsOwner,
         gateway,

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1320,7 +1320,34 @@ describe("runMessageAction plugin dispatch", () => {
         },
         expectedAccountId: "account-b",
       },
-    ])("$name", async ({ args, expectedAccountId }) => {
+      {
+        name: "prefers agent binding over inherited default account",
+        args: {
+          cfg: {
+            bindings: [
+              { agentId: "agent-b", match: { channel: "accountchat", accountId: "account-b" } },
+            ],
+          } as OpenClawConfig,
+          defaultAccountId: "parent-account",
+          agentId: "agent-b",
+        },
+        expectedAccountId: "account-b",
+      },
+      {
+        name: "keeps explicit accountId over agent binding",
+        args: {
+          cfg: {
+            bindings: [
+              { agentId: "agent-b", match: { channel: "accountchat", accountId: "account-b" } },
+            ],
+          } as OpenClawConfig,
+          defaultAccountId: "parent-account",
+          agentId: "agent-b",
+        },
+        params: { accountId: "explicit-account" },
+        expectedAccountId: "explicit-account",
+      },
+    ])("$name", async ({ args, params, expectedAccountId }) => {
       await runMessageAction({
         ...args,
         action: "send",
@@ -1328,6 +1355,7 @@ describe("runMessageAction plugin dispatch", () => {
           channel: "accountchat",
           target: "channel:123",
           message: "hi",
+          ...params,
         },
       });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -933,7 +933,7 @@ export async function runMessageAction(
   });
 
   const channel = await resolveChannel(cfg, params, input.toolContext);
-  let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  let accountId = readStringParam(params, "accountId");
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);
     const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));
@@ -941,6 +941,7 @@ export async function runMessageAction(
       accountId = boundAccountIds[0];
     }
   }
+  accountId ??= input.defaultAccountId;
   if (accountId) {
     params.accountId = accountId;
   }


### PR DESCRIPTION
## Summary

- Preserves explicit `message` tool `accountId` overrides.
- Stops the tool wrapper from writing the inherited/default account into `params.accountId` when the caller omitted it.
- Resolves omitted-account message actions as explicit accountId first, calling-agent channel binding second, inherited/default account last.
- Adds regression coverage for the combined inherited/default-account plus calling-agent-binding case.

Closes #73619.

## Testing

- `node scripts/test-projects.mjs src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- `git diff --check`
- `corepack pnpm tsgo:core`
- `corepack pnpm tsgo:core:test`

## AI Assistance

AI-assisted with Codex. I understand the change: it keeps user-specified account IDs authoritative while letting an omitted `accountId` resolve to the calling agent's configured channel binding before falling back to inherited/default context.