### PR TITLE
fix(model-picker): hide models from providers without auth configured

### DIFF
--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -295,7 +295,7 @@ function addModelSelectOption(params: {
     hints.push(routeHint);
   }
   if (!params.hasAuth(params.entry.provider)) {
-    hints.push("auth missing");
+    return;
   }
   const label = params.literalPrefixProviders.has(normalizeProviderId(params.entry.provider))
     ? `${params.entry.provider}/${params.entry.id}`


### PR DESCRIPTION
## Problem

`/models` command and the web chat model dropdown display the full model catalog (~900+ models), including models from providers that have no authentication configured. These entries show an "auth missing" hint but are not actionable, creating noise and poor UX.

## Root Cause

In `src/flows/model-picker.ts`, `addModelSelectOption` would push an "auth missing" hint string when `!params.hasAuth(params.entry.provider)` but still add the model to the options list.

## Fix

Early-return from `addModelSelectOption` when the provider lacks auth, so unconfigured-provider models are excluded from the picker entirely. Both `/models` and the web chat dropdown benefit since they share this code path.

Fixes #74423