### PR TITLE
fix(gateway/restart): write sentinel with continuationMessage on coalesced restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart: write the restart sentinel with the incoming `continuationMessage` when a restart request coalesces with an already-pending restart, so the continuation is not silently dropped for the coalesced caller. Fixes #74424. Thanks @hclsys.
 - Agents/errors: suppress malformed streaming tool-call JSON fragments before they reach chat surfaces while preserving provider request-validation diagnostics. Fixes #59076; keeps #59080 as duplicate coverage. (#59118) Thanks @singleGanghood.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/models: move the OpenAI listable catalog into the plugin manifest so `models list --all --provider openai` uses the manifest fast path instead of loading provider runtime normalization hooks. Thanks @shakkernerd.

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -9,6 +9,7 @@ import {
   buildRestartSuccessContinuation,
   formatDoctorNonInteractiveHint,
   removeRestartSentinelFile,
+  rewriteRestartSentinel,
   type RestartSentinelPayload,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
@@ -421,6 +422,15 @@ export function createGatewayTool(opts?: {
             },
           },
         });
+        // When coalesced with an already-pending restart, beforeEmit is never
+        // called so the sentinel is never written with this request's
+        // continuationMessage. Merge it into any existing sentinel now.
+        if (scheduled.coalesced && continuationMessage) {
+          await rewriteRestartSentinel((existing) => ({
+            ...existing,
+            continuation: buildRestartSuccessContinuation({ sessionKey, continuationMessage }),
+          })).catch(() => undefined);
+        }
         return jsonResult(scheduled);
       }
 


### PR DESCRIPTION
## Problem

When `scheduleGatewaySigusr1Restart` returns `{ coalesced: true }` (two paths in `src/infra/restart.ts`), the `beforeEmit` hook registered by the gateway tool is never called. This means `writeRestartSentinel` never fires, so the `continuationMessage` supplied by the caller is silently dropped.

## Fix

After `scheduleGatewaySigusr1Restart` returns, if the result is coalesced *and* the caller supplied a `continuationMessage`, call `rewriteRestartSentinel` to merge the continuation into any existing sentinel file. The call is fire-and-forget (`.catch(() => undefined)`) so a missing sentinel does not surface as an error on the coalesced path.

## Testing

- Typecheck passes: `tsc --noEmit --project tsconfig.core.json`
- Two paths fixed: in-flight coalesced (no hooks called at all) and already-scheduled coalesced (`updatePendingRestartEmitHooks` overwrites, does not chain)

Fixes #74424.