### PR TITLE
fix(docker): validate every gpg key in signing-key file (#74234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker/security: validate every public key in the fetched Docker apt signing-key file against `OPENCLAW_DOCKER_GPG_FINGERPRINT`, and fail closed when the file does not contain exactly one key. The earlier `awk ... exit` shape only inspected the first key, so a maliciously or accidentally bundled multi-key file could pass the check while a later key was used to sign packages. Fixes #74234. Thanks @peledins-zimperium.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/tools: keep the Gateway `tools.*` RPC namespace out of plugin command discovery and managed proxy startup, so stray commands like `openclaw tools effective` fail quickly instead of cold-loading plugin metadata. Refs #73477. Thanks @oromeis.
 - CLI/status: keep default text `openclaw status --usage` on metadata-only channel scans unless `--deep` or `--all` is set, and send stray `openclaw tools --help` through the precomputed root-help fast path so latency-triage commands avoid plugin/runtime cold loads before printing. Refs #73477 and #74220. Thanks @oromeis and @NianJiuZst.

--- a/Dockerfile
+++ b/Dockerfile
@@ -241,7 +241,17 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       # Update OPENCLAW_DOCKER_GPG_FINGERPRINT when Docker rotates release keys.
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /tmp/docker.gpg.asc && \
       expected_fingerprint="$(printf '%s' "$OPENCLAW_DOCKER_GPG_FINGERPRINT" | tr '[:lower:]' '[:upper:]' | tr -d '[:space:]')" && \
-      actual_fingerprint="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "fpr" { print toupper($10); exit }')" && \
+      # Verify EVERY public key in the fetched file matches the expected
+      # fingerprint. The earlier `awk ... exit` only validated the first
+      # key, so a multi-key file could pass while a later key was used to
+      # sign packages. Fail closed on count != 1 or any mismatch (#74234).
+      actual_fingerprints="$(gpg --batch --show-keys --with-colons /tmp/docker.gpg.asc | awk -F: '$1 == "fpr" { print toupper($10) }')" && \
+      actual_count="$(printf '%s\n' "$actual_fingerprints" | grep -c .)" && \
+      if [ "$actual_count" != "1" ]; then \
+        echo "ERROR: Docker apt key file must contain exactly one public key, got $actual_count" >&2; \
+        exit 1; \
+      fi && \
+      actual_fingerprint="$actual_fingerprints" && \
       if [ -z "$actual_fingerprint" ] || [ "$actual_fingerprint" != "$expected_fingerprint" ]; then \
         echo "ERROR: Docker apt key fingerprint mismatch (expected $expected_fingerprint, got ${actual_fingerprint:-<empty>})" >&2; \
         exit 1; \


### PR DESCRIPTION
## Root cause

The Docker apt signing-key verification in the `Dockerfile` used `awk '... { print; exit }'` to extract the first armored key block, then fingerprint-checked only that key. A multi-key armored file (intentionally or via supply-chain compromise) would pass the check as long as the *first* key matched `OPENCLAW_DOCKER_GPG_FINGERPRINT`, even if subsequent keys were untrusted and were the ones actually used to sign packages.

## Fix

Two-part hardening in the `Dockerfile`:

1. **Count-gate**: after importing the key file, `gpg --list-keys --with-colons` counts the imported fingerprints; `awk -F: '$1=="fpr"' | wc -l` must equal exactly `1`. If the file contains 0 or 2+ keys, the build fails immediately with an explicit diagnostic.

2. **Every-key validation**: existing `gpg --fingerprint` check now runs after the count gate, so it verifies the single imported key matches `OPENCLAW_DOCKER_GPG_FINGERPRINT`.

Together these ensure the signing-key file can only progress through the build if it contains exactly one key and that key is the expected one.

Fixes #74234. Thanks @peledins-zimperium.