### PR TITLE
perf(agents/tools): lazily list capability providers in tool model-config resolution

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -199,7 +199,7 @@ export function resolveImageGenerationModelConfigForTool(params: {
     cfg: params.cfg,
     agentDir: params.agentDir,
     modelConfig: params.cfg?.agents?.defaults?.imageGenerationModel,
-    providers: listRuntimeImageGenerationProviders({ config: params.cfg }),
+    providers: () => listRuntimeImageGenerationProviders({ config: params.cfg }),
   });
 }
 

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveMediaToolLocalRoots, resolveModelFromRegistry } from "./media-tool-shared.js";
+import {
+  resolveCapabilityModelConfigForTool,
+  resolveMediaToolLocalRoots,
+  resolveModelFromRegistry,
+} from "./media-tool-shared.js";
 
 function normalizeHostPath(value: string): string {
   return path.normalize(path.resolve(value));
@@ -97,4 +101,36 @@ describe("resolveModelFromRegistry", () => {
     ]);
     expect(result).toBe(foundModel);
   }, 180_000);
+});
+
+describe("resolveCapabilityModelConfigForTool", () => {
+  it("does not invoke the providers thunk when an explicit modelConfig resolves", () => {
+    // Regression: tools previously listed runtime providers eagerly even
+    // when the explicit modelConfig was complete and the provider list was
+    // unused. On hosted gateways with `plugins.entries` populated, listing
+    // providers triggers a full plugin-registry reload (~5–6s per call).
+    const providersThunk = vi.fn(() => []);
+
+    const result = resolveCapabilityModelConfigForTool({
+      cfg: { agents: { defaults: {} } } as never,
+      modelConfig: { primary: "openai/gpt-image-1" },
+      providers: providersThunk,
+    });
+
+    expect(result).toEqual({ primary: "openai/gpt-image-1" });
+    expect(providersThunk).not.toHaveBeenCalled();
+  });
+
+  it("invokes the providers thunk when modelConfig is incomplete", () => {
+    const providersThunk = vi.fn(() => []);
+
+    const result = resolveCapabilityModelConfigForTool({
+      cfg: { agents: { defaults: {} } } as never,
+      modelConfig: undefined,
+      providers: providersThunk,
+    });
+
+    expect(result).toBeNull();
+    expect(providersThunk).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -247,23 +247,36 @@ export function resolveCapabilityModelConfigForTool(params: {
   cfg?: OpenClawConfig;
   agentDir?: string;
   modelConfig?: AgentModelConfig;
-  providers: CapabilityProvider[];
+  /**
+   * Lazy provider list. Only invoked when the explicit `modelConfig` is
+   * incomplete and the function falls through to candidate resolution.
+   *
+   * Listing capability providers can trigger a full plugin-registry reload
+   * (see `resolvePluginCapabilityProviders` in `plugins/capability-provider-runtime`),
+   * which on a hosted gateway with `plugins.entries` populated costs ~5–6s
+   * per call. When the agent has an explicit and complete `modelConfig`,
+   * providers are unused — invoking the thunk would be pure waste. Tools
+   * that resolve a model config for image / video / music / TTS / etc.
+   * generation pass a thunk so the listing is deferred.
+   */
+  providers: () => CapabilityProvider[];
 }): ToolModelConfig | null {
   const explicit = coerceToolModelConfig(params.modelConfig);
   if (hasToolModelConfig(explicit)) {
     return explicit;
   }
+  const providers = params.providers();
   return buildToolModelConfigFromCandidates({
     explicit,
     agentDir: params.agentDir,
     candidates: resolveCapabilityModelCandidatesForTool({
       cfg: params.cfg,
       agentDir: params.agentDir,
-      providers: params.providers,
+      providers,
     }),
     isProviderConfigured: (providerId) =>
       isCapabilityProviderConfigured({
-        providers: params.providers,
+        providers,
         providerId,
         cfg: params.cfg,
         agentDir: params.agentDir,

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -135,7 +135,7 @@ export function resolveMusicGenerationModelConfigForTool(params: {
     cfg: params.cfg,
     agentDir: params.agentDir,
     modelConfig: params.cfg?.agents?.defaults?.musicGenerationModel,
-    providers: listRuntimeMusicGenerationProviders({ config: params.cfg }),
+    providers: () => listRuntimeMusicGenerationProviders({ config: params.cfg }),
   });
 }
 

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -229,7 +229,7 @@ export function resolveVideoGenerationModelConfigForTool(params: {
     cfg: params.cfg,
     agentDir: params.agentDir,
     modelConfig: params.cfg?.agents?.defaults?.videoGenerationModel,
-    providers: listRuntimeVideoGenerationProviders({ config: params.cfg }),
+    providers: () => listRuntimeVideoGenerationProviders({ config: params.cfg }),
   });
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `resolveCapabilityModelConfigForTool` (`src/agents/tools/media-tool-shared.ts:246`) takes `providers: CapabilityProvider[]` as a required eagerly-evaluated parameter, and short-circuits via `hasToolModelConfig(explicit)` *after* the caller has already computed the provider list. The 3 callers (`image-generate-tool.ts:202`, `video-generate-tool.ts:232`, `music-generate-tool.ts:138`) call `listRuntime{Image,Video,Music}GenerationProviders({ config: cfg })` eagerly. On hosted gateways with `plugins.entries` populated, each provider listing triggers a full plugin-registry reload through `resolvePluginCapabilityProviders → loadOpenClawPlugins` (~5–6s per call).
- **Why it matters:** For agents with an explicit, complete `modelConfig` for image / video / music generation, the provider list is pure waste — `resolveCapabilityModelConfigForTool` returns at the `hasToolModelConfig(explicit)` check without using it. With 3 generation tools registered on every agent, that's ~15–18s of wasted wall-clock per turn on hosted gateways. Repro and instrumented stack traces in #74096.
- **What changed:** `providers` is now `() => CapabilityProvider[]` (a thunk). It's only invoked when the function falls through to candidate resolution (i.e. when `modelConfig` is incomplete). The 3 internal callers pass thunks. Two regression tests added in `media-tool-shared.test.ts`.
- **What did NOT change (scope boundary):** Behavior when `modelConfig` is incomplete (still lists providers and resolves candidates). The provider listing logic itself (`listRuntime{Image,Video,Music}GenerationProviders`). The capability-provider runtime's caching behavior (separate concern, see #73793). All existing image/video/music tool tests pass unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #74096
- Related #73793 (independent capability-provider cache fix; this PR helps even without that one)
- [x] This PR fixes a bug or regression

## Root Cause

`resolveCapabilityModelConfigForTool` short-circuits via `hasToolModelConfig(explicit)` before using the provider list, but the provider list is computed by callers *before* calling the function. The eager evaluation was the natural choice when the helper was first written, but on hosted gateways it has a hidden cost of ~5–6s per call because `listRuntime*GenerationProviders` triggers a plugin-registry reload (see #73793 for the deeper cache-miss issue on the registry side). Making the parameter lazy lets the helper choose to evaluate it only when needed.

## Tests

- Added 2 tests in `src/agents/tools/media-tool-shared.test.ts`:
  - `does not invoke the providers thunk when an explicit modelConfig resolves`
  - `invokes the providers thunk when modelConfig is incomplete`
- All 116 existing tests in `image-generate-tool.test.ts` / `video-generate-tool.test.ts` / `music-generate-tool.test.ts` pass.

## Verification

```
$ pnpm vitest run src/agents/tools/media-tool-shared.test.ts \
                  src/agents/tools/image-generate-tool.test.ts \
                  src/agents/tools/video-generate-tool.test.ts \
                  src/agents/tools/music-generate-tool.test.ts
 Test Files  6 passed (6)
      Tests  116 passed (116)
```
