### PR TITLE
fix(cron): catch croner TypeError/RangeError in add/update and return INVALID_REQUEST

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -242,7 +242,17 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate);
+    let job;
+    try {
+      job = await context.cron.add(jobCreate);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `invalid cron.add: ${formatErrorMessage(err)}`),
+      );
+      return;
+    }
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -321,7 +331,17 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.update(jobId, patch);
+    let job;
+    try {
+      job = await context.cron.update(jobId, patch);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `invalid cron.update: ${formatErrorMessage(err)}`),
+      );
+      return;
+    }
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);
   },


### PR DESCRIPTION
Fix #74066: Wrap `context.cron.add()` and `context.cron.update()` in try-catch to intercept croner library throws and map them to `ErrorCodes.INVALID_REQUEST` instead of letting them escape as `UNAVAILABLE`.