### PR TITLE
fix(codex): handle terminal bound turns

### DIFF
--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClient } from "./app-server/client.js";
 import {
   handleCodexConversationBindingResolved,
   handleCodexConversationInboundClaim,
 } from "./conversation-binding.js";
+
+const sharedClientMocks = vi.hoisted(() => ({
+  getSharedCodexAppServerClient: vi.fn(),
+}));
+
+vi.mock("./app-server/shared-client.js", () => sharedClientMocks);
 
 let tempDir: string;
 
@@ -15,6 +22,7 @@ describe("codex conversation binding", () => {
   });
 
   afterEach(async () => {
+    sharedClientMocks.getSharedCodexAppServerClient.mockReset();
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -72,5 +80,76 @@ describe("codex conversation binding", () => {
     );
 
     expect(result).toEqual({ handled: true });
+  });
+
+  it("returns terminal turn/start text for inbound bound messages", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+      }),
+    );
+    const request = vi.fn(async (method: string) => {
+      if (method === "turn/start") {
+        return {
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            items: [{ type: "agentMessage", id: "msg-1", text: "already done" }],
+            error: null,
+            startedAt: null,
+            completedAt: null,
+            durationMs: null,
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request,
+      addNotificationHandler: vi.fn(() => () => undefined),
+      addRequestHandler: vi.fn(() => () => undefined),
+    } as unknown as CodexAppServerClient);
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "summarize this",
+        channel: "discord",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "discord",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel-1",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 100 },
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      reply: { text: "already done" },
+    });
+    expect(request).toHaveBeenCalledWith(
+      "turn/start",
+      expect.objectContaining({ threadId: "thread-1" }),
+      expect.any(Object),
+    );
   });
 });

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -319,6 +319,12 @@ async function runBoundTurn(params: {
       turnId,
     });
     collector.setTurnId(turnId);
+    if (isTerminalCodexTurn(response.turn)) {
+      collector.handleNotification({
+        method: "turn/completed",
+        params: { threadId, turn: response.turn },
+      });
+    }
     const completion = await collector
       .wait({
         timeoutMs: params.timeoutMs ?? DEFAULT_BOUND_TURN_TIMEOUT_MS,
@@ -351,6 +357,10 @@ function enqueueBoundTurn<T>(key: string, run: () => Promise<T>): Promise<T> {
     }
   });
   return next;
+}
+
+function isTerminalCodexTurn(turn: CodexTurnStartResponse["turn"]): boolean {
+  return turn.status === "completed" || turn.status === "failed" || turn.status === "interrupted";
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

- Problem: Codex conversation bindings waited only for a follow-up `turn/completed` notification after `turn/start`.
- Why it matters: if the app-server returns a terminal turn directly from `turn/start`, the bound chat flow times out instead of returning the assistant text.
- What changed: terminal `turn/start` responses are routed through the existing collector completion path.
- What did NOT change (scope boundary): dynamic tools, approvals, and the main Codex harness flow are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `runBoundTurn` set the active turn id and then waited for collector completion, but never inspected `response.turn.status` from `turn/start`.
- Missing detection / guardrail: conversation binding tests did not cover terminal `turn/start` responses without a later notification.
- Contributing context (if known): the main Codex harness already handles this protocol shape; the bound conversation path had drifted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/conversation-binding.test.ts`
- Scenario the test should lock in: inbound bound messages return assistant text when `turn/start` returns a completed turn and no `turn/completed` notification follows.
- Why this is the smallest reliable guardrail: it exercises the bound conversation entrypoint with a mocked app-server client and the real collector path.
- Existing test that already covers this (if any): main harness coverage exists in `extensions/codex/src/app-server/run-attempt.test.ts`, but not for conversation bindings.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bound Codex conversations no longer time out when Codex completes synchronously in the `turn/start` response.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux dev worktree
- Runtime/container: Node 22 / pnpm
- Model/provider: Codex app-server mocked in test
- Integration/channel (if any): Codex conversation binding
- Relevant config (redacted): N/A

### Steps

1. Bind a conversation to a Codex app-server thread.
2. Send an inbound authorized bound message.
3. Have `turn/start` return `{ status: "completed", items: [...] }` without emitting `turn/completed`.

### Expected

- OpenClaw returns the assistant text from the terminal turn.

### Actual

- Before this fix, OpenClaw waited for `turn/completed` and eventually replied with `codex app-server bound turn timed out`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing before patch: `pnpm test extensions/codex/src/conversation-binding.test.ts` failed the new test with `codex app-server bound turn timed out`.

Passing after patch:

```text
pnpm test extensions/codex/src/conversation-binding.test.ts
Test Files  1 passed (1)
Tests  3 passed (3)
```

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/codex/src/conversation-binding.test.ts`
  - `pnpm exec oxfmt --check extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-binding.test.ts`
  - `pnpm exec oxlint extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-binding.test.ts`
  - `codex review --base upstream/main --title "fix(codex): handle terminal bound turns"`
- Edge cases checked: terminal `completed` response path; existing non-authorized inbound handling still covered by the same test file.
- What you did **not** verify: full repo `pnpm check`, full test suite, and `pnpm build`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: synthetic completion could diverge from notification handling.
  - Mitigation: the fix intentionally reuses the same collector `turn/completed` path instead of introducing a second completion parser.
