### PR TITLE
fix(context-engine): honor assembled prompt authority in precheck

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -277,6 +277,73 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(contextCompiled?.data?.systemPrompt).toContain("internal heartbeat event");
   });
 
+  it("uses assembled context as the default precheck authority", async () => {
+    let sawPrompt = false;
+    const hugeHistory = `${"large raw history ".repeat(25_000)}`;
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({
+        assemble: async () => ({
+          messages: [
+            { role: "user", content: "small assembled context", timestamp: 1 },
+          ] as AgentMessage[],
+          estimatedTokens: 8,
+        }),
+      }),
+      sessionKey,
+      tempPaths,
+      sessionMessages: [{ role: "user", content: hugeHistory, timestamp: 1 }] as AgentMessage[],
+      attemptOverrides: {
+        contextTokenBudget: 500,
+      },
+      sessionPrompt: async (session) => {
+        sawPrompt = true;
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(sawPrompt).toBe(true);
+    expect(result.promptError).toBeNull();
+    expect(result.promptErrorSource).toBeNull();
+  });
+
+  it("honors context engines that opt into preassembly overflow authority", async () => {
+    let sawPrompt = false;
+    const hugeHistory = `${"large raw history ".repeat(25_000)}`;
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({
+        assemble: async () => ({
+          messages: [
+            { role: "user", content: "small assembled context", timestamp: 1 },
+          ] as AgentMessage[],
+          estimatedTokens: 8,
+          promptAuthority: "preassembly_may_overflow",
+        }),
+      }),
+      sessionKey,
+      tempPaths,
+      sessionMessages: [{ role: "user", content: hugeHistory, timestamp: 1 }] as AgentMessage[],
+      attemptOverrides: {
+        contextTokenBudget: 500,
+      },
+      sessionPrompt: async (session) => {
+        sawPrompt = true;
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "done", timestamp: 2 },
+        ];
+      },
+    });
+
+    expect(sawPrompt).toBe(false);
+    expect(result.promptErrorSource).toBe("precheck");
+    expect(result.preflightRecovery?.route).toBe("compact_only");
+  });
+
   it("keeps gateway model runs independent from agent context and session history", async () => {
     const bootstrap = vi.fn(async () => ({ bootstrapped: true }));
     const assemble = vi.fn(async ({ messages }: { messages: AgentMessage[] }) => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1457,6 +1457,7 @@ export async function runEmbeddedAttempt(
       }
       let prePromptMessageCount = activeSession.messages.length;
       let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
+      let contextEnginePromptAuthority: "assembled" | "preassembly_may_overflow" = "assembled";
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
@@ -1981,6 +1982,7 @@ export async function runEmbeddedAttempt(
             if (assembled.messages !== activeSession.messages) {
               activeSession.agent.state.messages = assembled.messages;
             }
+            contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
             if (assembled.systemPromptAddition) {
               systemPromptText = prependSystemPromptAddition({
                 systemPrompt: systemPromptText,
@@ -2620,7 +2622,9 @@ export async function runEmbeddedAttempt(
 
           const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
             messages: activeSession.messages,
-            unwindowedMessages: unwindowedContextEngineMessagesForPrecheck,
+            ...(contextEnginePromptAuthority === "preassembly_may_overflow"
+              ? { unwindowedMessages: unwindowedContextEngineMessagesForPrecheck }
+              : {}),
             systemPrompt: systemPromptText,
             prompt: effectivePrompt,
             contextTokenBudget,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -93,7 +93,7 @@ describe("preemptive-compaction", () => {
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
   });
 
-  it("uses the larger unwindowed message estimate when context engine assembly windows history", () => {
+  it("uses the larger unwindowed message estimate when explicitly provided", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory("small assembled window")],
       unwindowedMessages: [makeAssistantHistory(verboseHistory.repeat(4))],

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -8,6 +8,11 @@ export type AssembleResult = {
   messages: AgentMessage[];
   /** Estimated total tokens in assembled context */
   estimatedTokens: number;
+  /**
+   * Declares whether the assembled messages are the authoritative prompt for
+   * overflow prechecks. Defaults to "assembled".
+   */
+  promptAuthority?: "assembled" | "preassembly_may_overflow";
   /** Optional context-engine-provided instructions prepended to the runtime system prompt */
   systemPromptAddition?: string;
 };


### PR DESCRIPTION
## Summary

Fixes openclaw/openclaw#74233.

Context-engine assembly is documented as returning the ordered messages ready for the model, but the embedded runner still let the preemptive overflow gate hard-fail on the larger pre-assembly transcript. That made LCM/windowing engines look broken even when their assembled prompt fit the model.

This PR makes assembled context the default prompt authority and keeps the older max-of-assembled-and-unwindowed behavior only for engines that explicitly opt in with `promptAuthority: "preassembly_may_overflow"`.

## Changes

- Adds optional `AssembleResult.promptAuthority?: "assembled" | "preassembly_may_overflow"`, defaulting to `"assembled"`.
- Stops passing pre-assembly history into the hard precheck unless the context engine opts into raw-history overflow authority.
- Leaves the lower-level precheck helper capable of honoring explicit unwindowed messages.
- Adds attempt-level regressions for the LCM failure shape: huge raw history plus a small assembled prompt now proceeds, while explicit preassembly authority still fails early.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `pnpm build:plugin-sdk:strict-smoke`

## Notes

This is the production-side fix for the context blow-up path. LCM-side follow-ups add cache-policy hardening and assembly provenance so future incidents can be diagnosed from host-visible metadata instead of logs only.

Refs Martian-Engineering/lossless-claw#534.