### PR TITLE
ci: add plugin sdk package contract codeql quality shard

### DIFF
--- a/.github/codeql/codeql-plugin-sdk-package-contract-critical-quality.yml
+++ b/.github/codeql/codeql-plugin-sdk-package-contract-critical-quality.yml
@@ -1,0 +1,34 @@
+name: openclaw-codeql-plugin-sdk-package-contract-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - packages/plugin-sdk/src
+  - packages/plugin-package-contract/src
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -227,3 +227,24 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/plugin-boundary"
+
+  plugin-sdk-package-contract:
+    name: Critical Quality (plugin-sdk-package-contract)
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-plugin-sdk-package-contract-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/plugin-sdk-package-contract"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -307,7 +307,10 @@ understanding, image-generation, and media-generation runtime contracts under
 the separate `/codeql-critical-quality/web-media-runtime-boundary` category. The
 plugin-boundary job scans loader, registry, public-surface, and Plugin SDK
 entrypoint contracts under a separate `/codeql-critical-quality/plugin-boundary`
-category. Keep the workflow separate from security so quality findings can be
+category. The plugin-sdk-package-contract job scans the published package-side
+Plugin SDK source and plugin package contract helpers under the separate
+`/codeql-critical-quality/plugin-sdk-package-contract` category. Keep the
+workflow separate from security so quality findings can be
 scheduled, measured, disabled, or expanded without obscuring security signal.
 Swift, Python, and bundled-plugin CodeQL expansion should be added back as
 scoped or sharded follow-up work only after the narrow profiles have stable


### PR DESCRIPTION
## Summary

- Problem: `CodeQL Critical Quality` covers core plugin/runtime seams, but it does not yet scan the published package-side Plugin SDK source or the plugin package contract helper surface.
- Why it matters: package-facing SDK regressions should get their own narrow CodeQL signal before we attempt broader expansion.
- What changed: added a dedicated CodeQL quality shard and workflow job for `packages/plugin-sdk/src` and `packages/plugin-package-contract/src`, with its own `/codeql-critical-quality/plugin-sdk-package-contract` category.
- What did NOT change: no security profile expansion, no changes to existing shard scopes, and no repo-wide default CodeQL broadening.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/73404
- Related https://github.com/openclaw/openclaw/pull/73447
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

The current quality rollout intentionally stopped at core plugin boundary coverage. The package-side SDK and package-contract seam is a distinct surface that had not been sharded in yet.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
CodeQL Critical Quality
  -> /codeql-critical-quality/plugin-boundary

After:
CodeQL Critical Quality
  -> /codeql-critical-quality/plugin-boundary
  -> /codeql-critical-quality/plugin-sdk-package-contract
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux worktree
- Runtime/container: local Node/pnpm for workflow sanity
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check:workflows`
2. `git diff --check`
3. Count matched production files in the new shard scope

### Expected

- Workflow config is valid.
- The new shard is category-isolated and remains very small.

### Actual

- `pnpm check:workflows` passed.
- `git diff --check` passed.
- The new shard currently matches 22 non-test TypeScript files across `packages/plugin-sdk/src` and `packages/plugin-package-contract/src`.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: workflow sanity, whitespace check, narrow scope count, docs update.
- Edge cases checked: existing plugin-boundary shard remains unchanged; new shard uses its own category.
- What you did **not** verify: GitHub Actions CodeQL dispatch on this branch is still pending.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: another small runtime increase in the quality workflow.
  - Mitigation: this shard is isolated, uses the small 4 vCPU runner like the others, and scans only 22 non-test TS files.
