### PR TITLE
[debug][skill] add bundled skill for triage-ready OpenClaw agent bug reports

### DIFF
--- a/skills/file-openclaw-agent-bug/SKILL.md
+++ b/skills/file-openclaw-agent-bug/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: file-openclaw-agent-bug
+description: Create triage-ready OpenClaw GitHub issue drafts for reports that an agent is slow, broken, not responding, tool-starved, degraded, or "not as smart." Use when an agent needs to collect a conservative diagnostics snapshot, compare OpenClaw config against defaults or expected baseline, list installed and active plugins, capture relevant error logs, search similar openclaw/openclaw issues, and prepare a debuggable bug report for user approval before posting.
+---
+
+# File OpenClaw Agent Bug
+
+## Goal
+
+Turn vague reports like "my agent is slow," "it stopped responding," or "it is not as smart" into a privacy-safe GitHub issue that maintainers can triage. Prioritize concrete runtime evidence over speculation.
+
+Suggested public handoff text:
+
+```text
+Give this to your agent: Use $file-openclaw-agent-bug to collect conservative OpenClaw diagnostics, search for similar openclaw/openclaw issues, and draft a triage-ready bug report. Do not post secrets, raw credentials, full config files, private prompts, or unreviewed logs.
+```
+
+## Scenarios
+
+Use this skill for reports like:
+
+- "My agent is slow" or responses suddenly take much longer than before.
+- "My agent is broken" or stalls, times out, exits early, or never returns.
+- "It is not as smart" or appears to lose tools, context, planning quality, or model/provider routing.
+- "Tools are missing" or the agent cannot call tools that should be available.
+- "It stopped responding after an update" or after changing config, auth, models, plugins, MCP servers, gateway settings, or workspace instructions.
+- "A plugin made it worse" or a plugin is installed but disabled, failing validation, or changing runtime behavior.
+- "It only fails in this workspace/thread" or only through a specific entrypoint such as CLI, desktop UI, Telegram, or browser.
+
+Example handoff prompts a user might give their agent:
+
+```text
+Use $file-openclaw-agent-bug. OpenClaw got much slower after I installed a plugin yesterday. Collect conservative diagnostics, search for similar issues, and draft the GitHub issue for my approval.
+```
+
+```text
+Use $file-openclaw-agent-bug. My agent says tools are unavailable in this workspace, but they worked in a new install. Please capture config/plugin differences and draft an issue without posting private logs.
+```
+
+```text
+Use $file-openclaw-agent-bug. Since the last update, the desktop UI starts a run but the agent never responds. Gather the minimal evidence maintainers need and check for duplicate issues first.
+```
+
+## Flow
+
+```mermaid
+flowchart TD
+  A["User reports slow, broken, unresponsive, or degraded agent"] --> B["Agent asks structured intake questions"]
+  B --> C["Run conservative diagnostics collector"]
+  C --> D["Summarize system, OpenClaw, plugin, config-metadata, command failures, and nearby logs"]
+  D --> E["Search open and closed openclaw/openclaw issues"]
+  E --> F{"Likely duplicate?"}
+  F -->|Yes| G["Draft comment for existing issue with new reviewed evidence"]
+  F -->|No| H["Draft new issue from template"]
+  G --> I["Show final public text and selected excerpts"]
+  H --> I
+  I --> J{"User approves posting?"}
+  J -->|Yes| K["Post issue or comment"]
+  J -->|No| L["Leave draft local; do not upload diagnostics bundle"]
+```
+
+## Workflow
+
+1. Capture the symptom before collecting data.
+   - Ask these intake questions and record the answers before running diagnostics:
+     - What exact prompt, command, or UI action failed?
+     - What did you expect the agent to do?
+     - What happened instead, including latency, hangs, messages, missing tools, or weaker reasoning?
+     - When did it last work correctly, and when did it start failing?
+     - Does it reproduce in a new thread, new workspace, retry, or after disabling suspect plugins?
+     - Which model, provider, auth profile, workspace, and entrypoint were selected?
+     - What changed recently: OpenClaw update, config edit, plugin install, auth change, OS update, network/proxy change?
+     - May I collect a conservative local diagnostics bundle and search public issues?
+   - Classify the symptom as latency, no response, weaker reasoning, missing tools, crash, auth failure, plugin failure, config mismatch, or unknown.
+
+2. Collect a conservative diagnostics bundle.
+   - Prefer the bundled script from this skill directory. Run it by absolute path if your current working directory is not the skill directory:
+
+```bash
+bash /path/to/file-openclaw-agent-bug/scripts/collect-openclaw-diagnostics.sh --output ./openclaw-diagnostics
+```
+
+- If the script cannot run, manually collect equivalent evidence: OpenClaw version/status, OS, Node/package manager versions, active config, plugin list, recent logs, and relevant command output.
+- Default output is intentionally conservative: it records config metadata rather than raw config content, skips global `/tmp`, and summarizes git/env state.
+- Use `--include-private-config`, `--include-tmp-logs`, or `--include-git-details` only after explaining the risk and getting explicit user approval.
+- Inspect every generated file before sharing. Redaction is a defense-in-depth helper, not permission to post blindly.
+
+3. Compare config against baseline.
+   - Use native OpenClaw commands when available, such as status, config file, config validate, or any supported config dump/list/diff command. If a command does not exist, say so in the issue.
+   - State the baseline contract explicitly:
+     - Baseline used: release defaults / current main defaults / clean profile / unknown.
+     - Evidence: command output, file metadata, or repo/version source.
+     - Unavailable because: command missing, command failed, install too old, no repo checkout, or unknown.
+   - Highlight only meaningful non-defaults: provider/model routing, auth profile, gateway/transport settings, sandbox/approval mode, timeout settings, MCP/tool configuration, memory/context settings, plugin enablement, workspace overrides, and AGENTS/SKILL overlays.
+   - Do not paste full private config when a summarized diff will explain the risk.
+
+4. List plugins and extensions.
+   - Include installed plugins, active plugins, versions or source paths, validation errors, recent changes, and whether the issue reproduces with suspect plugins disabled.
+   - Separate "installed" from "active" and "loaded successfully" from "failed validation."
+
+5. Capture logs around the incident.
+   - Prefer a window from roughly 10 minutes before the user noticed the issue through 10 minutes after.
+   - Include gateway logs, UI/desktop logs, provider/API errors, plugin validation errors, session-run errors, tool-call failures, and timeout or heartbeat messages.
+   - Quote compact excerpts. Do not include unrelated conversations, credentials, personal data, or huge raw logs.
+
+6. Search for similar issues before filing.
+   - Read `references/similar-issue-search.md`.
+   - Search open and closed issues in `openclaw/openclaw` using symptom words, exact errors, plugin names, provider/model names, and log phrases.
+   - Record exact queries, result counts, top candidate issues, and the duplicate decision in the issue body.
+   - If a match exists, draft a comment for that issue with the new evidence or link it as related. Draft a new issue only when the failure is materially distinct or the existing issue lacks the needed evidence.
+
+7. Draft the issue and get posting approval.
+   - Use `references/issue-template.md`.
+   - Produce the completed issue body first, including the reviewed excerpt list and explicit unknowns.
+   - Do not upload the full diagnostics directory to GitHub. Paste only selected, reviewed, redacted excerpts.
+   - If GitHub access is configured, file with `gh issue create -R openclaw/openclaw` or the available GitHub tool only after the user approves the final body and attachment/excerpt list. Otherwise, produce the completed issue body for the user to post.
+   - Title pattern: `[diagnostics] Agent <symptom> on <platform/provider/plugin>`.
+   - Include links to similar issues, the diagnostics summary, command failures, and explicit unknowns.
+
+## Privacy Rules
+
+- Never post raw API keys, OAuth tokens, cookies, session tokens, bearer headers, private prompts, private conversation contents, or full unreviewed config files.
+- Default to draft-only public output until the user approves the final issue body after diagnostics collection.
+- Never attach the full diagnostics bundle to a public issue; quote only necessary redacted excerpts.
+- Redact usernames, emails, organization names, hostnames, and absolute home paths when they are not necessary for debugging.
+- Do not restart services, disable plugins, edit config, or delete state unless the user explicitly approves that action.
+- Mark evidence as "observed" and hypotheses as "suspected." Do not overclaim root cause from a symptom report.
+
+## Resources
+
+- `scripts/collect-openclaw-diagnostics.sh`: Best-effort local collector for conservative system, OpenClaw, plugin, config-metadata, and log evidence. Requires `bash` and `perl`; `openclaw`, `gh`, `node`, `npm`, `pnpm`, `git`, `systemctl`, and `launchctl` are optional.
+- `references/issue-template.md`: Issue body template.
+- `references/similar-issue-search.md`: Search queries and duplicate-linking guidance.
+
+## Final Draft Checklist
+
+Before asking the user to approve posting, verify the draft has a clear title, impact, reproduction status, baseline source, plugin/config summary, selected redacted log excerpts, command failures, duplicate-search decision, and an explicit sanitization review status.

--- a/skills/file-openclaw-agent-bug/references/issue-template.md
+++ b/skills/file-openclaw-agent-bug/references/issue-template.md
@@ -1,0 +1,96 @@
+# OpenClaw Agent Bug Issue Template
+
+## Summary
+
+One sentence describing the user-visible failure.
+
+## Impact
+
+- Severity: blocking / severe degradation / intermittent / minor
+- User-visible symptom: slow / no response / weaker reasoning / missing tools / crash / auth failure / plugin failure / other
+- Affected subsystem guess: gateway / runner / provider / auth / tools / plugin / UI / memory-context / unknown
+- Entrypoint: CLI / desktop UI / Telegram / browser / other
+- Started: date and approximate local time
+- Last known good version or time:
+- First known bad version or time:
+- Reproducible: yes / no / unknown
+- Minimal reproduction found: yes / no / unknown
+
+## Environment
+
+- OpenClaw version or commit:
+- Install method:
+- OS and architecture:
+- Node and package manager versions:
+- Workspace path or type, with private path segments redacted:
+- Model/provider/auth profile:
+- Transport or gateway mode:
+- OpenClaw command availability: all present / some failed / openclaw missing
+
+## Expected Behavior
+
+What should have happened.
+
+## Observed Behavior
+
+What actually happened, including exact messages, latency, hangs, or degraded behavior.
+
+## Reproduction Steps
+
+1. Start from a clean description of the state before the failure.
+2. List exact prompts, commands, UI actions, or workflow steps.
+3. Include whether the failure survives a retry, a new thread, a new workspace, or disabling suspect plugins, if tested.
+
+## Intake Answers
+
+- Exact prompt, command, or UI action that failed:
+- Expected result:
+- Observed result:
+- Recent changes:
+- New thread/workspace retry result:
+- Suspect plugin-disabled result:
+- Permission granted for diagnostics and public issue search: yes / no
+
+## Config Differences From Baseline
+
+Summarize meaningful differences only. Include provider/model routing, auth profile, gateway settings, sandbox/approval mode, timeout settings, MCP/tool config, memory/context settings, workspace overrides, AGENTS/SKILL overlays, and plugin enablement.
+
+- Baseline used: release defaults / current main defaults / clean profile / unknown
+- Baseline evidence:
+- Baseline unavailable because:
+
+## Plugins, Skills, and Extensions
+
+- Installed:
+- Active:
+- Failed validation:
+- Recently changed:
+- Suspect plugin or hook:
+- Reproduction with suspect plugins disabled:
+
+## Logs and Diagnostics
+
+Paste selected reviewed redacted excerpts only. Include the incident window and command outputs that failed. Do not attach the full diagnostics directory, raw secrets, unrelated private conversations, or huge logs.
+
+- Local diagnostics bundle path, redacted or omitted from public issue:
+- Sanitization review completed: yes / no
+- Public excerpts selected:
+- Diagnostics command failures: command, exit code, stderr excerpt, likely meaning
+- File index reviewed: yes / no
+
+## Similar Issues Searched
+
+- Exact error queries:
+- Symptom queries:
+- Plugin/provider/model queries:
+- Open matches and result counts:
+- Closed/regression matches and result counts:
+- Top candidate issues:
+- Top rejected candidates and reason:
+- Selected related issues:
+- Duplicate decision: new issue / comment on existing issue / unclear
+- Reason this is not a duplicate, or why the evidence belongs on an existing issue:
+
+## Notes and Hypotheses
+
+Separate observed facts from suspected causes. Include unknowns explicitly.

--- a/skills/file-openclaw-agent-bug/references/similar-issue-search.md
+++ b/skills/file-openclaw-agent-bug/references/similar-issue-search.md
@@ -1,0 +1,45 @@
+# Similar Issue Search
+
+Search before filing. Prefer exact error strings first, then broader symptom language.
+
+## GitHub CLI Queries
+
+```bash
+gh search issues "repo:openclaw/openclaw is:issue \"not responding\""
+gh search issues "repo:openclaw/openclaw is:issue slow agent"
+gh search issues "repo:openclaw/openclaw is:issue timeout gateway"
+gh search issues "repo:openclaw/openclaw is:issue plugin validation"
+gh search issues "repo:openclaw/openclaw is:issue auth profile provider"
+gh search issues "repo:openclaw/openclaw is:issue exact error phrase here"
+```
+
+If `gh search issues` is unavailable, use GitHub web search with:
+
+```text
+repo:openclaw/openclaw is:issue <symptom or exact error>
+```
+
+## What To Link
+
+- Exact same error, even if the user-visible symptom differs.
+- Same plugin, provider, auth profile, gateway mode, model, or transport path.
+- Same regression window or release version.
+- Prior issues closed as fixed if the current report suggests a regression.
+
+## Duplicate Decision
+
+Comment on an existing issue when the root symptom and likely subsystem match. File a new issue when the logs show a different subsystem, the existing issue lacks enough evidence, or the old issue is closed and the current version appears to regress.
+
+## Duplicate Search Record
+
+Record this in the final issue or existing-issue comment:
+
+- Exact error queries:
+- Symptom queries:
+- Plugin/provider/model queries:
+- Open matches and result counts:
+- Closed/regression matches and result counts:
+- Top candidate issues:
+- Selected related issues:
+- Duplicate decision: new issue / comment on existing issue / unclear
+- Reason:

--- a/skills/file-openclaw-agent-bug/scripts/collect-openclaw-diagnostics.sh
+++ b/skills/file-openclaw-agent-bug/scripts/collect-openclaw-diagnostics.sh
@@ -1,0 +1,540 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+OUTPUT_DIR=""
+SINCE_MINUTES="30"
+MAX_LOG_LINES="500"
+COMMAND_TIMEOUT="10"
+INCLUDE_PRIVATE_CONFIG="0"
+INCLUDE_TMP_LOGS="0"
+INCLUDE_GIT_DETAILS="0"
+
+OPENCLAW_HOME_DEFAULT="${OPENCLAW_HOME:-$HOME/.openclaw}"
+WORKSPACE_DEFAULT="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+
+usage() {
+  cat <<'USAGE'
+Usage: collect-openclaw-diagnostics.sh [options]
+
+Creates a conservative local diagnostics bundle for OpenClaw issue reports.
+The default bundle is meant to support a public-safe issue draft, not to be
+uploaded blindly.
+
+Options:
+  --output DIR              Directory to write. Defaults to ./openclaw-diagnostics-<UTC>.
+  --since-minutes N         Collect log files modified in the last N minutes. Default: 30.
+  --max-log-lines N         Tail at most N lines per matching log file. Default: 500.
+  --command-timeout N       Seconds before diagnostic commands time out. Default: 10.
+  --include-private-config  Copy small redacted config/AGENTS files. Default: metadata only.
+  --include-tmp-logs        Include matching logs under TMPDIR/tmp. Default: off.
+  --include-git-details     Include raw redacted git status/remotes. Default: summary only.
+  -h, --help                Show this help.
+
+Review every generated file before sharing anything publicly.
+USAGE
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2-}"
+  if [ -z "$value" ] || [ "${value#-}" != "$value" ]; then
+    echo "Missing value for $flag" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
+require_positive_int() {
+  local name="$1"
+  local value="$2"
+  if ! printf '%s' "$value" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "$name must be a positive integer: $value" >&2
+    exit 2
+  fi
+}
+
+require_command() {
+  local command_name="$1"
+  local purpose="$2"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name ($purpose)" >&2
+    exit 1
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      require_value "$1" "${2-}"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --since-minutes)
+      require_value "$1" "${2-}"
+      SINCE_MINUTES="$2"
+      shift 2
+      ;;
+    --max-log-lines)
+      require_value "$1" "${2-}"
+      MAX_LOG_LINES="$2"
+      shift 2
+      ;;
+    --command-timeout)
+      require_value "$1" "${2-}"
+      COMMAND_TIMEOUT="$2"
+      shift 2
+      ;;
+    --include-private-config)
+      INCLUDE_PRIVATE_CONFIG="1"
+      shift
+      ;;
+    --include-tmp-logs)
+      INCLUDE_TMP_LOGS="1"
+      shift
+      ;;
+    --include-git-details)
+      INCLUDE_GIT_DETAILS="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_positive_int "--since-minutes" "$SINCE_MINUTES"
+require_positive_int "--max-log-lines" "$MAX_LOG_LINES"
+require_positive_int "--command-timeout" "$COMMAND_TIMEOUT"
+require_command perl "redacting secrets and local identifiers from diagnostics output"
+
+if [ -z "$OUTPUT_DIR" ]; then
+  OUTPUT_DIR="./openclaw-diagnostics-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+if [ -e "$OUTPUT_DIR" ] && [ ! -d "$OUTPUT_DIR" ]; then
+  echo "Output path exists but is not a directory: $OUTPUT_DIR" >&2
+  exit 1
+fi
+if ! mkdir -p "$OUTPUT_DIR"/{commands,configs,logs,plugins}; then
+  echo "Could not create diagnostics output directory: $OUTPUT_DIR" >&2
+  exit 1
+fi
+COMMAND_INDEX="$OUTPUT_DIR/commands/command-index.tsv"
+FILE_INDEX="$OUTPUT_DIR/file-index.tsv"
+if ! printf 'name\tstatus\toutput\n' > "$COMMAND_INDEX"; then
+  echo "Could not write command index: $COMMAND_INDEX" >&2
+  exit 1
+fi
+if ! printf 'kind\tstatus\tsize_bytes\tmtime\tsha256\tpath\treason\n' > "$FILE_INDEX"; then
+  echo "Could not write file index: $FILE_INDEX" >&2
+  exit 1
+fi
+
+sanitize_stream() {
+  local host_short=""
+  local host_full=""
+  host_short="$(hostname -s 2>/dev/null || true)"
+  host_full="$(hostname 2>/dev/null || true)"
+  PERL_HOME="${HOME:-}" PERL_USER="${USER:-}" PERL_HOST_SHORT="$host_short" PERL_HOST_FULL="$host_full" \
+    perl -0777 -pe '
+      s#([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@#$1[USER]:[REDACTED]@#gi;
+      s/(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]{10,}/$1 [REDACTED]/g;
+      s/sk-[A-Za-z0-9_-]{16,}/sk-[REDACTED]/g;
+      s/(gh[pousr]_|github_pat_)[A-Za-z0-9_]{16,}/$1[REDACTED]/g;
+      s/(glpat-|hf_|npm_|pypi-)[A-Za-z0-9._-]{16,}/$1[REDACTED]/g;
+      s/xox[baprs]-[A-Za-z0-9-]{10,}/xox-[REDACTED]/g;
+      s/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/[AWS_ACCESS_KEY_REDACTED]/g;
+      s/\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/[JWT_REDACTED]/g;
+      s/-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----/[PRIVATE_KEY_BLOCK_REDACTED]/gs;
+      s/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/[EMAIL_REDACTED]/g;
+      s/([A-Za-z0-9_.-]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTHORIZATION|COOKIE|SESSION|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET|REFRESH[_-]?TOKEN|ACCESS[_-]?TOKEN|AWS[_-]?ACCESS[_-]?KEY[_-]?ID)[A-Za-z0-9_.-]*)(\s*[:=]\s*)("[^"]*"|'\''[^'\'']*'\''|[^,;\s}]+)/$1$2[REDACTED]/ig;
+      for my $name (qw(PERL_HOME PERL_HOST_SHORT PERL_HOST_FULL)) {
+        my $value = $ENV{$name} // "";
+        next unless length($value) > 1;
+        my $safe = quotemeta($value);
+        my $replacement = $name eq "PERL_HOME" ? "~" : "[LOCAL_ID_REDACTED]";
+        s/$safe/$replacement/g;
+      }
+      my $user = $ENV{PERL_USER} // "";
+      if (length($user) > 1) {
+        my $safe_user = quotemeta($user);
+        s/(?<![A-Za-z0-9._-])$safe_user(?![A-Za-z0-9._-])/[LOCAL_ID_REDACTED]/g;
+      }
+    '
+}
+
+safe_name() {
+  printf '%s' "$1" | sanitize_stream | sed -E 's#^/##; s#[/: ]+#_#g; s#[^A-Za-z0-9._-]#_#g' | cut -c 1-180
+}
+
+path_scope() {
+  local label="$1"
+  local path="$2"
+  local scope="outside HOME/XDG"
+  if [ -z "$path" ]; then
+    printf -- '- %s path: unset\n' "$label"
+    return 0
+  fi
+  if [ -n "${HOME:-}" ] && { [ "$path" = "$HOME" ] || [[ "$path" == "$HOME/"* ]]; }; then
+    scope="under HOME"
+  elif [ -n "${XDG_CONFIG_HOME:-}" ] && { [ "$path" = "$XDG_CONFIG_HOME" ] || [[ "$path" == "$XDG_CONFIG_HOME/"* ]]; }; then
+    scope="under XDG_CONFIG_HOME"
+  elif [ -n "${XDG_STATE_HOME:-}" ] && { [ "$path" = "$XDG_STATE_HOME" ] || [[ "$path" == "$XDG_STATE_HOME/"* ]]; }; then
+    scope="under XDG_STATE_HOME"
+  fi
+  printf -- '- %s path: [LOCAL_PATH_REDACTED]\n' "$label"
+  printf -- '- %s path scope: %s\n' "$label" "$scope"
+}
+
+file_size() {
+  wc -c < "$1" 2>/dev/null | tr -d ' ' || printf 'unknown'
+}
+
+file_mtime() {
+  stat -f '%Sm' -t '%Y-%m-%dT%H:%M:%S%z' "$1" 2>/dev/null ||
+    stat -c '%y' "$1" 2>/dev/null ||
+    printf 'unknown'
+}
+
+file_sha256() {
+  shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' ||
+    sha256sum "$1" 2>/dev/null | awk '{print $1}' ||
+    printf 'unknown'
+}
+
+record_file() {
+  local kind="$1"
+  local status="$2"
+  local path="$3"
+  local reason="$4"
+  local size="unknown"
+  local mtime="unknown"
+  local sha="unknown"
+  if [ -f "$path" ]; then
+    size="$(file_size "$path")"
+    mtime="$(file_mtime "$path")"
+    sha="$(file_sha256 "$path")"
+  fi
+  {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$kind" "$status" "$size" "$mtime" "$sha" "$path" "$reason"
+  } | sanitize_stream >> "$FILE_INDEX"
+}
+
+run_limited() {
+  local timeout_bin=""
+  timeout_bin="$(command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || true)"
+  if [ -n "$timeout_bin" ] && "$timeout_bin" --help 2>&1 | grep -q -- '--kill-after'; then
+    "$timeout_bin" --kill-after=2s "${COMMAND_TIMEOUT}s" "$@"
+    return $?
+  fi
+
+  perl -e 'setpgrp(0, 0); exec @ARGV or die "exec failed: $!\n"' "$@" &
+  local cmd_pid=$!
+  local elapsed=0
+  while kill -0 "$cmd_pid" 2>/dev/null; do
+    if [ "$elapsed" -ge "$COMMAND_TIMEOUT" ]; then
+      echo "[timeout after ${COMMAND_TIMEOUT}s]" >&2
+      kill -TERM "-$cmd_pid" 2>/dev/null || kill -TERM "$cmd_pid" 2>/dev/null || true
+      sleep 1
+      kill -KILL "-$cmd_pid" 2>/dev/null || kill -KILL "$cmd_pid" 2>/dev/null || true
+      wait "$cmd_pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  wait "$cmd_pid"
+}
+
+run_cmd() {
+  local name="$1"
+  shift
+  local outfile="$OUTPUT_DIR/commands/${name}.txt"
+  local status=0
+  {
+    printf '$'
+    printf ' %q' "$@"
+    printf '\n\n'
+    run_limited "$@"
+    status=$?
+    printf '\n[exit=%s]\n' "$status"
+    printf '%s\t%s\t%s\n' "$name" "$status" "commands/${name}.txt" >> "$COMMAND_INDEX"
+  } 2>&1 | sanitize_stream > "$outfile"
+}
+
+copy_redacted_file() {
+  local kind="$1"
+  local src="$2"
+  local dest_dir="$3"
+  [ -f "$src" ] || return 0
+  local size
+  size="$(file_size "$src")"
+  if [ "$size" = "unknown" ] || [ "$size" -gt 524288 ]; then
+    record_file "$kind" "skipped" "$src" "file too large for redacted copy"
+    return 0
+  fi
+  local dest="$dest_dir/$(safe_name "$src").txt"
+  {
+    printf '# Source: %s\n\n' "$src"
+    cat "$src"
+  } 2>&1 | sanitize_stream > "$dest"
+  record_file "$kind" "copied-redacted" "$src" "$dest"
+}
+
+record_metadata_only() {
+  local kind="$1"
+  local src="$2"
+  local reason="$3"
+  [ -f "$src" ] || return 0
+  record_file "$kind" "metadata-only" "$src" "$reason"
+}
+
+tail_redacted_file() {
+  local src="$1"
+  [ -f "$src" ] || return 0
+  local size
+  size="$(file_size "$src")"
+  if [ "$size" = "unknown" ] || [ "$size" -gt 10485760 ]; then
+    record_file "log" "skipped" "$src" "file too large for tail"
+    return 0
+  fi
+  local dest="$OUTPUT_DIR/logs/$(safe_name "$src").tail.txt"
+  {
+    printf '# Source: %s\n' "$src"
+    printf '# Last %s lines from files modified within the last %s minutes.\n\n' "$MAX_LOG_LINES" "$SINCE_MINUTES"
+    tail -n "$MAX_LOG_LINES" "$src"
+  } 2>&1 | sanitize_stream > "$dest"
+  record_file "log" "copied-redacted-tail" "$src" "$dest"
+}
+
+find_supports_mmin() {
+  local root="$1"
+  find "$root" -maxdepth 0 -mmin -1 -print >/dev/null 2>&1
+}
+
+file_mtime_epoch() {
+  stat -c '%Y' "$1" 2>/dev/null ||
+    stat -f '%m' "$1" 2>/dev/null
+}
+
+find_recent_logs() {
+  local root="$1"
+  [ -d "$root" ] || return 0
+  if find_supports_mmin "$root"; then
+    find "$root" -maxdepth 3 -type f \
+      \( -iname '*.log' -o -iname '*openclaw*' -o -iname '*gateway*' \) \
+      -mmin "-$SINCE_MINUTES" \
+      ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null
+    return 0
+  fi
+
+  local now
+  now="$(date +%s 2>/dev/null || printf '0')"
+  local cutoff=$((now - SINCE_MINUTES * 60))
+  local src
+  local mtime
+  find "$root" -maxdepth 3 -type f \
+    \( -iname '*.log' -o -iname '*openclaw*' -o -iname '*gateway*' \) \
+    ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null |
+    while IFS= read -r src; do
+      mtime="$(file_mtime_epoch "$src" || true)"
+      case "$mtime" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      [ "$mtime" -ge "$cutoff" ] && printf '%s\n' "$src"
+    done
+}
+
+write_env_summary() {
+  local outfile="$OUTPUT_DIR/commands/environment-summary.txt"
+  {
+    echo "# Environment Summary"
+    echo
+    for var in OPENCLAW_HOME OPENCLAW_CONFIG_PATH OPENCLAW_STATE_DIR XDG_CONFIG_HOME XDG_STATE_HOME CODEX_HOME SHELL TERM; do
+      if [ -n "${!var-}" ]; then
+        printf -- '- %s: set\n' "$var"
+      else
+        printf -- '- %s: unset\n' "$var"
+      fi
+    done
+    printf -- '- PATH entries: %s\n' "$(printf '%s' "${PATH:-}" | awk -F: '{print NF}')"
+    printf -- '- PATH contains openclaw: %s\n' "$(printf '%s' "${PATH:-}" | grep -qi openclaw && echo yes || echo no)"
+    for prefix in OPENAI ANTHROPIC CLAUDE CODEX; do
+      local count
+      count="$(env | awk -F= -v p="$prefix" 'index($1, p) == 1 { n += 1 } END { print n + 0 }')"
+      printf -- '- %s_* variables present: %s\n' "$prefix" "$count"
+    done
+  } | sanitize_stream > "$outfile"
+  printf '%s\t%s\t%s\n' "environment-summary" "0" "commands/environment-summary.txt" >> "$COMMAND_INDEX"
+}
+
+write_git_summary() {
+  local outfile="$OUTPUT_DIR/commands/git-summary.txt"
+  {
+    echo "# Git Summary"
+    echo
+    if ! command -v git >/dev/null 2>&1; then
+      echo "- git: not found"
+      return 0
+    fi
+    git --version
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      echo "- inside git repository: yes"
+      printf -- '- dirty entries: %s\n' "$(git status --porcelain=v1 2>/dev/null | wc -l | tr -d ' ')"
+      printf -- '- remotes configured: %s\n' "$(git remote 2>/dev/null | wc -l | tr -d ' ')"
+      printf -- '- current branch present: %s\n' "$(git branch --show-current >/dev/null 2>&1 && echo yes || echo unknown)"
+    else
+      echo "- inside git repository: no"
+    fi
+  } 2>&1 | sanitize_stream > "$outfile"
+  printf '%s\t%s\t%s\n' "git-summary" "0" "commands/git-summary.txt" >> "$COMMAND_INDEX"
+
+  if [ "$INCLUDE_GIT_DETAILS" = "1" ] && command -v git >/dev/null 2>&1; then
+    run_cmd git-status git status --short
+    run_cmd git-remote git remote -v
+  fi
+}
+
+{
+  echo "# OpenClaw Diagnostics Summary"
+  echo
+  echo "- Generated UTC: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  echo "- Local time: $(date '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || date)"
+  path_scope "Working directory" "$WORKSPACE_DEFAULT"
+  path_scope "OPENCLAW_HOME" "$OPENCLAW_HOME_DEFAULT"
+  echo "- Incident window requested: last $SINCE_MINUTES minutes"
+  echo "- Per-command timeout: ${COMMAND_TIMEOUT}s"
+  echo "- Private config copied: $INCLUDE_PRIVATE_CONFIG"
+  echo "- TMP log scan enabled: $INCLUDE_TMP_LOGS"
+  echo "- Raw git details enabled: $INCLUDE_GIT_DETAILS"
+  echo
+  echo "Default output is conservative, but it can still contain local identifiers or log excerpts."
+  echo "Review every generated file before attaching output to a public issue."
+} | sanitize_stream > "$OUTPUT_DIR/diagnostics-summary.md"
+
+run_cmd system-uname uname -a
+write_env_summary
+
+if command -v sw_vers >/dev/null 2>&1; then
+  run_cmd system-macos sw_vers
+fi
+if command -v node >/dev/null 2>&1; then
+  run_cmd node-version node --version
+fi
+if command -v npm >/dev/null 2>&1; then
+  run_cmd npm-version npm --version
+fi
+if command -v pnpm >/dev/null 2>&1; then
+  run_cmd pnpm-version pnpm --version
+fi
+write_git_summary
+
+if command -v openclaw >/dev/null 2>&1; then
+  run_cmd openclaw-version openclaw --version
+  run_cmd openclaw-status openclaw status
+  run_cmd openclaw-gateway-status-deep openclaw gateway status --deep
+  run_cmd openclaw-plugins-list openclaw plugins list
+  run_cmd openclaw-plugins-list-json openclaw plugins list --json
+  run_cmd openclaw-config-file openclaw config file
+  run_cmd openclaw-config-validate openclaw config validate
+else
+  echo "openclaw command not found on PATH." > "$OUTPUT_DIR/commands/openclaw-not-found.txt"
+  printf '%s\t%s\t%s\n' "openclaw-not-found" "127" "commands/openclaw-not-found.txt" >> "$COMMAND_INDEX"
+fi
+
+for root in "$OPENCLAW_HOME_DEFAULT" "$WORKSPACE_DEFAULT/.openclaw" "${XDG_CONFIG_HOME:-$HOME/.config}/openclaw" "${XDG_STATE_HOME:-$HOME/.local/state}/openclaw"; do
+  [ -d "$root" ] || continue
+  find "$root" -maxdepth 4 -type f \
+    \( -iname '*config*' -o -iname '*settings*' -o -iname '*preference*' -o -iname 'AGENTS.md' \) \
+    ! -iname '*.db' ! -iname '*.sqlite' ! -path '*/node_modules/*' ! -path '*/.git/*' \
+    2>/dev/null | while IFS= read -r file; do
+      if [ "$INCLUDE_PRIVATE_CONFIG" = "1" ]; then
+        copy_redacted_file "config" "$file" "$OUTPUT_DIR/configs"
+      else
+        record_metadata_only "config" "$file" "content skipped by default; rerun with --include-private-config after user approval"
+      fi
+    done
+done
+
+find "$WORKSPACE_DEFAULT" -maxdepth 3 -type f \
+  \( -iname 'AGENTS.md' -o -iname 'CLAUDE.md' -o -iname 'SUBAGENTS.md' -o -path '*/.agents/*' \) \
+  ! -path '*/node_modules/*' ! -path '*/.git/*' \
+  2>/dev/null | while IFS= read -r file; do
+    record_metadata_only "workspace-agent-instructions" "$file" "instruction content skipped by default; describe relevant overlays manually"
+  done
+
+for root in "$OPENCLAW_HOME_DEFAULT/plugins" "$OPENCLAW_HOME_DEFAULT/skills" "$WORKSPACE_DEFAULT/plugins" "$WORKSPACE_DEFAULT/skills" "$WORKSPACE_DEFAULT/.agents/plugins"; do
+  [ -d "$root" ] || continue
+  {
+    echo "# Plugin or skill directory: $root"
+    find "$root" -maxdepth 3 -type f \
+      \( -iname 'plugin.json' -o -iname 'manifest.json' -o -iname 'openclaw-plugin.json' -o -iname 'SKILL.md' -o -iname 'openai.yaml' \) \
+      ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null
+  } | sanitize_stream > "$OUTPUT_DIR/plugins/$(safe_name "$root").index.txt"
+
+  find "$root" -maxdepth 3 -type f \
+    \( -iname 'plugin.json' -o -iname 'manifest.json' -o -iname 'openclaw-plugin.json' -o -iname 'openai.yaml' \) \
+    ! -path '*/node_modules/*' ! -path '*/.git/*' \
+    2>/dev/null | while IFS= read -r file; do
+      if [ "$INCLUDE_PRIVATE_CONFIG" = "1" ]; then
+        copy_redacted_file "plugin-manifest" "$file" "$OUTPUT_DIR/plugins"
+      else
+        record_metadata_only "plugin-manifest" "$file" "manifest content skipped by default; rerun with --include-private-config after user approval"
+      fi
+    done
+done
+
+log_roots=(
+  "$OPENCLAW_HOME_DEFAULT/logs"
+  "$OPENCLAW_HOME_DEFAULT/.logs"
+  "$WORKSPACE_DEFAULT/.openclaw/logs"
+  "${XDG_STATE_HOME:-$HOME/.local/state}/openclaw/logs"
+  "${XDG_CONFIG_HOME:-$HOME/.config}/openclaw/logs"
+  "$HOME/Library/Logs/OpenClaw"
+)
+
+if [ "$INCLUDE_TMP_LOGS" = "1" ]; then
+  log_roots+=("${TMPDIR:-/tmp}/openclaw" "${TMPDIR:-/tmp}/OpenClaw" "/tmp")
+fi
+
+for root in "${log_roots[@]}"; do
+  [ -d "$root" ] || continue
+  find_recent_logs "$root" | head -n 40 | while IFS= read -r file; do
+    tail_redacted_file "$file"
+  done
+done
+
+if command -v systemctl >/dev/null 2>&1; then
+  run_cmd systemd-user-openclaw sh -c 'systemctl --user status openclaw* --no-pager'
+fi
+if command -v launchctl >/dev/null 2>&1; then
+  run_cmd launchctl-openclaw sh -c 'launchctl list | grep -i openclaw'
+fi
+
+cat > "$OUTPUT_DIR/next-steps.md" <<'NEXT'
+# Next Steps
+
+1. Review every file in this diagnostics bundle for secrets and unrelated private data.
+2. Fill out issue-template.md.
+3. Search existing openclaw/openclaw issues with exact errors, symptom terms, provider/model names, plugin names, and log phrases.
+4. Draft the issue first. Post only the issue body and selected reviewed excerpts after explicit user approval.
+5. Do not upload the whole diagnostics directory to a public issue.
+NEXT
+
+if [ -f "$SKILL_DIR/references/issue-template.md" ]; then
+  cp "$SKILL_DIR/references/issue-template.md" "$OUTPUT_DIR/issue-template.md"
+fi
+if [ -f "$SKILL_DIR/references/similar-issue-search.md" ]; then
+  cp "$SKILL_DIR/references/similar-issue-search.md" "$OUTPUT_DIR/similar-issue-search.md"
+fi
+
+echo "Diagnostics written to: $OUTPUT_DIR"
+echo "Review output before sharing publicly. Do not upload the full bundle to a public issue."


### PR DESCRIPTION
## Summary

Adds a bundled `file-bug-report` skill for turning vague agent-quality reports like "slow," "broken," "not responding," or "not as smart" into triage-ready OpenClaw issue drafts.

The skill includes:

- A required intake workflow before diagnostics collection.
- Scenario examples and handoff prompts for common reports.
- A conservative diagnostics collector script.
- A maintainer-oriented issue template.
- A duplicate/similar-issue search guide.
- A Mermaid flow diagram of intake → diagnostics → duplicate search → draft → approval/posting.

## Scenarios Covered

This skill is designed for reports like:

- Agent responses suddenly became slow or timeout-prone.
- Agent stalls, exits early, or never returns a response.
- Agent seems "not as smart" because tools, context, planning quality, or model/provider routing changed.
- Tools are unavailable in one workspace but work elsewhere.
- Behavior regressed after an OpenClaw update, config edit, auth change, model/provider change, plugin install, MCP change, or gateway setting change.
- A plugin is installed but disabled, failing validation, or suspected of changing runtime behavior.
- The failure only happens through one entrypoint such as CLI, desktop UI, Telegram, or browser.

Example handoff prompts are embedded in the skill, including:

```text
Use $file-bug-report. OpenClaw got much slower after I installed a plugin yesterday. Collect conservative diagnostics, search for similar issues, and draft the GitHub issue for my approval.
```

```text
Use $file-bug-report. My agent says tools are unavailable in this workspace, but they worked in a new install. Please capture config/plugin differences and draft an issue without posting private logs.
```

## Flow

```mermaid
flowchart TD
  A["User reports slow, broken, unresponsive, or degraded agent"] --> B["Agent asks structured intake questions"]
  B --> C["Run conservative diagnostics collector"]
  C --> D["Summarize system, OpenClaw, plugin, config-metadata, command failures, and nearby logs"]
  D --> E["Search open and closed openclaw/openclaw issues"]
  E --> F{"Likely duplicate?"}
  F -->|Yes| G["Draft comment for existing issue with new reviewed evidence"]
  F -->|No| H["Draft new issue from template"]
  G --> I["Show final public text and selected excerpts"]
  H --> I
  I --> J{"User approves posting?"}
  J -->|Yes| K["Post issue or comment"]
  J -->|No| L["Leave draft local; do not upload diagnostics bundle"]
```

## Why

Users often report agent degradation in informal channels with symptoms but without the evidence maintainers need: OpenClaw version, runtime path, plugin state, config baseline, command failures, and nearby logs. This skill gives users a short handoff prompt they can give their own agent, while keeping the default output safe enough for public issue drafting.

Suggested public handoff text included in the skill:

```text
Give this to your agent: Use $file-bug-report to collect conservative OpenClaw diagnostics, search for similar openclaw/openclaw issues, and draft a triage-ready bug report. Do not post secrets, raw credentials, full config files, private prompts, or unreviewed logs.
```

## Privacy and Safety Boundaries

The diagnostics collector is conservative by default:

- Does not copy raw config, AGENTS content, or plugin manifests by default; records metadata only.
- Does not scan global `/tmp` unless explicitly requested.
- Does not include raw git status/remotes unless explicitly requested.
- Does not upload or post anything.
- Requires the agent to draft first and get user approval before filing publicly.
- Warns against attaching the full diagnostics directory to GitHub.
- Records command failures explicitly so broken/stale installs are still debuggable.

Opt-in flags exist for higher-detail local collection after user approval:

- `--include-private-config`
- `--include-tmp-logs`
- `--include-git-details`

## Adversarial Review Performed

Before publication, the skill went through multiple read-only adversarial passes:

- Privacy/security red team: flagged broad config copying, `/tmp` log scraping, public-posting approval gaps, undercovered secret patterns, raw git/env leakage, and plugin-manifest copying.
- Runtime/portability review: flagged missing option-value parser loops, timeout child-process handling, output-path false success, unsupported config command assumptions, and silent diagnostic gaps.
- Usability/triage blue team: flagged missing structured intake, undefined baseline comparison contract, weak duplicate-search recording, portable script invocation, and issue-template gaps.
- Final sanity pass: found no remaining P0/P1 blockers; noted only non-blocking residual risk around noisy metadata and log excerpts, both covered by the review-before-posting rule.

The resulting implementation is draft-first and metadata-first by default.

## Published on ClawHub

Published as `file-bug-report@1.0.0` on ClawHub after local validation and scanner review. Users can install with `openclaw skills install file-bug-report` and invoke it as `$file-bug-report`.

## Validation

Ran from the PR worktree:

```bash
bash -n skills/file-bug-report/scripts/collect-openclaw-diagnostics.sh
python3 skills/skill-creator/scripts/quick_validate.py skills/file-bug-report
git diff --check origin/main...HEAD
```

Smoke-tested collector behavior:

```bash
OPENCLAW_HOME=/tmp/nonexistent-openclaw-home \
  skills/file-bug-report/scripts/collect-openclaw-diagnostics.sh \
  --output /tmp/openclaw-diagnostics-upstream-smoke-live \
  --max-log-lines 3 \
  --command-timeout 2
```

Verified it discovers as an eligible bundled skill:

```bash
OPENCLAW_BUNDLED_SKILLS_DIR=/path/to/openclaw/skills \
  openclaw skills list --json \
  | jq '.skills[] | select(.name=="file-bug-report") | {name, eligible, disabled, source, bundled, missing}'
```

Observed:

```json
{
  "name": "file-bug-report",
  "eligible": true,
  "disabled": false,
  "source": "openclaw-bundled",
  "bundled": true,
  "missing": {
    "bins": [],
    "anyBins": [],
    "env": [],
    "config": [],
    "os": []
  }
}
```

Also packaged successfully with:

```bash
python3 skills/skill-creator/scripts/package_skill.py skills/file-bug-report /tmp/openclaw-skill-package-test
```

## Notes for Reviewers

This PR intentionally adds a bundled skill only. It does not change OpenClaw runtime code, gateway behavior, plugin loading, issue templates, or docs outside the skill.



