### PR TITLE
fix(acpx): bridge Codex auth.json into isolated CODEX_HOME

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -286,7 +286,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.codexHome).toBeNull();
   });
 
-  it("does not copy source Codex auth", async () => {
+  it("bridges source Codex auth via symlink", async () => {
     const root = await makeTempDir();
     const sourceCodexHome = path.join(root, "source-codex");
     const agentDir = path.join(root, "agent");
@@ -322,12 +322,78 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain("CODEX_HOME: codexHome");
     expect(wrapper).not.toContain(sourceCodexHome);
+    expect(wrapper).toContain("symlinkSync");
+    expect(wrapper).toContain("auth.json");
     await expect(
       fs.access(path.join(agentDir, "acp-auth", "codex-source", "auth.json")),
     ).rejects.toMatchObject({ code: "ENOENT" });
     await expect(
       fs.access(path.join(agentDir, "acp-auth", "codex", "auth.json")),
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("symlinks canonical Codex auth.json into isolated CODEX_HOME at wrapper startup", async () => {
+    const root = await makeTempDir();
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => undefined,
+    });
+
+    const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
+    expect(wrapper).toContain("symlinkSync");
+    expect(wrapper).toContain("canonicalAuthPath");
+    expect(wrapper).toContain("isolatedAuthPath");
+    expect(wrapper).toContain('".codex"');
+    expect(wrapper).toContain('"auth.json"');
+  });
+
+  it("creates the isolated auth symlink at wrapper startup", async () => {
+    const root = await makeTempDir();
+    const fakeHome = path.join(root, "home");
+    const canonicalCodexHome = path.join(fakeHome, ".codex");
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const installedBinPath = path.join(root, "codex-acp-bin.js");
+    await fs.mkdir(canonicalCodexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(canonicalCodexHome, "auth.json"),
+      `${JSON.stringify({ auth_mode: "apikey", OPENAI_API_KEY: "test-api-key" }, null, 2)}\n`,
+    );
+    await fs.writeFile(installedBinPath, "console.log('ok');\n", "utf8");
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => installedBinPath,
+    });
+
+    await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+      },
+    });
+
+    const isolatedAuthPath = path.join(stateDir, "acpx", "codex-home", "auth.json");
+    const isolatedAuthStat = await fs.lstat(isolatedAuthPath);
+    expect(isolatedAuthStat.isSymbolicLink()).toBe(true);
+    expect(await fs.readlink(isolatedAuthPath)).toBe(path.join(canonicalCodexHome, "auth.json"));
+    expect(await fs.readFile(isolatedAuthPath, "utf8")).toContain(
+      '"OPENAI_API_KEY": "test-api-key"',
+    );
   });
 
   it("normalizes an explicitly configured Codex ACP command to the local wrapper", async () => {

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -127,12 +127,14 @@ function buildAdapterWrapperScript(params: {
   binName: string;
   installedBinPath?: string;
   envSetup: string;
+  extraImports?: string;
 }): string {
   return `#!/usr/bin/env node
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+${params.extraImports ?? ""}
 
 ${params.envSetup}
 const configuredArgs = process.argv.slice(2);
@@ -208,10 +210,25 @@ function buildCodexAcpWrapperScript(installedBinPath?: string): string {
     packageSpec: `${CODEX_ACP_PACKAGE}@${CODEX_ACP_PACKAGE_RANGE}`,
     binName: CODEX_ACP_BIN,
     installedBinPath,
+    extraImports: `import { symlinkSync } from "node:fs";
+import os from "node:os";`,
     envSetup: `const codexHome = fileURLToPath(new URL("./codex-home/", import.meta.url));
 const env = {
   ...process.env,
   CODEX_HOME: codexHome,
+};
+
+// Bridge auth.json from canonical Codex home into isolated CODEX_HOME
+// so that the codex-acp adapter can authenticate. Symlinks are preferred
+// over copies because they pick up token refreshes automatically.
+const canonicalAuthPath = path.join(os.homedir(), ".codex", "auth.json");
+const isolatedAuthPath = path.join(codexHome, "auth.json");
+if (existsSync(canonicalAuthPath) && !existsSync(isolatedAuthPath)) {
+  try {
+    symlinkSync(canonicalAuthPath, isolatedAuthPath);
+  } catch {
+    // If symlink fails (e.g. permissions), the adapter will surface auth error.
+  }
 };`,
   });
 }

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -130,7 +130,7 @@ function buildAdapterWrapperScript(params: {
   extraImports?: string;
 }): string {
   return `#!/usr/bin/env node
-import { existsSync } from "node:fs";
+import { existsSync, symlinkSync } from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -210,8 +210,7 @@ function buildCodexAcpWrapperScript(installedBinPath?: string): string {
     packageSpec: `${CODEX_ACP_PACKAGE}@${CODEX_ACP_PACKAGE_RANGE}`,
     binName: CODEX_ACP_BIN,
     installedBinPath,
-    extraImports: `import { symlinkSync } from "node:fs";
-import os from "node:os";`,
+    extraImports: `import os from "node:os";`,
     envSetup: `const codexHome = fileURLToPath(new URL("./codex-home/", import.meta.url));
 const env = {
   ...process.env,
@@ -229,7 +228,7 @@ if (existsSync(canonicalAuthPath) && !existsSync(isolatedAuthPath)) {
   } catch {
     // If symlink fails (e.g. permissions), the adapter will surface auth error.
   }
-};`,
+}`,
   });
 }
 


### PR DESCRIPTION
## Problem

The ACP/acpx `codex-auth-bridge` creates an isolated `CODEX_HOME` directory at `~/.openclaw/acpx/codex-home/` with only a generated `config.toml` — no `auth.json` is written or symlinked. When the Codex ACP wrapper (`codex-acp-wrapper.mjs`) sets `CODEX_HOME` to this isolated directory, the `codex-acp` adapter cannot find authentication and fails with:

```
{"status":"error","errorCode":"spawn_failed","error":"Authentication required","role":"codex"}
```

This is the ACP-path counterpart of #70511, which was fixed for the native Codex harness by switching to `account/login/start` protocol auth. However, the ACP path still uses the old isolated home approach.

Related: #73910

## Fix

Adds auto-symlinking of `auth.json` from the canonical `~/.codex/auth.json` into the isolated `CODEX_HOME` at wrapper startup time. The symlink is created by the generated `codex-acp-wrapper.mjs` script, which runs before spawning the codex-acp adapter.

Symlinks are preferred over copies because they automatically pick up token refreshes from `codex login`.

### Safety

The symlink is only created if:
1. The canonical `auth.json` exists at `os.homedir() + "/.codex/auth.json"`
2. No `auth.json` already exists in the isolated `CODEX_HOME`

If symlink creation fails (e.g., permissions), it is silently caught — the adapter will surface its own auth error if needed.

### Changes

**`extensions/acpx/src/codex-auth-bridge.ts`**
- Added `extraImports` parameter to `buildAdapterWrapperScript()` for injecting additional ESM imports into the wrapper template
- `buildCodexAcpWrapperScript()` now passes `symlinkSync` and `os` imports plus auth bridge logic in `envSetup`
- The bridge logic: `if (existsSync(canonicalAuthPath) && !existsSync(isolatedAuthPath)) { symlinkSync(canonicalAuthPath, isolatedAuthPath) }`
- Claude ACP wrapper is **unchanged** — no `extraImports`, no auth bridge

**`extensions/acpx/src/codex-auth-bridge.test.ts`**
- Renamed `"does not copy source Codex auth"` → `"bridges source Codex auth via symlink"` and added assertions for `symlinkSync` and `auth.json` in the generated wrapper
- Added `"symlinks canonical Codex auth.json into isolated CODEX_HOME at wrapper startup"` — verifies the generated wrapper contains bridge logic (`symlinkSync`, `canonicalAuthPath`, `isolatedAuthPath`, `.codex`, `auth.json`)
- Added `"creates the isolated auth symlink at wrapper startup"` — **behavioral test** that actually executes the wrapper with `HOME` pointing to a fake home dir containing `auth.json`, and verifies the symlink is created correctly in the isolated CODEX_HOME

### Test Results

All 15 tests pass, including the 3 new/modified auth bridge tests.

### Manual Workaround (until this ships)

```bash
ln -sf ~/.codex/auth.json ~/.openclaw/acpx/codex-home/auth.json
```