### PR TITLE
fix(agents): dedupe async media completion sends

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -29,6 +29,7 @@ function createContext(
       pendingCompactionRetry: 0,
       pendingToolMediaUrls: [],
       pendingToolAudioAsVoice: false,
+      messagingToolSentMediaUrls: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
       blockState: {
         thinking: true,
@@ -291,6 +292,19 @@ describe("handleAgentEnd", () => {
       mediaUrls: ["/tmp/reply.opus"],
       audioAsVoice: true,
     });
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+  });
+
+  it("does not flush generated media again after a messaging tool already sent it", async () => {
+    const ctx = createContext(undefined);
+    ctx.state.pendingToolMediaUrls = ["/tmp/generated-song.mp3"];
+    ctx.state.pendingToolAudioAsVoice = true;
+    ctx.state.messagingToolSentMediaUrls = ["/tmp/generated-song.mp3"];
+
+    await handleAgentEnd(ctx);
+
+    expect(ctx.emitBlockReply).not.toHaveBeenCalled();
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
   });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -9,6 +9,7 @@ import { classifyFailoverReason, formatAssistantErrorText } from "./pi-embedded-
 import { isIncompleteTerminalAssistantTurn } from "./pi-embedded-runner/run/incomplete-turn.js";
 import {
   consumePendingToolMediaReply,
+  discardAlreadySentPendingToolMedia,
   hasAssistantVisibleReply,
 } from "./pi-embedded-subscribe.handlers.messages.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -160,6 +161,7 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
   };
 
   const flushPendingMediaAndChannel = () => {
+    discardAlreadySentPendingToolMedia(ctx.state);
     const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
     if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
       ctx.emitBlockReply(pendingToolMediaReply);

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -4,6 +4,7 @@ import {
   buildAssistantStreamData,
   consumePendingToolMediaIntoReply,
   consumePendingToolMediaReply,
+  discardAlreadySentPendingToolMedia,
   handleMessageEnd,
   handleMessageUpdate,
   hasAssistantVisibleReply,
@@ -226,6 +227,34 @@ describe("consumePendingToolMediaIntoReply", () => {
     });
     expect(state.pendingToolMediaUrls).toEqual(["/tmp/a.png"]);
     expect(state.pendingToolAudioAsVoice).toBe(true);
+  });
+});
+
+describe("discardAlreadySentPendingToolMedia", () => {
+  it("removes pending media that was already delivered via a messaging tool", () => {
+    const state = {
+      pendingToolMediaUrls: ["/tmp/a.mp3", "/tmp/b.mp3"],
+      pendingToolAudioAsVoice: true,
+      messagingToolSentMediaUrls: ["/tmp/a.mp3"],
+    };
+
+    discardAlreadySentPendingToolMedia(state);
+
+    expect(state.pendingToolMediaUrls).toEqual(["/tmp/b.mp3"]);
+    expect(state.pendingToolAudioAsVoice).toBe(true);
+  });
+
+  it("clears the voice flag when all pending media was already delivered", () => {
+    const state = {
+      pendingToolMediaUrls: ["/tmp/a.mp3"],
+      pendingToolAudioAsVoice: true,
+      messagingToolSentMediaUrls: ["/tmp/a.mp3"],
+    };
+
+    discardAlreadySentPendingToolMedia(state);
+
+    expect(state.pendingToolMediaUrls).toEqual([]);
+    expect(state.pendingToolAudioAsVoice).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -137,6 +137,22 @@ export function consumePendingToolMediaIntoReply(
   return mergedPayload;
 }
 
+export function discardAlreadySentPendingToolMedia(
+  state: Pick<
+    EmbeddedPiSubscribeState,
+    "pendingToolMediaUrls" | "pendingToolAudioAsVoice" | "messagingToolSentMediaUrls"
+  >,
+): void {
+  if (state.pendingToolMediaUrls.length === 0 || state.messagingToolSentMediaUrls.length === 0) {
+    return;
+  }
+  const sent = new Set(state.messagingToolSentMediaUrls);
+  state.pendingToolMediaUrls = state.pendingToolMediaUrls.filter((mediaUrl) => !sent.has(mediaUrl));
+  if (state.pendingToolMediaUrls.length === 0) {
+    state.pendingToolAudioAsVoice = false;
+  }
+}
+
 export function consumePendingToolMediaReply(
   state: Pick<EmbeddedPiSubscribeState, "pendingToolMediaUrls" | "pendingToolAudioAsVoice">,
 ): BlockReplyPayload | null {


### PR DESCRIPTION
## Summary
- drop pending generated media at agent-end when the message tool already sent the same attachment
- keep orphaned generated media flushing for the no-message-tool path
- add regressions for the music completion double-post case

## Test
- pnpm vitest run src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
- committer gate / pnpm check