### PR TITLE
fix(agents): enforce exact skill path from <available_skills> [AI-assisted]

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -162,7 +162,7 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
   return [
     "## Skills (mandatory)",
     "Before replying: scan <available_skills> <description> entries.",
-    `- If exactly one skill clearly applies: read its SKILL.md at <location> with \`${params.readToolName}\`, then follow it.`,
+    `- If exactly one skill clearly applies: read its SKILL.md at <location> with \`${params.readToolName}\`, then follow it. You MUST use the exact <location> value from <available_skills>; never guess, fabricate, or hard-code a skill file path.`,
     "- If multiple could apply: choose the most specific one, then read/follow it.",
     "- If none clearly apply: do not read any SKILL.md.",
     "Constraints: never read more than one skill up front; only read after selecting.",


### PR DESCRIPTION
## Summary

- The agent could fabricate or guess SKILL.md file paths instead of using the exact `<location>` value from `<available_skills>`
- Add an explicit prompt-level constraint: "You MUST use the exact `<location>` value from `<available_skills>`; never guess, fabricate, or hard-code a skill file path"

## Motivation

This prevents path hallucination when `<available_skills>` is incomplete (see #43735, #44898) or when sandbox path resolution diverges (#50590, #43383). Even when the root causes are fixed upstream, this constraint ensures the agent never fabricates paths independently.

Builds on Peter's original skill prompt tightening in `b621d4550b`.

## Test plan

- [x] Lint passes
- [x] Prompt text change is additive — existing skill selection behavior unchanged

## Attribution

Original author: tianguicheng <tianguicheng@xiaomi.com>

🤖 Generated with [Claude Code](https://claude.ai/claude-code)