### PR TITLE
fix(gateway): isHeartbeatEnabledForAgent respects agents.defaults.hea…

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -314,7 +314,7 @@ describe("isHeartbeatEnabledForAgent", () => {
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
   });
 
-  it("falls back to default agent when no explicit heartbeat entries", () => {
+  it("enables all agents when defaults.heartbeat is set without per-agent overrides", () => {
     const cfg: OpenClawConfig = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },
@@ -322,6 +322,17 @@ describe("isHeartbeatEnabledForAgent", () => {
       },
     };
     expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(true);
+  });
+
+  it("disables all agents when no heartbeat is configured anywhere", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {},
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    };
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
     expect(isHeartbeatEnabledForAgent(cfg, "ops")).toBe(false);
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -180,6 +180,10 @@ function resolveHeartbeatSchedulerSeed(explicitSeed?: string) {
   }
 }
 
+function hasHeartbeatDefaults(cfg: OpenClawConfig): boolean {
+  return Boolean(cfg.agents?.defaults?.heartbeat);
+}
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
   return list.some((entry) => Boolean(entry?.heartbeat));
@@ -201,7 +205,7 @@ function resolveHeartbeatConfig(
 }
 
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
-  const list = cfg.agents?.list ?? [];
+  const list = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
   if (hasExplicitHeartbeatAgents(cfg)) {
     return list
       .filter((entry) => entry?.heartbeat)
@@ -211,8 +215,19 @@ function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       })
       .filter((entry) => entry.agentId);
   }
-  const fallbackId = resolveDefaultAgentId(cfg);
-  return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+  if (hasHeartbeatDefaults(cfg)) {
+    if (list.length === 0) {
+      const fallbackId = resolveDefaultAgentId(cfg);
+      return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+    }
+    return list
+      .map((entry) => {
+        const id = normalizeAgentId(entry.id);
+        return { agentId: id, heartbeat: resolveHeartbeatConfig(cfg, id) };
+      })
+      .filter((entry) => entry.agentId);
+  }
+  return [];
 }
 
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -24,6 +24,10 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
 
+function hasHeartbeatDefaults(cfg: OpenClawConfig): boolean {
+  return Boolean(cfg.agents?.defaults?.heartbeat);
+}
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
   return list.some((entry) => Boolean(entry?.heartbeat));
@@ -31,14 +35,20 @@ function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
 
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
-  const list = cfg.agents?.list ?? [];
+  const list = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
   const hasExplicit = hasExplicitHeartbeatAgents(cfg);
   if (hasExplicit) {
     return list.some(
       (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
     );
   }
-  return resolvedAgentId === resolveDefaultAgentId(cfg);
+  if (hasHeartbeatDefaults(cfg)) {
+    if (list.length === 0) {
+      return resolvedAgentId === resolveDefaultAgentId(cfg);
+    }
+    return list.some((entry) => normalizeAgentId(entry?.id) === resolvedAgentId);
+  }
+  return false;
 }
 
 export function resolveHeartbeatIntervalMs(


### PR DESCRIPTION
Fixes #41879

`isHeartbeatEnabledForAgent` previously ignored `agents.defaults.heartbeat` when no per-agent entries existed. This caused:

1. `defaults.heartbeat` set + no per-agent → only default agent got heartbeat (should be all agents)
2. No heartbeat anywhere → default agent still got heartbeat (should be none)

Changes:
- Added `hasHeartbeatDefaults()` check in both `heartbeat-summary.ts` and `heartbeat-runner.ts`
- `resolveHeartbeatAgents` now returns all list agents when defaults are configured
- Added test for "no heartbeat configured anywhere" scenario
- Updated existing test that encoded the buggy behavior