### PR TITLE
fix(plugins): discover library deps in packaged repair

### DIFF
--- a/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
@@ -1075,4 +1075,39 @@ describe("doctor bundled plugin runtime deps", () => {
     ]);
     expectNoLegacyRuntimeDepsManifest(installRoot);
   });
+
+  it("repairs library extension deps during doctor --fix", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    writeJson(path.join(root, "package.json"), { name: "openclaw" });
+    writeJson(path.join(root, "dist", "extensions", "media-understanding-core", "package.json"), {
+      name: "@openclaw/media-understanding-core",
+      dependencies: { sharp: "0.34.5" },
+      openclaw: { bundle: { stageRuntimeDependencies: true } },
+    });
+    const installed = createInstalledRuntimeDeps();
+
+    await maybeRepairBundledPluginRuntimeDeps({
+      runtime: createRuntime(),
+      prompter: createNonInteractiveRepairPrompter(),
+      packageRoot: root,
+      config: { plugins: { enabled: true } },
+      installDeps: (params) => {
+        installed.push(params);
+        materializeRuntimeDeps(params);
+      },
+    });
+
+    const installRoot = resolveBundledRuntimeDependencyPackageInstallRoot(root);
+    expect(installed).toEqual([
+      {
+        installRoot,
+        missingSpecs: ["sharp@0.34.5"],
+        installSpecs: ["sharp@0.34.5"],
+      },
+    ]);
+    expect(installRoot).not.toBe(root);
+    expect(readMaterializedRuntimeDepSpecs(installRoot, ["sharp@0.34.5"])).toEqual([
+      "sharp@0.34.5",
+    ]);
+  });
 });

--- a/src/plugins/bundled-runtime-deps-selection.ts
+++ b/src/plugins/bundled-runtime-deps-selection.ts
@@ -475,6 +475,23 @@ function isBundledProviderConfiguredForRuntimeDeps(params: {
   );
 }
 
+function isBundledLibraryExtensionConfiguredForRuntimeDeps(pluginDir: string): boolean {
+  try {
+    fs.accessSync(path.join(pluginDir, "openclaw.plugin.json"));
+    return false;
+  } catch {}
+  const pkg = readRuntimeDepsJsonObject(path.join(pluginDir, "package.json"));
+  const openclaw = pkg?.openclaw;
+  if (!openclaw || typeof openclaw !== "object" || Array.isArray(openclaw)) {
+    return false;
+  }
+  const bundle = (openclaw as JsonObject).bundle;
+  if (!bundle || typeof bundle !== "object" || Array.isArray(bundle)) {
+    return false;
+  }
+  return (bundle as JsonObject).stageRuntimeDependencies === true;
+}
+
 export function isBundledPluginConfiguredForRuntimeDeps(params: {
   config: OpenClawConfig;
   plugins: NormalizedPluginsConfig;
@@ -561,11 +578,15 @@ export function isBundledPluginConfiguredForRuntimeDeps(params: {
   ) {
     return true;
   }
-  return (
-    (params.includeEnabledByDefaultPlugins ?? true) &&
-    manifest.enabledByDefault &&
-    manifest.providers.length === 0
-  );
+  if (!(params.includeEnabledByDefaultPlugins ?? true)) {
+    return false;
+  }
+  if (manifest.enabledByDefault && manifest.providers.length === 0) {
+    return true;
+  }
+  // Library extensions have no openclaw.plugin.json, so package.json is their
+  // runtime-deps signal after the normal plugin policy gates have passed.
+  return isBundledLibraryExtensionConfiguredForRuntimeDeps(params.pluginDir);
 }
 
 function isBundledPluginExplicitlyDisabledForRuntimeDeps(params: {

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -2407,6 +2407,28 @@ describe("createBundledRuntimeDepsPackagePlan config policy", () => {
     ]);
     expect(result.missing.map((dep) => `${dep.name}@${dep.version}`)).toEqual(["grammy@1.37.0"]);
   });
+
+  it("includes library extensions with stageRuntimeDependencies set in package.json", () => {
+    const packageRoot = makeTempDir();
+    const pluginDir = path.join(packageRoot, "dist", "extensions", "media-understanding-core");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/media-understanding-core",
+        dependencies: { sharp: "0.34.5" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      }),
+    );
+
+    const result = createBundledRuntimeDepsPackagePlan({
+      packageRoot,
+      config: {},
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual(["sharp@0.34.5"]);
+    expect(result.conflicts).toEqual([]);
+  });
 });
 
 describe("ensureBundledPluginRuntimeDeps", () => {


### PR DESCRIPTION
## Summary

Bundled library extensions like `media-understanding-core` have no `openclaw.plugin.json`. For packaged runtime-dependency repair, their only staged-runtime-deps signal is `openclaw.bundle.stageRuntimeDependencies: true` in `package.json`.

This PR closes the remaining packaged repair gap for unscoped bundled runtime-deps scans and `openclaw doctor --fix`: manifest-less bundled library extensions that opt into staged runtime dependencies through `package.json` are now discovered without requiring a plugin manifest.

The user-facing image failures tracked in #73148 and #73424 were fixed separately by 09a2ffc47a through on-demand public-artifact runtime preparation. This PR does not change that path.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- [x] This PR fixes a packaged runtime-dependency repair gap
- Related: #73148 and #73424 were fixed by 09a2ffc47a; this PR covers the remaining packaged scan / doctor repair gap

## Root Cause

- Root cause: `isBundledPluginConfiguredForRuntimeDeps` only used `openclaw.plugin.json` to decide whether a bundled entry participates in config-driven runtime-deps repair. Manifest-less library extensions were therefore skipped even when their `package.json` declared `openclaw.bundle.stageRuntimeDependencies: true`.
- Missing detection / guardrail: no test covered manifest-less library extensions in the packaged runtime-deps scan or doctor repair path.

## Non-goals / Policy

- This PR does not change plugin gate semantics. `plugins.enabled: false`, `plugins.deny`, restrictive `plugins.allow`, and per-entry `enabled: false` still apply before the package.json fallback is considered.
- This PR does not claim gateway startup prestage coverage for `media-understanding-core`. On-demand public-artifact runtime preparation remains handled by 09a2ffc47a.
- This PR does not modify `docs/tools/plugin.md` or redefine the public plugin contract.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test files: `src/plugins/bundled-runtime-deps.test.ts`, `src/commands/doctor-bundled-plugin-runtime-deps.test.ts`
- Scenario locked in: a bundled directory with only `package.json` (no `openclaw.plugin.json`) and `openclaw.bundle.stageRuntimeDependencies: true` has its dependencies collected by the unscoped scan and repaired by `openclaw doctor --fix`.

## User-visible / Behavior Changes

Packaged runtime-deps scans and `openclaw doctor --fix` can now include manifest-less bundled library extensions that opt into staged runtime dependencies through package metadata. Explicit plugin disable/deny/allow behavior is unchanged.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Built from the same source tree. Uses clean staging dirs to avoid cached deps from the on-demand path (09a2ffc47a).

### Before (main baseline, df4136018e)

```bash
OPENCLAW_HOME=/tmp/oc-home-before \
OPENCLAW_PLUGIN_STAGE_DIR=/tmp/oc-stage-before \
node /tmp/oc-packaged-main/openclaw.mjs doctor --non-interactive
```

"Bundled plugin runtime deps need staging" lists 43 deps, but **no** `sharp@^0.34.5 (used by media-understanding-core)`.

### After (same main + fix, ce27dfc667)

```bash
OPENCLAW_HOME=/tmp/oc-home-after \
OPENCLAW_PLUGIN_STAGE_DIR=/tmp/oc-stage-after \
node /tmp/oc-packaged-fix/openclaw.mjs doctor --non-interactive
```

Same list now includes: `sharp@^0.34.5 (used by media-understanding-core)`.

### Repair path (`--fix`)

`openclaw doctor --fix` installs `sharp@^0.34.5` into the staging dir; confirmed `sharp/package.json` version is `0.34.5`.

## Evidence

- [x] Regression tests added
- [x] `pnpm test src/plugins/bundled-runtime-deps.test.ts src/commands/doctor-bundled-plugin-runtime-deps.test.ts`
- [x] `pnpm exec oxfmt --check --threads=1 src/commands/doctor-bundled-plugin-runtime-deps.test.ts src/plugins/bundled-runtime-deps-selection.ts src/plugins/bundled-runtime-deps.test.ts`
- [x] `git diff --check origin/main...HEAD`

## Human Verification

- Verified behavior by code path: `isBundledPluginConfiguredForRuntimeDeps` now checks the library-extension package metadata after existing plugin policy gates and after `includeEnabledByDefaultPlugins` filtering.
- Verified PR scope: latest diff touches only `src/plugins/bundled-runtime-deps-selection.ts`, `src/plugins/bundled-runtime-deps.test.ts`, and `src/commands/doctor-bundled-plugin-runtime-deps.test.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
