### PR TITLE
fix(media): surface real cause when optimizeImageToJpeg cannot produce any buffer

### DIFF
--- a/src/media/web-media.optimize-image.test.ts
+++ b/src/media/web-media.optimize-image.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock image-ops so we can drive the resize loop deterministically without
+// pulling in sharp or any real image bytes. The test below covers two
+// regression cases for `optimizeImageToJpeg`:
+//
+// 1. When every size/quality combination fails, the thrown error must
+//    surface the underlying cause and attempt counters so an operator can
+//    tell whether the source format was unsupported, sharp wasn't available,
+//    the buffer was unreadable, etc. Previously the catch was silent and
+//    the outer "Failed to optimize image" gave no clue why.
+// 2. When some resize calls succeed but every output stays above maxBytes,
+//    the function still returns the smallest buffer it found and does NOT
+//    throw — that is the documented size-budget contract.
+vi.mock("./image-ops.js", () => {
+  return {
+    isHeicSource: vi.fn(() => false),
+    convertHeicToJpeg: vi.fn(async (buf: Buffer) => buf),
+    resizeToJpeg: vi.fn(),
+  };
+});
+
+const imageOps = await import("./image-ops.js");
+const { optimizeImageToJpeg } = await import("./web-media.js");
+
+describe("optimizeImageToJpeg", () => {
+  it("surfaces the underlying resize failure when every attempt throws", async () => {
+    const sharpFailure = new Error("sharp: Input buffer contains unsupported image format");
+    vi.mocked(imageOps.resizeToJpeg).mockRejectedValue(sharpFailure);
+
+    const buffer = Buffer.from("not-an-image");
+    await expect(optimizeImageToJpeg(buffer, 1024)).rejects.toThrowError(
+      /Failed to optimize image \(resize attempts=\d+, failures=\d+\): .*unsupported image format/,
+    );
+
+    // Verify the original error is preserved as `cause` so callers can
+    // unwrap it for richer error reporting upstream.
+    let captured: unknown;
+    try {
+      await optimizeImageToJpeg(buffer, 1024);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error & { cause?: unknown }).cause).toBe(sharpFailure);
+  });
+
+  it("returns the smallest produced buffer when no attempt fits maxBytes", async () => {
+    // Each call returns a buffer larger than the requested 100-byte budget
+    // so the function falls through the inner `return` and ends up using
+    // the smallest of the produced buffers. This must NOT throw \u2014 the
+    // size-budget overflow case is recoverable, not a hard failure.
+    const sizes = [5000, 4000, 3000, 2500, 2000];
+    let i = 0;
+    vi.mocked(imageOps.resizeToJpeg).mockImplementation(async () => {
+      const next = sizes[Math.min(i, sizes.length - 1)];
+      i += 1;
+      return Buffer.alloc(next, 0);
+    });
+
+    const result = await optimizeImageToJpeg(Buffer.alloc(10_000, 0), 100);
+    expect(result.optimizedSize).toBeLessThanOrEqual(5000);
+    // 2000 is the smallest the mock will produce, so the loop should
+    // converge there regardless of iteration order.
+    expect(result.buffer.length).toBe(2000);
+  });
+
+  it("returns the first buffer that fits maxBytes and does not iterate further", async () => {
+    let calls = 0;
+    vi.mocked(imageOps.resizeToJpeg).mockImplementation(async () => {
+      calls += 1;
+      // First attempt already fits the budget.
+      return Buffer.alloc(50, 0);
+    });
+
+    const result = await optimizeImageToJpeg(Buffer.alloc(10_000, 0), 100);
+    expect(result.optimizedSize).toBe(50);
+    expect(calls).toBe(1);
+  });
+});

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -616,9 +616,19 @@ export async function optimizeImageToJpeg(
     resizeSide: number;
     quality: number;
   } | null = null;
+  // Track the last error we saw from resizeToJpeg so the outer throw can
+  // surface a real cause when *every* size/quality combination failed.
+  // Previously the catch was silent and "Failed to optimize image" gave
+  // no clue whether the source format was unsupported, sharp wasn't
+  // available, the buffer was unreadable, etc., which made image-tool
+  // failures unactionable in production logs.
+  let lastResizeError: unknown = null;
+  let resizeAttempts = 0;
+  let resizeFailures = 0;
 
   for (const side of sides) {
     for (const quality of qualities) {
+      resizeAttempts += 1;
       try {
         const out = await resizeToJpeg({
           buffer: source,
@@ -638,8 +648,11 @@ export async function optimizeImageToJpeg(
             quality,
           };
         }
-      } catch {
-        // Continue trying other size/quality combinations
+      } catch (err) {
+        // Continue trying other size/quality combinations, but remember
+        // the most recent failure so the outer throw can include it.
+        resizeFailures += 1;
+        lastResizeError = err;
       }
     }
   }
@@ -653,7 +666,18 @@ export async function optimizeImageToJpeg(
     };
   }
 
-  throw new Error("Failed to optimize image");
+  // No size/quality combination produced a usable buffer. Surface the last
+  // resize failure verbatim so the operator can tell whether the input was
+  // unreadable, an unsupported format, or hit a sharp/runtime issue. The
+  // attempt counters narrow the diagnosis: `attempts=25 failures=25`
+  // means every single resize call threw (systematic, e.g. the buffer
+  // wasn't a real image), while `attempts=25 failures=0` means resizes
+  // succeeded but every output stayed above maxBytes (size-budget issue).
+  const detail = lastResizeError ? `: ${String(lastResizeError)}` : "";
+  throw new Error(
+    `Failed to optimize image (resize attempts=${resizeAttempts}, failures=${resizeFailures})${detail}`,
+    lastResizeError ? { cause: lastResizeError } : undefined,
+  );
 }
 
 export { optimizeImageToPng };


### PR DESCRIPTION
## Problem

`optimizeImageToJpeg` in `src/media/web-media.ts` swallowed every failure inside its size/quality grid loop with a silent `catch {}`, then threw a bare `Failed to optimize image` from the outer scope. The thrown error carried no `cause` and no diagnostic counters, so production logs looked like:

```
[tools] image failed: Failed to optimize image raw_params={"image":"…","prompt":"…"}
```

…with zero indication of *why* none of the 25 attempts worked. Every plausible cause produces the same opaque message:

- Source buffer is not a real image (corrupted upload, wrong content-type)
- Source format is unsupported by sharp (older HEIC variants, CMYK JPEGs, broken PNGs)
- sharp itself is unavailable / not installed in the runtime
- Permissions / OOM in the libvips backend
- Every output stayed larger than `maxBytes` despite resizes succeeding (size-budget issue, *not* a hard failure)

The image-tool path that surfaced this in production logs has no way to triage further — the operator just sees the silent failure and has to reproduce locally to diagnose.

## Fix

- Capture the most recent `resizeToJpeg` failure inside the inner `catch` so the outer throw can include it verbatim.
- Add `attempts` and `failures` counters so an operator can immediately distinguish:
  - `attempts=25 failures=25` → every resize call threw; the failure is systematic (input format, runtime, sharp).
  - `attempts=25 failures=0` → resizes all succeeded but every output stayed above `maxBytes`; this is a size-budget issue and the function would normally have returned the smallest output (this branch only reaches the throw when no buffer was produced at all).
- Pass the captured error as the `cause` of the thrown `Error` so callers can unwrap it for richer error reporting upstream (e.g. embed in a tool-error response, surface in CI/diagnostics).

The size-budget overflow case is unchanged: when at least one resize succeeded, the function still returns the smallest produced buffer. Only the no-output-at-all path now produces a richer error.

## Tests

New `src/media/web-media.optimize-image.test.ts` with three regression cases:

- Every attempt throws → the thrown error contains the underlying message and `cause` is preserved.
- Some attempts succeed but no output fits `maxBytes` → the function still returns the smallest buffer (no regression on the size-budget contract).
- The first attempt already fits `maxBytes` → the function returns immediately and does not iterate further.

`pnpm exec vitest run src/media/web-media.optimize-image.test.ts` is green locally (3/3).

## Notes

- No public API change. `optimizeImageToJpeg`'s return shape and signature are unchanged; only the thrown `Error` instance carries more diagnostic content.
- No behavior change for callers that swallow the error with `catch {}` — the new message is strictly additive.
- The HEIC conversion path (`isHeicSource` + `convertHeicToJpeg`) already throws with `cause`; this PR brings the JPEG resize loop in line with that contract.
