### PR TITLE
Fix status context window for channel model overrides

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -601,6 +601,51 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("channel override");
   });
 
+  it("uses the channel override model context window instead of stale persisted context", () => {
+    const text = buildStatusMessage({
+      config: {
+        channels: {
+          modelByChannel: {
+            discord: {
+              "123": "minimax-portal/MiniMax-M2.7",
+            },
+          },
+        },
+        models: {
+          providers: {
+            "minimax-portal": {
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
+            },
+            anthropic: {
+              models: [{ id: "claude-opus-4-6", contextWindow: 1_048_576 }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "minimax-portal/MiniMax-M2.7",
+        contextTokens: 1_048_576,
+      },
+      sessionEntry: {
+        sessionId: "channel-context-window",
+        updatedAt: 0,
+        channel: "discord",
+        groupId: "123",
+        totalTokens: 49_000,
+        contextTokens: 1_048_576,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Model: minimax-portal/MiniMax-M2.7");
+    expect(normalized).toContain("channel override");
+    expect(normalized).toContain("Context: 49k/200k");
+    expect(normalized).not.toContain("Context: 49k/1.0m");
+  });
+
   it("shows 1M context window when anthropic context1m is enabled", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -489,6 +489,57 @@ const formatVoiceModeLine = (
   return parts.join(" · ");
 };
 
+function resolveChannelModelNote(params: {
+  config?: OpenClawConfig;
+  entry?: SessionEntry;
+  selectedProvider: string;
+  selectedModel: string;
+  parentSessionKey?: string;
+}): string | undefined {
+  if (!params.config || !params.entry) {
+    return undefined;
+  }
+  if (
+    normalizeOptionalString(params.entry.modelOverride) ||
+    normalizeOptionalString(params.entry.providerOverride)
+  ) {
+    return undefined;
+  }
+  const channelOverride = resolveChannelModelOverride({
+    cfg: params.config,
+    channel: params.entry.channel ?? params.entry.origin?.provider,
+    groupId: params.entry.groupId,
+    groupChatType: params.entry.chatType ?? params.entry.origin?.chatType,
+    groupChannel: params.entry.groupChannel,
+    groupSubject: params.entry.subject,
+    parentSessionKey: params.parentSessionKey,
+  });
+  if (!channelOverride) {
+    return undefined;
+  }
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.config,
+    defaultProvider: DEFAULT_PROVIDER,
+    allowPluginNormalization: false,
+  });
+  const resolvedOverride = resolveModelRefFromString({
+    raw: channelOverride.model,
+    defaultProvider: DEFAULT_PROVIDER,
+    aliasIndex,
+    allowPluginNormalization: false,
+  });
+  if (!resolvedOverride) {
+    return undefined;
+  }
+  if (
+    resolvedOverride.ref.provider !== params.selectedProvider ||
+    resolvedOverride.ref.model !== params.selectedModel
+  ) {
+    return undefined;
+  }
+  return "channel override";
+}
+
 export function buildStatusMessage(args: StatusArgs): string {
   const now = args.now ?? Date.now();
   const entry = args.sessionEntry;
@@ -650,9 +701,20 @@ export function buildStatusMessage(args: StatusArgs): string {
     model: contextLookupModel,
     allowAsyncLoad: false,
   });
+  const channelModelNote = resolveChannelModelNote({
+    config: args.config,
+    entry,
+    selectedProvider,
+    selectedModel,
+    parentSessionKey: args.parentSessionKey,
+  });
   const persistedContextTokens =
     typeof entry?.contextTokens === "number" && entry.contextTokens > 0
       ? entry.contextTokens
+      : undefined;
+  const agentContextTokens =
+    typeof args.agent?.contextTokens === "number" && args.agent.contextTokens > 0
+      ? args.agent.contextTokens
       : undefined;
   const explicitRuntimeContextTokens =
     typeof args.runtimeContextTokens === "number" && args.runtimeContextTokens > 0
@@ -669,6 +731,15 @@ export function buildStatusMessage(args: StatusArgs): string {
         ? Math.min(explicitConfiguredContextTokens, activeContextTokens)
         : explicitConfiguredContextTokens
       : undefined;
+  const channelOverrideContextTokens = channelModelNote
+    ? (explicitRuntimeContextTokens ??
+      cappedConfiguredContextTokens ??
+      (typeof activeContextTokens === "number"
+        ? typeof agentContextTokens === "number"
+          ? Math.min(agentContextTokens, activeContextTokens)
+          : activeContextTokens
+        : agentContextTokens))
+    : undefined;
   // When a fallback model is active, the selected-model context limit that
   // callers keep on the agent config is often stale. Prefer an explicit runtime
   // snapshot when available. Separately, callers can pass an explicit configured
@@ -715,7 +786,8 @@ export function buildStatusMessage(args: StatusArgs): string {
         cfg: contextConfig,
         ...(contextLookupProvider ? { provider: contextLookupProvider } : {}),
         model: contextLookupModel,
-        contextTokensOverride: persistedContextTokens ?? args.agent?.contextTokens,
+        contextTokensOverride:
+          channelOverrideContextTokens ?? persistedContextTokens ?? agentContextTokens,
         fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
         allowAsyncLoad: false,
       }) ?? DEFAULT_CONTEXT_TOKENS);
@@ -854,50 +926,6 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
-  const channelModelNote = (() => {
-    if (!args.config || !entry) {
-      return undefined;
-    }
-    if (
-      normalizeOptionalString(entry.modelOverride) ||
-      normalizeOptionalString(entry.providerOverride)
-    ) {
-      return undefined;
-    }
-    const channelOverride = resolveChannelModelOverride({
-      cfg: args.config,
-      channel: entry.channel ?? entry.origin?.provider,
-      groupId: entry.groupId,
-      groupChatType: entry.chatType ?? entry.origin?.chatType,
-      groupChannel: entry.groupChannel,
-      groupSubject: entry.subject,
-      parentSessionKey: args.parentSessionKey,
-    });
-    if (!channelOverride) {
-      return undefined;
-    }
-    const aliasIndex = buildModelAliasIndex({
-      cfg: args.config,
-      defaultProvider: DEFAULT_PROVIDER,
-      allowPluginNormalization: false,
-    });
-    const resolvedOverride = resolveModelRefFromString({
-      raw: channelOverride.model,
-      defaultProvider: DEFAULT_PROVIDER,
-      aliasIndex,
-      allowPluginNormalization: false,
-    });
-    if (!resolvedOverride) {
-      return undefined;
-    }
-    if (
-      resolvedOverride.ref.provider !== selectedProvider ||
-      resolvedOverride.ref.model !== selectedModel
-    ) {
-      return undefined;
-    }
-    return "channel override";
-  })();
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
 


### PR DESCRIPTION
## Summary

- Problem: `/status` could show a stale persisted context window when `channels.modelByChannel` selected the active model and the session still had old `contextTokens`.
- Why it matters: operators saw misleading context capacity after channel-level model switches until a fresh session or later runtime metadata refresh corrected it.
- What changed: status now resolves the channel model override before context-window selection and treats that active override as authoritative for display.
- What did NOT change (scope boundary): no session persistence or model selection behavior changed; this only affects status reporting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63425
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `buildStatusMessage()` detected channel model overrides only after resolving the context window, so `sessionEntry.contextTokens` still won when selected and active model labels matched.
- Missing detection / guardrail: there was no regression test combining `channels.modelByChannel` with stale persisted session `contextTokens`.
- Contributing context (if known): existing fallback logic handled stale context windows only when active and selected model labels differed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/status.test.ts`
- Scenario the test should lock in: channel override selects a 200k model while the session still has a stale 1M context window.
- Why this is the smallest reliable guardrail: the bug is in status-message formatting and context-window selection, so a direct status test covers the affected branch.
- Existing test that already covers this (if any): none for stale `contextTokens` plus `modelByChannel`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`/status` now reports the channel-selected model context window instead of stale persisted session context when no explicit session `/model` override exists.

## Diagram (if applicable)

```text
Before:
/modelByChannel active -> /status -> stale session contextTokens wins

After:
/modelByChannel active -> resolve override -> active model context window wins
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local repo, Node/pnpm
- Model/provider: synthetic status test models
- Integration/channel (if any): Discord `channels.modelByChannel`
- Relevant config (redacted): test config maps Discord group `123` to `minimax-portal/MiniMax-M2.7`

### Steps

1. Create a session entry with `channels.modelByChannel` selecting a 200k context model.
2. Leave stale persisted `sessionEntry.contextTokens` at 1,048,576.
3. Render `buildStatusMessage()`.

### Expected

- Status shows `Context: 49k/200k` and notes `channel override`.

### Actual

- Before this change, status showed `Context: 49k/1.0m`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Reproduced the new regression test failing before the fix.
  - Confirmed the same test passes after the fix.
  - Ran the full `src/auto-reply/status.test.ts` file.
  - Ran adjacent model override tests.
  - Ran changed-file gates and repo check.
- Edge cases checked:
  - Existing fallback context-window tests still pass.
  - Existing channel override note still appears.
- What you did **not** verify:
  - Full `pnpm test` did not complete; it was interrupted for fast handoff. Scoped and changed-file gates passed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: status could prefer the channel override window when an explicit session override exists.
  - Mitigation: channel override detection still returns nothing when `modelOverride` or `providerOverride` is present.

## Test Commands

- `pnpm test src/auto-reply/status.test.ts -t "uses the channel override model context window" -- --reporter=verbose`
- `pnpm test src/auto-reply/status.test.ts -- --reporter=verbose`
- `pnpm test src/sessions/model-overrides.test.ts src/channels/model-overrides.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `pnpm test:changed`
- `pnpm check`