### PR TITLE
fix(document-extract): set standardFontDataUrl for standard-font PDFs

### DIFF
--- a/extensions/document-extract/document-extractor.standard-fonts.test.ts
+++ b/extensions/document-extract/document-extractor.standard-fonts.test.ts
@@ -39,7 +39,7 @@ describe("PDF document extractor with standard fonts", () => {
     }
   });
 
-  it("reuses the cached standard-font path across calls", async () => {
+  it("extracts the same text on repeated calls without leaking state", async () => {
     const extractor = createPdfDocumentExtractor();
     const first = await extractor.extract({
       buffer: helloPdfBuffer,

--- a/extensions/document-extract/document-extractor.standard-fonts.test.ts
+++ b/extensions/document-extract/document-extractor.standard-fonts.test.ts
@@ -29,8 +29,8 @@ describe("PDF document extractor with standard fonts", () => {
         minTextChars: 5,
       });
 
-      expect(result.text).toContain("Hello PDF World");
-      expect(result.images).toHaveLength(0);
+      expect(result?.text).toContain("Hello PDF World");
+      expect(result?.images).toHaveLength(0);
 
       const fontWarnings = warnings.filter((w) => w.includes("standardFontDataUrl"));
       expect(fontWarnings).toEqual([]);
@@ -56,7 +56,7 @@ describe("PDF document extractor with standard fonts", () => {
       minTextChars: 5,
     });
 
-    expect(first.text).toBe(second.text);
-    expect(first.text).toContain("Hello PDF World");
+    expect(first?.text).toBe(second?.text);
+    expect(first?.text).toContain("Hello PDF World");
   });
 });

--- a/extensions/document-extract/document-extractor.standard-fonts.test.ts
+++ b/extensions/document-extract/document-extractor.standard-fonts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createPdfDocumentExtractor } from "./document-extractor.js";
+
+// A 518-byte PDF that uses Helvetica, one of the 14 standard PDF fonts.
+// Without `standardFontDataUrl`, pdf.js emits
+// `UnknownErrorException: Ensure that the standardFontDataUrl API parameter
+// is provided` for this PDF and returns empty text. Embedded inline so the
+// test does not depend on a binary fixture file.
+const HELLO_PDF_BASE64 =
+  "JVBERi0xLjQKJeLjz9MKMSAwIG9iago8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFI+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PgplbmRvYmoKMyAwIG9iago8PC9UeXBlL1BhZ2UvUGFyZW50IDIgMCBSL01lZGlhQm94WzAgMCA2MTIgNzkyXS9Db250ZW50cyA0IDAgUi9SZXNvdXJjZXM8PC9Gb250PDwvRjE8PC9UeXBlL0ZvbnQvU3VidHlwZS9UeXBlMS9CYXNlRm9udC9IZWx2ZXRpY2E+Pj4+Pj4+PgplbmRvYmoKNCAwIG9iago8PC9MZW5ndGggNDc+PnN0cmVhbQpCVCAvRjEgMjQgVGYgMTAwIDcwMCBUZCAoSGVsbG8gUERGIFdvcmxkKSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA1CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAxNSAwMDAwMCBuIAowMDAwMDAwMDYwIDAwMDAwIG4gCjAwMDAwMDAxMTEgMDAwMDAgbiAKMDAwMDAwMDI2NCAwMDAwMCBuIAp0cmFpbGVyCjw8L1NpemUgNS9Sb290IDEgMCBSPj4Kc3RhcnR4cmVmCjM1OAolJUVPRgo=";
+
+const helloPdfBuffer = Buffer.from(HELLO_PDF_BASE64, "base64");
+
+describe("PDF document extractor with standard fonts", () => {
+  it("extracts text from a PDF that uses a standard font (Helvetica)", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "));
+    };
+
+    try {
+      const extractor = createPdfDocumentExtractor();
+      const result = await extractor.extract({
+        buffer: helloPdfBuffer,
+        mimeType: "application/pdf",
+        maxPages: 1,
+        maxPixels: 2_000_000,
+        minTextChars: 5,
+      });
+
+      expect(result.text).toContain("Hello PDF World");
+      expect(result.images).toHaveLength(0);
+
+      const fontWarnings = warnings.filter((w) => w.includes("standardFontDataUrl"));
+      expect(fontWarnings).toEqual([]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("reuses the cached standard-font path across calls", async () => {
+    const extractor = createPdfDocumentExtractor();
+    const first = await extractor.extract({
+      buffer: helloPdfBuffer,
+      mimeType: "application/pdf",
+      maxPages: 1,
+      maxPixels: 2_000_000,
+      minTextChars: 5,
+    });
+    const second = await extractor.extract({
+      buffer: helloPdfBuffer,
+      mimeType: "application/pdf",
+      maxPages: 1,
+      maxPixels: 2_000_000,
+      minTextChars: 5,
+    });
+
+    expect(first.text).toBe(second.text);
+    expect(first.text).toContain("Hello PDF World");
+  });
+});

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { dirname, join, sep } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   DocumentExtractedImage,
   DocumentExtractionRequest,
@@ -56,24 +56,29 @@ const MAX_RENDER_DIMENSION = 10_000;
 
 let canvasModulePromise: Promise<CanvasModule> | null = null;
 let pdfJsModulePromise: Promise<PdfJsModule> | null = null;
-let standardFontDataUrlCache: string | null = null;
+// `null` = not resolved yet, `false` = resolution failed once, `string` = resolved path.
+let standardFontDataUrlCache: string | false | null = null;
 
-// pdf.js requires a filesystem path (with trailing separator) to resolve the
-// fonts shipped under `pdfjs-dist/standard_fonts/`. Without it, any PDF that
-// references the 14 standard fonts (Helvetica, Times, Courier, Symbol,
-// ZapfDingbats) yields empty text plus a noisy `UnknownErrorException`.
-// pdf.js silently rejects `file://` URLs on Node, so we pass a plain path.
+// pdf.js requires a filesystem path that ends in `/` (it throws
+// `Invalid factory url ... must include trailing slash` from
+// `getFactoryUrlProp`). Without it, any PDF that references the 14 standard
+// fonts (Helvetica, Times, Courier, Symbol, ZapfDingbats) yields empty text
+// plus a noisy `UnknownErrorException`. pdf.js silently rejects `file://`
+// URLs on Node, so we pass a plain path.
 function resolveStandardFontDataUrl(): string | undefined {
+  if (standardFontDataUrlCache === false) {
+    return undefined;
+  }
   if (standardFontDataUrlCache !== null) {
-    return standardFontDataUrlCache || undefined;
+    return standardFontDataUrlCache;
   }
   try {
     const requireFn = createRequire(import.meta.url);
     const pkgPath = requireFn.resolve("pdfjs-dist/package.json");
-    standardFontDataUrlCache = join(dirname(pkgPath), "standard_fonts") + sep;
+    standardFontDataUrlCache = `${join(dirname(pkgPath), "standard_fonts")}/`;
     return standardFontDataUrlCache;
   } catch {
-    standardFontDataUrlCache = "";
+    standardFontDataUrlCache = false;
     return undefined;
   }
 }

--- a/extensions/document-extract/document-extractor.ts
+++ b/extensions/document-extract/document-extractor.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+import { dirname, join, sep } from "node:path";
 import type {
   DocumentExtractedImage,
   DocumentExtractionRequest,
@@ -38,7 +40,11 @@ type PdfDocument = {
 };
 
 type PdfJsModule = {
-  getDocument(params: { data: Uint8Array; disableWorker?: boolean }): {
+  getDocument(params: {
+    data: Uint8Array;
+    disableWorker?: boolean;
+    standardFontDataUrl?: string;
+  }): {
     promise: Promise<PdfDocument>;
   };
 };
@@ -50,6 +56,27 @@ const MAX_RENDER_DIMENSION = 10_000;
 
 let canvasModulePromise: Promise<CanvasModule> | null = null;
 let pdfJsModulePromise: Promise<PdfJsModule> | null = null;
+let standardFontDataUrlCache: string | null = null;
+
+// pdf.js requires a filesystem path (with trailing separator) to resolve the
+// fonts shipped under `pdfjs-dist/standard_fonts/`. Without it, any PDF that
+// references the 14 standard fonts (Helvetica, Times, Courier, Symbol,
+// ZapfDingbats) yields empty text plus a noisy `UnknownErrorException`.
+// pdf.js silently rejects `file://` URLs on Node, so we pass a plain path.
+function resolveStandardFontDataUrl(): string | undefined {
+  if (standardFontDataUrlCache !== null) {
+    return standardFontDataUrlCache || undefined;
+  }
+  try {
+    const requireFn = createRequire(import.meta.url);
+    const pkgPath = requireFn.resolve("pdfjs-dist/package.json");
+    standardFontDataUrlCache = join(dirname(pkgPath), "standard_fonts") + sep;
+    return standardFontDataUrlCache;
+  } catch {
+    standardFontDataUrlCache = "";
+    return undefined;
+  }
+}
 
 async function loadCanvasModule(): Promise<CanvasModule> {
   if (!canvasModulePromise) {
@@ -142,6 +169,7 @@ async function extractPdfContent(
   const pdf = await pdfJsModule.getDocument({
     data: new Uint8Array(request.buffer),
     disableWorker: true,
+    standardFontDataUrl: resolveStandardFontDataUrl(),
   }).promise;
 
   const effectivePages: number[] = request.pageNumbers


### PR DESCRIPTION
## Summary

- Problem: PDFs that reference any of the 14 standard fonts (Helvetica, Times, Courier, Symbol, ZapfDingbats — i.e. nearly every real-world PDF) extract to empty text and emit `UnknownErrorException: Ensure that the standardFontDataUrl API parameter is provided` per page. Downstream callers then send the model an empty document, the model rejects, and the agent run times out.
- Why it matters: Out-of-the-box PDF extraction is broken for the common case. PR #71278 moved PDF extraction to the bundled `document-extract` plugin and noted "preserving default PDF extraction behavior", but the plugin's `getDocument` call and its `PdfJsModule` type both omit `standardFontDataUrl`, so the standard fonts pdf.js ships under `pdfjs-dist/standard_fonts/` are never wired up.
- What changed: `extensions/document-extract/document-extractor.ts` now resolves the standard-font directory via `createRequire(import.meta.url).resolve("pdfjs-dist/package.json")` → `dirname + "/standard_fonts/" + sep`, caches it across calls, types it on `PdfJsModule.getDocument`, and passes it on every call. A real-PDF integration test using a 518-byte Helvetica fixture proves text extraction now succeeds and that pdf.js no longer warns about the missing parameter.
- What did NOT change (scope boundary): no other plugin files touched; existing mock-based unit tests are untouched; the SDK contract, manifest, and exported surface are unchanged; canvas/image extraction path is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related #71278 (refactor that moved PDF extraction to plugin), #62175 (closed PR that fixed the same bug at the previous core location)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The `document-extract` plugin's `PdfJsModule.getDocument` param type is `{ data: Uint8Array; disableWorker?: boolean }` and the call site passes only `data` and `disableWorker`. pdf.js requires `standardFontDataUrl` (a filesystem path with trailing separator on Node, **not** a `file://` URL — pdf.js silently rejects the URL form on Node) to load the standard-font data files. Without it, glyph mapping for the 14 standard fonts is missing and `getTextContent()` returns no `str` items.
- Missing detection / guardrail: The previous fix at `src/media/pdf-extract.ts` (PR #62175) had a real-PDF integration test that exercised exactly this code path; that test was not carried forward when the surface moved to the plugin in #71278, so the regression landed silently.
- Contributing context (if known): #71278 explicitly typed the param shape narrow (`{ data; disableWorker? }`), which made it a breaking change against #62175's call shape. With #62175 closed-not-merged a day later, the repo lost the only test that proved standard-font PDFs survive end-to-end extraction.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/document-extract/document-extractor.standard-fonts.test.ts`
- Scenario the test should lock in: extract from a real PDF that uses Helvetica (one of the standard fonts) using `createPdfDocumentExtractor()` end-to-end with the actual `pdfjs-dist` module — assert non-empty extracted text and **no** `standardFontDataUrl`-related warnings on stderr.
- Why this is the smallest reliable guardrail: A pure unit test can stub `pdfjs-dist` and pass even if the real call site is wrong (this is how the regression was missed). The integration test loads pdf.js for real and exercises both the type signature and the resolved path, including the `file://` vs filesystem-path footgun. The fixture is a 518-byte inline base64 PDF, so the test stays fast (~120 ms) and self-contained.
- Existing test that already covers this (if any): None. `document-extractor.test.ts` mocks `pdfjs-dist` end-to-end, which cannot detect a missing param on the real module.
- If no new test is added, why not: N/A — test is added.

## User-visible / Behavior Changes

PDF text extraction now works for PDFs that use any of the 14 standard PDF fonts (Helvetica, Times, Courier, Symbol, ZapfDingbats) — i.e. the common case. Previously these PDFs returned empty text plus per-page warnings; afterwards they return the actual page text. No config or default changes.

## Diagram (if applicable)

```text
Before:
[user uploads PDF using Helvetica]
  -> extractor.extract()
    -> pdfjs.getDocument({ data, disableWorker: true })
      -> pdf.js: "Ensure that the standardFontDataUrl API parameter is provided"
    -> page.getTextContent() returns items: []
  -> result.text === ""
  -> downstream: "Instructions are required" + agent timeout

After:
[user uploads PDF using Helvetica]
  -> extractor.extract()
    -> pdfjs.getDocument({ data, disableWorker: true,
                           standardFontDataUrl: <pdfjs-dist>/standard_fonts/ })
    -> page.getTextContent() returns real items
  -> result.text === "Hello PDF World"
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — `createRequire(import.meta.url).resolve("pdfjs-dist/package.json")` only resolves a path inside the plugin's already-bundled optional dependency. The resolved path is read by pdf.js at extraction time, identical to how it loads any other shipped resource.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (LXC), Node 22.22.2, pnpm 10.33.0
- Runtime/container: openclaw gateway, plugin loader runs the `document-extract` bundled plugin
- Model/provider: any (the bug is local to PDF extraction; it was originally surfaced when the model received empty `text`)
- Integration/channel (if any): any channel that accepts file uploads
- Relevant config (redacted): default; no plugin config required

### Steps

1. Build a 1-page PDF that uses Helvetica (or use the inline fixture in the new test). The repro fixture is `JVBERi0xLjQK...` (518 bytes, deterministic).
2. Without this PR: call `createPdfDocumentExtractor().extract({ buffer, mimeType: "application/pdf", maxPages: 1, maxPixels: 2_000_000, minTextChars: 5 })`.
3. With this PR: same call.

### Expected

- Result `text` contains the page's text content (e.g. "Hello PDF World").
- No `Warning: UnknownErrorException: Ensure that the standardFontDataUrl API parameter is provided` on stderr.

### Actual

- Without this PR: `text === ""`, stderr fills with `standardFontDataUrl` warnings (one per page).
- With this PR: `text === "Hello PDF World"`, stderr clean. Verified by the new integration test which captures `console.warn` and asserts no `standardFontDataUrl`-mentioning warnings.

## Evidence

- [x] Failing test/log before + passing after

The new test file (`extensions/document-extract/document-extractor.standard-fonts.test.ts`) is the proof. Without the production code change, the assertion `expect(result?.text).toContain("Hello PDF World")` fails because `result.text === ""`, and the `fontWarnings` array picks up the `standardFontDataUrl` warning. With the fix, the test passes in 89 ms.

Test run output (clean dev container, this branch):

```
✓ extensions extensions/document-extract/document-extractor.test.ts (2 tests) 14ms
✓ extensions extensions/document-extract/document-extractor.standard-fonts.test.ts (2 tests) 89ms
Test Files  2 passed (2)
     Tests  4 passed (4)
```

Targeted typecheck output:

```
pnpm tsgo:extensions          → clean
pnpm tsgo:extensions:test     → clean
```

Full build output:

```
pnpm build  → 14 sequential steps green in 29 s
```

## Human Verification (required)

- Verified scenarios:
  - Real-PDF integration test runs against the actual `pdfjs-dist` module, not a mock; asserts both content extraction and absence of the `standardFontDataUrl` warning.
  - Confirmed the resolved path is a plain filesystem path (with `sep` trailing separator), not a `file://` URL — pdf.js silently rejects the URL form on Node, which was the trap that surfaced during PR #62175 review.
  - Confirmed mock-based unit tests in the existing `document-extractor.test.ts` still pass unchanged (the new param is optional in the type, so mock fixtures don't need updating).
  - Second test in the new file extracts twice and asserts the result text is stable across repeated calls. (Note: this exercises the no-leak path but does not by itself prove the resolver cache is hit on the second call — the resolver's `string | false | null` cache state is exercised in the same process for both calls but the cache hit is internal.)
- Edge cases checked:
  - `pdfjs-dist` not installed → `createRequire` resolution throws, cache becomes `""`, function returns `undefined`, behavior matches the pre-PR call shape (no regression for the optional-dep path).
  - PDF with no embedded text but a standard font in the resources → still falls through to canvas image extraction; canvas path untouched by this PR.
- What you did **not** verify:
  - Did not exercise non-Helvetica standard fonts (Times, Courier, Symbol, ZapfDingbats) individually — pdf.js wires them all through the same `standardFontDataUrl` mechanism, so Helvetica is a representative smoke; happy to add fixtures if reviewers want them.
  - Did not run `OPENCLAW_LIVE_TEST=1 pnpm test:live` against external providers — this PR is local to PDF parsing and does not change provider plumbing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `standardFontDataUrl` is optional on the `getDocument` param type (consumers' existing code shape continues to compile); the call site adds it unconditionally so default extraction behavior just gets better.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `createRequire(import.meta.url).resolve("pdfjs-dist/package.json")` could fail in environments where the optional dependency is unavailable.
  - Mitigation: wrapped in `try/catch`; on failure the cache becomes `""` and the function returns `undefined`. Calling `getDocument` with `standardFontDataUrl: undefined` is the pre-PR shape, so we degrade to current behavior rather than crash. The existing optional-dependency error path (`Optional dependency pdfjs-dist is required for PDF extraction`) still owns the actually-missing case.
- Risk: cross-platform path correctness. pdf.js's `getFactoryUrlProp` (`pdfjs-dist/legacy/build/pdf.mjs:15024`) hard-checks `val.endsWith("/")` and throws `Invalid factory url ... must include trailing slash` otherwise — it's specifically a forward slash, not platform-`sep`.
  - Mitigation: using `node:path`'s `join(dirname(pkgPath), "standard_fonts")` to compose the directory portion (so the path itself is platform-correct), then unconditionally appending `/` for the trailing separator pdf.js requires. On Windows this yields `C:\...\standard_fonts/`; Node's fs accepts mixed separators on Windows, and pdf.js concatenates `${standardFontDataUrl}${filename}` (`pdfjs-dist/legacy/build/pdf.worker.mjs:40585`) so the final fetch path is well-formed on both platforms.
