### PR TITLE
fix: catch croner errors in cron gateway handlers and fix false-positive allowlist error

### DIFF
--- a/src/agents/tool-allowlist-guard.test.ts
+++ b/src/agents/tool-allowlist-guard.test.ts
@@ -50,6 +50,18 @@ describe("tool allowlist guard", () => {
     ).toBeNull();
   });
 
+  it("allows disableTools without runtime toolsAllow (intentional no-tools run)", () => {
+    // When disableTools is true and no runtime toolsAllow is passed, the empty
+    // tool set is intentional — even if config-level allowlists exist.
+    const error = buildEmptyExplicitToolAllowlistError({
+      sources: [{ label: "tools.allow", entries: ["read", "write"] }],
+      callableToolNames: [],
+      toolsEnabled: true,
+      disableTools: true,
+    });
+    expect(error).toBeNull();
+  });
+
   it("allows explicit allowlists when at least one callable tool remains", () => {
     expect(
       buildEmptyExplicitToolAllowlistError({

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -21,6 +21,16 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   disableTools?: boolean;
 }): Error | null {
   const callableToolNames = params.callableToolNames.map(normalizeToolName).filter(Boolean);
+  // When the caller explicitly disabled tools and no runtime toolsAllow was passed,
+  // an empty tool set is intentional — not a misconfiguration.
+  if (params.disableTools === true && callableToolNames.length === 0) {
+    const hasRuntimeToolsAllow = params.sources.some(
+      (s) => s.label === "runtime toolsAllow" && s.entries.length > 0,
+    );
+    if (!hasRuntimeToolsAllow) {
+      return null;
+    }
+  }
   if (params.sources.length === 0 || callableToolNames.length > 0) {
     return null;
   }

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -437,6 +437,29 @@ describe("capability cli", () => {
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
   });
 
+  it("rejects empty or whitespace-only --prompt before dispatching to provider", async () => {
+    for (const argv of [
+      ["capability", "model", "run", "--prompt", "", "--json"],
+      ["capability", "model", "run", "--prompt", "   ", "--json"],
+      ["capability", "model", "run", "--prompt", "\n", "--json"],
+    ]) {
+      await expect(
+        runRegisteredCli({
+          register: registerCapabilityCli as (program: Command) => void,
+          argv,
+        }),
+      ).rejects.toThrow("exit 1");
+
+      expect(mocks.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("--prompt cannot be empty or whitespace-only"),
+      );
+      // Provider seams must never be called for empty prompts
+      expect(mocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(mocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+    }
+  });
+
   it("runs gateway model probes without chat-agent prompt policy or tools", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1487,6 +1487,10 @@ export function registerCapabilityCli(program: Command) {
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const promptText = String(opts.prompt);
+        if (promptText.trim().length === 0) {
+          throw new Error("--prompt cannot be empty or whitespace-only");
+        }
         const transport = resolveTransport({
           local: Boolean(opts.local),
           gateway: Boolean(opts.gateway),
@@ -1494,7 +1498,7 @@ export function registerCapabilityCli(program: Command) {
           defaultTransport: "local",
         });
         const result = await runModelRun({
-          prompt: String(opts.prompt),
+          prompt: promptText,
           model: opts.model as string | undefined,
           transport,
         });

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -154,15 +154,28 @@ export const cronHandlers: GatewayRequestHandlers = {
       sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
       sortDir?: "asc" | "desc";
     };
-    const page = await context.cron.listPage({
-      includeDisabled: p.includeDisabled,
-      limit: p.limit,
-      offset: p.offset,
-      query: p.query,
-      enabled: p.enabled,
-      sortBy: p.sortBy,
-      sortDir: p.sortDir,
-    });
+    let page;
+    try {
+      page = await context.cron.listPage({
+        includeDisabled: p.includeDisabled,
+        limit: p.limit,
+        offset: p.offset,
+        query: p.query,
+        enabled: p.enabled,
+        sortBy: p.sortBy,
+        sortDir: p.sortDir,
+      });
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.list params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return;
+    }
     const deliveryPreviews = await resolveCronDeliveryPreviews({
       cfg: context.getRuntimeConfig(),
       defaultAgentId: context.cron.getDefaultAgentId(),
@@ -182,7 +195,17 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const status = await context.cron.status();
+    let status;
+    try {
+      status = await context.cron.status();
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `cron.status failed: ${formatErrorMessage(err)}`),
+      );
+      return;
+    }
     respond(true, status, undefined);
   },
   "cron.add": async ({ params, respond, context }) => {
@@ -242,7 +265,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.add(jobCreate);
+    let job;
+    try {
+      job = await context.cron.add(jobCreate);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.add params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return;
+    }
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);
   },
@@ -321,7 +357,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const job = await context.cron.update(jobId, patch);
+    let job;
+    try {
+      job = await context.cron.update(jobId, patch);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.update params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return;
+    }
     context.logGateway.info("cron: job updated", { jobId });
     respond(true, job, undefined);
   },
@@ -347,7 +396,20 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const result = await context.cron.remove(jobId);
+    let result;
+    try {
+      result = await context.cron.remove(jobId);
+    } catch (err) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid cron.remove params: ${formatErrorMessage(err)}`,
+        ),
+      );
+      return;
+    }
     if (result.removed) {
       context.logGateway.info("cron: job removed", { jobId });
     }


### PR DESCRIPTION
## Problem

### #74066 — Invalid cron expressions return `UNAVAILABLE` instead of `INVALID_REQUEST`
When a user passes an invalid `--cron` expression (e.g. `"not-a-cron-expr"` or `"99 * * * *"`), the croner library throws a raw `TypeError` (bad shape) or `RangeError` (out-of-range field) from inside `context.cron.add(...)` / `context.cron.update(...)`. The throw escapes the handler, is caught by the WS dispatcher's catch-all, and mapped to `ErrorCodes.UNAVAILABLE` — a false-positive ERROR-level log that looks like a real gateway crash.

The same gap exists in `cron.remove`, `cron.list`, and `cron.status`.

### #74019 — Lobster `llm-task` fails with "No callable tools remain"
When `tools.alsoAllow` is configured (e.g. `["lobster", "llm-task"]`) but the caller sets `disableTools: true` (as the llm-task plugin does), the allowlist guard falsely reports an error because config-level allowlists exist but all tools are intentionally disabled.

## Fix

### Cron handlers (`src/gateway/server-methods/cron.ts`)
Wraps `context.cron.add/update/remove/list/status` calls in try/catch blocks, converting any thrown errors to `INVALID_REQUEST` responses with descriptive error messages.

### Tool allowlist guard (`src/agents/tool-allowlist-guard.ts`)
When `disableTools: true` and no runtime `toolsAllow` is passed, the empty tool set is intentional — the guard now returns `null` instead of an error, even when config-level allowlists exist.

## Tests
- `tool-allowlist-guard.test.ts`: Added test case for `disableTools` without runtime `toolsAllow`