### PR TITLE
fix(agents/tools): resolve sessionKey=current for channel-plugin clients

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -468,6 +468,29 @@ describe("session_status tool", () => {
     expect(details.sessionKey).toBe("main");
   });
 
+  it("resolves sessionKey=current for a channel-plugin session via implicit fallback", async () => {
+    // Regression: agents driven by a channel plugin (Slack, Discord, Scope, ...)
+    // pass channel-style requester keys (e.g. agent:scopy:scope:scopy:direct:scopy)
+    // that don't match `CURRENT_SESSION_CLIENT_ALIAS_IDS`. Without the implicit
+    // "current"-as-requester fallback in session-status-tool.ts, the tool
+    // throws `Unknown sessionKey: current` even though the requester's own
+    // session exists in the store — costing an extra LLM round-trip per turn
+    // for date/time / model-status questions.
+    resetSessionStore({
+      "agent:main:scope:scopy:direct:scopy": {
+        sessionId: "s-channel",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = getSessionStatusTool("agent:main:scope:scopy:direct:scopy");
+
+    const result = await tool.execute("call-current-channel", { sessionKey: "current" });
+    const details = result.details as { ok?: boolean; sessionKey?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe("agent:main:scope:scopy:direct:scopy");
+  });
+
   it("treats the TUI client label as the current requester session", async () => {
     resetSessionStore({
       "agent:main:main": {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -440,6 +440,29 @@ export function createSessionStatusTool(opts?: {
         });
       }
 
+      if (!resolved && requestedKeyRaw === "current" && effectiveRequesterKey) {
+        // Channel-plugin agents (Slack, Discord, Scope, ...) pass
+        // sessionKey="current" per the docstring, but
+        // `resolveCurrentSessionClientAlias` only maps first-party UI client
+        // ids (TUI, CLI, WEBCHAT_UI, ...) to the requester key. When the
+        // literal-current store lookup and the gateway's `sessions.resolve`
+        // call both find nothing matching, fall back to treating "current"
+        // as the requester's own session — the universal alias intent of the
+        // docstring. Without this fallback, the tool throws
+        // `Unknown sessionKey: current` and the agent retries with a
+        // constructed key, costing an extra LLM round-trip per turn.
+        requestedKeyRaw = effectiveRequesterKey;
+        resolvedViaImplicitCurrentFallback = true;
+        resolved = resolveSessionEntry({
+          store,
+          keyRaw: requestedKeyRaw,
+          alias,
+          mainKey,
+          requesterInternalKey: storeScopedRequesterKey,
+          includeAliasFallback: true,
+        });
+      }
+
       if (!resolved && requestedKeyParam === undefined) {
         for (const fallbackKey of listImplicitDefaultDirectFallbackKeys({
           keyRaw: requestedKeyRaw,


### PR DESCRIPTION
## Summary

- **Problem:** The `session_status` tool's docstring (`tool-description-presets.ts:63`) tells agents universally to pass `sessionKey="current"`, but `resolveCurrentSessionClientAlias` only honors the alias for first-party UI client ids (TUI, CLI, WEBCHAT_UI, CONTROL_UI, MACOS_APP, IOS_APP, ANDROID_APP). Channel-plugin clients (Slack, Discord, Scope, ...) fall through, the literal `"current"` is never resolved to the requester, the literal-current store lookup and `sessions.resolve("current")` both find nothing, and the tool throws `Unknown sessionKey: current`. The agent retries with a constructed key, that fails too, and only then produces a final reply — costing ~4s per turn on date/time / model-status queries.
- **Why it matters:** The system prompt (`system-prompt.ts:827`) directs agents to call `session_status` for date/time questions. Every such question on a channel-plugin agent burns ~4s of failed tool calls before the agent gives up and answers from internal state. Repro and gateway log slice in #74141.
- **What changed:** Added a final fallback in `session-status-tool.ts`: when the literal-current store lookup AND `resolveSessionReference` both return nothing matching, treat `"current"` as the requester's own session. Sets `resolvedViaImplicitCurrentFallback = true` so visibility-target-as-self handling at `:469-475` still works.
- **What did NOT change (scope boundary):** The existing prefer-literal-session-named-"current" feature documented by `prefers a literal current session key in session_status` and `resolves a literal current sessionId in session_status` — preserved by positioning the new fallback AFTER those paths. `resolveCurrentSessionClientAlias` itself — untouched, so `resolveSessionReference`'s strict-alias semantics for non-UI clients are unchanged. The `CURRENT_SESSION_CLIENT_ALIAS_IDS` set — untouched. Other tools that take a `sessionKey` param (`sessions_history`, `sessions_send`, `sessions_spawn`, `subagents`) — those have their own resolution paths and aren't affected by this PR (separate fix if/when they hit the same class of issue).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #74141
- [x] This PR fixes a bug or regression

## Root Cause

`resolveCurrentSessionClientAlias` was designed for the case where a UI/CLI client passes its own client id (e.g., `"openclaw-tui"`) as the `sessionKey` and the resolver translates that to the requester key. The literal alias `"current"` was not part of that contract — agents passing `"current"` were expected to be served by the deeper `resolveSessionReference` → `sessions.resolve("current")` path, which works *if* a real session is keyed literally `"current"` in the gateway.

That assumption holds for first-party UI clients (where the ACP gateway registers a session keyed by the client's session id and `"current"` happens to match in practice for TUI/CLI flows) but doesn't hold for channel-plugin clients. The docstring `Use sessionKey="current" for the current session` was added universally, ahead of the implementation actually supporting it universally — leaving channel-plugin agents to discover the gap at runtime.

## Tests

- Added `resolves sessionKey=current for a channel-plugin session via implicit fallback` in `src/agents/openclaw-tools.session-status.test.ts`. Uses a channel-style requester key (`agent:main:scope:scopy:direct:scopy`) and asserts `details.sessionKey` is the requester key.
- All 116 existing tests in `sessions-resolution.test.ts` + `openclaw-tools.session-status.test.ts` pass unchanged.

## Verification

```
$ pnpm vitest run \
    src/agents/tools/sessions-resolution.test.ts \
    src/agents/openclaw-tools.session-status.test.ts
 Test Files  4 passed (4)
      Tests  116 passed (116)
```
