### PR TITLE
fix(ssrf): restrict dangerouslyAllowPrivateNetwork to self-hosted providers only

### DIFF
--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -9,7 +9,7 @@ import {
   resolveSearchCount,
   resolveSiteName,
   resolveTimeoutSeconds,
-  withTrustedWebSearchEndpoint,
+  withSelfHostedWebSearchEndpoint,
   wrapWebContent,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
@@ -177,7 +177,7 @@ export async function runSearxngSearch(params: {
   });
 
   const startedAt = Date.now();
-  const results = await withTrustedWebSearchEndpoint(
+  const results = await withSelfHostedWebSearchEndpoint(
     {
       url,
       timeoutSeconds,

--- a/src/agents/tools/web-guarded-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-guarded-fetch.ssrf.test.ts
@@ -3,19 +3,48 @@
 // confirm that the policy assigned to each endpoint wrapper produces the expected
 // allow/block behaviour for private network addresses.
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../infra/net/ssrf.js";
 import {
   withSelfHostedWebToolsEndpoint,
   withTrustedWebToolsEndpoint,
 } from "./web-guarded-fetch.js";
 
+const PROXY_VARS = [
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "http_proxy",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+] as const;
+
 function makeLookup(address: string): LookupFn {
   return vi.fn(async () => [{ address, family: 4 }]) as unknown as LookupFn;
 }
 
 describe("web-guarded-fetch SSRF policy integration", () => {
+  let savedProxyEnv: Partial<Record<string, string>>;
+
+  beforeEach(() => {
+    savedProxyEnv = {};
+    for (const key of PROXY_VARS) {
+      savedProxyEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
   afterEach(() => {
+    for (const key of PROXY_VARS) {
+      const saved = savedProxyEnv[key];
+      if (saved === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved;
+      }
+    }
     vi.clearAllMocks();
   });
 

--- a/src/agents/tools/web-guarded-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-guarded-fetch.ssrf.test.ts
@@ -1,0 +1,142 @@
+// Integration tests for SSRF policy enforcement at the web-guarded-fetch boundary.
+// These tests do NOT mock fetchWithSsrFGuard — they exercise the real guard logic to
+// confirm that the policy assigned to each endpoint wrapper produces the expected
+// allow/block behaviour for private network addresses.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  withSelfHostedWebToolsEndpoint,
+  withTrustedWebToolsEndpoint,
+} from "./web-guarded-fetch.js";
+
+type LookupFn = (
+  hostname: string,
+  opts: { all: boolean },
+) => Promise<{ address: string; family: number }[]>;
+
+function makeLookup(address: string): LookupFn {
+  return vi.fn(async () => [{ address, family: 4 }]) as unknown as LookupFn;
+}
+
+describe("web-guarded-fetch SSRF policy integration", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("withTrustedWebToolsEndpoint", () => {
+    it("blocks requests to private IPv4 literals without calling fetch", async () => {
+      const fetchImpl = vi.fn();
+      await expect(
+        withTrustedWebToolsEndpoint(
+          { url: "http://127.0.0.1:8080/internal", fetchImpl },
+          async () => undefined,
+        ),
+      ).rejects.toThrow(/private|internal|blocked/i);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("blocks requests to RFC-1918 private IPv4 literals without calling fetch", async () => {
+      const fetchImpl = vi.fn();
+      await expect(
+        withTrustedWebToolsEndpoint(
+          { url: "http://192.168.1.1/admin", fetchImpl },
+          async () => undefined,
+        ),
+      ).rejects.toThrow(/private|internal|blocked/i);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("blocks requests when DNS resolves a hostname to a private address", async () => {
+      const fetchImpl = vi.fn();
+      const lookupFn = makeLookup("10.0.0.1");
+      await expect(
+        withTrustedWebToolsEndpoint(
+          { url: "https://internal.corp/api", fetchImpl, lookupFn },
+          async () => undefined,
+        ),
+      ).rejects.toThrow(/private|internal|blocked/i);
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    it("blocks redirect chains that hop to private hosts", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(null, { status: 302, headers: { location: "http://127.0.0.1:6379/" } }),
+        );
+      const lookupFn = makeLookup("93.184.216.34");
+      await expect(
+        withTrustedWebToolsEndpoint(
+          { url: "https://public.example/start", fetchImpl, lookupFn },
+          async () => undefined,
+        ),
+      ).rejects.toThrow(/private|internal|blocked/i);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows requests to public cloud API endpoints", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      const lookupFn = makeLookup("93.184.216.34");
+      const result = await withTrustedWebToolsEndpoint(
+        { url: "https://api.search.example/v1/search", fetchImpl, lookupFn },
+        async (res) => res.status,
+      );
+      expect(result).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("withSelfHostedWebToolsEndpoint", () => {
+    it("allows requests to private IPv4 literals (self-hosted services)", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      const result = await withSelfHostedWebToolsEndpoint(
+        { url: "http://192.168.1.100:8888/search", fetchImpl },
+        async (res) => res.status,
+      );
+      expect(result).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows requests to loopback addresses (self-hosted services)", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      const result = await withSelfHostedWebToolsEndpoint(
+        { url: "http://127.0.0.1:8080/search", fetchImpl },
+        async (res) => res.status,
+      );
+      expect(result).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows requests when DNS resolves a hostname to a private LAN address", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      const lookupFn = makeLookup("10.0.0.50");
+      const result = await withSelfHostedWebToolsEndpoint(
+        { url: "http://searxng.internal/search", fetchImpl, lookupFn },
+        async (res) => res.status,
+      );
+      expect(result).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("still allows requests to public endpoints", async () => {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
+      const lookupFn = makeLookup("93.184.216.34");
+      const result = await withSelfHostedWebToolsEndpoint(
+        { url: "https://public.example/search", fetchImpl, lookupFn },
+        async (res) => res.status,
+      );
+      expect(result).toBe(200);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/agents/tools/web-guarded-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-guarded-fetch.ssrf.test.ts
@@ -4,15 +4,11 @@
 // allow/block behaviour for private network addresses.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LookupFn } from "../../infra/net/ssrf.js";
 import {
   withSelfHostedWebToolsEndpoint,
   withTrustedWebToolsEndpoint,
 } from "./web-guarded-fetch.js";
-
-type LookupFn = (
-  hostname: string,
-  opts: { all: boolean },
-) => Promise<{ address: string; family: number }[]>;
 
 function makeLookup(address: string): LookupFn {
   return vi.fn(async () => [{ address, family: 4 }]) as unknown as LookupFn;
@@ -81,7 +77,7 @@ describe("web-guarded-fetch SSRF policy integration", () => {
       const lookupFn = makeLookup("93.184.216.34");
       const result = await withTrustedWebToolsEndpoint(
         { url: "https://api.search.example/v1/search", fetchImpl, lookupFn },
-        async (res) => res.status,
+        async (res) => res.response.status,
       );
       expect(result).toBe(200);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -95,7 +91,7 @@ describe("web-guarded-fetch SSRF policy integration", () => {
         .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
       const result = await withSelfHostedWebToolsEndpoint(
         { url: "http://192.168.1.100:8888/search", fetchImpl },
-        async (res) => res.status,
+        async (res) => res.response.status,
       );
       expect(result).toBe(200);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -107,7 +103,7 @@ describe("web-guarded-fetch SSRF policy integration", () => {
         .mockResolvedValueOnce(new Response(JSON.stringify({ results: [] }), { status: 200 }));
       const result = await withSelfHostedWebToolsEndpoint(
         { url: "http://127.0.0.1:8080/search", fetchImpl },
-        async (res) => res.status,
+        async (res) => res.response.status,
       );
       expect(result).toBe(200);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -120,7 +116,7 @@ describe("web-guarded-fetch SSRF policy integration", () => {
       const lookupFn = makeLookup("10.0.0.50");
       const result = await withSelfHostedWebToolsEndpoint(
         { url: "http://searxng.internal/search", fetchImpl, lookupFn },
-        async (res) => res.status,
+        async (res) => res.response.status,
       );
       expect(result).toBe(200);
       expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -133,7 +129,7 @@ describe("web-guarded-fetch SSRF policy integration", () => {
       const lookupFn = makeLookup("93.184.216.34");
       const result = await withSelfHostedWebToolsEndpoint(
         { url: "https://public.example/search", fetchImpl, lookupFn },
-        async (res) => res.status,
+        async (res) => res.response.status,
       );
       expect(result).toBe(200);
       expect(fetchImpl).toHaveBeenCalledTimes(1);

--- a/src/agents/tools/web-guarded-fetch.test.ts
+++ b/src/agents/tools/web-guarded-fetch.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../../infra/net/fetch-guard.js";
-import { withStrictWebToolsEndpoint, withTrustedWebToolsEndpoint } from "./web-guarded-fetch.js";
+import {
+  withSelfHostedWebToolsEndpoint,
+  withStrictWebToolsEndpoint,
+  withTrustedWebToolsEndpoint,
+} from "./web-guarded-fetch.js";
 
 vi.mock("../../infra/net/fetch-guard.js", () => {
   const GUARDED_FETCH_MODE = {
@@ -26,7 +30,7 @@ describe("web-guarded-fetch", () => {
     vi.clearAllMocks();
   });
 
-  it("uses trusted SSRF policy for trusted web tools endpoints", async () => {
+  it("uses a restrictive (empty) SSRF policy for trusted web tools endpoints", async () => {
     vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
       response: new Response("ok", { status: 200 }),
       finalUrl: "https://example.com",
@@ -38,6 +42,29 @@ describe("web-guarded-fetch", () => {
     expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://example.com",
+        policy: {},
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    );
+    const call = vi.mocked(fetchWithSsrFGuard).mock.calls[0]?.[0];
+    expect(call?.policy).not.toHaveProperty("dangerouslyAllowPrivateNetwork");
+  });
+
+  it("uses a private-network-allowing SSRF policy for self-hosted web tools endpoints", async () => {
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response: new Response("ok", { status: 200 }),
+      finalUrl: "http://192.168.1.100:8080",
+      release: async () => {},
+    });
+
+    await withSelfHostedWebToolsEndpoint(
+      { url: "http://192.168.1.100:8080/search" },
+      async () => undefined,
+    );
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "http://192.168.1.100:8080/search",
         policy: expect.objectContaining({
           dangerouslyAllowPrivateNetwork: true,
           allowRfc2544BenchmarkRange: true,

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -7,7 +7,13 @@ import {
 } from "../../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
-const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
+// Standard policy for cloud web search APIs with fixed public endpoints.
+const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {};
+
+// Policy for self-hosted services (e.g. SearXNG) that intentionally run on
+// private/LAN addresses. Only use this when the endpoint URL is operator-configured
+// and already validated to target a trusted private host.
+const WEB_TOOLS_SELF_HOSTED_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
   allowRfc2544BenchmarkRange: true,
 };
@@ -69,6 +75,20 @@ export async function withTrustedWebToolsEndpoint<T>(
     {
       ...params,
       policy: WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY,
+      useEnvProxy: true,
+    },
+    run,
+  );
+}
+
+export async function withSelfHostedWebToolsEndpoint<T>(
+  params: WebToolEndpointFetchOptions,
+  run: (result: { response: Response; finalUrl: string }) => Promise<T>,
+): Promise<T> {
+  return await withWebToolsNetworkGuard(
+    {
+      ...params,
+      policy: WEB_TOOLS_SELF_HOSTED_SSRF_POLICY,
       useEnvProxy: true,
     },
     run,

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -16,7 +16,7 @@ import {
 
 type WebGuardedFetchModule = Pick<
   typeof import("./web-guarded-fetch.js"),
-  "withTrustedWebToolsEndpoint"
+  "withTrustedWebToolsEndpoint" | "withSelfHostedWebToolsEndpoint"
 >;
 
 let webGuardedFetchPromise: Promise<WebGuardedFetchModule> | null = null;
@@ -26,6 +26,13 @@ async function loadTrustedWebToolsEndpoint(): Promise<
 > {
   webGuardedFetchPromise ??= import("./web-guarded-fetch.js");
   return (await webGuardedFetchPromise).withTrustedWebToolsEndpoint;
+}
+
+async function loadSelfHostedWebToolsEndpoint(): Promise<
+  WebGuardedFetchModule["withSelfHostedWebToolsEndpoint"]
+> {
+  webGuardedFetchPromise ??= import("./web-guarded-fetch.js");
+  return (await webGuardedFetchPromise).withSelfHostedWebToolsEndpoint;
 }
 
 export type SearchConfigRecord = (NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
@@ -84,6 +91,25 @@ export async function withTrustedWebSearchEndpoint<T>(
 ): Promise<T> {
   const withTrustedWebToolsEndpoint = await loadTrustedWebToolsEndpoint();
   return withTrustedWebToolsEndpoint(
+    {
+      url: params.url,
+      init: params.init,
+      timeoutSeconds: params.timeoutSeconds,
+    },
+    async ({ response }) => run(response),
+  );
+}
+
+export async function withSelfHostedWebSearchEndpoint<T>(
+  params: {
+    url: string;
+    timeoutSeconds: number;
+    init: RequestInit;
+  },
+  run: (response: Response) => Promise<T>,
+): Promise<T> {
+  const withSelfHostedWebToolsEndpoint = await loadSelfHostedWebToolsEndpoint();
+  return withSelfHostedWebToolsEndpoint(
     {
       url: params.url,
       init: params.init,

--- a/src/plugin-sdk/provider-web-fetch.ts
+++ b/src/plugin-sdk/provider-web-fetch.ts
@@ -7,6 +7,7 @@ import type {
 } from "../plugins/types.js";
 export { jsonResult, readNumberParam, readStringParam } from "../agents/tools/common.js";
 export {
+  withSelfHostedWebToolsEndpoint,
   withStrictWebToolsEndpoint,
   withTrustedWebToolsEndpoint,
 } from "../agents/tools/web-guarded-fetch.js";

--- a/src/plugin-sdk/provider-web-search.ts
+++ b/src/plugin-sdk/provider-web-search.ts
@@ -32,6 +32,7 @@ export {
   resolveSiteName,
   postTrustedWebToolsJson,
   throwWebSearchApiError,
+  withSelfHostedWebSearchEndpoint,
   withTrustedWebSearchEndpoint,
   writeCachedSearchPayload,
 } from "../agents/tools/web-search-provider-common.js";


### PR DESCRIPTION
Closes #74357

## What changed

`src/agents/tools/web-guarded-fetch.ts:10–13` previously defined a single SSRF policy applied to every web search call:

```typescript
// before — applied to ALL 10 web search providers
const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
  dangerouslyAllowPrivateNetwork: true,
  allowRfc2544BenchmarkRange: true,
};
```

This is replaced with two policies and two endpoint functions:

```typescript
// after — cloud providers get the strict default
const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {};

// self-hosted providers (SearXNG) keep private network access
const WEB_TOOLS_SELF_HOSTED_SSRF_POLICY: SsrFPolicy = {
  dangerouslyAllowPrivateNetwork: true,
  allowRfc2544BenchmarkRange: true,
};

export async function withSelfHostedWebToolsEndpoint<T>(...) // new
```

SearXNG is the only provider switched to `withSelfHostedWebSearchEndpoint`. All other providers (DuckDuckGo, Brave, Perplexity, xAI, Exa, Gemini, Tavily, Kimi, MiniMax) continue using `withTrustedWebSearchEndpoint`, which now uses the strict policy.

`withSelfHostedWebToolsEndpoint` and `withSelfHostedWebSearchEndpoint` are exported from the plugin SDK so third-party self-hosted provider plugins can opt in explicitly.

## Why SearXNG still works

SearXNG already validates its base URL in `validateSearxngBaseUrl()` before making any request — HTTP URLs must target a private/loopback host via `assertHttpUrlTargetsPrivateNetwork`. The self-hosted endpoint preserves the private network access that the fetch call needs after that validation passes.

## Files changed

- `src/agents/tools/web-guarded-fetch.ts` — split policy, add `withSelfHostedWebToolsEndpoint`
- `src/agents/tools/web-search-provider-common.ts` — add `withSelfHostedWebSearchEndpoint`
- `extensions/searxng/src/searxng-client.ts` — switch to `withSelfHostedWebSearchEndpoint`
- `src/plugin-sdk/provider-web-search.ts` — export `withSelfHostedWebSearchEndpoint`
- `src/plugin-sdk/provider-web-fetch.ts` — export `withSelfHostedWebToolsEndpoint`