### PR TITLE
fix media timeout propagation

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -105,6 +105,7 @@ describe("createOllamaStreamFn thinking events", () => {
 
   async function streamOllamaEvents(
     chunks: Array<Record<string, unknown>>,
+    options: Parameters<ReturnType<typeof createOllamaStreamFn>>[2] = {},
   ): Promise<Array<{ type: string; [key: string]: unknown }>> {
     const body = makeNdjsonBody(chunks);
     fetchWithSsrFGuardMock.mockResolvedValue({
@@ -116,7 +117,7 @@ describe("createOllamaStreamFn thinking events", () => {
     const stream = streamFn(
       { api: "ollama", provider: "ollama", id: "qwen3.5", contextWindow: 65536 } as never,
       { messages: [{ role: "user", content: "test" }] } as never,
-      {},
+      options,
     );
 
     const events: Array<{ type: string; [key: string]: unknown }> = [];
@@ -223,5 +224,15 @@ describe("createOllamaStreamFn thinking events", () => {
 
     const textStart = events.find((e) => e.type === "text_start") as { contentIndex?: number };
     expect(textStart?.contentIndex).toBe(0);
+  });
+
+  it("uses generic stream timeout for Ollama request timeout", async () => {
+    await streamOllamaEvents([makeOllamaResponse({ content: "ok" })], { timeoutMs: 2500 });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 2500,
+      }),
+    );
   });
 });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -938,10 +938,12 @@ function resolveOllamaModelHeaders(model: {
 
 function resolveOllamaRequestTimeoutMs(
   model: object,
-  options: { requestTimeoutMs?: unknown } | undefined,
+  options: { requestTimeoutMs?: unknown; timeoutMs?: unknown } | undefined,
 ): number | undefined {
   const raw =
-    options?.requestTimeoutMs ?? (model as { requestTimeoutMs?: unknown }).requestTimeoutMs;
+    options?.requestTimeoutMs ??
+    options?.timeoutMs ??
+    (model as { requestTimeoutMs?: unknown }).requestTimeoutMs;
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : undefined;
 }
 
@@ -1004,7 +1006,7 @@ export function createOllamaStreamFn(
           policy: ssrfPolicy,
           timeoutMs: resolveOllamaRequestTimeoutMs(
             model,
-            options as { requestTimeoutMs?: unknown } | undefined,
+            options as { requestTimeoutMs?: unknown; timeoutMs?: unknown } | undefined,
           ),
           auditContext: "ollama-stream.chat",
         });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -551,6 +551,7 @@ describe("describeImageWithModel", () => {
     await assertion;
     const [, , options] = completeMock.mock.calls[0] ?? [];
     expect(options?.signal?.aborted).toBe(true);
+    expect(options?.timeoutMs).toBe(25);
   });
 
   it("rejects when image runtime setup exceeds the request timeout", async () => {

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -401,13 +401,15 @@ async function describeImagesWithModelInternal(
   const maxTokens = resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512);
   const completeImage = async (onPayload?: ProviderStreamOptions["onPayload"]) => {
     const payloadHandler = composeImageDescriptionPayloadHandlers(onPayload, options.onPayload);
+    const timeoutMs = resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs);
     return await withImageDescriptionTimeout({
       controller,
-      timeoutMs: resolveImageDescriptionTimeoutMs(params.timeoutMs, startedAtMs),
+      timeoutMs,
       task: complete(model, context, {
         apiKey,
         maxTokens,
         signal: controller.signal,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
         ...(payloadHandler ? { onPayload: payloadHandler } : {}),
       }),
     });


### PR DESCRIPTION
## Summary
- pass image understanding timeouts into provider request options
- make Ollama native streams honor the generic provider timeout
- cover timeout forwarding in media and Ollama stream tests

## Verification
- pnpm test src/media-understanding/image.test.ts extensions/ollama/src/stream.test.ts
