### PR TITLE
fix(feishu): keep quick actions and status responsive

### DIFF
--- a/extensions/feishu/src/card-ux-launcher.test.ts
+++ b/extensions/feishu/src/card-ux-launcher.test.ts
@@ -44,7 +44,15 @@ describe("feishu quick-action launcher", () => {
       body: {
         elements: Array<{
           tag: string;
-          actions?: Array<{ value?: { oc?: string; c?: { s?: string; t?: string } } }>;
+          actions?: Array<{
+            value?: {
+              oc?: string;
+              k?: string;
+              a?: string;
+              q?: string;
+              c?: { s?: string; t?: string };
+            };
+          }>;
         }>;
       };
     };
@@ -57,6 +65,11 @@ describe("feishu quick-action launcher", () => {
     expect(actionBlock?.actions?.[0]?.value?.oc).toBe("ocf1");
     expect(actionBlock?.actions?.[0]?.value?.c?.s).toBe("agent:codex:feishu:chat:chat1");
     expect(actionBlock?.actions?.[0]?.value?.c?.t).toBeUndefined();
+    expect(actionBlock?.actions?.[1]?.value).toMatchObject({
+      k: "quick",
+      a: "feishu.quick_actions.new",
+      q: "/new",
+    });
   });
 
   it("opens the launcher from a supported bot menu event", async () => {

--- a/extensions/feishu/src/card-ux-launcher.ts
+++ b/extensions/feishu/src/card-ux-launcher.ts
@@ -55,12 +55,9 @@ export function createQuickActionLauncherCard(params: {
               label: "New session",
               type: "primary",
               value: createFeishuCardInteractionEnvelope({
-                k: "meta",
-                a: FEISHU_APPROVAL_REQUEST_ACTION,
-                m: {
-                  command: "/new",
-                  prompt: "Start a fresh session? This will reset the current chat context.",
-                },
+                k: "quick",
+                a: "feishu.quick_actions.new",
+                q: "/new",
                 c: context,
               }),
             }),

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -49,6 +49,7 @@ let createFeishuWSClient: CreateFeishuWSClient;
 let clearClientCache: ClearClientCache;
 let setFeishuClientRuntimeForTest: SetFeishuClientRuntimeForTest;
 let FEISHU_HTTP_TIMEOUT_MS: number;
+let FEISHU_WS_HTTP_TIMEOUT_MS: number;
 let FEISHU_HTTP_TIMEOUT_MAX_MS: number;
 let FEISHU_HTTP_TIMEOUT_ENV_VAR: string;
 
@@ -119,9 +120,17 @@ function readCallOptions(
   return isRecord(call) ? call : {};
 }
 
-function firstWsClientOptions(): { agent?: unknown; wsConfig?: unknown } {
+function firstWsClientOptions(): {
+  agent?: unknown;
+  httpInstance?: HttpInstanceLike;
+  wsConfig?: unknown;
+} {
   const options = readCallOptions(wsClientCtorMock, 0);
-  return { agent: options.agent, wsConfig: options.wsConfig };
+  return {
+    agent: options.agent,
+    httpInstance: options.httpInstance as HttpInstanceLike | undefined,
+    wsConfig: options.wsConfig,
+  };
 }
 
 beforeAll(async () => {
@@ -144,6 +153,7 @@ beforeAll(async () => {
     clearClientCache,
     setFeishuClientRuntimeForTest,
     FEISHU_HTTP_TIMEOUT_MS,
+    FEISHU_WS_HTTP_TIMEOUT_MS,
     FEISHU_HTTP_TIMEOUT_MAX_MS,
     FEISHU_HTTP_TIMEOUT_ENV_VAR,
   } = await import("./client.js"));
@@ -345,6 +355,20 @@ describe("createFeishuClient HTTP timeout", () => {
 });
 
 describe("createFeishuWSClient proxy handling", () => {
+  it("injects a short timeout into ws token requests", async () => {
+    await createFeishuWSClient(baseAccount);
+
+    const options = firstWsClientOptions();
+    expect(options.httpInstance).toBeDefined();
+    await options.httpInstance?.post("https://example.com/token", {});
+
+    expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
+      "https://example.com/token",
+      {},
+      expect.objectContaining({ timeout: FEISHU_WS_HTTP_TIMEOUT_MS }),
+    );
+  });
+
   it("passes heartbeat wsConfig defaults to Lark.WSClient", async () => {
     await createFeishuWSClient(baseAccount);
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -79,6 +79,7 @@ let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
 
 /** Default HTTP timeout for Feishu API requests (30 seconds). */
 export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
+export const FEISHU_WS_HTTP_TIMEOUT_MS = 3_000;
 export const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;
 export const FEISHU_HTTP_TIMEOUT_ENV_VAR = "OPENCLAW_FEISHU_HTTP_TIMEOUT_MS";
 
@@ -232,10 +233,15 @@ export async function createFeishuWSClient(account: ResolvedFeishuAccount): Prom
   }
 
   const agent = await getWsProxyAgent();
+  const wsHttpTimeoutMs = Math.min(
+    resolveConfiguredHttpTimeoutMs(account),
+    FEISHU_WS_HTTP_TIMEOUT_MS,
+  );
   return new feishuClientSdk.WSClient({
     appId,
     appSecret,
     domain: resolveDomain(domain),
+    httpInstance: createTimeoutHttpInstance(wsHttpTimeoutMs),
     loggerLevel: feishuClientSdk.LoggerLevel.info,
     wsConfig: FEISHU_WS_CONFIG,
     ...(agent ? { agent } : {}),

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -80,6 +80,10 @@ describe("Feishu monitor startup preflight", () => {
       await waitForStartedAccount(started, "alpha");
       expect(started).toEqual(["alpha"]);
       expect(maxInFlight).toBe(1);
+      expect(probeFeishuMock).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: "alpha" }),
+        expect.objectContaining({ timeoutMs: 3_000 }),
+      );
     } finally {
       releaseProbes();
       abortController.abort();

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -3,7 +3,7 @@ import type { RuntimeEnv } from "../runtime-api.js";
 import { probeFeishu } from "./probe.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
-const FEISHU_STARTUP_BOT_INFO_TIMEOUT_DEFAULT_MS = 30_000;
+const FEISHU_STARTUP_BOT_INFO_TIMEOUT_DEFAULT_MS = 3_000;
 const FEISHU_STARTUP_BOT_INFO_TIMEOUT_ENV = "OPENCLAW_FEISHU_STARTUP_PROBE_TIMEOUT_MS";
 
 function resolveStartupProbeTimeoutMs(): number {

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -143,6 +143,18 @@ describe("probeFeishu", () => {
     );
   });
 
+  it("clamps caller-provided probe timeout to the startup-safe default", async () => {
+    const requestFn = setupSuccessClient();
+
+    await probeFeishu(DEFAULT_CREDS, { timeoutMs: 30_000 });
+
+    expect(requestFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: FEISHU_PROBE_REQUEST_TIMEOUT_MS,
+      }),
+    );
+  });
+
   it("returns timeout error when request exceeds timeout", async () => {
     await withFakeTimers(async () => {
       const requestFn = vi.fn().mockImplementation(() => new Promise(() => {}));

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -12,7 +12,7 @@ const probeCache = new Map<string, { result: FeishuProbeResult; expiresAt: numbe
 const PROBE_SUCCESS_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const PROBE_ERROR_TTL_MS = 60 * 1000; // 1 minute
 const MAX_PROBE_CACHE_SIZE = 64;
-export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
+export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 3_000;
 export type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;
@@ -66,7 +66,13 @@ export async function probeFeishu(
     };
   }
 
-  const timeoutMs = options.timeoutMs ?? FEISHU_PROBE_REQUEST_TIMEOUT_MS;
+  // Startup probes should never inherit long caller timeouts: slow Feishu
+  // credential checks can otherwise hold channel startup and status probes for
+  // tens of seconds.
+  const timeoutMs = Math.min(
+    options.timeoutMs ?? FEISHU_PROBE_REQUEST_TIMEOUT_MS,
+    FEISHU_PROBE_REQUEST_TIMEOUT_MS,
+  );
 
   // Return cached result if still valid.
   // Use accountId when available; otherwise include appSecret prefix so two


### PR DESCRIPTION
## Summary
- route the Feishu Quick Actions `New session` button directly to `/new` instead of the approval-card flow
- bound Feishu startup probe and WS token HTTP timeouts so slow Feishu API calls do not stall startup/status
- document that Feishu startup probes clamp long caller-provided probe timeouts to the startup-safe default

## Testing
- `vitest --root /root/openclaw-pr-feishu-hotfix run extensions/feishu/src/card-ux-launcher.test.ts extensions/feishu/src/probe.test.ts extensions/feishu/src/client.test.ts --pool=forks --maxWorkers=1 --reporter=dot`
- `vitest --root /root/openclaw-pr-feishu-hotfix run extensions/feishu/src/monitor.startup.test.ts --pool=forks --maxWorkers=1 --reporter=dot`
- `git diff --check`

## Notes
- Removed the `chat.history` cache/default-thinking change from this PR to preserve the existing gateway contract and keep this focused on Feishu responsiveness.