### PR TITLE
fix(telegram): classify plain grammY network envelope as safe to retry for sends

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -202,6 +202,36 @@ describe("isSafeToRetrySendError", () => {
     const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", fetchError);
     expect(isSafeToRetrySendError(wrapped)).toBe(true);
   });
+
+  it("detects plain grammY envelope wrapping fetch failed (no error code)", () => {
+    // grammY HttpError wrapping TypeError("fetch failed") without a specific error code.
+    // This is the shape observed in issue #74203 — the fetch throws before any HTTP
+    // response, so it is safe to retry.
+    const fetchError = new TypeError("fetch failed");
+    const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", fetchError);
+    expect(isSafeToRetrySendError(wrapped)).toBe(true);
+  });
+
+  it("detects plain grammY envelope wrapping fetch failed for editMessageText", () => {
+    const fetchError = new TypeError("fetch failed");
+    const wrapped = new MockHttpError("Network request for 'editMessageText' failed!", fetchError);
+    expect(isSafeToRetrySendError(wrapped)).toBe(true);
+  });
+
+  it("does NOT retry plain grammY envelope without a fetch-level inner error", () => {
+    // If the inner error is not a recognized fetch failure, do not assume safe to retry.
+    const authError = new Error("Unauthorized");
+    const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", authError);
+    expect(isSafeToRetrySendError(wrapped)).toBe(false);
+  });
+
+  it("does NOT retry plain grammY envelope wrapping only a message snippet match", () => {
+    // "socket hang up" is a RECOVERABLE_MESSAGE_SNIPPET but NOT in ALWAYS_RECOVERABLE_MESSAGES.
+    // It could occur after the request was partially sent, so it is not safe for send retry.
+    const socketError = new Error("socket hang up");
+    const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", socketError);
+    expect(isSafeToRetrySendError(wrapped)).toBe(false);
+  });
 });
 
 describe("isTelegramServerError", () => {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -57,6 +57,19 @@ const ALWAYS_RECOVERABLE_MESSAGES = new Set(["fetch failed", "typeerror: fetch f
 const GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE =
   /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed\s+after\b.*[!.]?$/i;
 
+/**
+ * Matches grammY's plain pre-response network envelope:
+ *   "Network request for 'sendMessage' failed!"
+ *
+ * This fires when the underlying fetch throws *before* a response is received,
+ * so the request was never delivered to Telegram — safe to retry for
+ * non-idempotent sends.
+ *
+ * Distinct from GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE which requires "failed after".
+ */
+const GRAMMY_NETWORK_REQUEST_FAILED_RE =
+  /^network request(?:\s+for\s+["']?[^"']+["']?)?\s+failed[!.]?$/i;
+
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "undici",
   "network error",
@@ -155,6 +168,12 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
  * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
  * the request reached Telegram's servers, preventing duplicate message delivery.
  *
+ * Recognizes:
+ * 1. Pre-connect error codes (ECONNREFUSED, ENOTFOUND, etc.) at any depth.
+ * 2. grammY's plain "Network request for '<method>' failed!" envelope when the
+ *    wrapped inner error is a pre-response fetch failure (TypeError: fetch failed),
+ *    confirming no HTTP response was received.
+ *
  * Use this instead of isRecoverableTelegramNetworkError for sendMessage/sendPhoto/etc.
  * calls where a retry would create a duplicate visible message.
  */
@@ -162,10 +181,32 @@ export function isSafeToRetrySendError(err: unknown): boolean {
   if (!err) {
     return false;
   }
-  for (const candidate of collectTelegramErrorCandidates(err)) {
+  const candidates = collectTelegramErrorCandidates(err);
+  for (const candidate of candidates) {
     const code = normalizeCode(getErrorCode(candidate));
     if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
       return true;
+    }
+  }
+  // Check for grammY's plain pre-response network envelope:
+  // HttpError("Network request for '<method>' failed!") wrapping a fetch failure.
+  // The outer message confirms grammY never received an HTTP response, and the inner
+  // "fetch failed" TypeError confirms the request did not complete — safe to retry.
+  for (const candidate of candidates) {
+    const message = normalizeLowercaseStringOrEmpty(formatErrorMessage(candidate));
+    if (message && GRAMMY_NETWORK_REQUEST_FAILED_RE.test(message)) {
+      // The grammY envelope itself indicates a pre-response failure, but we
+      // additionally require that a nested error is a known fetch-level failure
+      // to avoid false positives from unexpected future grammY error shapes.
+      for (const inner of candidates) {
+        if (inner === candidate) {
+          continue;
+        }
+        const innerMessage = normalizeLowercaseStringOrEmpty(formatErrorMessage(inner));
+        if (innerMessage && ALWAYS_RECOVERABLE_MESSAGES.has(innerMessage)) {
+          return true;
+        }
+      }
     }
   }
   return false;


### PR DESCRIPTION
## Summary

Extends `isSafeToRetrySendError` to recognize grammY's plain pre-response network envelope (`Network request for '<method>' failed!`) when it wraps a `TypeError("fetch failed")`, classifying this combination as safe to retry for non-idempotent Telegram send operations.

## Problem

When grammY wraps a `TypeError("fetch failed")` without a specific pre-connect error code in the cause chain, the resulting `HttpError("Network request for 'sendMessage' failed!")` was not classified as retryable by `isSafeToRetrySendError`. This caused final Telegram replies to fail permanently on transient network issues even though the message was never delivered to Telegram.

The existing code:
- `isSafeToRetrySendError` only matched `PRE_CONNECT_ERROR_CODES` (ECONNREFUSED, ENOTFOUND, etc.)
- `GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE` required "failed after" in the message
- The plain envelope `Network request for '<method>' failed!` (without "after") was not covered

## Fix

Adds a second detection pass in `isSafeToRetrySendError`:

1. A new regex `GRAMMY_NETWORK_REQUEST_FAILED_RE` matches the plain grammY envelope (without "after")
2. When the plain envelope is detected, requires a nested `ALWAYS_RECOVERABLE_MESSAGES` match ("fetch failed" / "typeerror: fetch failed") to confirm the request never received a response
3. This two-part check avoids false positives from unexpected future grammY error shapes

## Safety

The fix is conservative:
- Only triggers when **both** the outer grammY envelope pattern **and** an inner fetch-level failure are present
- `TypeError("fetch failed")` means the HTTP request threw before any response — no data was sent to Telegram
- Does not match broader snippet-level errors (e.g. "socket hang up") which could occur after partial delivery
- Existing pre-connect code detection continues to work as before

## Tests

4 new test cases added to `isSafeToRetrySendError`:
- ✅ Plain grammY envelope + `TypeError("fetch failed")` → safe to retry
- ✅ Plain grammY envelope for editMessageText + `TypeError("fetch failed")` → safe to retry
- ✅ Plain grammY envelope + non-fetch inner error → NOT safe to retry
- ✅ Plain grammY envelope + snippet-only inner error → NOT safe to retry

All 45 network-errors tests and 87 send tests pass.

## Verification

```bash
pnpm test extensions/telegram/src/network-errors.test.ts  # 45 passed
pnpm test extensions/telegram/src/send.test.ts            # 87 passed
pnpm exec oxfmt --check --threads=1 extensions/telegram/src/network-errors.ts extensions/telegram/src/network-errors.test.ts  # clean
```

Closes #74203