### PR TITLE
chore(ci): add memory CodeQL quality shard

### DIFF
--- a/.github/codeql/codeql-memory-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-memory-runtime-boundary-critical-quality.yml
@@ -1,0 +1,41 @@
+name: openclaw-codeql-memory-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - packages/memory-host-sdk/src
+  - src/memory
+  - src/memory-host-sdk
+  - src/plugin-sdk/memory-*.ts
+  - src/plugin-sdk/memory-core-host-*.ts
+  - src/plugins/memory-*.ts
+  - src/gateway/server-startup-memory.ts
+  - src/commands/doctor-memory-search.ts
+  - src/commands/doctor-cron-dreaming-payload-migration.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -144,6 +144,27 @@ jobs:
         with:
           category: "/codeql-critical-quality/mcp-process-runtime-boundary"
 
+  memory-runtime-boundary:
+    name: Critical Quality (memory-runtime-boundary)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-memory-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/memory-runtime-boundary"
+
   ui-control-plane:
     name: Critical Quality (ui-control-plane)
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -288,6 +288,10 @@ the separate `/codeql-critical-quality/agent-runtime-boundary` category. The
 mcp-process-runtime-boundary job scans MCP servers and tool bridges, process
 supervision helpers, and outbound delivery contracts under the separate
 `/codeql-critical-quality/mcp-process-runtime-boundary` category. The
+memory-runtime-boundary job scans the memory host SDK, memory runtime facades,
+memory Plugin SDK aliases, memory runtime activation glue, and memory doctor
+commands under the separate `/codeql-critical-quality/memory-runtime-boundary`
+category. The
 ui-control-plane job scans Control UI bootstrap, local persistence, gateway
 control flows, and task control-plane runtime contracts under the separate
 `/codeql-critical-quality/ui-control-plane` category. The


### PR DESCRIPTION
## Summary
- add a narrow CodeQL critical-quality shard for the memory host/runtime boundary
- keep it on the 4-vCPU Blacksmith runner and the non-security error-severity query profile
- document the new category in the CI guide

## Validation
- git diff --check
- parsed CodeQL workflow/config YAML with Ruby

Manual CodeQL workflow dispatch will be run on this branch before merge.