### PR TITLE
fix(matrix): ignore malformed location geo params

### DIFF
--- a/extensions/matrix/src/matrix/monitor/location.test.ts
+++ b/extensions/matrix/src/matrix/monitor/location.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { LocationMessageEventContent } from "../sdk.js";
+import { resolveMatrixLocation } from "./location.js";
+import { EventType } from "./types.js";
+
+function createLocationContent(geoUri: string): LocationMessageEventContent {
+  return {
+    body: "Shared pin",
+    geo_uri: geoUri,
+    msgtype: EventType.Location,
+  };
+}
+
+describe("resolveMatrixLocation", () => {
+  it("resolves geo URI accuracy parameters", () => {
+    const payload = resolveMatrixLocation({
+      eventType: EventType.Location,
+      content: createLocationContent("geo:45.5,9.2;u=12%2E5"),
+    });
+
+    expect(payload?.text).toContain("45.500000, 9.200000");
+    expect(payload?.context).toMatchObject({
+      LocationAccuracy: 12.5,
+      LocationCaption: "Shared pin",
+      LocationIsLive: false,
+      LocationLat: 45.5,
+      LocationLon: 9.2,
+      LocationSource: "pin",
+    });
+  });
+
+  it("ignores malformed encoded geo URI parameters", () => {
+    expect(
+      resolveMatrixLocation({
+        eventType: EventType.Location,
+        content: createLocationContent("geo:45.5,9.2;u=%"),
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/location.ts
+++ b/extensions/matrix/src/matrix/monitor/location.ts
@@ -17,6 +17,14 @@ type GeoUriParams = {
   accuracy?: number;
 };
 
+function decodeGeoUriParamValue(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
 function parseGeoUri(value: string): GeoUriParams | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -51,7 +59,11 @@ function parseGeoUri(value: string): GeoUriParams | null {
       continue;
     }
     const valuePart = rawValue.trim();
-    params.set(key, valuePart ? decodeURIComponent(valuePart) : "");
+    const decodedValue = valuePart ? decodeGeoUriParamValue(valuePart) : "";
+    if (decodedValue == null) {
+      return null;
+    }
+    params.set(key, decodedValue);
   }
 
   const accuracyRaw = params.get("u");


### PR DESCRIPTION
## Summary

- Problem: Matrix inbound `geo:` location parsing decoded URI parameters without handling malformed percent-encoding.
- Why it matters: a malformed location event such as `geo:45.5,9.2;u=%` could throw `URIError` while the Matrix monitor was processing an inbound event.
- What changed: Matrix location parameter decoding now fails closed and treats malformed `geo:` parameters as an invalid location instead of throwing.
- What did NOT change (scope boundary): no Matrix routing, auth, media, outbound send, or location text formatting behavior changed for valid events.
- AI-assisted: Yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `parseGeoUri` called `decodeURIComponent` directly on Matrix `geo_uri` parameter values. Malformed percent escapes raise `URIError`.
- Missing detection / guardrail: Matrix location tests did not cover malformed percent-encoded URI parameters.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/location.test.ts`
- Scenario the test should lock in: valid encoded accuracy parameters still parse, while malformed encoded parameters return `null` instead of throwing.
- Why this is the smallest reliable guardrail: it exercises the parser that the Matrix monitor calls for inbound `m.location` events.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed Matrix location events are ignored as invalid locations instead of being able to interrupt inbound Matrix event processing. Valid Matrix location events continue to parse.

## Diagram (if applicable)

```text
Before:
Matrix m.location -> decode malformed geo param -> URIError

After:
Matrix m.location -> decode malformed geo param -> invalid location -> ignored
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm repo test entrypoint
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): N/A

### Steps

1. Parse an inbound Matrix location payload with `geo_uri: "geo:45.5,9.2;u=%"`.
2. Call `resolveMatrixLocation`.
3. Observe whether event processing throws or treats the location as invalid.

### Expected

- The malformed location returns `null` and does not throw.

### Actual

- Before the fix, `decodeURIComponent` threw `URIError: URI malformed`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/matrix/src/matrix/monitor/location.test.ts` failed before the fix with `URIError: URI malformed`.
  - `pnpm test extensions/matrix/src/matrix/monitor/location.test.ts` passed after the fix.
  - `pnpm exec oxfmt --check --threads=1 extensions/matrix/src/matrix/monitor/location.ts extensions/matrix/src/matrix/monitor/location.test.ts`
  - `pnpm exec oxlint extensions/matrix/src/matrix/monitor/location.ts extensions/matrix/src/matrix/monitor/location.test.ts`
  - `git diff --check`
  - `codex review --base upstream/main`
- Edge cases checked: valid percent-encoded accuracy (`u=12%2E5`) and malformed percent-encoding (`u=%`).
- What you did **not** verify: full `pnpm check`, to avoid the heavy local gate for this narrow parser fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: malformed Matrix `geo:` events are now dropped as invalid locations.
  - Mitigation: valid location payloads, including percent-encoded accuracy values, are covered by regression tests and still parse.