### PR TITLE
fix(canvas): handle malformed encoded paths

### DIFF
--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -12,7 +12,15 @@ export async function resolveFileWithinRoot(
   rootReal: string,
   urlPath: string,
 ): Promise<SafeOpenResult | null> {
-  const normalized = normalizeUrlPath(urlPath);
+  let normalized: string;
+  try {
+    normalized = normalizeUrlPath(urlPath);
+  } catch (err) {
+    if (err instanceof URIError) {
+      return null;
+    }
+    throw err;
+  }
   const rel = normalized.replace(/^\/+/, "");
   if (rel.split("/").some((p) => p === "..")) {
     return null;

--- a/src/canvas-host/server.test.ts
+++ b/src/canvas-host/server.test.ts
@@ -217,6 +217,20 @@ describe("canvas host", () => {
     }
   });
 
+  it("treats malformed encoded paths as not found", async () => {
+    const dir = await createCaseDir();
+    await fs.writeFile(path.join(dir, "index.html"), "<html><body>v1</body></html>", "utf8");
+    const handler = await createTestCanvasHostHandler(dir);
+
+    try {
+      const response = await captureHandlerResponse(handler, `${CANVAS_HOST_PATH}/%E0%A4%A`);
+      expect(response.status).toBe(404);
+      expect(response.body).toBe("not found");
+    } finally {
+      await handler.close();
+    }
+  });
+
   it("serves canvas content from the mounted base path and reuses handlers without double close", async () => {
     const dir = await createCaseDir();
     await fs.writeFile(path.join(dir, "index.html"), "<html><body>v1</body></html>", "utf8");


### PR DESCRIPTION
## Summary

AI-assisted: Yes.

- Problem: the canvas file resolver decoded request paths with `decodeURIComponent` without handling malformed percent-encoding.
- Why it matters: a request such as `/canvas/%E0%A4%A` could be treated as an internal canvas host failure and return 500 instead of a normal miss.
- What changed: `resolveFileWithinRoot` now treats malformed URL encoding as an unresolvable path, preserving existing 404 behavior for paths that cannot be safely served.
- What did NOT change (scope boundary): no auth, filesystem root, symlink, traversal, live reload, or A2UI asset behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
- [x] Canvas host

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared canvas file resolver assumed every URL pathname reaching it had valid percent-encoding.
- Missing detection / guardrail: existing canvas host tests covered traversal and symlink escape paths, but not malformed encoded paths.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/canvas-host/server.test.ts`
- Scenario the test should lock in: a malformed encoded canvas path returns 404 `not found`, not 500.
- Why this is the smallest reliable guardrail: it exercises the server handler through the same resolver path used for served canvas files.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed percent-encoded canvas paths now return 404 instead of surfacing as canvas host request errors.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v22.21.1, pnpm v10.33.0
- Model/provider: N/A
- Integration/channel (if any): Canvas host
- Relevant config (redacted): N/A

### Steps

1. Request a canvas host path containing malformed percent-encoding, for example `%E0%A4%A`.
2. Observe the response status from the canvas host handler.
3. Run targeted and local gate checks.

### Expected

- The malformed path is treated as not found.
- The canvas host responds with 404 `not found`.

### Actual

- Before the fix, the handler logged `URIError: URI malformed` and returned 500.
- After the fix, the handler returns 404 `not found`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```sh
pnpm test src/canvas-host/server.test.ts -t "malformed encoded paths"
pnpm test src/canvas-host/server.test.ts
pnpm exec oxfmt --check --threads=1 src/canvas-host/file-resolver.ts src/canvas-host/server.test.ts
pnpm exec oxlint src/canvas-host/file-resolver.ts src/canvas-host/server.test.ts
pnpm check
```

## Human Verification (required)

- Verified scenarios: reproduced the pre-fix 500 with `URIError: URI malformed`; verified the new 404 behavior; ran canvas host tests and `pnpm check`.
- Edge cases checked: malformed percent-encoded path through mounted canvas host route.
- What you did **not** verify: a browser-driven live canvas session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
