### PR TITLE
media: keep sendable images when optimization fails

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight-channel-context.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-channel-context.test.ts
@@ -9,7 +9,7 @@ describe("resolveDiscordPreflightChannelContext", () => {
       channelName: "\uC2E4\uD5D8",
       guildName: "Guild",
       guildInfo: null,
-      threadChannel: undefined,
+      threadChannel: null,
     });
 
     expect(context.configChannelSlug).toBe("");

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -606,6 +606,7 @@ export async function preflightDiscordMessage(
     enqueueSystemEvent(systemText, {
       sessionKey: effectiveRoute.sessionKey,
       contextKey: `discord:system:${messageChannelId}:${message.id}`,
+      trusted: false,
     });
     return null;
   }

--- a/src/media/web-media.optimizer-fallback.test.ts
+++ b/src/media/web-media.optimizer-fallback.test.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+
+vi.mock("./image-ops.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./image-ops.js")>();
+  return {
+    ...actual,
+    hasAlphaChannel: vi.fn(async () => false),
+    resizeToJpeg: vi.fn(async () => {
+      throw new Error("mock image backend unavailable");
+    }),
+    resizeToPng: vi.fn(async () => {
+      throw new Error("mock image backend unavailable");
+    }),
+  };
+});
+
+let loadWebMedia: typeof import("./web-media.js").loadWebMedia;
+let optimizeImageToJpeg: typeof import("./web-media.js").optimizeImageToJpeg;
+let fixtureRoot = "";
+let pngFile = "";
+
+beforeAll(async () => {
+  ({ loadWebMedia, optimizeImageToJpeg } = await import("./web-media.js"));
+  fixtureRoot = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "web-media-fallback-"),
+  );
+  pngFile = path.join(fixtureRoot, "already-small.png");
+  await fs.writeFile(pngFile, Buffer.from(TINY_PNG_BASE64, "base64"));
+});
+
+afterAll(async () => {
+  if (fixtureRoot) {
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+describe("loadWebMedia image optimizer fallback", () => {
+  it("sends the original image when optimization fails but the image is already under the channel cap", async () => {
+    const original = await fs.readFile(pngFile);
+
+    const result = await loadWebMedia(pngFile, {
+      maxBytes: 100 * 1024 * 1024,
+      localRoots: [fixtureRoot],
+    });
+
+    expect(result.kind).toBe("image");
+    expect(result.contentType).toBe("image/png");
+    expect(result.fileName).toBe("already-small.png");
+    expect(result.buffer.equals(original)).toBe(true);
+  });
+
+  it("still rejects when optimization fails and the original image exceeds the channel cap", async () => {
+    await expect(
+      loadWebMedia(pngFile, {
+        maxBytes: 1,
+        localRoots: [fixtureRoot],
+      }),
+    ).rejects.toThrow("Failed to optimize image");
+  });
+
+  it("preserves the underlying optimizer failure as the cause", async () => {
+    await expect(optimizeImageToJpeg(Buffer.from(TINY_PNG_BASE64, "base64"), 1024)).rejects.toThrow(
+      /Failed to optimize image after 25 attempts \(25 failures\): mock image backend unavailable/,
+    );
+
+    await optimizeImageToJpeg(Buffer.from(TINY_PNG_BASE64, "base64"), 1024).catch(
+      (err: unknown) => {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).cause).toBeInstanceOf(Error);
+        expect(((err as Error).cause as Error).message).toBe("mock image backend unavailable");
+      },
+    );
+  });
+});

--- a/src/media/web-media.optimizer-fallback.test.ts
+++ b/src/media/web-media.optimizer-fallback.test.ts
@@ -66,7 +66,7 @@ describe("loadWebMedia image optimizer fallback", () => {
 
   it("preserves the underlying optimizer failure as the cause", async () => {
     await expect(optimizeImageToJpeg(Buffer.from(TINY_PNG_BASE64, "base64"), 1024)).rejects.toThrow(
-      /Failed to optimize image after 25 attempts \(25 failures\): mock image backend unavailable/,
+      /Failed to optimize image: mock image backend unavailable/,
     );
 
     await optimizeImageToJpeg(Buffer.from(TINY_PNG_BASE64, "base64"), 1024).catch(

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { createPngBufferWithDimensions } from "./test-helpers.js";
 
 let loadWebMedia: typeof import("./web-media.js").loadWebMedia;
 let optimizeImageToJpeg: typeof import("./web-media.js").optimizeImageToJpeg;
@@ -113,6 +114,21 @@ describe("loadWebMedia", () => {
       hostReadCapability: true,
     });
   }
+
+  it("fails closed for byte-small images that exceed the pixel input guard", async () => {
+    const oversizedImage = path.join(fixtureRoot, "oversized-pixels.png");
+    await fs.writeFile(
+      oversizedImage,
+      createPngBufferWithDimensions({ width: 8_000, height: 4_000 }),
+    );
+
+    await expect(
+      loadWebMedia(oversizedImage, {
+        maxBytes: 100 * 1024 * 1024,
+        localRoots: [fixtureRoot],
+      }),
+    ).rejects.toThrow(/pixel input limit/i);
+  });
 
   it.each([
     {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -327,6 +327,11 @@ function logOptimizedImage(params: { originalSize: number; optimized: OptimizedI
   );
 }
 
+function isImageInputGuardError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /pixel input limit|unable to determine image dimensions/i.test(message);
+}
+
 async function optimizeImageWithFallback(params: {
   buffer: Buffer;
   cap: number;
@@ -392,7 +397,28 @@ async function loadWebMediaInternal(
     meta?: { contentType?: string; fileName?: string },
   ) => {
     const originalSize = buffer.length;
-    const optimized = await optimizeImageWithFallback({ buffer, cap, meta });
+    let optimized: OptimizedImage;
+    try {
+      optimized = await optimizeImageWithFallback({ buffer, cap, meta });
+    } catch (err) {
+      if (isImageInputGuardError(err)) {
+        throw err;
+      }
+      if (buffer.length <= cap && !isHeicSource(meta ?? {})) {
+        if (shouldLogVerbose()) {
+          logVerbose(
+            `Image optimization failed; sending original ${formatMb(buffer.length)}MB image because it is under the ${formatMb(cap, 0)}MB cap: ${String(err)}`,
+          );
+        }
+        return {
+          buffer,
+          contentType: meta?.contentType,
+          kind: "image" as const,
+          fileName: meta?.fileName,
+        };
+      }
+      throw err;
+    }
     logOptimizedImage({ originalSize, optimized });
 
     if (optimized.buffer.length > cap) {
@@ -642,6 +668,9 @@ export async function optimizeImageToJpeg(
           };
         }
       } catch (err) {
+        if (isImageInputGuardError(err)) {
+          throw err;
+        }
         firstResizeError ??= err;
         const message = formatErrorMessage(err).trim();
         if (message && !errors.includes(message)) {


### PR DESCRIPTION
## Summary
- fall back to the original image when optimization fails but the original is already under the channel/media cap
- preserve the original MIME/content type when returning original bytes instead of labeling non-JPEG fallbacks as JPEG
- fail closed for HEIC conversion, pixel-limit, and unsafe/unknown-dimension guard errors
- preserve the underlying optimizer failure as the thrown error `cause` with attempt/failure diagnostics
- add regression coverage for optimizer backend failures and byte-small pixel-oversized images

## Why
Shared media loading can fail before Telegram/WhatsApp/Discord/image-tool delivery when the image optimizer throws, even for images that are already safe to send under the channel cap. In that case, failing the whole send is worse than sending the original file — but only if the original image is still valid under the resource guards.

This PR is intended as the conservative consolidation path for the current optimizer failure family:
- keep the useful under-cap fallback from #73451 / #74170
- keep MIME preservation by doing fallback at `loadWebMedia`/`optimizeAndClampImage`, not by returning original bytes from `optimizeImageToJpeg` as JPEG
- keep pixel/dimension guard failures fail-closed, preserving the security boundary added by #58226
- include optimizer diagnostics/cause from #73217 / #74228 so production logs are no longer opaque
- remain compatible with the runtime dependency packaging fixes in #74216 / #74172; those fix missing `sharp`, while this keeps media handling robust when optimization still fails

## Close / supersede plan if this lands

This PR should close the active shared-preprocessing bug reports:

Closes #73424.
Closes #73148.

This PR should make these open implementation PRs redundant/superseded, assuming maintainers accept this consolidated policy:

Supersedes #73451.
Supersedes #74170.
Supersedes #74228.
Supersedes #73217.

This PR also resolves the shared-media failure described by these already-closed duplicate/evidence issues, but they do not need auto-closing:

Resolves duplicate evidence from #73473, #73591, #73665, #73224, #74111, #74248, and #7375.

This PR intentionally does **not** claim to close:

- #74216 — packaging/runtime-dependency staging for library extensions. This is complementary: it fixes missing `sharp` at install/update time, while this PR fixes shared media behavior when optimization fails or cannot produce output.
- #74172 — closed narrow `sharp` dependency fix. Same root family, but already closed and complementary.
- #38260 — native `libvips` SIGILL crash. A JavaScript fallback can handle thrown optimizer failures, but it cannot catch a hard native process crash after libvips terminates the gateway. That issue still needs reproduction/backtrace and crash-isolation or runtime-dependency work.
- #41769 — older macOS ARM64 sharp load issue that appears mostly superseded by runtime architecture changes; referenced only as historical context.

## Related issues / PRs checked

### Canonical / direct duplicates
- #73424 — canonical open `Failed to optimize image` preprocessing bug
- #73473 — closed duplicate: webchat/Feishu image tool broken after 2026.4.26
- #73591 — closed duplicate/additional evidence: WhatsApp media sends fail with same error
- #73665 — closed duplicate/additional evidence: MiniMax image understanding fails after 2026.4.26

### Same root family: missing/broken optimizer dependency
- #73148 — opaque failure when `sharp` is missing; this PR now preserves the underlying cause and keeps under-cap originals usable
- #73224 — `media-understanding-core`/`sharp` not installed after upgrade
- #74111 — staged `sharp` runtime dependency resolution failure
- #74248 — Discord image attachments fail when `sharp` is missing from package runtime
- #7375 — older Ubuntu/Slack PNG optimizer failure report
- #41769 — older macOS ARM64 sharp load issue; mostly superseded by runtime architecture changes, but same failure class

### Adjacent but not closed by this PR
- #74216 — install/runtime-deps staging for library extensions; complementary packaging fix
- #38260 — native `libvips` SIGILL crash; requires separate crash-level investigation/isolation

### Related PRs compared
- #73451 — fallback in `optimizeImageToJpeg`; useful policy, but risks MIME mismatch and overly broad fallback
- #74170 — similar fallback fork; this PR keeps the behavior but adds MIME preservation and guard boundaries
- #74228 — diagnostic cause/counter reporting; folded into this PR
- #73217 — earlier diagnostic cause PR for #73148; folded into this PR's error cause behavior
- #74216 — packaging/runtime-deps fix for library extensions; complementary, not replaced by this PR
- #74172 — closed narrow `sharp` dependency fix; complementary/root-cause packaging path
- #58226 — merged decoded pixel-area guard; this PR explicitly preserves its fail-closed behavior

## Test plan
- `corepack pnpm exec oxfmt --write --threads=1 src/media/web-media.ts src/media/web-media.test.ts src/media/web-media.optimizer-fallback.test.ts src/media/image-ops.input-guard.test.ts`
- `corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/media/web-media.ts src/media/web-media.optimizer-fallback.test.ts`
- `corepack pnpm vitest run src/media/web-media.optimizer-fallback.test.ts src/media/web-media.test.ts src/media/image-ops.input-guard.test.ts`
- `git diff --check`
