### PR TITLE
fix(memory): use db.loadExtension() instead of sqliteVec.load() for n…

### DIFF
--- a/src/memory-host-sdk/host/sqlite-vec.ts
+++ b/src/memory-host-sdk/host/sqlite-vec.ts
@@ -4,7 +4,6 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 
 type SqliteVecModule = {
   getLoadablePath: () => string;
-  load: (db: DatabaseSync) => void;
 };
 
 const SQLITE_VEC_MODULE_ID = "sqlite-vec";
@@ -25,11 +24,7 @@ export async function loadSqliteVecExtension(params: {
     const extensionPath = resolvedPath ?? sqliteVec.getLoadablePath();
 
     params.db.enableLoadExtension(true);
-    if (resolvedPath) {
-      params.db.loadExtension(extensionPath);
-    } else {
-      sqliteVec.load(params.db);
-    }
+    params.db.loadExtension(extensionPath);
 
     return { ok: true, extensionPath };
   } catch (err) {


### PR DESCRIPTION
## Problem

`sqliteVec.load(db)` is a `better-sqlite3` API. OpenClaw 2026.4.26 switched to `node:sqlite` (`DatabaseSync`), which does not support this method. This causes sqlite-vec to silently fail on all platforms, degrading vector recall to BM25-only.

## Fix

Remove the `sqliteVec.load(db)` branch. Both code paths now call `db.loadExtension(extensionPath)`, which `node:sqlite` supports natively.

Also removed the unused `load` method from the `SqliteVecModule` type definition.

Fixes #74401