### PR TITLE
fix(group-chat): add emoji mention opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/group mentions: add `messages.groupChat.emojiMention` and `agents.list[].groupChat.emojiMention` so identity-derived emoji fallback matching can be disabled without affecting native mentions or name-derived mention matching. Fixes #69544. Thanks @lzn970721.
+
 - Plugins/uninstall: remove tracked plugin files from their recorded managed extensions root even when the current state directory points somewhere else, so `openclaw plugins uninstall --force` does not leave the plugin discoverable. Thanks @shakkernerd.
 - Agents/runtime: add `agentRuntime.id` as the canonical config key, migrate
   legacy runtime-policy configs with `openclaw doctor --fix`, and route

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -258,6 +258,7 @@ Telegram, WhatsApp, Slack, Discord, Microsoft Teams, and ZaloUser.
         id: "main",
         groupChat: {
           mentionPatterns: ["@openclaw", "openclaw", "\\+15555550123"],
+          emojiMention: false,
           historyLimit: 50,
         },
       },
@@ -269,6 +270,7 @@ Telegram, WhatsApp, Slack, Discord, Microsoft Teams, and ZaloUser.
 Notes:
 
 - `mentionPatterns` are case-insensitive safe regex patterns; invalid patterns and unsafe nested-repetition forms are ignored.
+- `emojiMention: false` disables `identity.emoji` as a derived fallback mention trigger when `mentionPatterns` are not explicitly set. Native platform mentions and name-derived fallback matching still work.
 - Surfaces that provide explicit mentions still pass; patterns are a fallback.
 - Per-agent override: `agents.list[].groupChat.mentionPatterns` (useful when multiple agents share a group).
 - Mention gating is only enforced when mention detection is possible (native mentions or `mentionPatterns` are configured).

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -915,6 +915,7 @@ Live directory lookup uses the logged-in Matrix account:
 - `groupPolicy`: `open`, `allowlist`, or `disabled`.
 - `contextVisibility`: supplemental room-context visibility mode (`all`, `allowlist`, `allowlist_quote`).
 - `groupAllowFrom`: allowlist of user IDs for room traffic. Full Matrix user IDs are safest; exact directory matches are resolved at startup and when the allowlist changes while the monitor is running. Unresolved names are ignored.
+- `emojiMention`: when `messages.groupChat.mentionPatterns` / `agents.list[].groupChat.mentionPatterns` are not explicitly set, controls whether `identity.emoji` is included in the derived fallback mention matching for Matrix room gating. Default: `true`.
 - `historyLimit`: max room messages to include as group history context. Falls back to `messages.groupChat.historyLimit`; if both are unset, the effective default is `0`. Set `0` to disable.
 - `replyToMode`: `off`, `first`, `all`, or `batched`.
 - `markdown`: optional Markdown rendering configuration for outbound Matrix text.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -939,7 +939,7 @@ for provider examples and precedence.
           emoji: "🦥",
           avatar: "avatars/samantha.png",
         },
-        groupChat: { mentionPatterns: ["@openclaw"] },
+        groupChat: { mentionPatterns: ["@openclaw"], emojiMention: false },
         sandbox: { mode: "off" },
         runtime: {
           type: "acp",
@@ -976,6 +976,7 @@ for provider examples and precedence.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
+- `groupChat.emojiMention`: when `mentionPatterns` are not explicitly set, controls whether `identity.emoji` is included in derived fallback mention matching. Default: `true`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
 - `subagents.requireAgentId`: when true, block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection; default: false).

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -794,6 +794,44 @@ describe("mention helpers", () => {
     expect(matchesMentionPatterns("global: hi", regexes)).toBe(false);
   });
 
+  it("can disable identity emoji-derived mention matching globally", () => {
+    const regexes = buildMentionRegexes(
+      {
+        messages: { groupChat: { emojiMention: false } },
+        agents: {
+          list: [
+            {
+              id: "work",
+              identity: { name: "Work Bot", emoji: "📊" },
+            },
+          ],
+        },
+      },
+      "work",
+    );
+    expect(matchesMentionPatterns("@work bot hi", regexes)).toBe(true);
+    expect(matchesMentionPatterns("📊 update please", regexes)).toBe(false);
+  });
+
+  it("lets per-agent emojiMention override the global fallback", () => {
+    const regexes = buildMentionRegexes(
+      {
+        messages: { groupChat: { emojiMention: false } },
+        agents: {
+          list: [
+            {
+              id: "work",
+              identity: { name: "Work Bot", emoji: "📊" },
+              groupChat: { emojiMention: true },
+            },
+          ],
+        },
+      },
+      "work",
+    );
+    expect(matchesMentionPatterns("📊 update please", regexes)).toBe(true);
+  });
+
   it("strips safe mention patterns and ignores unsafe ones", () => {
     const stripped = stripMentions("openclaw " + "a".repeat(28) + "!", {} as MsgContext, {
       messages: {

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -21,7 +21,10 @@ export type {
   MatchesMentionWithExplicit,
 } from "./mentions.types.js";
 
-function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
+function deriveMentionPatterns(
+  identity?: { name?: string; emoji?: string },
+  opts?: { includeEmoji?: boolean },
+) {
   const patterns: string[] = [];
   const name = normalizeOptionalString(identity?.name);
   if (name) {
@@ -30,7 +33,7 @@ function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
     patterns.push(String.raw`\b@?${re}\b`);
   }
   const emoji = normalizeOptionalString(identity?.emoji);
-  if (emoji) {
+  if (emoji && opts?.includeEmoji !== false) {
     patterns.push(escapeRegExp(emoji));
   }
   return patterns;
@@ -128,7 +131,13 @@ function resolveMentionPatterns(cfg: OpenClawConfig | undefined, agentId?: strin
   if (globalGroupChat && Object.hasOwn(globalGroupChat, "mentionPatterns")) {
     return globalGroupChat.mentionPatterns ?? [];
   }
-  const derived = deriveMentionPatterns(agentConfig?.identity);
+  const includeEmoji =
+    agentGroupChat && Object.hasOwn(agentGroupChat, "emojiMention")
+      ? agentGroupChat.emojiMention !== false
+      : globalGroupChat && Object.hasOwn(globalGroupChat, "emojiMention")
+        ? globalGroupChat.emojiMention !== false
+        : true;
+  const derived = deriveMentionPatterns(agentConfig?.identity, { includeEmoji });
   return derived.length > 0 ? derived : [];
 }
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -7108,6 +7108,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         type: "string",
                       },
                     },
+                    emojiMention: {
+                      type: "boolean",
+                    },
                     historyLimit: {
                       type: "integer",
                       exclusiveMinimum: 0,
@@ -18745,6 +18748,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 description:
                   "Safe case-insensitive regex patterns used to detect explicit mentions/trigger phrases in group chats. Use precise patterns to reduce false positives in high-volume channels; invalid or unsafe nested-repetition patterns are ignored.",
               },
+              emojiMention: {
+                type: "boolean",
+                title: "Emoji Mention Fallback",
+                description:
+                  "When mentionPatterns are not explicitly set, controls whether identity.emoji is included in the derived fallback mention matching. Disable this to avoid emoji-triggered replies while keeping native mentions and name-derived fallback matching.",
+              },
               historyLimit: {
                 type: "integer",
                 exclusiveMinimum: 0,
@@ -27861,6 +27870,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "messages.groupChat.mentionPatterns": {
       label: "Group Mention Patterns",
       help: "Safe case-insensitive regex patterns used to detect explicit mentions/trigger phrases in group chats. Use precise patterns to reduce false positives in high-volume channels; invalid or unsafe nested-repetition patterns are ignored.",
+      tags: ["advanced"],
+    },
+    "messages.groupChat.emojiMention": {
+      label: "Emoji Mention Fallback",
+      help: "When mentionPatterns are not explicitly set, controls whether identity.emoji is included in the derived fallback mention matching. Disable this to avoid emoji-triggered replies while keeping native mentions and name-derived fallback matching.",
       tags: ["advanced"],
     },
     "messages.groupChat.historyLimit": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1574,6 +1574,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Group-message handling controls including mention triggers and history window sizing. Keep mention patterns narrow so group channels do not trigger on every message.",
   "messages.groupChat.mentionPatterns":
     "Safe case-insensitive regex patterns used to detect explicit mentions/trigger phrases in group chats. Use precise patterns to reduce false positives in high-volume channels; invalid or unsafe nested-repetition patterns are ignored.",
+  "messages.groupChat.emojiMention":
+    "When mentionPatterns are not explicitly set, controls whether identity.emoji is included in the derived fallback mention matching. Disable this to avoid emoji-triggered replies while keeping native mentions and name-derived fallback matching.",
   "messages.groupChat.historyLimit":
     "Maximum number of prior group messages loaded as context per turn for group sessions. Use higher values for richer continuity, or lower values for faster and cheaper responses.",
   "messages.queue":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -806,6 +806,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.responsePrefix": "Outbound Response Prefix",
   "messages.groupChat": "Group Chat Rules",
   "messages.groupChat.mentionPatterns": "Group Mention Patterns",
+  "messages.groupChat.emojiMention": "Emoji Mention Fallback",
   "messages.groupChat.historyLimit": "Group History Limit",
   "messages.queue": "Inbound Queue",
   "messages.queue.mode": "Queue Mode",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -3,6 +3,11 @@ import type { TtsConfig } from "./types.tts.js";
 
 export type GroupChatConfig = {
   mentionPatterns?: string[];
+  /**
+   * When mentionPatterns are not explicitly set, include identity.emoji in
+   * the derived fallback mention regexes. Default: true.
+   */
+  emojiMention?: boolean;
   historyLimit?: number;
 };
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -387,6 +387,7 @@ export const ModelsConfigSchema = z
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
+    emojiMention: z.boolean().optional(),
     historyLimit: z.number().int().positive().optional(),
   })
   .strict()


### PR DESCRIPTION
## Summary
- add a backward-compatible `emojiMention` toggle to shared `groupChat` config
- let derived mention fallback ignore `identity.emoji` while keeping native mentions and name-derived matching intact
- document the new config and regenerate the public config schema payload

Fixes #69544.

## Validation
- `pnpm test src/auto-reply/inbound.test.ts src/config/schema.base.generated.test.ts src/config/schema.help.quality.test.ts`
- `pnpm test extensions/matrix/src/matrix/monitor/mentions.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts`
- `git diff --check`

## Notes
- `pnpm check:changed` currently fails in unrelated pre-existing core typecheck drift outside this patch, including `src/agents/openai-transport-stream.ts`, `src/config/types.models.ts`, `src/media/qr-runtime.ts`, and `src/plugin-sdk/provider-*`.