### PR TITLE
ci: add codeql quality profile input

### DIFF
--- a/.github/codeql/codeql-plugin-sdk-package-contract-critical-quality.yml
+++ b/.github/codeql/codeql-plugin-sdk-package-contract-critical-quality.yml
@@ -25,6 +25,8 @@ paths-ignore:
   - "**/*-runtime.js"
   - "**/*.test.ts"
   - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
   - "**/*.e2e.test.ts"
   - "**/*.e2e.test.tsx"
   - "**/*test-support*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -29,6 +29,7 @@ permissions:
 jobs:
   core-auth-secrets:
     name: Critical Quality (core-auth-secrets)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -50,6 +51,7 @@ jobs:
 
   config-boundary:
     name: Critical Quality (config-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -71,6 +73,7 @@ jobs:
 
   gateway-runtime-boundary:
     name: Critical Quality (gateway-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -92,6 +95,7 @@ jobs:
 
   channel-runtime-boundary:
     name: Critical Quality (channel-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -113,6 +117,7 @@ jobs:
 
   agent-runtime-boundary:
     name: Critical Quality (agent-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -134,6 +139,7 @@ jobs:
 
   mcp-process-runtime-boundary:
     name: Critical Quality (mcp-process-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -155,6 +161,7 @@ jobs:
 
   memory-runtime-boundary:
     name: Critical Quality (memory-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -176,6 +183,7 @@ jobs:
 
   ui-control-plane:
     name: Critical Quality (ui-control-plane)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -197,6 +205,7 @@ jobs:
 
   web-media-runtime-boundary:
     name: Critical Quality (web-media-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -218,6 +227,7 @@ jobs:
 
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -2,6 +2,15 @@ name: CodeQL Critical Quality
 
 on:
   workflow_dispatch:
+    inputs:
+      profile:
+        description: CodeQL quality profile to run
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - plugin-sdk-package-contract
   schedule:
     - cron: "30 6 * * *"
 
@@ -230,6 +239,7 @@ jobs:
 
   plugin-sdk-package-contract:
     name: Critical Quality (plugin-sdk-package-contract)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-sdk-package-contract' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -279,6 +279,10 @@ default workflow because the macOS build dominates runtime even when clean.
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
+manual dispatch accepts `profile=all|plugin-sdk-package-contract`; the narrow
+profile is the first teaching/iteration hook for running one quality shard in
+isolation without dispatching the rest of the matrix.
+Its
 core-auth-secrets job scans auth, secrets, sandbox, cron, and gateway security
 boundary code under the separate `/codeql-critical-quality/core-auth-secrets`
 category. The config-boundary

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -281,7 +281,7 @@ runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 manual dispatch accepts `profile=all|plugin-sdk-package-contract`; the narrow
 profile is the first teaching/iteration hook for running one quality shard in
-isolation without dispatching the rest of the matrix.
+isolation without dispatching the rest of the workflow.
 Its
 core-auth-secrets job scans auth, secrets, sandbox, cron, and gateway security
 boundary code under the separate `/codeql-critical-quality/core-auth-secrets`


### PR DESCRIPTION
## Summary

- Problem: `CodeQL Critical Quality` could only be manually dispatched as an all-shards workflow, which made iterative shard rollout clumsy.
- Why it matters: when adding small CodeQL expansions, we need a cheap way to exercise one shard on a branch before broadening the workflow contract further.
- What changed: added a `profile` workflow-dispatch input and gated every quality shard so `profile=plugin-sdk-package-contract` runs only that shard, while `profile=all` preserves the current full manual run.
- What this PR intentionally does **not** do: it does not add a full menu for every shard yet; it adds the first real selective path for the new teaching shard.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/74342
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

The quality workflow was authored as a flat list of always-on jobs for schedule/manual dispatch. A dispatch input alone does not narrow the run unless each job or a shared matrix respects that input.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
workflow_dispatch(profile=plugin-sdk-package-contract)
  -> all CodeQL Critical Quality jobs still ran

After:
workflow_dispatch(profile=plugin-sdk-package-contract)
  -> plugin-sdk-package-contract runs
  -> all other quality jobs skip
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux worktree
- Runtime/container: local Node/pnpm for workflow sanity; GitHub Actions for dispatch proof
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check:workflows`
2. `git diff --check`
3. `gh workflow run codeql-critical-quality.yml --ref mason/codeql-quality-profile-input -f profile=plugin-sdk-package-contract`
4. Inspect the jobs for that run

### Expected

- Workflow syntax is valid.
- The new input is accepted by workflow dispatch.
- Only the selected shard runs for the narrow profile.

### Actual

- `pnpm check:workflows` passed.
- `git diff --check` passed.
- Dispatch accepted the new `profile` input.
- Run `25112224394` shows `Critical Quality (plugin-sdk-package-contract)` running while all other quality jobs are skipped.

## Evidence

- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: workflow sanity, dispatch input acceptance, manual dispatch on branch, job inventory inspection.
- Edge cases checked: scheduled behavior remains unchanged; `profile=all` still maps to the existing full manual run behavior.
- What you did **not** verify: adding a selectable profile for every existing shard.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: only one narrow profile is selectable today.
  - Mitigation: that keeps the change small and gives a proven pattern for adding more profiles later.
