### PR TITLE
fix(subagent-announce-delivery): prefer parent session binding for completion announce

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -307,24 +307,9 @@ export async function resolveSubagentCompletionOrigin(params: {
   const requesterConversation: ConversationRef | undefined =
     channel && conversationId ? { channel, accountId, conversationId } : undefined;
 
-  const router = createBoundDeliveryRouter();
-  const childRoute = router.resolveDestination({
-    eventKind: "task_completion",
-    targetSessionKey: params.childSessionKey,
-    requester: requesterConversation,
-    failClosed: true,
-  });
-  if (childRoute.mode === "bound" && childRoute.binding) {
-    return mergeDeliveryContext(
-      resolveBoundConversationOrigin({
-        bindingConversation: childRoute.binding.conversation,
-        requesterConversation,
-        requesterOrigin,
-      }),
-      requesterOrigin,
-    );
-  }
-
+  // Prefer the requester (parent session) binding — the delivery must use the
+  // parent's accountId, not the child's. The child session key is only here as
+  // a fallback when the parent has no bound delivery context.
   const route = router.resolveDestination({
     eventKind: "task_completion",
     targetSessionKey: params.requesterSessionKey,
@@ -335,6 +320,24 @@ export async function resolveSubagentCompletionOrigin(params: {
     return mergeDeliveryContext(
       resolveBoundConversationOrigin({
         bindingConversation: route.binding.conversation,
+        requesterConversation,
+        requesterOrigin,
+      }),
+      requesterOrigin,
+    );
+  }
+
+  // Fallback: try the child session key if the parent has no binding.
+  const childRoute = router.resolveDestination({
+    eventKind: "task_completion",
+    targetSessionKey: params.childSessionKey,
+    requester: requesterConversation,
+    failClosed: true,
+  });
+  if (childRoute.mode === "bound" && childRoute.binding) {
+    return mergeDeliveryContext(
+      resolveBoundConversationOrigin({
+        bindingConversation: childRoute.binding.conversation,
         requesterConversation,
         requesterOrigin,
       }),


### PR DESCRIPTION
Fix #74080

When a parent agent (bound to Feishu app A) spawns a subagent running under a different agent (bound to Feishu app B), the completion announce delivery was first looking up the child agent's binding, then falling back to the parent.

On multi-Feishu configurations this causes delivery to use the child's `accountId` (app B) when the parent's `accountId` (app A) is needed, resulting in a Feishu 400 `open_id cross app` error.

**The fix:** try the parent (requester) session binding first, and only fall back to the child session if the parent has no bound delivery context.

Key change in `subagent-announce-delivery.ts`:
- `route` (requester/parent) is now resolved before `childRoute`\n- Fallback order: parent binding → child binding → hook runner