### PR TITLE
fix(ci): skip empty release-only extension aggregate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       run_checks_fast: ${{ steps.manifest.outputs.run_checks_fast }}
       checks_fast_core_matrix: ${{ steps.manifest.outputs.checks_fast_core_matrix }}
       channel_contracts_matrix: ${{ steps.manifest.outputs.channel_contracts_matrix }}
+      run_checks_node_extensions: ${{ steps.manifest.outputs.run_checks_node_extensions }}
       checks_node_extensions_matrix: ${{ steps.manifest.outputs.checks_node_extensions_matrix }}
       run_checks: ${{ steps.manifest.outputs.run_checks }}
       checks_matrix: ${{ steps.manifest.outputs.checks_matrix }}
@@ -229,23 +230,22 @@ jobs:
           const extensionTestShardCount = isCanonicalRepository
             ? DEFAULT_EXTENSION_TEST_SHARD_COUNT
             : Math.max(DEFAULT_EXTENSION_TEST_SHARD_COUNT, 36);
-          const extensionShardMatrix = createMatrix(
-            runReleaseOnlyPluginSuites
-              ? createExtensionTestShards({
-                  shardCount: extensionTestShardCount,
-                }).map((shard) => ({
-                  check_name: shard.checkName,
-                  extensions_csv: shard.extensionIds.join(","),
-                  runner: isCanonicalRepository && [0, 3, 4].includes(shard.index)
-                    ? "blacksmith-8vcpu-ubuntu-2404"
-                    : isCanonicalRepository
-                      ? "blacksmith-4vcpu-ubuntu-2404"
-                      : "ubuntu-24.04",
-                  shard_index: shard.index + 1,
-                  task: "extensions-batch",
-                }))
-              : [],
-          );
+          const extensionShardEntries = runReleaseOnlyPluginSuites
+            ? createExtensionTestShards({
+                shardCount: extensionTestShardCount,
+              }).map((shard) => ({
+                check_name: shard.checkName,
+                extensions_csv: shard.extensionIds.join(","),
+                runner: isCanonicalRepository && [0, 3, 4].includes(shard.index)
+                  ? "blacksmith-8vcpu-ubuntu-2404"
+                  : isCanonicalRepository
+                    ? "blacksmith-4vcpu-ubuntu-2404"
+                    : "ubuntu-24.04",
+                shard_index: shard.index + 1,
+                task: "extensions-batch",
+              }))
+            : [];
+          const extensionShardMatrix = createMatrix(extensionShardEntries);
           const checksFastCoreTasks = [];
           if (runNodeFull) {
             checksFastCoreTasks.push(
@@ -304,6 +304,7 @@ jobs:
             channel_contracts_matrix: createMatrix(
               runNodeFull ? createChannelContractTestShards() : [],
             ),
+            run_checks_node_extensions: extensionShardEntries.length > 0,
             checks_node_extensions_matrix: extensionShardMatrix,
             run_checks: runNodeFull,
             checks_matrix: createMatrix(
@@ -822,7 +823,7 @@ jobs:
       contents: read
     name: ${{ matrix.checkName }}
     needs: [preflight]
-    if: needs.preflight.outputs.run_checks_fast == 'true'
+    if: needs.preflight.outputs.run_checks_node_extensions == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -906,7 +907,7 @@ jobs:
       contents: read
     name: checks-fast-contracts-channels
     needs: [preflight, checks-fast-channel-contracts-shard]
-    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_checks_fast == 'true' }}
+    if: ${{ !cancelled() && always() && needs.preflight.outputs.run_checks_node_extensions == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -217,6 +217,7 @@ async function withAllowFromCacheReadSpy(params: {
     accountId: "yy",
     allowFrom: ["1001"],
   });
+  clearPairingAllowFromReadCacheForTest();
   const readSpy = params.createReadSpy();
   await assertAllowFromCacheInvalidation({
     stateDir: params.stateDir,


### PR DESCRIPTION
## Summary
- skip the extension shard aggregate when release-only extension shards are intentionally omitted
- clear the pairing allowFrom read cache before cache-spy assertions to avoid stale state in broad CI shards

## Validation
- git diff --check
- pnpm check:workflows
- pnpm test:serial test/scripts/ci-node-test-plan.test.ts src/pairing/pairing-store.test.ts src/plugins/contracts/config-footprint-guardrails.test.ts
