### PR TITLE
fix(ssrf): extend allowRfc2544BenchmarkRange to cover IPv6 uniqueLocal (fc00::/7) (#74351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Security/SSRF: extend `allowRfc2544BenchmarkRange: true` to also exempt IPv6 `fc00::/7` (uniqueLocal) addresses so that fake-ip proxy tools (sing-box, Clash, Surge) that map both IPv4 198.18.0.0/15 and IPv6 fc00::/7 to foreign domains work without SSRF blocking. Fixes #74351. Thanks @hclsys.
 - Messages: add global `messages.visibleReplies` so operators can require visible output to go through `message(action=send)` for any source chat, while `messages.groupChat.visibleReplies` stays available as the group/channel override. Thanks @scoootscooob.
 - Gateway/dev: run `pnpm gateway:watch` through a named tmux session by default, with `gateway:watch:raw` and `OPENCLAW_GATEWAY_WATCH_TMUX=0` for foreground mode, so repeated starts respawn an inspectable watcher without trapping the invoking agent shell. Thanks @vincentkoc.
 - Plugin SDK: mark remaining legacy alias exports and diffs tool/config aliases with deprecation metadata, and add a guard so future legacy alias comments require `@deprecated` tags. Thanks @vincentkoc.

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -7,6 +7,7 @@ import {
   isBlockedSpecialUseIpv6Address,
   isCanonicalDottedDecimalIPv4,
   type Ipv4SpecialUseBlockOptions,
+  type Ipv6SpecialUseBlockOptions,
   isIpv4Address,
   isLegacyIpv4Literal,
   parseCanonicalIpAddress,
@@ -132,6 +133,12 @@ function resolveIpv4SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv4SpecialUseB
   };
 }
 
+function resolveIpv6SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv6SpecialUseBlockOptions {
+  return {
+    allowRfc2544BenchmarkRange: policy?.allowRfc2544BenchmarkRange === true,
+  };
+}
+
 export function isHostnameAllowedByPattern(hostname: string, pattern: string): boolean {
   if (pattern.startsWith("*.")) {
     const suffix = pattern.slice(2);
@@ -170,13 +177,14 @@ export function isPrivateIpAddress(address: string, policy?: SsrFPolicy): boolea
     return false;
   }
   const blockOptions = resolveIpv4SpecialUseBlockOptions(policy);
+  const ipv6BlockOptions = resolveIpv6SpecialUseBlockOptions(policy);
 
   const strictIp = parseCanonicalIpAddress(normalized);
   if (strictIp) {
     if (isIpv4Address(strictIp)) {
       return isBlockedSpecialUseIpv4Address(strictIp, blockOptions);
     }
-    if (isBlockedSpecialUseIpv6Address(strictIp)) {
+    if (isBlockedSpecialUseIpv6Address(strictIp, ipv6BlockOptions)) {
       return true;
     }
     const embeddedIpv4 = extractEmbeddedIpv4FromIpv6(strictIp);

--- a/src/shared/net/ip.test.ts
+++ b/src/shared/net/ip.test.ts
@@ -3,6 +3,7 @@ import { blockedIpv6MulticastLiterals } from "./ip-test-fixtures.js";
 import {
   extractEmbeddedIpv4FromIpv6,
   isBlockedSpecialUseIpv4Address,
+  isBlockedSpecialUseIpv6Address,
   isCanonicalDottedDecimalIPv4,
   isCarrierGradeNatIpv4Address,
   isIpInCidr,
@@ -101,6 +102,26 @@ describe("shared ip helpers", () => {
     expect(isBlockedSpecialUseIpv4Address(benchmark)).toBe(true);
     expect(isBlockedSpecialUseIpv4Address(benchmark, { allowRfc2544BenchmarkRange: true })).toBe(
       false,
+    );
+  });
+
+  it("blocks IPv6 uniqueLocal (fc00::/7) by default but exempts it when allowRfc2544BenchmarkRange is set", () => {
+    // fc00::/7 (uniqueLocal) is the IPv6 counterpart used by fake-ip proxies (sing-box, Clash, Surge)
+    // alongside the IPv4 198.18.0.0/15 RFC 2544 benchmark range.
+    const ula = parseCanonicalIpAddress("fc00::1");
+    const loopback6 = parseCanonicalIpAddress("::1");
+
+    expect(ula?.kind()).toBe("ipv6");
+    expect(loopback6?.kind()).toBe("ipv6");
+    if (!ula || isIpv4Address(ula) || !loopback6 || isIpv4Address(loopback6)) {
+      throw new Error("expected ipv6 fixtures");
+    }
+
+    expect(isBlockedSpecialUseIpv6Address(ula)).toBe(true);
+    expect(isBlockedSpecialUseIpv6Address(ula, { allowRfc2544BenchmarkRange: true })).toBe(false);
+    expect(isBlockedSpecialUseIpv6Address(loopback6)).toBe(true);
+    expect(isBlockedSpecialUseIpv6Address(loopback6, { allowRfc2544BenchmarkRange: true })).toBe(
+      true,
     );
   });
 });

--- a/src/shared/net/ip.ts
+++ b/src/shared/net/ip.ts
@@ -40,6 +40,10 @@ export type Ipv4SpecialUseBlockOptions = {
   allowRfc2544BenchmarkRange?: boolean;
 };
 
+export type Ipv6SpecialUseBlockOptions = {
+  allowRfc2544BenchmarkRange?: boolean;
+};
+
 const EMBEDDED_IPV4_SENTINEL_RULES: Array<{
   matches: (parts: number[]) => boolean;
   toHextets: (parts: number[]) => [high: number, low: number];
@@ -237,10 +241,19 @@ export function isPrivateOrLoopbackIpAddress(raw: string | undefined): boolean {
   return isBlockedSpecialUseIpv6Address(normalized);
 }
 
-export function isBlockedSpecialUseIpv6Address(address: ipaddr.IPv6): boolean {
+export function isBlockedSpecialUseIpv6Address(
+  address: ipaddr.IPv6,
+  options: Ipv6SpecialUseBlockOptions = {},
+): boolean {
   // ipaddr.js returns "discard" at runtime for 100::/64, but its published
   // TypeScript IPv6Range union omits that literal.
   const range = address.range() as BlockedIpv6Range;
+  // fc00::/7 (uniqueLocal) is used by fake-ip proxy tools (sing-box, Clash, Surge) as the
+  // IPv6 counterpart to the IPv4 198.18.0.0/15 RFC 2544 benchmark range. Exempt both when
+  // allowRfc2544BenchmarkRange is set so that fake-ip proxy configurations work symmetrically.
+  if (range === "uniqueLocal" && options.allowRfc2544BenchmarkRange === true) {
+    return false;
+  }
   if (BLOCKED_IPV6_SPECIAL_USE_RANGES.has(range)) {
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes #74351.

Fake-ip proxy tools (sing-box, Clash, Surge) resolve foreign domains to **both** IPv4 `198.18.0.0/15` (RFC 2544 range) and IPv6 `fc00::/7` (uniqueLocal). Setting `tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange: true` correctly exempted the IPv4 side but `isBlockedSpecialUseIpv6Address` had no options parameter, so the IPv6 ULA range remained unconditionally blocked — causing `web_fetch` to fail for all foreign domains through fake-ip proxies.

**Root cause:** `isPrivateIpAddress` in `src/infra/net/ssrf.ts` called `isBlockedSpecialUseIpv6Address(strictIp)` without forwarding the policy options that were already threaded for IPv4.

**Fix (2 files, backward-compatible):**
- `src/shared/net/ip.ts`: add `Ipv6SpecialUseBlockOptions` type (mirrors `Ipv4SpecialUseBlockOptions`); extend `isBlockedSpecialUseIpv6Address` with an optional `options` param (default `{}`); exempt `uniqueLocal` range when `allowRfc2544BenchmarkRange === true`
- `src/infra/net/ssrf.ts`: add `resolveIpv6SpecialUseBlockOptions` helper (mirrors `resolveIpv4SpecialUseBlockOptions`); pass it to the IPv6 check

**Pre-implement audit:**
1. Existing helper: reusing `isBlockedSpecialUseIpv6Address` — extended in-place, not duplicated ✓
2. Shared helper callers: called in 2 places (`ip.ts:237`, `ssrf.ts:186`) — default `{}` preserves backward compatibility for both ✓
3. Rival scan: no competing PR found for #74351 ✓

## Test plan

- [ ] `isBlockedSpecialUseIpv6Address(fc00::1)` → `true` (default, no exemption)
- [ ] `isBlockedSpecialUseIpv6Address(fc00::1, { allowRfc2544BenchmarkRange: true })` → `false` (exempted)
- [ ] `isBlockedSpecialUseIpv6Address(::1, { allowRfc2544BenchmarkRange: true })` → `true` (loopback not exempted)
- [ ] `isPrivateIpAddress("fc00::1", { allowRfc2544BenchmarkRange: true })` → `false` (end-to-end via ssrf.ts)
- [ ] `isPrivateIpAddress("fc00::1")` → `true` (default still blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)