### PR TITLE
fix(reply): harden headless cron exec prompt defaults

### DIFF
--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -35,6 +35,26 @@ describe("buildExecOverridePromptHint", () => {
     expect(result).toContain("Do not assume a prior denial still applies");
   });
 
+  it("prefers effective exec defaults and adds headless guidance for system turns", () => {
+    const result = buildExecOverridePromptHint({
+      effectiveExecDefaults: {
+        host: "auto",
+        effectiveHost: "gateway",
+        security: "full",
+        ask: "off",
+        canRequestNode: true,
+      },
+      elevatedLevel: "off",
+      headlessExec: true,
+    });
+
+    expect(result).toContain(
+      "Current session exec defaults: host=auto effective=gateway security=full ask=off.",
+    );
+    expect(result).toContain("This is a headless/system-driven turn.");
+    expect(result).toContain("do not choose interactive approvals");
+  });
+
   it("still reports elevated state when exec overrides are inherited", () => {
     const result = buildExecOverridePromptHint({
       elevatedLevel: "full",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
+import { resolveExecDefaults } from "../../agents/exec-defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveEmbeddedFullAccessState } from "../../agents/pi-embedded-runner/sandbox-info.js";
 import type { EmbeddedFullAccessBlockedReason } from "../../agents/pi-embedded-runner/types.js";
@@ -202,16 +203,21 @@ export function resolvePromptSessionContextForSystemEvent(params: {
 
 export function buildExecOverridePromptHint(params: {
   execOverrides?: ExecOverrides;
+  effectiveExecDefaults?: ReturnType<typeof resolveExecDefaults>;
   elevatedLevel: ElevatedLevel;
   fullAccessAvailable?: boolean;
   fullAccessBlockedReason?: EmbeddedFullAccessBlockedReason;
+  headlessExec?: boolean;
 }): string | undefined {
-  const exec = params.execOverrides;
+  const exec = params.effectiveExecDefaults ?? params.execOverrides;
   if (!exec && params.elevatedLevel === "off") {
     return undefined;
   }
   const parts = [
     exec?.host ? `host=${exec.host}` : undefined,
+    "effectiveHost" in (exec ?? {}) && exec?.effectiveHost
+      ? `effective=${exec.effectiveHost}`
+      : undefined,
     exec?.security ? `security=${exec.security}` : undefined,
     exec?.ask ? `ask=${exec.ask}` : undefined,
     exec?.node ? `node=${exec.node}` : undefined,
@@ -225,11 +231,16 @@ export function buildExecOverridePromptHint(params: {
     params.fullAccessAvailable === false
       ? `Auto-approved /elevated full is unavailable here (${params.fullAccessBlockedReason ?? "runtime"}). Do not ask the user to switch to /elevated full.`
       : undefined;
+  const headlessLine =
+    params.headlessExec === true
+      ? "This is a headless/system-driven turn. Do not invent stricter exec settings than the current defaults above. Prefer omitting host/security/ask unless the task explicitly requires a different target or restriction. In autonomous cron/monitor work, do not choose interactive approvals (`ask=on-miss` or `ask=always`) or ad-hoc allowlist mode unless the task explicitly requires human approval."
+      : undefined;
   return [
     "## Current Exec Session State",
     execLine,
     elevatedLine,
     fullAccessLine,
+    headlessLine,
     "If the user asks to run a command, use the current exec state above. Do not assume a prior denial still applies after `/exec` or `/elevated` changed.",
   ]
     .filter(Boolean)
@@ -488,6 +499,12 @@ export async function runPreparedReply(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
     { includeFormattingHints: !useFastReplyRuntime },
   );
+  const effectiveExecDefaults = resolveExecDefaults({
+    cfg,
+    agentId,
+    sessionKey,
+    sessionEntry,
+  });
   const extraSystemPromptParts = [
     inboundMetaPrompt,
     directChatContext,
@@ -496,9 +513,11 @@ export async function runPreparedReply(
     groupSystemPrompt,
     buildExecOverridePromptHint({
       execOverrides,
+      effectiveExecDefaults,
       elevatedLevel: resolvedElevatedLevel,
       fullAccessAvailable: fullAccessState.available,
       fullAccessBlockedReason: fullAccessState.blockedReason,
+      headlessExec: systemSent === true,
     }),
   ].filter(Boolean);
   // Static parts only (no per-message inbound metadata) for CLI session reuse hashing.
@@ -509,9 +528,11 @@ export async function runPreparedReply(
     groupSystemPrompt,
     buildExecOverridePromptHint({
       execOverrides,
+      effectiveExecDefaults,
       elevatedLevel: resolvedElevatedLevel,
       fullAccessAvailable: fullAccessState.available,
       fullAccessBlockedReason: fullAccessState.blockedReason,
+      headlessExec: systemSent === true,
     }),
   ].filter(Boolean);
   const silentReplyPromptMode: SilentReplyPromptMode =


### PR DESCRIPTION
## Summary
- include effective exec defaults in the reply prompt hint instead of only explicit per-message overrides
- add a headless/system-turn warning so cron monitors do not invent interactive exec approval settings
- cover the new hint behavior in the exec-hint test

## Validation
- live local OpenClaw install patched and restarted successfully on Owen’s Mac
- `vmto-pr-5348-monitor` now uses `host=auto security=full ask=off`
- attempted focused repo test run:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/auto-reply/reply/get-reply-run.exec-hint.test.ts`
  - blocked in this environment because `corepack pnpm install --frozen-lockfile --ignore-scripts` failed with `ERR_PNPM_FETCH_401` from the private `@pdm` CodeArtifact registry
