### PR TITLE
chore(ci): add MCP process CodeQL shard

### DIFF
--- a/.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
+++ b/.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
@@ -1,0 +1,58 @@
+name: openclaw-codeql-mcp-process-tool-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+  - exclude:
+      problem.severity:
+        - recommendation
+        - warning
+
+paths:
+  - src/mcp
+  - src/process
+  - src/infra/outbound
+  - src/agents/bash-tools.exec*.ts
+  - src/agents/bash-tools.process*.ts
+  - src/agents/exec-*.ts
+  - src/agents/execution-contract.ts
+  - src/agents/openclaw-plugin-tools.ts
+  - src/agents/openclaw-tools.runtime.ts
+  - src/agents/openclaw-tools.registration.ts
+  - src/agents/pi-tool-definition-adapter.ts
+  - src/agents/pi-tools.abort.ts
+  - src/agents/pi-tools.before-tool-call*.ts
+  - src/agents/pi-tools.host-edit.ts
+  - src/agents/pi-tools-parameter-schema.ts
+  - src/agents/pi-embedded-runner/effective-tool-policy.ts
+  - src/agents/pi-embedded-runner/tool-name-allowlist.ts
+  - src/agents/pi-embedded-runner/tool-schema-runtime.ts
+  - src/agents/tools/gateway-tool.ts
+  - src/agents/tools/message-tool.ts
+  - src/agents/tools/sessions-send-tool.ts
+  - src/agents/tools/sessions-spawn-tool.ts
+  - src/agents/tools/subagents-tool.ts
+  - src/agents/tools/tool-runtime.helpers.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,11 @@ jobs:
             runs_on: blacksmith-4vcpu-ubuntu-2404
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-network-ssrf-boundary-critical-security.yml
+          - language: javascript-typescript
+            category: mcp-process-tool-boundary
+            runs_on: blacksmith-4vcpu-ubuntu-2404
+            timeout_minutes: 25
+            config_file: ./.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
           - language: actions
             category: actions
             runs_on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -267,6 +267,11 @@ JS/TS category. The network-ssrf-boundary job scans core SSRF, IP parsing,
 network guard, web-fetch, and Plugin SDK SSRF policy surfaces under the
 `/codeql-critical-security/network-ssrf-boundary` category so network trust
 boundary signal stays separate from the broader JS/TS security baseline.
+The mcp-process-tool-boundary job scans MCP servers, process execution helpers,
+outbound delivery, and agent tool-execution gates under the
+`/codeql-critical-security/mcp-process-tool-boundary` category so command and
+tool boundary signal stays separate from both the general JS/TS baseline and
+the non-security MCP/process quality shard.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android
 security shard. It builds the Android app manually for CodeQL on the smallest


### PR DESCRIPTION
## Summary

- Problem: the current critical-security CodeQL profile does not isolate MCP, process execution, outbound delivery, or agent tool-execution gates as their own high-risk security surface.
- Why it matters: these paths are where command execution, tool invocation, MCP exposure, and outbound delivery mistakes become security bugs.
- What changed: added a `mcp-process-tool-boundary` critical-security CodeQL config, wired it into the security profile on Blacksmith 4-vCPU runners, and documented the new category in `docs/ci.md`.
- What did NOT change (scope boundary): no runtime behavior, dependency, permissions, package, or broad default-query expansion.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: MCP/process/tool-execution security paths were covered only by broader or non-security shards, not a dedicated critical-security category.
- Contributing context (if known): CodeQL coverage is being scaled through small critical surfaces instead of restoring broad default scans.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml`
- Scenario the test should lock in: CodeQL runs `security-extended` on the MCP/process/tool path set under `/codeql-critical-security/mcp-process-tool-boundary`.
- Why this is the smallest reliable guardrail: this is CI-analysis coverage, so the proof is a successful CodeQL upload plus alert review for the new category.
- Existing test that already covers this (if any): existing CodeQL workflow/profile validation.
- If no new test is added, why not: no runtime code changed; GitHub CodeQL execution is the relevant gate.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host, GitHub Actions on Blacksmith Ubuntu runners
- Runtime/container: GitHub Actions CodeQL workflow
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Parse workflow/config YAML.
2. Run `git diff --check`.
3. Run `pnpm check:workflows`.
4. Dispatch the CodeQL security profile on this branch.
5. Review the new `/codeql-critical-security/mcp-process-tool-boundary` analysis and alerts.

### Expected

- The new CodeQL shard initializes, analyzes, uploads SARIF, and reports no actionable alerts unless it finds real MCP/process/tool-execution issues.

### Actual

- Local static validation passed. Branch CodeQL proof pending.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `git diff --check`; Ruby parsed `.github/workflows/codeql.yml` and `.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml`; `pnpm check:workflows`; `pnpm docs:list` confirmed `docs/ci.md` is the relevant doc.
- Edge cases checked: branch was rebased on current `origin/main` before opening the PR.
- What you did **not** verify: branch CodeQL security run is pending and will be dispatched next.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: this adds one more CodeQL security job.
  - Mitigation: path scope is narrow and the job uses a smaller Blacksmith 4-vCPU runner with a 25 minute timeout.
