### PR TITLE
fix(ci): exempt automation PRs from Barnacle PR limit

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -375,10 +375,12 @@ jobs:
               return false;
             };
 
-            const isClawsweeperPullRequest =
-              typeof headRefName === "string" && headRefName.startsWith("clawsweeper/");
+            const automationPrHeadPrefixes = ["clawsweeper/", "clownfish/"];
+            const isAutomationPullRequest =
+              typeof headRefName === "string" &&
+              automationPrHeadPrefixes.some((prefix) => headRefName.startsWith(prefix));
 
-            if ((await isPrivilegedAuthor()) || isClawsweeperPullRequest) {
+            if ((await isPrivilegedAuthor()) || isAutomationPullRequest) {
               if (labelNames.has(activePrLimitLabel)) {
                 try {
                   await github.rest.issues.removeLabel({

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -237,10 +237,14 @@ const candidateActionRules = [
 ];
 
 const normalizeLogin = (login) => login.toLowerCase();
+const automationPrHeadPrefixes = ["clawsweeper/", "clownfish/"];
 
-export function isClawsweeperPullRequest(pullRequest) {
+export function isAutomationPullRequest(pullRequest) {
   const headRefName = pullRequest.headRefName ?? pullRequest.head?.ref ?? "";
-  return typeof headRefName === "string" && headRefName.startsWith("clawsweeper/");
+  return (
+    typeof headRefName === "string" &&
+    automationPrHeadPrefixes.some((prefix) => headRefName.startsWith(prefix))
+  );
 }
 
 export function extractIssueFormValue(body, field) {
@@ -1031,7 +1035,7 @@ export async function runBarnacleAutoResponse({ github, context, core = console 
   if (pullRequest && labelSet.has(activePrLimitOverrideLabel)) {
     labelSet.delete(activePrLimitLabel);
   }
-  if (pullRequest && isClawsweeperPullRequest(pullRequest)) {
+  if (pullRequest && isAutomationPullRequest(pullRequest)) {
     await removeLabels(github, context, pullRequest.number, [activePrLimitLabel], labelSet);
   }
 

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -290,20 +290,26 @@ describe("barnacle-auto-response", () => {
     );
   });
 
-  it("does not close ClawSweeper PRs for the active PR limit", async () => {
-    for (const headRef of [
-      { head: { ref: "clawsweeper/openclaw-openclaw-73880" } },
-      { headRefName: "clawsweeper/openclaw-openclaw-73880" },
+  it("does not close automation PRs for the active PR limit", async () => {
+    for (const automationPullRequest of [
+      { head: { ref: "clawsweeper/openclaw-openclaw-73880" }, login: "app/openclaw-clawsweeper" },
+      { headRefName: "clawsweeper/openclaw-openclaw-73880", login: "app/openclaw-clawsweeper" },
+      {
+        head: { ref: "clownfish/ghcrawl-156993-autonomous-smoke" },
+        login: "app/openclaw-clownfish",
+      },
+      { headRefName: "clownfish/ghcrawl-156993-autonomous-smoke", login: "app/openclaw-clownfish" },
     ]) {
       const { calls, github } = barnacleGithub([]);
+      const { login, ...pullRequest } = automationPullRequest;
 
       await runBarnacleAutoResponse({
         github,
         context: barnacleContext(
           {
-            ...headRef,
+            ...pullRequest,
             user: {
-              login: "app/openclaw-clawsweeper",
+              login,
             },
           },
           ["r: too-many-prs"],


### PR DESCRIPTION
## Summary
- Treat `clownfish/` head refs as maintainer automation PRs for Barnacle PR-limit handling
- Keep the existing `clawsweeper/` exemption behavior
- Add a regression test proving automation PRs lose `r: too-many-prs` without closure

## Test Plan
- `pnpm test:serial test/scripts/barnacle-auto-response.test.ts`
- `node scripts/check-workflows.mjs`
- `git diff --check`
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_ID=tbx_01kqdg8d3p8909bcsqqc64pdme pnpm check:changed`
