### PR TITLE
fix(cli): handle uv_cwd error when working directory is deleted

### DIFF
--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -2,9 +2,19 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
 
+function safeProcessCwd(): string {
+  try {
+    return process.cwd();
+  } catch (error) {
+    // If cwd is deleted, uv_cwd throws. Return a fallback path that won't have .env.
+    // The error will be surfaced earlier in run-main.ts shouldLoadCliDotEnv().
+    return process.env.HOME ?? process.env.USERPROFILE ?? "/";
+  }
+}
+
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
+  const cwdEnvPath = path.join(safeProcessCwd(), ".env");
   loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
 
   // Then load the global fallback set without overriding any env vars that

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -1,16 +1,7 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
-
-function safeProcessCwd(): string {
-  try {
-    return process.cwd();
-  } catch (error) {
-    // If cwd is deleted, uv_cwd throws. Return a fallback path that won't have .env.
-    // The error will be surfaced earlier in run-main.ts shouldLoadCliDotEnv().
-    return process.env.HOME ?? process.env.USERPROFILE ?? "/";
-  }
-}
+import { safeProcessCwd } from "./utils/cwd.js";
 
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -216,18 +216,7 @@ export function resolveMissingPluginCommandMessage(
   );
 }
 
-function safeProcessCwd(): string {
-  try {
-    return process.cwd();
-  } catch (error) {
-    const message =
-      error instanceof Error && error.message.includes("uv_cwd")
-        ? "Current working directory has been deleted. Please cd to a valid directory before running openclaw."
-        : `Failed to resolve current working directory: ${error instanceof Error ? error.message : String(error)}`;
-    console.error(`[openclaw] Error: ${message}`);
-    process.exit(1);
-  }
-}
+import { safeProcessCwd } from "./utils/cwd.js";
 
 function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   if (existsSync(path.join(safeProcessCwd(), ".env"))) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -216,8 +216,21 @@ export function resolveMissingPluginCommandMessage(
   );
 }
 
+function safeProcessCwd(): string {
+  try {
+    return process.cwd();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.includes("uv_cwd")
+        ? "Current working directory has been deleted. Please cd to a valid directory before running openclaw."
+        : `Failed to resolve current working directory: ${error instanceof Error ? error.message : String(error)}`;
+    console.error(`[openclaw] Error: ${message}`);
+    process.exit(1);
+  }
+}
+
 function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (existsSync(path.join(process.cwd(), ".env"))) {
+  if (existsSync(path.join(safeProcessCwd(), ".env"))) {
     return true;
   }
   return existsSync(path.join(resolveStateDir(env), ".env"));

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -16,6 +16,7 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { resolveOptionFromCommand } from "./cli-utils.js";
+import { safeProcessCwdOptional } from "./utils/cwd.js";
 import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
 
 export type {
@@ -34,15 +35,6 @@ type ResolveSkillsWorkspaceOptions = {
   cwd?: string;
 };
 
-function safeProcessCwd(): string | undefined {
-  try {
-    return process.cwd();
-  } catch {
-    // If cwd is deleted, uv_cwd throws. Return undefined to use default agent.
-    return undefined;
-  }
-}
-
 function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   config: ReturnType<typeof getRuntimeConfig>;
   workspaceDir: string;
@@ -51,7 +43,7 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   const explicitAgentId = normalizeOptionalString(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
-    : resolveAgentIdByWorkspacePath(config, options?.cwd ?? safeProcessCwd());
+    : resolveAgentIdByWorkspacePath(config, options?.cwd ?? safeProcessCwdOptional());
   const agentId = explicitAgentId ?? inferredAgentId ?? resolveDefaultAgentId(config);
   return {
     config,

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -34,6 +34,15 @@ type ResolveSkillsWorkspaceOptions = {
   cwd?: string;
 };
 
+function safeProcessCwd(): string | undefined {
+  try {
+    return process.cwd();
+  } catch {
+    // If cwd is deleted, uv_cwd throws. Return undefined to use default agent.
+    return undefined;
+  }
+}
+
 function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   config: ReturnType<typeof getRuntimeConfig>;
   workspaceDir: string;
@@ -42,7 +51,7 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   const explicitAgentId = normalizeOptionalString(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
-    : resolveAgentIdByWorkspacePath(config, options?.cwd ?? process.cwd());
+    : resolveAgentIdByWorkspacePath(config, options?.cwd ?? safeProcessCwd());
   const agentId = explicitAgentId ?? inferredAgentId ?? resolveDefaultAgentId(config);
   return {
     config,

--- a/src/cli/utils/cwd.ts
+++ b/src/cli/utils/cwd.ts
@@ -1,0 +1,33 @@
+/**
+ * Safe wrapper for process.cwd() that handles uv_cwd error when directory is deleted.
+ */
+
+/**
+ * Get cwd, exit with error message if it fails.
+ * Use when cwd is required (run-main, dotenv).
+ */
+export function safeProcessCwd(): string {
+  try {
+    return process.cwd();
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.includes("uv_cwd")
+        ? "Current working directory has been deleted. Please cd to a valid directory before running openclaw."
+        : `Failed to resolve current working directory: ${error instanceof Error ? error.message : String(error)}`;
+    console.error(`[openclaw] Error: ${message}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Get cwd, return undefined if it fails.
+ * Use when cwd is optional (skills-cli).
+ */
+export function safeProcessCwdOptional(): string | undefined {
+  try {
+    return process.cwd();
+  } catch {
+    // If cwd is deleted, uv_cwd throws. Return undefined to use default.
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #73676

CLI now gracefully handles the `uv_cwd` error that occurs when the current working directory has been deleted before running `openclaw` commands.

## Changes

- **run-main.ts**: Add `safeProcessCwd()` that catches `uv_cwd` error and exits with a clear message:
  ```
  Current working directory has been deleted. Please cd to a valid directory before running openclaw.
  ```
- **dotenv.ts**: Add `safeProcessCwd()` fallback to HOME if cwd is deleted (error already surfaced in `run-main.ts shouldLoadCliDotEnv()`)
- **skills-cli.ts**: Add `safeProcessCwd()` that returns `undefined` to use default agent if cwd is deleted

## Testing

Manually tested by:
1. Creating and entering a directory: `mkdir test-dir && cd test-dir`
2. Deleting the directory from another shell: `rm -rf ../test-dir`
3. Running `openclaw tui` - now shows clear error message instead of crash

## Security

No security implications. Purely error handling improvement for better UX.

## Notes

- Pattern follows existing error handling in `run-main.ts` (using `console.error` and `process.exit(1)`)
- Error message matches similar cwd issues in other CLIs (npm, etc.)
- Fallback paths use HOME/USERPROFILE or "/" as safe defaults