### PR TITLE
fix(tools): skip allowlist guard when tools are explicitly disabled

### DIFF
--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -17,7 +17,7 @@ describe("tool allowlist guard", () => {
     expect(error?.message).toContain("no registered tools matched");
   });
 
-  it("fails closed for runtime toolsAllow when tools are disabled", () => {
+  it("skips guard when tools are explicitly disabled for the run", () => {
     const error = buildEmptyExplicitToolAllowlistError({
       sources: [{ label: "runtime toolsAllow", entries: ["query_db"] }],
       callableToolNames: [],
@@ -25,8 +25,7 @@ describe("tool allowlist guard", () => {
       disableTools: true,
     });
 
-    expect(error?.message).toContain("runtime toolsAllow: query_db");
-    expect(error?.message).toContain("tools are disabled for this run");
+    expect(error).toBeNull();
   });
 
   it("fails closed when the selected model cannot use requested tools", () => {

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -20,6 +20,9 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
 }): Error | null {
+  if (params.disableTools === true) {
+    return null;
+  }
   const callableToolNames = params.callableToolNames.map(normalizeToolName).filter(Boolean);
   if (params.sources.length === 0 || callableToolNames.length > 0) {
     return null;
@@ -27,12 +30,9 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   const requested = params.sources
     .map((source) => `${source.label}: ${source.entries.map(normalizeToolName).join(", ")}`)
     .join("; ");
-  const reason =
-    params.disableTools === true
-      ? "tools are disabled for this run"
-      : params.toolsEnabled
-        ? "no registered tools matched"
-        : "the selected model does not support tools";
+  const reason = params.toolsEnabled
+    ? "no registered tools matched"
+    : "the selected model does not support tools";
   return new Error(
     `No callable tools remain after resolving explicit tool allowlist (${requested}); ${reason}. Fix the allowlist or enable the plugin that registers the requested tool.`,
   );


### PR DESCRIPTION
## Summary

When an embedded model run (e.g. `llm-task` invoked from a Lobster workflow) intentionally disables tools, the explicit tool allowlist guard from the parent session's `tools.alsoAllow` config should not fire.

## Root Cause

`buildEmptyExplicitToolAllowlistError` in `src/agents/tool-allowlist-guard.ts` would see:
- `sources.length > 0` (from parent config's `alsoAllow` entries like `lobster`, `llm-task`)
- `callableToolNames.length === 0` (tools are intentionally disabled for the embedded run)

This combination triggered the error: *"No callable tools remain after resolving explicit tool allowlist ... tools are disabled for this run"*.

## Fix

Early-return `null` from the guard when `disableTools === true`, since disabling tools is an intentional choice that should not be treated as a configuration failure. Removed the now-unreachable `disableTools` branch from the error reason.

Fixes #74019