### PR TITLE
chore(ci): add network SSRF CodeQL shard

### DIFF
--- a/.github/codeql/codeql-network-ssrf-boundary-critical-security.yml
+++ b/.github/codeql/codeql-network-ssrf-boundary-critical-security.yml
@@ -1,0 +1,43 @@
+name: openclaw-codeql-network-ssrf-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+  - exclude:
+      problem.severity:
+        - recommendation
+        - warning
+
+paths:
+  - src/infra/net
+  - src/shared/net
+  - src/agents/tools/web-fetch.ts
+  - src/agents/tools/web-guarded-fetch.ts
+  - src/agents/tools/web-shared.ts
+  - src/plugin-sdk/ssrf-policy.ts
+  - src/web-fetch
+  - src/web/provider-runtime-shared.ts
+  - packages/memory-host-sdk/src/host/ssrf-policy.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,11 @@ jobs:
             runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-channel-runtime-boundary-critical-security.yml
+          - language: javascript-typescript
+            category: network-ssrf-boundary
+            runs_on: blacksmith-4vcpu-ubuntu-2404
+            timeout_minutes: 25
+            config_file: ./.github/codeql/codeql-network-ssrf-boundary-critical-security.yml
           - language: actions
             category: actions
             runs_on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -263,7 +263,10 @@ channel-runtime-boundary job separately scans core channel implementation
 contracts plus the channel plugin runtime, gateway, Plugin SDK, secrets, and
 audit touchpoints under the `/codeql-critical-security/channel-runtime-boundary`
 category so channel security signal can scale without broadening the baseline
-JS/TS category.
+JS/TS category. The network-ssrf-boundary job scans core SSRF, IP parsing,
+network guard, web-fetch, and Plugin SDK SSRF policy surfaces under the
+`/codeql-critical-security/network-ssrf-boundary` category so network trust
+boundary signal stays separate from the broader JS/TS security baseline.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android
 security shard. It builds the Android app manually for CodeQL on the smallest


### PR DESCRIPTION
## Summary

- Problem: the current critical-security CodeQL shards do not explicitly cover the network/SSRF boundary where URL fetch, IP parsing, and SSRF policy behavior live.
- Why it matters: this is a high-value security surface and should be scanned narrowly before we scale broader CodeQL coverage.
- What changed: added a `network-ssrf-boundary` critical-security CodeQL config, wired it into the security profile on Blacksmith 4-vCPU runners, and documented the category in `docs/ci.md`.
- What did NOT change (scope boundary): no runtime behavior, dependency, or broad default-query expansion.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: network/SSRF-specific code paths were not isolated as a critical-security CodeQL shard.
- Contributing context (if known): CodeQL coverage is being built up from small critical surfaces instead of enabling large default scans.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `.github/codeql/codeql-network-ssrf-boundary-critical-security.yml`
- Scenario the test should lock in: CodeQL runs `security-extended` on the SSRF/network path set under `/codeql-critical-security/network-ssrf-boundary`.
- Why this is the smallest reliable guardrail: this is a CI-analysis coverage change, so the proof is a successful CodeQL upload plus alert review for the new category.
- Existing test that already covers this (if any): existing CodeQL workflow/profile validation.
- If no new test is added, why not: no runtime code changed; GitHub CodeQL execution is the relevant gate.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host, GitHub Actions on Blacksmith Ubuntu runners
- Runtime/container: GitHub Actions CodeQL workflow
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Parse workflow/config YAML.
2. Run `git diff --check`.
3. Dispatch the CodeQL security profile on this branch.
4. Review the new `/codeql-critical-security/network-ssrf-boundary` analysis and alerts.

### Expected

- The new CodeQL shard initializes, analyzes, uploads SARIF, and reports no actionable alerts unless it finds real network/SSRF issues.

### Actual

- Local static validation passed. Branch CodeQL proof pending.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `git diff --check`; Ruby parsed `.github/workflows/codeql.yml` and `.github/codeql/codeql-network-ssrf-boundary-critical-security.yml`; `pnpm docs:list` confirmed `docs/ci.md` is the relevant doc.
- Edge cases checked: branch was rebased on current `origin/main` before opening the PR.
- What you did **not** verify: branch CodeQL security run is pending and will be dispatched next.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: this adds one more CodeQL security job.
  - Mitigation: path scope is narrow and the job uses a smaller Blacksmith 4-vCPU runner with a 25 minute timeout.
