### PR TITLE
fix(openai-codex): show device-pairing code in SSH (#74212)

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -234,7 +234,7 @@ describe("openai codex provider", () => {
     expect(result?.profiles[0]?.credential).not.toHaveProperty("accountId");
   });
 
-  it("does not log the device pairing code in remote mode", async () => {
+  it("surfaces the device pairing code in remote (SSH) mode (#74212)", async () => {
     const provider = buildOpenAICodexProviderPlugin();
     const deviceCodeMethod = provider.auth?.find((method) => method.id === "device-code");
     const note = vi.fn(async () => {});
@@ -273,15 +273,20 @@ describe("openai codex provider", () => {
       }),
     ).resolves.toBeDefined();
 
+    // OAuth device flow requires the user to see the code so they can
+    // type it into the verification URL on a device with a browser. In
+    // an SSH session the terminal IS the only place the user sees
+    // output. Both the prompter note and the runtime log fallback must
+    // include the code (matching upstream `codex login` behaviour).
     const logOutput = runtime.log.mock.calls.flat().join("\n");
     expect(logOutput).toContain("https://auth.openai.com/codex/device");
-    expect(logOutput).not.toContain("CODE-12345");
+    expect(logOutput).toContain("CODE-12345");
     expect(note).toHaveBeenCalledWith(
-      expect.stringContaining("Code: [shown on the local device only]"),
+      expect.stringContaining("Code: CODE-12345"),
       "OpenAI Codex device code",
     );
     expect(note).not.toHaveBeenCalledWith(
-      expect.stringContaining("Code: CODE-12345"),
+      expect.stringContaining("Code: [shown on the local device only]"),
       "OpenAI Codex device code",
     );
   });

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -352,22 +352,27 @@ async function runOpenAICodexDeviceCode(ctx: ProviderAuthContext) {
       onProgress: (message) => spin.update(message),
       onVerification: async ({ verificationUrl, userCode, expiresInMs }) => {
         const expiresInMinutes = Math.max(1, Math.round(expiresInMs / 60_000));
-        const codeLine = ctx.isRemote
-          ? "Code: [shown on the local device only]"
-          : `Code: ${userCode}`;
+        // OAuth device flow REQUIRES the user to see the code so they can
+        // type it into the verification URL on the device that has a
+        // browser. In an SSH session the terminal IS where the user
+        // sees output, so hiding the code there makes the flow
+        // unusable (#74212). Upstream `codex login` prints the code in
+        // the same terminal; matching that behaviour here.
         await ctx.prompter.note(
           [
             ctx.isRemote
               ? "Open this URL in your LOCAL browser and enter the code below."
               : "Open this URL in your browser and enter the code below.",
             `URL: ${verificationUrl}`,
-            codeLine,
+            `Code: ${userCode}`,
             `Code expires in ${expiresInMinutes} minutes. Never share it.`,
           ].join("\n"),
           "OpenAI Codex device code",
         );
         if (ctx.isRemote) {
-          ctx.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${verificationUrl}\n`);
+          ctx.runtime.log(
+            `\nOpen this URL in your LOCAL browser:\n\n${verificationUrl}\n\nCode: ${userCode}\n`,
+          );
           return;
         }
         try {


### PR DESCRIPTION
Closes #74212.

## Bug
`openclaw models auth login --provider openai-codex` → "OpenAI Codex Device Pairing" over SSH renders the prompt as:

```
Code: [shown on the local device only]
```

…and prints only the URL to the terminal. The user has nowhere to see the code, so the flow is unrecoverable. Upstream `codex login` run in the same SSH session prints the code correctly.

## Root cause
`extensions/openai/openai-codex-provider.ts:355` had:

```ts
const codeLine = ctx.isRemote
  ? "Code: [shown on the local device only]"
  : `Code: ${userCode}`;
```

The intent appears to have been "don't echo a sensitive code over an SSH wire," but **OAuth device flow requires the user to see the code** — that's the whole point: they read it from the device-without-a-browser and type it into the verification URL on a device-with-a-browser. In an SSH session the terminal **is** the only place the user sees output; there is no "local device" to fall back to. Hiding the code makes the flow unusable.

The runtime-log fallback for `isRemote` also only printed the URL, not the code.

## Fix
- Always include `Code: <userCode>` in the prompter note (drop the `isRemote` branch on the code line).
- Append `Code: <userCode>` to the `runtime.log` fallback alongside the verification URL.

Behaviour now matches upstream `codex login` in SSH sessions.

```ts
await ctx.prompter.note(
  [
    ctx.isRemote
      ? "Open this URL in your LOCAL browser and enter the code below."
      : "Open this URL in your browser and enter the code below.",
    `URL: ${verificationUrl}`,
    `Code: ${userCode}`,
    `Code expires in ${expiresInMinutes} minutes. Never share it.`,
  ].join("\n"),
  "OpenAI Codex device code",
);
if (ctx.isRemote) {
  ctx.runtime.log(
    `\nOpen this URL in your LOCAL browser:\n\n${verificationUrl}\n\nCode: ${userCode}\n`,
  );
  return;
}
```

## Security note
The pairing code is short-lived (~15 min), single-use, and useless without the user-controlled verification URL flow. Not exposing it is what blocks legitimate use; it doesn't add meaningful security. Same posture upstream `codex login` ships with.

## Test
Existing test `does not log the device pairing code in remote mode` asserted the broken behaviour (note must contain `[shown on the local device only]`, runtime.log must NOT contain the code). Renamed and inverted to:

**`surfaces the device pairing code in remote (SSH) mode (#74212)`**

Asserts:
- `runtime.log` contains the verification URL **and** `CODE-12345`
- `prompter.note` contains `Code: CODE-12345`
- `prompter.note` does **not** contain `[shown on the local device only]`

```
$ npx vitest run extensions/openai/openai-codex-provider.test.ts
✓ extension-provider-openai .../openai-codex-provider.test.ts (28 tests)
Test Files 1 passed (1) | Tests 28 passed (28)
```

28/28, no regressions.