### PR TITLE
fix(deepseek): expose xhigh and max thinking levels for V4 models

### DIFF
--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -397,6 +397,60 @@ describe("deepseek provider plugin", () => {
     );
   });
 
+  it("exposes xhigh and max thinking levels for deepseek-v4-pro", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    const profile = provider.resolveThinkingProfile?.({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+    } as never);
+
+    expect(profile).toBeDefined();
+    const levelIds = profile!.levels.map((level: { id: string }) => level.id);
+    expect(levelIds).toContain("xhigh");
+    expect(levelIds).toContain("max");
+    expect(levelIds).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+  });
+
+  it("exposes xhigh and max thinking levels for deepseek-v4-flash", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    const profile = provider.resolveThinkingProfile?.({
+      provider: "deepseek",
+      modelId: "deepseek-v4-flash",
+    } as never);
+
+    expect(profile).toBeDefined();
+    const levelIds = profile!.levels.map((level: { id: string }) => level.id);
+    expect(levelIds).toContain("xhigh");
+    expect(levelIds).toContain("max");
+  });
+
+  it("does not expose xhigh or max for deepseek-reasoner", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    const profile = provider.resolveThinkingProfile?.({
+      provider: "deepseek",
+      modelId: "deepseek-reasoner",
+    } as never);
+
+    expect(profile).toBeDefined();
+    const levelIds = profile!.levels.map((level: { id: string }) => level.id);
+    expect(levelIds).not.toContain("xhigh");
+    expect(levelIds).not.toContain("max");
+    expect(levelIds).toEqual(["off", "minimal", "low", "medium", "high"]);
+  });
+
+  it("does not expose xhigh or max for deepseek-chat", async () => {
+    const provider = await registerSingleProviderPlugin(deepseekPlugin);
+    const profile = provider.resolveThinkingProfile?.({
+      provider: "deepseek",
+      modelId: "deepseek-chat",
+    } as never);
+
+    expect(profile).toBeDefined();
+    const levelIds = profile!.levels.map((level: { id: string }) => level.id);
+    expect(levelIds).not.toContain("xhigh");
+    expect(levelIds).not.toContain("max");
+  });
+
   it("publishes configured DeepSeek models through plugin-owned catalog augmentation", async () => {
     const provider = await registerSingleProviderPlugin(deepseekPlugin);
 

--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -7,6 +7,29 @@ import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
 
 const PROVIDER_ID = "deepseek";
 
+const DEEPSEEK_V4_BASE_THINKING_LEVELS = [
+  { id: "off" },
+  { id: "minimal" },
+  { id: "low" },
+  { id: "medium" },
+  { id: "high" },
+  { id: "xhigh" },
+  { id: "max" },
+] as const;
+
+const DEEPSEEK_FALLBACK_THINKING_LEVELS = [
+  { id: "off" },
+  { id: "minimal" },
+  { id: "low" },
+  { id: "medium" },
+  { id: "high" },
+] as const;
+
+function isDeepSeekV4ModelId(modelId: string): boolean {
+  const lower = modelId.toLowerCase();
+  return lower === "deepseek-v4-flash" || lower === "deepseek-v4-pro";
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "DeepSeek Provider",
@@ -46,6 +69,11 @@ export default defineSingleProviderPluginEntry({
       /\bdeepseek\b.*(?:input.*too long|context.*exceed)/i.test(errorMessage),
     ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
     wrapStreamFn: (ctx) => createDeepSeekV4ThinkingWrapper(ctx.streamFn, ctx.thinkingLevel),
+    resolveThinkingProfile: ({ modelId }) => ({
+      levels: isDeepSeekV4ModelId(modelId)
+        ? [...DEEPSEEK_V4_BASE_THINKING_LEVELS]
+        : [...DEEPSEEK_FALLBACK_THINKING_LEVELS],
+    }),
     isModernModelRef: ({ modelId }) => {
       const lower = modelId.toLowerCase();
       return lower === "deepseek-v4-flash" || lower === "deepseek-v4-pro";


### PR DESCRIPTION
## Summary

Fixes #73718

- Adds `resolveThinkingProfile` hook to the DeepSeek provider plugin
- V4 models (`deepseek-v4-flash`, `deepseek-v4-pro`) now advertise `xhigh` and `max` thinking levels in the UI/session/directive surfaces
- Non-V4 models (`deepseek-chat`, `deepseek-reasoner`) keep the standard base profile (off through high)
- The transport layer already mapped `xhigh`/`max` to `reasoning_effort: "max"` — this change exposes those levels so users can select them

## Details

The DeepSeek provider registered stream wrapping, catalog, replay, and auth hooks but no `resolveThinkingProfile`. Without it, the resolver fell back to the base thinking profile which only includes `off`/`minimal`/`low`/`medium`/`high`. The catalog path (`catalogSupportsXHigh`) could append `xhigh` via `supportedReasoningEfforts`, but not `max`, and the catalog entry lacked that array anyway.

The fix adds a provider-owned `resolveThinkingProfile` that returns the full level set for V4 models and the standard set for others, matching how Anthropic, OpenAI, and other providers expose extended thinking levels.

## Testing

- 4 new tests in `extensions/deepseek/index.test.ts` (13 total pass):
  - `deepseek-v4-pro` exposes `xhigh` and `max`
  - `deepseek-v4-flash` exposes `xhigh` and `max`
  - `deepseek-reasoner` does NOT expose `xhigh` or `max`
  - `deepseek-chat` does NOT expose `xhigh` or `max`
- Existing thinking resolution tests (`src/auto-reply/thinking.test.ts`: 36 pass) and session tests (`src/gateway/session-utils.test.ts`: 74 pass) unaffected