### PR TITLE
fix(plugin-sdk): restore feishu compatibility facades

### DIFF
--- a/package.json
+++ b/package.json
@@ -669,6 +669,10 @@
       "types": "./dist/plugin-sdk/discord.d.ts",
       "default": "./dist/plugin-sdk/discord.js"
     },
+    "./plugin-sdk/feishu": {
+      "types": "./dist/plugin-sdk/feishu.d.ts",
+      "default": "./dist/plugin-sdk/feishu.js"
+    },
     "./plugin-sdk/device-bootstrap": {
       "types": "./dist/plugin-sdk/device-bootstrap.d.ts",
       "default": "./dist/plugin-sdk/device-bootstrap.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -150,6 +150,7 @@
   "direct-dm-access",
   "direct-dm-guard-policy",
   "discord",
+  "feishu",
   "device-bootstrap",
   "diagnostic-runtime",
   "error-runtime",

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -12,6 +12,7 @@ export const reservedBundledPluginSdkEntrypoints = [] as const;
 // until they move to generic, plugin-neutral contracts.
 export const supportedBundledFacadeSdkEntrypoints = [
   "discord",
+  "feishu",
   "lmstudio",
   "lmstudio-runtime",
   "memory-core-engine-runtime",

--- a/src/plugin-sdk/feishu-conversation.ts
+++ b/src/plugin-sdk/feishu-conversation.ts
@@ -1,0 +1,109 @@
+// Manual facade. Keep loader boundary explicit.
+import type { OpenClawConfig } from "../config/types.js";
+import type { BindingTargetKind } from "../infra/outbound/session-binding-service.js";
+import {
+  createLazyFacadeArrayValue,
+  createLazyFacadeObjectValue,
+  loadBundledPluginPublicSurfaceModuleSync,
+} from "./facade-loader.js";
+
+type FeishuGroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
+
+type FeishuThreadBindingRecord = {
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+  deliveryTo?: string;
+  deliveryThreadId?: string;
+  targetKind: "subagent" | "acp";
+  targetSessionKey: string;
+  agentId?: string;
+  label?: string;
+  boundBy?: string;
+  boundAt: number;
+  lastActivityAt: number;
+};
+
+type FeishuThreadBindingManager = {
+  accountId: string;
+  getByConversationId: (conversationId: string) => FeishuThreadBindingRecord | undefined;
+  listBySessionKey: (targetSessionKey: string) => FeishuThreadBindingRecord[];
+  bindConversation: (params: {
+    conversationId: string;
+    parentConversationId?: string;
+    targetKind: BindingTargetKind;
+    targetSessionKey: string;
+    metadata?: Record<string, unknown>;
+  }) => FeishuThreadBindingRecord | null;
+  touchConversation: (conversationId: string, at?: number) => FeishuThreadBindingRecord | null;
+  unbindConversation: (conversationId: string) => FeishuThreadBindingRecord | null;
+  unbindBySessionKey: (targetSessionKey: string) => FeishuThreadBindingRecord[];
+  stop: () => void;
+};
+
+type FacadeModule = {
+  buildFeishuConversationId: (params: {
+    chatId: string;
+    scope: FeishuGroupSessionScope;
+    senderOpenId?: string;
+    topicId?: string;
+  }) => string;
+  createFeishuThreadBindingManager: (params: {
+    accountId?: string;
+    cfg: OpenClawConfig;
+  }) => FeishuThreadBindingManager;
+  feishuSessionBindingAdapterChannels: readonly ["feishu"];
+  feishuThreadBindingTesting: {
+    resetFeishuThreadBindingsForTests: () => void;
+  };
+  parseFeishuDirectConversationId: (raw: unknown) => string | undefined;
+  parseFeishuConversationId: (params: {
+    conversationId: string;
+    parentConversationId?: string;
+  }) => {
+    canonicalConversationId: string;
+    chatId: string;
+    topicId?: string;
+    senderOpenId?: string;
+    scope: FeishuGroupSessionScope;
+  } | null;
+  parseFeishuTargetId: (raw: unknown) => string | undefined;
+};
+
+function loadFacadeModule(): FacadeModule {
+  return loadBundledPluginPublicSurfaceModuleSync<FacadeModule>({
+    dirName: "feishu",
+    artifactBasename: "contract-api.js",
+  });
+}
+export const buildFeishuConversationId: FacadeModule["buildFeishuConversationId"] = ((...args) =>
+  loadFacadeModule()["buildFeishuConversationId"](
+    ...args,
+  )) as FacadeModule["buildFeishuConversationId"];
+export const createFeishuThreadBindingManager: FacadeModule["createFeishuThreadBindingManager"] = ((
+  ...args
+) =>
+  loadFacadeModule()["createFeishuThreadBindingManager"](
+    ...args,
+  )) as FacadeModule["createFeishuThreadBindingManager"];
+export const feishuSessionBindingAdapterChannels: FacadeModule["feishuSessionBindingAdapterChannels"] =
+  createLazyFacadeArrayValue(
+    () =>
+      loadFacadeModule()["feishuSessionBindingAdapterChannels"] as unknown as readonly unknown[],
+  ) as FacadeModule["feishuSessionBindingAdapterChannels"];
+export const feishuThreadBindingTesting: FacadeModule["feishuThreadBindingTesting"] =
+  createLazyFacadeObjectValue(
+    () => loadFacadeModule()["feishuThreadBindingTesting"] as object,
+  ) as FacadeModule["feishuThreadBindingTesting"];
+export const parseFeishuDirectConversationId: FacadeModule["parseFeishuDirectConversationId"] = ((
+  ...args
+) =>
+  loadFacadeModule()["parseFeishuDirectConversationId"](
+    ...args,
+  )) as FacadeModule["parseFeishuDirectConversationId"];
+export const parseFeishuConversationId: FacadeModule["parseFeishuConversationId"] = ((...args) =>
+  loadFacadeModule()["parseFeishuConversationId"](
+    ...args,
+  )) as FacadeModule["parseFeishuConversationId"];
+export const parseFeishuTargetId: FacadeModule["parseFeishuTargetId"] = ((...args) =>
+  loadFacadeModule()["parseFeishuTargetId"](...args)) as FacadeModule["parseFeishuTargetId"];

--- a/src/plugin-sdk/feishu-setup.ts
+++ b/src/plugin-sdk/feishu-setup.ts
@@ -1,0 +1,25 @@
+// Manual facade. Keep loader boundary explicit.
+import type { ChannelSetupWizard } from "../channels/plugins/setup-wizard-types.js";
+import type { ChannelSetupAdapter } from "../channels/plugins/types.adapters.js";
+import {
+  createLazyFacadeObjectValue,
+  loadBundledPluginPublicSurfaceModuleSync,
+} from "./facade-loader.js";
+
+type FacadeModule = {
+  feishuSetupAdapter: ChannelSetupAdapter;
+  feishuSetupWizard: ChannelSetupWizard;
+};
+
+function loadFacadeModule(): FacadeModule {
+  return loadBundledPluginPublicSurfaceModuleSync<FacadeModule>({
+    dirName: "feishu",
+    artifactBasename: "setup-api.js",
+  });
+}
+export const feishuSetupAdapter: FacadeModule["feishuSetupAdapter"] = createLazyFacadeObjectValue(
+  () => loadFacadeModule()["feishuSetupAdapter"] as object,
+) as FacadeModule["feishuSetupAdapter"];
+export const feishuSetupWizard: FacadeModule["feishuSetupWizard"] = createLazyFacadeObjectValue(
+  () => loadFacadeModule()["feishuSetupWizard"] as object,
+) as FacadeModule["feishuSetupWizard"];

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -1,0 +1,157 @@
+/**
+ * Compatibility facade for the `openclaw/plugin-sdk/feishu` subpath.
+ *
+ * Restores the export surface consumed by `@openclaw/feishu@2026.3.13`
+ * (and earlier) which was removed in 1e3ce10e2.  Without this shim the
+ * published npm extension crashes at runtime with:
+ *
+ *   TypeError: (0 , _feishu.createScopedPairingAccess) is not a function
+ *
+ * Fixes #74138
+ *
+ * @deprecated New channel plugins should import from the generic
+ *   channel SDK subpaths (e.g. `openclaw/plugin-sdk/channel-pairing`).
+ */
+
+// ── auto-reply / history ─────────────────────────────────────────────
+export type { HistoryEntry } from "../auto-reply/reply/history.js";
+export {
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  recordPendingHistoryEntryIfEnabled,
+} from "../auto-reply/reply/history.js";
+
+// ── reply payload ────────────────────────────────────────────────────
+export type { ReplyPayload } from "./reply-payload.js";
+
+// ── channels / logging ───────────────────────────────────────────────
+export { logTypingFailure } from "../channels/logging.js";
+
+// ── channels / plugins ───────────────────────────────────────────────
+export type { AllowlistMatch } from "../channels/plugins/allowlist-match.js";
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export {
+  buildSingleChannelSecretPromptState,
+  addWildcardAllowFrom,
+  mergeAllowFromEntries,
+  promptSingleChannelSecretInput,
+  setTopLevelChannelAllowFrom,
+  setTopLevelChannelDmPolicyWithAllowFrom,
+  setTopLevelChannelGroupPolicy,
+  splitSetupEntries,
+  splitSetupEntries as splitOnboardingEntries,
+} from "../channels/plugins/setup-wizard-helpers.js";
+export { PAIRING_APPROVED_MESSAGE } from "../channels/plugins/pairing-message.js";
+export type {
+  BaseProbeResult,
+  ChannelGroupContext,
+  ChannelMessageActionName,
+  ChannelMeta,
+  ChannelOutboundAdapter,
+} from "../channels/plugins/types.public.js";
+export type {
+  ChannelConfiguredBindingProvider,
+  ChannelConfiguredBindingConversationRef,
+  ChannelConfiguredBindingMatch,
+} from "../channels/plugins/types.adapters.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+
+// ── channels / reply ─────────────────────────────────────────────────
+export { createReplyPrefixContext } from "../channels/reply-prefix.js";
+export { createChannelReplyPipeline } from "./channel-reply-pipeline.js";
+
+// ── channels / typing ────────────────────────────────────────────────
+export { createTypingCallbacks } from "../channels/typing.js";
+
+// ── config ───────────────────────────────────────────────────────────
+export type { OpenClawConfig as ClawdbotConfig, OpenClawConfig } from "../config/types.js";
+export { resolveChannelContextVisibilityMode } from "../config/context-visibility.js";
+export {
+  resolveAllowlistProviderRuntimeGroupPolicy,
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+  warnMissingProviderGroupPolicyFallbackOnce,
+} from "../config/runtime-group-policy.js";
+export type { DmPolicy, GroupToolPolicyConfig } from "../config/types.js";
+
+// ── security ─────────────────────────────────────────────────────────
+export {
+  evaluateSupplementalContextVisibility,
+  filterSupplementalContextItems,
+  shouldIncludeSupplementalContext,
+  type ContextVisibilityKind,
+} from "../security/context-visibility.js";
+
+// ── secret-input ─────────────────────────────────────────────────────
+export type { SecretInput } from "./secret-input.js";
+export {
+  buildSecretInputSchema,
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "./secret-input.js";
+
+// ── infra ────────────────────────────────────────────────────────────
+export { createDedupeCache } from "../infra/dedupe.js";
+export { installRequestBodyLimitGuard, readJsonBodyWithLimit } from "../infra/http-body.js";
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { resolveAgentOutboundIdentity } from "../infra/outbound/identity.js";
+export type { OutboundIdentity } from "../infra/outbound/identity.js";
+
+// ── plugins ──────────────────────────────────────────────────────────
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { AnyAgentTool, OpenClawPluginApi } from "../plugins/types.js";
+
+// ── routing ──────────────────────────────────────────────────────────
+export { DEFAULT_ACCOUNT_ID, normalizeAgentId } from "../routing/session-key.js";
+
+// ── runtime / terminal ───────────────────────────────────────────────
+export type { RuntimeEnv } from "../runtime.js";
+export { formatDocsLink } from "../terminal/links.js";
+
+// ── plugin-sdk helpers ───────────────────────────────────────────────
+export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
+export { createActionGate } from "../agents/tools/common.js";
+export { chunkTextForOutbound } from "./text-chunking.js";
+export type { WizardPrompter } from "../wizard/prompts.js";
+export { createClackPrompter } from "../wizard/clack-prompter.js";
+export { feishuSetupWizard, feishuSetupAdapter } from "./feishu-setup.js";
+export { buildAgentMediaPayload } from "./agent-media-payload.js";
+export { readJsonFileWithFallback } from "./json-store.js";
+export { createChannelPairingController } from "./channel-pairing.js";
+export { createPersistentDedupe } from "./persistent-dedupe.js";
+export {
+  buildBaseChannelStatusSummary,
+  buildProbeChannelStatusSummary,
+  buildRuntimeAccountStatusSnapshot,
+  createDefaultChannelRuntimeState,
+} from "./status-helpers.js";
+export { withTempDownloadPath } from "./temp-path.js";
+
+// ── feishu-conversation helpers ──────────────────────────────────────
+export {
+  buildFeishuConversationId,
+  createFeishuThreadBindingManager,
+  parseFeishuDirectConversationId,
+  parseFeishuConversationId,
+  parseFeishuTargetId,
+} from "./feishu-conversation.js";
+
+// ── webhook ingress ──────────────────────────────────────────────────
+export {
+  createWebhookAnomalyTracker,
+  createFixedWindowRateLimiter,
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  applyBasicWebhookRequestGuards,
+} from "./webhook-ingress.js";
+
+// ── pairing (new exports required by @openclaw/feishu@2026.3.13) ─────
+export { createScopedPairingAccess } from "./pairing-access.js";
+export { issuePairingChallenge } from "../pairing/pairing-challenge.js";
+
+// ── onboarding type aliases (renamed since 2026.3.x) ────────────────
+export type { ChannelSetupAdapter as ChannelOnboardingAdapter } from "../channels/plugins/types.adapters.js";
+export type { ChannelSetupDmPolicy as ChannelOnboardingDmPolicy } from "../channels/plugins/setup-wizard-types.js";


### PR DESCRIPTION
## Summary

Restores the `openclaw/plugin-sdk/feishu` (and helper `feishu-setup`, `feishu-conversation`) subpath facades that were removed in 1e3ce10e2.

## Root Cause

The published `@openclaw/feishu@2026.3.13` imports from `openclaw/plugin-sdk/feishu`, which was removed in the `refactor(plugin-sdk): remove unused reserved helper exports` commit. After upgrading to `openclaw@2026.4.26`, the import fails at runtime:

```
TypeError: (0 , _feishu.createScopedPairingAccess) is not a function
```

This is the same class of regression as #73685 (Discord facade removal).

## Changes

- **`src/plugin-sdk/feishu.ts`** — Restored facade with all exports needed by `@openclaw/feishu@2026.3.13`, including:
  - `createScopedPairingAccess` (from `./pairing-access.js`)
  - `issuePairingChallenge` (from `../pairing/pairing-challenge.js`)
  - `createTypingCallbacks` (from `../channels/typing.js`)
  - `splitOnboardingEntries` (alias for `splitSetupEntries`)
  - `ChannelOnboardingAdapter` / `ChannelOnboardingDmPolicy` (type aliases for renamed types)
- **`src/plugin-sdk/feishu-setup.ts`** — Restored lazy facade loader for feishu setup wizard
- **`src/plugin-sdk/feishu-conversation.ts`** — Restored lazy facade loader for feishu conversation/thread binding helpers
- **`scripts/lib/plugin-sdk-entrypoints.json`** — Added `feishu` entry
- **`src/plugin-sdk/entrypoints.ts`** — Added `feishu` to `supportedBundledFacadeSdkEntrypoints`
- **`package.json`** — Synced exports map via `sync-plugin-sdk-exports.mjs`

Fixes #74138