### PR TITLE
Fix GitHub Copilot model picker catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and allow `channels.whatsapp.exposeErrorText` to suppress visible error text per channel or account. (#71830) Thanks @rubencu.
 - Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
 - Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
+- Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
 
 ## 2026.4.27
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -4,16 +4,20 @@ import path from "node:path";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
+  upsertAuthProfile,
 } from "openclaw/plugin-sdk/agent-runtime";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const resolveCopilotApiTokenMock = vi.hoisted(() => vi.fn());
+const mocks = vi.hoisted(() => ({
+  githubCopilotLoginCommand: vi.fn(),
+  resolveCopilotApiToken: vi.fn(),
+}));
 
 vi.mock("./register.runtime.js", () => ({
   DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
-  resolveCopilotApiToken: resolveCopilotApiTokenMock,
-  githubCopilotLoginCommand: vi.fn(),
+  resolveCopilotApiToken: mocks.resolveCopilotApiToken,
+  githubCopilotLoginCommand: mocks.githubCopilotLoginCommand,
   fetchCopilotUsage: vi.fn(),
 }));
 
@@ -22,6 +26,7 @@ import plugin from "./index.js";
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.clearAllMocks();
   clearRuntimeAuthProfileStoreSnapshots();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
@@ -98,11 +103,11 @@ describe("github-copilot plugin", () => {
     } as never);
 
     expect(result).toBeNull();
-    expect(resolveCopilotApiTokenMock).not.toHaveBeenCalled();
+    expect(mocks.resolveCopilotApiToken).not.toHaveBeenCalled();
   });
 
   it("uses live plugin config to re-enable discovery after startup disable", async () => {
-    resolveCopilotApiTokenMock.mockResolvedValueOnce({
+    mocks.resolveCopilotApiToken.mockResolvedValueOnce({
       token: "copilot_api_token",
       baseUrl: "https://api.githubcopilot.live",
     });
@@ -125,7 +130,7 @@ describe("github-copilot plugin", () => {
       resolveProviderApiKey: () => ({ apiKey: "gh_test_token" }),
     } as never);
 
-    expect(resolveCopilotApiTokenMock).toHaveBeenCalledWith({
+    expect(mocks.resolveCopilotApiToken).toHaveBeenCalledWith({
       githubToken: "gh_test_token",
       env: { GH_TOKEN: "gh_test_token" },
     });
@@ -135,6 +140,135 @@ describe("github-copilot plugin", () => {
         models: [],
       },
     });
+  });
+
+  it("offers to reuse an existing token profile during interactive onboarding", async () => {
+    const provider = registerProviderWithPluginConfig({});
+    const method = provider.auth[0];
+    const agentDir = await createAgentDir();
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "github-copilot:github": {
+            type: "token",
+            provider: "github-copilot",
+            token: "existing-token",
+          },
+        },
+      }),
+    );
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      note: vi.fn(),
+    };
+
+    const result = await method.run({
+      config: {},
+      env: {},
+      agentDir,
+      workspaceDir: "/tmp/workspace",
+      prompter,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      opts: {},
+      secretInputMode: "plaintext",
+      allowSecretRefPrompt: false,
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as never);
+
+    expect(prompter.confirm).toHaveBeenCalledWith({
+      message: "GitHub Copilot auth already exists. Re-run login?",
+      initialValue: false,
+    });
+    expect(mocks.githubCopilotLoginCommand).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      profiles: [
+        {
+          profileId: "github-copilot:github",
+          credential: {
+            type: "token",
+            provider: "github-copilot",
+            token: "existing-token",
+          },
+        },
+      ],
+      defaultModel: "github-copilot/claude-opus-4.7",
+    });
+  });
+
+  it("can refresh an existing token profile during interactive onboarding", async () => {
+    const provider = registerProviderWithPluginConfig({});
+    const method = provider.auth[0];
+    const agentDir = await createAgentDir();
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "github-copilot:github": {
+            type: "token",
+            provider: "github-copilot",
+            token: "existing-token",
+          },
+        },
+      }),
+    );
+    mocks.githubCopilotLoginCommand.mockImplementationOnce(async (opts: { agentDir?: string }) => {
+      upsertAuthProfile({
+        profileId: "github-copilot:github",
+        credential: {
+          type: "token",
+          provider: "github-copilot",
+          token: "refreshed-token",
+        },
+        agentDir: opts.agentDir,
+      });
+    });
+    const prompter = {
+      confirm: vi.fn(async () => true),
+      note: vi.fn(),
+    };
+    const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+
+    try {
+      const result = await method.run({
+        config: {},
+        env: {},
+        agentDir,
+        workspaceDir: "/tmp/workspace",
+        prompter,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        opts: {},
+        secretInputMode: "plaintext",
+        allowSecretRefPrompt: false,
+        isRemote: false,
+        openUrl: vi.fn(),
+        oauth: { createVpsAwareHandlers: vi.fn() },
+      } as never);
+
+      expect(mocks.githubCopilotLoginCommand).toHaveBeenCalledWith(
+        { yes: true, profileId: "github-copilot:github", agentDir },
+        expect.any(Object),
+      );
+      expect(result.profiles[0]?.credential).toEqual({
+        type: "token",
+        provider: "github-copilot",
+        token: "refreshed-token",
+      });
+    } finally {
+      if (isTtyDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", isTtyDescriptor);
+      } else {
+        delete (process.stdin as { isTTY?: boolean }).isTTY;
+      }
+    }
   });
 
   it("stores GitHub Copilot token from non-interactive onboarding", async () => {

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -3,6 +3,7 @@ import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-run
 import {
   definePluginEntry,
   type ProviderAuthContext,
+  type ProviderAuthResult,
   type ProviderAuthMethodNonInteractiveContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -84,6 +85,29 @@ function resolveExistingCopilotTokenProfileId(agentDir?: string): string | undef
       normalizeOptionalSecretInput(profile.token) || coerceSecretRef(profile.tokenRef)?.id.trim(),
     );
   });
+}
+
+function resolveExistingCopilotAuthResult(agentDir?: string): ProviderAuthResult | null {
+  const profileId = resolveExistingCopilotTokenProfileId(agentDir);
+  if (!profileId) {
+    return null;
+  }
+  const authStore = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const credential = authStore.profiles[profileId];
+  if (!credential || credential.type !== "token") {
+    return null;
+  }
+  return {
+    profiles: [
+      {
+        profileId,
+        credential,
+      },
+    ],
+    defaultModel: DEFAULT_COPILOT_MODEL,
+  };
 }
 
 async function resolveCopilotNonInteractiveToken(
@@ -233,6 +257,17 @@ export default definePluginEntry({
 
     async function runGitHubCopilotAuth(ctx: ProviderAuthContext) {
       const { githubCopilotLoginCommand } = await loadGithubCopilotRuntime();
+      let authResult = resolveExistingCopilotAuthResult(ctx.agentDir);
+      if (authResult) {
+        const runLogin = await ctx.prompter.confirm({
+          message: "GitHub Copilot auth already exists. Re-run login?",
+          initialValue: false,
+        });
+        if (!runLogin) {
+          return authResult;
+        }
+      }
+
       await ctx.prompter.note(
         [
           "This will open a GitHub device login to authorize Copilot.",
@@ -251,7 +286,7 @@ export default definePluginEntry({
 
       try {
         await githubCopilotLoginCommand(
-          { yes: true, profileId: "github-copilot:github" },
+          { yes: true, profileId: "github-copilot:github", agentDir: ctx.agentDir },
           ctx.runtime,
         );
       } catch (err) {
@@ -259,23 +294,8 @@ export default definePluginEntry({
         return { profiles: [] };
       }
 
-      const authStore = ensureAuthProfileStore(undefined, {
-        allowKeychainPrompt: false,
-      });
-      const credential = authStore.profiles["github-copilot:github"];
-      if (!credential || credential.type !== "token") {
-        return { profiles: [] };
-      }
-
-      return {
-        profiles: [
-          {
-            profileId: DEFAULT_COPILOT_PROFILE_ID,
-            credential,
-          },
-        ],
-        defaultModel: DEFAULT_COPILOT_MODEL,
-      };
+      authResult = resolveExistingCopilotAuthResult(ctx.agentDir);
+      return authResult ?? { profiles: [] };
     }
 
     api.registerMemoryEmbeddingProvider(githubCopilotMemoryEmbeddingProviderAdapter);
@@ -301,6 +321,9 @@ export default definePluginEntry({
           choiceLabel: "GitHub Copilot",
           choiceHint: "Device login with your GitHub account",
           methodId: "device",
+          modelAllowlist: {
+            loadCatalog: true,
+          },
         },
       },
       catalog: {

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -117,7 +117,7 @@ async function pollForAccessToken(params: {
 }
 
 export async function githubCopilotLoginCommand(
-  opts: { profileId?: string; yes?: boolean },
+  opts: { profileId?: string; yes?: boolean; agentDir?: string },
   runtime: RuntimeEnv,
 ) {
   if (!process.stdin.isTTY) {
@@ -127,7 +127,7 @@ export async function githubCopilotLoginCommand(
   intro(stylePromptTitle("GitHub Copilot login"));
 
   const profileId = opts.profileId?.trim() || "github-copilot:github";
-  const store = ensureAuthProfileStore(undefined, {
+  const store = ensureAuthProfileStore(opts.agentDir, {
     allowKeychainPrompt: false,
   });
 
@@ -169,6 +169,7 @@ export async function githubCopilotLoginCommand(
       // GitHub device flow token doesn't reliably include expiry here.
       // Leave expires unset; we'll exchange into Copilot token plus expiry later.
     },
+    agentDir: opts.agentDir,
   });
 
   await updateConfig((cfg) =>

--- a/extensions/github-copilot/models-defaults.ts
+++ b/extensions/github-copilot/models-defaults.ts
@@ -8,16 +8,27 @@ const DEFAULT_MAX_TOKENS = 8192;
 // We keep this list intentionally broad; if a model isn't available Copilot will
 // return an error and users can remove it from their config.
 const DEFAULT_MODEL_IDS = [
+  "claude-haiku-4.5",
+  "claude-opus-4.5",
+  "claude-opus-4.6",
   "claude-opus-4.7",
+  "claude-sonnet-4",
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
-  "gpt-4o",
+  "gemini-2.5-pro",
+  "gemini-3-flash",
+  "gemini-3.1-pro",
   "gpt-4.1",
-  "gpt-4.1-mini",
-  "gpt-4.1-nano",
-  "o1",
-  "o1-mini",
-  "o3-mini",
+  "gpt-5-mini",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.4-nano",
+  "grok-code-fast-1",
+  "raptor-mini",
+  "goldeneye",
 ] as const;
 
 export function getDefaultCopilotModelIds(): string[] {

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -23,12 +23,14 @@ vi.mock("openclaw/plugin-sdk/provider-model-shared", () => ({
   }),
 }));
 
-const loadJsonFile = vi.fn();
-const saveJsonFile = vi.fn();
+const jsonStoreMocks = vi.hoisted(() => ({
+  loadJsonFile: vi.fn(),
+  saveJsonFile: vi.fn(),
+}));
 
 vi.mock("openclaw/plugin-sdk/json-store", () => ({
-  loadJsonFile,
-  saveJsonFile,
+  loadJsonFile: jsonStoreMocks.loadJsonFile,
+  saveJsonFile: jsonStoreMocks.saveJsonFile,
 }));
 
 vi.mock("openclaw/plugin-sdk/state-paths", () => ({
@@ -67,7 +69,7 @@ describe("github-copilot model defaults", () => {
   describe("getDefaultCopilotModelIds", () => {
     it("includes claude-opus-4.7", () => {
       expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.7");
-      expect(getDefaultCopilotModelIds()).not.toContain("claude-opus-4.6");
+      expect(getDefaultCopilotModelIds()).toContain("claude-opus-4.6");
     });
 
     it("includes claude-sonnet-4.6", () => {
@@ -303,8 +305,8 @@ describe("github-copilot token", () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    loadJsonFile.mockClear();
-    saveJsonFile.mockClear();
+    jsonStoreMocks.loadJsonFile.mockClear();
+    jsonStoreMocks.saveJsonFile.mockClear();
     ({ deriveCopilotApiBaseUrlFromToken, resolveCopilotApiToken } = await import("./token.js"));
   });
 
@@ -319,7 +321,7 @@ describe("github-copilot token", () => {
 
   it("uses cache when token is still valid", async () => {
     const now = Date.now();
-    loadJsonFile.mockReturnValue({
+    jsonStoreMocks.loadJsonFile.mockReturnValue({
       token: "cached;proxy-ep=proxy.example.com;",
       expiresAt: now + 60 * 60 * 1000,
       updatedAt: now,
@@ -329,8 +331,8 @@ describe("github-copilot token", () => {
     const res = await resolveCopilotApiToken({
       githubToken: "gh",
       cachePath,
-      loadJsonFileImpl: loadJsonFile,
-      saveJsonFileImpl: saveJsonFile,
+      loadJsonFileImpl: jsonStoreMocks.loadJsonFile,
+      saveJsonFileImpl: jsonStoreMocks.saveJsonFile,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
@@ -341,7 +343,7 @@ describe("github-copilot token", () => {
   });
 
   it("fetches and stores token when cache is missing", async () => {
-    loadJsonFile.mockReturnValue(undefined);
+    jsonStoreMocks.loadJsonFile.mockReturnValue(undefined);
 
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
@@ -355,13 +357,13 @@ describe("github-copilot token", () => {
     const res = await resolveCopilotApiToken({
       githubToken: "gh",
       cachePath,
-      loadJsonFileImpl: loadJsonFile,
-      saveJsonFileImpl: saveJsonFile,
+      loadJsonFileImpl: jsonStoreMocks.loadJsonFile,
+      saveJsonFileImpl: jsonStoreMocks.saveJsonFile,
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
     expect(res.token).toBe("fresh;proxy-ep=https://proxy.contoso.test;");
     expect(res.baseUrl).toBe("https://api.contoso.test");
-    expect(saveJsonFile).toHaveBeenCalledTimes(1);
+    expect(jsonStoreMocks.saveJsonFile).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -18,6 +18,201 @@
       }
     }
   },
+  "modelCatalog": {
+    "providers": {
+      "github-copilot": {
+        "baseUrl": "https://api.individual.githubcopilot.com",
+        "api": "openai-responses",
+        "models": [
+          {
+            "id": "claude-haiku-4.5",
+            "name": "Claude Haiku 4.5",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-opus-4.5",
+            "name": "Claude Opus 4.5",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-opus-4.6",
+            "name": "Claude Opus 4.6",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-opus-4.7",
+            "name": "Claude Opus 4.7",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-sonnet-4",
+            "name": "Claude Sonnet 4",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-sonnet-4.5",
+            "name": "Claude Sonnet 4.5",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "claude-sonnet-4.6",
+            "name": "Claude Sonnet 4.6",
+            "api": "anthropic-messages",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gemini-2.5-pro",
+            "name": "Gemini 2.5 Pro",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gemini-3-flash",
+            "name": "Gemini 3 Flash",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gemini-3.1-pro",
+            "name": "Gemini 3.1 Pro",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-4.1",
+            "name": "GPT-4.1",
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5-mini",
+            "name": "GPT-5 mini",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.2",
+            "name": "GPT-5.2",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.2-codex",
+            "name": "GPT-5.2-Codex",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.3-codex",
+            "name": "GPT-5.3-Codex",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.4",
+            "name": "GPT-5.4",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "name": "GPT-5.4 mini",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "gpt-5.4-nano",
+            "name": "GPT-5.4 nano",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "grok-code-fast-1",
+            "name": "Grok Code Fast 1",
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "raptor-mini",
+            "name": "Raptor mini",
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          },
+          {
+            "id": "goldeneye",
+            "name": "Goldeneye",
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 8192,
+            "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "github-copilot": "static"
+    }
+  },
   "contracts": {
     "memoryEmbeddingProviders": ["github-copilot"]
   },

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   promptCustomApiConfig: vi.fn(),
   resolvePluginProviders: vi.fn(() => []),
   resolveProviderPluginChoice: vi.fn<() => unknown>(() => null),
+  loadStaticManifestCatalogRowsForList: vi.fn(() => []),
   resolvePreferredProviderForAuthChoice: vi.fn<() => Promise<string | undefined>>(
     async () => undefined,
   ),
@@ -52,7 +53,15 @@ vi.mock("../plugins/provider-wizard.js", () => ({
   resolveProviderPluginChoice: mocks.resolveProviderPluginChoice,
 }));
 
+vi.mock("./models/list.manifest-catalog.js", () => ({
+  loadStaticManifestCatalogRowsForList: mocks.loadStaticManifestCatalogRowsForList,
+}));
+
 import { promptAuthConfig } from "./configure.gateway-auth.js";
+
+beforeEach(() => {
+  mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([]);
+});
 
 function makeRuntime(): RuntimeEnv {
   return {
@@ -309,6 +318,88 @@ describe("promptAuthConfig", () => {
         loadCatalog: true,
       }),
     );
+  });
+
+  it("loads plugin catalog when the selected provider allowlist requires it", async () => {
+    vi.clearAllMocks();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("github-copilot");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("github-copilot");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+            models: {
+              "github-copilot/claude-opus-4.7": {},
+            },
+          },
+        },
+      },
+    });
+    mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+    mocks.resolveProviderPluginChoice.mockReturnValue({
+      provider: {
+        id: "github-copilot",
+        label: "GitHub Copilot",
+        auth: [],
+        wizard: {
+          setup: {
+            modelAllowlist: {
+              loadCatalog: true,
+            },
+          },
+        },
+      },
+      method: { id: "device", label: "GitHub device login", kind: "device_code" },
+    });
+
+    await promptAuthConfig({}, makeRuntime(), noopPrompter);
+
+    expect(mocks.promptModelAllowlist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredProvider: "github-copilot",
+        loadCatalog: true,
+      }),
+    );
+  });
+
+  it("loads catalog when the selected provider has manifest catalog rows", async () => {
+    vi.clearAllMocks();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("github-copilot");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("github-copilot");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "github-copilot/claude-opus-4.7": {},
+            },
+          },
+        },
+      },
+    });
+    mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+    mocks.resolvePluginProviders.mockReturnValue([]);
+    mocks.resolveProviderPluginChoice.mockReturnValue(null);
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([
+      {
+        provider: "github-copilot",
+        id: "claude-opus-4.7",
+        name: "Claude Opus 4.7",
+        ref: "github-copilot/claude-opus-4.7",
+        mergeKey: "github-copilot:claude-opus-4.7",
+        source: "manifest",
+        input: ["text"],
+        reasoning: false,
+        status: "available",
+      },
+    ]);
+
+    await promptAuthConfig({}, makeRuntime(), noopPrompter);
+
+    const call = mocks.promptModelAllowlist.mock.calls[0]?.[0];
+    expect(call?.preferredProvider).toBe("github-copilot");
+    expect(call?.loadCatalog).toBe(true);
   });
 
   it("returns to auth selection when plugin install onboarding asks for a retry", async () => {

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -13,10 +13,18 @@ import {
   promptDefaultModel,
   promptModelAllowlist,
 } from "./model-picker.js";
+import { loadStaticManifestCatalogRowsForList } from "./models/list.manifest-catalog.js";
 import { promptCustomApiConfig } from "./onboard-custom.js";
 import { randomToken } from "./onboard-helpers.js";
 
 type GatewayAuthChoice = "token" | "password" | "trusted-proxy";
+type ProviderChoiceModelPrompt = {
+  provider?: string;
+  allowedKeys?: string[];
+  initialSelections?: string[];
+  message?: string;
+  loadCatalog?: boolean;
+};
 
 /** Reject undefined, empty, and common JS string-coercion artifacts for token auth. */
 function sanitizeTokenValue(value: unknown): string | undefined {
@@ -35,16 +43,7 @@ async function resolveProviderChoiceModelPrompt(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<
-  | {
-      provider?: string;
-      allowedKeys?: string[];
-      initialSelections?: string[];
-      message?: string;
-      loadCatalog?: boolean;
-    }
-  | undefined
-> {
+}): Promise<ProviderChoiceModelPrompt | undefined> {
   const { resolvePluginProviders, resolveProviderPluginChoice } =
     await import("../plugins/provider-auth-choice.runtime.js");
   const providers = resolvePluginProviders({
@@ -58,12 +57,11 @@ async function resolveProviderChoiceModelPrompt(params: {
     choice: params.authChoice,
   });
   const wizard = resolved?.provider.wizard?.setup;
-  const provider = resolved?.provider.id;
   if (!wizard) {
-    return provider ? { provider } : undefined;
+    return resolved?.provider.id ? { provider: resolved.provider.id } : undefined;
   }
   return {
-    provider,
+    provider: resolved.provider.id,
     ...wizard.modelAllowlist,
     ...(wizard.modelSelection?.promptWhenAuthChoiceProvided === true ? { loadCatalog: true } : {}),
   };
@@ -73,7 +71,25 @@ function hasConfiguredProviderModels(cfg: OpenClawConfig, provider: string | und
   if (!provider) {
     return false;
   }
-  return (cfg.models?.providers?.[provider]?.models?.length ?? 0) > 0;
+  if ((cfg.models?.providers?.[provider]?.models?.length ?? 0) > 0) {
+    return true;
+  }
+  const providerPrefix = `${provider}/`;
+  return Object.keys(cfg.agents?.defaults?.models ?? {}).some((key) =>
+    key.trim().startsWith(providerPrefix),
+  );
+}
+
+function hasStaticManifestCatalogRows(cfg: OpenClawConfig, provider: string | undefined): boolean {
+  if (!provider) {
+    return false;
+  }
+  return (
+    loadStaticManifestCatalogRowsForList({
+      cfg,
+      providerFilter: provider,
+    }).length > 0
+  );
 }
 
 function listConfiguredModelProviders(cfg: OpenClawConfig): string[] {
@@ -240,7 +256,9 @@ export async function promptAuthConfig(
       message: modelPrompt?.message,
       preferredProvider: promptProvider,
       loadCatalog:
-        modelPrompt?.loadCatalog ?? hasConfiguredProviderModels(next, promptProvider) ?? false,
+        modelPrompt?.loadCatalog ??
+        (hasConfiguredProviderModels(next, promptProvider) ||
+          hasStaticManifestCatalogRows(next, promptProvider)),
     });
     if (allowlistSelection.models) {
       next = applyModelFallbacksFromSelection(next, allowlistSelection.models, {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -13,6 +13,11 @@ vi.mock("../agents/model-catalog.js", () => ({
   loadModelCatalog,
 }));
 
+const loadStaticManifestCatalogRowsForList = vi.hoisted(() => vi.fn(() => []));
+vi.mock("./models/list.manifest-catalog.js", () => ({
+  loadStaticManifestCatalogRowsForList,
+}));
+
 const ensureAuthProfileStore = vi.hoisted(() =>
   vi.fn(() => ({
     version: 1,
@@ -111,6 +116,7 @@ function configuredTextModel(id: string, name: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  loadStaticManifestCatalogRowsForList.mockReturnValue([]);
   providerModelPickerContributionRuntime.enabled = false;
   resolveOwningPluginIdsForProvider.mockImplementation(({ provider }: { provider: string }) => {
     if (provider === "byteplus" || provider === "byteplus-plan") {
@@ -563,6 +569,41 @@ describe("promptModelAllowlist", () => {
       "anthropic/claude-opus-4-6",
     ]);
     expect(result.scopeKeys).toEqual(["anthropic/claude-opus-4-6"]);
+  });
+
+  it("uses static manifest catalog rows for a preferred provider without loading runtime catalog", async () => {
+    loadStaticManifestCatalogRowsForList.mockReturnValue([
+      {
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        ref: "github-copilot/gpt-5.4",
+        mergeKey: "github-copilot:gpt-5.4",
+        source: "manifest",
+        input: ["text"],
+        reasoning: true,
+        status: "available",
+      },
+    ]);
+
+    const multiselect = createSelectAllMultiselect();
+    const prompter = makePrompter({ multiselect });
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
+
+    await promptModelAllowlist({
+      config,
+      prompter,
+      preferredProvider: "github-copilot",
+    });
+
+    expect(loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
+      cfg: config,
+      providerFilter: "github-copilot",
+    });
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(
+      multiselect.mock.calls[0]?.[0]?.options.map((option: { value: string }) => option.value),
+    ).toEqual(["github-copilot/gpt-5.4"]);
   });
 
   it("uses configured provider models without loading the full catalog in replace mode", async () => {

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -2,6 +2,7 @@ import { ensureAuthProfileStore, listProfilesForProvider } from "../agents/auth-
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { hasUsableCustomProviderApiKey, resolveEnvApiKey } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   isModelPickerVisibleModelRef,
   isModelPickerVisibleProvider,
@@ -16,6 +17,7 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../agents/model-selection.js";
+import { loadStaticManifestCatalogRowsForList } from "../commands/models/list.manifest-catalog.js";
 import { formatTokenK } from "../commands/models/shared.js";
 import {
   resolveAgentModelFallbackValues,
@@ -116,11 +118,38 @@ function resolveConfiguredModelKeys(cfg: OpenClawConfig): string[] {
     .filter((key) => key.length > 0);
 }
 
-function loadPickerModelCatalog(cfg: OpenClawConfig): ReturnType<typeof loadModelCatalog> {
+function toPickerCatalogEntry(
+  row: ReturnType<typeof loadStaticManifestCatalogRowsForList>[number],
+): ModelCatalogEntry {
+  return {
+    id: row.id,
+    name: row.name,
+    provider: row.provider,
+    ...(row.contextWindow !== undefined ? { contextWindow: row.contextWindow } : {}),
+    reasoning: row.reasoning,
+    input: row.input,
+  };
+}
+
+function loadPickerModelCatalog(
+  cfg: OpenClawConfig,
+  opts: { preferredProvider?: string } = {},
+): ReturnType<typeof loadModelCatalog> {
   if (cfg.models?.mode === "replace") {
     return Promise.resolve(buildConfiguredModelCatalog({ cfg }));
   }
-  return loadModelCatalog({ config: cfg });
+  if (opts.preferredProvider) {
+    const manifestRows = loadStaticManifestCatalogRowsForList({
+      cfg,
+      providerFilter: opts.preferredProvider,
+    });
+    if (manifestRows.length > 0) {
+      return Promise.resolve(manifestRows.map(toPickerCatalogEntry));
+    }
+  }
+  return loadModelCatalog({
+    config: cfg,
+  });
 }
 
 function normalizeModelKeys(values: string[]): string[] {
@@ -905,7 +934,7 @@ export async function promptModelAllowlist(params: {
   const allowlistProgress = params.prompter.progress("Loading available models");
   let catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
   try {
-    catalog = await loadPickerModelCatalog(cfg);
+    catalog = await loadPickerModelCatalog(cfg, { preferredProvider });
   } finally {
     allowlistProgress.stop();
   }

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -308,7 +308,7 @@ export function describeGithubCopilotProviderAuthContract(load: ProviderAuthCont
       return requireProvider(await registerProviders(githubCopilotPlugin), "github-copilot");
     }
 
-    it("keeps device auth results provider-owned", async () => {
+    it("keeps existing device auth results provider-owned", async () => {
       const provider = await getProvider();
       state.authStore.profiles["github-copilot:github"] = {
         type: "token",
@@ -327,10 +327,7 @@ export function describeGithubCopilotProviderAuthContract(load: ProviderAuthCont
 
       try {
         const result = await provider.auth[0]?.run(buildAuthContext() as never);
-        expect(githubCopilotLoginCommandMock).toHaveBeenCalledWith(
-          { yes: true, profileId: "github-copilot:github" },
-          expect.any(Object),
-        );
+        expect(githubCopilotLoginCommandMock).not.toHaveBeenCalled();
         expect(result).toEqual({
           profiles: [
             {


### PR DESCRIPTION
Summary:
- Reuse existing GitHub Copilot auth profiles during configure instead of forcing a second login.
- Add GitHub Copilot models to the existing manifest `modelCatalog` contract.
- Teach configure/model picker to reuse manifest-owned model catalogs for the selected provider before falling back to runtime catalog loading.

Distill pass:
- Removed the separate auth-choice `modelAllowlist` path from this PR. `modelCatalog` is now the source of truth for whether provider models are listed.
- Reused Shakker's merged manifest contract/planner/listing path instead of adding a separate Copilot runtime discovery implementation.

Validation:
- pnpm build
- pnpm vitest run src/commands/configure.gateway-auth.prompt-auth-config.test.ts src/commands/model-picker.test.ts extensions/github-copilot/models.test.ts extensions/github-copilot/index.test.ts src/commands/models/list.manifest-catalog.test.ts src/model-catalog/manifest-planner.test.ts