### PR TITLE
[AI-assisted] fix(feishu): probe status with account credentials

### DIFF
--- a/extensions/feishu/src/setup-surface.test.ts
+++ b/extensions/feishu/src/setup-surface.test.ts
@@ -5,10 +5,18 @@ import {
   createTestWizardPrompter,
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeishuProbeResult } from "./types.js";
+
+const { probeFeishuMock } = vi.hoisted(() => ({
+  probeFeishuMock: vi.fn<() => Promise<FeishuProbeResult>>(async () => ({
+    ok: false,
+    error: "mocked",
+  })),
+}));
 
 vi.mock("./probe.js", () => ({
-  probeFeishu: vi.fn(async () => ({ ok: false, error: "mocked" })),
+  probeFeishu: probeFeishuMock,
 }));
 
 vi.mock("./app-registration.js", () => ({
@@ -69,6 +77,11 @@ const feishuConfigure = createPluginSetupWizardConfigure(feishuPlugin);
 const feishuGetStatus = createPluginSetupWizardStatus(feishuPlugin);
 
 describe("feishu setup wizard", () => {
+  beforeEach(() => {
+    probeFeishuMock.mockReset();
+    probeFeishuMock.mockResolvedValue({ ok: false, error: "mocked" });
+  });
+
   it("does not throw when config appId/appSecret are SecretRef objects", async () => {
     const text = vi
       .fn()
@@ -101,6 +114,11 @@ describe("feishu setup wizard", () => {
 });
 
 describe("feishu setup wizard status", () => {
+  beforeEach(() => {
+    probeFeishuMock.mockReset();
+    probeFeishuMock.mockResolvedValue({ ok: false, error: "mocked" });
+  });
+
   it("treats SecretRef appSecret as configured when appId is present", async () => {
     const status = await feishuGetStatus({
       cfg: {
@@ -119,6 +137,39 @@ describe("feishu setup wizard status", () => {
     });
 
     expect(status.configured).toBe(true);
+  });
+
+  it("probes the resolved default account in multi-account config", async () => {
+    probeFeishuMock.mockResolvedValueOnce({ ok: true, botName: "Feishu Main" });
+
+    const status = await feishuGetStatus({
+      cfg: {
+        channels: {
+          feishu: {
+            enabled: true,
+            defaultAccount: "main-bot",
+            accounts: {
+              "main-bot": {
+                appId: "cli_main",
+                appSecret: "main-app-secret", // pragma: allowlist secret
+                connectionMode: "websocket",
+              },
+            },
+          },
+        },
+      } as never,
+      ...baseStatusContext,
+    });
+
+    expect(status.configured).toBe(true);
+    expect(status.statusLines).toEqual(["Feishu: connected as Feishu Main"]);
+    expect(probeFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main-bot",
+        appId: "cli_main",
+        appSecret: "main-app-secret", // pragma: allowlist secret
+      }),
+    );
   });
 
   it("does not fallback to top-level appId when account explicitly sets empty appId", async () => {

--- a/extensions/feishu/src/setup-surface.ts
+++ b/extensions/feishu/src/setup-surface.ts
@@ -12,7 +12,7 @@ import {
   type OpenClawConfig,
   type SecretInput,
 } from "openclaw/plugin-sdk/setup";
-import { inspectFeishuCredentials, resolveDefaultFeishuAccountId } from "./accounts.js";
+import { resolveDefaultFeishuAccountId, resolveFeishuAccount } from "./accounts.js";
 import type { AppRegistrationResult } from "./app-registration.js";
 import type { FeishuConfig, FeishuDomain } from "./types.js";
 
@@ -517,14 +517,13 @@ export const feishuSetupWizard: ChannelSetupWizard = {
     configuredScore: 2,
     unconfiguredScore: 0,
     resolveConfigured: ({ cfg }) => isFeishuConfigured(cfg),
-    resolveStatusLines: async ({ cfg, configured }) => {
-      const feishuCfg = cfg.channels?.feishu as FeishuConfig | undefined;
-      const resolvedCredentials = inspectFeishuCredentials(feishuCfg);
+    resolveStatusLines: async ({ cfg, accountId, configured }) => {
+      const account = resolveFeishuAccount({ cfg, accountId });
       let probeResult = null;
-      if (configured && resolvedCredentials) {
+      if (configured && account.configured) {
         try {
           const { probeFeishu } = await import("./probe.js");
-          probeResult = await probeFeishu(resolvedCredentials);
+          probeResult = await probeFeishu(account);
         } catch {}
       }
       if (!configured) {


### PR DESCRIPTION
## Summary

- Resolves Feishu setup/status probes through the configured account, not only top-level `channels.feishu` credentials.
- Allows multi-account Feishu configs with `defaultAccount` and `accounts.*.appId/appSecret` to report and verify the resolved account.
- Adds regression coverage for account-scoped Feishu status probing.

Closes #72930.

## Testing

- `node scripts/test-projects.mjs extensions/feishu/src/setup-surface.test.ts`
- `corepack pnpm exec oxlint extensions/feishu/src/setup-surface.ts extensions/feishu/src/setup-surface.test.ts`
- `corepack pnpm exec oxfmt --check extensions/feishu/src/setup-surface.ts extensions/feishu/src/setup-surface.test.ts`
- `git diff --check`
- `corepack pnpm tsgo:core`
- `corepack pnpm lint`

## AI Assistance

AI-assisted with Codex. I understand the change: Feishu status now uses the same resolved account credential shape that runtime/probe paths already use, so account-scoped credentials are not skipped by setup/status verification.