### PR TITLE
fix(bonjour): cap advertiser restarts in a sliding window (#74209)

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -727,6 +727,65 @@ describe("gateway bonjour advertiser", () => {
     expect(shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("disables bonjour when the advertiser flaps within a sliding window even if it briefly announces between restarts (#74209)", async () => {
+    enableAdvertiserUnitMode();
+    vi.useFakeTimers();
+
+    // Simulate the user-reported pattern: the service repeatedly enters
+    // probing, briefly hits announced (resetting `consecutiveRestarts`),
+    // then slides back into probing — for example, a duplicate-name
+    // conflict on the LAN. Without the sliding-window cap, the watchdog
+    // would churn forever (#74209).
+    const stateRef = { value: "announced" };
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy, stateRef });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    // Drive the watchdog through repeated flap cycles. Each cycle:
+    //   1. State is "announced" — watchdog observes it and resets
+    //      `consecutiveRestarts` to 0.
+    //   2. State is forced to "probing" for >STUCK_ANNOUNCING_MS
+    //      so the watchdog calls `recreateAdvertiser`.
+    //   3. After the restart, the test heals state back to "announced"
+    //      to mimic a duplicate-name conflict that briefly resolves.
+    // Without the sliding-window cap this loop would never end; with
+    // it, the disable log fires once we exceed MAX_RESTARTS_IN_WINDOW.
+    for (let cycle = 0; cycle < 12; cycle += 1) {
+      // Watchdog observes announced → consecutiveRestarts = 0.
+      stateRef.value = "announced";
+      await vi.advanceTimersByTimeAsync(5_000);
+      // Stuck in probing long enough to trip STUCK_ANNOUNCING_MS.
+      stateRef.value = "probing";
+      await vi.advanceTimersByTimeAsync(25_000);
+      if (
+        (logger.warn.mock.calls as unknown[][]).some(
+          (call) => typeof call[0] === "string" && call[0].includes("disabling advertiser after"),
+        )
+      ) {
+        break;
+      }
+    }
+    const disableLog = (logger.warn.mock.calls as unknown[][]).find(
+      (call) => typeof call[0] === "string" && call[0].includes("disabling advertiser after"),
+    );
+    expect(disableLog).toBeDefined();
+    expect(String(disableLog?.[0])).toMatch(/restarts within \d+ minutes/);
+
+    // After being disabled, no further advertise/createService work happens.
+    const advertiseCallsAtDisable = advertise.mock.calls.length;
+    const createServiceCallsAtDisable = createService.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(advertise.mock.calls.length).toBe(advertiseCallsAtDisable);
+    expect(createService.mock.calls.length).toBe(createServiceCallsAtDisable);
+
+    await started.stop();
+  });
+
   it("normalizes hostnames with domains for service names", async () => {
     // Allow advertiser to run in unit tests.
     delete process.env.VITEST;

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -88,6 +88,15 @@ const REPAIR_DEBOUNCE_MS = 30_000;
 // See https://github.com/openclaw/openclaw/issues/72481
 const STUCK_ANNOUNCING_MS = 20_000;
 const MAX_CONSECUTIVE_RESTARTS = 3;
+// Sliding-window absolute cap: an advertiser that flaps between probing and
+// briefly-announced (e.g. a duplicate-name conflict on the LAN) can reset the
+// `consecutiveRestarts` counter every time it momentarily hits "announced",
+// so the consecutive cap never fires and the watchdog churns indefinitely
+// (see https://github.com/openclaw/openclaw/issues/74209). Bound the total
+// number of restarts that can happen within a rolling window so unhealthy
+// hosts disable mDNS instead of rewriting the journal forever.
+const RESTART_WINDOW_MS = 30 * 60_000;
+const MAX_RESTARTS_IN_WINDOW = 5;
 const BONJOUR_ANNOUNCED_STATE = "announced";
 const CIAO_SELF_PROBE_RETRY_FRAGMENT =
   "failed probing with reason: Error: Can't probe for a service which is announced already.";
@@ -563,6 +572,7 @@ export async function startGatewayBonjourAdvertiser(
     let recreatePromise: Promise<void> | null = null;
     let disabled = false;
     let consecutiveRestarts = 0;
+    const restartTimestamps: number[] = [];
     let cycle: BonjourCycle | null = createCycle();
     const stateTracker = new Map<string, ServiceStateTracker>();
 
@@ -590,10 +600,25 @@ export async function startGatewayBonjourAdvertiser(
       }
       recreatePromise = (async () => {
         consecutiveRestarts += 1;
-        if (consecutiveRestarts > MAX_CONSECUTIVE_RESTARTS) {
+        const now = Date.now();
+        while (
+          restartTimestamps.length > 0 &&
+          now - (restartTimestamps[0] ?? 0) > RESTART_WINDOW_MS
+        ) {
+          restartTimestamps.shift();
+        }
+        restartTimestamps.push(now);
+        const tooManyConsecutive = consecutiveRestarts > MAX_CONSECUTIVE_RESTARTS;
+        const tooManyInWindow = restartTimestamps.length > MAX_RESTARTS_IN_WINDOW;
+        if (tooManyConsecutive || tooManyInWindow) {
           disabled = true;
+          const detail = tooManyConsecutive
+            ? `${MAX_CONSECUTIVE_RESTARTS} failed restarts`
+            : `${MAX_RESTARTS_IN_WINDOW} restarts within ${Math.round(
+                RESTART_WINDOW_MS / 60_000,
+              )} minutes`;
           logger.warn(
-            `bonjour: disabling advertiser after ${MAX_CONSECUTIVE_RESTARTS} failed restarts (${reason}); set discovery.mdns.mode="off" or OPENCLAW_DISABLE_BONJOUR=1 to disable mDNS discovery`,
+            `bonjour: disabling advertiser after ${detail} (${reason}); set discovery.mdns.mode="off" or OPENCLAW_DISABLE_BONJOUR=1 to disable mDNS discovery`,
           );
           const previous = cycle;
           cycle = null;

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -609,7 +609,7 @@ export async function startGatewayBonjourAdvertiser(
         }
         restartTimestamps.push(now);
         const tooManyConsecutive = consecutiveRestarts > MAX_CONSECUTIVE_RESTARTS;
-        const tooManyInWindow = restartTimestamps.length > MAX_RESTARTS_IN_WINDOW;
+        const tooManyInWindow = restartTimestamps.length >= MAX_RESTARTS_IN_WINDOW;
         if (tooManyConsecutive || tooManyInWindow) {
           disabled = true;
           const detail = tooManyConsecutive


### PR DESCRIPTION
Fixes one of the concrete bug shapes in #74209: an indefinite `bonjour: watchdog detected non-announced service; attempting re-advertise` / `bonjour: restarting advertiser` log loop that the existing safety net was supposed to catch.

## The bug

`extensions/bonjour/src/advertiser.ts` already has a "disable after `MAX_CONSECUTIVE_RESTARTS` failed restarts" cap. But the watchdog resets `consecutiveRestarts = 0` on **every** tick where any service is observed in the `"announced"` state:

```ts
if (stateUnknown === "announced") {
  consecutiveRestarts = 0;
}
```

A flapping advertiser — e.g. a duplicate-name conflict on the LAN, or any environment where the service briefly announces and then slides back into `probing` — cycles between `probing` and `announced` and never accumulates 4 consecutive restarts. So the cap never fires and the watchdog churns indefinitely, exactly matching the journal excerpt in #74209 (~1.5 hours of repeating restart/re-advertise log lines).

This also keeps holding cycle state and console-log/exec patches that the disable path is supposed to clean up, which is meaningful on constrained Linux hosts during gateway startup.

## The fix

Add a sliding-window absolute cap that is immune to transient announced flips:

```
const RESTART_WINDOW_MS = 30 * 60_000;
const MAX_RESTARTS_IN_WINDOW = 5;
```

The watchdog now records each restart timestamp, drops entries outside the window, and disables bonjour the moment **either** cap (consecutive or windowed) is exceeded. The disable log distinguishes the two reasons and still points at `discovery.mdns.mode="off"` / `OPENCLAW_DISABLE_BONJOUR=1`.

The original consecutive-restart path is preserved unchanged for healthy networks where restarts pile up without any announced reset.

## Scope

This is intentionally narrow. The broader policy debate in #74209 about default-on bundled plugins and Bonjour startup activation needs maintainer judgment (per the codex review on the issue) and is out of scope for this PR.

## Test

A regression test in `advertiser.test.ts` drives the announced ↔ probing flap through the watchdog with fake timers and asserts:

- The new disable log (`"restarts within N minutes"`) fires.
- After disable, no further `advertise()` / `createService()` calls happen.

Verified that the test fails on `main` (the watchdog churns forever) and passes with the fix. All 44 bonjour tests still green:

```
✓ extensions/bonjour/src/advertiser.test.ts (26 tests)
✓ extensions/bonjour/src/ciao.test.ts (14 tests)
✓ extensions/bonjour/src/errors.test.ts (4 tests)
```

Refs #74209.