### PR TITLE
fix(agents): preserve CLI wake-up session metadata

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -25,7 +25,11 @@ import {
   resetClaudeLiveSessionsForTest,
   runClaudeLiveSessionTurn,
 } from "./cli-runner/claude-live-session.js";
-import { buildCliEnvAuthLog, executePreparedCliRun } from "./cli-runner/execute.js";
+import {
+  buildCliEnvAuthLog,
+  buildCliExecLogLine,
+  executePreparedCliRun,
+} from "./cli-runner/execute.js";
 import { buildSystemPrompt } from "./cli-runner/helpers.js";
 import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
@@ -127,6 +131,27 @@ function buildPreparedCliRunContext(params: {
 }
 
 describe("runCliAgent spawn path", () => {
+  it("formats redacted CLI resume diagnostics without exposing raw session ids", () => {
+    const logLine = buildCliExecLogLine({
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      promptChars: 42,
+      trigger: "heartbeat",
+      useResume: true,
+      cliSessionId: "claude-session-secret",
+      resolvedSessionId: "claude-session-secret",
+      reusableSessionId: "claude-session-secret",
+      hasHistoryPrompt: false,
+    });
+
+    expect(logLine).toContain("trigger=heartbeat");
+    expect(logLine).toContain("useResume=true");
+    expect(logLine).toContain("session=present");
+    expect(logLine).toContain("reuse=reusable");
+    expect(logLine).toContain("historyPrompt=none");
+    expect(logLine).not.toContain("claude-session-secret");
+  });
+
   it("does not inject hardcoded 'Tools are disabled' text into CLI arguments", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { shouldLogVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
@@ -164,6 +165,44 @@ function buildCliEnvMcpLog(childEnv: Record<string, string>): string {
   ].join(" ");
 }
 
+function fingerprintCliSessionId(sessionId?: string): string {
+  const trimmed = sessionId?.trim();
+  if (!trimmed) {
+    return "none";
+  }
+  return crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 12);
+}
+
+export function buildCliExecLogLine(params: {
+  provider: string;
+  model: string;
+  promptChars: number;
+  trigger?: string;
+  useResume: boolean;
+  cliSessionId?: string;
+  resolvedSessionId?: string;
+  reusableSessionId?: string;
+  invalidatedReason?: string;
+  hasHistoryPrompt: boolean;
+}): string {
+  const reuseState = params.reusableSessionId
+    ? "reusable"
+    : params.invalidatedReason
+      ? `invalidated:${params.invalidatedReason}`
+      : "none";
+  return [
+    `cli exec: provider=${params.provider}`,
+    `model=${params.model}`,
+    `promptChars=${params.promptChars}`,
+    `trigger=${params.trigger ?? "unknown"}`,
+    `useResume=${params.useResume ? "true" : "false"}`,
+    `session=${params.cliSessionId ? "present" : "none"}`,
+    `resumeSession=${params.useResume ? fingerprintCliSessionId(params.resolvedSessionId) : "none"}`,
+    `reuse=${reuseState}`,
+    `historyPrompt=${params.hasHistoryPrompt ? "present" : "none"}`,
+  ].join(" ");
+}
+
 export function buildCliEnvAuthLog(childEnv: Record<string, string>): string {
   const hostKeys = listPresentCliAuthEnvKeys(process.env);
   const childKeys = listPresentCliAuthEnvKeys(childEnv);
@@ -273,7 +312,18 @@ export async function executePreparedCliRun(
         : undefined;
       try {
         cliBackendLog.info(
-          `cli exec: provider=${params.provider} model=${context.normalizedModel} promptChars=${basePrompt.length}`,
+          buildCliExecLogLine({
+            provider: params.provider,
+            model: context.normalizedModel,
+            promptChars: basePrompt.length,
+            trigger: params.trigger,
+            useResume,
+            cliSessionId: cliSessionIdToUse,
+            resolvedSessionId,
+            reusableSessionId: context.reusableCliSession.sessionId,
+            invalidatedReason: context.reusableCliSession.invalidatedReason,
+            hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
+          }),
         );
         const logOutputText =
           isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]) ||

--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+import type { TemplateContext } from "../templating.js";
 import {
   buildExecOverridePromptHint,
+  resolvePromptSessionContextForSystemEvent,
   resolvePromptSilentReplyConversationType,
 } from "./get-reply-run.js";
 import { buildGetReplyCtx, buildGetReplyGroupCtx } from "./get-reply.test-fixtures.js";
@@ -104,5 +107,97 @@ describe("resolvePromptSilentReplyConversationType", () => {
         inboundSessionKey: "agent:main:telegram:group:source",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("resolvePromptSessionContextForSystemEvent", () => {
+  it("rebuilds missing system-event chat metadata from the persisted session entry", () => {
+    const sessionCtx = {
+      Body: "wake up",
+      Provider: "cron-event",
+      Surface: "cron-event",
+    } as TemplateContext;
+    const sessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      chatType: "channel",
+      channel: "discord",
+      groupId: "guild-1",
+      groupChannel: "#ops",
+      space: "Ops Guild",
+      origin: {
+        provider: "discord",
+        surface: "discord",
+        chatType: "channel",
+        to: "channel-1",
+        accountId: "acct-1",
+        threadId: "thread-1",
+      },
+      lastChannel: "discord",
+      lastTo: "channel-1",
+      lastAccountId: "acct-1",
+      lastThreadId: "thread-1",
+    } satisfies SessionEntry;
+
+    const result = resolvePromptSessionContextForSystemEvent({
+      sessionCtx,
+      sessionEntry,
+      ctx: { Provider: "cron-event" },
+    });
+
+    expect(result).not.toBe(sessionCtx);
+    expect(result).toMatchObject({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
+      GroupChannel: "#ops",
+      GroupSpace: "Ops Guild",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel-1",
+      AccountId: "acct-1",
+      MessageThreadId: "thread-1",
+    });
+  });
+
+  it("keeps normal user turns on their live chat metadata", () => {
+    const sessionCtx = buildGetReplyGroupCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "group",
+    }) as TemplateContext;
+    const result = resolvePromptSessionContextForSystemEvent({
+      sessionCtx,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        chatType: "direct",
+        channel: "telegram",
+      },
+      ctx: { Provider: "discord" },
+    });
+
+    expect(result).toBe(sessionCtx);
+  });
+
+  it("does not overwrite explicit system-event chat metadata", () => {
+    const sessionCtx = {
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+      OriginatingChannel: "discord",
+    } as TemplateContext;
+    const result = resolvePromptSessionContextForSystemEvent({
+      sessionCtx,
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+        chatType: "channel",
+        channel: "discord",
+        groupChannel: "#ops",
+      },
+      ctx: { Provider: "heartbeat" },
+    });
+
+    expect(result).toBe(sessionCtx);
   });
 });

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -130,6 +130,7 @@ let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
 let routeReply: typeof import("./route-reply.runtime.js").routeReply;
 let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
 let resolveTypingMode: typeof import("./typing-mode.js").resolveTypingMode;
+let buildGroupChatContext: typeof import("./groups.js").buildGroupChatContext;
 let buildInboundUserContextPrefix: typeof import("./inbound-meta.js").buildInboundUserContextPrefix;
 let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
 let replyRunTesting: typeof import("./reply-run-registry.js").__testing;
@@ -241,6 +242,7 @@ describe("runPreparedReply media-only handling", () => {
     ({ routeReply } = await import("./route-reply.runtime.js"));
     ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
     ({ resolveTypingMode } = await import("./typing-mode.js"));
+    ({ buildGroupChatContext } = await import("./groups.js"));
     ({ buildInboundUserContextPrefix } = await import("./inbound-meta.js"));
     ({ __testing: replyRunTesting, getActiveReplyRunCount } =
       await import("./reply-run-registry.js"));
@@ -1017,6 +1019,62 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain(heartbeatPrompt);
     expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
+  });
+
+  it("uses persisted Discord chat metadata for system-event CLI static prompt identity", async () => {
+    vi.mocked(buildGroupChatContext).mockImplementationOnce(({ sessionCtx }) =>
+      [`group`, sessionCtx.Provider, sessionCtx.ChatType, sessionCtx.GroupChannel].join(":"),
+    );
+
+    await runPreparedReply(
+      baseParams({
+        opts: { isHeartbeat: true },
+        isNewSession: false,
+        systemSent: true,
+        ctx: {
+          Body: "scheduled wake",
+          RawBody: "scheduled wake",
+          CommandBody: "scheduled wake",
+          Provider: "cron-event",
+          SessionKey: "agent:main:discord:guild-1:channel-1",
+        },
+        sessionCtx: {
+          Body: "scheduled wake",
+          BodyStripped: "scheduled wake",
+          Provider: "cron-event",
+        },
+        sessionEntry: {
+          sessionId: "session-1",
+          updatedAt: 1,
+          systemSent: true,
+          chatType: "channel",
+          channel: "discord",
+          groupId: "guild-1",
+          groupChannel: "#ops",
+          lastChannel: "discord",
+          lastTo: "channel-1",
+          origin: {
+            provider: "discord",
+            surface: "discord",
+            chatType: "channel",
+            to: "channel-1",
+          },
+        } as SessionEntry,
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(buildGroupChatContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionCtx: expect.objectContaining({
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "channel",
+          GroupChannel: "#ops",
+        }),
+      }),
+    );
+    expect(call?.followupRun.run.extraSystemPromptStatic).toBe("group:discord:channel:#ops");
   });
 
   it("uses a non-empty transcript marker while keeping bare reset startup instructions out of visible transcript prompt", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -45,6 +45,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { applySessionHints } from "./body.js";
 import type { buildCommandContext } from "./commands.js";
 import type { InlineDirectives } from "./directive-handling.js";
+import { isSystemEventProvider } from "./effective-reply-route.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { resolvePreparedReplyQueueState } from "./get-reply-run-queue.js";
 import {
@@ -92,6 +93,111 @@ export function resolvePromptSilentReplyConversationType(params: {
     return "group";
   }
   return undefined;
+}
+
+function normalizePromptRouteChannel(raw?: string | null): string | undefined {
+  const normalized = normalizeOptionalString(raw);
+  return normalized && normalized !== "none" ? normalized : undefined;
+}
+
+function resolvePersistedPromptProvider(entry?: SessionEntry): string | undefined {
+  return (
+    normalizePromptRouteChannel(entry?.origin?.provider) ??
+    normalizePromptRouteChannel(entry?.channel) ??
+    normalizePromptRouteChannel(entry?.lastChannel) ??
+    normalizePromptRouteChannel(entry?.deliveryContext?.channel)
+  );
+}
+
+function resolvePersistedPromptSurface(entry?: SessionEntry): string | undefined {
+  return (
+    normalizePromptRouteChannel(entry?.origin?.surface) ?? resolvePersistedPromptProvider(entry)
+  );
+}
+
+export function resolvePromptSessionContextForSystemEvent(params: {
+  sessionCtx: TemplateContext;
+  sessionEntry?: SessionEntry;
+  ctx?: Pick<MsgContext, "Provider">;
+  isHeartbeat?: boolean;
+}): TemplateContext {
+  const { sessionCtx, sessionEntry } = params;
+  const isSystemEvent =
+    params.isHeartbeat === true ||
+    isSystemEventProvider(params.ctx?.Provider) ||
+    isSystemEventProvider(sessionCtx.Provider);
+  if (!isSystemEvent || !sessionEntry) {
+    return sessionCtx;
+  }
+
+  const persistedChatType =
+    normalizeChatType(sessionEntry.chatType) ?? normalizeChatType(sessionEntry.origin?.chatType);
+  const liveChatType = normalizeChatType(sessionCtx.ChatType);
+  const effectiveChatType = liveChatType ?? persistedChatType;
+  const persistedProvider = resolvePersistedPromptProvider(sessionEntry);
+  const persistedSurface = resolvePersistedPromptSurface(sessionEntry);
+  const liveProvider = normalizeOptionalString(sessionCtx.Provider);
+  const liveSurface = normalizeOptionalString(sessionCtx.Surface);
+  const nextProvider =
+    liveProvider && !isSystemEventProvider(liveProvider)
+      ? liveProvider
+      : (persistedProvider ?? liveProvider);
+  const nextSurface =
+    liveSurface && !isSystemEventProvider(liveSurface)
+      ? liveSurface
+      : (persistedSurface ?? liveSurface);
+
+  const next: TemplateContext = { ...sessionCtx };
+  let changed = false;
+  const setIfMissing = <K extends keyof TemplateContext>(key: K, value: TemplateContext[K]) => {
+    if (next[key] != null && next[key] !== "") {
+      return;
+    }
+    if (value == null || value === "") {
+      return;
+    }
+    next[key] = value;
+    changed = true;
+  };
+  const setIfChanged = <K extends keyof TemplateContext>(key: K, value: TemplateContext[K]) => {
+    if (value == null || value === "" || next[key] === value) {
+      return;
+    }
+    next[key] = value;
+    changed = true;
+  };
+
+  setIfChanged("Provider", nextProvider);
+  setIfChanged("Surface", nextSurface);
+  setIfMissing("ChatType", persistedChatType);
+  if (effectiveChatType === "group" || effectiveChatType === "channel") {
+    setIfMissing("GroupSubject", normalizeOptionalString(sessionEntry.subject));
+    setIfMissing("GroupChannel", normalizeOptionalString(sessionEntry.groupChannel));
+    setIfMissing("GroupSpace", normalizeOptionalString(sessionEntry.space));
+  }
+  setIfMissing("OriginatingChannel", persistedProvider);
+  setIfMissing(
+    "OriginatingTo",
+    normalizeOptionalString(
+      sessionEntry.lastTo ?? sessionEntry.deliveryContext?.to ?? sessionEntry.origin?.to,
+    ),
+  );
+  setIfMissing(
+    "AccountId",
+    normalizeOptionalString(
+      sessionEntry.lastAccountId ??
+        sessionEntry.deliveryContext?.accountId ??
+        sessionEntry.origin?.accountId,
+    ),
+  );
+  setIfMissing(
+    "MessageThreadId",
+    sessionEntry.lastThreadId ??
+      sessionEntry.deliveryContext?.threadId ??
+      sessionEntry.origin?.threadId,
+  );
+
+  return changed ? next : sessionCtx;
 }
 
 export function buildExecOverridePromptHint(params: {
@@ -278,15 +384,6 @@ export async function runPreparedReply(
     ctx,
     sessionKey,
   });
-  const silentReplySettings = resolveSilentReplySettings({
-    cfg,
-    sessionKey: runtimePolicySessionKey,
-    surface: sessionCtx.Surface ?? sessionCtx.Provider,
-    conversationType: resolvePromptSilentReplyConversationType({
-      ctx: sessionCtx,
-      inboundSessionKey: ctx.SessionKey,
-    }),
-  });
   let {
     sessionEntry,
     resolvedThinkLevel,
@@ -296,6 +393,22 @@ export async function runPreparedReply(
     execOverrides,
     abortedLastRun,
   } = params;
+  const isHeartbeat = opts?.isHeartbeat === true;
+  const promptSessionCtx = resolvePromptSessionContextForSystemEvent({
+    sessionCtx,
+    sessionEntry,
+    ctx,
+    isHeartbeat,
+  });
+  const silentReplySettings = resolveSilentReplySettings({
+    cfg,
+    sessionKey: runtimePolicySessionKey,
+    surface: promptSessionCtx.Surface ?? promptSessionCtx.Provider,
+    conversationType: resolvePromptSilentReplyConversationType({
+      ctx: promptSessionCtx,
+      inboundSessionKey: ctx.SessionKey,
+    }),
+  });
   const useFastReplyRuntime = shouldUseReplyFastTestRuntime({
     cfg,
     isFastTestEnv: process.env.OPENCLAW_TEST_FAST === "1",
@@ -310,9 +423,9 @@ export async function runPreparedReply(
   let currentSystemSent = systemSent;
 
   const isFirstTurnInSession = isNewSession || !currentSystemSent;
-  const isGroupChat = sessionCtx.ChatType === "group" || sessionCtx.ChatType === "channel";
+  const isGroupChat =
+    promptSessionCtx.ChatType === "group" || promptSessionCtx.ChatType === "channel";
   const wasMentioned = ctx.WasMentioned === true;
-  const isHeartbeat = opts?.isHeartbeat === true;
   const { typingPolicy, suppressTyping } = resolveRunTypingPolicy({
     requestedPolicy: opts?.typingPolicy,
     suppressTyping: opts?.suppressTyping === true,
@@ -332,9 +445,9 @@ export async function runPreparedReply(
     isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),
   );
   const directChatContext =
-    sessionCtx.ChatType === "direct" || sessionCtx.ChatType === "dm"
+    promptSessionCtx.ChatType === "direct" || promptSessionCtx.ChatType === "dm"
       ? buildDirectChatContext({
-          sessionCtx,
+          sessionCtx: promptSessionCtx,
           silentReplyPolicy: silentReplySettings.policy,
           silentReplyRewrite: silentReplySettings.rewrite,
           silentToken: SILENT_REPLY_TOKEN,
@@ -343,7 +456,7 @@ export async function runPreparedReply(
   // Always include persistent group chat context (provider + reply guidance).
   const groupChatContext = isGroupChat
     ? buildGroupChatContext({
-        sessionCtx,
+        sessionCtx: promptSessionCtx,
         sourceReplyDeliveryMode: opts?.sourceReplyDeliveryMode,
         silentReplyPolicy: silentReplySettings.policy,
         silentReplyRewrite: silentReplySettings.rewrite,
@@ -354,7 +467,7 @@ export async function runPreparedReply(
   const groupIntro = shouldInjectGroupIntro
     ? buildGroupIntro({
         cfg,
-        sessionCtx,
+        sessionCtx: promptSessionCtx,
         sessionEntry,
         defaultActivation,
         silentToken: SILENT_REPLY_TOKEN,
@@ -370,7 +483,7 @@ export async function runPreparedReply(
       silentReplyPolicy: silentReplySettings.policy,
       silentReplyRewrite: silentReplySettings.rewrite,
     }).allowEmptyAssistantReplyAsSilent;
-  const groupSystemPrompt = normalizeOptionalString(sessionCtx.GroupSystemPrompt) ?? "";
+  const groupSystemPrompt = normalizeOptionalString(promptSessionCtx.GroupSystemPrompt) ?? "";
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
     { includeFormattingHints: !useFastReplyRuntime },


### PR DESCRIPTION
## Summary

- Problem: post-restart wake/cron/heartbeat turns for Discord Claude CLI sessions could rebuild CLI prompt identity from synthetic system-event context instead of persisted Discord chat metadata.
- Why it matters: the static prompt hash could drift, causing `--resume` to be skipped even when the prior CLI session binding was still valid.
- What changed: system-event prompt construction now restores missing prompt-only chat/route metadata from the persisted session entry before building static CLI prompt identity, and CLI exec logs include redacted resume diagnostics.
- What did NOT change: auth, auth-epoch, MCP, and real system-prompt mismatch invalidation remain strict. This does not address the separate group-intro prompt drift tracked in #69118.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74125
- Related #69118
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: wake/heartbeat/cron turns can arrive with `Provider=heartbeat|cron-event|exec-event` and no live `ChatType`, while CLI reuse hashes were built from that live context instead of the persisted Discord session entry.
- Missing detection / guardrail: existing tests covered no-reset behavior and static prompt forwarding, but not a post-restart system-event turn rebuilding the same static CLI prompt identity as the prior Discord channel session.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/get-reply-run.exec-hint.test.ts`
  - `src/auto-reply/reply/get-reply-run.media-only.test.ts`
  - `src/agents/cli-runner.spawn.test.ts`
- Scenario the test should lock in: a cron/system-event turn with no live `ChatType` uses persisted Discord channel metadata for static CLI prompt identity and logs resume diagnostics without exposing raw CLI session IDs.
- Why this is the smallest reliable guardrail: the bug is at prompt identity construction before CLI reuse, so the prepared-reply seam proves the hash input is stable without needing a live Discord or Claude CLI run.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Wake/heartbeat/cron system-event turns targeting a persisted Discord Claude CLI session now keep CLI continuity when auth and MCP identity still match. CLI exec logs also include redacted resume/reuse diagnostics.

## Diagram (if applicable)

```text
Before:
post-restart wake -> synthetic cron/heartbeat context -> static prompt hash drifts -> CLI resume skipped -> cold turn

After:
post-restart wake -> persisted Discord prompt metadata restored -> static prompt hash remains stable -> CLI resume can continue
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. Resume diagnostics intentionally log only presence/state and a short one-way session fingerprint, not raw CLI session IDs or argv.

## Repro + Verification

### Environment

- OS: Linux container
- Runtime/container: Node v24.11.0 via `/tmp/node-v24.11.0-linux-x64/bin`
- Model/provider: Claude CLI path exercised through unit/seam tests
- Integration/channel (if any): Discord session metadata simulated at the prepared-reply seam
- Relevant config (redacted): persisted Discord channel session entry with stored CLI binding metadata

### Steps

1. Start from a persisted Discord channel session entry with CLI session metadata.
2. Simulate a post-restart cron/system-event turn with `Provider=cron-event` and no live `ChatType`.
3. Build the prepared reply and inspect the static CLI prompt identity passed toward the runner.

### Expected

- The static prompt identity is built from persisted Discord channel metadata.
- CLI diagnostics show trigger/reuse state without leaking raw CLI session IDs.

### Actual

- Before this fix, the synthetic system-event context could omit group/channel prompt context and drift the static prompt hash.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `PATH=/tmp/node-v24.11.0-linux-x64/bin:$PATH pnpm test src/agents/cli-session.test.ts src/agents/cli-runner/prepare.test.ts src/agents/cli-runner.spawn.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/gateway/server-cron.test.ts`
  - `PATH=/tmp/node-v24.11.0-linux-x64/bin:$PATH pnpm test src/auto-reply/reply/get-reply-run.exec-hint.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/cli-runner.spawn.test.ts`
  - `PATH=/tmp/node-v24.11.0-linux-x64/bin:$PATH pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/session.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/agent-runner-execution.ts src/agents/cli-runner/prepare.ts src/agents/cli-runner/execute.ts src/agents/cli-session.ts src/infra/heartbeat-runner.ts src/gateway/server-cron.ts CHANGELOG.md src/auto-reply/reply/get-reply-run.exec-hint.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/cli-runner.spawn.test.ts`
  - `PATH=/tmp/node-v24.11.0-linux-x64/bin:$PATH pnpm check:changed`
- Edge cases checked:
  - missing system-event `ChatType`
  - synthetic `heartbeat`/`cron-event` provider labels
  - persisted Discord channel route metadata
  - normal user turns remain on live metadata
  - explicit system-event metadata is not overwritten
  - raw CLI session IDs are not logged
- What you did **not** verify:
  - a live Discord + Claude CLI gateway restart repro

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: restoring persisted prompt metadata too broadly could mask a real auth/MCP/system-prompt mismatch.
 - Mitigation: this only changes prompt context reconstruction; CLI reuse invalidation for auth profile, auth epoch, MCP, and durable prompt hash mismatch remains strict.