### PR TITLE
fix: enable native require fast path on Windows for bundled plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,6 +315,7 @@ Docs: https://docs.openclaw.ai
 - Auth/device pairing: bound bootstrap handoff token issuance, redemption, and approved pairing baselines to the documented per-role scope allowlist, so bootstrap approvals cannot persistently grant `operator.admin`, `operator.pairing`, or `node.exec` scopes. Thanks @eleqtrizit.
 - Providers/GitHub Copilot: support the GUI/RPC wizard device-code auth flow so onboarding from non-TTY clients (gateway RPC bridge, GUI wizards) completes instead of returning empty profiles. Dangerous-state handling now distinguishes `access_denied` and `expired_token` from transport errors. (#73290) Thanks @indierawk2k2.
 - Installer/Linux: warn before switching an unwritable npm global prefix to `~/.npm-global`, then tell users to run future global updates with `npm i -g openclaw@latest` without `sudo` so npm keeps using the redirected user prefix. Fixes #44365; carries forward #50479. Thanks @Sayeem3051.
+- Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 
 ## 2026.4.27
 

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -48,7 +48,7 @@ function getJiti(modulePath: string) {
 }
 
 function loadPluginDoctorContractModule(modulePath: string): PluginDoctorContractModule {
-  const nativeModule = tryNativeRequireJavaScriptModule(modulePath);
+  const nativeModule = tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true });
   if (nativeModule.ok) {
     return nativeModule.moduleExport as PluginDoctorContractModule;
   }

--- a/src/plugins/jiti-loader-cache.test.ts
+++ b/src/plugins/jiti-loader-cache.test.ts
@@ -208,13 +208,14 @@ describe("getCachedPluginJitiLoader", () => {
     const jitiLoader = vi.fn();
     const createJiti = vi.fn(() => jitiLoader);
     vi.doMock("jiti", () => ({ createJiti }));
+    const nativeStub = vi.fn((target: string) => ({
+      ok: true as const,
+      moduleExport: { loadedFrom: target },
+    }));
     vi.doMock("./native-module-require.js", () => ({
       isJavaScriptModulePath: (p: string) =>
         p.endsWith(".js") || p.endsWith(".mjs") || p.endsWith(".cjs"),
-      tryNativeRequireJavaScriptModule: (target: string) => ({
-        ok: true,
-        moduleExport: { loadedFrom: target },
-      }),
+      tryNativeRequireJavaScriptModule: nativeStub,
     }));
     const { getCachedPluginJitiLoader } = await importFreshModule<
       typeof import("./jiti-loader-cache.js")
@@ -233,6 +234,10 @@ describe("getCachedPluginJitiLoader", () => {
     // jiti is created eagerly, but its loader must NOT be invoked for .js
     // targets that `tryNativeRequireJavaScriptModule` resolves.
     expect(jitiLoader).not.toHaveBeenCalled();
+    // allowWindows must be passed so the native fast path works on Windows too.
+    expect(nativeStub).toHaveBeenCalledWith("/repo/dist/extensions/demo/api.js", {
+      allowWindows: true,
+    });
   });
 
   it("falls back to jiti when the native-require helper declines", async () => {

--- a/src/plugins/jiti-loader-cache.ts
+++ b/src/plugins/jiti-loader-cache.ts
@@ -105,7 +105,7 @@ export function getCachedPluginJitiLoader(params: {
   // async-module fallbacks `tryNativeRequireJavaScriptModule` declines to
   // handle.
   const loader = ((target: string, ...rest: unknown[]) => {
-    const native = tryNativeRequireJavaScriptModule(target);
+    const native = tryNativeRequireJavaScriptModule(target, { allowWindows: true });
     if (native.ok) {
       return native.moduleExport;
     }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1316,6 +1316,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     let selectedMemoryPluginId: string | null = null;
     let memorySlotMatched = false;
     const dreamingEngineId = resolveDreamingSidecarEngineId({ cfg, memorySlot });
+    const pluginLoadStartMs = performance.now();
 
     for (const candidate of orderedCandidates) {
       const manifestRecord = manifestByRoot.get(candidate.rootDir);
@@ -1702,6 +1703,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         // Track the plugin as imported once module evaluation begins. Top-level
         // code may have already executed even if evaluation later throws.
         recordImportedPluginId(record.id);
+        logger.debug(`[plugins] loading ${record.id} from ${safeSource}`);
         mod = withProfile(
           { pluginId: record.id, source: safeSource },
           registrationMode,
@@ -2063,6 +2065,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           diagnosticMessagePrefix: "plugin failed during register: ",
         });
       }
+    }
+
+    const pluginLoadElapsedMs = performance.now() - pluginLoadStartMs;
+    const loadedCount = registry.plugins.length;
+    if (loadedCount > 0) {
+      logger.debug(
+        `[plugins] loaded ${loadedCount} plugin(s) in ${pluginLoadElapsedMs.toFixed(1)}ms`,
+      );
     }
 
     // Scoped snapshot loads may intentionally omit the configured memory plugin, so only

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1317,6 +1317,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     let memorySlotMatched = false;
     const dreamingEngineId = resolveDreamingSidecarEngineId({ cfg, memorySlot });
     const pluginLoadStartMs = performance.now();
+    let pluginLoadAttemptCount = 0;
 
     for (const candidate of orderedCandidates) {
       const manifestRecord = manifestByRoot.get(candidate.rootDir);
@@ -1703,7 +1704,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         // Track the plugin as imported once module evaluation begins. Top-level
         // code may have already executed even if evaluation later throws.
         recordImportedPluginId(record.id);
-        logger.debug(`[plugins] loading ${record.id} from ${safeSource}`);
+        pluginLoadAttemptCount++;
+        logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
         mod = withProfile(
           { pluginId: record.id, source: safeSource },
           registrationMode,
@@ -2068,10 +2070,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     }
 
     const pluginLoadElapsedMs = performance.now() - pluginLoadStartMs;
-    const loadedCount = registry.plugins.length;
-    if (loadedCount > 0) {
-      logger.debug(
-        `[plugins] loaded ${loadedCount} plugin(s) in ${pluginLoadElapsedMs.toFixed(1)}ms`,
+    if (pluginLoadAttemptCount > 0) {
+      logger.debug?.(
+        `[plugins] loaded ${registry.plugins.length} plugin(s) (${pluginLoadAttemptCount} attempted) in ${pluginLoadElapsedMs.toFixed(1)}ms`,
       );
     }
 

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -111,7 +111,7 @@ afterEach(() => {
 });
 
 describe("bundled plugin public surface loader", () => {
-  it("uses transpiled Jiti import for Windows dist public artifact loads", async () => {
+  it("uses native Jiti import for Windows dist public artifact loads", async () => {
     const createJiti = vi.fn(() => vi.fn(() => ({ marker: "windows-dist-ok" })));
     vi.doMock("jiti", () => ({
       createJiti,
@@ -140,7 +140,7 @@ describe("bundled plugin public surface loader", () => {
       expect(createJiti).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          tryNative: false,
+          tryNative: true,
         }),
       );
     } finally {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -952,7 +952,7 @@ describe("plugin sdk alias helpers", () => {
     }
   });
 
-  it("disables native Jiti loads on Windows for built JavaScript entries", () => {
+  it("enables native Jiti loads on Windows for built JavaScript entries", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       configurable: true,
@@ -960,9 +960,9 @@ describe("plugin sdk alias helpers", () => {
     });
 
     try {
-      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(false);
+      expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(true);
       expect(shouldPreferNativeJiti(`/repo/${bundledDistPluginFile("browser", "index.js")}`)).toBe(
-        false,
+        true,
       );
     } finally {
       Object.defineProperty(process, "platform", {
@@ -972,7 +972,7 @@ describe("plugin sdk alias helpers", () => {
     }
   });
 
-  it("keeps plugin loader dist shortcuts on transpiled Jiti on Windows", () => {
+  it("keeps plugin loader dist shortcuts on native Jiti on Windows for JS entries", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", {
       configurable: true,
@@ -984,7 +984,7 @@ describe("plugin sdk alias helpers", () => {
         resolvePluginLoaderJitiTryNative(`/repo/${bundledDistPluginFile("browser", "index.js")}`, {
           preferBuiltDist: true,
         }),
-      ).toBe(false);
+      ).toBe(true);
       expect(
         resolvePluginLoaderJitiTryNative(`/repo/${bundledDistPluginFile("browser", "helper.ts")}`, {
           preferBuiltDist: true,

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -695,7 +695,7 @@ export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
 
 function supportsNativeJitiRuntime(): boolean {
   const versions = process.versions as { bun?: string };
-  return typeof versions.bun !== "string" && process.platform !== "win32";
+  return typeof versions.bun !== "string";
 }
 
 function isBundledPluginDistModulePath(modulePath: string): boolean {

--- a/src/test-utils/jiti-runtime.ts
+++ b/src/test-utils/jiti-runtime.ts
@@ -1,5 +1,3 @@
 export function shouldExpectNativeJitiForJavaScriptTestRuntime(): boolean {
-  return (
-    typeof (process.versions as { bun?: string }).bun !== "string" && process.platform !== "win32"
-  );
+  return typeof (process.versions as { bun?: string }).bun !== "string";
 }


### PR DESCRIPTION
## Summary

- Problem: Gateway startup takes ~39s on Windows with a ~37.5s silent gap before plugin registration (#68656). All plugin modules are forced through Jiti's slow transform pipeline because `supportsNativeJitiRuntime()` hard-excludes `win32`.
- Why it matters: 100% of Windows users experience this on every startup. Other platforms are unaffected (~2-3s startup).
- What changed: Removed the `win32` exclusion from `supportsNativeJitiRuntime()` so bundled `.js` plugin modules use native `require()` instead of Jiti. Also added `{ allowWindows: true }` to all `tryNativeRequireJavaScriptModule` call sites, and added per-plugin debug logging to eliminate the silent gap.
- What did NOT change (scope boundary): TypeScript source plugins still use Jiti. The Bun exclusion remains. No changes to plugin discovery, registration, or activation logic. macOS/Linux behavior is identical before and after.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68656
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `supportsNativeJitiRuntime()` in `src/plugins/sdk-alias.ts:696-698` returned `false` on `win32`, forcing every plugin module through Jiti's transform pipeline. Jiti adds several seconds of overhead per module (documented in `jiti-loader-cache.ts:102-103`). With 6 plugins loaded sequentially, this compounds to ~37.5s.
- Missing detection / guardrail: No startup profiling was enabled by default; the silent gap had no logging to indicate where time was spent.
- Contributing context (if known): The win32 exclusion was likely added as a caution flag when native require on Windows hadn't been validated. The `tryNativeRequireJavaScriptModule` function also independently blocks win32 unless `allowWindows: true` is explicitly passed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/sdk-alias.test.ts`, `src/plugins/jiti-loader-cache.test.ts`
- Scenario the test should lock in: `shouldPreferNativeJiti` returns `true` for `.js` files on Windows; `resolvePluginLoaderJitiTryNative` returns `true` for bundled dist JS on Windows; `allowWindows: true` is passed to native require.
- Why this is the smallest reliable guardrail: These unit tests directly verify the decision points that gate the fast path on Windows.
- Existing test that already covers this (if any): Existing tests asserted the old (slow) behavior; updated to assert the new (fast) behavior.

## User-visible / Behavior Changes

- Gateway startup on Windows should be significantly faster (estimated ~37s reduction for typical 6-plugin setups).
- New debug-level log lines during plugin loading: `[plugins] loading <id> from <source>` and `[plugins] loaded N plugin(s) in Xms`. These are debug-level and not shown by default.

## Diagram (if applicable)

```text
Before (Windows):
[gateway starting] -> [Jiti transform per plugin ~6s each] -> [37.5s gap] -> [ready 38.8s]

After (Windows):
[gateway starting] -> [native require() per plugin ~0.1s each] -> [ready ~1-2s]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows Server (reported), Windows 11 (dev)
- Runtime/container: Node 24.15.0
- Model/provider: glm/GLM-5.1 (reported)
- Integration/channel (if any): N/A
- Relevant config (redacted): Default config, 6 bundled plugins

### Steps

1. Install OpenClaw on Windows
2. Run `openclaw gateway run`
3. Observe startup time

### Expected

- Startup completes in under 5s with per-plugin debug logging visible

### Actual

- Before fix: ~39s startup with 37.5s silent gap

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Updated unit tests in `sdk-alias.test.ts`, `jiti-loader-cache.test.ts`, `public-surface-loader.test.ts` now assert the native fast path is active on Windows. Code review confirmed zero behavioral change on macOS/Linux.

**Startup profiling** (`OPENCLAW_PLUGIN_LOAD_PROFILE=1 OPENCLAW_GATEWAY_STARTUP_TRACE=1 pnpm openclaw gateway run --allow-unconfigured`) on Windows 11 / Node 24.15.0:

| Plugin | Load (ms) | Register (ms) |
|--------|-----------|---------------|
| acpx | 26.3 | 0.4 |
| bonjour | 87.0 | 0.2 |
| browser | 27.9 | 0.9 |
| device-pair | 243.8 | 0.9 |
| memory-core | 180.2 | 0.9 |
| phone-control | 15.0 | 0.3 |
| talk-voice | 16.1 | 0.3 |
| **Total** | **~596ms** | **~3.9ms** |

Plugin module loading: **~0.6s** (was ~37.5s in the bug report — **~63x speedup**). Total first-run startup was 43.5s due to one-time npm runtime-dep installs (browser: 17.6s, memory-core: 7.5s) and Control UI build (2.8s); these are cached on subsequent runs.

## Human Verification (required)

- Verified scenarios: All modified tests pass on Windows. Ran `pnpm openclaw gateway run --allow-unconfigured` on Windows 11 with startup trace + plugin load profiling enabled — confirmed plugin module loads complete in ~596ms total via native require. Code review confirmed macOS/Linux paths are identical before/after (the removed condition was `!win32`, which was already `true` on non-Windows). Traced all 4 call sites of `tryNativeRequireJavaScriptModule` to confirm consistent `allowWindows` usage.
- Edge cases checked: Bun exclusion preserved. TS source files still route through Jiti. Native require fallback to Jiti on failure (try/catch in `native-module-require.ts:20-23`). Third-party plugins unaffected (only bundled dist JS uses native path).
- What you did **not** verify: Comparative before/after timing on the same machine (would require reverting the fix and re-running). The reporter's environment (Windows Server + GLM-5.1) was not available for testing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Native `require()` on Windows may fail for edge-case module formats (e.g., ESM with top-level await).
  - Mitigation: The existing fallback in `jiti-loader-cache.ts:107-113` and `native-module-require.ts:20-23` gracefully catches any require error and falls through to Jiti. No behavioral change for modules that fail native require.
- Risk: Third-party plugins with non-standard module formats.
  - Mitigation: Only `.js`/`.mjs`/`.cjs` files use the native path; TS sources still go through Jiti with alias rewriting.
