### PR TITLE
Fix duplicate Control UI assistant-media replies

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -715,6 +715,48 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("does not persist agent media supplements when no playable media resolves", async () => {
+    const transcriptDir = createTranscriptFixture("openclaw-chat-send-agent-stale-tts-");
+    const staleAudioPath = path.join(transcriptDir, "stale.mp3");
+    mockState.config = {
+      agents: {
+        defaults: {
+          workspace: transcriptDir,
+        },
+      },
+    };
+    mockState.triggerAgentRunStart = true;
+    mockState.dispatchedReplies = [
+      {
+        kind: "final",
+        payload: {
+          text: "Text-only test: one clean reply, no TTS, no media, no tool narration.",
+          mediaUrl: staleAudioPath,
+          mediaUrls: [staleAudioPath],
+          trustedLocalMedia: true,
+        },
+      },
+    ];
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-stale-agent-media",
+      expectBroadcast: false,
+      waitFor: "dedupe",
+    });
+
+    const assistantUpdates = mockState.emittedTranscriptUpdates.filter(
+      (update) =>
+        typeof update.message === "object" &&
+        update.message !== null &&
+        (update.message as { role?: unknown }).role === "assistant",
+    );
+    expect(assistantUpdates).toEqual([]);
+  });
+
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {
     const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2250,6 +2250,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         const persistedContentForAppend = hasAssistantDisplayMediaContent(persistedAssistantContent)
           ? persistedAssistantContent
           : undefined;
+        if (!persistedContentForAppend?.length) {
+          return;
+        }
         const transcriptReply =
           mediaMessage?.transcriptText ??
           extractAssistantDisplayTextFromContent(assistantContent) ??


### PR DESCRIPTION
## Summary

- Problem: Control UI/WebChat could persist a second `gateway-injected` assistant message from the `:assistant-media` path when a media-bearing agent payload no longer resolved to playable media.
- Why it matters: stale or non-playable TTS/media references could repeat the final assistant text in the transcript, making the assistant appear to reply twice.
- What changed: the agent-run assistant-media transcript append now requires resolved media content before writing the supplemental transcript message.
- What did NOT change (scope boundary): command/non-agent media replies still preserve visible text when no model transcript exists.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73956
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the agent-run assistant-media append path gated on the presence of `mediaUrl`/`mediaUrls`, then fell back to text when those media references failed to resolve to embeddable content.
- Missing detection / guardrail: there was coverage for resolved TTS audio not duplicating text, but not for stale/non-playable media references with visible text.
- Contributing context: the supplemental assistant-media message is only needed when it can carry media content that the normal model transcript does not already contain.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/chat.directive-tags.test.ts`
- Scenario the test should lock in: an agent-run final payload with text and a stale local audio path must not append a second assistant transcript message.
- Why this is the smallest reliable guardrail: the test exercises the WebChat `chat.send` transcript append seam where the duplicate was created.
- Existing test that already covers this (if any): resolved auto-TTS media is covered by the adjacent audio-only transcript test.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Control UI/WebChat should no longer show duplicate text-only assistant replies from stale or non-playable assistant-media/TTS supplements.

## Diagram (if applicable)

```text
Before:
agent final text + stale media ref -> assistant-media fallback -> duplicate text transcript message

After:
agent final text + stale media ref -> no resolved media -> no supplemental assistant-media transcript message
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local dev environment
- Runtime/container: Node/pnpm local repo checkout
- Model/provider: Not provider-specific
- Integration/channel (if any): Control UI / WebChat
- Relevant config (redacted): agent-run payload with text plus stale local audio media path

### Steps

1. Run WebChat `chat.send` through the gateway seam with an agent run started.
2. Emit a final reply payload containing visible text and a stale local audio `mediaUrl`/`mediaUrls`.
3. Inspect emitted assistant transcript updates.

### Expected

- No supplemental `:assistant-media` assistant transcript message is appended when no playable media resolves.

### Actual

- Before this change, the assistant-media path could append a text-only duplicate of the normal final answer.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -- --reporter=verbose`
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -t "does not persist agent media supplements" -- --reporter=verbose`
- `pnpm check:changed`

Edge cases checked:

- Resolved auto-TTS media still appends audio-only assistant media content via the existing adjacent test.

What I did not verify:

- Full `pnpm test` suite.
- Browser-driven Control UI manual session.

Note:

- `pnpm test:changed` currently fails on unrelated Windows path expectations in `src/crestodian/operations.test.ts` and `src/crestodian/rescue-message.test.ts` (`/tmp/work` vs `C:\tmp\work`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a malformed media payload might no longer create a text-only supplemental transcript entry.
  - Mitigation: agent final text is already represented by the normal model transcript; command/non-agent media fallback behavior is unchanged.

Supersedes #74501, which used the previous codex-prefixed branch name.