### PR TITLE
fix(ci): stop ClawSweeper dispatch PAT fallback

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -37,11 +37,12 @@ jobs:
           private-key: ${{ secrets.CLAWSWEEPER_APP_PRIVATE_KEY }}
           owner: openclaw
           repositories: clawsweeper
+          permission-contents: write
 
       - name: Dispatch exact ClawSweeper review
         if: ${{ github.event_name != 'push' }}
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token || secrets.OPENCLAW_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}
@@ -49,7 +50,7 @@ jobs:
           SOURCE_ACTION: ${{ github.event.action }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::Skipping ClawSweeper dispatch because no dispatch credential is configured."
+            echo "::notice::Skipping ClawSweeper dispatch because no ClawSweeper app token is configured. Not falling back to a maintainer token."
             exit 0
           fi
           payload="$(jq -nc \
@@ -71,7 +72,7 @@ jobs:
       - name: Dispatch ClawSweeper commit review
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.event.deleted != true }}
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token || secrets.OPENCLAW_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
           BEFORE_SHA: ${{ github.event.before }}
           AFTER_SHA: ${{ github.sha }}
@@ -79,7 +80,7 @@ jobs:
           CREATE_CHECKS: ${{ vars.CLAWSWEEPER_COMMIT_REVIEW_CREATE_CHECKS || 'false' }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::notice::Skipping ClawSweeper commit dispatch because no dispatch credential is configured."
+            echo "::notice::Skipping ClawSweeper commit dispatch because no ClawSweeper app token is configured. Not falling back to a maintainer token."
             exit 0
           fi
           case "$CREATE_CHECKS" in


### PR DESCRIPTION
## Summary

- Problem: `ClawSweeper Dispatch` fell back to `OPENCLAW_GH_TOKEN` when no ClawSweeper app key existed in `openclaw/openclaw`, so downstream ClawSweeper runs were attributed to the maintainer PAT owner.
- Why it matters: ClawSweeper activity should be bot-owned; target repositories should not need to store the ClawSweeper app private key.
- What changed: dispatch now uses only the GitHub App token output, requests explicit `contents: write` for repository dispatch, and skips with a clear notice instead of falling back to a maintainer token.
- What did NOT change: no secrets were added, no Clownfish files were changed, and no ClawSweeper-owned key is introduced to `openclaw/openclaw`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the dispatch workflow allowed `OPENCLAW_GH_TOKEN` as a cross-repo dispatch credential when the ClawSweeper app token was unavailable.
- Missing detection / guardrail: no guard prevented maintainer PAT fallback from driving bot-owned automation.
- Contributing context (if known): live run logs showed `HAS_CLAWSWEEPER_APP_PRIVATE_KEY: false` and a successful dispatch via fallback token.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `.github/workflows/clawsweeper-dispatch.yml`
- Scenario the test should lock in: no app token means skip dispatch, not fallback to maintainer token.
- Why this is the smallest reliable guardrail: this is workflow credential routing only.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: GitHub Actions credential expression behavior is covered by workflow review plus live dry inspection, not app runtime tests.

## User-visible / Behavior Changes

None for OpenClaw runtime. ClawSweeper event dispatch from this repo now skips unless a ClawSweeper app token is available; it no longer uses maintainer PAT fallback.

## Diagram (if applicable)

```text
Before:
OpenClaw event -> ClawSweeper Dispatch -> app token or OPENCLAW_GH_TOKEN -> ClawSweeper run attributed to maintainer fallback

After:
OpenClaw event -> ClawSweeper Dispatch -> app token only, otherwise skip -> no maintainer token attribution
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the app token requests explicit `contents: write` for repository dispatch, while the workflow removes the broader human PAT fallback. This reduces maintainer-token exposure and makes missing bot auth fail closed.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: GitHub Actions workflow YAML only
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions / ClawSweeper dispatch
- Relevant config (redacted): live logs showed missing `CLAWSWEEPER_APP_PRIVATE_KEY` in `openclaw/openclaw`

### Steps

1. Inspect `ClawSweeper Dispatch` workflow credential selection.
2. Confirm live run logs showed `HAS_CLAWSWEEPER_APP_PRIVATE_KEY: false` and successful dispatch with fallback credential.
3. Remove fallback to `OPENCLAW_GH_TOKEN`.

### Expected

- Missing app token skips dispatch without using a maintainer token.

### Actual

- Before this PR, missing app token fell back to `OPENCLAW_GH_TOKEN`.

## Evidence

- [x] Trace/log snippets

Live evidence checked locally:

- `openclaw/openclaw` run `25131128464` showed `HAS_CLAWSWEEPER_APP_PRIVATE_KEY: false`, `GH_TOKEN: ***`, and `Dispatched ClawSweeper review.`
- downstream `openclaw/clawsweeper` repository_dispatch runs showed actor/triggering actor `steipete`.

## Human Verification (required)

- Verified scenarios: diff review; `git diff --check`; live run-log inspection for the fallback path.
- Edge cases checked: push dispatch and PR/issue dispatch both now use app-token-only env wiring.
- What you did **not** verify: `actionlint` was not installed locally; no live workflow run was triggered from this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: do not add a maintainer PAT fallback. ClawSweeper-owned event intake should use the ClawSweeper app identity from the ClawSweeper-owned surface.

## Risks and Mitigations

- Risk: immediate ClawSweeper dispatches skip when no app token exists in this repo.
  - Mitigation: fail closed instead of using a human PAT; ClawSweeper-owned intake should run from the bot-owned repository/surface.

AI-assisted: yes. Local checks: `git diff --check`; `actionlint` unavailable.
