### PR TITLE
fix(cron): catch croner parse errors in cron.add and cron.update handlers

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -241,7 +241,13 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate).catch((err) => {
+    let job: Awaited<ReturnType<typeof context.cron.add>>;
+    try {
+      job = await context.cron.add(jobCreate);
+    } catch (err) {
+      if (!(err instanceof TypeError) && !(err instanceof RangeError)) {
+        throw err;
+      }
       respond(
         false,
         undefined,
@@ -250,9 +256,8 @@ export const cronHandlers: GatewayRequestHandlers = {
           `invalid cron.add params: ${formatErrorMessage(err)}`,
         ),
       );
-      return undefined;
-    });
-    if (!job) return;
+      return;
+    }
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -331,7 +336,13 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.update(jobId, patch).catch((err) => {
+    let job: Awaited<ReturnType<typeof context.cron.update>>;
+    try {
+      job = await context.cron.update(jobId, patch);
+    } catch (err) {
+      if (!(err instanceof TypeError) && !(err instanceof RangeError)) {
+        throw err;
+      }
       respond(
         false,
         undefined,
@@ -340,9 +351,8 @@ export const cronHandlers: GatewayRequestHandlers = {
           `invalid cron.update params: ${formatErrorMessage(err)}`,
         ),
       );
-      return undefined;
-    });
-    if (!job) return;
+      return;
+    }
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);
   },

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -241,7 +241,18 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate);
+    const job = await context.cron.add(jobCreate).catch((err) => {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.add params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return undefined;
+    });
+    if (!job) return;
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -320,7 +331,18 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.update(jobId, patch);
+    const job = await context.cron.update(jobId, patch).catch((err) => {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.update params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return undefined;
+    });
+    if (!job) return;
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);
   },

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -294,4 +294,65 @@ describe("cron method validation", () => {
       }),
     );
   });
+
+  it("returns INVALID_REQUEST when cron.add throws a croner parse error (#74066)", async () => {
+    const context = createCronContext();
+    context.cron.add.mockRejectedValueOnce(new TypeError("CronPattern: Expected 5 or 6 fields"));
+    const respond = vi.fn();
+    await cronHandlers["cron.add"]({
+      req: {} as never,
+      params: {
+        name: "bad-cron",
+        enabled: true,
+        schedule: { kind: "cron", cron: "not-a-cron-expr" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "ping" },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("CronPattern"),
+      }),
+    );
+  });
+
+  it("returns INVALID_REQUEST when cron.update throws a croner parse error (#74066)", async () => {
+    const existingJob = createCronJob();
+    const context = createCronContext(existingJob);
+    context.cron.update.mockRejectedValueOnce(
+      new RangeError("CronPattern: Value out of range (99)"),
+    );
+    const respond = vi.fn();
+    await cronHandlers["cron.update"]({
+      req: {} as never,
+      params: {
+        id: existingJob.id,
+        patch: {
+          schedule: { kind: "cron", cron: "99 * * * *" },
+        },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("CronPattern"),
+      }),
+    );
+  });
 });

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -355,4 +355,28 @@ describe("cron method validation", () => {
       }),
     );
   });
+
+  it("re-throws non-parse errors from cron.add instead of masking as INVALID_REQUEST", async () => {
+    const context = createCronContext();
+    context.cron.add.mockRejectedValueOnce(new Error("DB write failed"));
+    const respond = vi.fn();
+    await expect(
+      cronHandlers["cron.add"]({
+        req: {} as never,
+        params: {
+          name: "db-fail",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "ping" },
+        } as never,
+        respond: respond as never,
+        context: context as never,
+        client: null,
+        isWebchatConnect: () => false,
+      }),
+    ).rejects.toThrow("DB write failed");
+    expect(respond).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #74066

- Wrap `context.cron.add()` and `context.cron.update()` in `.catch()` handlers so croner `TypeError`/`RangeError` from invalid cron expressions are returned as `INVALID_REQUEST` errors instead of crashing the gateway RPC handler
- Follows existing adjacent guard pattern (`assertValidCronCreateDelivery`)
- Adds two new tests covering croner parse errors on both add and update paths

## Changes

- `src/gateway/server-methods/cron.ts`: `.catch()` around `context.cron.add()` (line ~244) and `context.cron.update()` (line ~323), returning `errorShape(ErrorCodes.INVALID_REQUEST, ...)` with formatted message
- `src/gateway/server-methods/cron.validation.test.ts`: Two new test cases for TypeError (add) and RangeError (update) from croner