### PR TITLE
fix: block STATE_DIRECTORY from workspace .env and reject relative systemd state paths [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix: block STATE_DIRECTORY from workspace .env and reject relative systemd state paths [AI]. (#74461) Thanks @pgondhi987.
 - Thinking/providers: resolve bundled provider thinking profiles through lightweight provider policy artifacts when startup-lazy providers are not active, so OpenAI Codex GPT-5.x keeps xhigh available in Gateway session validation. Fixes #74796. Thanks @maxschachere.
 - Plugins/TTS: keep bundled speech-provider discovery available on cold package Gateway paths and add bundled plugin matrix runtime probes for health, readiness, RPC, TTS discovery, and post-ready runtime-deps watchdog coverage. Refs #75283. Thanks @vincentkoc.
 - Google Meet/Twilio: show delegated voice call ID, DTMF, and intro-greeting state in `googlemeet doctor`, and avoid claiming DTMF was sent when no Meet PIN sequence was configured. Refs #72478. Thanks @DougButdorf.

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -35,6 +35,7 @@ import {
 import {
   isWritableDirectory,
   pruneUnknownBundledRuntimeDepsRoots,
+  resolveBundledRuntimeDependencyPackageInstallRootPlan,
   resolveBundledRuntimeDependencyInstallRoot,
   resolveBundledRuntimeDependencyInstallRootPlan,
   resolveBundledRuntimeDependencyPackageInstallRoot,
@@ -2380,6 +2381,149 @@ describe("createBundledRuntimeDepsPackagePlan config policy", () => {
       "grammy@1.37.0",
     ]);
     expect(result.missing.map((dep) => `${dep.name}@${dep.version}`)).toEqual(["grammy@1.37.0"]);
+  });
+
+  it("uses absolute systemd state directories for external runtime deps", () => {
+    const packageRoot = makeTempDir();
+    const stateDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+    const pluginRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "slack",
+      deps: { grammy: "1.37.0" },
+      enabledByDefault: true,
+    });
+
+    const installRootPlan = resolveBundledRuntimeDependencyInstallRootPlan(pluginRoot, {
+      env: { STATE_DIRECTORY: stateDir },
+    });
+
+    expect(installRootPlan.external).toBe(true);
+    expect(installRootPlan.installRoot).toContain(
+      path.join(stateDir, "plugin-runtime-deps", "openclaw-2026.4.25-"),
+    );
+  });
+
+  it("ignores relative systemd state directories for external runtime deps", () => {
+    const packageRoot = makeTempDir();
+    const trustedStateDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+    const pluginRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "slack",
+      deps: { grammy: "1.37.0" },
+      enabledByDefault: true,
+    });
+
+    const installRootPlan = resolveBundledRuntimeDependencyInstallRootPlan(pluginRoot, {
+      env: {
+        OPENCLAW_STATE_DIR: trustedStateDir,
+        STATE_DIRECTORY: "./.evil-state",
+      },
+    });
+
+    expect(installRootPlan.external).toBe(true);
+    expect(installRootPlan.installRoot).toContain(
+      path.join(trustedStateDir, "plugin-runtime-deps", "openclaw-2026.4.25-"),
+    );
+    expect(installRootPlan.installRoot).not.toContain(".evil-state");
+  });
+
+  it("uses absolute systemd state directories for package-level runtime deps", () => {
+    const packageRoot = makeTempDir();
+    const stateDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+
+    const installRootPlan = resolveBundledRuntimeDependencyPackageInstallRootPlan(packageRoot, {
+      env: { STATE_DIRECTORY: stateDir },
+    });
+
+    expect(installRootPlan.external).toBe(true);
+    expect(installRootPlan.installRoot).toContain(
+      path.join(stateDir, "plugin-runtime-deps", "openclaw-2026.4.25-"),
+    );
+  });
+
+  it("ignores relative systemd state directories for package-level runtime deps", () => {
+    const packageRoot = makeTempDir();
+    const trustedStateDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+
+    const installRootPlan = resolveBundledRuntimeDependencyPackageInstallRootPlan(packageRoot, {
+      env: {
+        OPENCLAW_STATE_DIR: trustedStateDir,
+        STATE_DIRECTORY: "./.evil-state",
+      },
+    });
+
+    expect(installRootPlan.external).toBe(true);
+    expect(installRootPlan.installRoot).toContain(
+      path.join(trustedStateDir, "plugin-runtime-deps", "openclaw-2026.4.25-"),
+    );
+    expect(installRootPlan.installRoot).not.toContain(".evil-state");
+  });
+
+  it("does not force package-level external staging for relative systemd state directories", () => {
+    const packageRoot = makeTempDir();
+    const trustedStateDir = makeTempDir();
+    fs.mkdirSync(path.join(packageRoot, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(packageRoot, "src"), { recursive: true });
+    fs.mkdirSync(path.join(packageRoot, "extensions"), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.25" }),
+    );
+
+    const installRootPlan = resolveBundledRuntimeDependencyPackageInstallRootPlan(packageRoot, {
+      env: {
+        OPENCLAW_STATE_DIR: trustedStateDir,
+        STATE_DIRECTORY: "./.evil-state",
+      },
+    });
+
+    expect(installRootPlan).toEqual({
+      installRoot: packageRoot,
+      searchRoots: [packageRoot],
+      external: false,
+    });
+  });
+
+  it("does not force external staging for relative systemd state directories", () => {
+    const packageRoot = makeTempDir();
+    const trustedStateDir = makeTempDir();
+    fs.mkdirSync(path.join(packageRoot, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(packageRoot, "src"), { recursive: true });
+    const pluginRoot = path.join(packageRoot, "extensions", "slack");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({ dependencies: { grammy: "1.37.0" } }),
+    );
+
+    const installRootPlan = resolveBundledRuntimeDependencyInstallRootPlan(pluginRoot, {
+      env: {
+        OPENCLAW_STATE_DIR: trustedStateDir,
+        STATE_DIRECTORY: "./.evil-state",
+      },
+    });
+
+    expect(installRootPlan).toEqual({
+      installRoot: pluginRoot,
+      searchRoots: [pluginRoot],
+      external: false,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Problem:** `STATE_DIRECTORY` was not blocked in workspace `.env` loading, and the bundled runtime-deps resolver accepted relative `STATE_DIRECTORY` values, resolving them against CWD via `path.resolve()`. A malicious repository could set `STATE_DIRECTORY=./.evil-state` to redirect plugin runtime-dependency installs to an attacker-controlled directory.
- **Why it matters:** Bundled plugin runtime deps rely on version/hash sentinels for trust. Redirecting the state root to a pre-seeded directory bypasses that trust check and allows attacker-controlled modules to be loaded in bundled plugin context.
- **What changed:**
  - Added `STATE_DIRECTORY` to `BLOCKED_WORKSPACE_DOTENV_KEYS` in `src/infra/dotenv.ts` (same treatment as `OPENCLAW_STATE_DIR` and other trust roots).
  - `resolveSystemdStateDirectory` in `src/plugins/bundled-runtime-deps.ts` now rejects relative path entries and only returns an absolute path (trimming each colon-separated entry before the `path.isAbsolute` check).
  - The "force external staging" guards in both `resolveBundledRuntimeDependencyInstallRootPlan` and `resolveBundledRuntimeDependencyPackageInstallRootPlan` now use the validated `systemdStateDir` value instead of the raw `env.STATE_DIRECTORY?.trim()` check, so a relative value no longer triggers external mode.
- **What did NOT change:** The actual install root computation logic, plugin loading, or any other env-var blocking rules are unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Auth / tokens

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `STATE_DIRECTORY` was treated as an unvalidated passthrough in both the workspace dotenv loader and the bundled-deps staging logic — neither blocked it from workspace injection nor required it to be an absolute path.
- Missing detection / guardrail: No entry for `STATE_DIRECTORY` in `BLOCKED_WORKSPACE_DOTENV_KEYS`; no absolute-path guard in `resolveSystemdStateDirectory`.
- Contributing context (if known): systemd always sets `STATE_DIRECTORY` to an absolute path; relative values are not a valid systemd-sourced input.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/infra/dotenv.test.ts`, `src/plugins/bundled-runtime-deps.test.ts`
- Scenario the test should lock in:
  - Workspace `.env` cannot override `STATE_DIRECTORY` (added to existing workspace-block test and "unset in process env" test).
  - Absolute `STATE_DIRECTORY` is accepted and used as the external install root.
  - Relative `STATE_DIRECTORY` is ignored; install root falls back to `OPENCLAW_STATE_DIR`.
  - Relative `STATE_DIRECTORY` does not force external staging mode on a source checkout.
- Why this is the smallest reliable guardrail: These are direct unit tests of the two affected functions at their input boundaries.
- Existing test that already covers this (if any): Extended existing `loadDotEnv` workspace-block tests.

## User-visible / Behavior Changes

None for legitimate deployments. Systemd-managed installs set `STATE_DIRECTORY` to an absolute path, which continues to work. Relative `STATE_DIRECTORY` values (not a valid systemd output) are now silently ignored.

## Diagram (if applicable)

```text
Before:
workspace .env STATE_DIRECTORY=./.evil → loaded into process.env → forces external staging → path.resolve("./.evil") used as install root

After:
workspace .env STATE_DIRECTORY=./.evil → BLOCKED by dotenv loader
                                       → if somehow present: relative value rejected by resolveSystemdStateDirectory → null → no external-mode forcing, no CWD-relative install root
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — workspace `.env` can no longer influence the plugin runtime-dependency install root via `STATE_DIRECTORY`.
- Risk + mitigation: The change is strictly restrictive; it removes an attack surface without affecting legitimate systemd deployments.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. Place `STATE_DIRECTORY=./.evil-state` in a workspace `.env`.
2. Start OpenClaw from that workspace directory.
3. Observe that `STATE_DIRECTORY` is not applied to `process.env` and the plugin runtime-deps root is not redirected.

### Expected

- `process.env.STATE_DIRECTORY` remains unset after dotenv load.
- Plugin runtime-deps resolve to the trusted `OPENCLAW_STATE_DIR`-based path, not `.evil-state`.

### Actual (after fix)

- Both assertions hold.

## Evidence

- [x] Failing test/log before + passing after — three new targeted unit tests added in `src/plugins/bundled-runtime-deps.test.ts` and two extended assertions in `src/infra/dotenv.test.ts` cover all behavioral cases of this fix.

## Human Verification (required)

> This PR was generated by AI (OpenAI Codex) and reviewed by Claude. No human code modifications were made.

- Verified scenarios: dotenv blocking test, absolute-path acceptance, relative-path rejection, no-force-external for relative path.
- Edge cases checked: empty `STATE_DIRECTORY`, whitespace-padded absolute path, colon-separated mixed absolute/relative list.
- What you did **not** verify: live end-to-end systemd deployment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A non-systemd deployment that intentionally set a relative `STATE_DIRECTORY` (non-standard usage) would silently lose that override.
  - Mitigation: This is not a documented or supported use of `STATE_DIRECTORY`; systemd spec requires absolute paths. No known legitimate use case is affected.