### PR TITLE
feat(agents): add OPENCLAW_LOG_ABORT_SOURCES diagnostic for embedded run aborts

### DIFF
--- a/src/agents/pi-embedded-runner/run/abort-source-log.test.ts
+++ b/src/agents/pi-embedded-runner/run/abort-source-log.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { log } from "../logger.js";
+import {
+  classifyAbortSource,
+  isAbortSourceLoggingEnabled,
+  logAbortSource,
+} from "./abort-source-log.js";
+
+const baseCtx = {
+  runId: "run-1",
+  sessionId: "session-1",
+  isTimeout: false,
+  externalAbort: false,
+  idleTimedOut: false,
+  timedOutDuringCompaction: false,
+  reason: undefined,
+};
+
+describe("classifyAbortSource", () => {
+  it("prefers external signal over any timeout flag", () => {
+    expect(
+      classifyAbortSource({
+        ...baseCtx,
+        externalAbort: true,
+        isTimeout: true,
+        idleTimedOut: true,
+      }),
+    ).toBe("external-signal");
+  });
+
+  it("flags llm-idle-timeout when idle wrapper fired", () => {
+    expect(classifyAbortSource({ ...baseCtx, isTimeout: true, idleTimedOut: true })).toBe(
+      "llm-idle-timeout",
+    );
+  });
+
+  it("flags compaction-timeout when compaction guard fired", () => {
+    expect(
+      classifyAbortSource({
+        ...baseCtx,
+        isTimeout: true,
+        timedOutDuringCompaction: true,
+      }),
+    ).toBe("compaction-timeout");
+  });
+
+  it("falls back to run-timer for unattributed timeout", () => {
+    expect(classifyAbortSource({ ...baseCtx, isTimeout: true })).toBe("run-timer");
+  });
+
+  it("classifies a non-timeout abort as explicit-cancel", () => {
+    expect(classifyAbortSource(baseCtx)).toBe("explicit-cancel");
+  });
+});
+
+describe("isAbortSourceLoggingEnabled", () => {
+  const original = process.env.OPENCLAW_LOG_ABORT_SOURCES;
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.OPENCLAW_LOG_ABORT_SOURCES;
+    } else {
+      process.env.OPENCLAW_LOG_ABORT_SOURCES = original;
+    }
+  });
+
+  it("is false when env var is unset", () => {
+    delete process.env.OPENCLAW_LOG_ABORT_SOURCES;
+    expect(isAbortSourceLoggingEnabled()).toBe(false);
+  });
+
+  it("is true when env var is truthy", () => {
+    process.env.OPENCLAW_LOG_ABORT_SOURCES = "1";
+    expect(isAbortSourceLoggingEnabled()).toBe(true);
+  });
+
+  it("is false when env var is empty string", () => {
+    process.env.OPENCLAW_LOG_ABORT_SOURCES = "";
+    expect(isAbortSourceLoggingEnabled()).toBe(false);
+  });
+});
+
+describe("logAbortSource", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  const original = process.env.OPENCLAW_LOG_ABORT_SOURCES;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    if (original === undefined) {
+      delete process.env.OPENCLAW_LOG_ABORT_SOURCES;
+    } else {
+      process.env.OPENCLAW_LOG_ABORT_SOURCES = original;
+    }
+  });
+
+  it("emits nothing when gating env var is unset", () => {
+    delete process.env.OPENCLAW_LOG_ABORT_SOURCES;
+    logAbortSource({ ...baseCtx, isTimeout: true, idleTimedOut: true });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits a warn line tagged with classified source when enabled", () => {
+    process.env.OPENCLAW_LOG_ABORT_SOURCES = "1";
+    logAbortSource({
+      ...baseCtx,
+      isTimeout: true,
+      idleTimedOut: true,
+      reason: new Error("idle limit"),
+    });
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const message = warnSpy.mock.calls[0]?.[0] ?? "";
+    expect(message).toContain("[abort-source]");
+    expect(message).toContain("source=llm-idle-timeout");
+    expect(message).toContain("runId=run-1");
+    expect(message).toContain("reason=Error: idle limit");
+    expect(message).toContain("stack=");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/abort-source-log.ts
+++ b/src/agents/pi-embedded-runner/run/abort-source-log.ts
@@ -1,0 +1,76 @@
+import { isTruthyEnvValue } from "../../../infra/env.js";
+import { log } from "../logger.js";
+
+export type AbortSource =
+  | "external-signal"
+  | "llm-idle-timeout"
+  | "compaction-timeout"
+  | "run-timer"
+  | "explicit-cancel";
+
+export interface AbortSourceContext {
+  runId: string;
+  sessionId: string;
+  isTimeout: boolean;
+  externalAbort: boolean;
+  idleTimedOut: boolean;
+  timedOutDuringCompaction: boolean;
+  reason: unknown;
+}
+
+export function isAbortSourceLoggingEnabled(): boolean {
+  return isTruthyEnvValue(process.env.OPENCLAW_LOG_ABORT_SOURCES);
+}
+
+export function classifyAbortSource(ctx: AbortSourceContext): AbortSource {
+  if (ctx.externalAbort) return "external-signal";
+  if (ctx.idleTimedOut) return "llm-idle-timeout";
+  if (ctx.timedOutDuringCompaction) return "compaction-timeout";
+  if (ctx.isTimeout) return "run-timer";
+  return "explicit-cancel";
+}
+
+function formatReason(reason: unknown): string {
+  if (reason === undefined) return "<none>";
+  if (reason instanceof Error) {
+    return `${reason.name}: ${reason.message}`;
+  }
+  if (typeof reason === "string") return reason;
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+function captureCallerStack(): string {
+  // Frames: [0] "Error", [1] captureCallerStack, [2] logAbortSource, [3..] caller chain.
+  const stack = new Error().stack;
+  if (!stack) return "<unavailable>";
+  return stack
+    .split("\n")
+    .slice(3, 8)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" | ");
+}
+
+/**
+ * Emit a structured log line describing the cause of a mid-run abort.
+ *
+ * Gated by `OPENCLAW_LOG_ABORT_SOURCES=1` so production logs stay clean.
+ * The category + caller stack lets operators distinguish an external
+ * AbortSignal from internal run/idle/compaction timers when triaging
+ * mysterious mid-stream cutoffs that surface only as a generic AbortError.
+ */
+export function logAbortSource(ctx: AbortSourceContext): void {
+  if (!isAbortSourceLoggingEnabled()) return;
+  const source = classifyAbortSource(ctx);
+  const stack = captureCallerStack();
+  log.warn(
+    `[abort-source] runId=${ctx.runId} sessionId=${ctx.sessionId} ` +
+      `source=${source} isTimeout=${ctx.isTimeout} ` +
+      `idleTimeout=${ctx.idleTimedOut} compactionTimeout=${ctx.timedOutDuringCompaction} ` +
+      `external=${ctx.externalAbort} reason=${formatReason(ctx.reason)} stack=${stack}`,
+  );
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -227,6 +227,7 @@ import {
 import { splitSdkTools } from "../tool-split.js";
 import { mapThinkingLevel } from "../utils.js";
 import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.js";
+import { logAbortSource } from "./abort-source-log.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import {
@@ -2003,6 +2004,15 @@ export async function runEmbeddedAttempt(
         }
       };
       const abortRun = (isTimeout = false, reason?: unknown) => {
+        logAbortSource({
+          runId: params.runId,
+          sessionId: params.sessionId,
+          isTimeout,
+          externalAbort,
+          idleTimedOut,
+          timedOutDuringCompaction,
+          reason,
+        });
         aborted = true;
         if (isTimeout) {
           timedOut = true;


### PR DESCRIPTION
## Summary

Add an opt-in structured diagnostic for embedded run aborts. Gated by env var `OPENCLAW_LOG_ABORT_SOURCES=1`; default off (no behavior change). When enabled, every `abortRun()` entry in `src/agents/pi-embedded-runner/run/attempt.ts` emits a `[abort-source]` line classifying the trigger and capturing five caller stack frames.

No linked upstream issue — this PR adds a missing operator-facing observability seam. Filing it because we hit the gap during real triage and want a first-class hook so the next operator doesn't have to dist-patch.

## Problem

When an embedded agent run aborts mid-stream, the user-visible signal is a generic `AbortError("This operation was aborted")`. Five different paths can trip the abort:

- External `params.abortSignal` from the caller
- `scheduleAbortTimer` (run-level timer firing on `params.timeoutMs`)
- `idleTimeoutTrigger` (LLM idle wrapper)
- Compaction guard (`shouldFlagCompactionTimeout` path)
- Public `cancel()` API

There is no log line distinguishing them. Operators triaging unexpected mid-stream cutoffs end up grepping bundled dist code, hand-instrumenting `console.warn(new Error().stack)` into `selection-*.js:abortRun`, redeploying, and waiting for another reproduction. We just walked through that loop on a real ~13s cutoff in our deployment.

## Change

`src/agents/pi-embedded-runner/run/abort-source-log.ts` (new, 76 LOC):

- `isAbortSourceLoggingEnabled()` reads the env var via existing `isTruthyEnvValue` helper.
- `classifyAbortSource(ctx)` returns a discriminated union over five categories: `external-signal | llm-idle-timeout | compaction-timeout | run-timer | explicit-cancel`. Priority order matches actual abort semantics (external signal beats internal flags).
- `logAbortSource(ctx)` formats the line via the existing `agent/embedded` subsystem logger when gated.

`src/agents/pi-embedded-runner/run/attempt.ts`: 1-line import + 9-line call at the head of the `abortRun` closure. Captures `runId`, `sessionId`, the four state flags (`externalAbort`, `idleTimedOut`, `timedOutDuringCompaction`, `isTimeout`), and the abort `reason`.

No public API change. No new dependency. No changelog entry (internal operator-facing diagnostic).

## Why this shape

- **Default-off**: zero log volume / behavior impact for users who don't enable it.
- **Single emission point** inside `abortRun` covers every existing call site and any future ones automatically.
- **Existing logger** keeps formatting consistent with surrounding `agent/embedded` lines.
- **Discriminated union** for `source` prevents freeform-string drift in downstream consumers.
- **Stack capture** via `new Error().stack` is gated, so cost is paid only when explicitly enabled.

Alternatives considered: always-on (rejected: log volume), per-call-site instrumentation (rejected: easy to miss new sources), structured `AbortError` subclass (rejected: API-surface ripple beyond the value of a diagnostic).

## Tests

`src/agents/pi-embedded-runner/run/abort-source-log.test.ts` (new, 10 cases):

- Classification × 5 — one per category, including priority ordering (external beats idle beats compaction beats timeout).
- Gating × 3 — unset / `"1"` / empty string env var.
- Emission × 2 — silent when gated off; emits expected fields when on, including `source=`, `runId=`, `reason=`, and a non-empty `stack=` segment.

```
$ pnpm test src/agents/pi-embedded-runner/run/abort-source-log.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
```

`pnpm build` clean; the resulting `selection-*.js` bundle contains the `[abort-source]` log statement and `classifyAbortSource` symbol.

## Notes

- Env var name follows the existing `OPENCLAW_RAW_STREAM` precedent (operator-facing diagnostic, off by default, blocked from workspace `.env` by the `OPENCLAW_*` prefix policy in `src/infra/dotenv.ts`).
- Could grow into richer abort tracing later (correlation IDs, downstream propagation) but kept minimal here — single diagnostic line, opt-in, easy to revert.
