### PR TITLE
Fix gateway timeout embedded fallback session lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 - Ollama: normalize provider-prefixed tool-call names at the native stream boundary so Kimi/Ollama calls such as `functions.exec` dispatch as `exec` instead of missing configured tools. Fixes #74487. Thanks @afurm and @carreipeia.
 - Security/audit: resolve configured model aliases before model-tier and small-parameter checks, so alias-based GPT-5/Codex configs no longer report false weak-model warnings. Fixes #74455. Thanks @blaspat.
+- CLI/agent: isolate Gateway-timeout embedded fallback runs under explicit `gateway-fallback-*` sessions so accepted Gateway runs cannot race transcript locks or replace the routed conversation session. Fixes #62981. Thanks @HemantSudarshan.
 - Models/UI: hide unauthenticated providers from the default Web chat, `/models`, and model setup pickers while keeping explicit full-catalog browse paths through `view: "all"`, `/models <provider> all`, and `models list --all`. Fixes #74423. Thanks @guarismo and @SymbolStar.
 - Slack/prompts: rely on Slack `interactiveReplies` guidance instead of generic `inlineButtons` config hints so enabled Slack button directives are not contradicted. Fixes #46647. Thanks @jeremykoerber.
 - Slack/reactions: treat duplicate `already_reacted` responses as idempotent success so repeated agent reaction adds no longer surface as tool failures. Fixes #69005. Thanks @shipitsteven and @martingarramon.

--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -59,6 +59,7 @@ openclaw agent --agent ops --message "Run locally" --local
 - `--channel`, `--reply-channel`, and `--reply-account` affect reply delivery, not session routing.
 - `--json` keeps stdout reserved for the JSON response. Gateway, plugin, and embedded-fallback diagnostics are routed to stderr so scripts can parse stdout directly.
 - Embedded fallback JSON includes `meta.transport: "embedded"` and `meta.fallbackFrom: "gateway"` so scripts can distinguish fallback runs from Gateway runs.
+- If the Gateway accepts an agent run but the CLI times out waiting for the final reply, embedded fallback uses a fresh explicit `gateway-fallback-*` session/run id and reports `meta.fallbackReason: "gateway_timeout"` plus the fallback session fields. This avoids racing the Gateway-owned transcript lock or silently replacing the original routed conversation session.
 - When this command triggers `models.json` regeneration, SecretRef-managed provider credentials are persisted as non-secret markers (for example env var names, `secretref-env:ENV_VAR_NAME`, or `secretref-managed`), not resolved secret plaintext.
 - Marker writes are source-authoritative: OpenClaw persists markers from the active source config snapshot, not from resolved runtime secret values.
 

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -54,7 +54,10 @@ type SessionIdMatchSet = {
   storeByKey: Map<string, SessionKeyResolution>;
 };
 
-function buildExplicitSessionIdSessionKey(params: { sessionId: string; agentId?: string }): string {
+export function buildExplicitSessionIdSessionKey(params: {
+  sessionId: string;
+  agentId?: string;
+}): string {
   return `agent:${normalizeAgentId(params.agentId)}:explicit:${params.sessionId.trim()}`;
 }
 

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -17,6 +17,9 @@ export type { AgentStreamParams } from "./shared-types.js";
 export type AgentCommandResultMetaOverrides = {
   transport?: "embedded";
   fallbackFrom?: "gateway";
+  fallbackReason?: "gateway_timeout";
+  fallbackSessionId?: string;
+  fallbackSessionKey?: string;
 };
 
 export type AcpTurnSource = "manual_spawn";

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -224,15 +224,20 @@ describe("agentCliCommand", () => {
       expect(agentCommand).toHaveBeenCalledTimes(1);
       const fallbackOpts = agentCommand.mock.calls[0]?.[0] as {
         sessionId?: string;
+        sessionKey?: string;
         runId?: string;
         resultMetaOverrides?: unknown;
       };
       expect(fallbackOpts.sessionId).toMatch(/^gateway-fallback-/);
       expect(fallbackOpts.sessionId).not.toBe("locked-session");
+      expect(fallbackOpts.sessionKey).toBe(`agent:main:explicit:${fallbackOpts.sessionId}`);
       expect(fallbackOpts.runId).toBe(fallbackOpts.sessionId);
       expect(fallbackOpts.resultMetaOverrides).toMatchObject({
         transport: "embedded",
         fallbackFrom: "gateway",
+        fallbackReason: "gateway_timeout",
+        fallbackSessionId: fallbackOpts.sessionId,
+        fallbackSessionKey: fallbackOpts.sessionKey,
       });
       expect(runtime.error).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -240,6 +245,31 @@ describe("agentCliCommand", () => {
         ),
       );
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("keeps timeout fallback from replacing the routed conversation session key", async () => {
+    await withTempStore(async () => {
+      callGateway.mockRejectedValue(createGatewayTimeoutError());
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          to: "+1555",
+        },
+        runtime,
+      );
+
+      const fallbackOpts = agentCommand.mock.calls[0]?.[0] as {
+        sessionId?: string;
+        sessionKey?: string;
+        to?: string;
+      };
+      expect(fallbackOpts.to).toBe("+1555");
+      expect(fallbackOpts.sessionId).toMatch(/^gateway-fallback-/);
+      expect(fallbackOpts.sessionKey).toBe(`agent:main:explicit:${fallbackOpts.sessionId}`);
+      expect(fallbackOpts.sessionKey).not.toBe("agent:main:+1555");
     });
   });
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -10,6 +10,15 @@ import type { agentCommand as AgentCommand } from "./agent.js";
 
 const loadConfig = vi.hoisted(() => vi.fn());
 const callGateway = vi.hoisted(() => vi.fn());
+const isGatewayTransportError = vi.hoisted(() =>
+  vi.fn((value: unknown) => {
+    if (!(value instanceof Error) || value.name !== "GatewayTransportError") {
+      return false;
+    }
+    const kind = (value as { kind?: unknown }).kind;
+    return kind === "closed" || kind === "timeout";
+  }),
+);
 const agentCommand = vi.hoisted(() => vi.fn());
 
 const runtime: RuntimeEnv = {
@@ -78,9 +87,24 @@ function mockLocalAgentReply(text = "local") {
   });
 }
 
+function createGatewayTimeoutError() {
+  const err = new Error("gateway timeout after 90000ms");
+  err.name = "GatewayTransportError";
+  return Object.assign(err, {
+    kind: "timeout",
+    timeoutMs: 90_000,
+    connectionDetails: {
+      url: "ws://127.0.0.1:18789",
+      urlSource: "local loopback",
+      message: "Gateway target: ws://127.0.0.1:18789",
+    },
+  });
+}
+
 vi.mock("../config/config.js", () => ({ getRuntimeConfig: loadConfig, loadConfig }));
 vi.mock("../gateway/call.js", () => ({
   callGateway,
+  isGatewayTransportError,
   randomIdempotencyKey: () => "idem-1",
 }));
 vi.mock("./agent.js", () => ({ agentCommand }));
@@ -177,6 +201,43 @@ describe("agentCliCommand", () => {
       });
       expect(runtime.error).toHaveBeenCalledWith(
         expect.stringContaining("EMBEDDED FALLBACK: Gateway agent failed"),
+      );
+      expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("uses a fresh embedded session when gateway agent times out", async () => {
+    await withTempStore(async () => {
+      callGateway.mockRejectedValue(createGatewayTimeoutError());
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          sessionId: "locked-session",
+          runId: "locked-run",
+        },
+        runtime,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      const fallbackOpts = agentCommand.mock.calls[0]?.[0] as {
+        sessionId?: string;
+        runId?: string;
+        resultMetaOverrides?: unknown;
+      };
+      expect(fallbackOpts.sessionId).toMatch(/^gateway-fallback-/);
+      expect(fallbackOpts.sessionId).not.toBe("locked-session");
+      expect(fallbackOpts.runId).toBe(fallbackOpts.sessionId);
+      expect(fallbackOpts.resultMetaOverrides).toMatchObject({
+        transport: "embedded",
+        fallbackFrom: "gateway",
+      });
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Gateway agent timed out; running embedded agent with fresh session",
+        ),
       );
       expect(runtime.log).toHaveBeenCalledWith("local");
     });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -14,7 +14,7 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { agentCommand } from "./agent.js";
-import { resolveSessionKeyForRequest } from "./agent/session.js";
+import { buildExplicitSessionIdSessionKey, resolveSessionKeyForRequest } from "./agent/session.js";
 
 type AgentGatewayResult = {
   payloads?: Array<{
@@ -107,6 +107,17 @@ function isGatewayAgentTimeoutError(err: unknown): boolean {
 
 function createGatewayTimeoutFallbackSessionId(): string {
   return `${GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
+}
+
+function createGatewayTimeoutFallbackSession(agentId?: string): {
+  sessionId: string;
+  sessionKey: string;
+} {
+  const sessionId = createGatewayTimeoutFallbackSessionId();
+  return {
+    sessionId,
+    sessionKey: buildExplicitSessionIdSessionKey({ sessionId, agentId }),
+  };
 }
 
 export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
@@ -221,16 +232,22 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     return await agentViaGatewayCommand(opts, runtime);
   } catch (err) {
     if (isGatewayAgentTimeoutError(err)) {
-      const fallbackSessionId = createGatewayTimeoutFallbackSessionId();
+      const fallbackSession = createGatewayTimeoutFallbackSession(opts.agent);
       runtime.error?.(
-        `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSessionId}: ${String(err)}`,
+        `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSession.sessionId}: ${String(err)}`,
       );
       return await agentCommand(
         {
           ...localOpts,
-          sessionId: fallbackSessionId,
-          runId: fallbackSessionId,
-          resultMetaOverrides: EMBEDDED_FALLBACK_META,
+          sessionId: fallbackSession.sessionId,
+          sessionKey: fallbackSession.sessionKey,
+          runId: fallbackSession.sessionId,
+          resultMetaOverrides: {
+            ...EMBEDDED_FALLBACK_META,
+            fallbackReason: "gateway_timeout",
+            fallbackSessionId: fallbackSession.sessionId,
+            fallbackSessionKey: fallbackSession.sessionKey,
+          },
         },
         runtime,
         deps,

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { listAgentIds } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -5,7 +6,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
+import { callGateway, isGatewayTransportError, randomIdempotencyKey } from "../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -36,6 +37,7 @@ const EMBEDDED_FALLBACK_META = {
   transport: "embedded",
   fallbackFrom: "gateway",
 } as const;
+const GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
 
 export type AgentCliOpts = {
   message: string;
@@ -94,6 +96,17 @@ function formatPayloadForLog(payload: {
     lines.push(`MEDIA:${url}`);
   }
   return lines.join("\n").trimEnd();
+}
+
+function isGatewayAgentTimeoutError(err: unknown): boolean {
+  if (isGatewayTransportError(err)) {
+    return err.kind === "timeout";
+  }
+  return err instanceof Error && err.message.includes("gateway request timeout for agent");
+}
+
+function createGatewayTimeoutFallbackSessionId(): string {
+  return `${GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
 }
 
 export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: RuntimeEnv) {
@@ -207,6 +220,23 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   try {
     return await agentViaGatewayCommand(opts, runtime);
   } catch (err) {
+    if (isGatewayAgentTimeoutError(err)) {
+      const fallbackSessionId = createGatewayTimeoutFallbackSessionId();
+      runtime.error?.(
+        `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSessionId}: ${String(err)}`,
+      );
+      return await agentCommand(
+        {
+          ...localOpts,
+          sessionId: fallbackSessionId,
+          runId: fallbackSessionId,
+          resultMetaOverrides: EMBEDDED_FALLBACK_META,
+        },
+        runtime,
+        deps,
+      );
+    }
+
     runtime.error?.(
       `EMBEDDED FALLBACK: Gateway agent failed; running embedded agent: ${String(err)}`,
     );


### PR DESCRIPTION
## Summary

- Problem: when `openclaw agent` hit the gateway final-response timeout, embedded fallback reused the same session/run id while the gateway could still hold the session lock.
- Why it matters: the fallback could immediately fail with `session file locked`, then cascade through model fallbacks.
- What changed: gateway timeout fallbacks now run the embedded agent under a fresh fallback session/run id while preserving normal embedded fallback behavior for non-timeout gateway failures.
- What did NOT change (scope boundary): no gateway protocol, session-store format, or non-timeout fallback behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62981
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `agentCliCommand()` reused the original local options after a gateway timeout, so embedded fallback inherited the same session id/run id as the still-running gateway agent path.
- Missing detection / guardrail: there was no regression test distinguishing gateway timeout fallback from other gateway connection failures.
- Contributing context (if known): the gateway `agent` RPC can acknowledge a run and continue working after the CLI-side final response timeout expires.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/agent-via-gateway.test.ts`
- Scenario the test should lock in: gateway timeout fallback invokes embedded agent with a fresh `gateway-fallback-*` session/run id instead of the locked original values.
- Why this is the smallest reliable guardrail: the bug is in CLI fallback option construction after `callGateway()` rejects.
- Existing test that already covers this (if any): existing fallback tests covered generic gateway failures, not timeout lock isolation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Gateway timeout fallback still attempts embedded execution, but the embedded run uses a fresh fallback session/run id to avoid racing the gateway-held session lock.

## Diagram (if applicable)

```text
Before:
[gateway timeout] -> [embedded fallback with same session id] -> [session lock failure]

After:
[gateway timeout] -> [embedded fallback with fresh session id] -> [fallback can acquire its own transcript]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node 22 via repo scripts
- Model/provider: mocked tests
- Integration/channel (if any): Gateway CLI fallback path
- Relevant config (redacted): default test config

### Steps

1. Mock `callGateway()` to reject with a typed gateway timeout.
2. Run `agentCliCommand()` with an existing `sessionId` and `runId`.
3. Assert embedded fallback receives a fresh `gateway-fallback-*` session/run id.

### Expected

- Embedded fallback does not reuse the gateway-locked session/run id.

### Actual

- Fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/commands/agent-via-gateway.test.ts -t "uses a fresh embedded session when gateway agent times out" -- --reporter=verbose`
  - `pnpm test src/commands/agent-via-gateway.test.ts -- --reporter=verbose`
  - `pnpm test src/commands/agent-via-gateway.test.ts src/gateway/call.test.ts src/agents/run-wait.test.ts -- --reporter=verbose`
  - `pnpm check:changed`
  - `pnpm test:changed`
- Edge cases checked: generic gateway failure fallback still uses the existing path; timeout fallback overrides both `sessionId` and `runId`.
- What you did **not** verify: live gateway/model timeout against a real provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: timeout fallback starts a new transcript instead of continuing the original session context.
  - Mitigation: this only applies after gateway timeout, where the original session may still be locked by the gateway run; non-timeout fallback behavior is unchanged.