### PR TITLE
fix(duckduckgo): tolerate invalid html entities

### DIFF
--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -34,6 +34,14 @@ type DuckDuckGoResult = {
   snippet: string;
 };
 
+function decodeNumericHtmlEntity(entity: string, code: string, radix: 10 | 16): string {
+  const codePoint = Number.parseInt(code, radix);
+  if (!Number.isInteger(codePoint) || codePoint < 0 || codePoint > 0x10ffff) {
+    return entity;
+  }
+  return String.fromCodePoint(codePoint);
+}
+
 function decodeHtmlEntities(text: string): string {
   return text
     .replace(/&amp;/g, "&")
@@ -48,8 +56,8 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&ndash;/g, "-")
     .replace(/&mdash;/g, "--")
     .replace(/&hellip;/g, "...")
-    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code) => String.fromCodePoint(Number.parseInt(code, 16)));
+    .replace(/&#(\d+);/g, (entity, code) => decodeNumericHtmlEntity(entity, code, 10))
+    .replace(/&#x([0-9a-f]+);/gi, (entity, code) => decodeNumericHtmlEntity(entity, code, 16));
 }
 
 function stripHtml(html: string): string {

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -151,6 +151,12 @@ describe("duckduckgo web search provider", () => {
     expect(ddgClientTesting.decodeHtmlEntities("Fish &amp; Chips&nbsp;&hellip; &#39;ok&#39;")).toBe(
       "Fish & Chips ... 'ok'",
     );
+    expect(ddgClientTesting.decodeHtmlEntities("smile &#128512; &#x1f600;")).toBe(
+      "smile \u{1F600} \u{1F600}",
+    );
+    expect(ddgClientTesting.decodeHtmlEntities("bad &#9999999999; &#x110000; ok")).toBe(
+      "bad &#9999999999; &#x110000; ok",
+    );
   });
 
   it("parses results when href appears before class", () => {

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -183,6 +183,21 @@ describe("duckduckgo web search provider", () => {
     ]);
   });
 
+  it("preserves invalid numeric entities while parsing results", () => {
+    const html = `
+      <a class="result__a" href="https://example.com/?q=&#9999999999;">Bad &#x110000;</a>
+      <a class="result__snippet">Snippet &#128512;</a>
+    `;
+
+    expect(ddgClientTesting.parseDuckDuckGoHtml(html)).toEqual([
+      {
+        title: "Bad &#x110000;",
+        url: "https://example.com/?q=&#9999999999;",
+        snippet: "Snippet \u{1F600}",
+      },
+    ]);
+  });
+
   it("detects bot challenge pages without flagging ordinary result snippets", () => {
     const challengeHtml = `
       <html>


### PR DESCRIPTION
## Summary

AI-assisted: Yes.

- Problem: DuckDuckGo HTML decoding called `String.fromCodePoint` directly for arbitrary numeric entities from remote HTML.
- Why it matters: an out-of-range entity such as `&#9999999999;` could throw `RangeError` and fail the whole DuckDuckGo parse/search path.
- What changed: numeric HTML entities are decoded only when the parsed code point is valid; invalid decimal/hex entities are left unchanged.
- What did NOT change (scope boundary): no provider config, network behavior, cache behavior, or plugin contracts changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: DuckDuckGo result parsing trusted numeric HTML entities to always be valid Unicode code points.
- Missing detection / guardrail: tests covered common entities but not invalid out-of-range numeric entities.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/duckduckgo/src/ddg-search-provider.test.ts`
- Scenario the test should lock in: valid decimal/hex numeric entities still decode, while out-of-range numeric entities do not throw and are preserved.
- Why this is the smallest reliable guardrail: the parser funnels result title, URL, and snippet entity decoding through the same helper.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

DuckDuckGo search result parsing no longer fails when remote HTML contains an out-of-range numeric entity.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.21.1, pnpm v10.33.0
- Model/provider: DuckDuckGo web search plugin
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Decode a malformed numeric entity with the DuckDuckGo HTML entity helper.
2. Decode valid decimal and hex numeric entities.
3. Run the DuckDuckGo provider test lane.

### Expected

- Invalid numeric entities are preserved without throwing.
- Valid numeric entities still decode.
- DuckDuckGo plugin tests pass.

### Actual

- Before the fix, `&#9999999999;` threw `RangeError: Invalid code point 9999999999`.
- After the fix, the malformed entity remains unchanged and tests pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```sh
pnpm exec tsx -e "import { __testing } from './extensions/duckduckgo/src/ddg-client.ts'; console.log(__testing.decodeHtmlEntities('bad &#9999999999;'));"
pnpm exec tsx -e "import { __testing } from './extensions/duckduckgo/src/ddg-client.ts'; console.log(__testing.decodeHtmlEntities('bad &#9999999999; ok'));"
pnpm test extensions/duckduckgo/src/ddg-search-provider.test.ts
pnpm test:extension duckduckgo
pnpm exec oxfmt --check --threads=1 extensions/duckduckgo/src/ddg-client.ts extensions/duckduckgo/src/ddg-search-provider.test.ts
pnpm exec oxlint extensions/duckduckgo/src/ddg-client.ts extensions/duckduckgo/src/ddg-search-provider.test.ts
```

## Human Verification (required)

- Verified scenarios: reproduced the pre-fix `RangeError`, verified malformed entities are preserved after the fix, and ran targeted DuckDuckGo tests.
- Edge cases checked: valid decimal entity, valid hex entity, invalid decimal entity, invalid hex entity.
- What you did **not** verify: live DuckDuckGo network search against the external service.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
