### PR TITLE
ci: shard web media codeql quality

### DIFF
--- a/.github/codeql/codeql-web-media-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-web-media-runtime-boundary-critical-quality.yml
@@ -1,0 +1,39 @@
+name: openclaw-codeql-web-media-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/web-fetch
+  - src/web-search
+  - src/web/provider-runtime-shared.ts
+  - src/media
+  - src/media-understanding
+  - src/image-generation
+  - src/media-generation
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -144,6 +144,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/ui-control-plane"
 
+  web-media-runtime-boundary:
+    name: Critical Quality (web-media-runtime-boundary)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-web-media-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/web-media-runtime-boundary"
+
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -287,6 +287,9 @@ the separate `/codeql-critical-quality/agent-runtime-boundary` category. The
 ui-control-plane job scans Control UI bootstrap, local persistence, gateway
 control flows, and task control-plane runtime contracts under the separate
 `/codeql-critical-quality/ui-control-plane` category. The
+web-media-runtime-boundary job scans core web fetch/search, media IO, media
+understanding, image-generation, and media-generation runtime contracts under
+the separate `/codeql-critical-quality/web-media-runtime-boundary` category. The
 plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
 entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
 category. Keep the workflow separate from security so quality findings can be


### PR DESCRIPTION
## Summary

- Problem: the non-security CodeQL quality workflow still needs narrow, independently measurable runtime shards before we scale it wider.
- Why it matters: web fetch/search and media runtime boundaries handle external IO, provider dispatch, file/media normalization, and payload shaping; they deserve quality signal without pulling in plugins, Swift, or Python noise.
- What changed: added a `web-media-runtime-boundary` Critical Quality job and config for core web/media JavaScript/TypeScript runtime paths.
- What did NOT change (scope boundary): no security query expansion, no Swift/Python/bundled-plugin scan, no runtime behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #70079
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: the quality rollout did not yet have a separate web/media runtime shard.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/codeql-critical-quality.yml`
- Scenario the test should lock in: CodeQL can initialize and analyze the new web/media runtime quality category independently.
- Why this is the smallest reliable guardrail: this is workflow/config-only; the actual guardrail is the CodeQL run for the new category.
- Existing test that already covers this (if any): `pnpm check:workflows`
- If no new test is added, why not: no runtime behavior changed.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS maintainer worktree
- Runtime/container: Node 22 / pnpm via repo tooling
- Model/provider: N/A
- Integration/channel (if any): GitHub CodeQL / Blacksmith runner
- Relevant config (redacted): N/A

### Steps

1. Parse the workflow and new CodeQL config as YAML.
2. Run repository workflow sanity checks.
3. Dispatch CodeQL Critical Quality on this branch.

### Expected

- Workflow/config parse cleanly.
- Workflow sanity passes.
- CodeQL uploads a separate `/codeql-critical-quality/web-media-runtime-boundary` category.

### Actual

- Local workflow/config checks pass. Branch CodeQL pending after PR creation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: YAML parse, whitespace diff check, `pnpm check:workflows`.
- Edge cases checked: shard scope excludes plugins, Swift, Python, generated/bundle/test/mock/fixture files.
- What you did **not** verify: branch CodeQL result is pending and will be checked before ready/merge.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the new shard may surface existing quality findings.
  - Mitigation: keep the PR draft until the branch CodeQL run is reviewed and remediate narrow findings in follow-up commits before merge.
