### PR TITLE
chore(ci): rename CodeQL auth security shard

### DIFF
--- a/.github/codeql/codeql-core-auth-secrets-critical-security.yml
+++ b/.github/codeql/codeql-core-auth-secrets-critical-security.yml
@@ -1,4 +1,4 @@
-name: openclaw-codeql-javascript-typescript-critical-security
+name: openclaw-codeql-core-auth-secrets-critical-security
 
 disable-default-queries: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,10 @@ jobs:
       matrix:
         include:
           - language: javascript-typescript
-            category: javascript-typescript
+            category: core-auth-secrets
             runs_on: blacksmith-8vcpu-ubuntu-2404
             timeout_minutes: 25
-            config_file: ./.github/codeql/codeql-javascript-typescript-critical-security.yml
+            config_file: ./.github/codeql/codeql-core-auth-secrets-critical-security.yml
           - language: javascript-typescript
             category: channel-runtime-boundary
             runs_on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -258,19 +258,20 @@ or overlapping changed hunks.
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner,
 not the full repository sweep. Daily and manual runs scan Actions workflow code
 plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
-gateway surfaces with high-precision security queries. The
+gateway surfaces with high-precision security queries under the
+`/codeql-critical-security/core-auth-secrets` category. The
 channel-runtime-boundary job separately scans core channel implementation
 contracts plus the channel plugin runtime, gateway, Plugin SDK, secrets, and
 audit touchpoints under the `/codeql-critical-security/channel-runtime-boundary`
 category so channel security signal can scale without broadening the baseline
-JS/TS category. The network-ssrf-boundary job scans core SSRF, IP parsing,
+auth/secrets category. The network-ssrf-boundary job scans core SSRF, IP parsing,
 network guard, web-fetch, and Plugin SDK SSRF policy surfaces under the
 `/codeql-critical-security/network-ssrf-boundary` category so network trust
-boundary signal stays separate from the broader JS/TS security baseline.
+boundary signal stays separate from the auth/secrets security baseline.
 The mcp-process-tool-boundary job scans MCP servers, process execution helpers,
 outbound delivery, and agent tool-execution gates under the
 `/codeql-critical-security/mcp-process-tool-boundary` category so command and
-tool boundary signal stays separate from both the general JS/TS baseline and
+tool boundary signal stays separate from both the auth/secrets baseline and
 the non-security MCP/process quality shard.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android


### PR DESCRIPTION
## Summary
- rename the auth/secrets security CodeQL config from the generic javascript-typescript label to core-auth-secrets
- update the default CodeQL matrix category and CI docs to match the actual scoped surface
- keep the same paths, query pack, filters, timeout, and Blacksmith runner

## Verification
- git diff --check
- ruby YAML parse for .github/workflows/codeql.yml and .github/codeql/codeql-core-auth-secrets-critical-security.yml
- pnpm check:workflows

## Notes
This is intentionally not a new scan surface. It fixes the misleading language-named CodeQL category so GitHub UI and alert triage show the real security boundary.