### PR TITLE
ci: rename codeql quality baseline shard

### DIFF
--- a/.github/codeql/codeql-core-auth-secrets-critical-quality.yml
+++ b/.github/codeql/codeql-core-auth-secrets-critical-quality.yml
@@ -1,4 +1,4 @@
-name: openclaw-codeql-javascript-typescript-critical-quality
+name: openclaw-codeql-core-auth-secrets-critical-quality
 
 disable-default-queries: true
 

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -18,8 +18,8 @@ permissions:
   security-events: write
 
 jobs:
-  javascript-typescript:
-    name: Critical Quality (javascript-typescript)
+  core-auth-secrets:
+    name: Critical Quality (core-auth-secrets)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -32,12 +32,12 @@ jobs:
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: javascript-typescript
-          config-file: ./.github/codeql/codeql-javascript-typescript-critical-quality.yml
+          config-file: ./.github/codeql/codeql-core-auth-secrets-critical-quality.yml
 
       - name: Analyze
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
-          category: "/codeql-critical-quality/javascript-typescript"
+          category: "/codeql-critical-quality/core-auth-secrets"
 
   config-boundary:
     name: Critical Quality (config-boundary)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -272,8 +272,9 @@ default workflow because the macOS build dominates runtime even when clean.
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
-baseline job scans the same auth, secrets, sandbox, cron, and gateway surface
-as the security workflow. The config-boundary
+core-auth-secrets job scans auth, secrets, sandbox, cron, and gateway security
+boundary code under the separate `/codeql-critical-quality/core-auth-secrets`
+category. The config-boundary
 job scans config schema, migration, normalization, and IO contracts under the
 separate `/codeql-critical-quality/config-boundary` category. The
 gateway-runtime-boundary job scans gateway protocol schemas and server method


### PR DESCRIPTION
## Summary

- Problem: the CodeQL Critical Quality baseline shard is named by language (`javascript-typescript`), so GitHub code scanning surfaces old error-severity quality history under a vague language bucket.
- Why it matters: the rollout is supposed to be surface-area based. Language-named categories make the GH UI look like a broad/default language scan instead of a narrow auth/secrets/sandbox quality shard.
- What changed: renamed the quality baseline job/config/category to `core-auth-secrets`.
- What did NOT change (scope boundary): no query broadening, no runtime behavior changes, no security workflow changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #74091
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: the first quality baseline kept its language-style category after the rollout moved to surface-area shards.
- Contributing context (if known): GitHub code scanning UI keeps showing historical error-severity quality alerts under that language bucket even after they are fixed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/codeql-critical-quality.yml`
- Scenario the test should lock in: CodeQL initializes and uploads the baseline quality shard as `/codeql-critical-quality/core-auth-secrets`.
- Why this is the smallest reliable guardrail: this is workflow/config-only; the real proof is a CodeQL run on the renamed category.
- Existing test that already covers this (if any): `pnpm check:workflows`
- If no new test is added, why not: no runtime behavior changed.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS maintainer worktree
- Runtime/container: Node 22 / pnpm via repo tooling
- Model/provider: N/A
- Integration/channel (if any): GitHub CodeQL / Blacksmith runner
- Relevant config (redacted): N/A

### Steps

1. Parse the workflow and renamed CodeQL config as YAML.
2. Run repository workflow sanity checks.
3. Dispatch CodeQL Critical Quality on this branch.

### Expected

- Workflow/config parse cleanly.
- Workflow sanity passes.
- CodeQL uploads `/codeql-critical-quality/core-auth-secrets` instead of the language-named `/codeql-critical-quality/javascript-typescript` category.

### Actual

- Local workflow/config checks pass. Branch CodeQL pending after PR creation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: YAML parse, whitespace diff check, stale repo references removed, `pnpm check:workflows`.
- Edge cases checked: security workflow category remains unchanged; this PR only renames the non-security quality baseline shard.
- What you did **not** verify: branch CodeQL result is pending and will be checked before ready/merge.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: GitHub will retain old fixed alerts under the old language category in history.
  - Mitigation: future analyses use the surface-area category so current UI/check signal no longer registers the baseline as a language bucket.
