### PR TITLE
docs: list openclaw-workspace-sync in community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -131,6 +131,20 @@ formatting, built-in access control, and document/meeting/messaging skills.
 openclaw plugins install @wecom/wecom-openclaw-plugin
 ```
 
+### Workspace Sync & Backup
+
+Workspace cloud sync (mailbox, mirror, bisync modes) and encrypted backups
+via rclone. Supports Dropbox, Google Drive, OneDrive, S3, and 70+ providers.
+Includes inbox notifications with an interactive agent tool for filing incoming
+files. Zero LLM cost for sync operations.
+
+- **npm:** `openclaw-workspace-sync`
+- **repo:** [github.com/ashbrener/openclaw-workspace-sync](https://github.com/ashbrener/openclaw-workspace-sync)
+
+```bash
+openclaw plugins install openclaw-workspace-sync
+```
+
 ### Yuanbao
 
 Yuanbao channel plugin for OpenClaw by the Tencent Yuanbao team. Powered by


### PR DESCRIPTION
## Summary

Adds [openclaw-workspace-sync](https://github.com/ashbrener/openclaw-workspace-sync) to the community plugins list. **Single-file docs change** (`docs/plugins/community.md`).

## History

This PR replaces two prior PRs that didn't make it through the review process:

1. **[#20440](https://github.com/openclaw/openclaw/pull/20440)** — Original PR. **Approved by @nikolasdehor**. Accidentally closed while resolving merge conflicts.
2. **[#20695](https://github.com/openclaw/openclaw/pull/20695)** — Replacement PR (clean rebase). Auto-closed for inactivity on Apr 5 after multiple maintainer pings without review. Greptile review: *"Confidence Score: 5/5 — This PR is safe to merge with no risks."*

This is the third attempt — fresh branch off latest `main`, no conflicts.

## Plugin status

The plugin has matured significantly since the original PR:

- **Three explicit sync modes**: `mailbox` (recommended), `mirror`, `bisync`
- **Encrypted AES-256 backup snapshots** to S3/R2/B2/etc.
- **Inbox notifications** with interactive `workspace_inbox` agent tool (list/peek/move)
- **Security-hardened**: path traversal protection, symlink safety (12 Copilot review comments addressed across 3 review rounds in [PR #4](https://github.com/ashbrener/openclaw-workspace-sync/pull/4))
- **Published on ClawHub**: https://clawhub.ai/ashbrener/openclaw-workspace-sync
- **Clean ClawHub security scan** as of v2.4.1 (LLM verdict: *benign*, high confidence)
- **Active maintenance**: real users filing issues that get resolved
- **Production usage**: deployed on Fly.io with active workloads

Per @steipete's direction on [#18106](https://github.com/openclaw/openclaw/issues/18106), this lives as a community plugin rather than core. This PR is purely the docs listing to make it discoverable.

## Test plan

- [x] Single file changed (`docs/plugins/community.md`)
- [x] Entry follows the established format used by other plugins in the file
- [x] Inserted in alphabetical position (between `wecom` and `Yuanbao`)
- [x] All linked URLs verified (npm, GitHub repo, ClawHub)
- [x] Clean rebase against latest `main`, no conflicts

cc: @steipete @vincentkoc @nikolasdehor

Made with [Cursor](https://cursor.com)