### PR TITLE
test(plugins): cover dead-PID stale runtime-deps lock removal

### DIFF
--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -2104,6 +2104,28 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     ).toBe(false);
   });
 
+  it("expires runtime-deps install locks whose owner PID is dead", () => {
+    expect(
+      bundledRuntimeDepsTesting.shouldRemoveRuntimeDepsLock(
+        // Conventional non-existent PID for dead-process simulation
+        { pid: 99999, createdAtMs: 0 },
+        1_000,
+        () => false,
+      ),
+    ).toBe(true);
+  });
+
+  it("expires runtime-deps install locks whose owner PID is dead regardless of age", () => {
+    expect(
+      bundledRuntimeDepsTesting.shouldRemoveRuntimeDepsLock(
+        // Conventional non-existent PID for dead-process simulation
+        { pid: 99999, createdAtMs: Date.now() },
+        Date.now(),
+        () => false,
+      ),
+    ).toBe(true);
+  });
+
   it("does not expire fresh ownerless runtime-deps install locks", () => {
     expect(
       bundledRuntimeDepsTesting.shouldRemoveRuntimeDepsLock(


### PR DESCRIPTION
## Summary

- Problem: `shouldRemoveRuntimeDepsLock` returns `true` for owner-with-PID locks when `isAlive(pid) === false`, recovering SIGKILL/OOM-killed install locks. The path was added in 830bd2e236 but lacked direct unit-test coverage — every existing `isAlive` injection in this suite passes `() => true`.
- Why it matters: a silent regression in this branch would re-introduce stale lock-timeout stalls on next gateway start after an abnormal shutdown, with no test catching it.
- What changed: two unit tests in `src/plugins/bundled-runtime-deps.test.ts` that inject `isAlive: () => false` and assert removal, including one case where `createdAtMs` is fresh (to lock in that the dead-PID branch short-circuits the age check).
- What did NOT change (scope boundary): no production code changes, no new helpers, no fixture-builder additions; only two `it(...)` blocks added next to existing alive-PID coverage.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra — test coverage backfill only

## Scope (select all touched areas)

- [x] CI/CD / infra — test surface only (no behavior change)

## Linked Issue/PR

- Related #73874 (operator-visible regression whose recovery path leans on this branch)
- Related commit 830bd2e236 `fix: recover stale runtime deps locks`
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — test coverage backfill, not a fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugins/bundled-runtime-deps.test.ts`
- Scenario the test should lock in: when `owner.pid` is set but the process is no longer alive, `shouldRemoveRuntimeDepsLock` returns `true` regardless of `createdAtMs`, so the recovery path runs without waiting on the stale-lock age window.
- Why this is the smallest reliable guardrail: `shouldRemoveRuntimeDepsLock` is a pure function with explicit `isAlive` injection. Calling it directly with `isAlive: () => false` is the smallest way to assert the dead-PID branch behavior; nothing else (filesystem, child processes, signals) is needed.
- Existing test that already covers this (if any): existing alive-PID test (`does not expire active runtime-deps install locks by age alone`) covers the negative case but not the positive dead-PID path.

## User-visible / Behavior Changes

None. Test-only.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.8 (Ubuntu 22.04, Node v22.x, pnpm 10.x)
- Runtime/container: Node, pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm test src/plugins/bundled-runtime-deps.test.ts`

### Expected

- 90 tests pass, including the two new dead-PID cases.

### Actual

- 90 tests pass.

## Evidence

- [ ] Failing test/log before + passing after — N/A; this is a coverage backfill for existing behavior added in 830bd2e236.
- [x] Passing targeted test output — see below.

```
Test Files  1 passed (1)
Tests  90 passed (90)
```

Locally also verified via `pnpm format:check` (clean) and `pnpm check:changed` (typecheck pass, lint 0/0, import cycles 0).

## Human Verification (required)

- Verified scenarios: dead-PID with stale `createdAtMs`; dead-PID with fresh `createdAtMs` (asserts the PID branch short-circuits the age check).
- Edge cases checked: existing alive-PID tests still pass (no regression in the negative case).
- What I did not verify: integration-level path through `removeRuntimeDepsLockIfStale` and `ensureBundledPluginRuntimeDeps`. Out of scope for this test-only PR; the existing suite already exercises the wiring at the integration seam.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: the assertion uses the existing `bundledRuntimeDepsTesting.shouldRemoveRuntimeDepsLock` injection seam; if that seam changes shape, this test would need a small follow-up.
  - Mitigation: kept exactly aligned with the existing alive-PID test directly above it, so the maintenance burden is identical.
