### PR TITLE
fix(whatsapp): use sender lid for ack reactions

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
@@ -140,6 +140,38 @@ describe("maybeSendAckReaction", () => {
     );
   });
 
+  it("uses the sender LID as group ack reaction participant when JID is unavailable", async () => {
+    const ackReaction = await runAckReaction({
+      msg: createMessage({
+        chatType: "group",
+        chatId: "12345@g.us",
+        conversationId: "12345@g.us",
+        from: "12345@g.us",
+        wasMentioned: true,
+        sender: {
+          lid: "abc123@lid",
+          name: "Alice",
+        },
+      }),
+      sessionKey: "whatsapp:default:12345@g.us",
+      conversationId: "12345@g.us",
+    });
+
+    expect(ackReaction?.ackReactionValue).toBe("👀");
+    await expect(ackReaction?.ackReactionPromise).resolves.toBe(true);
+    expect(hoisted.sendReactionWhatsApp).toHaveBeenCalledWith(
+      "12345@g.us",
+      "msg-1",
+      "👀",
+      expect.objectContaining({
+        verbose: false,
+        fromMe: false,
+        participant: "abc123@lid",
+        accountId: "default",
+      }),
+    );
+  });
+
   it("records ack send failures on the handle", async () => {
     const warn = vi.fn();
     hoisted.sendReactionWhatsApp.mockRejectedValueOnce(new Error("session down"));

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
@@ -172,6 +172,39 @@ describe("maybeSendAckReaction", () => {
     );
   });
 
+  it("prefers the sender JID over LID for group ack reaction participants", async () => {
+    const ackReaction = await runAckReaction({
+      msg: createMessage({
+        chatType: "group",
+        chatId: "12345@g.us",
+        conversationId: "12345@g.us",
+        from: "12345@g.us",
+        wasMentioned: true,
+        sender: {
+          jid: "15551234567@s.whatsapp.net",
+          lid: "abc123@lid",
+          name: "Alice",
+        },
+      }),
+      sessionKey: "whatsapp:default:12345@g.us",
+      conversationId: "12345@g.us",
+    });
+
+    expect(ackReaction?.ackReactionValue).toBe("👀");
+    await expect(ackReaction?.ackReactionPromise).resolves.toBe(true);
+    expect(hoisted.sendReactionWhatsApp).toHaveBeenCalledWith(
+      "12345@g.us",
+      "msg-1",
+      "👀",
+      expect.objectContaining({
+        verbose: false,
+        fromMe: false,
+        participant: "15551234567@s.whatsapp.net",
+        accountId: "default",
+      }),
+    );
+  });
+
   it("records ack send failures on the handle", async () => {
     const warn = vi.fn();
     hoisted.sendReactionWhatsApp.mockRejectedValueOnce(new Error("session down"));

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
@@ -73,10 +73,11 @@ export async function maybeSendAckReaction(params: {
     "sending ack reaction",
   );
   const sender = getSenderIdentity(params.msg);
+  const participant = sender.jid ?? sender.lid;
   const reactionOptions = {
     verbose: params.verbose,
     fromMe: false,
-    ...(sender.jid ? { participant: sender.jid } : {}),
+    ...(participant ? { participant } : {}),
     ...(params.accountId ? { accountId: params.accountId } : {}),
     cfg: params.cfg,
   };


### PR DESCRIPTION
## Summary

- Problem: WhatsApp automatic ack reactions in groups only passed `sender.jid` as the Baileys reaction participant.
- Why it matters: Modern WhatsApp group events can identify the sender only by LID (`@lid`), and Baileys needs the real participant key for group reactions to render.
- What changed: The ack reaction path now uses `sender.jid ?? sender.lid` when building reaction options.
- What did NOT change (scope boundary): User-triggered WhatsApp reactions, direct messages, reaction emoji selection, and ack gating policy are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The ack reaction monitor assumed group senders always have a classic WhatsApp JID.
- Missing detection / guardrail: There was no unit coverage for LID-only group senders in automatic ack reactions.
- Contributing context (if known): Other WhatsApp reaction paths already support LID participants, but this monitor path built its own reaction options.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts`
- Scenario the test should lock in: A group message with only `sender.lid` sends the ack reaction with that LID as `participant`.
- Why this is the smallest reliable guardrail: The bug is in option construction before calling the WhatsApp send layer.
- Existing test that already covers this (if any): None for this ack monitor path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

WhatsApp group ack reactions should now appear for LID-only sender events instead of silently no-oping at the Baileys reaction layer.

## Diagram (if applicable)

```text
Before:
[group message with sender.lid only] -> [ack reaction options without participant] -> [reaction may not render]

After:
[group message with sender.lid only] -> [participant = sender.lid] -> [reaction key matches sender]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local workspace
- Runtime/container: Node/pnpm test runner
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): default ack reaction config with group mentions enabled

### Steps

1. Process a WhatsApp group inbound message with `sender.lid` set and no `sender.jid`.
2. Let `maybeSendAckReaction` build reaction options.
3. Observe the `sendReactionWhatsApp` call.

### Expected

- The reaction options include `participant: <sender lid>`.

### Actual

- Before this patch, the participant was omitted when `sender.jid` was unavailable.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: LID-only WhatsApp group ack reaction participant via unit test.
- Edge cases checked: Existing direct ack behavior, reaction removal handle, failure recording through the same test file.
- What you did **not** verify: Live WhatsApp/Baileys group delivery against a real account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some rare sender shape could contain both JID and LID where JID remains the preferred Baileys participant.
  - Mitigation: The fallback preserves current JID-first behavior and only uses LID when JID is absent.
