### PR TITLE
fix #74205: [Bug]: kimi/k2p6 returns incomplete terminal response and gateway status probe times out

### DIFF
--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -144,4 +144,37 @@ describe("fireworks provider plugin", () => {
       reasoning: false,
     });
   });
+
+  it("preserves native Kimi tool_call IDs in replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+
+    const policy = provider.buildReplayPolicy?.({
+      provider: "fireworks",
+      modelApi: "openai-completions",
+      modelId: "accounts/fireworks/models/kimi-k2p6",
+    } as never);
+
+    expect(policy).toMatchObject({
+      applyAssistantFirstOrderingFix: true,
+      validateGeminiTurns: true,
+      validateAnthropicTurns: true,
+    });
+    expect(policy).not.toHaveProperty("sanitizeToolCallIds");
+    expect(policy).not.toHaveProperty("toolCallIdMode");
+  });
+
+  it("sanitizes tool_call IDs for non-Kimi Fireworks models in replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+
+    const policy = provider.buildReplayPolicy?.({
+      provider: "fireworks",
+      modelApi: "openai-completions",
+      modelId: "accounts/fireworks/models/llama4-maverick",
+    } as never);
+
+    expect(policy).toMatchObject({
+      sanitizeToolCallIds: true,
+      toolCallIdMode: "strict",
+    });
+  });
 });

--- a/extensions/fireworks/index.ts
+++ b/extensions/fireworks/index.ts
@@ -1,10 +1,10 @@
 import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildOpenAICompatibleReplayPolicy } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   cloneFirstTemplateModel,
   DEFAULT_CONTEXT_TOKENS,
   normalizeModelCompat,
-  OPENAI_COMPATIBLE_REPLAY_HOOKS,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { isFireworksKimiModelId } from "./model-id.js";
 import { applyFireworksConfig, FIREWORKS_DEFAULT_MODEL_REF } from "./onboard.js";
@@ -75,7 +75,14 @@ export default defineSingleProviderPluginEntry({
       buildProvider: buildFireworksProvider,
       allowExplicitBaseUrl: true,
     },
-    ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+    // Kimi K2+ returns native tool_call IDs shaped like `functions.<name>:<index>`.
+    // Sanitizing them to alphanumeric-only breaks Kimi's serving-layer matching in
+    // multi-turn replay. See openclaw/openclaw#62319 and openclaw/openclaw#74205.
+    buildReplayPolicy: (ctx) =>
+      buildOpenAICompatibleReplayPolicy(ctx.modelApi, {
+        sanitizeToolCallIds: !isFireworksKimiModelId(ctx.modelId ?? ""),
+        modelId: ctx.modelId,
+      }),
     wrapStreamFn: wrapFireworksProviderStream,
     resolveDynamicModel: (ctx) => resolveFireworksDynamicModel(ctx),
     isModernModelRef: () => true,


### PR DESCRIPTION
## Summary
Fixes #74205

### Issue
[[Bug]: kimi/k2p6 returns incomplete terminal response and gateway status probe times out](https://github.com/openclaw/openclaw/issues/74205)

### Solution
<!-- Describe the changes made -->


### Testing
<!-- Describe how the fix was tested -->

