### PR TITLE
fix(feishu): support form_value, option, and options in card action callbacks

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -21,6 +21,9 @@ export type FeishuCardActionEvent = {
   action: {
     value: Record<string, unknown>;
     tag: string;
+    form_value?: Record<string, unknown>;
+    option?: string;
+    options?: string[];
   };
   open_message_id?: string;
   context: {
@@ -328,7 +331,7 @@ export async function handleFeishuCardAction(params: {
     }
 
     if (decoded.kind === "structured") {
-      const { envelope } = decoded;
+      const { envelope, formValue, option, options } = decoded;
       log(
         `feishu[${account.accountId}]: handling structured card action ${envelope.a} from ${event.operator.open_id}`,
       );
@@ -385,7 +388,24 @@ export async function handleFeishuCardAction(params: {
       }
 
       if (envelope.a === FEISHU_APPROVAL_CONFIRM_ACTION || envelope.k === "quick") {
-        const command = envelope.q?.trim();
+        let command = envelope.q?.trim();
+
+        if (formValue && Object.keys(formValue).length > 0) {
+          const formText = Object.entries(formValue)
+            .map(([key, value]) => `${key}=${String(value)}`)
+            .join(" ");
+          command = command ? `${command} ${formText}` : formText;
+        }
+
+        if (option !== undefined) {
+          command = command ? `${command} option=${option}` : `option=${option}`;
+        }
+
+        if (options && options.length > 0) {
+          const optionsText = `options=${options.join(",")}`;
+          command = command ? `${command} ${optionsText}` : optionsText;
+        }
+
         if (!command) {
           await sendInvalidInteractionNotice({
             cfg,

--- a/extensions/feishu/src/card-interaction.test.ts
+++ b/extensions/feishu/src/card-interaction.test.ts
@@ -52,6 +52,117 @@ describe("feishu card interaction decoder", () => {
     ).toBe("/new");
   });
 
+  it("includes form_value in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          form_value: { Input_xxx: "user input", Select_yyy: "option1" },
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        formValue: { Input_xxx: "user input", Select_yyy: "option1" },
+      }),
+    );
+  });
+
+  it("includes option in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          option: "opt_a",
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        option: "opt_a",
+      }),
+    );
+  });
+
+  it("includes options in structured result", () => {
+    const result = decodeFeishuCardAction({
+      event: {
+        operator: { open_id: "u123" },
+        context: { chat_id: "chat1" },
+        action: {
+          value: createFeishuCardInteractionEnvelope({
+            k: "quick",
+            a: "feishu.quick_actions.help",
+            q: "/help",
+          }),
+          options: ["opt_a", "opt_b"],
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "structured",
+        options: ["opt_a", "opt_b"],
+      }),
+    );
+  });
+
+  it("appends form_value to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/command" },
+        form_value: { Input_xxx: "user input" },
+      },
+    });
+
+    expect(text).toBe("/command Input_xxx=user input");
+  });
+
+  it("appends option to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/select" },
+        option: "opt_a",
+      },
+    });
+
+    expect(text).toBe("/select option=opt_a");
+  });
+
+  it("appends options to legacy text fallback", () => {
+    const text = buildFeishuCardActionTextFallback({
+      operator: { open_id: "u123" },
+      context: { chat_id: "chat1" },
+      action: {
+        value: { text: "/select" },
+        options: ["opt_a", "opt_b"],
+      },
+    });
+
+    expect(text).toBe("/select options=opt_a,opt_b");
+  });
+
   it("rejects malformed structured payloads", () => {
     const result = decodeFeishuCardAction({
       event: {

--- a/extensions/feishu/src/card-interaction.ts
+++ b/extensions/feishu/src/card-interaction.ts
@@ -35,6 +35,9 @@ export type FeishuCardActionEventLike = {
   };
   action: {
     value: unknown;
+    form_value?: Record<string, unknown>;
+    option?: string;
+    options?: string[];
   };
   context: {
     chat_id?: string;
@@ -45,6 +48,9 @@ export type DecodedFeishuCardAction =
   | {
       kind: "structured";
       envelope: FeishuCardInteractionEnvelope;
+      formValue?: Record<string, unknown>;
+      option?: string;
+      options?: string[];
     }
   | {
       kind: "legacy";
@@ -80,16 +86,40 @@ export function createFeishuCardInteractionEnvelope(
 
 export function buildFeishuCardActionTextFallback(event: FeishuCardActionEventLike): string {
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+  const option = event.action.option;
+  const options = event.action.options;
+
+  let text = "";
   if (isRecord(actionValue)) {
     if (typeof actionValue.text === "string") {
-      return actionValue.text;
+      text = actionValue.text;
+    } else if (typeof actionValue.command === "string") {
+      text = actionValue.command;
+    } else {
+      text = JSON.stringify(actionValue);
     }
-    if (typeof actionValue.command === "string") {
-      return actionValue.command;
-    }
-    return JSON.stringify(actionValue);
+  } else {
+    text = String(actionValue);
   }
-  return String(actionValue);
+
+  if (formValue && Object.keys(formValue).length > 0) {
+    const formText = Object.entries(formValue)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(" ");
+    text = text ? `${text} ${formText}` : formText;
+  }
+
+  if (option !== undefined) {
+    text = text ? `${text} option=${option}` : `option=${option}`;
+  }
+
+  if (options && options.length > 0) {
+    const optionsText = `options=${options.join(",")}`;
+    text = text ? `${text} ${optionsText}` : optionsText;
+  }
+
+  return text;
 }
 
 export function decodeFeishuCardAction(params: {
@@ -98,6 +128,9 @@ export function decodeFeishuCardAction(params: {
 }): DecodedFeishuCardAction {
   const { event, now = Date.now() } = params;
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+  const option = event.action.option;
+  const options = event.action.options;
   if (!isRecord(actionValue) || actionValue.oc !== FEISHU_CARD_INTERACTION_VERSION) {
     return {
       kind: "legacy",
@@ -162,5 +195,8 @@ export function decodeFeishuCardAction(params: {
   return {
     kind: "structured",
     envelope: actionValue as FeishuCardInteractionEnvelope,
+    formValue,
+    option,
+    options,
   };
 }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -210,6 +210,12 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
   const unionId = firstString(operator.union_id);
   const tag = readString(action.tag);
   const actionValue = action.value;
+  const formValue = isRecord(action.form_value) ? action.form_value : undefined;
+  const option = readString(action.option);
+  const options =
+    Array.isArray(action.options) && action.options.every((item) => typeof item === "string")
+      ? action.options
+      : undefined;
   const openMessageId = firstString(value.open_message_id, context.open_message_id);
   const contextOpenId = firstString(context.open_id, openId);
   const contextUserId = firstString(context.user_id, userId);
@@ -227,6 +233,9 @@ function parseFeishuCardActionEventPayload(value: unknown): FeishuCardActionEven
     action: {
       value: actionValue,
       tag,
+      ...(formValue !== undefined ? { form_value: formValue } : {}),
+      ...(option !== undefined ? { option } : {}),
+      ...(options !== undefined ? { options } : {}),
     },
     ...(openMessageId ? { open_message_id: openMessageId } : {}),
     context: {


### PR DESCRIPTION
## Summary

  - Problem: Feishu card action callbacks carry interactive component data in `form_value` (form submissions), `option` (select), and `options` (multi-select), but all
  three fields were silently discarded at every layer of the pipeline.
  - Why it matters: Any interactive card with input fields, dropdowns, or checkboxes was completely broken — user-entered data never reached the bot.
  - What changed: Added pass-through for `form_value`, `option`, and `options` from the raw event parser through the decoder and handler, appending them to the synthetic
  command string.
  - What did NOT change: Plain button clicks with no interactive fields are unaffected.

  ## Change Type

  - [x] Bug fix

  ## Scope

  - [x] Integrations

  ## Linked Issue/PR

  - Related #42754
  - Related #43202
  - [ ] This PR fixes a bug or regression

  ## Root Cause

  - Root cause: `parseFeishuCardActionEventPayload` only extracted `value` and `tag` from the raw action object, discarding `form_value`, `option`, and `options` before
  they could reach `handleFeishuCardAction`. Even if the downstream handler had processed them, the data was already gone.
  - Missing detection / guardrail: No tests covered the form container submission path.
  - Contributing context: Feishu sends interactive component data in separate fields alongside `value`.

  ## Regression Test Plan

  - Coverage level that should have caught this:
    - [x] Unit test
  - Target test or file: `extensions/feishu/src/card-interaction.test.ts`
  - Scenario the test should lock in: `decodeFeishuCardAction` returns `formValue`, `option`, `options`; `buildFeishuCardActionTextFallback` appends them to the output
  text.
  - Why this is the smallest reliable guardrail: The decode and text-building functions are pure — unit tests fully cover all new paths.
  - If no new test is added, why not: Tests were added.

  ## User-visible / Behavior Changes

  When a user submits a Feishu card form or interacts with a select/checkbox, the values are now appended to the command string as space-separated tokens, e.g. `/confirm
  fuel=11 mileage=1000 option=premium`.

  ## Diagram

  ```text
  Before:
  [user submits form] → form_value stripped in parser → bot receives `/confirm` only

  After:
  [user submits form] → form_value preserved → appended to command → bot receives `/confirm fuel=11 mileage=1000`

  Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No — form values are appended as plain text, subject to the same downstream handling as existing command fields.
  - Data access scope changed? No

  Repro + Verification

  Steps

  1. Create a Feishu card with a form container containing input fields and a submit button
  2. Configure the button's value with an OpenClaw interaction envelope (e.g. k: "quick", q: "/confirm")
  3. Submit the form with values filled in

  Expected

  Bot receives /confirm Input_field=user_value

  Actual (before fix)

  Bot receives /confirm with no form values

  Evidence

  - Unit tests added: card-interaction.test.ts covers form_value, option, and options extraction and appending

  Human Verification

  - Verified scenarios: Unit tests pass locally
  - What you did not verify: Live Feishu environment end-to-end test

  Compatibility / Migration

  - Backward compatible? Yes — cards without interactive fields are unaffected
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: Pre-existing CI failures in extensions/ollama and src/plugins/plugin-registry may surface because monitor.account.ts expands the CI check scope. These failures
  exist on main and are unrelated to this PR.
    - Mitigation: Documented here for maintainer awareness.

  ---