### PR TITLE
perf(agents/runtime): short-circuit ensureRuntimePluginsLoaded when active registry exists

### DIFF
--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   resolveRuntimePluginRegistry: vi.fn(),
+  getActivePluginRegistry: vi.fn<() => unknown>(() => undefined),
   getActivePluginRuntimeSubagentMode: vi.fn<() => "default" | "explicit" | "gateway-bindable">(
     () => "default",
   ),
@@ -12,6 +13,7 @@ vi.mock("../plugins/loader.js", () => ({
 }));
 
 vi.mock("../plugins/runtime.js", () => ({
+  getActivePluginRegistry: hoisted.getActivePluginRegistry,
   getActivePluginRuntimeSubagentMode: hoisted.getActivePluginRuntimeSubagentMode,
 }));
 
@@ -21,14 +23,23 @@ describe("ensureRuntimePluginsLoaded", () => {
   beforeEach(async () => {
     hoisted.resolveRuntimePluginRegistry.mockReset();
     hoisted.resolveRuntimePluginRegistry.mockReturnValue(undefined);
+    hoisted.getActivePluginRegistry.mockReset();
+    hoisted.getActivePluginRegistry.mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("default");
     vi.resetModules();
     ({ ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js"));
   });
 
-  it("does not reactivate plugins when a process already has an active registry", async () => {
-    hoisted.resolveRuntimePluginRegistry.mockReturnValue({});
+  it("short-circuits without rebuilding load options when an active registry exists", async () => {
+    // Regression: every inbound dispatch was calling
+    // resolveRuntimePluginRegistry with a 3-field options set that hashes
+    // to a different cacheKey than boot's 9+ field set, so
+    // getCompatibleActivePluginRegistry's strict equality check failed
+    // and the dispatcher fell through to a full loadOpenClawPlugins
+    // rebuild — costing ~5–6s per inbound message on hosted gateways even
+    // though the active registry was already a valid answer.
+    hoisted.getActivePluginRegistry.mockReturnValue({ plugins: [], channels: [] });
 
     ensureRuntimePluginsLoaded({
       config: {} as never,
@@ -36,10 +47,10 @@ describe("ensureRuntimePluginsLoaded", () => {
       allowGatewaySubagentBinding: true,
     });
 
-    expect(hoisted.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
+    expect(hoisted.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
   });
 
-  it("resolves runtime plugins through the shared runtime helper", async () => {
+  it("resolves runtime plugins through the shared runtime helper when no active registry is present", async () => {
     ensureRuntimePluginsLoaded({
       config: {} as never,
       workspaceDir: "/tmp/workspace",

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRuntimePluginRegistry } from "../plugins/loader.js";
-import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
+import { getActivePluginRegistry, getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
 import { resolveUserPath } from "../utils.js";
 
 export function ensureRuntimePluginsLoaded(params: {
@@ -8,6 +8,29 @@ export function ensureRuntimePluginsLoaded(params: {
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
 }): void {
+  // Fast path: if the active plugin registry is already populated (the boot
+  // path ran `loadGatewayPlugins`), the function's intent — "ensure runtime
+  // plugins are loaded" — is already satisfied. Skip rebuilding load options
+  // and re-asking the loader.
+  //
+  // Without this short-circuit, every inbound dispatch hits
+  // `resolveRuntimePluginRegistry` with a 3-field options set
+  // (`config`, `workspaceDir`, `runtimeOptions`), which derives a different
+  // `cacheKey` than boot's 9+ field set (which includes `onlyPluginIds`,
+  // `activationSourceConfig`, `autoEnabledReasons`, etc.).
+  // `getCompatibleActivePluginRegistry`'s strict `cacheKey` equality fails;
+  // the call falls through to a full `loadOpenClawPlugins`, re-imports every
+  // plugin, and re-runs each plugin's `register()` — ~5–6s per inbound
+  // message on hosted gateways. The rebuild is wasted because the active
+  // registry is already a valid answer.
+  //
+  // Plugin reconfiguration (`installs`/`uninstalls`/auto-enable changes)
+  // already invalidates the active registry through other code paths
+  // (`setActivePluginRegistry`, gateway restart on config write), so a stale
+  // active registry is not a concern here.
+  if (getActivePluginRegistry()) {
+    return;
+  }
   const workspaceDir =
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)


### PR DESCRIPTION
## Summary

- **Problem:** `ensureRuntimePluginsLoaded` (`src/agents/runtime-plugins.ts:6`) is called from `dispatchReplyFromConfig` on every inbound message and rebuilds the entire plugin registry on each call. It builds a 3-field options object (`config`, `workspaceDir`, `runtimeOptions`) and hands it to `resolveRuntimePluginRegistry`. `getCompatibleActivePluginRegistry`'s strict `cacheKey` equality comparison fails — boot's options set has 9+ fields (`onlyPluginIds`, `activationSourceConfig`, `autoEnabledReasons`, etc.), so the two hashes always differ. The fall-through runs a full `loadOpenClawPlugins`: Jiti-loads every plugin module, re-validates manifests, re-runs each plugin's `register()`.
- **Why it matters:** ~5–6s of wasted wall-clock per inbound message on hosted gateways. The active registry is already a valid answer; rebuilding it produces no useful state change. Repro and instrumented stack traces in #74117.
- **What changed:** Fast path in `ensureRuntimePluginsLoaded` — if `getActivePluginRegistry()` is populated, return immediately. The function's intent is to *ensure* plugins are loaded; if they already are, the goal is met. Updates the existing test (which was asserting one call — that assertion was wrong; the prior behavior reactivated every time) into a proper regression test that asserts zero calls when the active registry exists.
- **What did NOT change (scope boundary):** Behavior when no active registry exists (still builds load options and calls `resolveRuntimePluginRegistry`). `loadGatewayPlugins`'s boot path. `getCompatibleActivePluginRegistry`'s strict-equality logic — that's a more intrusive change to file separately if desired. Plugin reconfiguration paths that explicitly invalidate the active registry (`setActivePluginRegistry`, gateway restart on config write) — those continue to work as before.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Closes #74117
- Related #73793 / #74096 (independent fixes for the same class of strict-cache-key issue in different code paths)
- [x] This PR fixes a bug or regression

## Root Cause

`ensureRuntimePluginsLoaded` is the simplest member of a family of "ensure registry is loaded" helpers (cf. `ensurePluginRegistryLoaded` in `plugins/runtime/runtime-registry-loader.ts`, which has its own scope-tracking short-circuit via `pluginRegistryLoaded` rank). The agent-side `ensureRuntimePluginsLoaded` is a thin wrapper that defers all caching responsibility to `resolveRuntimePluginRegistry → getCompatibleActivePluginRegistry`. That worked when the cache-key derivation matched between boot and dispatch. It stopped working when the boot path grew additional options (`onlyPluginIds`, `activationSourceConfig`, etc.) that the dispatch path doesn't supply, but the strict-equality check was never relaxed to a "is-compatible-subset" check.

A more thorough fix would be to make `getCompatibleActivePluginRegistry` accept subset-compatibility, but that's a larger surface area touching multiple call sites. This PR takes the minimal approach for this specific call site: short-circuit at the helper level. The function's contract is "ensure plugins are loaded", not "always rebuild the registry".

## Tests

- Updated `src/agents/runtime-plugins.test.ts`:
  - Added `getActivePluginRegistry` mock to the existing `vi.mock("../plugins/runtime.js", ...)` block.
  - Renamed and rewrote the existing test (`does not reactivate plugins when a process already has an active registry` — which was incorrectly asserting one call) into `short-circuits without rebuilding load options when an active registry exists`, asserting zero calls to `resolveRuntimePluginRegistry`.
  - Other tests (`resolves runtime plugins through the shared runtime helper when no active registry is present`, etc.) now mock `getActivePluginRegistry` to return `undefined` so they exercise the fall-through path.

## Verification

```
$ pnpm vitest run src/agents/runtime-plugins.test.ts
 Test Files  2 passed (2)
      Tests  8 passed (8)
```
