### PR TITLE
feat(feishu): add userToolAllowFrom for trusted tool actions

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -55,25 +55,26 @@ openclaw pairing list feishu
 openclaw pairing approve feishu <CODE>
 ```
 
-### Approval approvers
+### User tool allowlist
 
 By default, Feishu same-chat approvals infer approvers from `allowFrom` for
-backward compatibility. To let different users chat with the bot while only a
-smaller trusted set can approve sensitive actions, configure
-`approvalApprovers` with Feishu user `open_id` values:
+backward compatibility. To separate users who can chat with the bot from users
+trusted for higher-privilege Feishu tool actions, configure `userToolAllowFrom`
+with Feishu user `open_id` values. The built-in Feishu channel uses this list
+for same-chat approval authorization.
 
 ```json5
 {
   channels: {
     feishu: {
       allowFrom: ["ou_regular_user", "ou_operator"],
-      approvalApprovers: ["ou_operator"],
+      userToolAllowFrom: ["ou_operator"],
     },
   },
 }
 ```
 
-`channels.feishu.accounts.<id>.approvalApprovers` can be used for named
+`channels.feishu.accounts.<id>.userToolAllowFrom` can be used for named
 accounts.
 
 ### Group chats
@@ -441,7 +442,7 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.accounts.<id>.tts`               | Per-account TTS override                                                         | `messages.tts`   |
 | `channels.feishu.dmPolicy`                        | DM policy                                                                        | `allowlist`      |
 | `channels.feishu.allowFrom`                       | DM allowlist (open_id list)                                                      | [BotOwnerId]     |
-| `channels.feishu.approvalApprovers`               | Explicit same-chat approval approvers                                            | `allowFrom`      |
+| `channels.feishu.userToolAllowFrom`               | Trusted users for higher-privilege Feishu tool actions                           | `allowFrom`      |
 | `channels.feishu.groupPolicy`                     | Group policy                                                                     | `allowlist`      |
 | `channels.feishu.groupAllowFrom`                  | Group allowlist                                                                  | —                |
 | `channels.feishu.requireMention`                  | Require @mention in groups                                                       | `true`           |

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -55,6 +55,27 @@ openclaw pairing list feishu
 openclaw pairing approve feishu <CODE>
 ```
 
+### Approval approvers
+
+By default, Feishu same-chat approvals infer approvers from `allowFrom` for
+backward compatibility. To let different users chat with the bot while only a
+smaller trusted set can approve sensitive actions, configure
+`approvalApprovers` with Feishu user `open_id` values:
+
+```json5
+{
+  channels: {
+    feishu: {
+      allowFrom: ["ou_regular_user", "ou_operator"],
+      approvalApprovers: ["ou_operator"],
+    },
+  },
+}
+```
+
+`channels.feishu.accounts.<id>.approvalApprovers` can be used for named
+accounts.
+
 ### Group chats
 
 **Group policy** (`channels.feishu.groupPolicy`):
@@ -420,6 +441,7 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.accounts.<id>.tts`               | Per-account TTS override                                                         | `messages.tts`   |
 | `channels.feishu.dmPolicy`                        | DM policy                                                                        | `allowlist`      |
 | `channels.feishu.allowFrom`                       | DM allowlist (open_id list)                                                      | [BotOwnerId]     |
+| `channels.feishu.approvalApprovers`               | Explicit same-chat approval approvers                                            | `allowFrom`      |
 | `channels.feishu.groupPolicy`                     | Group policy                                                                     | `allowlist`      |
 | `channels.feishu.groupAllowFrom`                  | Group allowlist                                                                  | —                |
 | `channels.feishu.requireMention`                  | Require @mention in groups                                                       | `true`           |

--- a/extensions/feishu/src/approval-auth.test.ts
+++ b/extensions/feishu/src/approval-auth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { feishuApprovalAuth } from "./approval-auth.js";
 
 describe("feishuApprovalAuth", () => {
-  it("authorizes open_id approvers and ignores user_id-only allowlists", () => {
+  it("authorizes open_id approvers from allowFrom for backward compatibility", () => {
     expect(
       feishuApprovalAuth.authorizeActorAction({
         cfg: { channels: { feishu: { allowFrom: ["ou_owner"] } } },
@@ -18,6 +18,67 @@ describe("feishuApprovalAuth", () => {
         senderId: "ou_attacker",
         action: "approve",
         approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+  });
+
+  it("uses approvalApprovers before allowFrom when configured", () => {
+    expect(
+      feishuApprovalAuth.authorizeActorAction({
+        cfg: {
+          channels: {
+            feishu: {
+              allowFrom: ["ou_dm_user"],
+              approvalApprovers: ["ou_approver"],
+            },
+          },
+        },
+        senderId: "ou_approver",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+
+    expect(
+      feishuApprovalAuth.authorizeActorAction({
+        cfg: {
+          channels: {
+            feishu: {
+              allowFrom: ["ou_dm_user"],
+              approvalApprovers: ["ou_approver"],
+            },
+          },
+        },
+        senderId: "ou_dm_user",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({
+      authorized: false,
+      reason: "❌ You are not authorized to approve exec requests on Feishu.",
+    });
+  });
+
+  it("uses account-level approvalApprovers for named accounts", () => {
+    expect(
+      feishuApprovalAuth.authorizeActorAction({
+        cfg: {
+          channels: {
+            feishu: {
+              allowFrom: ["ou_top_level"],
+              accounts: {
+                work: {
+                  allowFrom: ["ou_account_dm_user"],
+                  approvalApprovers: ["ou_account_approver"],
+                },
+              },
+            },
+          },
+        },
+        accountId: "work",
+        senderId: "ou_account_approver",
+        action: "approve",
+        approvalKind: "plugin",
       }),
     ).toEqual({ authorized: true });
   });

--- a/extensions/feishu/src/approval-auth.test.ts
+++ b/extensions/feishu/src/approval-auth.test.ts
@@ -22,18 +22,18 @@ describe("feishuApprovalAuth", () => {
     ).toEqual({ authorized: true });
   });
 
-  it("uses approvalApprovers before allowFrom when configured", () => {
+  it("uses userToolAllowFrom before allowFrom when configured", () => {
     expect(
       feishuApprovalAuth.authorizeActorAction({
         cfg: {
           channels: {
             feishu: {
               allowFrom: ["ou_dm_user"],
-              approvalApprovers: ["ou_approver"],
+              userToolAllowFrom: ["ou_tool_user"],
             },
           },
         },
-        senderId: "ou_approver",
+        senderId: "ou_tool_user",
         action: "approve",
         approvalKind: "exec",
       }),
@@ -45,7 +45,7 @@ describe("feishuApprovalAuth", () => {
           channels: {
             feishu: {
               allowFrom: ["ou_dm_user"],
-              approvalApprovers: ["ou_approver"],
+              userToolAllowFrom: ["ou_tool_user"],
             },
           },
         },
@@ -59,7 +59,7 @@ describe("feishuApprovalAuth", () => {
     });
   });
 
-  it("uses account-level approvalApprovers for named accounts", () => {
+  it("uses account-level userToolAllowFrom for named accounts", () => {
     expect(
       feishuApprovalAuth.authorizeActorAction({
         cfg: {
@@ -69,14 +69,14 @@ describe("feishuApprovalAuth", () => {
               accounts: {
                 work: {
                   allowFrom: ["ou_account_dm_user"],
-                  approvalApprovers: ["ou_account_approver"],
+                  userToolAllowFrom: ["ou_account_tool_user"],
                 },
               },
             },
           },
         },
         accountId: "work",
-        senderId: "ou_account_approver",
+        senderId: "ou_account_tool_user",
         action: "approve",
         approvalKind: "plugin",
       }),

--- a/extensions/feishu/src/approval-auth.ts
+++ b/extensions/feishu/src/approval-auth.ts
@@ -17,7 +17,7 @@ export const feishuApprovalAuth = createResolvedApproverActionAuthAdapter({
   resolveApprovers: ({ cfg, accountId }) => {
     const account = resolveFeishuAccount({ cfg, accountId }).config;
     return resolveApprovalApprovers({
-      explicit: account.approvalApprovers,
+      explicit: account.userToolAllowFrom,
       allowFrom: account.allowFrom,
       normalizeApprover: normalizeFeishuApproverId,
     });

--- a/extensions/feishu/src/approval-auth.ts
+++ b/extensions/feishu/src/approval-auth.ts
@@ -17,6 +17,7 @@ export const feishuApprovalAuth = createResolvedApproverActionAuthAdapter({
   resolveApprovers: ({ cfg, accountId }) => {
     const account = resolveFeishuAccount({ cfg, accountId }).config;
     return resolveApprovalApprovers({
+      explicit: account.approvalApprovers,
       allowFrom: account.allowFrom,
       normalizeApprover: normalizeFeishuApproverId,
     });

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -45,18 +45,18 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.groupPolicy).toBe("open");
   });
 
-  it("accepts explicit approval approvers at top-level and account-level", () => {
+  it("accepts explicit user tool allowlists at top-level and account-level", () => {
     const result = FeishuConfigSchema.parse({
-      approvalApprovers: ["ou_top_level"],
+      userToolAllowFrom: ["ou_top_level"],
       accounts: {
         main: {
-          approvalApprovers: ["ou_account"],
+          userToolAllowFrom: ["ou_account"],
         },
       },
     });
 
-    expect(result.approvalApprovers).toEqual(["ou_top_level"]);
-    expect(result.accounts?.main?.approvalApprovers).toEqual(["ou_account"]);
+    expect(result.userToolAllowFrom).toEqual(["ou_top_level"]);
+    expect(result.accounts?.main?.userToolAllowFrom).toEqual(["ou_account"]);
   });
 
   it("rejects top-level webhook mode without verificationToken", () => {

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -45,6 +45,20 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.groupPolicy).toBe("open");
   });
 
+  it("accepts explicit approval approvers at top-level and account-level", () => {
+    const result = FeishuConfigSchema.parse({
+      approvalApprovers: ["ou_top_level"],
+      accounts: {
+        main: {
+          approvalApprovers: ["ou_account"],
+        },
+      },
+    });
+
+    expect(result.approvalApprovers).toEqual(["ou_top_level"]);
+    expect(result.accounts?.main?.approvalApprovers).toEqual(["ou_account"]);
+  });
+
   it("rejects top-level webhook mode without verificationToken", () => {
     const result = FeishuConfigSchema.safeParse({
       connectionMode: "webhook",

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -178,6 +178,7 @@ const FeishuSharedConfigShape = {
   configWrites: z.boolean().optional(),
   dmPolicy: DmPolicySchema.optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  approvalApprovers: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional(),
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -178,7 +178,7 @@ const FeishuSharedConfigShape = {
   configWrites: z.boolean().optional(),
   dmPolicy: DmPolicySchema.optional(),
   allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-  approvalApprovers: z.array(z.union([z.string(), z.number()])).optional(),
+  userToolAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupPolicy: GroupPolicySchema.optional(),
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -3916,6 +3916,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             ],
           },
         },
+        approvalApprovers: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
+        },
         groupPolicy: {
           default: "allowlist",
           anyOf: [
@@ -4533,6 +4546,19 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 enum: ["open", "pairing", "allowlist"],
               },
               allowFrom: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+              approvalApprovers: {
                 type: "array",
                 items: {
                   anyOf: [

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -3916,7 +3916,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             ],
           },
         },
-        approvalApprovers: {
+        userToolAllowFrom: {
           type: "array",
           items: {
             anyOf: [
@@ -4558,7 +4558,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   ],
                 },
               },
-              approvalApprovers: {
+              userToolAllowFrom: {
                 type: "array",
                 items: {
                   anyOf: [


### PR DESCRIPTION
## Summary

This PR adds `channels.feishu.userToolAllowFrom`, an optional Feishu user `open_id` allowlist for users trusted to perform higher-privilege Feishu tool actions.

For the built-in Feishu channel, the first integration point is same-chat approval authorization:

- when `userToolAllowFrom` resolves to one or more valid Feishu `open_id`s, those users are used as the explicit approver set
- when `userToolAllowFrom` is not configured, OpenClaw keeps the existing `allowFrom`-based approver inference for backward compatibility
- named accounts can configure their own `channels.feishu.accounts.<id>.userToolAllowFrom`

## Pain Point

`allowFrom` currently carries too much meaning for Feishu installs. It answers “who may talk to the bot”, but same-chat approvals also infer approvers from that same list. In real deployments, those are different trust boundaries:

- a user may be allowed to DM the bot for ordinary assistant workflows
- a smaller operator/admin set should be allowed to approve sensitive or higher-privilege tool actions

Without a separate user-tool trust list, admins have to choose between two imperfect setups:

- keep `allowFrom` narrow, which blocks legitimate regular users from using the bot
- broaden `allowFrom`, which also broadens who can approve sensitive actions

## Motivation

Feishu/Lark integrations often need to distinguish normal message access from user-tool authorization. This PR introduces that distinction in the built-in Feishu channel without changing the default behavior for existing users.

The name `userToolAllowFrom` is intentionally broader than “approval approvers”: same-chat approvals are the immediate built-in use case, but the config represents the user set trusted for higher-privilege Feishu tool actions. That makes the permission boundary reusable as the Feishu tool surface grows.

## Benefits

- Improves least-privilege configuration: regular bot access and trusted tool authorization no longer have to be the same list.
- Preserves compatibility: installs that only use `allowFrom` continue to behave as before.
- Supports multi-account deployments through account-level overrides.
- Documents the trust boundary explicitly so operators can configure Feishu access without relying on overloaded `allowFrom` semantics.

## Implementation Notes

- `approval-auth.ts` passes `account.userToolAllowFrom` as the explicit approver source before falling back to `account.allowFrom`.
- The schema accepts `userToolAllowFrom` in both top-level and account-level Feishu config.
- The generated bundled channel config metadata is updated.
- Tests cover backward-compatible `allowFrom` behavior, `userToolAllowFrom` precedence, and account-level configuration.

## Testing

- `pnpm test:extension feishu -- extensions/feishu/src/approval-auth.test.ts extensions/feishu/src/config-schema.test.ts`
- `pnpm tsgo:test:extensions`
- `pnpm exec tsx scripts/generate-bundled-channel-config-metadata.ts --check`
- `git diff --check`
