### PR TITLE
fix(openai-codex): surface device-pairing code without logging it (#74212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory Wiki: accept relative Markdown links that include the `.md` suffix during broken-wikilink validation, avoiding false positives for native render-mode links. Thanks @Kenneth8128.
+- OpenAI Codex: show the device-pairing code in the interactive SSH/headless prompt while keeping the short-lived code out of persistent runtime logs. Fixes #74212. Thanks @da22le123.
 - Plugins/CLI: cache plugin CLI registration entries per command program so completion state generation does not repeat the full plugin sweep in one invocation. Thanks @ScientificProgrammer.
 - Plugins: reuse gateway-bindable plugin loader cache entries for later default-mode loads without serving default-built registries to gateway-bound requests, reducing repeated plugin registration during dispatch. Refs #61756. Thanks @DmitryPogodaev.
 - Gateway/secrets: include the caught error message in `secrets.reload` and `secrets.resolve` warning logs while keeping RPC errors generic, so operators can diagnose reload and permission failures. Thanks @davidangularme.

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -234,7 +234,7 @@ describe("openai codex provider", () => {
     expect(result?.profiles[0]?.credential).not.toHaveProperty("idToken");
   });
 
-  it("does not log the device pairing code in remote mode", async () => {
+  async function runRemoteDeviceCodeAuthFlow() {
     const provider = buildOpenAICodexProviderPlugin();
     const deviceCodeMethod = provider.auth?.find((method) => method.id === "device-code");
     const note = vi.fn(async () => {});
@@ -273,17 +273,28 @@ describe("openai codex provider", () => {
       }),
     ).resolves.toBeDefined();
 
-    const logOutput = runtime.log.mock.calls.flat().join("\n");
-    expect(logOutput).toContain("https://auth.openai.com/codex/device");
-    expect(logOutput).not.toContain("CODE-12345");
+    return { note, runtime };
+  }
+
+  it("surfaces the device pairing code via the prompter note in remote (SSH) mode (#74212)", async () => {
+    const { note } = await runRemoteDeviceCodeAuthFlow();
+
     expect(note).toHaveBeenCalledWith(
-      expect.stringContaining("Code: [shown on the local device only]"),
-      "OpenAI Codex device code",
-    );
-    expect(note).not.toHaveBeenCalledWith(
       expect.stringContaining("Code: CODE-12345"),
       "OpenAI Codex device code",
     );
+    expect(note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Code: [shown on the local device only]"),
+      "OpenAI Codex device code",
+    );
+  });
+
+  it("does not write the device pairing code to the runtime log in remote mode", async () => {
+    const { runtime } = await runRemoteDeviceCodeAuthFlow();
+
+    const logOutput = runtime.log.mock.calls.flat().join("\n");
+    expect(logOutput).toContain("https://auth.openai.com/codex/device");
+    expect(logOutput).not.toContain("CODE-12345");
   });
 
   it("owns native reasoning output mode for Codex responses", () => {

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -378,16 +378,15 @@ async function runOpenAICodexDeviceCode(ctx: ProviderAuthContext) {
       onProgress: (message) => spin.update(message),
       onVerification: async ({ verificationUrl, userCode, expiresInMs }) => {
         const expiresInMinutes = Math.max(1, Math.round(expiresInMs / 60_000));
-        const codeLine = ctx.isRemote
-          ? "Code: [shown on the local device only]"
-          : `Code: ${userCode}`;
+        // The prompter note is the user-facing TTY surface, so remote/headless
+        // users need the code there; keep the persistent runtime log URL-only.
         await ctx.prompter.note(
           [
             ctx.isRemote
               ? "Open this URL in your LOCAL browser and enter the code below."
               : "Open this URL in your browser and enter the code below.",
             `URL: ${verificationUrl}`,
-            codeLine,
+            `Code: ${userCode}`,
             `Code expires in ${expiresInMinutes} minutes. Never share it.`,
           ].join("\n"),
           "OpenAI Codex device code",


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw models auth login --provider openai-codex` (Device Pairing auth) renders the device code as `Code: [shown on the local device only]` in the prompter note, which makes the OAuth flow unrecoverable in any session that has no other surface — over SSH, the SSH terminal *is* the local device, so there is nowhere else for the code to appear.
- **Why it matters:** this is the only auth path for the openai-codex provider for users who don't ship an `OPENAI_API_KEY` (e.g. ChatGPT subscription users on a remote/headless host).
- **What changed:** in `extensions/openai/openai-codex-provider.ts`, the `prompter.note` payload now always includes `Code: ${userCode}` regardless of `ctx.isRemote`. The note is the user-facing TTY surface — the same surface upstream `codex login` writes to in the same SSH session.
- **What did NOT change (scope boundary):** the `ctx.runtime.log(...)` line in the `isRemote` branch is left exactly as it was — it still emits only the verification URL, never the user code. `runtime.log` is the persistent diagnostic logger; device codes must not land there. The "LOCAL browser" intro copy in the note is unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #74212
- Related #74221 — alternative fix for the same symptom that adds the user code to `ctx.runtime.log(...)`, which regresses the existing `does not log the device pairing code in remote mode` assertion. This PR keeps that boundary intact.
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `extensions/openai/openai-codex-provider.ts:355-357` masked the device code in the `prompter.note` payload whenever `ctx.isRemote` was true. The intent appears to have been "don't echo a sensitive code over an SSH wire," but OAuth device flow requires the user to read the code from the same device that initiated the flow — over SSH, that device is the SSH terminal. Hiding the code there makes the flow unusable, with no fallback surface.
- **Missing detection / guardrail:** there was no test asserting the prompter note actually contains the user code in remote mode. The existing test only asserted the inverse (that `runtime.log` does not contain the code) — a security guard that this PR preserves.
- **Contributing context:** upstream `codex login` prints the code in the terminal in the same SSH session correctly; only OpenClaw's wrapper masks it.

## Regression Test Plan

- Coverage level: [x] Unit test
- Target test or file: `extensions/openai/openai-codex-provider.test.ts`
- Scenario the test should lock in: in `isRemote: true` mode, the prompter note must contain the literal `Code: <userCode>` (no masking placeholder), AND the runtime log must not contain the user code.
- Why this is the smallest reliable guardrail: both invariants are verifiable via the existing `loginOpenAICodexDeviceCode` mock; a unit test is the same level of coverage the previous (broken) behavior was already specified at.
- The previous single test `does not log the device pairing code in remote mode` was split into two focused tests so the prompter and the log are guarded independently:
  - `surfaces the device pairing code via the prompter note in remote (SSH) mode (#74212)`
  - `does not write the device pairing code to the runtime log in remote mode`

## User-visible / Behavior Changes

When running `openclaw models auth login --provider openai-codex` and selecting `OpenAI Codex Device Pairing` in remote mode (e.g. SSH), the device code is now printed in the prompter note (the terminal). Previously the code field was masked as `[shown on the local device only]`. The runtime log surface is unchanged and continues to print only the verification URL.

## Diagram

```text
Before (remote mode, e.g. SSH):
  prompter.note → URL: <url>, Code: [shown on the local device only]
  runtime.log   → URL: <url>
  → user has no surface from which to retrieve the code

After (remote mode, e.g. SSH):
  prompter.note → URL: <url>, Code: <userCode>
  runtime.log   → URL: <url>                ← intentionally unchanged
  → user reads the code from the same terminal upstream `codex login` writes to
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** — the device code is short-lived (~15 min), single-use, and the only change in handling is to surface it on the existing user-facing TTY surface (not on a persistent surface). The persistent `runtime.log` surface is intentionally untouched and a dedicated test now guards that boundary.
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Debian GNU/Linux 12 (bookworm) on the host where the bug was filed
- Runtime/container: OpenClaw 2026.4.23, npm global install
- Model/provider: openai-codex
- Integration/channel: N/A
- Relevant config: default (no `OPENAI_API_KEY` in env)

### Steps

1. SSH into a host running OpenClaw.
2. Run `openclaw models auth login --provider openai-codex`.
3. Select `OpenAI Codex Device Pairing`.

### Expected

- The prompter note prints both the verification URL and the device code; the user can complete the flow over SSH the same way upstream `codex login` allows.

### Actual (without this PR, on `main`)

- The prompter note prints `Code: [shown on the local device only]` and the user has no other surface to retrieve the code from.

## Evidence

- Failing → passing test: the previous test `does not log the device pairing code in remote mode` asserted `note` was called with `[shown on the local device only]`. Replaced with `surfaces the device pairing code via the prompter note in remote (SSH) mode (#74212)` which asserts the inverse and now passes after the source change. The log-hygiene assertions remain in a separate test that passes both before and after.
- `pnpm test:extension openai` → 22 test files, 204 tests, all passing.
- `pnpm build` → clean.
- `pnpm check` (lint + policy guards + cycle check) → exit 0.

## Human Verification (required)

- Verified scenarios:
  - `pnpm test:extension openai` locally, both new tests reported `✓`.
  - Inspected `extensions/openai/openai-codex-provider.ts:348-379` after the change: the only modified surface is the `prompter.note` payload; the `ctx.runtime.log(...)` calls are byte-identical to `main`.
  - Confirmed the LOCAL/non-LOCAL browser intro copy on the note is untouched.
- Edge cases checked: the local (non-`isRemote`) branch was not modified — its behavior is preserved. The split tests share a `runRemoteDeviceCodeAuthFlow` helper so both exercise the exact same call path.
- What I did **not** verify:
  - End-to-end against a real ChatGPT subscription account — codex auth is the subject of the bug, so no live `codex login` was performed from this environment.
  - `codex review --base origin/main` (recommended by CONTRIBUTING) for the same reason; happy to run it once Codex auth is available.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — same auth flow surfaces, same data shape, same persisted credentials.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: a future change adds the user code to a persistent surface (e.g. `runtime.log`), reintroducing the boundary issue.
  - Mitigation: the second new test (`does not write the device pairing code to the runtime log in remote mode`) and its accompanying comment explicitly guard this invariant.

---

**AI-assisted disclosure** (per CONTRIBUTING §"AI/Vibe-Coded PRs Welcome"):

- [x] Marked AI-assisted: this PR was authored with assistance from Claude (Anthropic).
- Degree of testing: fully tested locally — `pnpm test:extension openai`, `pnpm build`, `pnpm check` all pass.
- I confirm I understand what the code does.
- `codex review --base origin/main` was not run locally — codex auth itself is the subject of the bug being fixed, and no codex auth is set up in this environment. Happy to re-run if a maintainer can point me at an alternative.
