### PR TITLE
Fix CLI text command hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/agents/status: keep `openclaw agents`, text `agents list`, and plain text `status` on read-only metadata paths so human output no longer preloads plugin runtimes or live channel scans before printing. Fixes #74195. Thanks @NianJiuZst.
 - Media: treat legacy Word/OLE attachments with `application/msword` or `application/x-cfb` MIME as binary so printable-looking `.doc` files are not embedded into prompts as text. Fixes #54176; carries forward #54380. Thanks @andyliu.
 - Config: accept documented `browser.tabCleanup` keys in strict root config validation, so configured tab cleanup no longer fails before runtime reads it. Fixes #74577. Thanks @lonexreb and @ezdlp.
 - Cron: validate disabled job schedule edits before persisting updates, so invalid cron changes no longer partially mutate stored jobs. Fixes #74459. Thanks @yfge.

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -61,6 +61,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   { commandPath: ["directory"], policy: { loadPlugins: "always" } },
   { commandPath: ["agents"], policy: { loadPlugins: "always", networkProxy: "bypass" } },
   {
+    commandPath: ["agents"],
+    exact: true,
+    policy: { loadPlugins: "never", networkProxy: "bypass" },
+    route: { id: "agents-list" },
+  },
+  {
     commandPath: ["agents", "bind"],
     exact: true,
     policy: { loadPlugins: "never" },
@@ -143,12 +149,9 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   },
   {
     commandPath: ["agents", "list"],
-    // JSON callers (dashboards, monitoring scripts, IDE plugins) poll this
-    // command and don't need the plugin-derived `providers` enrichment that
-    // is only used in human text output. text-only skips the bundled-plugin
-    // import waterfall in `--json` mode, mirroring what `channels list`
-    // already does. Human (non-JSON) invocations still load plugins. (#71739)
-    policy: { loadPlugins: "text-only", networkProxy: "bypass" },
+    // Text and JSON output are derived from config plus read-only channel
+    // metadata, so the route should not preload bundled plugin runtimes.
+    policy: { loadPlugins: "never", networkProxy: "bypass" },
     route: { id: "agents-list" },
   },
   {

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -77,6 +77,8 @@ describe("command-path-policy", () => {
     });
 
     for (const commandPath of [
+      ["agents"],
+      ["agents", "list"],
       ["agents", "bind"],
       ["agents", "bindings"],
       ["agents", "unbind"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -115,13 +115,16 @@ describe("command-startup-policy", () => {
     ).toBe(true);
     expect(
       shouldLoadPluginsForCommandPath({
+        commandPath: ["agents"],
+        jsonOutputMode: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadPluginsForCommandPath({
         commandPath: ["agents", "list"],
         jsonOutputMode: false,
       }),
-    ).toBe(true);
-    // text-only opts agents list out of plugin preload in --json mode so
-    // dashboards/scripts that poll this command don't pay the bundled-plugin
-    // import waterfall when they only consume config-derived fields. (#71739)
+    ).toBe(false);
     expect(
       shouldLoadPluginsForCommandPath({
         commandPath: ["agents", "list"],

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -201,7 +201,7 @@ describe("registerPreActionHooks", () => {
     await preActionHook(program, actionCommand);
   }
 
-  it("handles debug mode and plugin-required command preaction", async () => {
+  it("handles debug mode and config-only command preaction", async () => {
     const processTitleSetSpy = vi.spyOn(process, "title", "set");
     await runPreAction({
       parseArgv: ["status"],
@@ -229,7 +229,7 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["agents", "list"],
     });
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     processTitleSetSpy.mockRestore();
   });
 
@@ -512,19 +512,13 @@ describe("registerPreActionHooks", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
-  it("does not route logs to stderr during plugin loading without --json", async () => {
-    let stderrDuringPluginLoad = false;
-    ensurePluginRegistryLoadedMock.mockImplementation(() => {
-      stderrDuringPluginLoad = loggingState.forceConsoleToStderr;
-    });
-
+  it("does not preload plugins or route logs to stderr for agents list without --json", async () => {
     await runPreAction({
       parseArgv: ["agents", "list"],
       processArgv: ["node", "openclaw", "agents", "list"],
     });
 
-    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
-    expect(stderrDuringPluginLoad).toBe(false);
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -111,6 +111,10 @@ describe("route-args", () => {
       json: true,
       bindings: true,
     });
+    expect(parseAgentsListRouteArgs(["node", "openclaw", "agents"])).toEqual({
+      json: false,
+      bindings: false,
+    });
   });
 
   it("parses config routes", () => {

--- a/src/cli/program/routes.test.ts
+++ b/src/cli/program/routes.test.ts
@@ -11,6 +11,7 @@ const tasksListJsonCommandMock = vi.hoisted(() => vi.fn(async () => {}));
 const tasksAuditJsonCommandMock = vi.hoisted(() => vi.fn(async () => {}));
 const channelsListCommandMock = vi.hoisted(() => vi.fn(async () => {}));
 const channelsStatusCommandMock = vi.hoisted(() => vi.fn(async () => {}));
+const agentsListCommandMock = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("../config-cli.js", () => ({
   runConfigGet: runConfigGetMock,
@@ -49,6 +50,10 @@ vi.mock("../../commands/channels/status.js", () => ({
   channelsStatusCommand: channelsStatusCommandMock,
 }));
 
+vi.mock("../../commands/agents.js", () => ({
+  agentsListCommand: agentsListCommandMock,
+}));
+
 describe("program routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,6 +83,34 @@ describe("program routes", () => {
   it("matches channel read-only routes without plugin preload", () => {
     expect(expectRoute(["channels", "list"])?.loadPlugins).toBeUndefined();
     expect(expectRoute(["channels", "status"])?.loadPlugins).toBeUndefined();
+  });
+
+  it("matches agents read-only routes without plugin preload", () => {
+    expect(expectRoute(["agents"])?.loadPlugins).toBeUndefined();
+    expect(expectRoute(["agents", "list"])?.loadPlugins).toBeUndefined();
+  });
+
+  it("passes parsed agents list flags through", async () => {
+    await expect(expectRoute(["agents"])?.run(["node", "openclaw", "agents"])).resolves.toBe(true);
+    expect(agentsListCommandMock).toHaveBeenCalledWith(
+      { json: false, bindings: false },
+      expect.any(Object),
+    );
+
+    await expect(
+      expectRoute(["agents", "list"])?.run([
+        "node",
+        "openclaw",
+        "agents",
+        "list",
+        "--json",
+        "--bindings",
+      ]),
+    ).resolves.toBe(true);
+    expect(agentsListCommandMock).toHaveBeenLastCalledWith(
+      { json: true, bindings: true },
+      expect.any(Object),
+    );
   });
 
   it("passes parsed channel read-only route flags through", async () => {

--- a/src/commands/agents.commands.list.test.ts
+++ b/src/commands/agents.commands.list.test.ts
@@ -112,4 +112,17 @@ describe("agentsListCommand", () => {
       }),
     ]);
   });
+
+  it("keeps human output enriched from read-only provider metadata", async () => {
+    const runtime = createRuntime();
+
+    await agentsListCommand({}, runtime);
+
+    expect(buildProviderStatusIndexMock).toHaveBeenCalledOnce();
+    expect(buildProviderSummaryMetadataIndexMock).toHaveBeenCalledOnce();
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Providers:"));
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Telegram default: configured"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #74195.

This PR keeps the affected human-readable CLI paths on the same lightweight, read-only startup path as their working JSON counterparts:

- routes bare `openclaw agents` through the route-first `agents-list` implementation
- prevents text `openclaw agents list` from preloading bundled plugin runtimes before output
- keeps plain text `openclaw status` from running live `channels.status` RPC work or setup-runtime channel fallback by default
- preserves the richer live channel behavior for explicit deep/full status paths

## Root Cause

`agents list --json` was already optimized to avoid plugin/runtime bootstrap, but the default text path still opted into plugin loading for provider enrichment. Bare `openclaw agents` also fell through to the Commander parent action, which called the same text list behavior after the broader `agents` startup policy had already selected plugin preload.

For `status`, the JSON fast path skipped channel table/live-channel work, while the text path still queried `channels.status` and allowed setup-runtime fallback when building the channel table. That made the text path materially heavier and more likely to hit the plugin/metadata/runtime hang reported in the issue even though the gateway itself was responsive.

## Fix Details

- Add an exact route-first catalog entry for bare `agents`, mapped to `agents-list`, with `loadPlugins: "never"`.
- Change `agents list` startup policy from text-only plugin preload to `loadPlugins: "never"`; text output still uses config plus read-only channel metadata for useful provider/routing summaries.
- Thread `deep` into the text status scan so plain status and deep status can choose different scan depth.
- Add explicit controls to `collectStatusScanOverview` for live channel status and setup-runtime fallback.
- Make default text `status` skip live channel status and setup-runtime fallback, while `status --deep` / `status --all` keep the richer live behavior.
- Add focused regression coverage for agents routing/startup policy and status scan depth behavior.

## Validation

- `pnpm test src/cli/command-startup-policy.test.ts src/cli/command-path-policy.test.ts src/cli/route.test.ts src/cli/program/register.agent.test.ts src/cli/program/route-args.test.ts src/cli/program/routes.test.ts src/commands/agents.commands.list.test.ts src/commands/status.scan-overview.test.ts src/commands/status.scan.test.ts src/commands/status.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/command-catalog.ts src/cli/program/register.agent.ts src/cli/route.ts src/cli/program/routed-command-definitions.ts src/commands/agents.commands.list.ts src/commands/agents.providers.ts src/commands/status.command.ts src/commands/status.scan.ts src/commands/status.scan-overview.ts CHANGELOG.md`
- `git diff --check`
- Smoke checked built CLI exits for:
  - `node dist/entry.js agents list`
  - `node dist/entry.js agents`
  - `node dist/entry.js status --timeout 5000`
