### PR TITLE
fix(announce): accept ANNOUNCE_SKIP on its own line in multi-line output

### DIFF
--- a/src/agents/tools/sessions-send-tokens.ts
+++ b/src/agents/tools/sessions-send-tokens.ts
@@ -2,7 +2,8 @@ export const ANNOUNCE_SKIP_TOKEN = "ANNOUNCE_SKIP";
 export const REPLY_SKIP_TOKEN = "REPLY_SKIP";
 
 export function isAnnounceSkip(text?: string) {
-  return (text ?? "").trim() === ANNOUNCE_SKIP_TOKEN;
+  const t = (text ?? "").trim();
+  return t === ANNOUNCE_SKIP_TOKEN || t.endsWith("\n" + ANNOUNCE_SKIP_TOKEN);
 }
 
 export function isReplySkip(text?: string) {


### PR DESCRIPTION
Before: strict equality `trim() === ANNOUNCE_SKIP_TOKEN` only matched when the entire output was the token.\n\nAfter: also matches when the trimmed text ends with a newline followed by `ANNOUNCE_SKIP` (the common case when sub-agents produce a summary followed by ANNOUNCE_SKIP on its own line).\n\nFix #74071