### PR TITLE
fix(codex): normalize file url media paths

### DIFF
--- a/extensions/codex/src/conversation-turn-input.test.ts
+++ b/extensions/codex/src/conversation-turn-input.test.ts
@@ -41,4 +41,65 @@ describe("codex conversation turn input", () => {
       { type: "image", url: "https://example.test/photo.webp?sig=1" },
     ]);
   });
+
+  it("decodes local file urls before forwarding image attachments", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file:///tmp/photo%20one.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([
+      { type: "text", text: "look", text_elements: [] },
+      {
+        type: "localImage",
+        path: expect.stringMatching(/[\\/]tmp[\\/]photo one\.png$/),
+      },
+    ]);
+  });
+
+  it("falls back to remote image urls when local file urls are not usable", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file://example.test/share/photo.png",
+            mediaUrl: "https://example.test/photo.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([
+      { type: "text", text: "look", text_elements: [] },
+      { type: "image", url: "https://example.test/photo.png" },
+    ]);
+  });
+
+  it("ignores malformed local file urls without failing the turn input", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file:///tmp/%E0%A4%A.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([{ type: "text", text: "look", text_elements: [] }]);
+  });
 });

--- a/extensions/codex/src/conversation-turn-input.ts
+++ b/extensions/codex/src/conversation-turn-input.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { safeFileURLToPath } from "openclaw/plugin-sdk/file-access-runtime";
 import type { PluginHookInboundClaimEvent } from "openclaw/plugin-sdk/plugin-entry";
 import type { CodexUserInput } from "./app-server/protocol.js";
 
@@ -49,7 +50,10 @@ function toCodexImageInput(media: InboundMedia): CodexUserInput | undefined {
     return undefined;
   }
   if (media.path) {
-    return { type: "localImage", path: normalizeFileUrl(media.path) };
+    const localPath = normalizeFilePath(media.path);
+    if (localPath) {
+      return { type: "localImage", path: localPath };
+    }
   }
   return media.url ? { type: "image", url: media.url } : undefined;
 }
@@ -65,8 +69,15 @@ function isImageMedia(media: InboundMedia): boolean {
   return IMAGE_EXTENSIONS.has(path.extname(candidate.split(/[?#]/, 1)[0] ?? "").toLowerCase());
 }
 
-function normalizeFileUrl(value: string): string {
-  return value.startsWith("file://") ? new URL(value).pathname : value;
+function normalizeFilePath(value: string): string | undefined {
+  if (!value.startsWith("file://")) {
+    return value;
+  }
+  try {
+    return safeFileURLToPath(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function readStringArray(value: unknown): string[] {


### PR DESCRIPTION
## Summary

- Problem: Codex conversation-bound image attachments normalized `file://` paths with `new URL(...).pathname`, which left encoded path bytes such as `%20` and allowed unusable or remote-host `file://` values to be treated as local image paths.
- Why it matters: image attachments from channels can be skipped or forwarded with a path Codex cannot open, and a bad local file URL could fail the whole turn input build instead of falling back to a remote media URL.
- What changed: use the public `safeFileURLToPath` helper for Codex local image media paths, fall back to the remote media URL when the local file URL is not usable, and ignore malformed local file URLs without throwing.
- What did NOT change (scope boundary): no Codex app-server protocol changes, no media loading changes, and no channel metadata contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex conversation turn adapter used generic URL pathname extraction for local file URLs instead of the repo's local-file URL normalization helper.
- Missing detection / guardrail: `conversation-turn-input` tests only covered plain local paths and remote image URLs, not encoded, remote-host, or malformed `file://` media paths.
- Contributing context (if known): channel media metadata can carry either staged local paths or remote URLs, and the Codex adapter prefers `localImage` when a path is present.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/conversation-turn-input.test.ts`
- Scenario the test should lock in: encoded `file://` image paths decode to filesystem paths, unusable local file URLs fall back to remote image URLs, and malformed local file URLs are ignored without failing input construction.
- Why this is the smallest reliable guardrail: the bug is in the pure adapter that maps hook metadata to Codex user input.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex-bound conversations handle image attachments with encoded or malformed local file URLs more reliably.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Codex plugin conversation turn input
- Relevant config (redacted): N/A

### Steps

1. Build Codex conversation turn input with `metadata.mediaPath` set to `file:///tmp/photo%20one.png` and `metadata.mediaType` set to `image/png`.
2. Build input with `metadata.mediaPath` set to an unusable `file://` URL and `metadata.mediaUrl` set to a remote image URL.
3. Build input with malformed local file URL metadata.

### Expected

- Encoded local file URLs are decoded before `localImage` forwarding.
- Unusable local file URLs fall back to the remote image URL when available.
- Malformed local file URLs do not throw while building turn input.

### Actual

- Before this change, Codex used raw URL pathname normalization for `file://` paths and could forward unusable local paths or throw on malformed input.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/codex/src/conversation-turn-input.test.ts`; `pnpm exec oxfmt --check extensions/codex/src/conversation-turn-input.ts extensions/codex/src/conversation-turn-input.test.ts`; `pnpm exec oxlint extensions/codex/src/conversation-turn-input.ts extensions/codex/src/conversation-turn-input.test.ts`; `codex review --uncommitted --title "fix(codex): normalize file url media paths"`
- Edge cases checked: encoded local file URL, remote-host local file URL with remote fallback, malformed local file URL without fallback.
- What you did **not** verify: full `pnpm check` or full test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: malformed local file URLs are now ignored instead of failing the whole turn input.
  - Mitigation: this path only affects optional media attachments; the text prompt still proceeds, and a remote media URL is used when present.

AI-assisted by OpenAI Codex.
