### PR TITLE
fix(tools): ignore streamTo for native subagent spawns

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -175,7 +175,7 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const expectsCompletionMessage = params.expectsCompletionMessage !== false;
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
       if (runtime === "acp" && lightContext) {
         throw new Error("lightContext is only supported for runtime='subagent'.");
@@ -200,13 +200,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (resumeSessionId && runtime !== "acp") {
         return jsonResult({


### PR DESCRIPTION
## Summary
- ignore `streamTo` unless `sessions_spawn` is running with `runtime="acp"`
- stop rejecting native `runtime="subagent"` spawns when an optional `streamTo: "parent"` field leaks into generated tool args

## Why
Some Studio/tool-call builders include optional schema fields even when they are not valid for the selected runtime. Native subagent spawning should be tolerant of ACP-only `streamTo` noise and proceed normally instead of returning:

`streamTo is only supported for runtime=acp; got runtime=subagent`

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/sessions-spawn-tool.test.ts` → 24 passed
- `pnpm format:check -- src/agents/tools/sessions-spawn-tool.ts` → passed
- `pnpm tsgo:core --pretty false` → passed on current upstream-based branch

Note: while preparing a fork branch from the existing fork base, the repo pre-commit `pnpm check` path failed because `madge` was missing in that checkout. The focused tests/typecheck above passed on current upstream main before pushing this PR branch.
