### PR TITLE
feat(gateway): make chat-delta broadcast throttle configurable via OPENCLAW_CHAT_DELTA_THROTTLE_MS

### DIFF
--- a/src/gateway/chat-delta-throttle.test.ts
+++ b/src/gateway/chat-delta-throttle.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_CHAT_DELTA_THROTTLE_MS,
+  resolveChatDeltaThrottleMs,
+} from "./chat-delta-throttle.js";
+
+describe("resolveChatDeltaThrottleMs", () => {
+  const originalEnv = process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS;
+    } else {
+      process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = originalEnv;
+    }
+  });
+
+  it("returns the default when env var is unset", () => {
+    delete process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS;
+    expect(resolveChatDeltaThrottleMs()).toBe(DEFAULT_CHAT_DELTA_THROTTLE_MS);
+  });
+
+  it("returns the default when env var is empty string", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "";
+    expect(resolveChatDeltaThrottleMs()).toBe(DEFAULT_CHAT_DELTA_THROTTLE_MS);
+  });
+
+  it("honors a positive integer override", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "30";
+    expect(resolveChatDeltaThrottleMs()).toBe(30);
+  });
+
+  it("honors zero (disables throttle)", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "0";
+    expect(resolveChatDeltaThrottleMs()).toBe(0);
+  });
+
+  it("honors fractional values", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "75.5";
+    expect(resolveChatDeltaThrottleMs()).toBe(75.5);
+  });
+
+  it("falls back to the default when the value is non-numeric", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "abc";
+    expect(resolveChatDeltaThrottleMs()).toBe(DEFAULT_CHAT_DELTA_THROTTLE_MS);
+  });
+
+  it("falls back to the default when the value is NaN", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "NaN";
+    expect(resolveChatDeltaThrottleMs()).toBe(DEFAULT_CHAT_DELTA_THROTTLE_MS);
+  });
+
+  it("falls back to the default when the value is negative", () => {
+    process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS = "-50";
+    expect(resolveChatDeltaThrottleMs()).toBe(DEFAULT_CHAT_DELTA_THROTTLE_MS);
+  });
+});

--- a/src/gateway/chat-delta-throttle.ts
+++ b/src/gateway/chat-delta-throttle.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_CHAT_DELTA_THROTTLE_MS = 150;
+
+/**
+ * Resolve the gateway chat-delta broadcast throttle, in milliseconds.
+ *
+ * Reads `OPENCLAW_CHAT_DELTA_THROTTLE_MS` and falls back to
+ * `DEFAULT_CHAT_DELTA_THROTTLE_MS` when the value is unset, empty,
+ * non-numeric, NaN, or negative. Lower values trade more WebSocket frames
+ * for smoother per-token rendering; `0` disables the throttle entirely.
+ */
+export function resolveChatDeltaThrottleMs(): number {
+  const raw = process.env.OPENCLAW_CHAT_DELTA_THROTTLE_MS;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_CHAT_DELTA_THROTTLE_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_CHAT_DELTA_THROTTLE_MS;
+  }
+  return parsed;
+}

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -5,6 +5,7 @@ import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-event
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
+import { resolveChatDeltaThrottleMs } from "./chat-delta-throttle.js";
 import {
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
@@ -666,7 +667,7 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
-    if (now - last < 150) {
+    if (now - last < resolveChatDeltaThrottleMs()) {
       return;
     }
     chatRunState.deltaSentAt.set(clientRunId, now);
@@ -762,9 +763,10 @@ export function createAgentEventHandler({
       suppressLeadFragments: false,
     });
     // Flush any throttled delta so streaming clients receive the complete text
-    // before the final event. The 150 ms throttle in emitChatDelta may have
-    // suppressed the most recent chunk, leaving the client with stale text.
-    // Only flush if the buffer has grown since the last broadcast to avoid duplicates.
+    // before the final event. The emitChatDelta throttle (default 150ms,
+    // overridable via OPENCLAW_CHAT_DELTA_THROTTLE_MS) may have suppressed the
+    // most recent chunk, leaving the client with stale text. Only flush if the
+    // buffer has grown since the last broadcast to avoid duplicates.
     flushBufferedChatDeltaIfNeeded(sessionKey, clientRunId, sourceRunId, seq);
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.rawBuffers.delete(clientRunId);


### PR DESCRIPTION
## Summary

Make the gateway chat-delta broadcast throttle configurable via `OPENCLAW_CHAT_DELTA_THROTTLE_MS`. Default stays at the existing **150 ms**, so behavior is unchanged for everyone who does not opt in.

No linked issue — operator observability/UX seam, filed in response to a real deployment where the hardcoded value did not fit.

## Problem

`emitChatDelta` in `src/gateway/server-chat.ts` rate-limits assistant text broadcasts to one frame per 150 ms per run via a hardcoded threshold. With fast LLMs (Gemma 31B at OpenRouter, Sonnet 4.6, etc. emitting 30–40 ms/token), the visible streaming pattern lands at ~6 frames/second with ~5 tokens batched per visible chunk, plus a residual flush at the final event. On small mobile screens this reads as "silent then chunks" rather than the smoother per-token rendering that providers' SSE streams already make available.

The 150 ms value is a sensible default but it is the wrong default for some deployments:

- Local/loopback gateways where bandwidth is free and operators want maximum smoothness.
- Mobile-only deployments where operators are willing to trade extra WebSocket frames for a more readable stream.
- Bandwidth-constrained / metered links where operators want to *raise* the throttle.

Today there is no knob to tune this without a recompile.

For comparison, channel-side throttles like Telegram's existing `streamThrottleMs` request (#38066) cover their own surface — the gateway broadcast path that feeds Control UI / mobile / 3rd-party WebSocket clients has no equivalent.

## Change

`src/gateway/chat-delta-throttle.ts` (new, 22 LOC):

- Exports `DEFAULT_CHAT_DELTA_THROTTLE_MS = 150` and `resolveChatDeltaThrottleMs()`.
- Reads `OPENCLAW_CHAT_DELTA_THROTTLE_MS` and falls back to the default on unset / empty / non-numeric / `NaN` / negative.
- `0` is honored (disables the throttle).

`src/gateway/server-chat.ts`:

- One-line import of the resolver.
- Replaces the hardcoded `< 150` in `emitChatDelta` with `< resolveChatDeltaThrottleMs()`.
- Updates the existing comment near `flushBufferedChatDeltaIfNeeded` so it stays accurate ("default 150 ms, overridable via env var").

No public API change. No new dependency. No changelog entry (operator-facing diagnostic / tuning knob, off by default — same convention as `OPENCLAW_RAW_STREAM`).

## Why this shape

- **Default unchanged**: existing 150 ms preserved; users who do not set the env var see zero behavior change.
- **Resolver called per emit**, not memoized at module load — keeps env mutation honored under tests and avoids a restart-only contract for an operator knob.
- **Single env var, no schema change**: matches `OPENCLAW_RAW_STREAM` precedent for operator-only diagnostic/tuning knobs and is automatically blocked from workspace `.env` by the existing `OPENCLAW_*` prefix policy in `src/infra/dotenv.ts`.
- **Strict fallback**: `Number.isFinite` + `>= 0` keeps a typo (`abc`, `-50`, `NaN`) from silently breaking streaming in a hard-to-debug way.

### Alternatives considered

- **Config-file knob** (`agents.defaults.streaming.chatDeltaThrottleMs`): would be more discoverable but introduces a config-schema migration for a setting with narrow operator audience. Easy to add later if there is demand.
- **Per-channel override**: out of scope — this PR targets the gateway broadcast path that all WebSocket clients share.
- **Memoized at module load**: rejected; tests need to mutate env between assertions, and operator restarts are an unnecessary tax on a knob this small.

## Tests

`src/gateway/chat-delta-throttle.test.ts` (new, 8 cases):

- Default returned when env var is unset / empty.
- Honors a positive integer override.
- Honors `0` (disables throttle).
- Honors fractional values (e.g. `75.5`).
- Falls back to default on non-numeric / `NaN` / negative.

```
$ pnpm test src/gateway/chat-delta-throttle.test.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
$ pnpm test src/gateway/server-chat.agent-events.test.ts
Test Files  1 passed (1)
     Tests  42 passed (42)
```

`pnpm build` clean; the resulting `server-chat-*.js` bundle contains the new env-var lookup.

## Notes

- `OPENCLAW_CHAT_DELTA_THROTTLE_MS` is operator-only by design; workspace `.env` already cannot set it.
- A config-file alias under `agents.defaults.streaming` is a possible follow-up if maintainers prefer that surface. Happy to roll it into this PR if requested — kept minimal here so the contract is one knob, one place.
