### PR TITLE
fix(active-memory): preserve setup grace for embedded recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Active Memory: apply `setupGraceTimeoutMs` to the embedded recall runner as well as the outer prompt-build watchdog, so very-cold first recalls keep the configured setup grace end-to-end. (#74480) Thanks @volcano303.
 - Plugins/tools: keep disabled bundled tool plugins out of explicit runtime allowlist ownership and fall back from loaded-but-empty channel registries to tool-bearing plugin registries, so Active Memory can use bundled `memory-core` search/get tools even when `memory-lancedb` is disabled. Fixes #76603. Thanks @jwong-art.
 - Plugins/externalization: keep official ACPX, Google Chat, and LINE install specs on production package names, leaving beta-tag probing to the explicit OpenClaw beta update channel. Thanks @vincentkoc.
 - CLI/doctor: keep missing-plugin repair from overriding official catalog metadata with runtime fallbacks, so ACPX repairs preserve the official npm spec during the externalization rollout. Thanks @vincentkoc.

--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -658,13 +658,9 @@ blocking prompt-build hook budget by default and move cold-start setup grace
 behind explicit `setupGraceTimeoutMs` config, so the plugin no longer silently
 extends 15000 ms configs to 45000 ms on the main lane."_
 
-The embedded recall runner currently still receives the raw `timeoutMs` value
-as its inner budget; the in-flight fix to extend that with `setupGraceTimeoutMs`
-is tracked at [#74480](https://github.com/openclaw/openclaw/pull/74480). Until
-that lands, very-cold first recalls can still time out at the inner layer even
-with `setupGraceTimeoutMs` set — though the outer-layer setting still
-substantially mitigates the symptom by giving the prompt-build hook room to
-cover the warm-up window.
+The embedded recall runner uses the same effective timeout budget, so
+`setupGraceTimeoutMs` covers both the outer prompt-build watchdog and the inner
+blocking recall run.
 
 For resource-tight gateways where cold-start latency is a known trade-off,
 lower values (5000–15000 ms) work too — the trade-off is a higher chance of
@@ -735,8 +731,7 @@ default `memory-core` path uses `memory_search`; `memory-lancedb` uses
     around the first eligible reply after a restart.
 
     See [Cold-start grace](#cold-start-grace) under Recommended setup for the
-    recommended `setupGraceTimeoutMs` value (and the open caveat about the
-    embedded recall budget tracked at #74480).
+    recommended `setupGraceTimeoutMs` value.
 
   </Accordion>
 </AccordionGroup>

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -2256,7 +2256,7 @@ describe("active-memory plugin", () => {
     );
 
     expect(result?.prependContext).toContain("remember the ramen place");
-    expect(runEmbeddedPiAgent.mock.calls.at(-1)?.[0]?.timeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
+    expect(runEmbeddedPiAgent.mock.calls.at(-1)?.[0]?.timeoutMs).toBe(CONFIGURED_TIMEOUT_MS + 100);
     const infoLines = vi
       .mocked(api.logger.info)
       .mock.calls.map((call: unknown[]) => String(call[0]));

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2273,6 +2273,7 @@ async function runRecallSubagent(params: {
 
   try {
     const embeddedConfig = applyActiveMemoryRuntimeConfigSnapshot(params.api.config, params.config);
+    const embeddedTimeoutMs = params.config.timeoutMs + params.config.setupGraceTimeoutMs;
     const result = await params.api.runtime.agent.runEmbeddedPiAgent({
       sessionId: subagentSessionId,
       sessionKey: subagentSessionKey,
@@ -2286,7 +2287,7 @@ async function runRecallSubagent(params: {
       prompt,
       provider: modelRef.provider,
       model: modelRef.model,
-      timeoutMs: params.config.timeoutMs,
+      timeoutMs: embeddedTimeoutMs,
       runId: subagentSessionId,
       trigger: "manual",
       toolsAllow: ["memory_recall", "memory_search", "memory_get"],


### PR DESCRIPTION
## Summary

- Fixes Active Memory setup grace at the embedded-runner boundary.
- Previously the outer prompt-build watchdog used `timeoutMs + setupGraceTimeoutMs`, but `runEmbeddedPiAgent` still received raw `timeoutMs` and could self-timeout first.
- Now the embedded recall runner receives the same effective timeout budget as the outer watchdog.
- Also updates the focused regression test, changelog, and Active Memory docs.

## Scope

This is intentionally narrow. It does not change memory search behavior, provider routing, circuit breaker behavior, model selection, or timeout clamps.

## Verification

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/concepts/active-memory.md extensions/active-memory/index.ts extensions/active-memory/index.test.ts`
- `pnpm test extensions/active-memory/index.test.ts extensions/active-memory/config.test.ts`
- `pnpm check:docs`
- `pnpm lint:extensions -- extensions/active-memory/index.ts extensions/active-memory/index.test.ts`
- `git diff --check`

## Notes

Rewritten on current `main` as a single maintainer patch while preserving contributor credit.

Closes #73306.
