### PR TITLE
fix(agents): recognize flat JSON billing payloads and snake_case error codes

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -134,6 +134,16 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("API provider");
     expect(result).toBe(BILLING_ERROR_USER_MESSAGE);
   });
+  it("returns a friendly billing message for flat JSON insufficient_balance payloads (#74079)", () => {
+    const msg = makeAssistantError(
+      '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}',
+    );
+    const result = formatAssistantErrorText(msg, {
+      provider: "google",
+      model: "gemini-3.1-pro-preview",
+    });
+    expect(result).toBe(formatBillingErrorMessage("google", "gemini-3.1-pro-preview"));
+  });
   it("returns a friendly message for rate limit errors", () => {
     const msg = makeAssistantError("429 rate limit reached");
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
@@ -403,5 +413,14 @@ describe("raw API error payload helpers", () => {
     expect(isRawApiErrorPayload(raw)).toBe(true);
     expect(getApiErrorPayloadFingerprint(raw)).toContain("server_error");
     expect(getApiErrorPayloadFingerprint(raw)).toContain("req_123");
+  });
+
+  it("recognizes flat JSON payloads with string error code and message (#74079)", () => {
+    const raw =
+      '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}';
+    expect(isRawApiErrorPayload(raw)).toBe(true);
+    expect(formatRawAssistantErrorForUi(raw)).toBe(
+      "LLM error insufficient_balance: Insufficient MBT balance. Top up or upgrade your subscription to continue.",
+    );
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -205,6 +205,21 @@ describe("isBillingErrorMessage", () => {
     expect(isBillingErrorMessage(sample)).toBe(false);
     expect(classifyFailoverReason(sample)).toBeNull();
   });
+  it("matches insufficient_balance snake_case error codes (#74079)", () => {
+    expect(isBillingErrorMessage("insufficient_balance")).toBe(true);
+    expect(classifyFailoverReason("insufficient_balance")).toBe("billing");
+  });
+  it("matches 'Insufficient MBT balance' with intervening words (#74079)", () => {
+    const msg = "Insufficient MBT balance. Top up or upgrade your subscription to continue.";
+    expect(isBillingErrorMessage(msg)).toBe(true);
+    expect(classifyFailoverReason(msg)).toBe("billing");
+  });
+  it("classifies flat JSON billing payloads with string error code (#74079)", () => {
+    const raw =
+      '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}';
+    expect(isBillingErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("billing");
+  });
   it("still matches explicit 402 markers in long payloads", () => {
     const longStructuredError =
       '{"error":{"code":402,"message":"payment required","details":"' + "x".repeat(700) + '"}}';

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -182,10 +182,9 @@ const ERROR_PATTERNS = {
     /insufficient[_ ]quota/i,
     "credit balance",
     "plans & billing",
-    "insufficient balance",
     /insufficient[_ ]balance/i,
     // Fuzzy: "Insufficient MBT balance", "Insufficient token balance", etc.
-    // Only up to ~3 short words between to avoid false positives like
+    // Exactly one intervening word — avoids false positives like
     // "insufficient to reconcile the final balance"
     /\binsufficient\s+\w+\s+balance\b/i,
     "insufficient usd or diem balance",

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -183,6 +183,11 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    /insufficient[_ ]balance/i,
+    // Fuzzy: "Insufficient MBT balance", "Insufficient token balance", etc.
+    // Only up to ~3 short words between to avoid false positives like
+    // "insufficient to reconcile the final balance"
+    /\binsufficient\s+\w+\s+balance\b/i,
     "insufficient usd or diem balance",
     /requires?\s+more\s+credits/i,
     /out of extra usage/i,

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -47,6 +47,10 @@ function isErrorPayloadObject(payload: unknown): payload is ErrorPayload {
         return true;
       }
     }
+    // Flat error payloads: {"error":"insufficient_balance","message":"..."}
+    if (typeof err === "string" && typeof record.message === "string") {
+      return true;
+    }
   }
   return false;
 }
@@ -165,6 +169,9 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
     if (typeof err.message === "string") {
       errMessage = err.message;
     }
+  } else if (typeof payload.error === "string") {
+    // Flat error payloads: {"error":"insufficient_balance","message":"..."}
+    errType = payload.error;
   }
 
   return {


### PR DESCRIPTION
## Summary
- Recognizes flat JSON error payloads (`{"error":"string_code","message":"..."}`) in the API error parser, in addition to the existing OpenAI/Anthropic-style nested envelope (`{"error":{"type":"...","message":"..."}}`)
- Adds billing pattern matching for `insufficient_balance` (underscore variant) and fuzzy `Insufficient <word> balance` (e.g., "Insufficient MBT balance")
- Together these prevent raw JSON from leaking to user-facing chat when providers return 402-style flat payloads

## Problem
When an LLM provider/proxy returns a billing error as a flat JSON payload without using the OpenAI/Anthropic-style envelope, both classifiers miss it:

1. `isBillingErrorMessage` misses `"insufficient_balance"` (underscore, not space) and `"Insufficient MBT balance"` (intervening word breaks substring match)
2. `isErrorPayloadObject` / `parseApiErrorInfo` only recognize `{"error":{"type":"…","message":"…"}}` (nested object), not `{"error":"string_code","message":"…"}` (string at top level)

Result: raw JSON like `{"error":"insufficient_balance","message":"Insufficient MBT balance...","upgradeUrl":"..."}` leaks verbatim into the assistant's user-facing reply.

## Changes

### `src/shared/assistant-error-format.ts`
- `isErrorPayloadObject`: Added recognition of flat payloads where `record.error` is a string and `record.message` is a string
- `parseApiErrorInfo`: When `payload.error` is a string (not an object), extracts it as `errType` so the formatter can produce `"LLM error insufficient_balance: <message>"`

### `src/agents/pi-embedded-helpers/failover-matches.ts`
- Added `/insufficient[_ ]balance/i` to match underscore and space variants
- Added `/\binsufficient\s+\w+\s+balance\b/i` to match "Insufficient MBT balance", "Insufficient token balance", etc. (one intervening word, avoids false positives like "insufficient to reconcile the final balance")

### Tests
- 2 new tests in `formatassistanterrortext.test.ts`: flat JSON billing payload through `formatAssistantErrorText` and `formatRawAssistantErrorForUi`
- 3 new tests in `isbillingerrormessage.test.ts`: snake_case error code, intervening-word pattern, and full flat JSON payload classification

Fixes #74079