### PR TITLE
Update QA lab parity gate for GPT-5.5 vs Opus 4.7

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -535,7 +535,7 @@ jobs:
           case "${QA_PARITY_LANE}" in
             candidate)
               model="${OPENCLAW_CI_OPENAI_MODEL}"
-              alt_model="openai/gpt-5.5-alt"
+              alt_model="${OPENCLAW_CI_OPENAI_MODEL}-alt"
               ;;
             baseline)
               model="anthropic/claude-opus-4-7"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -493,9 +493,9 @@ jobs:
       matrix:
         include:
           - lane: candidate
-            output_dir: gpt54
+            output_dir: openai-candidate
           - lane: baseline
-            output_dir: opus46
+            output_dir: anthropic-baseline
     env:
       QA_PARITY_CONCURRENCY: "1"
       OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "180000"
@@ -535,10 +535,10 @@ jobs:
           case "${QA_PARITY_LANE}" in
             candidate)
               model="${OPENCLAW_CI_OPENAI_MODEL}"
-              alt_model="openai/gpt-5.4-alt"
+              alt_model="openai/gpt-5.5-alt"
               ;;
             baseline)
-              model="anthropic/claude-opus-4-6"
+              model="anthropic/claude-opus-4-7"
               alt_model="anthropic/claude-sonnet-4-6"
               ;;
             *)
@@ -605,10 +605,10 @@ jobs:
         run: |
           pnpm openclaw qa parity-report \
             --repo-root . \
-            --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-            --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+            --candidate-summary .artifacts/qa-e2e/openai-candidate/qa-suite-summary.json \
+            --baseline-summary .artifacts/qa-e2e/anthropic-baseline/qa-suite-summary.json \
             --candidate-label "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --baseline-label anthropic/claude-opus-4-6 \
+            --baseline-label anthropic/claude-opus-4-7 \
             --output-dir .artifacts/qa-e2e/parity
 
       - name: Upload parity artifacts

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -85,7 +85,7 @@ jobs:
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model openai/gpt-5.5-alt \
+            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}-alt" \
             --output-dir .artifacts/qa-e2e/openai-candidate
 
       - name: Run Opus 4.7 lane

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   parity-gate:
-    name: Run the OpenAI / Opus 4.6 parity gate against the qa-lab mock
+    name: Run the OpenAI / Opus 4.7 parity gate against the qa-lab mock
     if: ${{ github.event.pull_request.draft != true }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -85,27 +85,27 @@ jobs:
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model openai/gpt-5.4-alt \
-            --output-dir .artifacts/qa-e2e/gpt54
+            --alt-model openai/gpt-5.5-alt \
+            --output-dir .artifacts/qa-e2e/openai-candidate
 
-      - name: Run Opus 4.6 lane
+      - name: Run Opus 4.7 lane
         run: |
           pnpm openclaw qa suite \
             --provider-mode mock-openai \
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
-            --model anthropic/claude-opus-4-6 \
+            --model anthropic/claude-opus-4-7 \
             --alt-model anthropic/claude-sonnet-4-6 \
-            --output-dir .artifacts/qa-e2e/opus46
+            --output-dir .artifacts/qa-e2e/anthropic-baseline
 
       - name: Generate parity report
         run: |
           pnpm openclaw qa parity-report \
             --repo-root . \
-            --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-            --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+            --candidate-summary .artifacts/qa-e2e/openai-candidate/qa-suite-summary.json \
+            --baseline-summary .artifacts/qa-e2e/anthropic-baseline/qa-suite-summary.json \
             --candidate-label "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --baseline-label anthropic/claude-opus-4-6 \
+            --baseline-label anthropic/claude-opus-4-7 \
             --output-dir .artifacts/qa-e2e/parity
 
       - name: Upload parity artifacts

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -179,7 +179,7 @@ jobs:
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model openai/gpt-5.5-alt \
+            --alt-model "${OPENCLAW_CI_OPENAI_MODEL}-alt" \
             --output-dir .artifacts/qa-e2e/openai-candidate
 
       - name: Run Opus 4.7 lane

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -179,27 +179,27 @@ jobs:
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
             --model "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --alt-model openai/gpt-5.4-alt \
-            --output-dir .artifacts/qa-e2e/gpt54
+            --alt-model openai/gpt-5.5-alt \
+            --output-dir .artifacts/qa-e2e/openai-candidate
 
-      - name: Run Opus 4.6 lane
+      - name: Run Opus 4.7 lane
         run: |
           pnpm openclaw qa suite \
             --provider-mode mock-openai \
             --parity-pack agentic \
             --concurrency "${QA_PARITY_CONCURRENCY}" \
-            --model anthropic/claude-opus-4-6 \
+            --model anthropic/claude-opus-4-7 \
             --alt-model anthropic/claude-sonnet-4-6 \
-            --output-dir .artifacts/qa-e2e/opus46
+            --output-dir .artifacts/qa-e2e/anthropic-baseline
 
       - name: Generate parity report
         run: |
           pnpm openclaw qa parity-report \
             --repo-root . \
-            --candidate-summary .artifacts/qa-e2e/gpt54/qa-suite-summary.json \
-            --baseline-summary .artifacts/qa-e2e/opus46/qa-suite-summary.json \
+            --candidate-summary .artifacts/qa-e2e/openai-candidate/qa-suite-summary.json \
+            --baseline-summary .artifacts/qa-e2e/anthropic-baseline/qa-suite-summary.json \
             --candidate-label "${OPENCLAW_CI_OPENAI_MODEL}" \
-            --baseline-label anthropic/claude-opus-4-6 \
+            --baseline-label anthropic/claude-opus-4-7 \
             --output-dir .artifacts/qa-e2e/parity
 
       - name: Upload parity artifacts

--- a/extensions/qa-lab/src/agentic-parity-report.test.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.test.ts
@@ -75,7 +75,7 @@ describe("qa agentic parity report", () => {
   it("fails the parity gate when the candidate regresses against baseline", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
@@ -103,10 +103,10 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "openai/gpt-5.5 completion rate 80.0% is below anthropic/claude-opus-4-6 100.0%.",
+      "openai/gpt-5.5 completion rate 80.0% is below anthropic/claude-opus-4-7 100.0%.",
     );
     expect(comparison.failures).toContain(
-      "openai/gpt-5.5 unintended-stop rate 20.0% exceeds anthropic/claude-opus-4-6 0.0%.",
+      "openai/gpt-5.5 unintended-stop rate 20.0% exceeds anthropic/claude-opus-4-7 0.0%.",
     );
   });
 
@@ -121,7 +121,7 @@ describe("qa agentic parity report", () => {
     ];
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: baselineScenarios.filter(
           (scenario) => scenario.name !== "Extra non-parity lane",
@@ -133,14 +133,14 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Scenario coverage mismatch for Extra non-parity lane: openai/gpt-5.5=missing, anthropic/claude-opus-4-6=pass.",
+      "Scenario coverage mismatch for Extra non-parity lane: openai/gpt-5.5=missing, anthropic/claude-opus-4-7=pass.",
     );
   });
 
   it("reports each missing required parity scenario exactly once (no double-counting)", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
@@ -182,7 +182,7 @@ describe("qa agentic parity report", () => {
 
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: summaryWithExtras,
       baselineSummary: scopedSummary,
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -204,7 +204,7 @@ describe("qa agentic parity report", () => {
   it("fails the parity gate when required parity scenarios are missing on both sides", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
       },
@@ -216,14 +216,14 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Missing required parity scenario coverage for Image understanding from attachment: openai/gpt-5.5=missing, anthropic/claude-opus-4-6=missing.",
+      "Missing required parity scenario coverage for Image understanding from attachment: openai/gpt-5.5=missing, anthropic/claude-opus-4-7=missing.",
     );
   });
 
   it("fails the parity gate when required parity scenarios are skipped", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: [
           { name: "Approval turn tool followthrough", status: "pass" },
@@ -247,7 +247,7 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Missing required parity scenario coverage for Compaction retry after mutating tool: openai/gpt-5.5=skip, anthropic/claude-opus-4-6=skip.",
+      "Missing required parity scenario coverage for Compaction retry after mutating tool: openai/gpt-5.5=skip, anthropic/claude-opus-4-7=skip.",
     );
   });
 
@@ -264,7 +264,7 @@ describe("qa agentic parity report", () => {
     });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: { scenarios: scenariosWithBothFail },
       baselineSummary: { scenarios: scenariosWithBothFail },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -272,7 +272,7 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.5=fail, anthropic/claude-opus-4-6=fail.",
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.5=fail, anthropic/claude-opus-4-7=fail.",
     );
     // Metric comparisons are relative, so a same-on-both-sides failure
     // must not appear as a relative metric failure. The required-scenario
@@ -290,7 +290,7 @@ describe("qa agentic parity report", () => {
     });
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: { scenarios: candidateWithOneFail },
       baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -298,7 +298,7 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toContain(
-      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.5=fail, anthropic/claude-opus-4-6=pass.",
+      "Required parity scenario Approval turn tool followthrough failed: openai/gpt-5.5=fail, anthropic/claude-opus-4-7=pass.",
     );
   });
 
@@ -307,7 +307,7 @@ describe("qa agentic parity report", () => {
     // below is the isolated gate failure under test (no coverage-gap noise).
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
       },
@@ -321,7 +321,7 @@ describe("qa agentic parity report", () => {
 
     expect(comparison.pass).toBe(false);
     expect(comparison.failures).toEqual([
-      "anthropic/claude-opus-4-6 produced 1 suspicious pass result(s); baseline fake-success count must also be 0.",
+      "anthropic/claude-opus-4-7 produced 1 suspicious pass result(s); baseline fake-success count must also be 0.",
     ]);
   });
 
@@ -491,14 +491,14 @@ status=done`,
     expect(() =>
       buildQaAgenticParityComparison({
         candidateLabel: "openai/gpt-5.5",
-        baselineLabel: "anthropic/claude-opus-4-6",
+        baselineLabel: "anthropic/claude-opus-4-7",
         candidateSummary: {
           scenarios: parityPassScenarios,
-          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-7" },
         },
         baselineSummary: {
           scenarios: parityPassScenarios,
-          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-6" },
+          run: { primaryProvider: "anthropic", primaryModel: "claude-opus-4-7" },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
       }),
@@ -513,7 +513,7 @@ status=done`,
     expect(() =>
       buildQaAgenticParityComparison({
         candidateLabel: "openai/gpt-5.5",
-        baselineLabel: "anthropic/claude-opus-4-6",
+        baselineLabel: "anthropic/claude-opus-4-7",
         candidateSummary: {
           scenarios: parityPassScenarios,
           run: { primaryProvider: "openai" },
@@ -532,7 +532,7 @@ status=done`,
   it("accepts matching run.primaryProvider labels without throwing", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
@@ -545,8 +545,8 @@ status=done`,
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
           primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-6",
-          primaryModelName: "claude-opus-4-6",
+          primaryModel: "anthropic/claude-opus-4-7",
+          primaryModelName: "claude-opus-4-7",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -559,7 +559,7 @@ status=done`,
     // work against those, trusting the caller-supplied label.
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -570,7 +570,7 @@ status=done`,
   it("skips provider verification for arbitrary display labels when run metadata is present", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "GPT-5.5 candidate",
-      baselineLabel: "Opus 4.6 baseline",
+      baselineLabel: "Opus 4.7 baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
@@ -583,8 +583,8 @@ status=done`,
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
           primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-6",
-          primaryModelName: "claude-opus-4-6",
+          primaryModel: "anthropic/claude-opus-4-7",
+          primaryModelName: "claude-opus-4-7",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -596,7 +596,7 @@ status=done`,
   it("skips provider verification for mixed-case or decorated display labels", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "Candidate: GPT-5.5",
-      baselineLabel: "Opus 4.6 / baseline",
+      baselineLabel: "Opus 4.7 / baseline",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
@@ -609,8 +609,8 @@ status=done`,
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
           primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-6",
-          primaryModelName: "claude-opus-4-6",
+          primaryModel: "anthropic/claude-opus-4-7",
+          primaryModelName: "claude-opus-4-7",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -623,7 +623,7 @@ status=done`,
     expect(() =>
       buildQaAgenticParityComparison({
         candidateLabel: "openai/gpt-5.5",
-        baselineLabel: "anthropic/claude-opus-4-6",
+        baselineLabel: "anthropic/claude-opus-4-7",
         candidateSummary: {
           scenarios: FULL_PARITY_PASS_SCENARIOS,
           run: {
@@ -636,8 +636,8 @@ status=done`,
           scenarios: FULL_PARITY_PASS_SCENARIOS,
           run: {
             primaryProvider: "anthropic",
-            primaryModel: "anthropic/claude-opus-4-6",
-            primaryModelName: "claude-opus-4-6",
+            primaryModel: "anthropic/claude-opus-4-7",
+            primaryModelName: "claude-opus-4-7",
           },
         },
         comparedAt: "2026-04-11T00:00:00.000Z",
@@ -650,7 +650,7 @@ status=done`,
   it("accepts colon-delimited structured labels when provider and model both match", () => {
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai:gpt-5.5",
-      baselineLabel: "anthropic:claude-opus-4-6",
+      baselineLabel: "anthropic:claude-opus-4-7",
       candidateSummary: {
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
@@ -663,8 +663,8 @@ status=done`,
         scenarios: FULL_PARITY_PASS_SCENARIOS,
         run: {
           primaryProvider: "anthropic",
-          primaryModel: "anthropic/claude-opus-4-6",
-          primaryModelName: "claude-opus-4-6",
+          primaryModel: "anthropic/claude-opus-4-7",
+          primaryModelName: "claude-opus-4-7",
         },
       },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -679,7 +679,7 @@ status=done`,
     // added by the second-wave expansion.
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5",
-      baselineLabel: "anthropic/claude-opus-4-6",
+      baselineLabel: "anthropic/claude-opus-4-7",
       candidateSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       baselineSummary: { scenarios: FULL_PARITY_PASS_SCENARIOS },
       comparedAt: "2026-04-11T00:00:00.000Z",
@@ -688,7 +688,7 @@ status=done`,
     const report = renderQaAgenticParityMarkdownReport(comparison);
 
     expect(report).toContain(
-      "# OpenClaw Agentic Parity Report — openai/gpt-5.5 vs anthropic/claude-opus-4-6",
+      "# OpenClaw Agentic Parity Report — openai/gpt-5.5 vs anthropic/claude-opus-4-7",
     );
     expect(report).toContain("| Completion rate | 100.0% | 100.0% |");
     expect(report).toContain("### Approval turn tool followthrough");
@@ -699,7 +699,7 @@ status=done`,
     // Regression for the loop-7 Copilot finding: callers that configure
     // non-gpt-5.5 / non-opus labels (for example an internal candidate vs
     // another candidate) must see the labels in the rendered H1 instead of
-    // the hardcoded "GPT-5.5 / Opus 4.6" title that would otherwise confuse
+    // the hardcoded "GPT-5.5 / Opus 4.7" title that would otherwise confuse
     // readers of saved reports.
     const comparison = buildQaAgenticParityComparison({
       candidateLabel: "openai/gpt-5.5-alt",

--- a/extensions/qa-lab/src/agentic-parity-report.ts
+++ b/extensions/qa-lab/src/agentic-parity-report.ts
@@ -488,7 +488,7 @@ export function renderQaAgenticParityMarkdownReport(comparison: QaAgenticParityC
   // Title is parametrized from the candidate / baseline labels so reports
   // for any candidate/baseline pair (not only gpt-5.5 vs opus 4.6) render
   // with an accurate header. The default CLI labels are still
-  // openai/gpt-5.5 vs anthropic/claude-opus-4-6, but the helper works for
+  // openai/gpt-5.5 vs anthropic/claude-opus-4-7, but the helper works for
   // any parity comparison a caller configures.
   const lines = [
     `# OpenClaw Agentic Parity Report — ${comparison.candidateLabel} vs ${comparison.baselineLabel}`,

--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -206,7 +206,7 @@ describe("runQaCharacterEval", () => {
       { model: "openai/gpt-5.5", rank: 1, score: 8, summary: "ok" },
       { model: "openai/gpt-5.2", rank: 2, score: 7.5, summary: "ok" },
       { model: "openai/gpt-5", rank: 3, score: 7.2, summary: "ok" },
-      { model: "anthropic/claude-opus-4-6", rank: 4, score: 7, summary: "ok" },
+      { model: "anthropic/claude-opus-4-7", rank: 4, score: 7, summary: "ok" },
       { model: "anthropic/claude-sonnet-4-6", rank: 5, score: 6.8, summary: "ok" },
       { model: "zai/glm-5.1", rank: 6, score: 6.3, summary: "ok" },
       { model: "moonshot/kimi-k2.5", rank: 7, score: 6.2, summary: "ok" },
@@ -226,7 +226,7 @@ describe("runQaCharacterEval", () => {
       "openai/gpt-5.5",
       "openai/gpt-5.2",
       "openai/gpt-5",
-      "anthropic/claude-opus-4-6",
+      "anthropic/claude-opus-4-7",
       "anthropic/claude-sonnet-4-6",
       "zai/glm-5.1",
       "moonshot/kimi-k2.5",
@@ -255,7 +255,7 @@ describe("runQaCharacterEval", () => {
     expect(runJudge).toHaveBeenCalledTimes(2);
     expect(runJudge.mock.calls.map(([params]) => params.judgeModel)).toEqual([
       "openai/gpt-5.5",
-      "anthropic/claude-opus-4-6",
+      "anthropic/claude-opus-4-7",
     ]);
     expect(runJudge.mock.calls.map(([params]) => params.judgeThinkingDefault)).toEqual([
       "xhigh",
@@ -519,11 +519,11 @@ describe("runQaCharacterEval", () => {
       candidateModelOptions: {
         "openai/gpt-5.5": { thinkingDefault: "xhigh", fastMode: false },
       },
-      judgeModels: ["openai/gpt-5.5", "anthropic/claude-opus-4-6"],
+      judgeModels: ["openai/gpt-5.5", "anthropic/claude-opus-4-7"],
       judgeThinkingDefault: "medium",
       judgeModelOptions: {
         "openai/gpt-5.5": { thinkingDefault: "xhigh", fastMode: true },
-        "anthropic/claude-opus-4-6": { thinkingDefault: "high" },
+        "anthropic/claude-opus-4-7": { thinkingDefault: "high" },
       },
       runSuite,
       runJudge,

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -552,7 +552,7 @@ describe("qa cli runtime", () => {
       repoRoot: "/tmp/openclaw-repo",
       providerMode: "mock-openai",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-opus-4-7",
       preflight: true,
     });
 
@@ -564,7 +564,7 @@ describe("qa cli runtime", () => {
       transportId: "qa-channel",
       providerMode: "mock-openai",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-opus-4-7",
       scenarioIds: ["approval-turn-tool-followthrough"],
       concurrency: 1,
     });
@@ -758,7 +758,7 @@ describe("qa cli runtime", () => {
       fast: true,
       thinking: "medium",
       modelThinking: ["codex-cli/test-model=medium"],
-      judgeModel: ["openai/gpt-5.5,thinking=xhigh,fast", "anthropic/claude-opus-4-6,thinking=high"],
+      judgeModel: ["openai/gpt-5.5,thinking=xhigh,fast", "anthropic/claude-opus-4-7,thinking=high"],
       judgeTimeoutMs: 180_000,
       blindJudgeModels: true,
       concurrency: 4,
@@ -777,10 +777,10 @@ describe("qa cli runtime", () => {
         "openai/gpt-5.5": { thinkingDefault: "xhigh", fastMode: false },
         "codex-cli/test-model": { thinkingDefault: "high", fastMode: true },
       },
-      judgeModels: ["openai/gpt-5.5", "anthropic/claude-opus-4-6"],
+      judgeModels: ["openai/gpt-5.5", "anthropic/claude-opus-4-7"],
       judgeModelOptions: {
         "openai/gpt-5.5": { thinkingDefault: "xhigh", fastMode: true },
-        "anthropic/claude-opus-4-6": { thinkingDefault: "high" },
+        "anthropic/claude-opus-4-7": { thinkingDefault: "high" },
       },
       judgeTimeoutMs: 180_000,
       judgeBlindModels: true,
@@ -1095,7 +1095,7 @@ describe("qa cli runtime", () => {
       providerMode: "mock-openai",
       parityPack: "agentic",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-opus-4-7",
     });
 
     expect(runQaSuiteFromRuntime).toHaveBeenCalledWith({
@@ -1104,7 +1104,7 @@ describe("qa cli runtime", () => {
       transportId: "qa-channel",
       providerMode: "mock-openai",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-opus-4-7",
       fastMode: undefined,
       scenarioIds: [
         "approval-turn-tool-followthrough",

--- a/extensions/qa-lab/src/live-timeout.test.ts
+++ b/extensions/qa-lab/src/live-timeout.test.ts
@@ -8,7 +8,7 @@ describe("qa live timeout policy", () => {
         {
           providerMode: "mock-openai",
           primaryModel: "anthropic/claude-sonnet-4-6",
-          alternateModel: "anthropic/claude-opus-4-6",
+          alternateModel: "anthropic/claude-opus-4-7",
         },
         30_000,
       ),
@@ -47,7 +47,7 @@ describe("qa live timeout policy", () => {
         {
           providerMode: "live-frontier",
           primaryModel: "anthropic/claude-sonnet-4-6",
-          alternateModel: "anthropic/claude-opus-4-6",
+          alternateModel: "anthropic/claude-opus-4-7",
         },
         30_000,
       ),
@@ -60,10 +60,10 @@ describe("qa live timeout policy", () => {
         {
           providerMode: "live-frontier",
           primaryModel: "anthropic/claude-sonnet-4-6",
-          alternateModel: "anthropic/claude-opus-4-6",
+          alternateModel: "anthropic/claude-opus-4-7",
         },
         30_000,
-        "anthropic/claude-opus-4-6",
+        "anthropic/claude-opus-4-7",
       ),
     ).toBe(240_000);
   });

--- a/extensions/qa-lab/src/providers/live-frontier/character-eval.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/character-eval.ts
@@ -9,7 +9,7 @@ export const QA_FRONTIER_CHARACTER_EVAL_MODELS = Object.freeze([
   "openai/gpt-5.5",
   "openai/gpt-5.2",
   "openai/gpt-5",
-  "anthropic/claude-opus-4-6",
+  "anthropic/claude-opus-4-7",
   "anthropic/claude-sonnet-4-6",
   "zai/glm-5.1",
   "moonshot/kimi-k2.5",
@@ -25,12 +25,12 @@ export const QA_FRONTIER_CHARACTER_THINKING_BY_MODEL: Readonly<Record<string, Qa
 
 export const QA_FRONTIER_CHARACTER_JUDGE_MODELS = Object.freeze([
   "openai/gpt-5.5",
-  "anthropic/claude-opus-4-6",
+  "anthropic/claude-opus-4-7",
 ]);
 
 export const QA_FRONTIER_CHARACTER_JUDGE_MODEL_OPTIONS: Readonly<
   Record<string, QaFrontierCharacterModelOptions>
 > = Object.freeze({
   "openai/gpt-5.5": { thinkingDefault: "xhigh", fastMode: true },
-  "anthropic/claude-opus-4-6": { thinkingDefault: "high" },
+  "anthropic/claude-opus-4-7": { thinkingDefault: "high" },
 });

--- a/extensions/qa-lab/src/providers/live-frontier/parity.ts
+++ b/extensions/qa-lab/src/providers/live-frontier/parity.ts
@@ -1,2 +1,2 @@
 export const QA_FRONTIER_PARITY_CANDIDATE_LABEL = "openai/gpt-5.5";
-export const QA_FRONTIER_PARITY_BASELINE_LABEL = "anthropic/claude-opus-4-6";
+export const QA_FRONTIER_PARITY_BASELINE_LABEL = "anthropic/claude-opus-4-7";

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -2210,7 +2210,7 @@ describe("qa mock openai server", () => {
     });
   });
 
-  it("advertises Anthropic claude-opus-4-6 baseline model on /v1/models", async () => {
+  it("advertises Anthropic claude-opus-4-7 baseline model on /v1/models", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
       port: 0,
@@ -2223,7 +2223,7 @@ describe("qa mock openai server", () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as { data: Array<{ id: string }> };
     const ids = body.data.map((entry) => entry.id);
-    expect(ids).toContain("claude-opus-4-6");
+    expect(ids).toContain("claude-opus-4-7");
     expect(ids).toContain("gpt-5.5");
   });
 
@@ -2240,7 +2240,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         messages: [
           {
@@ -2265,7 +2265,7 @@ describe("qa mock openai server", () => {
     };
     expect(body.type).toBe("message");
     expect(body.role).toBe("assistant");
-    expect(body.model).toBe("claude-opus-4-6");
+    expect(body.model).toBe("claude-opus-4-7");
     expect(body.stop_reason).toBe("tool_use");
     const toolUseBlock = body.content.find((block) => block.type === "tool_use") as
       | { name: string; input: Record<string, unknown> }
@@ -2276,7 +2276,7 @@ describe("qa mock openai server", () => {
     const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
     expect(debugResponse.status).toBe(200);
     expect(await debugResponse.json()).toMatchObject({
-      model: "claude-opus-4-6",
+      model: "claude-opus-4-7",
       plannedToolName: "read",
     });
   });
@@ -2288,7 +2288,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         tools: [
           {
@@ -2330,7 +2330,7 @@ describe("qa mock openai server", () => {
     const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
     expect(debugResponse.status).toBe(200);
     expect(await debugResponse.json()).toMatchObject({
-      model: "claude-opus-4-6",
+      model: "claude-opus-4-7",
       plannedToolName: "sessions_spawn",
     });
   });
@@ -2355,7 +2355,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         messages: [
           {
@@ -2429,7 +2429,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         messages: [
           {
@@ -2510,7 +2510,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         stream: true,
         messages: [
@@ -2551,7 +2551,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         stream: true,
         messages: [
@@ -2610,7 +2610,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         stream: true,
         system: [
@@ -2653,7 +2653,7 @@ describe("qa mock openai server", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         stream: true,
         system: [
@@ -2698,7 +2698,7 @@ describe("qa mock openai server", () => {
     const response = await fetch(`${server.baseUrl}/v1/messages`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: '{"model":"claude-opus-4-6","messages":[',
+      body: '{"model":"claude-opus-4-7","messages":[',
     });
 
     expect(response.status).toBe(400);
@@ -2711,12 +2711,12 @@ describe("qa mock openai server", () => {
     expect(body.error.message).toContain("Malformed JSON body");
   });
 
-  it("defaults empty-string Anthropic /v1/messages model to claude-opus-4-6", async () => {
+  it("defaults empty-string Anthropic /v1/messages model to claude-opus-4-7", async () => {
     // Regression for the loop-7 Copilot finding: a bare `typeof
     // body.model === "string"` check lets an empty-string model leak
     // through to `lastRequest.model` and `responseBody.model`. Empty
     // strings must be treated the same as absent and default to
-    // `"claude-opus-4-6"` so parity consumers can trust the echoed label.
+    // `"claude-opus-4-7"` so parity consumers can trust the echoed label.
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",
       port: 0,
@@ -2741,12 +2741,12 @@ describe("qa mock openai server", () => {
     });
     expect(response.status).toBe(200);
     const body = (await response.json()) as { model: string };
-    expect(body.model).toBe("claude-opus-4-6");
+    expect(body.model).toBe("claude-opus-4-7");
 
     const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
     expect(debugResponse.status).toBe(200);
     const debug = (await debugResponse.json()) as { model: string };
-    expect(debug.model).toBe("claude-opus-4-6");
+    expect(debug.model).toBe("claude-opus-4-7");
   });
 
   it("scripts a reasoning-only recovery sequence after a replay-safe read", async () => {
@@ -3004,9 +3004,9 @@ describe("resolveProviderVariant", () => {
   });
 
   it("tags prefix-qualified anthropic models", () => {
-    expect(resolveProviderVariant("anthropic/claude-opus-4-6")).toBe("anthropic");
-    expect(resolveProviderVariant("anthropic:claude-opus-4-6")).toBe("anthropic");
-    expect(resolveProviderVariant("claude-cli/claude-opus-4-6")).toBe("anthropic");
+    expect(resolveProviderVariant("anthropic/claude-opus-4-7")).toBe("anthropic");
+    expect(resolveProviderVariant("anthropic:claude-opus-4-7")).toBe("anthropic");
+    expect(resolveProviderVariant("claude-cli/claude-opus-4-7")).toBe("anthropic");
   });
 
   it("tags bare model names by prefix", () => {
@@ -3014,7 +3014,7 @@ describe("resolveProviderVariant", () => {
     expect(resolveProviderVariant("gpt-5.5-alt")).toBe("openai");
     expect(resolveProviderVariant("gpt-4.5")).toBe("openai");
     expect(resolveProviderVariant("o1-preview")).toBe("openai");
-    expect(resolveProviderVariant("claude-opus-4-6")).toBe("anthropic");
+    expect(resolveProviderVariant("claude-opus-4-7")).toBe("anthropic");
     expect(resolveProviderVariant("claude-sonnet-4-6")).toBe("anthropic");
   });
 
@@ -3072,7 +3072,7 @@ describe("qa mock openai server provider variant tagging", () => {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        model: "claude-opus-4-6",
+        model: "claude-opus-4-7",
         max_tokens: 256,
         messages: [{ role: "user", content: "Heartbeat check" }],
       }),
@@ -3082,7 +3082,7 @@ describe("qa mock openai server provider variant tagging", () => {
       model: string;
       providerVariant: string;
     };
-    expect(debug.model).toBe("claude-opus-4-6");
+    expect(debug.model).toBe("claude-opus-4-7");
     expect(debug.providerVariant).toBe("anthropic");
   });
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -78,7 +78,7 @@ export function resolveProviderVariant(model: string | undefined): MockOpenAiPro
     return "anthropic";
   }
   // Fall back to model-name prefix matching for bare model strings like
-  // `gpt-5.5` or `claude-opus-4-6`.
+  // `gpt-5.5` or `claude-opus-4-7`.
   if (/^(?:gpt-|o1-|openai-)/.test(trimmed)) {
     return "openai";
   }
@@ -1652,7 +1652,7 @@ async function buildResponsesPayload(
 //
 // The QA parity gate needs two comparable scenario runs: one against the
 // "candidate" (openai/gpt-5.5) and one against the "baseline"
-// (anthropic/claude-opus-4-6). The OpenAI mock above already dispatches all
+// (anthropic/claude-opus-4-7). The OpenAI mock above already dispatches all
 // the scenario prompt branches we care about. Rather than duplicating that
 // machinery, the /v1/messages route below translates Anthropic request
 // shapes into the shared ResponsesInputItem[] format, calls the same
@@ -1875,7 +1875,7 @@ function buildAnthropicMessageResponse(params: {
     id: `msg_mock_${Math.floor(Math.random() * 1_000_000).toString(16)}`,
     type: "message",
     role: "assistant",
-    model: params.model || "claude-opus-4-6",
+    model: params.model || "claude-opus-4-7",
     content,
     stop_reason: stopReason,
     stop_sequence: null,
@@ -1903,7 +1903,7 @@ function buildAnthropicMessageStreamEvents(params: {
         id: messageId,
         type: "message",
         role: "assistant",
-        model: params.model || "claude-opus-4-6",
+        model: params.model || "claude-opus-4-7",
         content: [],
         stop_reason: null,
         stop_sequence: null,
@@ -2002,7 +2002,7 @@ async function buildMessagesPayload(
   // which then confuses parity consumers that assume the mock always
   // echoes the real provider label. Normalize once and reuse everywhere.
   const normalizedModel =
-    typeof body.model === "string" && body.model.trim() !== "" ? body.model : "claude-opus-4-6";
+    typeof body.model === "string" && body.model.trim() !== "" ? body.model : "claude-opus-4-7";
   // Dispatch through the same scenario logic the /v1/responses route uses.
   // Preserve declared tools so route-specific adapters mirror what the
   // real provider request made available to the model.
@@ -2044,7 +2044,7 @@ export async function startQaMockOpenAiServer(params?: { host?: string; port?: n
           { id: "gpt-5.5-alt", object: "model" },
           { id: "gpt-image-1", object: "model" },
           { id: "text-embedding-3-small", object: "model" },
-          { id: "claude-opus-4-6", object: "model" },
+          { id: "claude-opus-4-7", object: "model" },
           { id: "claude-sonnet-4-6", object: "model" },
         ],
       });

--- a/extensions/qa-lab/src/providers/shared/mock-model-config.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-model-config.ts
@@ -71,8 +71,8 @@ export function createMockAnthropicMessagesProvider(baseUrl: string): ModelProvi
     },
     models: [
       {
-        id: "claude-opus-4-6",
-        name: "claude-opus-4-6",
+        id: "claude-opus-4-7",
+        name: "claude-opus-4-7",
         api: "anthropic-messages",
         reasoning: false,
         input: ["text", "image"],

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -93,7 +93,7 @@ describe("buildQaGatewayConfig", () => {
       workspaceDir: "/tmp/qa-workspace",
       providerMode: "mock-openai",
       primaryModel: "openai/gpt-5.5",
-      alternateModel: "anthropic/claude-opus-4-6",
+      alternateModel: "anthropic/claude-opus-4-7",
     });
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.5");
@@ -104,7 +104,7 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.models?.providers?.anthropic?.baseUrl).toBe("http://127.0.0.1:44080");
     expect(cfg.models?.providers?.anthropic?.request).toEqual({ allowPrivateNetwork: true });
     expect(cfg.models?.providers?.anthropic?.models.map((model) => model.id)).toContain(
-      "claude-opus-4-6",
+      "claude-opus-4-7",
     );
     expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core"]);
   });

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -148,7 +148,7 @@ describe("qa suite planning helpers", () => {
       makeQaSuiteTestScenario("anthropic-only", {
         config: {
           requiredProvider: "anthropic",
-          requiredModel: "claude-opus-4-6",
+          requiredModel: "claude-opus-4-7",
         },
       }),
     ];
@@ -277,7 +277,7 @@ describe("qa suite planning helpers", () => {
         config: { requiredProvider: "openai", requiredModel: "gpt-5.5" },
       }),
       makeQaSuiteTestScenario("anthropic-only", {
-        config: { requiredProvider: "anthropic", requiredModel: "claude-opus-4-6" },
+        config: { requiredProvider: "anthropic", requiredModel: "claude-opus-4-7" },
       }),
       makeQaSuiteTestScenario("claude-subscription", {
         config: { requiredProvider: "claude-cli", authMode: "subscription" },

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -60,13 +60,13 @@ describe("buildQaSuiteSummaryJson", () => {
   it("records an Anthropic baseline lane cleanly for parity runs", () => {
     const json = buildQaSuiteSummaryJson({
       ...baseParams,
-      primaryModel: "anthropic/claude-opus-4-6",
+      primaryModel: "anthropic/claude-opus-4-7",
       alternateModel: "anthropic/claude-sonnet-4-6",
     });
     expect(json.run).toMatchObject({
-      primaryModel: "anthropic/claude-opus-4-6",
+      primaryModel: "anthropic/claude-opus-4-7",
       primaryProvider: "anthropic",
-      primaryModelName: "claude-opus-4-6",
+      primaryModelName: "claude-opus-4-7",
       alternateModel: "anthropic/claude-sonnet-4-6",
       alternateProvider: "anthropic",
       alternateModelName: "claude-sonnet-4-6",

--- a/qa/scenarios/models/anthropic-opus-api-key-smoke.md
+++ b/qa/scenarios/models/anthropic-opus-api-key-smoke.md
@@ -12,7 +12,7 @@ coverage:
 objective: Verify the regular Anthropic Opus lane can complete a quick chat turn using API-key auth.
 successCriteria:
   - A live-frontier run fails fast unless the selected primary provider is anthropic.
-  - The selected primary model is Anthropic Opus 4.6.
+  - The selected primary model is Anthropic Opus 4.7.
   - The QA gateway worker has an Anthropic API key available through environment auth.
   - The agent replies through the regular Anthropic provider.
 docsRefs:
@@ -24,10 +24,10 @@ codeRefs:
   - extensions/qa-lab/src/suite.ts
 execution:
   kind: flow
-  summary: Run with `pnpm openclaw qa suite --provider-mode live-frontier --model anthropic/claude-opus-4-6 --alt-model anthropic/claude-opus-4-6 --scenario anthropic-opus-api-key-smoke`.
+  summary: Run with `pnpm openclaw qa suite --provider-mode live-frontier --model anthropic/claude-opus-4-7 --alt-model anthropic/claude-opus-4-7 --scenario anthropic-opus-api-key-smoke`.
   config:
     requiredProvider: anthropic
-    requiredModel: claude-opus-4-6
+    requiredModel: claude-opus-4-7
     chatPrompt: "Anthropic Opus API key smoke. Reply exactly: ANTHROPIC-OPUS-API-KEY-OK"
     chatExpected: ANTHROPIC-OPUS-API-KEY-OK
 ```

--- a/qa/scenarios/models/anthropic-opus-setup-token-smoke.md
+++ b/qa/scenarios/models/anthropic-opus-setup-token-smoke.md
@@ -12,7 +12,7 @@ coverage:
 objective: Verify the regular Anthropic Opus lane can complete a quick chat turn using setup-token auth.
 successCriteria:
   - A live-frontier run fails fast unless the selected primary provider is anthropic.
-  - The selected primary model is Anthropic Opus 4.6.
+  - The selected primary model is Anthropic Opus 4.7.
   - The QA gateway worker stages a token auth profile in the isolated agent store.
   - The agent replies through the regular Anthropic provider.
 docsRefs:
@@ -24,10 +24,10 @@ codeRefs:
   - extensions/qa-lab/src/suite.ts
 execution:
   kind: flow
-  summary: Run with `OPENCLAW_LIVE_SETUP_TOKEN_VALUE=<setup-token> pnpm openclaw qa suite --provider-mode live-frontier --model anthropic/claude-opus-4-6 --alt-model anthropic/claude-opus-4-6 --scenario anthropic-opus-setup-token-smoke`.
+  summary: Run with `OPENCLAW_LIVE_SETUP_TOKEN_VALUE=<setup-token> pnpm openclaw qa suite --provider-mode live-frontier --model anthropic/claude-opus-4-7 --alt-model anthropic/claude-opus-4-7 --scenario anthropic-opus-setup-token-smoke`.
   config:
     requiredProvider: anthropic
-    requiredModel: claude-opus-4-6
+    requiredModel: claude-opus-4-7
     profileId: "anthropic:qa-setup-token"
     chatPrompt: "Anthropic Opus setup-token smoke. Reply exactly: ANTHROPIC-OPUS-SETUP-TOKEN-OK"
     chatExpected: ANTHROPIC-OPUS-SETUP-TOKEN-OK

--- a/qa/scenarios/runtime/approval-turn-tool-followthrough.md
+++ b/qa/scenarios/runtime/approval-turn-tool-followthrough.md
@@ -54,14 +54,14 @@ steps:
             message:
               expr: config.preActionPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 20000)
+              expr: liveTurnTimeoutMs(env, 60000)
       - call: waitForOutboundMessage
         args:
           - ref: state
           - lambda:
               params: [candidate]
               expr: "candidate.conversation.id === 'qa-operator'"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 60000)
       - set: beforeApprovalCursor
         value:
           expr: state.getSnapshot().messages.length
@@ -72,7 +72,7 @@ steps:
             message:
               expr: config.approvalPrompt
             timeoutMs:
-              expr: liveTurnTimeoutMs(env, 30000)
+              expr: liveTurnTimeoutMs(env, 60000)
       - set: expectedReplyAny
         value:
           expr: config.expectedReplyAny.map(normalizeLowercaseStringOrEmpty)
@@ -81,7 +81,7 @@ steps:
         args:
           - lambda:
               expr: "state.getSnapshot().messages.slice(beforeApprovalCursor).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && expectedReplyAny.some((needle) => normalizeLowercaseStringOrEmpty(candidate.text).includes(needle))).at(-1)"
-          - expr: liveTurnTimeoutMs(env, 20000)
+          - expr: liveTurnTimeoutMs(env, 60000)
           - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
     detailsExpr: outbound.text
 ```

--- a/test/helpers/auto-reply/trigger-handling-test-harness.ts
+++ b/test/helpers/auto-reply/trigger-handling-test-harness.ts
@@ -87,14 +87,14 @@ const modelCatalogMocks = getSharedMocks("openclaw.trigger-handling.model-catalo
   loadModelCatalog: vi.fn().mockResolvedValue([
     {
       provider: "anthropic",
-      id: "claude-opus-4-6",
-      name: "Claude Opus 4.5",
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
       contextWindow: 200000,
     },
     {
       provider: "openrouter",
-      id: "anthropic/claude-opus-4-6",
-      name: "Claude Opus 4.5 (OpenRouter)",
+      id: "anthropic/claude-opus-4-7",
+      name: "Claude Opus 4.7 (OpenRouter)",
       contextWindow: 200000,
     },
     { provider: "openai", id: "gpt-4.1-mini", name: "GPT-4.1 mini" },
@@ -276,7 +276,7 @@ export function makeCfg(home: string): OpenClawConfig {
   return withFastReplyConfig({
     agents: {
       defaults: {
-        model: { primary: "anthropic/claude-opus-4-6" },
+        model: { primary: "anthropic/claude-opus-4-7" },
         workspace: join(home, "openclaw"),
         // Test harness: avoid 1s coalescer idle sleeps that dominate trigger suites.
         blockStreamingCoalesce: { idleMs: 1 },


### PR DESCRIPTION
## Summary

Filed by `100yenadmin`.

This updates the QA lab parity gates from the mixed GPT-5.4 / Opus 4.6 era naming to the current target comparison:

```text
openai/gpt-5.5 candidate vs anthropic/claude-opus-4-7 baseline
```

The PR also hardens the mock preflight sentinel that was timing out on cold startup by giving the full `approval-turn-tool-followthrough` turn chain a 60s fallback budget: both agent calls and the paired outbound/wait conditions now align.

Fixes #74262.

## What Changed

- Updated parity workflow surfaces in `parity-gate`, release checks, and the Convex live-transport QA gate:
  - candidate alt: `openai/gpt-5.5-alt`
  - baseline: `anthropic/claude-opus-4-7`
  - stable artifact dirs: `openai-candidate` and `anthropic-baseline`
- Updated QA-lab parity/report labels, character eval defaults, summary/report tests, live-timeout tests, and CLI runtime tests for Opus 4.7.
- Updated the mock Anthropic provider default/model catalog and mock server tests to use `claude-opus-4-7` as the active baseline model.
- Updated Anthropic Opus smoke scenario metadata and the trigger-handling helper catalog/defaults to Opus 4.7.
- Increased the `approval-turn-tool-followthrough` run-agent and follow-up wait timeouts to 60s so `--preflight` can survive a cold mock gateway path.

## Validation

- `rg "gpt54|gpt-5\\.4-alt|opus46|opus-4-6|Opus 4\\.6|GPT-5\\.4" .github/workflows extensions/qa-lab qa/scenarios test/helpers/auto-reply` returned no matches on final head.
- `git diff --check`
- `pnpm exec vitest run --config test/vitest/vitest.extension-qa.config.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-lab/src/qa-gateway-config.test.ts extensions/qa-lab/src/suite-planning.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/agentic-parity-report.test.ts extensions/qa-lab/src/character-eval.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/live-timeout.test.ts`
  - 8 files, 189 tests passed on final head
- `pnpm exec vitest run --config test/vitest/vitest.extension-qa.config.ts`
  - 63 files, 527 tests passed before the final main-only rebase; that rebase was conflict-free across QA files
- `OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 pnpm build`
  - passed before the final main-only rebase
- Isolated mock preflight:

```bash
env \
  HOME=/tmp/openclaw-qa-preflight-home \
  OPENCLAW_HOME=/tmp/openclaw-qa-preflight-home \
  OPENCLAW_STATE_DIR=/tmp/openclaw-qa-preflight-state \
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-qa-preflight-home/openclaw.json \
  OPENCLAW_BUILD_PRIVATE_QA=1 \
  OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 \
  OPENCLAW_QA_SUITE_PROGRESS=1 \
  OPENAI_API_KEY= \
  ANTHROPIC_API_KEY= \
  OPENCLAW_LIVE_OPENAI_KEY= \
  OPENCLAW_LIVE_ANTHROPIC_KEY= \
  pnpm openclaw qa suite \
    --provider-mode mock-openai \
    --parity-pack agentic \
    --concurrency 1 \
    --model openai/gpt-5.5 \
    --alt-model openai/gpt-5.5-alt \
    --preflight
```

Result before the final main-only rebase: `approval-turn-tool-followthrough` passed 1/1; the final rebase was conflict-free across QA files.

- `pnpm exec vitest run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts`
  - 1 file, 20 tests passed before the final rebase; the rebase did not touch `src/auto-reply` or the trigger helper conflict-free change.

