### PR TITLE
Fix provider-scoped manifest model picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
 - Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
 - Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
+- Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
 
 ## 2026.4.27
 

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1046,6 +1046,81 @@ describe("applyAuthChoice", () => {
     );
   });
 
+  it("enables the owning plugin for manifest provider auth choices", async () => {
+    await setupTempState();
+    const provider = createFixedChoiceProvider({
+      providerId: "github-copilot",
+      label: "GitHub Copilot",
+      choiceId: "github-copilot-github",
+      method: {
+        id: "github",
+        label: "GitHub Copilot",
+        kind: "token",
+        run: vi.fn(
+          async (): Promise<ProviderAuthResult> => ({
+            profiles: [
+              {
+                profileId: "github-copilot:github",
+                credential: {
+                  type: "token",
+                  provider: "github-copilot",
+                  token: "gho_copilot_test",
+                },
+              },
+            ],
+            defaultModel: "github-copilot/claude-opus-4.7",
+          }),
+        ),
+      },
+    });
+    const manifestSpy = vi
+      .spyOn(providerAuthChoices, "resolveManifestProviderAuthChoice")
+      .mockReturnValue({
+        pluginId: "github-copilot",
+        providerId: "github-copilot",
+        methodId: "github",
+        choiceId: "github-copilot-github",
+        choiceLabel: "GitHub Copilot",
+      });
+    providerAuthChoiceTesting.setDepsForTest({
+      loadPluginProviderRuntime: async () => ({
+        resolvePluginProviders,
+        resolvePluginSetupProvider: () => provider,
+        resolveProviderPluginChoice,
+        runProviderModelSelectedHook,
+      }),
+    });
+    try {
+      const result = await applyAuthChoice({
+        authChoice: "github-copilot-github",
+        config: { plugins: { entries: { "github-copilot": { enabled: false } } } },
+        prompter: createPrompter({}),
+        runtime: createExitThrowingRuntime(),
+        setDefaultModel: true,
+        preserveExistingDefaultModel: true,
+      });
+
+      expect(result.config.plugins?.entries?.["github-copilot"]).toEqual({ enabled: true });
+      expect(result.config.auth?.profiles?.["github-copilot:github"]).toMatchObject({
+        provider: "github-copilot",
+        mode: "token",
+      });
+      expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
+        "github-copilot/claude-opus-4.7",
+      );
+    } finally {
+      manifestSpy.mockRestore();
+      providerAuthChoiceTesting.setDepsForTest({
+        loadPluginProviderRuntime: async () => ({
+          resolvePluginProviders,
+          resolvePluginSetupProvider: () => undefined,
+          resolveProviderPluginChoice,
+          runProviderModelSelectedHook,
+        }),
+      });
+    }
+  });
+
   it("uses explicit env for plugin auth resolution instead of host env", async () => {
     await setupTempState();
     process.env.OPENAI_API_KEY = "sk-openai-host"; // pragma: allowlist secret

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -288,6 +288,78 @@ describe("promptAuthConfig", () => {
     );
   });
 
+  it("keeps the selected provider scope when existing config has another provider", async () => {
+    vi.clearAllMocks();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("github-copilot");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("github-copilot");
+    const existingConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "ollama/deepseek-v4-pro" },
+        },
+      },
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "https://ollama.com",
+            api: "ollama",
+            models: [{ id: "deepseek-v4-pro", name: "deepseek-v4-pro" }],
+          },
+        },
+      },
+    };
+    mocks.applyAuthChoice.mockResolvedValue({ config: existingConfig });
+    mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+    mocks.resolveProviderPluginChoice.mockReturnValue(null);
+
+    await promptAuthConfig(existingConfig, makeRuntime(), noopPrompter);
+
+    expect(mocks.promptModelAllowlist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredProvider: "github-copilot",
+      }),
+    );
+  });
+
+  it("loads the selected provider catalog after auth enables that plugin", async () => {
+    vi.clearAllMocks();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("github-copilot");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("github-copilot");
+    const existingConfig = {
+      agents: { defaults: { model: { primary: "ollama/deepseek-v4-pro" } } },
+      models: {
+        providers: {
+          ollama: {
+            baseUrl: "https://ollama.com",
+            api: "ollama",
+            models: [{ id: "deepseek-v4-pro", name: "deepseek-v4-pro" }],
+          },
+        },
+      },
+    };
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        ...existingConfig,
+        plugins: { entries: { "github-copilot": { enabled: true } } },
+      },
+    });
+    mocks.loadStaticManifestCatalogRowsForList.mockReturnValueOnce([
+      {
+        ref: "github-copilot/claude-opus-4.7",
+        provider: "github-copilot",
+        id: "claude-opus-4.7",
+        name: "Claude Opus 4.7",
+      },
+    ]);
+    mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+    mocks.resolveProviderPluginChoice.mockReturnValue(null);
+
+    await promptAuthConfig(existingConfig, makeRuntime(), noopPrompter);
+
+    expect(mocks.promptModelAllowlist.mock.calls[0]?.[0]?.preferredProvider).toBe("github-copilot");
+    expect(mocks.promptModelAllowlist.mock.calls[0]?.[0]?.loadCatalog).toBe(true);
+  });
+
   it("loads configured provider models after Ollama Cloud + Local and Cloud only setup", async () => {
     vi.clearAllMocks();
     mocks.promptAuthChoiceGrouped.mockResolvedValue("ollama");

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -124,7 +124,10 @@ function resolveConfiguredProviderFromAuthChange(params: {
     return changedProviders[0];
   }
 
-  return configuredProviders.length === 1 ? configuredProviders[0] : params.preferredProvider;
+  return (
+    params.preferredProvider ??
+    (configuredProviders.length === 1 ? configuredProviders[0] : undefined)
+  );
 }
 
 export function buildGatewayAuthConfig(params: {

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -296,10 +296,15 @@ export async function applyAuthChoiceLoadedPluginProvider(
     env: params.env,
     includeUntrustedWorkspacePlugins: false,
   });
-  if (installCatalogEntry) {
-    const enableResult = enablePluginInConfig(nextConfig, installCatalogEntry.pluginId);
+  const choicePlugin = manifestAuthChoice
+    ? { pluginId: manifestAuthChoice.pluginId, label: manifestAuthChoice.choiceLabel }
+    : installCatalogEntry
+      ? { pluginId: installCatalogEntry.pluginId, label: installCatalogEntry.label }
+      : undefined;
+  if (choicePlugin) {
+    const enableResult = enablePluginInConfig(nextConfig, choicePlugin.pluginId);
     if (!enableResult.enabled) {
-      const safeLabel = sanitizeTerminalText(installCatalogEntry.label);
+      const safeLabel = sanitizeTerminalText(choicePlugin.label);
       await params.prompter.note(
         `${safeLabel} plugin is disabled (${enableResult.reason ?? "blocked"}).`,
         safeLabel,


### PR DESCRIPTION
## Summary
- keep model picker scope on the selected provider after auth
- enable the selected manifest provider plugin before catalog lookup
- cover Copilot-over-Ollama configure and manifest-auth plugin enabling regressions

## Verification
- pnpm test src/commands/auth-choice.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts