### PR TITLE
fix(tts): synthesize tagged hidden text under short-skip threshold (#73758)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Speech/TTS: synthesize explicitly tagged hidden TTS text (`[[tts:text]]...[[/tts:text]]`) even when shorter than the auto-TTS short-skip threshold, so short tagged replies on backends like claude-cli no longer arrive as empty voice-only payloads that channels skip. Fixes #73758. Thanks @asidko.
 - Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00 and @vyctorbrzezowski.
 - Build/Gateway: route restart, shutdown, respawn, diagnostics, command-queue cleanup, and runtime cleanup through one stable gateway lifecycle runtime entry so rebuilt packages do not strand long-running gateways on stale hashed chunks. Carries forward #73964. Thanks @pashpashpash.
 - Memory/wiki: keep broad shared-source and generated related-link blocks from turning every page into a search hit, cap noisy backlinks, support all-term searches such as people-routing queries, and prefer readable page body snippets over generated metadata. Thanks @vincentkoc.

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1524,6 +1524,10 @@ export async function maybeApplyTtsToPayload(params: {
   const trimmedCleaned = cleanedText.trim();
   const visibleText = trimmedCleaned.length > 0 ? trimmedCleaned : "";
   const ttsText = directives.ttsText?.trim() || visibleText;
+  // Tagged hidden text (`[[tts:text]]...[[/tts:text]]`) is an explicit user
+  // opt-in to synthesis; bypass the short-text suppression that exists to
+  // avoid noisy auto-TTS on tiny visible replies. Fixes #73758.
+  const hasExplicitTaggedTtsText = (directives.ttsText?.trim().length ?? 0) > 0;
 
   const nextPayload =
     visibleText === text.trim()
@@ -1554,7 +1558,7 @@ export async function maybeApplyTtsToPayload(params: {
   if (text.includes("MEDIA:")) {
     return nextPayload;
   }
-  if (ttsText.trim().length < 10) {
+  if (ttsText.trim().length < 10 && !hasExplicitTaggedTtsText) {
     return nextPayload;
   }
 
@@ -1594,7 +1598,7 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   textForAudio = stripMarkdown(textForAudio).trim();
-  if (textForAudio.length < 10) {
+  if (textForAudio.length < 10 && !hasExplicitTaggedTtsText) {
     return nextPayload;
   }
 

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1312,6 +1312,12 @@ export function describeTtsAutoApplyContract() {
         expectedFetchCalls: 1,
         expectSamePayload: false,
       },
+      {
+        name: "tagged short hidden text bypasses the short-skip (regression for #73758)",
+        payload: { text: "[[tts:text]]hello[[/tts:text]]" },
+        expectedFetchCalls: 1,
+        expectSamePayload: false,
+      },
     ] as const)("respects tagged-mode auto-TTS gating: $name", async (testCase) => {
       await expectAutoTtsOutcome({
         cfg: taggedCfg,


### PR DESCRIPTION
## Summary

- **Problem:** `[[tts:text]]hello[[/tts:text]]` (or any tagged hidden text under 10 characters) silently fails to synthesize. The auto-TTS short-text skip at `extensions/speech-core/src/tts.ts:1557` returns `nextPayload` before reaching `textToSpeech`, even when the user explicitly opted into synthesis via the `[[tts:text]]...[[/tts:text]]` block. With `[[audio_as_voice]]` also set, Telegram receives an empty voice-only payload (no text, no media, `audioAsVoice: true`) and skips delivery, so the reply vanishes entirely.
- **Why it matters:** Reported in #73758 against `2026.4.25` and `2026.4.26` with the `regression` label. Reporter @asidko's setup uses tagged short hidden TTS replies on the claude-cli backend; they're forced to switch backends to work around it.
- **What changed:** In `maybeApplyTtsToPayload`, derive `hasExplicitTaggedTtsText` from `directives.ttsText`, and gate both short-text skip points (the pre-summarize check at L1557 and the post-`stripMarkdown` check at L1597) on `&& !hasExplicitTaggedTtsText`. Tagged hidden text now reaches synthesis regardless of length; untagged short visible text continues to be suppressed as before.
- **What did NOT change:** Untagged auto-TTS short-text suppression (the noise-control default), the directive parser at `src/tts/directives.ts`, the request-body serialization path, the `audioAsVoice` flag handling, or anything in `src/auto-reply/reply/dispatch-from-config.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73758
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `extensions/speech-core/src/tts.ts:1557` (`if (ttsText.trim().length < 10) return nextPayload`) was originally added to suppress noisy auto-TTS on tiny visible replies (`"ok"`, `"yes"`). It correctly suppresses untagged auto-mode synthesis but over-applies to explicitly tagged hidden text, where the user has already opted in via `[[tts:text]]...[[/tts:text]]` regardless of length. The post-`stripMarkdown` check at L1597 has the same shape and the same blast radius.
- **Missing detection / guardrail:** The shared TTS contract suite at `src/plugins/contracts/tts-contract-suites.ts:1276` covered tagged `Hello world` (long) and untagged `### **bold**` (short stripped) but not tagged-short hidden text.
- **Contributing context:** The reporter mentions claude-cli specifically because that backend's short tool-driven replies more often produce tagged hidden text under 10 chars. The bug applies to any backend, not just claude-cli.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/contracts/tts-contract-suites.ts` parametric block `respects tagged-mode auto-TTS gating`
- Scenario the test should lock in: a tagged payload `[[tts:text]]hello[[/tts:text]]` (5 chars, under the 10-char threshold) routes through `maybeApplyTtsToPayload` and triggers exactly one synthesis fetch.
- Why this is the smallest reliable guardrail: the helper already mocks the TTS fetch path; asserting `expectedFetchCalls: 1` for the short-tagged case is the smallest behavior assertion that proves the bypass works without touching channel delivery logic.

## User-visible / Behavior Changes

- `[[tts:text]]X[[/tts:text]]` now synthesizes audio for any non-empty `X` (previously: under 10 chars silently dropped).
- `[[audio_as_voice]] [[tts:text]]X[[/tts:text]]` now reliably delivers audio on Telegram for short `X`.
- Untagged short visible replies (`"ok"`, `"yes"`) continue to skip auto-TTS as before.
- No config changes, no new directive shapes.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (the synthesis fetch was always the next step; we just stop short-circuiting before it)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 24.3.0
- Runtime: Node 22.22.0
- Channel: Telegram delivery
- Backend: claude-cli (per reporter; bug applies to any backend)

### Steps

1. Configure a Telegram channel with TTS auto mode `tagged` and a working speech provider.
2. Have the agent emit a final reply containing `[[audio_as_voice]] [[tts:text]]hello[[/tts:text]]`.
3. Observe Telegram delivery.

### Expected

A voice-note arrives with the synthesized "hello" audio.

### Actual (before this PR)

No delivery — Telegram skips the empty voice-only payload because the short-skip fires before synthesis and leaves `audioAsVoice: true` with no text and no media.

### Actual (after this PR)

Synthesis fires for the 5-character tagged hidden text. Voice-note delivers as intended.

## Evidence

```
RUN  v4.1.5
Test Files  1 passed (1)
     Tests  42 passed (42)
```

`pnpm test src/plugins/contracts/tts.contract.test.ts` → 42 passed (41 prior + 1 new regression case).
`pnpm test extensions/speech-core/src/tts.test.ts` → 20 passed.
`pnpm tsgo:extensions` clean. `pnpm tsgo:core:test` clean. `oxlint` 0 warnings, 0 errors. Format check clean.

## Human Verification

- Verified the new regression case catches the bug: removing the `&& !hasExplicitTaggedTtsText` guard on either skip point makes the new test fail (`expected 1 calls, received 0`).
- Verified the inverse: untagged short visible text (`"ok"`) continues to be skipped, so the noise-control default for auto-TTS is preserved.
- Verified `directives.ttsText` is populated by both `[[tts:text]]X[[/tts:text]]` (hidden) and `[[tts]]X[[/tts]]` (visible) forms per `src/tts/directives.ts:224-241`, so both tagged shapes route to synthesis under the new bypass.
- What I did **not** verify: live Telegram round-trip with a real ElevenLabs/OpenAI key. Synthesis path serialization is unchanged; the fix is at the synthesis-skip gate, upstream of any channel-specific delivery handling.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Future tagged TTS shapes (e.g. a hypothetical `[[tts:audio]]...[[/tts:audio]]`) might want the short-skip to apply for cost-control reasons. **Mitigation:** Only `directives.ttsText` is tracked here; any future explicit-tag fields can independently decide whether to route through the short-skip. The bypass is narrowly scoped to existing `ttsText` semantics.
- **Risk:** Operators relying on the < 10 skip to suppress accidental tagged whitespace. **Mitigation:** The bypass condition is `(directives.ttsText?.trim().length ?? 0) > 0`, so empty/whitespace-only `[[tts:text]][[/tts:text]]` blocks still hit the existing skip path through `if (!ttsText.trim()) return nextPayload` at L1548.
