### PR TITLE
fix(hooks): deduplicate boot-md startup tasks by workspaceDir

### DIFF
--- a/src/hooks/bundled/boot-md/handler.test.ts
+++ b/src/hooks/bundled/boot-md/handler.test.ts
@@ -134,4 +134,18 @@ describe("boot-md handler", () => {
       reason: "missing",
     });
   });
+
+  it("deduplicates agents sharing the same workspaceDir (#74072)", async () => {
+    const cfg = { agents: { list: [{ id: "main" }, { id: "alias" }] } };
+    listAgentIds.mockReturnValue(["main", "alias"]);
+    resolveAgentWorkspaceDir.mockReturnValue(MAIN_WORKSPACE_DIR);
+    runBootOnce.mockResolvedValue({ status: "ran" });
+
+    await runBootChecklist(makeEvent({ context: { cfg } }));
+
+    expect(runBootOnce).toHaveBeenCalledTimes(1);
+    expect(runBootOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg, workspaceDir: MAIN_WORKSPACE_DIR, agentId: "main" }),
+    );
+  });
 });

--- a/src/hooks/bundled/boot-md/handler.ts
+++ b/src/hooks/bundled/boot-md/handler.ts
@@ -19,15 +19,25 @@ const runBootChecklist: HookHandler = async (event) => {
 
   const cfg = event.context.cfg;
   const deps = event.context.deps ?? createDefaultDeps();
-  const tasks: StartupTask[] = listAgentIds(cfg).map((agentId) => {
-    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-    return {
-      source: "boot-md",
+  const seenWorkspaces = new Set<string>();
+  const tasks: StartupTask[] = listAgentIds(cfg)
+    .map((agentId) => {
+      const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+      return { agentId, workspaceDir };
+    })
+    .filter(({ workspaceDir }) => {
+      if (seenWorkspaces.has(workspaceDir)) {
+        return false;
+      }
+      seenWorkspaces.add(workspaceDir);
+      return true;
+    })
+    .map(({ agentId, workspaceDir }) => ({
+      source: "boot-md" as const,
       agentId,
       workspaceDir,
       run: () => runBootOnce({ cfg, deps, workspaceDir, agentId }),
-    };
-  });
+    }));
 
   await runStartupTasks({ tasks, log });
 };


### PR DESCRIPTION
## Summary

Fixes #74072

- `runBootChecklist` previously created one `StartupTask` per agent ID, causing duplicate `runBootOnce` calls when multiple agents share the same `workspaceDir`
- Added a `seenWorkspaces` Set to deduplicate tasks by resolved workspace directory — only the first agent per workspace triggers a boot run
- Adds a new test verifying two agents mapping to the same workspace produce only one `runBootOnce` call

## Changes

- `src/hooks/bundled/boot-md/handler.ts`: Filter agent list through `seenWorkspaces: Set<string>` before mapping to `StartupTask[]`
- `src/hooks/bundled/boot-md/handler.test.ts`: New test case "deduplicates agents sharing the same workspaceDir"