### PR TITLE
fix(markdown): preserve loose list paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00 and @vyctorbrzezowski.
 - Google/Gemini: send non-empty placeholder content when a Gemini run is triggered with empty or filtered user content, avoiding `contents is not specified` API errors. Thanks @CaoYuhaoCarl.
 - Heartbeat: preserve non-task `HEARTBEAT.md` context around `tasks:` blocks and apply `agents.defaults.heartbeat` to all agents unless per-agent heartbeat entries restrict scope. Thanks @Sekhar03.
+- Markdown: preserve paragraph breaks inside loose list items in shared outbound formatting while keeping tight list spacing stable. Thanks @Lucenx9.
 - Build/Gateway: route restart, shutdown, respawn, diagnostics, command-queue cleanup, and runtime cleanup through one stable gateway lifecycle runtime entry so rebuilt packages do not strand long-running gateways on stale hashed chunks. Carries forward #73964. Thanks @pashpashpash.
 - Memory/wiki: keep broad shared-source and generated related-link blocks from turning every page into a search hit, cap noisy backlinks, support all-term searches such as people-routing queries, and prefer readable page body snippets over generated metadata. Thanks @vincentkoc.
 - Cron/Gateway: abort and bounded-clean up timed-out isolated agent turns before recording the timeout, so stale cron sessions cannot leave Discord or other chat lanes stuck in `processing` after a timeout. Thanks @vincentkoc.

--- a/src/markdown/ir.nested-lists.test.ts
+++ b/src/markdown/ir.nested-lists.test.ts
@@ -373,6 +373,16 @@ second paragraph
 • B`);
   });
 
+  it("keeps tight blockquote list items single-spaced", () => {
+    const input = `- > quote
+- next`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`• quote
+• next`);
+  });
+
   it("adds blank line between bullet list and following paragraph", () => {
     const input = `- item 1
 - item 2

--- a/src/markdown/ir.nested-lists.test.ts
+++ b/src/markdown/ir.nested-lists.test.ts
@@ -301,6 +301,36 @@ describe("Nested Lists - Edge Cases", () => {
 });
 
 describe("list paragraph spacing", () => {
+  it("preserves paragraph breaks inside loose bullet list items", () => {
+    const input = `- first paragraph
+
+  second paragraph
+- next`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`• first paragraph
+
+second paragraph
+
+• next`);
+  });
+
+  it("preserves paragraph breaks inside loose ordered list items", () => {
+    const input = `1. first paragraph
+
+   second paragraph
+2. next`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`1. first paragraph
+
+second paragraph
+
+2. next`);
+  });
+
   it("adds blank line between bullet list and following paragraph", () => {
     const input = `- item 1
 - item 2

--- a/src/markdown/ir.nested-lists.test.ts
+++ b/src/markdown/ir.nested-lists.test.ts
@@ -331,6 +331,38 @@ second paragraph
 2. next`);
   });
 
+  it("does not add triple newlines before loose nested bullet lists", () => {
+    const input = `- parent
+
+  - child
+
+- next`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`• parent
+
+  • child
+• next`);
+    expect(result.text).not.toContain("\n\n\n");
+  });
+
+  it("does not add triple newlines before loose nested ordered lists", () => {
+    const input = `1. parent
+
+   1. child
+
+2. next`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`1. parent
+
+  1. child
+2. next`);
+    expect(result.text).not.toContain("\n\n\n");
+  });
+
   it("adds blank line between bullet list and following paragraph", () => {
     const input = `- item 1
 - item 2

--- a/src/markdown/ir.nested-lists.test.ts
+++ b/src/markdown/ir.nested-lists.test.ts
@@ -363,6 +363,16 @@ second paragraph
     expect(result.text).not.toContain("\n\n\n");
   });
 
+  it("keeps tight heading list items single-spaced", () => {
+    const input = `- # A
+- # B`;
+
+    const result = markdownToIR(input);
+
+    expect(result.text).toBe(`• A
+• B`);
+  });
+
   it("adds blank line between bullet list and following paragraph", () => {
     const input = `- item 1
 - item 2

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -23,6 +23,7 @@ type MarkdownToken = {
   attrs?: [string, string][];
   attrGet?: (name: string) => string | null;
   hidden?: boolean;
+  level?: number;
 };
 
 export type MarkdownStyle =
@@ -268,7 +269,12 @@ function appendParagraphSeparator(state: RenderState, token?: MarkdownToken) {
     return;
   } // Don't add paragraph separators inside tables
   if (state.env.listStack.length > 0) {
-    if (token?.type !== "paragraph_close" || token.hidden) {
+    const directListParagraphLevel = state.env.listStack.length * 2;
+    if (
+      token?.type !== "paragraph_close" ||
+      token.hidden ||
+      token.level !== directListParagraphLevel
+    ) {
       return;
     }
   }

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -264,12 +264,14 @@ function closeStyle(state: RenderState, style: MarkdownStyle) {
 }
 
 function appendParagraphSeparator(state: RenderState, token?: MarkdownToken) {
-  if (state.env.listStack.length > 0 && token?.hidden) {
-    return;
-  }
   if (state.table) {
     return;
   } // Don't add paragraph separators inside tables
+  if (state.env.listStack.length > 0) {
+    if (token?.type !== "paragraph_close" || token.hidden) {
+      return;
+    }
+  }
   state.text += "\n\n";
 }
 

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -22,6 +22,7 @@ type MarkdownToken = {
   children?: MarkdownToken[];
   attrs?: [string, string][];
   attrGet?: (name: string) => string | null;
+  hidden?: boolean;
 };
 
 export type MarkdownStyle =
@@ -262,14 +263,21 @@ function closeStyle(state: RenderState, style: MarkdownStyle) {
   }
 }
 
-function appendParagraphSeparator(state: RenderState) {
-  if (state.env.listStack.length > 0) {
+function appendParagraphSeparator(state: RenderState, token?: MarkdownToken) {
+  if (state.env.listStack.length > 0 && token?.hidden) {
     return;
   }
   if (state.table) {
     return;
   } // Don't add paragraph separators inside tables
   state.text += "\n\n";
+}
+
+function appendTopLevelListSeparator(state: RenderState) {
+  const trailingNewlines = state.text.match(/\n*$/)?.[0].length ?? 0;
+  if (trailingNewlines < 2) {
+    state.text += "\n";
+  }
 }
 
 function appendListPrefix(state: RenderState) {
@@ -636,7 +644,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         appendText(state, "\n");
         break;
       case "paragraph_close":
-        appendParagraphSeparator(state);
+        appendParagraphSeparator(state, token);
         break;
       case "heading_open":
         if (state.headingStyle === "bold") {
@@ -668,7 +676,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "bullet_list_close":
         state.env.listStack.pop();
         if (state.env.listStack.length === 0) {
-          state.text += "\n";
+          appendTopLevelListSeparator(state);
         }
         break;
       case "ordered_list_open": {
@@ -683,7 +691,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "ordered_list_close":
         state.env.listStack.pop();
         if (state.env.listStack.length === 0) {
-          state.text += "\n";
+          appendTopLevelListSeparator(state);
         }
         break;
       case "list_item_open":

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -280,6 +280,12 @@ function appendTopLevelListSeparator(state: RenderState) {
   }
 }
 
+function appendNestedListSeparator(state: RenderState) {
+  if (!state.text.endsWith("\n")) {
+    state.text += "\n";
+  }
+}
+
 function appendListPrefix(state: RenderState) {
   const stack = state.env.listStack;
   const top = stack[stack.length - 1];
@@ -669,7 +675,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "bullet_list_open":
         // Add newline before nested list starts (so nested items appear on new line)
         if (state.env.listStack.length > 0) {
-          state.text += "\n";
+          appendNestedListSeparator(state);
         }
         state.env.listStack.push({ type: "bullet", index: 0 });
         break;
@@ -682,7 +688,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "ordered_list_open": {
         // Add newline before nested list starts (so nested items appear on new line)
         if (state.env.listStack.length > 0) {
-          state.text += "\n";
+          appendNestedListSeparator(state);
         }
         const start = Number(getAttr(token, "start") ?? "1");
         state.env.listStack.push({ type: "ordered", index: start - 1 });


### PR DESCRIPTION
## Summary

- Problem: loose Markdown list items with multiple direct paragraphs collapsed the paragraph text together in plain-text IR.
- Why it matters: channel renderers can send unreadable replies when model output uses loose Markdown lists.
- What changed: direct non-hidden list item paragraphs now emit paragraph separators, while tight list block spacing, nested lists, headings, and blockquotes keep their previous spacing.
- What did NOT change (scope boundary): table rendering, channel-specific formatting, and non-list paragraph behavior.

AI-assisted: Yes, implemented with Codex. Final `codex review --base origin/main` reported no actionable regressions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `appendParagraphSeparator` suppressed every `paragraph_close` while inside a list. That matched tight list paragraphs, but markdown-it marks loose direct list item paragraphs as visible (`hidden=false`), so their required separator was dropped.
- Missing detection / guardrail: existing list spacing tests covered list-to-paragraph and nested-list spacing, but not multiple direct paragraphs in one loose list item.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/markdown/ir.nested-lists.test.ts`
- Scenario the test should lock in: loose bullet and ordered list items preserve direct paragraph breaks without adding triple newlines or changing tight list block spacing.
- Why this is the smallest reliable guardrail: the bug is in Markdown IR token rendering and can be asserted directly at `markdownToIR` output.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Loose Markdown list items now preserve paragraph breaks in rendered plain text instead of concatenating direct paragraphs.

## Diagram (if applicable)

```text
Before:
- first paragraph

  second paragraph
=> "• first paragraphsecond paragraph"

After:
- first paragraph

  second paragraph
=> "• first paragraph\n\nsecond paragraph"
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22.21.1, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): Markdown IR shared renderer
- Relevant config (redacted): N/A

### Steps

1. Convert a loose Markdown list item with two direct paragraphs through `markdownToIR`.
2. Inspect the returned `text`.

### Expected

- The two paragraphs are separated by a blank line.

### Actual

- Before this fix, the paragraphs were concatenated.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before fix, the repro rendered as `"• first paragraphsecond paragraph\n• next"`. Added regression tests now cover the fixed bullet and ordered cases, plus nested loose lists and tight heading/blockquote list items.

## Human Verification (required)

What I personally verified:

- `pnpm exec oxfmt --check --threads=1 src/markdown/ir.ts src/markdown/ir.nested-lists.test.ts`
- `pnpm exec oxlint src/markdown/ir.ts src/markdown/ir.nested-lists.test.ts`
- `pnpm test src/markdown/ir.nested-lists.test.ts` (24 tests passed)
- `pnpm test src/markdown/frontmatter.test.ts src/markdown/ir.blockquote-spacing.test.ts src/markdown/ir.hr-spacing.test.ts src/markdown/ir.nested-lists.test.ts src/markdown/ir.table-block.test.ts src/markdown/ir.table-bullets.test.ts src/markdown/ir.table-code.test.ts src/markdown/render-aware-chunking.test.ts src/markdown/tables.test.ts` (9 files, 80 tests passed)
- `codex review --base origin/main` (final run: no actionable regressions)

What I did not verify:

- Full `pnpm test` and `pnpm build`.
- Full `pnpm check` currently fails on an unrelated lint issue in `ui/src/ui/components/dashboard-header.ts:39` (`typescript-eslint(unbound-method)`). The touched files passed targeted format/lint/type-adjacent test coverage above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub review conversations exist yet for this new PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: list spacing changes could accidentally loosen tight list rendering.
  - Mitigation: regression tests cover tight heading and blockquote list items, loose nested lists, and existing nested-list spacing behavior.
