### PR TITLE
fix(models): reject suppressed inline model rows with api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/OpenAI Codex: reject stale configured `openai-codex/gpt-5.4-mini` inline rows before runtime selection, so ChatGPT-backed Codex sessions fail with the documented route guidance instead of repeated assistant-turn errors. Fixes #74451. Thanks @Marvae.
 - Models/UI: hide unauthenticated providers from the default Web chat, `/models`, and model setup pickers while keeping explicit full-catalog browse paths through `view: "all"`, `/models <provider> all`, and `models list --all`. Fixes #74423. Thanks @guarismo and @SymbolStar.
 - Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00 and @vyctorbrzezowski.
 - Google/Gemini: send non-empty placeholder content when a Gemini run is triggered with empty or filtered user content, avoiding `contents is not specified` API errors. Thanks @CaoYuhaoCarl.

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1511,6 +1511,35 @@ describe("resolveModel", () => {
     );
   });
 
+  it("rejects configured openai-codex gpt-5.4-mini inline rows with api", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4-mini",
+                name: "GPT-5.4 Mini",
+                api: "openai-codex-responses",
+                input: ["text"],
+                reasoning: true,
+                contextWindow: 64_000,
+                maxTokens: 8_192,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("openai-codex", "gpt-5.4-mini", "/tmp/agent", cfg);
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe(
+      "Unknown model: openai-codex/gpt-5.4-mini. gpt-5.4-mini is not supported by the OpenAI Codex OAuth route. Use openai/gpt-5.4-mini with an OpenAI API key or openai-codex/gpt-5.5 with Codex OAuth.",
+    );
+  });
+
   it("does not build an openai-codex fallback for removed gpt-5.3-codex-spark", () => {
     mockOpenAICodexTemplateModel(discoverModels);
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -593,6 +593,14 @@ function resolveExplicitModelWithRegistry(params: {
     modelId,
   });
   if (inlineMatch?.api) {
+    if (
+      shouldSuppressBuiltInModel({
+        provider,
+        id: modelId,
+      })
+    ) {
+      return { kind: "suppressed" };
+    }
     const resolvedParams = mergeConfiguredRuntimeModelParams({
       cfg,
       provider,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -592,13 +592,14 @@ function resolveExplicitModelWithRegistry(params: {
     provider,
     modelId,
   });
+  const globallySuppressedBuiltInModel = shouldSuppressBuiltInModel({
+    provider,
+    id: modelId,
+  });
   if (inlineMatch?.api) {
-    if (
-      shouldSuppressBuiltInModel({
-        provider,
-        id: modelId,
-      })
-    ) {
+    // Inline rows can intentionally override endpoint-conditional suppressions;
+    // unconditional retirements still reject stale configured rows.
+    if (globallySuppressedBuiltInModel) {
       return { kind: "suppressed" };
     }
     const resolvedParams = mergeConfiguredRuntimeModelParams({


### PR DESCRIPTION
## Summary

- Problem: Configured inline model rows with `api` bypass the suppression check, allowing `openai-codex/gpt-5.4-mini` to resolve even though ChatGPT-backed Codex accounts do not support it
- Why it matters: Users with stale config entries see repeated runtime failures instead of a clear rejection
- What changed: Added suppression check before returning inline matches in `resolveExplicitModelWithRegistry`
- What did NOT change: Suppression logic itself unchanged; only the check placement extended

**Regression**: Worked in 2026.4.23, broken in 2026.4.26. The suppression was added in `dc6031197b` but only covered built-in/discovered rows, not configured inline rows with explicit `api`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74451
- Related #73242, #73280
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveExplicitModelWithRegistry` returns `inlineMatch` when `inlineMatch?.api` exists BEFORE checking `shouldSuppressBuiltInModel`, allowing stale configured rows to bypass suppression
- Missing detection / guardrail: No suppression check for inline matches with explicit `api`
- Contributing context: User had `gpt-5.4-mini` in their `openclaw.json` from before the suppression was added

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- Target test file: `src/agents/pi-embedded-runner/model.test.ts`
- Scenario the test should lock in: Configured `openai-codex/gpt-5.4-mini` inline row with `api: "openai-codex-responses"` is rejected with the suppression message
- Why this is the smallest reliable guardrail: Tests the exact resolver path that was bypassing suppression
- Existing test that already covers this: None for inline rows with `api`

## User-visible / Behavior Changes

- Configured `openai-codex/gpt-5.4-mini` with `api` now returns the suppression error instead of failing at runtime

## Diagram (if applicable)

```text
Before:
[configured inline row with api] -> [returns inlineMatch] -> [runtime error from vendor]

After:
[configured inline row with api] -> [suppression check] -> [clear rejection with guidance]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 24.6.0
- Runtime/container: Node.js v25.6.1
- Model/provider: openai-codex
- Integration/channel: N/A

### Steps

1. Add `gpt-5.4-mini` with `api: "openai-codex-responses"` to `models.providers.openai-codex.models[]` in config
2. Try to use `openai-codex/gpt-5.4-mini`
3. Observe rejection with suppression message instead of runtime failure

### Expected

- Clear rejection: "gpt-5.4-mini is not supported by the OpenAI Codex OAuth route..."

### Actual

- Works as expected after fix

## Evidence

- [x] Failing test/log before + passing after

```
pnpm test src/agents/pi-embedded-runner/model.test.ts
# 69 tests passed (1 new)
```

New test verifies:
```ts
expect(result.error).toBe(
  "Unknown model: openai-codex/gpt-5.4-mini. gpt-5.4-mini is not supported by the OpenAI Codex OAuth route. Use openai/gpt-5.4-mini with an OpenAI API key or openai-codex/gpt-5.5 with Codex OAuth.",
);
```

## Human Verification (required)

- Verified scenarios: Unit tests pass (69/69), code review, resolver logic inspection
- Edge cases checked: Configured row with and without `api`, suppression check ordering
- What you did NOT verify: E2E with live Codex session (unit tests cover the resolver path)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Could reject valid configured models if suppression is too broad
  - Mitigation: Only applies to models explicitly marked as suppressed in plugin manifest; existing suppression logic unchanged