### PR TITLE
fix(msteams): avoid double decoding graph html entities

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -28,6 +28,12 @@ describe("stripHtmlFromTeamsMessage", () => {
     );
   });
 
+  it("does not double-decode escaped HTML entities", () => {
+    expect(stripHtmlFromTeamsMessage("&amp;lt;b&amp;gt;safe&amp;lt;/b&amp;gt;")).toBe(
+      "&lt;b&gt;safe&lt;/b&gt;",
+    );
+  });
+
   it("normalizes multiple whitespace to single space", () => {
     expect(stripHtmlFromTeamsMessage("hello   world")).toBe("hello world");
   });

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -23,14 +23,14 @@ export function stripHtmlFromTeamsMessage(html: string): string {
   let text = html.replace(/<at[^>]*>(.*?)<\/at>/gi, "@$1");
   // Strip remaining HTML tags.
   text = text.replace(/<[^>]*>/g, " ");
-  // Decode common HTML entities.
+  // Decode &amp; last so escaped tags such as &amp;lt;b&amp;gt; do not become raw tags.
   text = text
-    .replace(/&amp;/g, "&")
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&");
   // Normalize whitespace.
   return text.replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary

- Problem: Microsoft Teams Graph thread context decoded `&amp;` before other HTML entities, so double-escaped text like `&amp;lt;b&amp;gt;` became raw-looking `<b>` text in the agent context.
- Why it matters: Teams parent/thread context should preserve escaped HTML as text and avoid changing the meaning of quoted or historical messages.
- What changed: decode `&amp;` last in `stripHtmlFromTeamsMessage`, matching the existing inbound Teams entity-decoding guardrail.
- What did NOT change (scope boundary): no Graph API calls, auth, message routing, or outbound formatting behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `stripHtmlFromTeamsMessage` decoded `&amp;` before `&lt;` / `&gt;`, allowing double-escaped HTML entity sequences to be decoded twice.
- Missing detection / guardrail: `graph-thread` tests covered ordinary entity decoding but not escaped entity text.
- Contributing context (if known): the Teams inbound parser already documents that `&amp;` must be decoded last, but the Graph thread parser had a separate implementation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/graph-thread.test.ts`
- Scenario the test should lock in: `&amp;lt;b&amp;gt;safe&amp;lt;/b&amp;gt;` stays escaped as `&lt;b&gt;safe&lt;/b&gt;` after Teams Graph thread HTML cleanup.
- Why this is the smallest reliable guardrail: the bug is isolated to the pure Teams Graph thread HTML cleanup helper.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Teams thread context preserves escaped HTML entity text more accurately when parent/reply messages contain double-escaped HTML.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Microsoft Teams
- Relevant config (redacted): N/A

### Steps

1. Call `stripHtmlFromTeamsMessage("&amp;lt;b&amp;gt;safe&amp;lt;/b&amp;gt;")`.
2. Compare the result before and after this change.

### Expected

- The double-escaped HTML remains escaped as `&lt;b&gt;safe&lt;/b&gt;`.

### Actual

- Before this change it became raw-looking `<b>safe</b>`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test extensions/msteams/src/graph-thread.test.ts -t "does not double-decode"` failed before the implementation change and passed after; `pnpm test extensions/msteams/src/graph-thread.test.ts`; `pnpm exec oxfmt --check extensions/msteams/src/graph-thread.ts extensions/msteams/src/graph-thread.test.ts`; `pnpm exec oxlint extensions/msteams/src/graph-thread.ts extensions/msteams/src/graph-thread.test.ts`; `codex review --uncommitted --title "fix(msteams): avoid double decoding graph html entities"`.
- Edge cases checked: ordinary entity decoding still passes, double-escaped HTML entities stay escaped, mention display names remain covered by existing tests.
- What you did **not** verify: full `pnpm check` or full test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: double-escaped ampersand entity sequences remain escaped instead of being fully decoded.
  - Mitigation: this matches the existing Teams inbound decoder behavior and prevents escaped HTML from being transformed into raw-looking tag text.

AI-assisted by OpenAI Codex.
