### PR TITLE
fix(tasks): cache maintenance session lookups

### DIFF
--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -53,6 +53,9 @@ afterEach(() => {
 function createTaskRegistryMaintenanceHarness(params: {
   tasks: TaskRecord[];
   sessionStore?: Record<string, SessionEntry>;
+  loadSessionStore?: TaskRegistryMaintenanceRuntime["loadSessionStore"];
+  resolveStorePath?: TaskRegistryMaintenanceRuntime["resolveStorePath"];
+  deriveSessionChatType?: TaskRegistryMaintenanceRuntime["deriveSessionChatType"];
   acpEntry?: AcpSessionStoreEntry["entry"];
   activeCronJobIds?: string[];
   activeRunIds?: string[];
@@ -87,8 +90,11 @@ function createTaskRegistryMaintenanceHarness(params: {
             entry: undefined,
             storeReadFailed: false,
           } satisfies AcpSessionStoreEntry),
-    loadSessionStore: () => sessionStore,
-    resolveStorePath: () => "",
+    loadSessionStore: params.loadSessionStore ?? (() => sessionStore),
+    resolveStorePath: params.resolveStorePath ?? (() => ""),
+    ...(params.deriveSessionChatType
+      ? { deriveSessionChatType: params.deriveSessionChatType }
+      : {}),
     isCronJobActive: (jobId: string) => activeCronJobIds.has(jobId),
     getAgentRunContext: (runId: string) =>
       activeRunIds.has(runId) ? { sessionKey: "main" } : undefined,
@@ -162,6 +168,46 @@ function createTaskRegistryMaintenanceHarness(params: {
 }
 
 describe("task-registry maintenance issue #60299", () => {
+  it("reuses session store reads across stale subagent task checks in one pass", async () => {
+    const tasks = Array.from({ length: 10 }, (_, index) =>
+      makeStaleTask({
+        runtime: "subagent",
+        taskId: `task-subagent-stale-${index}`,
+        childSessionKey: `agent:main:subagent:stale-${index}`,
+      }),
+    );
+    const loadSessionStoreMock = vi.fn(() => ({}));
+
+    createTaskRegistryMaintenanceHarness({
+      tasks,
+      loadSessionStore: loadSessionStoreMock,
+      resolveStorePath: () => "/tmp/openclaw-test-sessions-main.json",
+    });
+
+    expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: tasks.length });
+    expect(loadSessionStoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses CLI channel session type derivation across duplicate stale task checks", async () => {
+    const childSessionKey = "agent:main:discord:direct:user-1";
+    const tasks = Array.from({ length: 10 }, (_, index) =>
+      makeStaleTask({
+        runtime: "cli",
+        taskId: `task-cli-channel-stale-${index}`,
+        childSessionKey,
+      }),
+    );
+    const deriveSessionChatTypeMock = vi.fn(() => "direct" as const);
+
+    createTaskRegistryMaintenanceHarness({
+      tasks,
+      deriveSessionChatType: deriveSessionChatTypeMock,
+    });
+
+    expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: tasks.length });
+    expect(deriveSessionChatTypeMock).toHaveBeenCalledTimes(1);
+  });
+
   it("marks stale cron tasks lost once the runtime no longer tracks the job as active", async () => {
     const childSessionKey = "agent:main:workspace:channel:test-channel";
     const task = makeStaleTask({

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -20,11 +20,15 @@ import {
 } from "../plugin-state/plugin-state-store.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { deriveSessionChatType } from "../sessions/session-chat-type.js";
+import type { SessionKeyChatType } from "../sessions/session-chat-type.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
-import { tryRecoverTaskBeforeMarkLost } from "./detached-task-runtime.js";
+import {
+  getDetachedTaskLifecycleRuntime,
+  tryRecoverTaskBeforeMarkLost,
+} from "./detached-task-runtime.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -74,6 +78,7 @@ type TaskRegistryMaintenanceRuntime = {
   unbindSessionBindings?: ReturnType<typeof getSessionBindingService>["unbind"];
   loadSessionStore: typeof loadSessionStore;
   resolveStorePath: typeof resolveStorePath;
+  deriveSessionChatType?: typeof deriveSessionChatType;
   isCronJobActive: typeof isCronJobActive;
   getAgentRunContext: typeof getAgentRunContext;
   parseAgentSessionKey: typeof parseAgentSessionKey;
@@ -112,6 +117,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   unbindSessionBindings: (input) => getSessionBindingService().unbind(input),
   loadSessionStore,
   resolveStorePath,
+  deriveSessionChatType,
   isCronJobActive,
   getAgentRunContext,
   parseAgentSessionKey,
@@ -160,6 +166,16 @@ type CronRecoveryContext = {
   runLogsByJobId: Map<string, CronRunLogEntry[]>;
 };
 
+type SessionStoreLookup = {
+  store: Record<string, unknown>;
+  normalizedLiveKeys?: Set<string>;
+};
+
+type BackingSessionLookupContext = {
+  sessionStoresByPath: Map<string, SessionStoreLookup>;
+  sessionChatTypesByKey: Map<string, SessionKeyChatType>;
+};
+
 function createCronRecoveryContext(): CronRecoveryContext {
   return {
     storePath: taskRegistryMaintenanceRuntime.resolveCronStorePath(),
@@ -167,18 +183,73 @@ function createCronRecoveryContext(): CronRecoveryContext {
   };
 }
 
-function findSessionEntryByKey(store: Record<string, unknown>, sessionKey: string): unknown {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
+function createBackingSessionLookupContext(): BackingSessionLookupContext {
+  return {
+    sessionStoresByPath: new Map<string, SessionStoreLookup>(),
+    sessionChatTypesByKey: new Map<string, SessionKeyChatType>(),
+  };
+}
+
+function getSessionStoreLookup(
+  storePath: string,
+  context?: BackingSessionLookupContext,
+): SessionStoreLookup {
+  if (!context) {
+    return {
+      store: taskRegistryMaintenanceRuntime.loadSessionStore(storePath),
+    };
   }
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
-  for (const [key, entry] of Object.entries(store)) {
-    if (normalizeLowercaseStringOrEmpty(key) === normalized) {
-      return entry;
+  const cached = context.sessionStoresByPath.get(storePath);
+  if (cached) {
+    return cached;
+  }
+  const lookup = {
+    store: taskRegistryMaintenanceRuntime.loadSessionStore(storePath),
+  };
+  context.sessionStoresByPath.set(storePath, lookup);
+  return lookup;
+}
+
+function getNormalizedLiveSessionKeys(lookup: SessionStoreLookup): Set<string> {
+  if (lookup.normalizedLiveKeys) {
+    return lookup.normalizedLiveKeys;
+  }
+  const keys = new Set<string>();
+  for (const [key, entry] of Object.entries(lookup.store)) {
+    if (entry) {
+      keys.add(normalizeLowercaseStringOrEmpty(key));
     }
   }
-  return undefined;
+  lookup.normalizedLiveKeys = keys;
+  return keys;
+}
+
+function hasSessionEntryByKey(lookup: SessionStoreLookup, sessionKey: string): boolean {
+  if (lookup.store[sessionKey]) {
+    return true;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalized ? getNormalizedLiveSessionKeys(lookup).has(normalized) : false;
+}
+
+function resolveSessionChatType(
+  sessionKey: string,
+  context?: BackingSessionLookupContext,
+): SessionKeyChatType {
+  if (!context) {
+    return (taskRegistryMaintenanceRuntime.deriveSessionChatType ?? deriveSessionChatType)(
+      sessionKey,
+    );
+  }
+  const cached = context.sessionChatTypesByKey.get(sessionKey);
+  if (cached) {
+    return cached;
+  }
+  const chatType = (taskRegistryMaintenanceRuntime.deriveSessionChatType ?? deriveSessionChatType)(
+    sessionKey,
+  );
+  context.sessionChatTypesByKey.set(sessionKey, chatType);
+  return chatType;
 }
 
 function isActiveTask(task: TaskRecord): boolean {
@@ -341,7 +412,7 @@ function hasActiveCliRun(task: TaskRecord): boolean {
   return false;
 }
 
-function hasBackingSession(task: TaskRecord): boolean {
+function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupContext): boolean {
   if (task.runtime === "cron") {
     if (!taskRegistryMaintenanceRuntime.isCronRuntimeAuthoritative()) {
       return true;
@@ -369,28 +440,48 @@ function hasBackingSession(task: TaskRecord): boolean {
   }
   if (task.runtime === "subagent" || task.runtime === "cli") {
     if (task.runtime === "cli") {
-      const chatType = deriveSessionChatType(childSessionKey);
+      const chatType = resolveSessionChatType(childSessionKey, context);
       if (chatType === "channel" || chatType === "group" || chatType === "direct") {
         return false;
       }
     }
     const agentId = taskRegistryMaintenanceRuntime.parseAgentSessionKey(childSessionKey)?.agentId;
     const storePath = taskRegistryMaintenanceRuntime.resolveStorePath(undefined, { agentId });
-    const store = taskRegistryMaintenanceRuntime.loadSessionStore(storePath);
-    return Boolean(findSessionEntryByKey(store, childSessionKey));
+    return hasSessionEntryByKey(getSessionStoreLookup(storePath, context), childSessionKey);
   }
 
   return true;
 }
 
-function shouldMarkLost(task: TaskRecord, now: number): boolean {
+function shouldMarkLost(
+  task: TaskRecord,
+  now: number,
+  context?: BackingSessionLookupContext,
+): boolean {
   if (!isActiveTask(task)) {
     return false;
   }
   if (!hasLostGraceExpired(task, now)) {
     return false;
   }
-  return !hasBackingSession(task);
+  return !hasBackingSession(task, context);
+}
+
+function hasTaskLostDecisionInputChanged(before: TaskRecord, after: TaskRecord): boolean {
+  return (
+    before.status !== after.status ||
+    before.runtime !== after.runtime ||
+    before.childSessionKey !== after.childSessionKey ||
+    before.sourceId !== after.sourceId ||
+    before.runId !== after.runId ||
+    before.createdAt !== after.createdAt ||
+    before.startedAt !== after.startedAt ||
+    before.lastEventAt !== after.lastEventAt
+  );
+}
+
+function hasDetachedTaskRecoveryHook(): boolean {
+  return Boolean(getDetachedTaskLifecycleRuntime().tryRecoverTaskBeforeMarkLost);
 }
 
 function shouldPruneTerminalTask(task: TaskRecord, now: number): boolean {
@@ -675,13 +766,14 @@ function projectTaskLost(task: TaskRecord, now: number): TaskRecord {
 export function reconcileTaskRecordForOperatorInspection(
   task: TaskRecord,
   context: CronRecoveryContext = createCronRecoveryContext(),
+  backingSessionContext: BackingSessionLookupContext = createBackingSessionLookupContext(),
 ): TaskRecord {
   const cronRecovery = resolveDurableCronTaskRecovery(task, context);
   if (cronRecovery) {
     return projectTaskRecovered(task, cronRecovery);
   }
   const now = Date.now();
-  if (!shouldMarkLost(task, now)) {
+  if (!shouldMarkLost(task, now, backingSessionContext)) {
     return task;
   }
   return projectTaskLost(task, now);
@@ -690,9 +782,12 @@ export function reconcileTaskRecordForOperatorInspection(
 export function reconcileInspectableTasks(): TaskRecord[] {
   taskRegistryMaintenanceRuntime.ensureTaskRegistryReady();
   const cronRecoveryContext = createCronRecoveryContext();
+  const backingSessionContext = createBackingSessionLookupContext();
   return taskRegistryMaintenanceRuntime
     .listTaskRecords()
-    .map((task) => reconcileTaskRecordForOperatorInspection(task, cronRecoveryContext));
+    .map((task) =>
+      reconcileTaskRecordForOperatorInspection(task, cronRecoveryContext, backingSessionContext),
+    );
 }
 
 configureTaskAuditTaskProvider(reconcileInspectableTasks);
@@ -723,12 +818,13 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
   let cleanupStamped = 0;
   let pruned = 0;
   const cronRecoveryContext = createCronRecoveryContext();
+  const backingSessionContext = createBackingSessionLookupContext();
   for (const task of taskRegistryMaintenanceRuntime.listTaskRecords()) {
     if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
       recovered += 1;
       continue;
     }
-    if (shouldMarkLost(task, now)) {
+    if (shouldMarkLost(task, now, backingSessionContext)) {
       reconciled += 1;
       continue;
     }
@@ -772,6 +868,8 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
   const cronRecoveryContext = createCronRecoveryContext();
+  const backingSessionContext = createBackingSessionLookupContext();
+  const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
   let processed = 0;
   for (const task of tasks) {
     const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
@@ -790,7 +888,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       }
       continue;
     }
-    if (shouldMarkLost(current, now)) {
+    if (shouldMarkLost(current, now, backingSessionContext)) {
       const recovery = await tryRecoverTaskBeforeMarkLost({
         taskId: current.taskId,
         runtime: current.runtime,
@@ -798,7 +896,14 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
         now,
       });
       const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
-      if (!freshAfterHook || !shouldMarkLost(freshAfterHook, now)) {
+      const shouldRecheckFreshTask =
+        Boolean(freshAfterHook) &&
+        (recoveryHookRegistered || hasTaskLostDecisionInputChanged(current, freshAfterHook));
+      if (
+        !freshAfterHook ||
+        (shouldRecheckFreshTask &&
+          !shouldMarkLost(freshAfterHook, now, createBackingSessionLookupContext()))
+      ) {
         processed += 1;
         if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
           await yieldToEventLoop();

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -896,13 +896,18 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
         now,
       });
       const freshAfterHook = taskRegistryMaintenanceRuntime.getTaskById(current.taskId);
+      if (!freshAfterHook) {
+        processed += 1;
+        if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+          await yieldToEventLoop();
+        }
+        continue;
+      }
       const shouldRecheckFreshTask =
-        Boolean(freshAfterHook) &&
-        (recoveryHookRegistered || hasTaskLostDecisionInputChanged(current, freshAfterHook));
+        recoveryHookRegistered || hasTaskLostDecisionInputChanged(current, freshAfterHook);
       if (
-        !freshAfterHook ||
-        (shouldRecheckFreshTask &&
-          !shouldMarkLost(freshAfterHook, now, createBackingSessionLookupContext()))
+        shouldRecheckFreshTask &&
+        !shouldMarkLost(freshAfterHook, now, createBackingSessionLookupContext())
       ) {
         processed += 1;
         if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {


### PR DESCRIPTION
## Summary

- Problem: Task registry maintenance can repeatedly reload and clone the same session store while reconciling many stale subagent/CLI task records.
- Why it matters: On a stale or large `~/.openclaw/tasks/runs.sqlite`, that repeated `loadSessionStore` path can keep the gateway CPU-bound during maintenance and make the machine sluggish.
- What changed: Added a per-maintenance-pass backing-session lookup context that caches session store reads and CLI session chat-type derivation while preserving the existing recovery-hook recheck semantics.
- What did NOT change (scope boundary): This does not change the task registry schema, retention policy, task statuses, cron recovery behavior, ACP cleanup behavior, or any user config.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73517
- Related #73517
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `runTaskRegistryMaintenance` called `shouldMarkLost` for each stale task, and `hasBackingSession` loaded the session store for each subagent/CLI task check. Because `loadSessionStore` can clone the full sessions store, many stale task records pointing at the same store could repeatedly pay that cost in one maintenance pass. CLI channel session checks also repeatedly derived the same chat type, which can walk plugin metadata.
- Missing detection / guardrail: Existing tests covered stale-task reconciliation outcomes, but not the number of session-store reads or chat-type derivations performed during one maintenance pass.
- Contributing context (if known): The issue profile showed hot stacks through `runTaskRegistryMaintenance -> shouldMarkLost -> hasBackingSession -> loadSessionStore -> readSessionStoreCache -> structuredClone` and repeated `deriveSessionChatType` plugin metadata resolution.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tasks/task-registry.maintenance.issue-60299.test.ts`
- Scenario the test should lock in: A maintenance pass with multiple stale subagent tasks sharing a session store loads that store once; duplicate stale CLI channel task checks derive the session chat type once.
- Why this is the smallest reliable guardrail: The bug is in the task-maintenance backing-session lookup path, so a runtime-injected maintenance harness can assert both behavior and lookup counts without needing a real SQLite task DB profile fixture.
- Existing test that already covers this (if any): Existing task maintenance tests covered reconciliation behavior, not the repeated lookup cost.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Task registry maintenance should do less repeated synchronous work when stale task records share the same backing session store or CLI channel session key. No CLI flags or config values changed.

## Diagram (if applicable)

```text
Before:
[stale task A] -> load sessions.json
[stale task B] -> load sessions.json again
[stale task C] -> load sessions.json again

After:
[maintenance pass] -> load sessions.json once -> reuse lookup for stale task checks
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Arch Linux observed in the issue; local tests run on macOS
- Runtime/container: OpenClaw gateway task registry maintenance
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Stale `~/.openclaw/tasks/runs.sqlite*` with historical task/session records

### Steps

1. Accumulate stale active task records in the task registry.
2. Ensure multiple stale subagent/CLI records point at the same agent session store or channel session key.
3. Run task registry maintenance.

### Expected

- Maintenance still reconciles stale tasks correctly.
- The same session store is not reloaded/cloned for each stale task in the same pass.
- Duplicate CLI channel session keys do not repeatedly trigger chat-type/plugin metadata derivation in the same pass.

### Actual

- Before this PR, each stale task check could reload/clone the same session store and repeat chat-type derivation work.
- After this PR, a maintenance pass reuses cached backing-session lookup data.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```text
node --no-maglev node_modules/vitest/vitest.mjs run src/tasks/task-registry.maintenance.issue-60299.test.ts src/tasks/task-registry.test.ts
Test Files  2 passed (2)
Tests       68 passed (68)
```

```text
node_modules/.bin/oxfmt --check src/tasks/task-registry.maintenance.ts src/tasks/task-registry.maintenance.issue-60299.test.ts
All matched files use the correct format.
```

```text
node_modules/.bin/oxlint src/tasks/task-registry.maintenance.ts src/tasks/task-registry.maintenance.issue-60299.test.ts
Found 0 warnings and 0 errors.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Existing task registry maintenance behavior remains green; stale subagent tasks sharing one session store load that store once per pass; duplicate stale CLI channel session checks derive chat type once per pass.
- Edge cases checked: Recovery-hook safety is preserved by rechecking with a fresh lookup context when a recovery hook is registered or the task changed before mark-lost.
- What you did **not** verify: Full `pnpm check` / `pnpm test`; this local checkout does not currently have `pnpm`/`corepack` available. I also avoided full-repo `tsgo` because it previously saturated local CPU on this machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Cached lookups could hide a session-store change made by a detached-task recovery hook.
  - Mitigation: The maintenance pass rechecks with a fresh backing-session lookup context when a recovery hook is registered, and also rechecks if the task changed before mark-lost.
