### PR TITLE
fix(agents): adopt peer-rotated OAuth credential from in-process cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
 - Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
+- Agents/OAuth: add an in-process credential cache so queued peer agents can adopt a leader's rotated token even when the disk-side mirror is dropped by Windows file-lock contention, an external process rollback, or a silent `withFileLock` timeout, preventing `refresh_token_reused` 401s in multi-agent OpenAI Codex swarms. Fixes #74055. (#74214) Thanks @openperf.
 
 ## 2026.4.27
 

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -13,6 +13,7 @@ import {
 } from "./oauth-refresh-lock-errors.js";
 import {
   areOAuthCredentialsEquivalent,
+  hasOAuthIdentity,
   hasUsableOAuthCredential,
   isSafeToAdoptBootstrapOAuthIdentity,
   isSafeToAdoptMainStoreOAuthIdentity,
@@ -207,6 +208,92 @@ export function resolveEffectiveOAuthCredential(params: {
 }
 
 export function createOAuthManager(adapter: OAuthManagerAdapter) {
+  // In-process cache of the most recent successful refresh per
+  // (provider, profileId). The cross-agent file lock and the in-process
+  // refresh queue serialize refresh callers so that only one peer hits the
+  // provider per (provider, profileId), but the recovery for queued peers
+  // historically relied on the leader's mirror-to-main write being visible
+  // on disk. That mirror is best-effort: the silent catch in
+  // `mirrorRefreshedCredentialIntoMainStore`, transient
+  // `withFileLock` timeouts on Windows when antivirus or another tool is
+  // briefly holding the main auth-profiles.json, and external rollbacks of
+  // the file (e.g. `openclaw doctor` writing back a doctor-cached store)
+  // can all leave main on disk holding the pre-rotation credential while
+  // the leader's refresh succeeded. Without this cache, a queued peer
+  // would then re-enter the refresh path with its own already-rotated
+  // refresh_token and produce the `refresh_token_reused` 401 reported in
+  // issue #74055. The cache is the authoritative in-process record of "a
+  // peer of mine just refreshed this profile and got these credentials" —
+  // every adoption checkpoint consults it before deciding to refresh.
+  const recentlyRefreshedCredentials = new Map<string, OAuthCredential>();
+
+  function refreshQueueKey(provider: string, profileId: string): string {
+    return `${provider}\u0000${profileId}`;
+  }
+
+  function rememberRefreshedCredential(
+    provider: string,
+    profileId: string,
+    credential: OAuthCredential,
+  ): void {
+    // Bound process-lifetime growth without adding LRU/TTL machinery: any
+    // entry whose access token is no longer usable can never satisfy
+    // `findInProcessRefreshedCredential`, so drop those siblings whenever
+    // we publish a new one. Stable in N=1 swarms (the common case) and O(N)
+    // in N≫1 churn scenarios where N is the number of distinct profiles
+    // that have rotated during this process's lifetime.
+    for (const [key, entry] of recentlyRefreshedCredentials) {
+      if (!hasUsableOAuthCredential(entry)) {
+        recentlyRefreshedCredentials.delete(key);
+      }
+    }
+    recentlyRefreshedCredentials.set(refreshQueueKey(provider, profileId), credential);
+  }
+
+  /**
+   * Look up the most recent in-process refresh result for `(provider,
+   * profileId)` that is still usable and identity-safe to adopt.
+   *
+   * Callers always pass a real `OAuthCredential` for `requesting` (it
+   * originates from a store load that already gated on `cred.type ===
+   * "oauth"`), so the `existing === undefined` branch inside
+   * `isSafeToAdoptMainStoreOAuthIdentity` is unreachable here. That helper
+   * is shared with the disk-backed main-store adoption path, where
+   * `existing` can legitimately be undefined; we deliberately reuse the
+   * same identity policy so the cache and disk paths cannot disagree on
+   * what counts as "same account".
+   */
+  function findInProcessRefreshedCredential(
+    provider: string,
+    profileId: string,
+    requesting: OAuthCredential,
+  ): OAuthCredential | null {
+    const cached = recentlyRefreshedCredentials.get(refreshQueueKey(provider, profileId));
+    if (
+      !cached ||
+      cached.type !== "oauth" ||
+      cached.provider !== requesting.provider ||
+      !hasUsableOAuthCredential(cached)
+    ) {
+      return null;
+    }
+    // Strict identity match. The disk-side adoption path is intentionally
+    // lenient — a local store that lost its identity (e.g., after a Codex
+    // refresh that drops accountId) is allowed to inherit identity from
+    // main on first contact. The in-process cache must NOT be that lenient,
+    // because it acts as a process-wide "the leader just refreshed THIS
+    // identity" channel: a fuzzy hit could let a freshly-seeded credential
+    // for an unrelated identity adopt a peer's rotated token. Require both
+    // sides to bear identity and to match.
+    if (!hasOAuthIdentity(requesting) || !hasOAuthIdentity(cached)) {
+      return null;
+    }
+    if (!isSafeToAdoptMainStoreOAuthIdentity(requesting, cached)) {
+      return null;
+    }
+    return cached;
+  }
+
   function adoptNewerMainOAuthCredential(params: {
     store: AuthProfileStore;
     profileId: string;
@@ -215,6 +302,31 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }): OAuthCredential | null {
     if (!params.agentDir) {
       return null;
+    }
+    // Prefer the in-process refresh result over disk: it is always at least
+    // as fresh as main on disk and is the only source guaranteed to survive
+    // a dropped mirror (#74055). Mirror the disk path's freshness guard so a
+    // still-valid local credential is not silently rewritten just because a
+    // peer's rotation result is sitting in the cache; only adopt when the
+    // cached credential is strictly newer (or local has no finite expiry).
+    const cached = findInProcessRefreshedCredential(
+      params.credential.provider,
+      params.profileId,
+      params.credential,
+    );
+    if (
+      cached &&
+      Number.isFinite(cached.expires) &&
+      (!Number.isFinite(params.credential.expires) || cached.expires > params.credential.expires)
+    ) {
+      params.store.profiles[params.profileId] = { ...cached };
+      saveAuthProfileStore(params.store, params.agentDir);
+      log.info("adopted newer OAuth credentials from in-process refresh cache", {
+        profileId: params.profileId,
+        agentDir: params.agentDir,
+        expires: new Date(cached.expires).toISOString(),
+      });
+      return cached;
     }
     try {
       const mainStore = ensureAuthProfileStore(undefined);
@@ -246,10 +358,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   const refreshQueues = new Map<string, Promise<unknown>>();
-
-  function refreshQueueKey(provider: string, profileId: string): string {
-    return `${provider}\u0000${profileId}`;
-  }
 
   async function withRefreshCallTimeout<T>(
     label: string,
@@ -337,6 +445,35 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               apiKey: await adapter.buildApiKey(cred.provider, cred),
               credential: cred,
             };
+          }
+
+          // Defense in depth before consulting main on disk: the leader of
+          // the in-process refresh queue may have just refreshed under the
+          // same lock and returned. The mirror to main is best-effort, so
+          // we cannot rely on disk being up to date — see the cache notes
+          // on `recentlyRefreshedCredentials` (#74055).
+          if (params.agentDir) {
+            const cachedFromPeer = findInProcessRefreshedCredential(
+              params.provider,
+              params.profileId,
+              cred,
+            );
+            if (cachedFromPeer) {
+              store.profiles[params.profileId] = { ...cachedFromPeer };
+              saveAuthProfileStore(store, params.agentDir);
+              log.info(
+                "adopted fresh OAuth credential from in-process refresh cache (under refresh lock)",
+                {
+                  profileId: params.profileId,
+                  agentDir: params.agentDir,
+                  expires: new Date(cachedFromPeer.expires).toISOString(),
+                },
+              );
+              return {
+                apiKey: await adapter.buildApiKey(cachedFromPeer.provider, cachedFromPeer),
+                credential: cachedFromPeer,
+              };
+            }
           }
 
           if (params.agentDir) {
@@ -431,6 +568,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           if (!refreshedCredentials) {
             return null;
           }
+          // Publish the rotated credential to the in-process cache before
+          // doing anything that can fail (mirror, save) so peers waiting
+          // behind us in the refresh queue can adopt this result even if
+          // the disk-side mirror is dropped. The cache is the only
+          // recovery seam that survives a silent mirror failure (#74055).
+          rememberRefreshedCredential(params.provider, params.profileId, refreshedCredentials);
           store.profiles[params.profileId] = refreshedCredentials;
           saveAuthProfileStore(store, ownerAgentDir);
           if (ownerAgentDir) {
@@ -559,6 +702,34 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         }
       }
       if (params.agentDir) {
+        // The leader's refresh may have populated the in-process cache
+        // before our refresh attempt failed (timing of error vs. cache
+        // publish under the lock). Honor the cache before falling back to
+        // the disk-side main store so #74055-class mirror losses do not
+        // turn a recoverable race into a thrown OAuthManagerRefreshError.
+        // Match against `params.credential` (the original stale credential
+        // that entered resolveOAuthAccess) rather than the disk-reloaded
+        // `refreshed`: identity must be evaluated from the caller's known
+        // starting point, not from a disk view that may itself have just
+        // been rolled back to the same pre-rotation state.
+        const cachedFromPeer = findInProcessRefreshedCredential(
+          params.credential.provider,
+          params.profileId,
+          params.credential,
+        );
+        if (cachedFromPeer) {
+          refreshedStore.profiles[params.profileId] = { ...cachedFromPeer };
+          saveAuthProfileStore(refreshedStore, params.agentDir);
+          log.info("inherited fresh OAuth credentials from in-process refresh cache", {
+            profileId: params.profileId,
+            agentDir: params.agentDir,
+            expires: new Date(cachedFromPeer.expires).toISOString(),
+          });
+          return {
+            apiKey: await adapter.buildApiKey(cachedFromPeer.provider, cachedFromPeer),
+            credential: cachedFromPeer,
+          };
+        }
         try {
           const mainStore = ensureAuthProfileStore(undefined);
           const mainCred = mainStore.profiles[params.profileId];
@@ -594,6 +765,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
   function resetRefreshQueuesForTest(): void {
     refreshQueues.clear();
+    recentlyRefreshedCredentials.clear();
   }
 
   return {

--- a/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
+++ b/src/agents/auth-profiles/oauth.concurrent-agents.test.ts
@@ -19,6 +19,7 @@ import {
   ensureAuthProfileStore,
   saveAuthProfileStore,
 } from "./store.js";
+import type { AuthProfileStore } from "./types.js";
 
 const {
   refreshProviderOAuthCredentialWithPluginMock,
@@ -121,5 +122,409 @@ describe("resolveApiKeyForProfile cross-agent refresh coordination (#26322)", ()
       expect(result?.apiKey).toBe("cross-agent-refreshed-access");
       expect(result?.provider).toBe(provider);
     }
+  }, 10_000);
+
+  // Regression for #74055. The cross-agent refresh lock prevents two peers
+  // from spending the same refresh_token *concurrently*, but the recovery
+  // path that lets a queued peer skip its own refresh depends entirely on
+  // the leader's mirror-to-main write actually landing on disk. When that
+  // mirror is dropped — which happens in the field on Windows when the
+  // main auth-profiles.json is briefly held by a security agent, when the
+  // mirror's withFileLock times out, or when an external process rolls the
+  // file back — the leader's refresh succeeds but the disk under main is
+  // stale. The next peer then hits the inside-lock adoption check, finds
+  // main "still expired", falls through to refresh, and burns its own (now
+  // already-rotated) refresh_token, surfacing 401 refresh_token_reused.
+  //
+  // We reproduce that failure mode below by letting the leader refresh and
+  // mirror normally, then forcibly reverting main on disk to the pre-mirror
+  // state and stalling any subsequent refresh with refresh_token_reused.
+  // A correct fix must let the second peer recover from the leader's
+  // result without touching main on disk.
+  it("rescues a queued peer when the leader's mirror to main is lost (issue #74055)", async () => {
+    const profileId = "openai-codex:user@example.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const email = "user@example.com";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    const mainAuthFile = path.join(mainAgentDir, "auth-profiles.json");
+
+    const leaderAgentDir = path.join(tempRoot, "agents", "leader", "agent");
+    const followerAgentDir = path.join(tempRoot, "agents", "follower", "agent");
+    await fs.mkdir(leaderAgentDir, { recursive: true });
+    await fs.mkdir(followerAgentDir, { recursive: true });
+    const seedExpiredStore = (): AuthProfileStore =>
+      createExpiredOauthStore({ profileId, provider, accountId, email });
+    saveAuthProfileStore(seedExpiredStore(), leaderAgentDir);
+    saveAuthProfileStore(seedExpiredStore(), followerAgentDir);
+    saveAuthProfileStore(seedExpiredStore(), mainAgentDir);
+
+    // The leader's refresh succeeds with the post-rotation token. Every
+    // subsequent attempt fails the way the OpenAI provider actually fails
+    // when a peer presents an already-rotated refresh_token, which is the
+    // exact 401 the user reported in #74055.
+    let callCount = 0;
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(async () => {
+      callCount += 1;
+      await new Promise((resolve) => setImmediate(resolve));
+      if (callCount > 1) {
+        throw new Error('Token refresh failed: 401 {"error":{"code":"refresh_token_reused"}}');
+      }
+      return {
+        type: "oauth",
+        provider,
+        access: "leader-rotated-access",
+        refresh: "leader-rotated-refresh",
+        expires: freshExpiry,
+        accountId,
+        email,
+      } as never;
+    });
+
+    const leaderResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(leaderAgentDir),
+      profileId,
+      agentDir: leaderAgentDir,
+    });
+    expect(leaderResult?.apiKey).toBe("leader-rotated-access");
+    expect(callCount).toBe(1);
+
+    // The leader's refresh briefly mirrored to main; we now simulate the
+    // mirror being lost — antivirus reverting the file, an external
+    // process rewriting it, an EBUSY swallowed by the silent catch in
+    // mirrorRefreshedCredentialIntoMainStore, etc. The follower must not
+    // assume disk-side main is the only source of truth.
+    saveAuthProfileStore(seedExpiredStore(), mainAgentDir);
+    const mainAfterRollback = JSON.parse(
+      await fs.readFile(mainAuthFile, "utf8"),
+    ) as AuthProfileStore;
+    expect(mainAfterRollback.profiles[profileId]).toMatchObject({
+      access: "cached-access-token",
+      refresh: "refresh-token",
+    });
+
+    // The follower must rescue itself from the leader's still-fresh
+    // in-process refresh result rather than spending its own already-
+    // rotated refresh_token on the provider.
+    const followerResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(followerAgentDir),
+      profileId,
+      agentDir: followerAgentDir,
+    });
+
+    // No second refresh: follower must adopt the leader's already-rotated
+    // credential without going to the provider with its own stale token.
+    expect(callCount).toBe(1);
+    expect(followerResult).not.toBeNull();
+    expect(followerResult?.apiKey).toBe("leader-rotated-access");
+    expect(followerResult?.provider).toBe(provider);
+
+    // Follower's own store on disk now carries the rescued credential so
+    // the next request short-circuits before re-entering the queue.
+    const followerOnDisk = JSON.parse(
+      await fs.readFile(path.join(followerAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(followerOnDisk.profiles[profileId]).toMatchObject({
+      access: "leader-rotated-access",
+      refresh: "leader-rotated-refresh",
+      expires: freshExpiry,
+    });
+  }, 10_000);
+
+  // Greptile review feedback on #74214: align the in-process cache adoption
+  // path with the disk-side adoption path's freshness guard. A still-valid
+  // local credential must not be silently rewritten on every resolve just
+  // because a peer's rotation result sits in the cache; only adopt when the
+  // cached credential is strictly newer than the agent's local view.
+  it("leaves a still-valid local credential alone when the cached peer credential is not strictly newer", async () => {
+    const profileId = "openai-codex:user@example.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const email = "user@example.com";
+    const localExpiry = Date.now() + 30 * 60 * 1000;
+    const peerExpiry = localExpiry; // same expiry — not strictly newer
+
+    const leaderAgentDir = path.join(tempRoot, "agents", "freshness-leader", "agent");
+    const followerAgentDir = path.join(tempRoot, "agents", "freshness-follower", "agent");
+    await fs.mkdir(leaderAgentDir, { recursive: true });
+    await fs.mkdir(followerAgentDir, { recursive: true });
+
+    // Both leader and follower already hold valid credentials. Only the
+    // leader actually goes through a refresh (because we expire it first
+    // to force one); the follower's local credential is healthy and must
+    // not be replaced.
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId, email }),
+      leaderAgentDir,
+    );
+    const followerLocal = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth" as const,
+          provider,
+          access: "follower-still-valid-access",
+          refresh: "follower-still-valid-refresh",
+          expires: localExpiry,
+          accountId,
+          email,
+        },
+      },
+    } satisfies AuthProfileStore;
+    saveAuthProfileStore(followerLocal, followerAgentDir);
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId, email }),
+      mainAgentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "leader-rotated-access",
+          refresh: "leader-rotated-refresh",
+          expires: peerExpiry,
+          accountId,
+          email,
+        }) as never,
+    );
+
+    // Leader populates the in-process refresh cache.
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(leaderAgentDir),
+      profileId,
+      agentDir: leaderAgentDir,
+    });
+
+    // Follower resolves with a still-valid credential. The cached peer
+    // credential is not strictly newer (same expiry), so the follower must
+    // keep its own credential and must not write to its store.
+    const followerResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(followerAgentDir),
+      profileId,
+      agentDir: followerAgentDir,
+    });
+    expect(followerResult?.apiKey).toBe("follower-still-valid-access");
+
+    const followerOnDisk = JSON.parse(
+      await fs.readFile(path.join(followerAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(followerOnDisk.profiles[profileId]).toMatchObject({
+      access: "follower-still-valid-access",
+      refresh: "follower-still-valid-refresh",
+      expires: localExpiry,
+    });
+  }, 10_000);
+
+  // Branch coverage for the freshness guard's left disjunct: when the local
+  // credential lacks a finite expiry (legacy stores written before expiry
+  // tracking, or a malformed copy), the cache must still be consulted so a
+  // peer's rotated token can take over rather than the agent forever
+  // believing it has a "valid" credential.
+  it("adopts a peer-rotated credential when the local credential has no finite expiry", async () => {
+    const profileId = "openai-codex:user@example.com";
+    const provider = "openai-codex";
+    const accountId = "acct-shared";
+    const email = "user@example.com";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const leaderAgentDir = path.join(tempRoot, "agents", "infexp-leader", "agent");
+    const followerAgentDir = path.join(tempRoot, "agents", "infexp-follower", "agent");
+    await fs.mkdir(leaderAgentDir, { recursive: true });
+    await fs.mkdir(followerAgentDir, { recursive: true });
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId, email }),
+      leaderAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider, accountId, email }),
+      mainAgentDir,
+    );
+    // Follower has a credential with no finite expiry — exercises the
+    // `!Number.isFinite(params.credential.expires)` branch of the cache
+    // freshness guard in `adoptNewerMainOAuthCredential`.
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth" as const,
+            provider,
+            access: "follower-no-expiry-access",
+            refresh: "follower-no-expiry-refresh",
+            expires: Number.POSITIVE_INFINITY,
+            accountId,
+            email,
+          },
+        },
+      } satisfies AuthProfileStore,
+      followerAgentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "leader-rotated-access",
+          refresh: "leader-rotated-refresh",
+          expires: freshExpiry,
+          accountId,
+          email,
+        }) as never,
+    );
+
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(leaderAgentDir),
+      profileId,
+      agentDir: leaderAgentDir,
+    });
+
+    const followerResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(followerAgentDir),
+      profileId,
+      agentDir: followerAgentDir,
+    });
+
+    // Follower must adopt the cached peer credential even though its own
+    // local view appears "non-expired" (Infinity > everything).
+    expect(followerResult?.apiKey).toBe("leader-rotated-access");
+    const followerOnDisk = JSON.parse(
+      await fs.readFile(path.join(followerAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(followerOnDisk.profiles[profileId]).toMatchObject({
+      access: "leader-rotated-access",
+      refresh: "leader-rotated-refresh",
+      expires: freshExpiry,
+    });
+  }, 10_000);
+
+  // Reviewer IMPORTANT on #74214: the in-process cache has no LRU/TTL, and
+  // `rememberRefreshedCredential` now sweeps expired siblings on every
+  // publish. The Map is closure-private, so this test exercises the
+  // externally-observable invariant that the sweep is meant to preserve:
+  // an already-expired cached entry for one (provider, profileId) must NOT
+  // hijack a subsequent rotation for the same profile from a different
+  // agent, even after a fresh publish for an unrelated profile has run.
+  // The freshness gate inside `findInProcessRefreshedCredential` plus the
+  // new sweep together pin this behavior; a regression in either layer
+  // would surface as a stale-token reuse here.
+  it("evicts expired sibling cache entries when a new refresh result is published", async () => {
+    const provider = "openai-codex";
+    const accountIdA = "acct-A";
+    const accountIdB = "acct-B";
+    const emailA = "userA@example.com";
+    const emailB = "userB@example.com";
+    const profileIdA = "openai-codex:userA@example.com";
+    const profileIdB = "openai-codex:userB@example.com";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const agentA = path.join(tempRoot, "agents", "evict-A", "agent");
+    const agentB = path.join(tempRoot, "agents", "evict-B", "agent");
+    await fs.mkdir(agentA, { recursive: true });
+    await fs.mkdir(agentB, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId: profileIdA,
+        provider,
+        accountId: accountIdA,
+        email: emailA,
+      }),
+      agentA,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId: profileIdB,
+        provider,
+        accountId: accountIdB,
+        email: emailB,
+      }),
+      agentB,
+    );
+
+    // Profile A's leader rotates first. The mock returns a credential
+    // that is ALREADY EXPIRED — this lets us verify the entry exists in
+    // the cache (it is the most recent successful refresh result) but
+    // becomes ineligible for adoption immediately, so a later publish
+    // for profile B must sweep it.
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "A-rotated-but-expired-access",
+          refresh: "A-rotated-but-expired-refresh",
+          // Just-past expiry — usable check returns false going forward.
+          expires: Date.now() - 1,
+          accountId: accountIdA,
+          email: emailA,
+        }) as never,
+    );
+    await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentA),
+      profileId: profileIdA,
+      agentDir: agentA,
+    });
+
+    // Profile B's leader rotates next. The new publish must sweep A's
+    // now-expired sibling entry while inserting B's fresh entry.
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "B-rotated-fresh-access",
+          refresh: "B-rotated-fresh-refresh",
+          expires: freshExpiry,
+          accountId: accountIdB,
+          email: emailB,
+        }) as never,
+    );
+    const bResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(agentB),
+      profileId: profileIdB,
+      agentDir: agentB,
+    });
+    expect(bResult?.apiKey).toBe("B-rotated-fresh-access");
+
+    // Now another agent for profile A asks to resolve. Because the cache
+    // entry for A was swept (or, equivalently, is no longer usable), it
+    // must NOT be returned: a fresh refresh must run instead. We assert
+    // by setting up the mock to fail if called — if the cache somehow
+    // held A's stale entry without the freshness gate catching it, this
+    // would surface; if it correctly refreshes, the mock's third call
+    // produces a fresh credential.
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider,
+          access: "A-second-rotated-access",
+          refresh: "A-second-rotated-refresh",
+          expires: freshExpiry,
+          accountId: accountIdA,
+          email: emailA,
+        }) as never,
+    );
+    const aSecondAgent = path.join(tempRoot, "agents", "evict-A2", "agent");
+    await fs.mkdir(aSecondAgent, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId: profileIdA,
+        provider,
+        accountId: accountIdA,
+        email: emailA,
+      }),
+      aSecondAgent,
+    );
+    const aResult = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(aSecondAgent),
+      profileId: profileIdA,
+      agentDir: aSecondAgent,
+    });
+    // Second A agent gets a brand-new rotation, not the stale cache entry.
+    expect(aResult?.apiKey).toBe("A-second-rotated-access");
   }, 10_000);
 });


### PR DESCRIPTION
### Summary

- **Problem**: Multi-agent OAuth swarms that share a single Codex profile via mirrored `auth-profiles.json` files (the documented multi-agent shape) crash with `OAuthManagerRefreshError: ... refresh_token_reused` 401s the moment a queued peer in the same gateway process picks up a refresh request after a peer has already rotated the token. The user-visible failure is reproduced verbatim by `src/agents/auth-profiles/oauth.concurrent-agents.test.ts > rescues a queued peer when the leader's mirror to main is lost (issue #74055)`, which fails on current `main` with the same error string the user reported.
- **Root Cause**: `doRefreshOAuthTokenWithLock` (`src/agents/auth-profiles/oauth-manager.ts`) and `resolveOAuthAccess` rely on a single hand-off between peers: when the leader rotates the token, it persists the new credential to its own per-agent store and then calls `mirrorRefreshedCredentialIntoMainStore`, which performs a best-effort `updateAuthProfileStoreWithLock(undefined, …)` write to the main store. The next queued peer is supposed to discover that mirror through one of three adoption checkpoints (`adoptNewerMainOAuthCredential` outside the lock, the inside-lock `loadAuthProfileStoreForSecretsRuntime(undefined)` check, and the post-failure main-store fallback in `resolveOAuthAccess`). Every one of those checkpoints reads main from the filesystem. When the disk-side mirror is dropped — `mirrorRefreshedCredentialIntoMainStore`'s catch block silently swallows errors at `log.debug`, `withFileLock(mainPath, …)` can time out under transient Windows file-lock contention with antivirus tooling, and external processes (e.g. a doctor flow writing back a cached store) can roll the file back — the leader's refresh succeeded but the disk under main is stale. The queued peer then loads the stale main view, falls through to `adapter.refreshCredential(credentialToRefresh)` with its own already-rotated `refresh_token`, and the OpenAI Codex token endpoint replies `401 refresh_token_reused`. There is no in-process channel that lets the peer discover the leader's result independent of the disk mirror.
- **Fix**: Make the leader's refresh result first-class state inside the OAuth manager. `createOAuthManager` now keeps a small `recentlyRefreshedCredentials` map keyed by `(provider, profileId)` that is populated the moment a refresh succeeds (before the disk mirror runs) and consulted by all three adoption checkpoints — `adoptNewerMainOAuthCredential` (pre-queue), the inside-lock adoption inside `doRefreshOAuthTokenWithLock` (just after `hasUsableOAuthCredential` rejects the agent's stale view), and the post-failure main-store fallback in `resolveOAuthAccess` (so a refresh that already raised `refresh_token_reused` can still recover). Cache hits require a strict positive identity match: both the requesting and cached credentials must bear `accountId` or `email` and pass `isSafeToAdoptMainStoreOAuthIdentity`, which prevents fuzzy hits from leaking across unrelated profiles or test fixtures. The disk-side adoption paths are unchanged; the cache is purely additive defense in depth and survives any failure mode that drops the mirror to main on disk. The cache is reset alongside `refreshQueues` in the existing `resetRefreshQueuesForTest` hook so the test surface stays unchanged.
- **What changed**:
  - `src/agents/auth-profiles/oauth-manager.ts`: introduce `recentlyRefreshedCredentials` and the `rememberRefreshedCredential` / `findInProcessRefreshedCredential` helpers inside `createOAuthManager`; consult the cache in `adoptNewerMainOAuthCredential`, in the inside-lock adoption block of `doRefreshOAuthTokenWithLock`, and in the post-failure main-store fallback of `resolveOAuthAccess`; publish to the cache the moment a refresh succeeds; clear it in `resetRefreshQueuesForTest`; import `hasOAuthIdentity` from `oauth-shared.js` for the strict identity gate.
  - `src/agents/auth-profiles/oauth.concurrent-agents.test.ts`: add the `rescues a queued peer when the leader's mirror to main is lost (issue #74055)` regression. It seeds a leader and a follower sub-agent plus main with the same expired credential, lets the leader rotate the token through the real flow, then forcibly reverts main on disk to the pre-mirror state and configures the refresh mock to throw `refresh_token_reused` for any subsequent call. Without this PR the test fails with the exact user-reported `OAuthManagerRefreshError`; with it the follower adopts the leader's result from the in-process cache without ever spending its own already-rotated `refresh_token`. Adds `AuthProfileStore` to the type imports.
- **What did NOT change (scope boundary)**:
  - The cross-process file-lock backbone in `src/plugin-sdk/file-lock.ts` and the per-profile lock path in `src/agents/auth-profiles/path-resolve.ts`.
  - The in-process refresh queue (`refreshQueues`) and the FIFO gate semantics in `refreshOAuthTokenWithLock`.
  - The `doRefreshOAuthTokenWithLock` critical section ordering (global lock → per-agent store lock → reload → adopt → refresh → save → mirror).
  - `mirrorRefreshedCredentialIntoMainStore`, `shouldMirrorRefreshedOAuthCredential`, `isSafeToAdoptMainStoreOAuthIdentity`, and every other identity / mirror policy helper in `oauth-shared.ts` and `oauth-identity.ts`.
  - The disk-side fallback chain in `resolveOAuthAccess` (`loadFreshStoredOAuthCredential` re-read, retry-once after `refresh_token_reused`, ensure-from-main inheritance, final `OAuthManagerRefreshError`).
  - The Codex provider plugin (`extensions/openai/openai-codex-provider.ts`), the embedded runner, the Discord channel, doctor flows, secrets runtime activation, and any public Plugin SDK / API surface.
  - `CHANGELOG.md`, docs, and the existing concurrent-agent test are unmodified.
  - No `any`, no public type changes, no new exports outside the manager closure.

### Reproduction

1. Install OpenClaw `2026.4.26` on Windows 11 with PowerShell.
2. `openclaw models auth login --provider openai-codex` to write a fresh credential into `~\.openclaw\agents\main\agent\auth-profiles.json`.
3. Mirror that file byte-for-byte into five per-agent dirs (`~\.openclaw\agents\<atlas|axon|nova|nexis|lumi>\agent\auth-profiles.json`).
4. In `~\.openclaw\openclaw.json`, configure each agent to use `openai-codex/gpt-5.5` and route `auth.profiles.openai-codex:<email> -> openai-codex` with `auth.routing.openai -> openai-codex:<email>`.
5. Bind each agent to its own Discord channel and run `openclaw gateway restart`.
6. Wait for the shared OAuth credential to enter its near-expiry window. Send a prompt to one agent (`atlas`); when its rotated credential is mirrored to main, immediately have an antivirus tool, an `openclaw doctor` invocation, or any process briefly hold `~\.openclaw\agents\main\agent\auth-profiles.json` so the mirror's `withFileLock` write times out and is silently swallowed. Now post a prompt to a different agent (`nova`).
7. Observe: `nova`'s lane fails with `OAuth token refresh failed for openai-codex: 401 refresh_token_reused`. Inspect `nova`'s on-disk `auth-profiles.json` and confirm it still holds the pre-rotation credential despite `atlas` having a freshly rotated token in its own per-agent store.

After this PR, step 7 instead resolves successfully. `nova` discovers `atlas`'s rotation through the in-process refresh cache, adopts the credential, and writes it to its own per-agent store — without ever touching main on disk and without spending its own already-rotated `refresh_token`. The deterministic version of step 6 is exercised in CI by the new regression test, which forcibly reverts main on disk after the leader's refresh.

### Risk / Mitigation

- **Risk**: Adding a process-scoped credential cache could let a stale refresh result mask a fresh disk-side update, or could leak between unrelated profiles in the same process (including across tests that share the manager singleton).
- **Mitigation**: The cache is keyed by `(provider, profileId)` and gated by a strict positive identity match (`hasOAuthIdentity` plus `isSafeToAdoptMainStoreOAuthIdentity`), so a freshly-seeded credential without identity (and any unrelated profile) cannot fuzzy-match a peer's rotated token. The cache is publish-on-success only — failed refreshes leave it untouched — and it is cleared by the existing `resetRefreshQueuesForTest` hook so vitest isolation works without changing other test files. The disk-side adoption chain is preserved unchanged: the cache is consulted before the disk paths, but the disk paths still run if the cache misses (e.g., across process restarts), and a successful disk-side adoption still saves to the agent's own store. All three adoption call sites that consult the cache only ever return its credential after passing the existing identity-safety check, which already gates the disk-side adoption path. The full `pnpm test src/agents/auth-profiles/` suite passes (16 files / 162 tests, including the 22 oauth-mirror, fallback-to-main, openai-codex-refresh-fallback, and adopt-identity invariants), `pnpm exec oxfmt --check` and `pnpm tsgo:core` are clean, and the new regression flips from RED (exact user error) on `main` to GREEN with this patch.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / OAuth refresh manager (`src/agents/auth-profiles/oauth-manager.ts`)
- [x] Tests (`src/agents/auth-profiles/oauth.concurrent-agents.test.ts`)

### Linked Issue/PR

Fixes #74055