### PR TITLE
fix(matrix): close owner-side device verification loop on SAS confirm

### DIFF
--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Matrix/E2EE: close the owner-side device verification loop when SAS lands via the CLI. `verify confirm-sas` now (1) awaits the rust-crypto verifier promise so the done-exchange and any cross-signing uploads triggered by `crossSignDevice` settle before the verb returns, (2) cross-signs the bot device on the auto-confirmed inbound SAS path (previously skipped), and (3) calls `trustOwnIdentityAfterSelfVerification` from the standalone `confirmMatrixVerificationSas` action so the operator's Element X clears the "Verify" prompt without waiting for a passive sync tick [AI-assisted].
 - Matrix/E2EE: stabilize recovery and broken-device QA flows while avoiding device-cleanup sync races that could leave shutdown-time crypto work running. Thanks @gumadeiras.
 
 ## 2026.4.25

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Matrix/E2EE: close the owner-side device verification loop when SAS lands via the CLI. `verify confirm-sas` now (1) awaits the rust-crypto verifier promise so the done-exchange and any cross-signing uploads triggered by `crossSignDevice` settle before the verb returns, (2) cross-signs the bot device on the auto-confirmed inbound SAS path (previously skipped), and (3) calls `trustOwnIdentityAfterSelfVerification` from the standalone `confirmMatrixVerificationSas` action so the operator's Element X clears the "Verify" prompt without waiting for a passive sync tick [AI-assisted].
+- Matrix/E2EE: close the owner-side device verification loop when SAS lands via the CLI. `verify confirm-sas` now (1) awaits the rust-crypto verifier promise so the done-exchange and any cross-signing uploads triggered by `crossSignDevice` settle before the verb returns, (2) cross-signs the bot device on the auto-confirmed inbound SAS path (previously skipped), and (3) calls `trustOwnIdentityAfterSelfVerification` from the standalone `confirmMatrixVerificationSas` action so the operator's Element X clears the "Verify" prompt without waiting for a passive sync tick [AI-assisted]. Thanks @nklock.
 - Matrix/E2EE: stabilize recovery and broken-device QA flows while avoiding device-cleanup sync races that could leave shutdown-time crypto work running. Thanks @gumadeiras.
 
 ## 2026.4.25

--- a/extensions/matrix/src/matrix/actions/verification.test.ts
+++ b/extensions/matrix/src/matrix/actions/verification.test.ts
@@ -38,10 +38,12 @@ let getMatrixVerificationStatus: typeof import("./verification.js").getMatrixVer
 let restoreMatrixRoomKeyBackup: typeof import("./verification.js").restoreMatrixRoomKeyBackup;
 let runMatrixSelfVerification: typeof import("./verification.js").runMatrixSelfVerification;
 let startMatrixVerification: typeof import("./verification.js").startMatrixVerification;
+let confirmMatrixVerificationSas: typeof import("./verification.js").confirmMatrixVerificationSas;
 
 describe("matrix verification actions", () => {
   beforeAll(async () => {
     ({
+      confirmMatrixVerificationSas,
       getMatrixEncryptionStatus,
       getMatrixRoomKeyBackupStatus,
       getMatrixVerificationStatus,
@@ -1000,5 +1002,51 @@ describe("matrix verification actions", () => {
       code: "m.user",
       reason: "OpenClaw self-verification did not complete",
     });
+  });
+
+  it("confirmMatrixVerificationSas calls trustOwnIdentityAfterSelfVerification on a self-verification", async () => {
+    const crypto = {
+      confirmVerificationSas: vi.fn(async () => ({
+        completed: true,
+        hasSas: true,
+        id: "verification-self",
+        isSelfVerification: true,
+        phaseName: "done",
+        transactionId: "tx-self",
+      })),
+    };
+    const trustOwnIdentityAfterSelfVerification = vi.fn(async () => {});
+    withStartedActionClientMock.mockImplementation(async (_opts, run) => {
+      return await run({ crypto, trustOwnIdentityAfterSelfVerification });
+    });
+
+    const summary = await confirmMatrixVerificationSas("verification-self");
+
+    expect(crypto.confirmVerificationSas).toHaveBeenCalledWith("verification-self");
+    expect(trustOwnIdentityAfterSelfVerification).toHaveBeenCalledTimes(1);
+    expect(summary.isSelfVerification).toBe(true);
+  });
+
+  it("confirmMatrixVerificationSas does not call trustOwnIdentityAfterSelfVerification on a non-self verification", async () => {
+    const crypto = {
+      confirmVerificationSas: vi.fn(async () => ({
+        completed: true,
+        hasSas: true,
+        id: "verification-remote",
+        isSelfVerification: false,
+        phaseName: "done",
+        transactionId: "tx-remote",
+      })),
+    };
+    const trustOwnIdentityAfterSelfVerification = vi.fn(async () => {});
+    withStartedActionClientMock.mockImplementation(async (_opts, run) => {
+      return await run({ crypto, trustOwnIdentityAfterSelfVerification });
+    });
+
+    const summary = await confirmMatrixVerificationSas("verification-remote");
+
+    expect(crypto.confirmVerificationSas).toHaveBeenCalledWith("verification-remote");
+    expect(trustOwnIdentityAfterSelfVerification).not.toHaveBeenCalled();
+    expect(summary.isSelfVerification).toBe(false);
   });
 });

--- a/extensions/matrix/src/matrix/actions/verification.test.ts
+++ b/extensions/matrix/src/matrix/actions/verification.test.ts
@@ -1049,4 +1049,28 @@ describe("matrix verification actions", () => {
     expect(trustOwnIdentityAfterSelfVerification).not.toHaveBeenCalled();
     expect(summary.isSelfVerification).toBe(false);
   });
+
+  it("confirmMatrixVerificationSas does not trust own identity when self-verification failed", async () => {
+    const crypto = {
+      confirmVerificationSas: vi.fn(async () => ({
+        completed: false,
+        error: "verifier rejected mid-protocol",
+        hasSas: true,
+        id: "verification-self",
+        isSelfVerification: true,
+        phaseName: "started",
+        transactionId: "tx-self",
+      })),
+    };
+    const trustOwnIdentityAfterSelfVerification = vi.fn(async () => {});
+    withStartedActionClientMock.mockImplementation(async (_opts, run) => {
+      return await run({ crypto, trustOwnIdentityAfterSelfVerification });
+    });
+
+    const summary = await confirmMatrixVerificationSas("verification-self");
+
+    expect(crypto.confirmVerificationSas).toHaveBeenCalledWith("verification-self");
+    expect(trustOwnIdentityAfterSelfVerification).not.toHaveBeenCalled();
+    expect(summary.error).toMatch(/verifier rejected mid-protocol/);
+  });
 });

--- a/extensions/matrix/src/matrix/actions/verification.ts
+++ b/extensions/matrix/src/matrix/actions/verification.ts
@@ -443,7 +443,7 @@ export async function confirmMatrixVerificationSas(
     // completeMatrixSelfVerification: cross-sign the operator's master key
     // from the bot side so Element X clears the "Verify" prompt without
     // waiting for a passive sync tick. Non-self verifications are a no-op.
-    if (summary.isSelfVerification) {
+    if (summary.isSelfVerification && summary.completed && !summary.error) {
       await client.trustOwnIdentityAfterSelfVerification?.();
     }
     return summary;

--- a/extensions/matrix/src/matrix/actions/verification.ts
+++ b/extensions/matrix/src/matrix/actions/verification.ts
@@ -437,7 +437,16 @@ export async function confirmMatrixVerificationSas(
   return await withStartedActionClient(opts, async (client) => {
     const crypto = requireCrypto(client, opts);
     await ensureMatrixVerificationDmTracked(crypto, opts);
-    return await crypto.confirmVerificationSas(resolveVerificationId(requestId));
+    const summary = await crypto.confirmVerificationSas(resolveVerificationId(requestId));
+    // For self-verifications, mirror the trust-own-identity step that the
+    // higher-level runMatrixSelfVerification path already performs at
+    // completeMatrixSelfVerification: cross-sign the operator's master key
+    // from the bot side so Element X clears the "Verify" prompt without
+    // waiting for a passive sync tick. Non-self verifications are a no-op.
+    if (summary.isSelfVerification) {
+      await client.trustOwnIdentityAfterSelfVerification?.();
+    }
+    return summary;
   });
 }
 

--- a/extensions/matrix/src/matrix/sdk/verification-manager.test.ts
+++ b/extensions/matrix/src/matrix/sdk/verification-manager.test.ts
@@ -573,11 +573,9 @@ describe("MatrixVerificationManager", () => {
     expect(verifyImpl).toHaveBeenCalledTimes(1);
 
     let confirmResolved = false;
-    const confirmPromise = manager
-      .confirmVerificationSas(tracked.id)
-      .then(() => {
-        confirmResolved = true;
-      });
+    const confirmPromise = manager.confirmVerificationSas(tracked.id).then(() => {
+      confirmResolved = true;
+    });
 
     // Yield once so confirmSasForSession + trustOwnDeviceAfterSas finish, but
     // verifyPromise stays pending. confirmVerificationSas must still be

--- a/extensions/matrix/src/matrix/sdk/verification-manager.test.ts
+++ b/extensions/matrix/src/matrix/sdk/verification-manager.test.ts
@@ -520,7 +520,7 @@ describe("MatrixVerificationManager", () => {
     }
   });
 
-  it("does not cross-sign the other own device after auto-confirmed self-verification SAS", async () => {
+  it("cross-signs the other own device after auto-confirmed self-verification SAS", async () => {
     vi.useFakeTimers();
     const { confirm, verifier } = createSasVerifierFixture({
       decimal: [6158, 1986, 3513],
@@ -541,10 +541,81 @@ describe("MatrixVerificationManager", () => {
       await vi.advanceTimersByTimeAsync(30_100);
 
       expect(confirm).toHaveBeenCalledTimes(1);
-      expect(trustOwnDeviceAfterSas).not.toHaveBeenCalled();
+      expect(trustOwnDeviceAfterSas).toHaveBeenCalledWith("OTHERDEVICE");
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("confirmVerificationSas awaits the verifier's verify promise before resolving", async () => {
+    let resolveVerify!: () => void;
+    const verifyPromise = new Promise<void>((res) => {
+      resolveVerify = res;
+    });
+    const verifyImpl = vi.fn(() => verifyPromise);
+    const { confirm, verifier } = createSasVerifierFixture({
+      decimal: [111, 222, 333],
+      emoji: [["cat", "Cat"]],
+      verifyImpl,
+    });
+    const trustOwnDeviceAfterSas = vi.fn(async () => {});
+    const request = new MockVerificationRequest({
+      isSelfVerification: true,
+      otherDeviceId: "OTHERDEVICE",
+      transactionId: "txn-await-verify",
+      initiatedByMe: true,
+      verifier,
+    });
+    const manager = new MatrixVerificationManager({ trustOwnDeviceAfterSas });
+    const tracked = manager.trackVerificationRequest(request);
+
+    await manager.startVerification(tracked.id, "sas");
+    expect(verifyImpl).toHaveBeenCalledTimes(1);
+
+    let confirmResolved = false;
+    const confirmPromise = manager
+      .confirmVerificationSas(tracked.id)
+      .then(() => {
+        confirmResolved = true;
+      });
+
+    // Yield once so confirmSasForSession + trustOwnDeviceAfterSas finish, but
+    // verifyPromise stays pending. confirmVerificationSas must still be
+    // blocked awaiting verifyPromise.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(trustOwnDeviceAfterSas).toHaveBeenCalledWith("OTHERDEVICE");
+    expect(confirmResolved).toBe(false);
+
+    resolveVerify();
+    await confirmPromise;
+    expect(confirmResolved).toBe(true);
+  });
+
+  it("confirmVerificationSas surfaces a verifier-promise rejection on session.error", async () => {
+    const verifyImpl = vi.fn(async () => {
+      throw new Error("verifier rejected mid-protocol");
+    });
+    const { verifier } = createSasVerifierFixture({
+      decimal: [111, 222, 333],
+      emoji: [["cat", "Cat"]],
+      verifyImpl,
+    });
+    const request = new MockVerificationRequest({
+      isSelfVerification: true,
+      otherDeviceId: "OTHERDEVICE",
+      transactionId: "txn-verify-rejects",
+      initiatedByMe: true,
+      verifier,
+    });
+    const manager = new MatrixVerificationManager();
+    const tracked = manager.trackVerificationRequest(request);
+
+    await manager.startVerification(tracked.id, "sas");
+    const summary = await manager.confirmVerificationSas(tracked.id);
+
+    expect(summary.error).toMatch(/verifier rejected mid-protocol/);
   });
 
   it("does not auto-confirm SAS for verifications initiated by this device", async () => {

--- a/extensions/matrix/src/matrix/sdk/verification-manager.ts
+++ b/extensions/matrix/src/matrix/sdk/verification-manager.ts
@@ -504,7 +504,11 @@ export class MatrixVerificationManager {
         return;
       }
       session.sasAutoConfirmStarted = true;
-      void this.confirmSasForSession(session, callbacks, { trustOwnDevice: false })
+      // For self-verifications, trustOwnDeviceAfterConfirmedSas is gated on
+      // isSelfVerification, so non-self requests remain unaffected. Without
+      // this, the bot's own device never gets cross-signed when SAS lands
+      // via the auto-confirm timer (initiated remotely).
+      void this.confirmSasForSession(session, callbacks, { trustOwnDevice: true })
         .then(() => {
           this.touchVerificationSession(session);
         })
@@ -732,6 +736,15 @@ export class MatrixVerificationManager {
     session.sasCallbacks = callbacks;
     session.sasAutoConfirmStarted = true;
     await this.confirmSasForSession(session, callbacks);
+    // Wait for the rust-crypto verifier to fully resolve (done-exchange + any
+    // pending cross-signing uploads triggered by trustOwnDeviceAfterSas) so
+    // the operator's client sees a settled state on the next /keys/query.
+    // verifyPromise is set inside ensureVerificationStarted and already
+    // funnels its own rejection into session.error, so awaiting it here
+    // cannot double-throw.
+    if (session.verifyPromise) {
+      await session.verifyPromise;
+    }
     this.touchVerificationSession(session);
     return this.buildVerificationSummary(session);
   }


### PR DESCRIPTION
# Close owner-side device verification loop on SAS confirm

## What this PR does

After running `openclaw matrix verify confirm-sas` on a self-verification, the operator's Element X stayed in "Verifying…" because three things on the bot side did not happen before the verb returned:

1. **`confirmVerificationSas` did not await the rust-crypto verifier promise.** `Verifier.verify()` in matrix-js-sdk resolves only after both sides exchange MACs and the protocol fully settles, including the cross-signing-key uploads triggered by `crossSignDevice`. Returning early meant the operator's next `/keys/query` saw an inconsistent state and the prompt persisted.

2. **The 30-second auto-confirm path explicitly skipped device cross-signing.** When the operator initiated SAS from their phone (`initiatedByMe === false`), the bot's auto-confirm timer fired but called `confirmSasForSession` with `{ trustOwnDevice: false }`. The bot's own device was never cross-signed on this path. The check inside `trustOwnDeviceAfterConfirmedSas` already gates on `isSelfVerification`, so flipping the flag is safe — non-self requests remain a no-op.

3. **The standalone `confirmMatrixVerificationSas` action did not call `trustOwnIdentityAfterSelfVerification`.** Only the higher-level `runMatrixSelfVerification` path called it (at `completeMatrixSelfVerification`). The standalone CLI verb skipped cross-signing the operator's master key from the bot side, so Element X had no path to clear the prompt without a passive sync tick.

After this change, `verify confirm-sas` on a self-verification settles all three before returning, and Element X's device-list view shows the bot device with a green shield with no remaining "Verify" prompt.

## Changes

### `extensions/matrix/src/matrix/sdk/verification-manager.ts`

- `confirmVerificationSas` (line 725) — after `confirmSasForSession`, await `session.verifyPromise` if defined. `verifyPromise` is the `.then().catch()` chain set by `ensureVerificationStarted`, which already routes rejections into `session.error`, so awaiting it cannot double-throw.
- `maybeAutoConfirmSas` (line 507) — pass `{ trustOwnDevice: true }` to `confirmSasForSession`. The check inside `trustOwnDeviceAfterConfirmedSas` (gates on `isSelfVerification`) keeps non-self verifications unaffected.

### `extensions/matrix/src/matrix/actions/verification.ts`

- `confirmMatrixVerificationSas` (line 433) — after `crypto.confirmVerificationSas` resolves, if the returned summary has `isSelfVerification: true`, call `client.trustOwnIdentityAfterSelfVerification?.()`. Mirrors the pattern already in `completeMatrixSelfVerification` at line 224.

### Tests

`extensions/matrix/src/matrix/sdk/verification-manager.test.ts`:
- Flipped the existing "auto-confirmed self-verification SAS" test to assert `trustOwnDeviceAfterSas` IS called (was: NOT called).
- New: `confirmVerificationSas awaits the verifier's verify promise before resolving` — uses a deferred verifyPromise to assert the verb blocks until the verifier settles.
- New: `confirmVerificationSas surfaces a verifier-promise rejection on session.error` — asserts a rejecting `verify()` lands the error in `summary.error` rather than throwing.

`extensions/matrix/src/matrix/actions/verification.test.ts`:
- New: `confirmMatrixVerificationSas calls trustOwnIdentityAfterSelfVerification on a self-verification`.
- New: `confirmMatrixVerificationSas does not call trustOwnIdentityAfterSelfVerification on a non-self verification`.

`pnpm test:extension matrix` — 117 test files green; 23 tests in `actions/verification.test.ts`, 20 in `verification-manager.test.ts`.

## What this PR explicitly does **not** do

- Does **not** expose the QR-code verification flow as new CLI verbs. The manager methods exist (`generateVerificationQr`, `scanVerificationQr`, `confirmVerificationReciprocateQr`) but adding CLI surface for them is a separate change. SAS is sufficient for the failure mode addressed here.
- Does **not** add cross-restart persistence for in-flight verification sessions. Sessions remain in-memory; if the bot restarts mid-verification the operator can re-initiate from their client and the bot will auto-accept the fresh request.
- Does **not** change the cross-signing bootstrap path; that is the companion MSC3967 PR (filed separately).

## Verified end-to-end

Confirmed against `matrix.thepolycule.ca` (Synapse 1.145.0+ess.1, MAS-fronted). After bootstrap and a SAS round-trip with an Element X session, the bot device shows the green shield in the operator's device list and encrypted DMs decrypt round-trip without UTD warnings.

## AI-assisted disclosure

This change was authored with AI assistance (Claude). The author reviewed every line, ran `pnpm test:extension matrix` locally, and verified the closure end-to-end against a MAS-fronted Synapse 1.145.0+ess.1 deployment.
