### PR TITLE
docs(security): clarify proxy SSRF reporting scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 - Gateway/memory: add a read-only `doctor.memory.remHarness` RPC so operator clients can preview bounded REM dreaming output without running mutation paths. (#66673) Thanks @samzong.
 - Gateway/events: surface `spawnedBy` on subagent chat and agent broadcast payloads so clients can route child session events without an extra session lookup. (#63244) Thanks @samzong.
+- Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311) Thanks @steipete.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs: https://docs.openclaw.ai
 - Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 - Gateway/memory: add a read-only `doctor.memory.remHarness` RPC so operator clients can preview bounded REM dreaming output without running mutation paths. (#66673) Thanks @samzong.
 - Gateway/events: surface `spawnedBy` on subagent chat and agent broadcast payloads so clients can route child session events without an extra session lookup. (#63244) Thanks @samzong.
-- Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311) Thanks @steipete.
+- Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311)
 
 ### Fixes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,7 +76,7 @@ These are frequently reported but are typically closed with no code change:
 - Claims that Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl` is attacker-controlled without demonstrating one of: auth boundary bypass, a real authenticated Teams/Bot Framework event carrying attacker-chosen URL, or compromise of the Microsoft/Bot trust path.
 - Scanner-only claims against stale/nonexistent paths, or claims without a working repro.
 - Reports that restate an already-fixed issue against later released versions without showing the vulnerable path still exists in the shipped tag or published artifact for that later version.
-- SSRF reports against the operator-managed HTTP/WebSocket proxy-routing feature whose only claim is that ordinary process-local HTTP clients (`fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients) can reach an internal, metadata, private, or otherwise sensitive destination when proxy routing is disabled, missing, or the operator-managed proxy policy allows it. For this feature, OpenClaw provides fail-closed proxy routing when enabled; the external proxy's destination policy is operator infrastructure, not an OpenClaw-controlled security boundary.
+- SSRF reports against the operator-managed HTTP/WebSocket proxy-routing feature whose only claim is that ordinary process-local HTTP clients (`fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients) can reach an internal, metadata, private, or otherwise sensitive destination when proxy routing is disabled, missing, or the operator-managed proxy policy allows it. For this feature, OpenClaw provides fail-closed proxy routing when enabled; the external proxy's destination policy is operator infrastructure, not an OpenClaw-controlled security boundary. See [Network proxy](https://docs.openclaw.ai/security/network-proxy).
 
 ### Duplicate Report Handling
 
@@ -130,27 +130,6 @@ Plugins/extensions are part of OpenClaw's trusted computing base for a gateway.
 - Plugin behavior such as reading env/files or running host commands is expected inside this trust boundary.
 - Security reports must show a boundary bypass (for example unauthenticated plugin load, allowlist/policy bypass, or sandbox/path-safety bypass), not only malicious behavior from a trusted-installed plugin.
 
-## HTTP/WS SSRF and Operator-Managed Proxy Routing
-
-OpenClaw's SSRF boundary for this feature is operator-managed proxy routing for normal JavaScript HTTP egress:
-
-- For process-local HTTP and WebSocket clients, operators can enable proxy routing with `proxy.enabled=true` plus a valid `http://` forward proxy URL from `proxy.proxyUrl` or `OPENCLAW_PROXY_URL`.
-- The `proxy.enabled` setting is fail-closed by design: when proxy routing is enabled but no valid proxy URL is configured, protected commands fail startup instead of silently falling back to direct network access.
-- While routing is active, OpenClaw clears destination bypass environment variables (`NO_PROXY`, `no_proxy`, and `GLOBAL_AGENT_NO_PROXY`) and preserves only a narrow literal-loopback Gateway control-plane path.
-
-For this specific feature, OpenClaw generally will not accept SSRF reports whose only claim is that `fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients, or similar process-local HTTP(S)/WebSocket egress can reach a destination that a correctly configured operator proxy is expected to block. Reports that depend on proxy routing being disabled, absent, permissive, or misconfigured are also not treated as OpenClaw vulnerabilities.
-
-The proxy itself is operator-managed infrastructure. OpenClaw does not ship, start, certify, inspect, or control the proxy's destination denylist, DNS resolution behavior, connect-time policy, authentication, or logging. If that external proxy allows a destination, that decision is outside OpenClaw's control.
-
-A report may still be in scope if it demonstrates that OpenClaw violates this feature's documented routing or fail-closed contract with `proxy.enabled=true` and a valid filtering proxy, such as:
-
-- a supported HTTP/WebSocket client unexpectedly bypassing the configured proxy
-- invalid proxy configuration falling back to direct egress instead of failing startup
-- destination bypass environment variables remaining active while proxy routing is active
-- OpenClaw applying an unintended direct-egress exemption beyond the documented literal-loopback Gateway control-plane path
-
-This feature-specific policy does not classify non-HTTP/WebSocket egress, raw `net`/`tls`/`http2` sockets, native addons, child processes, or other OpenClaw features. Those reports are assessed under their own documented boundaries.
-
 ## Out of Scope
 
 - Public Internet Exposure
@@ -175,7 +154,7 @@ This feature-specific policy does not classify non-HTTP/WebSocket egress, raw `n
 - Exposed secrets that are third-party/user-controlled credentials (not OpenClaw-owned and not granting access to OpenClaw-operated infrastructure/services) without demonstrated OpenClaw impact
 - Reports whose only claim is host-side exec when sandbox runtime is disabled/unavailable (documented default behavior in the trusted-operator model), without a boundary bypass.
 - Reports whose only claim is that a platform-provided upload destination URL is untrusted (for example Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl`) without proving attacker control in an authenticated production flow.
-- SSRF reports limited to the operator-managed HTTP/WebSocket proxy-routing feature where the demonstrated mitigation is to enable/configure `proxy.enabled` with a filtering `proxy.proxyUrl`/`OPENCLAW_PROXY_URL`, or where impact depends on a permissive/misconfigured operator proxy. This only covers normal process-local HTTP(S)/WebSocket egress (`fetch`, Node HTTP(S), and similar JavaScript clients); non-HTTP egress and other features are assessed separately.
+- SSRF reports limited to the operator-managed HTTP/WebSocket proxy-routing feature where the demonstrated mitigation is to enable/configure `proxy.enabled` with a filtering `proxy.proxyUrl`/`OPENCLAW_PROXY_URL`, or where impact depends on a permissive/misconfigured operator proxy. This only covers normal process-local HTTP(S)/WebSocket egress (`fetch`, Node HTTP(S), and similar JavaScript clients); non-HTTP egress and other features are assessed separately. See [Network proxy](https://docs.openclaw.ai/security/network-proxy).
 
 ## Deployment Assumptions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,7 @@ These are frequently reported but are typically closed with no code change:
 - Claims that Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl` is attacker-controlled without demonstrating one of: auth boundary bypass, a real authenticated Teams/Bot Framework event carrying attacker-chosen URL, or compromise of the Microsoft/Bot trust path.
 - Scanner-only claims against stale/nonexistent paths, or claims without a working repro.
 - Reports that restate an already-fixed issue against later released versions without showing the vulnerable path still exists in the shipped tag or published artifact for that later version.
+- SSRF reports against the operator-managed HTTP/WebSocket proxy-routing feature whose only claim is that ordinary process-local HTTP clients (`fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients) can reach an internal, metadata, private, or otherwise sensitive destination when proxy routing is disabled, missing, or the operator-managed proxy policy allows it. For this feature, OpenClaw provides guarded fetch paths plus fail-closed proxy routing when enabled; the external proxy's destination policy is operator infrastructure, not an OpenClaw-controlled security boundary.
 
 ### Duplicate Report Handling
 
@@ -129,6 +130,28 @@ Plugins/extensions are part of OpenClaw's trusted computing base for a gateway.
 - Plugin behavior such as reading env/files or running host commands is expected inside this trust boundary.
 - Security reports must show a boundary bypass (for example unauthenticated plugin load, allowlist/policy bypass, or sandbox/path-safety bypass), not only malicious behavior from a trusted-installed plugin.
 
+## HTTP/WS SSRF and Operator-Managed Proxy Routing
+
+OpenClaw's SSRF boundary for normal JavaScript HTTP egress is layered:
+
+- Application fetches that intentionally retrieve user-supplied URLs should use guarded paths such as `fetchWithSsrFGuard`.
+- For broader process-local HTTP and WebSocket clients, operators can enable proxy routing with `proxy.enabled=true` plus a valid `http://` forward proxy URL from `proxy.proxyUrl` or `OPENCLAW_PROXY_URL`.
+- The `proxy.enabled` setting is fail-closed by design: when proxy routing is enabled but no valid proxy URL is configured, protected commands fail startup instead of silently falling back to direct network access.
+- While routing is active, OpenClaw clears destination bypass environment variables (`NO_PROXY`, `no_proxy`, and `GLOBAL_AGENT_NO_PROXY`) and preserves only a narrow literal-loopback Gateway control-plane path.
+
+For this specific feature, OpenClaw generally will not accept SSRF reports whose only claim is that `fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients, or similar process-local HTTP(S)/WebSocket egress can reach a destination that a correctly configured operator proxy is expected to block. Reports that depend on proxy routing being disabled, absent, permissive, or misconfigured are also not treated as OpenClaw vulnerabilities.
+
+The proxy itself is operator-managed infrastructure. OpenClaw does not ship, start, certify, inspect, or control the proxy's destination denylist, DNS resolution behavior, connect-time policy, authentication, or logging. If that external proxy allows a destination, that decision is outside OpenClaw's control.
+
+A report may still be in scope if it demonstrates that OpenClaw violates this feature's documented routing or fail-closed contract with `proxy.enabled=true` and a valid filtering proxy, such as:
+
+- a supported HTTP/WebSocket client unexpectedly bypassing the configured proxy
+- invalid proxy configuration falling back to direct egress instead of failing startup
+- destination bypass environment variables remaining active while proxy routing is active
+- a guarded OpenClaw fetch path being bypassed or misclassifying a blocked destination
+
+This feature-specific policy does not classify non-HTTP/WebSocket egress, raw `net`/`tls`/`http2` sockets, native addons, child processes, or other OpenClaw features. Those reports are assessed under their own documented boundaries.
+
 ## Out of Scope
 
 - Public Internet Exposure
@@ -153,6 +176,7 @@ Plugins/extensions are part of OpenClaw's trusted computing base for a gateway.
 - Exposed secrets that are third-party/user-controlled credentials (not OpenClaw-owned and not granting access to OpenClaw-operated infrastructure/services) without demonstrated OpenClaw impact
 - Reports whose only claim is host-side exec when sandbox runtime is disabled/unavailable (documented default behavior in the trusted-operator model), without a boundary bypass.
 - Reports whose only claim is that a platform-provided upload destination URL is untrusted (for example Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl`) without proving attacker control in an authenticated production flow.
+- SSRF reports limited to the operator-managed HTTP/WebSocket proxy-routing feature where the demonstrated mitigation is to enable/configure `proxy.enabled` with a filtering `proxy.proxyUrl`/`OPENCLAW_PROXY_URL`, or where impact depends on a permissive/misconfigured operator proxy. This only covers normal process-local HTTP(S)/WebSocket egress (`fetch`, Node HTTP(S), and similar JavaScript clients); non-HTTP egress and other features are assessed separately.
 
 ## Deployment Assumptions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,7 +76,7 @@ These are frequently reported but are typically closed with no code change:
 - Claims that Microsoft Teams `fileConsent/invoke` `uploadInfo.uploadUrl` is attacker-controlled without demonstrating one of: auth boundary bypass, a real authenticated Teams/Bot Framework event carrying attacker-chosen URL, or compromise of the Microsoft/Bot trust path.
 - Scanner-only claims against stale/nonexistent paths, or claims without a working repro.
 - Reports that restate an already-fixed issue against later released versions without showing the vulnerable path still exists in the shipped tag or published artifact for that later version.
-- SSRF reports against the operator-managed HTTP/WebSocket proxy-routing feature whose only claim is that ordinary process-local HTTP clients (`fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients) can reach an internal, metadata, private, or otherwise sensitive destination when proxy routing is disabled, missing, or the operator-managed proxy policy allows it. For this feature, OpenClaw provides guarded fetch paths plus fail-closed proxy routing when enabled; the external proxy's destination policy is operator infrastructure, not an OpenClaw-controlled security boundary.
+- SSRF reports against the operator-managed HTTP/WebSocket proxy-routing feature whose only claim is that ordinary process-local HTTP clients (`fetch`, `node:http`, `node:https`, WebSocket clients, axios/got/node-fetch-style clients) can reach an internal, metadata, private, or otherwise sensitive destination when proxy routing is disabled, missing, or the operator-managed proxy policy allows it. For this feature, OpenClaw provides fail-closed proxy routing when enabled; the external proxy's destination policy is operator infrastructure, not an OpenClaw-controlled security boundary.
 
 ### Duplicate Report Handling
 
@@ -132,10 +132,9 @@ Plugins/extensions are part of OpenClaw's trusted computing base for a gateway.
 
 ## HTTP/WS SSRF and Operator-Managed Proxy Routing
 
-OpenClaw's SSRF boundary for normal JavaScript HTTP egress is layered:
+OpenClaw's SSRF boundary for this feature is operator-managed proxy routing for normal JavaScript HTTP egress:
 
-- Application fetches that intentionally retrieve user-supplied URLs should use guarded paths such as `fetchWithSsrFGuard`.
-- For broader process-local HTTP and WebSocket clients, operators can enable proxy routing with `proxy.enabled=true` plus a valid `http://` forward proxy URL from `proxy.proxyUrl` or `OPENCLAW_PROXY_URL`.
+- For process-local HTTP and WebSocket clients, operators can enable proxy routing with `proxy.enabled=true` plus a valid `http://` forward proxy URL from `proxy.proxyUrl` or `OPENCLAW_PROXY_URL`.
 - The `proxy.enabled` setting is fail-closed by design: when proxy routing is enabled but no valid proxy URL is configured, protected commands fail startup instead of silently falling back to direct network access.
 - While routing is active, OpenClaw clears destination bypass environment variables (`NO_PROXY`, `no_proxy`, and `GLOBAL_AGENT_NO_PROXY`) and preserves only a narrow literal-loopback Gateway control-plane path.
 
@@ -148,7 +147,7 @@ A report may still be in scope if it demonstrates that OpenClaw violates this fe
 - a supported HTTP/WebSocket client unexpectedly bypassing the configured proxy
 - invalid proxy configuration falling back to direct egress instead of failing startup
 - destination bypass environment variables remaining active while proxy routing is active
-- a guarded OpenClaw fetch path being bypassed or misclassifying a blocked destination
+- OpenClaw applying an unintended direct-egress exemption beyond the documented literal-loopback Gateway control-plane path
 
 This feature-specific policy does not classify non-HTTP/WebSocket egress, raw `net`/`tls`/`http2` sockets, native addons, child processes, or other OpenClaw features. Those reports are assessed under their own documented boundaries.
 

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -23,7 +23,7 @@ A proxy gives operators one network control point for outbound HTTP and WebSocke
 - Auditability: log allowed and denied destinations at the egress boundary.
 - Operational control: enforce destination rules, network segmentation, rate limits, or outbound allowlists without rebuilding OpenClaw.
 
-OpenClaw still keeps application-level SSRF guards such as `fetchWithSsrFGuard`. Proxy routing is an additional process-level guardrail for normal HTTP and WebSocket egress, not a replacement for guarded fetches or an OS-level network sandbox.
+Proxy routing is a process-level guardrail for normal HTTP and WebSocket egress. It gives operators a fail-closed path for routing supported JavaScript HTTP clients through their own filtering proxy, but it is not an OS-level network sandbox and does not make OpenClaw certify the proxy's destination policy.
 
 ## How OpenClaw Routes Traffic
 
@@ -147,7 +147,7 @@ proxy:
 
 ## Limits
 
-- The proxy improves coverage for process-local JavaScript HTTP and WebSocket clients, but it does not replace application-level `fetchWithSsrFGuard`.
+- The proxy improves coverage for process-local JavaScript HTTP and WebSocket clients, but it is not an OS-level network sandbox.
 - Raw `net`, `tls`, and `http2` sockets, native addons, and child processes may bypass Node-level proxy routing unless they inherit and respect proxy environment variables.
 - User local WebUIs and local model servers should be allowlisted in the operator proxy policy when needed; OpenClaw does not expose a general local-network bypass for them.
 - Gateway control-plane proxy bypass is intentionally limited to `localhost` and literal loopback IP URLs. Use `ws://127.0.0.1:18789`, `ws://[::1]:18789`, or `ws://localhost:18789` for local direct Gateway control-plane connections; other hostnames route like ordinary hostname-based traffic.


### PR DESCRIPTION
## Summary

- Problem: SECURITY.md did not yet point researchers to the Network proxy docs when describing SSRF report triage for #70044.
- Why it matters: researchers need a clear boundary for reports about `fetch`, Node HTTP(S), WebSocket clients, and similar process-local HTTP egress without over-scoping non-HTTP features.
- What changed: added concise SECURITY.md false-positive/out-of-scope bullets that refer to the Network proxy docs, updated `docs/security/network-proxy.md` to avoid naming `fetchWithSsrFGuard` as a protection, and added the requested changelog entry for #74311 / abaa4326d81b56da1c468190a5006365b2a49cdc.
- What did NOT change (scope boundary): this does not classify non-HTTP/WebSocket egress, raw sockets, native addons, child processes, or unrelated OpenClaw features.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #70044
- Related #74311
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not: docs-only policy clarification.

## User-visible / Behavior Changes

Updates SECURITY.md triage policy for SSRF reports about the operator-managed HTTP/WebSocket proxy-routing feature, points readers to the Network proxy docs, and adds the missing #74311 changelog entry.

## Diagram (if applicable)

N/A

```text
Before:
SSRF report scope for proxy-routed fetch/HTTP/WebSocket egress was implicit in SECURITY.md.

After:
SECURITY.md has concise scoped bullets and links to the Network proxy docs for details.
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/pnpm local repo
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Review SECURITY.md and `docs/security/network-proxy.md` policy wording.
2. Add the requested `CHANGELOG.md` entry for #74311.
3. Run scoped docs formatting and prepare gates.

### Expected

- SECURITY.md clearly documents the HTTP/WebSocket proxy-routing SSRF reporting scope and links to the canonical docs.
- Network proxy docs do not refer to `fetchWithSsrFGuard` as a protection.
- CHANGELOG.md includes the requested #74311 entry.
- Scoped docs formatting passes.

### Actual

- SECURITY.md now includes concise false-positive/out-of-scope bullets with Network proxy links.
- Network proxy docs frame the feature around operator-managed fail-closed proxy routing.
- CHANGELOG.md includes the requested #74311 entry.
- Scoped docs formatting passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation runs:

```text
pnpm format:check SECURITY.md docs/security/network-proxy.md
pnpm format:check CHANGELOG.md SECURITY.md docs/security/network-proxy.md
pnpm build
```

Prepare gate note: after rebasing onto the latest `origin/main`, `scripts/pr-prepare gates 74338` reran `pnpm build` successfully, then `pnpm check` hit an unrelated baseline lint error in `src/plugins/providers.test.ts` (`oxc(no-map-spread)`). This PR changes only `CHANGELOG.md`, `SECURITY.md`, and `docs/security/network-proxy.md`; `git diff --quiet origin/main -- src/plugins/providers.test.ts` confirms the failing file is identical to latest `origin/main`.

## Human Verification (required)

- Verified scenarios: Read the rendered Markdown diff, ran format check for edited docs/changelog, and synced/pushed the prepared branch onto latest `origin/main`.
- Edge cases checked: Wording explicitly limits the policy to normal process-local HTTP(S)/WebSocket egress and leaves non-HTTP egress/other features assessed separately.
- What you did **not** verify: Full test suite; change is documentation/changelog-only and CI docs checks are expected to cover the changed surface.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Policy wording could be read as covering more than the proxy-routing feature.
  - Mitigation: The new text scopes the policy to normal process-local HTTP/WebSocket egress and says non-HTTP egress/other features are assessed separately.
