### PR TITLE
Fix OpenAI Codex stream auth preservation

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1021,10 +1021,7 @@ describe("openai transport stream", () => {
     );
     expect(params.prompt_cache_key).toBe("session-123");
     expect(params.prompt_cache_retention).toBeUndefined();
-    expect(params.metadata).toEqual({
-      openclaw_session_id: "session-123",
-      openclaw_turn_id: "turn-123",
-    });
+    expect(params).not.toHaveProperty("metadata");
     expect(params.store).toBe(false);
     expect(params.max_output_tokens).toBe(1024);
     expect(params.temperature).toBe(0.2);
@@ -1611,6 +1608,37 @@ describe("openai transport stream", () => {
       openclaw_turn_attempt: "1",
       openclaw_transport: "stream",
     });
+  });
+
+  it("omits native turn metadata on Codex Responses routes", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      { sessionId: "session-123" } as never,
+      {
+        openclaw_session_id: "session-123",
+        openclaw_turn_id: "turn-123",
+        openclaw_turn_attempt: "1",
+        openclaw_transport: "stream",
+      },
+    ) as { metadata?: Record<string, string> };
+
+    expect(params).not.toHaveProperty("metadata");
   });
 
   it("leaves proxy-like OpenAI Responses routes without native turn metadata by default", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -748,6 +748,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           attempt: 1,
           transport: "stream",
         });
+        const turnMetadata = isOpenAICodexResponsesModel(model) ? undefined : turnState?.metadata;
         const client = createOpenAIResponsesClient(
           model,
           context,
@@ -759,13 +760,13 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           context,
           options as OpenAIResponsesOptions,
-          turnState?.metadata,
+          turnMetadata,
         );
         const nextParams = await options?.onPayload?.(params, model);
         if (nextParams !== undefined) {
           params = nextParams as typeof params;
         }
-        params = mergeTransportMetadata(params, turnState?.metadata);
+        params = mergeTransportMetadata(params, turnMetadata);
         const responseStream = (await client.responses.create(
           params as never,
           buildOpenAISdkRequestOptions(model, options?.signal),
@@ -903,7 +904,7 @@ export function buildOpenAIResponsesParams(
     prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
     ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
-    ...(metadata ? { metadata } : {}),
+    ...(metadata && !isCodexResponses ? { metadata } : {}),
   };
   if (options?.maxTokens) {
     params.max_output_tokens = options.maxTokens;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -205,6 +205,7 @@ import {
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentBaseStreamFn,
   resolveEmbeddedAgentStreamFn,
+  wrapEmbeddedAgentStreamFnWithApiKey,
 } from "../stream-resolution.js";
 import {
   applySystemPromptOverrideToSession,
@@ -1703,6 +1704,15 @@ export async function runEmbeddedAttempt(
         preparedRuntimeExtraParams
           ? { preparedExtraParams: preparedRuntimeExtraParams }
           : undefined,
+      );
+      activeSession.agent.streamFn = wrapEmbeddedAgentStreamFnWithApiKey(
+        activeSession.agent.streamFn,
+        {
+          runSignal: runAbortController.signal,
+          resolvedApiKey: params.resolvedApiKey,
+          authStorage: params.authStorage,
+          providerId: params.provider,
+        },
       );
       const effectivePromptCacheRetention = resolveCacheRetention(
         effectiveExtraParams,

--- a/src/agents/pi-embedded-runner/stream-resolution.test.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.test.ts
@@ -6,6 +6,7 @@ import {
   describeEmbeddedAgentStreamStrategy,
   resolveEmbeddedAgentApiKey,
   resolveEmbeddedAgentStreamFn,
+  wrapEmbeddedAgentStreamFnWithApiKey,
 } from "./stream-resolution.js";
 
 // Wrap createBoundaryAwareStreamFnForModel with a spy that delegates to the
@@ -173,6 +174,21 @@ describe("resolveEmbeddedAgentStreamFn", () => {
     });
     expect(authStorage.getApiKey).not.toHaveBeenCalled();
     expect(providerStreamFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("can re-apply the resolved api key after provider wrappers replace the stream function", async () => {
+    const replacementStreamFn = vi.fn(async (_model, _context, options) => options);
+    const streamFn = wrapEmbeddedAgentStreamFnWithApiKey(replacementStreamFn as never, {
+      runSignal: undefined,
+      resolvedApiKey: "resolved-key",
+      authStorage: undefined,
+      providerId: "openai-codex",
+    });
+
+    await expect(
+      streamFn({ provider: "openai-codex", id: "gpt-5.5" } as never, {} as never, {}),
+    ).resolves.toMatchObject({ apiKey: "resolved-key" });
+    expect(replacementStreamFn).toHaveBeenCalledTimes(1);
   });
 
   it("forwards the run abort signal into provider-owned stream functions", async () => {

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -73,7 +73,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
   if (params.providerStreamFn) {
-    return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
+    return wrapEmbeddedAgentStreamFnWithApiKey(params.providerStreamFn, {
       runSignal: params.signal,
       resolvedApiKey: params.resolvedApiKey,
       authStorage: params.authStorage,
@@ -112,7 +112,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       // inject the resolved runtime key for them. Without this wrap, OAuth
       // providers (e.g. openai-codex/gpt-5.5) hit the Responses API with an
       // empty bearer and fail with 401 Missing bearer auth header.
-      return wrapEmbeddedAgentStreamFn(boundaryAwareStreamFn, {
+      return wrapEmbeddedAgentStreamFnWithApiKey(boundaryAwareStreamFn, {
         runSignal: params.signal,
         resolvedApiKey: params.resolvedApiKey,
         authStorage: params.authStorage,
@@ -124,7 +124,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   return currentStreamFn;
 }
 
-function wrapEmbeddedAgentStreamFn(
+export function wrapEmbeddedAgentStreamFnWithApiKey(
   inner: StreamFn,
   params: {
     runSignal: AbortSignal | undefined;


### PR DESCRIPTION
## Summary
- preserve resolved auth-profile API keys after provider stream wrappers replace the embedded stream function
- omit native Responses metadata on OpenAI Codex Responses requests because the Codex endpoint rejects that parameter
- add focused regression coverage for wrapper replacement auth and Codex metadata omission

## Verification
- `pnpm test src/agents/pi-embedded-runner/stream-resolution.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=verbose`
- live local/gateway probe before split returned `ok` with `openai-codex/gpt-5.5`

## Context
This is split out from #73583 because it fixes the OpenAI Codex transport/auth path, not Telegram delivery behavior.
