### PR TITLE
fix(slack): route block-action wakes to the thread session key

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -9,7 +9,7 @@ import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -80,6 +80,7 @@ export type SlackMonitorContext = {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => string;
   isChannelAllowed: (params: {
     channelId?: string;
@@ -179,10 +180,17 @@ export function createSlackMonitorContext(params: {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => {
     const channelId = normalizeOptionalString(p.channelId) ?? "";
+    const threadTs = normalizeOptionalString(p.threadTs);
+    const applyThread = (baseSessionKey: string) =>
+      threadTs
+        ? resolveThreadSessionKeys({ baseSessionKey, threadId: threadTs }).sessionKey
+        : baseSessionKey;
+
     if (!channelId) {
-      return params.mainKey;
+      return applyThread(params.mainKey);
     }
     const channelType = normalizeSlackChannelType(p.channelType, channelId);
     const isDirectMessage = channelType === "im";
@@ -208,16 +216,18 @@ export function createSlackMonitorContext(params: {
           teamId: params.teamId,
           peer: { kind: peerKind, id: peerId },
         });
-        return route.sessionKey;
+        return applyThread(route.sessionKey);
       }
     } catch {
       // Fall through to legacy key derivation.
     }
 
-    return resolveSessionKey(
-      params.sessionScope,
-      { From: from, ChatType: chatType, Provider: "slack" },
-      params.mainKey,
+    return applyThread(
+      resolveSessionKey(
+        params.sessionScope,
+        { From: from, ChatType: chatType, Provider: "slack" },
+        params.mainKey,
+      ),
     );
   };
 

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -701,6 +701,7 @@ function enqueueSlackBlockActionEvent(params: {
     channelId: params.parsed.channelId,
     channelType: params.auth.channelType,
     senderId: params.parsed.userId,
+    threadTs: params.parsed.threadTs,
   });
   const contextParts = [
     "slack:interaction",

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -368,9 +368,60 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C1",
       channelType: "channel",
       senderId: "U123",
+      threadTs: "100.100",
     });
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards threadTs so wake events match the thread session key", async () => {
+    // Regression: button clicks under an AskUserQuestion in a thread used to
+    // enqueue against the base channel session key, while the pending
+    // question lived on `:thread:<ts>`. The wake never matched, so the
+    // agent never replied.
+    const { ctx, getHandler, resolveSessionKey } = createContext();
+    resolveSessionKey.mockImplementation(({ threadTs }: { threadTs?: string | null }) =>
+      threadTs ? `agent:ops:slack:channel:C1:thread:${threadTs}` : "agent:ops:slack:channel:C1",
+    );
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const handler = getHandler();
+    expect(handler).toBeTruthy();
+
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await handler!({
+      ack,
+      body: {
+        user: { id: "U123" },
+        team: { id: "T9" },
+        trigger_id: "123.trigger",
+        response_url: "https://hooks.slack.test/response",
+        channel: { id: "C1" },
+        container: { channel_id: "C1", message_ts: "100.200", thread_ts: "100.100" },
+        message: {
+          ts: "100.200",
+          text: "fallback",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "ask_block",
+              elements: [{ type: "button", action_id: "openclaw:reply_button:1:0" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:reply_button:1:0",
+        block_id: "ask_block",
+        value: "approve",
+        text: { type: "plain_text", text: "Approve" },
+      },
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const [, options] = enqueueSystemEventMock.mock.calls[0] as [string, { sessionKey: string }];
+    expect(options.sessionKey).toBe("agent:ops:slack:channel:C1:thread:100.100");
   });
 
   it("registers a matcher that accepts plugin action ids beyond the OpenClaw prefix", () => {
@@ -1309,6 +1360,7 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C222",
       channelType: "channel",
       senderId: "U111",
+      threadTs: "222.111",
     });
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     const [eventText] = enqueueSystemEventMock.mock.calls[0] as [string];

--- a/extensions/slack/src/monitor/events/system-event-context.ts
+++ b/extensions/slack/src/monitor/events/system-event-context.ts
@@ -13,9 +13,10 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
   senderId?: string;
   channelId?: string;
   channelType?: string | null;
+  threadTs?: string | null;
   eventKind: string;
 }): Promise<SlackAuthorizedSystemEventContext | undefined> {
-  const { ctx, senderId, channelId, channelType, eventKind } = params;
+  const { ctx, senderId, channelId, channelType, threadTs, eventKind } = params;
   const auth = await authorizeSlackSystemEventSender({
     ctx,
     senderId,
@@ -37,6 +38,7 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
     channelId,
     channelType: auth.channelType,
     senderId,
+    threadTs,
   });
   return {
     channelLabel,

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -242,6 +242,66 @@ describe("resolveSlackSystemEventSessionKey", () => {
       }),
     ).toBe("agent:ops-dm:main");
   });
+
+  it("appends a thread suffix when threadTs is provided", () => {
+    // Wake events for thread-scoped interactions (e.g. block_action button
+    // clicks under an AskUserQuestion in a thread) must match the same
+    // session key that inbound thread replies use, otherwise the agent
+    // never wakes for the click.
+    const ctx = createSlackMonitorContext(baseParams());
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C123",
+        channelType: "channel",
+        threadTs: "1700000000.000100",
+      }),
+    ).toBe("agent:main:slack:channel:c123:thread:1700000000.000100");
+  });
+
+  it("preserves the base key when threadTs is empty or missing", () => {
+    const ctx = createSlackMonitorContext(baseParams());
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C123",
+        channelType: "channel",
+        threadTs: "",
+      }),
+    ).toBe("agent:main:slack:channel:c123");
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C123",
+        channelType: "channel",
+        threadTs: null,
+      }),
+    ).toBe("agent:main:slack:channel:c123");
+  });
+
+  it("appends a thread suffix to binding-resolved DM sessions", () => {
+    const ctx = createSlackMonitorContext({
+      ...baseParams(),
+      accountId: "work",
+      cfg: {
+        bindings: [
+          {
+            agentId: "ops-dm",
+            match: {
+              channel: "slack",
+              accountId: "work",
+              peer: { kind: "direct", id: "U123" },
+            },
+          },
+        ],
+      },
+    });
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "D123",
+        channelType: "im",
+        senderId: "U123",
+        threadTs: "1700000000.000200",
+      }),
+    ).toBe("agent:ops-dm:main:thread:1700000000.000200");
+  });
 });
 
 describe("isChannelAllowed with groupPolicy and channelsConfig", () => {


### PR DESCRIPTION
## Summary

- Slack block_action wakes were resolved against the base channel/DM session key while pending `AskUserQuestion` sessions live on the thread-suffixed key (`…:thread:<ts>`). The wake never matched, so button clicks silently dropped (issue #61502).
- Made `resolveSlackSystemEventSessionKey` thread-aware: when callers forward `threadTs`, the resolved base key is run through `resolveThreadSessionKeys` — the same suffixing rule `prepare-routing.ts` already applies to inbound thread replies.
- Forwarded `threadTs` from the block-action dispatcher (`interactions.block-actions.ts`) and threaded it through `authorizeAndResolveSlackSystemEventContext` so future thread-aware system events don't need another signature change.
- No public Plugin SDK change. The fix is contained inside the Slack extension.

Closes openclaw/openclaw#61502.

## Out of scope

- The downstream `heartbeat-wake.ts` "timer fired without active handler" / "timer fired while already running" symptoms flagged in the issue. Those are unrelated wake-state concerns; this PR only fixes the deterministic key-mismatch break.
- Modal `view_submission` thread routing — modal metadata does not carry `threadTs` today and the path already supports caller-supplied `metadata.sessionKey`.
- Reaction / channel system-event keys — those events are not thread-scoped today and changing them risks regressing per-channel session continuity.

## Test plan

- [x] `pnpm test extensions/slack` — 803 passed
- [x] `pnpm check:changed` — typecheck (extensions + extension tests), lint, runtime import cycles, all 12 affected slack test files green
- [x] Added 3 unit cases in `monitor.test.ts` (thread suffix appended; absent/empty `threadTs` preserved; binding-resolved DM + thread)
- [x] Added a behavior case in `interactions.test.ts` asserting `enqueueSystemEvent` receives a `:thread:<ts>`-suffixed `sessionKey`
- [ ] Live end-to-end (DM → thread → AskUserQuestion → button click → assistant reply lands in same thread). Not exercised here — needs a running Slack workspace with the bot installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)