### PR TITLE
fix(auto-reply): honour silentReplyPolicy=allow on direct/DM chats (#74409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/silent: remove `isGroupChat` guard from `allowEmptyAssistantReplyAsSilent` so `silentReplyPolicy: "allow"` is honoured on direct/DM chats, not only group chats; direct-chat heartbeats with `silentReply.direct: "allow"` no longer trigger the empty-response retry and fallback cascade. Fixes #74409.
 - Agents/errors: suppress malformed streaming tool-call JSON fragments before they reach chat surfaces while preserving provider request-validation diagnostics. Fixes #59076; keeps #59080 as duplicate coverage. (#59118) Thanks @singleGanghood.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/tools: keep the Gateway `tools.*` RPC namespace out of plugin command discovery and managed proxy startup, so stray commands like `openclaw tools effective` fail quickly instead of cold-loading plugin metadata. Refs #73477. Thanks @oromeis.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -302,7 +302,7 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
   });
 
-  it("does not propagate empty-assistant silence for direct runs", async () => {
+  it("does not propagate empty-assistant silence for direct runs by default", async () => {
     await runPreparedReply(
       baseParams({
         ctx: {
@@ -329,6 +329,40 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(false);
+  });
+
+  it("propagates empty-assistant silence for direct runs when silentReplyPolicy is allow (#74409)", async () => {
+    await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadHistoryBody: "Earlier direct message",
+          OriginatingChannel: "slack",
+          OriginatingTo: "D123",
+          ChatType: "direct",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadHistoryBody: "Earlier direct message",
+          MediaPath: "/tmp/input.png",
+          Provider: "slack",
+          ChatType: "direct",
+          OriginatingChannel: "slack",
+          OriginatingTo: "D123",
+        },
+        cfg: {
+          session: {},
+          channels: {},
+          agents: { defaults: { silentReply: { direct: "allow" } } },
+        },
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
   });
 
   it("allows media-only prompts and preserves thread context in queued followups", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -475,14 +475,12 @@ export async function runPreparedReply(
         silentReplyRewrite: silentReplySettings.rewrite,
       })
     : "";
-  const allowEmptyAssistantReplyAsSilent =
-    isGroupChat &&
-    resolveGroupSilentReplyBehavior({
-      sessionEntry,
-      defaultActivation,
-      silentReplyPolicy: silentReplySettings.policy,
-      silentReplyRewrite: silentReplySettings.rewrite,
-    }).allowEmptyAssistantReplyAsSilent;
+  const allowEmptyAssistantReplyAsSilent = resolveGroupSilentReplyBehavior({
+    sessionEntry,
+    defaultActivation,
+    silentReplyPolicy: silentReplySettings.policy,
+    silentReplyRewrite: silentReplySettings.rewrite,
+  }).allowEmptyAssistantReplyAsSilent;
   const groupSystemPrompt = normalizeOptionalString(promptSessionCtx.GroupSystemPrompt) ?? "";
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },


### PR DESCRIPTION
## Root cause

`allowEmptyAssistantReplyAsSilent` in `get-reply-run.ts` was gated behind `isGroupChat &&`, so `resolveGroupSilentReplyBehavior` was never called for direct/DM conversations. The function itself already returns `silentReplyPolicy === "allow"` regardless of conversation type — the outer `isGroupChat &&` was the sole blocker.

Result: direct-chat heartbeats with `silentReply.direct: "allow"` still hit the empty-response retry → fallback cascade and surfaced as user-facing errors, even though policy explicitly permitted silent absorption.

## Fix

Remove the `isGroupChat &&` short-circuit. `resolveGroupSilentReplyBehavior` now runs for all conversation types and its return value drives `allowEmptyAssistantReplyAsSilent` unconditionally.

## Tests

- Renamed existing "does not propagate empty-assistant silence for direct runs" test to clarify it tests the *default* (no policy configured, `silentReplyPolicy` resolves to `"disallow"`) — still passes, `false` unchanged.
- Added new test: "propagates empty-assistant silence for direct runs when silentReplyPolicy is allow (#74409)" — verifies `allowEmptyAssistantReplyAsSilent: true` when `agents.defaults.silentReply.direct: "allow"`.

41/41 tests pass. Lint clean.

Fixes #74409.