### PR TITLE
Fix Telegram WSL2 gateway stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Docs: https://docs.openclaw.ai
 - Core/channels: tighten selected runtime, media, and plugin edge-case handling while preserving existing behavior. Thanks @jesse-merhi.
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and allow `channels.whatsapp.exposeErrorText` to suppress visible error text per channel or account. (#71830) Thanks @rubencu.
 - Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
+- Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
 
 ## 2026.4.27
 

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -12,8 +12,15 @@ describe("resolveTelegramRequestTimeoutMs", () => {
     expect(resolveTelegramRequestTimeoutMs("getupdates")).toBe(45_000);
   });
 
+  it("bounds outbound delivery methods", () => {
+    expect(resolveTelegramRequestTimeoutMs("sendmessage")).toBe(20_000);
+    expect(resolveTelegramRequestTimeoutMs("sendchataction")).toBe(10_000);
+    expect(resolveTelegramRequestTimeoutMs("editmessagetext")).toBe(15_000);
+    expect(resolveTelegramRequestTimeoutMs("sendphoto")).toBe(30_000);
+  });
+
   it("does not assign hard timeouts to unrelated Telegram methods", () => {
-    expect(resolveTelegramRequestTimeoutMs("sendmessage")).toBeUndefined();
+    expect(resolveTelegramRequestTimeoutMs("answercallbackquery")).toBeUndefined();
     expect(resolveTelegramRequestTimeoutMs(null)).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -2,8 +2,24 @@ const TELEGRAM_REQUEST_TIMEOUTS_MS = {
   // Bound startup/control-plane calls so the gateway cannot report Telegram as
   // healthy while provider startup is still hung on Bot API setup.
   deletewebhook: 15_000,
+  deletemessage: 15_000,
+  editforumtopic: 15_000,
+  editmessagetext: 15_000,
+  getchat: 15_000,
+  getfile: 30_000,
   getme: 15_000,
   getupdates: 45_000,
+  pinchatmessage: 15_000,
+  sendanimation: 30_000,
+  sendaudio: 30_000,
+  sendchataction: 10_000,
+  senddocument: 30_000,
+  sendmessage: 20_000,
+  sendmessagedraft: 20_000,
+  sendphoto: 30_000,
+  sendvideo: 30_000,
+  sendvoice: 30_000,
+  setmessagereaction: 10_000,
   setwebhook: 15_000,
 } as const;
 

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -44,7 +44,12 @@ const BUILT_IN_PLUGIN_ALIAS_LOOKUP = new Map<string, string>([
   ...BUILT_IN_PLUGIN_ALIAS_FALLBACKS.map(([, pluginId]) => [pluginId, pluginId] as const),
 ]);
 
+let bundledPluginAliasLookup: ReadonlyMap<string, string> | undefined;
+
 function getBundledPluginAliasLookup(): ReadonlyMap<string, string> {
+  if (bundledPluginAliasLookup) {
+    return bundledPluginAliasLookup;
+  }
   const lookup = new Map<string, string>();
   for (const plugin of listBundledPluginMetadata({ includeChannelConfigs: false })) {
     const pluginId = normalizeOptionalLowercaseString(plugin.manifest.id);
@@ -67,7 +72,8 @@ function getBundledPluginAliasLookup(): ReadonlyMap<string, string> {
   for (const [alias, pluginId] of BUILT_IN_PLUGIN_ALIAS_FALLBACKS) {
     lookup.set(alias, pluginId);
   }
-  return lookup;
+  bundledPluginAliasLookup = lookup;
+  return bundledPluginAliasLookup;
 }
 
 export function normalizePluginId(id: string): string {


### PR DESCRIPTION
## Summary
- bound Telegram outbound Bot API calls so stalled sends/actions do not wedge delivery
- cache bundled plugin alias lookup to avoid repeated synchronous plugin metadata scans during config normalization

## Validation
- Live WSL2 gateway smoke confirmed Telegram replies after the fix
- Focused tests passed before the requested test skip
- Testbox stopped per request; no further checks run
