### PR TITLE
fix(boot-md): deduplicate BOOT.md runs by workspace path

### DIFF
--- a/src/hooks/bundled/boot-md/handler.ts
+++ b/src/hooks/bundled/boot-md/handler.ts
@@ -19,15 +19,26 @@ const runBootChecklist: HookHandler = async (event) => {
 
   const cfg = event.context.cfg;
   const deps = event.context.deps ?? createDefaultDeps();
-  const tasks: StartupTask[] = listAgentIds(cfg).map((agentId) => {
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-    return {
+
+  // Deduplicate by workspace path — multiple agents may share the same workspace,
+  // in which case BOOT.md should only fire once per workspace, not once per agent.
+  const seenWorkspaces = new Set<string>();
+  const tasks: StartupTask[] = listAgentIds(cfg)
+    .map((agentId) => {
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+      return { agentId, workspaceDir };
+    })
+    .filter(({ workspaceDir }) => {
+      if (seenWorkspaces.has(workspaceDir)) return false;
+      seenWorkspaces.add(workspaceDir);
+      return true;
+    })
+    .map(({ agentId, workspaceDir }) => ({
       source: "boot-md",
       agentId,
       workspaceDir,
       run: () => runBootOnce({ cfg, deps, workspaceDir, agentId }),
-    };
-  });
+    }));
 
   await runStartupTasks({ tasks, log });
 };


### PR DESCRIPTION
Fix #74072\n\nWhen multiple agents share the same workspace directory, `runBootChecklist` was firing BOOT.md once per agent, producing N duplicate announcements on gateway restart.\n\nNow deduplicates by `workspaceDir` using a `Set` before creating tasks, so BOOT.md fires at most once per unique workspace.