### PR TITLE
fix(media): fall back when image optimization fails

### DIFF
--- a/src/media/web-media.optimize.test.ts
+++ b/src/media/web-media.optimize.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resizeToJpegMock = vi.fn();
+const convertHeicToJpegMock = vi.fn();
+const optimizeImageToPngMock = vi.fn();
+const hasAlphaChannelMock = vi.fn();
+
+vi.mock("./image-ops.js", () => ({
+  convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
+  hasAlphaChannel: (...args: unknown[]) => hasAlphaChannelMock(...args),
+  optimizeImageToPng: (...args: unknown[]) => optimizeImageToPngMock(...args),
+  resizeToJpeg: (...args: unknown[]) => resizeToJpegMock(...args),
+}));
+
+let optimizeImageToJpeg: typeof import("./web-media.js").optimizeImageToJpeg;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ optimizeImageToJpeg } = await import("./web-media.js"));
+});
+
+describe("optimizeImageToJpeg", () => {
+  it("falls back to the original buffer when all optimization attempts fail", async () => {
+    const original = Buffer.from("not-decodable-by-image-backends");
+    resizeToJpegMock.mockRejectedValue(new Error("sharp is unavailable"));
+
+    const result = await optimizeImageToJpeg(original, 1024 * 1024, {
+      contentType: "image/png",
+      fileName: "broken.png",
+    });
+
+    expect(result).toEqual({
+      buffer: original,
+      optimizedSize: original.length,
+      resizeSide: 0,
+      quality: 0,
+    });
+    expect(resizeToJpegMock).toHaveBeenCalledTimes(25);
+  });
+
+  it("still returns the smallest optimized buffer when every attempt exceeds the cap", async () => {
+    const original = Buffer.from("original-image");
+    const large = Buffer.alloc(10, 1);
+    const smallest = Buffer.alloc(5, 2);
+    resizeToJpegMock.mockResolvedValueOnce(large).mockResolvedValue(smallest);
+
+    const result = await optimizeImageToJpeg(original, 1);
+
+    expect(result).toEqual({
+      buffer: smallest,
+      optimizedSize: smallest.length,
+      resizeSide: 2048,
+      quality: 70,
+    });
+    expect(resizeToJpegMock).toHaveBeenCalledTimes(25);
+  });
+});

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -451,6 +451,8 @@ export async function optimizeImageToJpeg(
     quality: number;
   } | null = null;
 
+  let lastError: unknown = null;
+
   for (const side of sides) {
     for (const quality of qualities) {
       try {
@@ -472,7 +474,8 @@ export async function optimizeImageToJpeg(
             quality,
           };
         }
-      } catch {
+      } catch (err) {
+        lastError = err;
         // Continue trying other size/quality combinations
       }
     }
@@ -487,7 +490,17 @@ export async function optimizeImageToJpeg(
     };
   }
 
-  throw new Error("Failed to optimize image");
+  if (lastError && shouldLogVerbose()) {
+    logVerbose(
+      `Image optimization failed for every resize/quality combination; using original buffer: ${String(lastError)}`,
+    );
+  }
+  return {
+    buffer: source,
+    optimizedSize: source.length,
+    resizeSide: 0,
+    quality: 0,
+  };
 }
 
 export { optimizeImageToPng };


### PR DESCRIPTION
## Summary
- fall back to the original image buffer when every JPEG optimization attempt fails
- keep the existing best-effort smallest optimized output behavior when optimization succeeds but remains over cap
- add regression coverage for optimization backend failures such as missing or unavailable image processors

## Why
A missing/failed image optimization backend currently makes media loading fail with `Failed to optimize image`, even when the original image buffer is available and could still be sent to a vision model. This makes image analysis brittle in environments where optional image-processing dependencies are unavailable or fail to decode a particular image.

## Test plan
- `bunx pnpm@10.33.0 exec vitest run src/media/web-media.optimize.test.ts src/media/web-media.test.ts`
- `bunx pnpm@10.33.0 exec vitest run --config test/vitest/vitest.media.config.ts src/media/web-media.optimize.test.ts src/media/web-media.test.ts`
- `bunx pnpm@10.33.0 exec oxfmt --check --threads=1 src/media/web-media.ts src/media/web-media.optimize.test.ts`
