### PR TITLE
fix(web_fetch): honor env proxy in guarded fetch

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -418,6 +418,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
       lookupFn: params.lookupFn,
+      useEnvProxy: true,
       policy: allowRfc2544BenchmarkRange ? { allowRfc2544BenchmarkRange } : undefined,
       init: {
         headers: {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -21,6 +21,19 @@ vi.mock("../../web-fetch/content-extractors.runtime.js", async () => {
 vi.mock("../../web-fetch/runtime.js", () => ({
   resolveWebFetchDefinition: resolveWebFetchDefinitionMock,
 }));
+const { fetchWithWebToolsNetworkGuardMock } = vi.hoisted(() => ({
+  fetchWithWebToolsNetworkGuardMock: vi.fn(),
+}));
+vi.mock("./web-guarded-fetch.js", async () => {
+  const actual = await vi.importActual<typeof import("./web-guarded-fetch.js")>(
+    "./web-guarded-fetch.js",
+  );
+  fetchWithWebToolsNetworkGuardMock.mockImplementation(actual.fetchWithWebToolsNetworkGuard);
+  return {
+    ...actual,
+    fetchWithWebToolsNetworkGuard: fetchWithWebToolsNetworkGuardMock,
+  };
+});
 import { createWebFetchTool } from "./web-fetch.js";
 
 const lookupMock = vi.fn();
@@ -147,6 +160,7 @@ describe("web_fetch extraction fallbacks", () => {
     extractReadableContentMock.mockResolvedValue(null);
     resolveWebFetchDefinitionMock.mockReset();
     resolveWebFetchDefinitionMock.mockReturnValue(null);
+    fetchWithWebToolsNetworkGuardMock.mockClear();
     lookupMock.mockImplementation(async (hostname: string) => {
       void hostname;
       return [
@@ -161,6 +175,27 @@ describe("web_fetch extraction fallbacks", () => {
     lookupMock.mockReset();
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it("passes useEnvProxy to guarded fetch", async () => {
+    fetchWithWebToolsNetworkGuardMock.mockResolvedValueOnce({
+      response: new Response("plain body", {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      }),
+      finalUrl: "https://example.com/plain",
+      release: async () => {},
+    });
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    await tool?.execute?.("call", { url: "https://example.com/plain", extractMode: "text" });
+
+    expect(fetchWithWebToolsNetworkGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/plain",
+        useEnvProxy: true,
+      }),
+    );
   });
 
   it("wraps fetched text with external content markers", async () => {


### PR DESCRIPTION
## Summary
- pass `useEnvProxy: true` from the `web_fetch` tool into guarded fetch
- keep `web_fetch` aligned with `withTrustedWebToolsEndpoint(...)` behavior
- add a regression test that verifies `createWebFetchTool` forwards `useEnvProxy: true`

## Problem
`web_fetch` is expected to honor Gateway env proxy settings (`HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` + `NO_PROXY`) when fetching public URLs.

In practice, the tool entrypoint called `fetchWithWebToolsNetworkGuard(...)` without `useEnvProxy: true`, which meant it fell back to strict guarded-fetch mode instead of the trusted env-proxy path.

That caused real-world failures for proxied environments, including cases where:
- direct access to the target site was unavailable, and
- strict local DNS / SSRF checks blocked a hostname before the env proxy path could be used.

## Fix
Add `useEnvProxy: true` to the `runWebFetch(...)` call site in `src/agents/tools/web-fetch.ts`.

## Validation
- reproduced the issue locally against Google with a configured Gateway env proxy
- verified that the tool succeeds after forwarding `useEnvProxy: true`
- added a regression test to assert the flag is passed through the web-fetch tool entrypoint

## Notes
This is intentionally a minimal fix: it changes only the tool call site and leaves the existing guarded-fetch / SSRF implementation unchanged.
