### PR TITLE
fix(gateway): persist offloaded image refs in transcript for iOS share/node ingress

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -698,12 +698,14 @@ function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"
   return scopes.includes(ADMIN_SCOPE);
 }
 
-async function persistChatSendImages(params: {
+export async function persistChatSendImages(params: {
   images: ChatImageContent[];
   imageOrder: PromptImageOrderEntry[];
   offloadedRefs: OffloadedRef[];
   client: GatewayRequestHandlerOptions["client"];
-  logGateway: GatewayRequestContext["logGateway"];
+  // Only `.warn` is consumed; widen so callers with a narrower logger
+  // (e.g. server-node-events.ts) can reuse this helper without coupling.
+  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
 }): Promise<SavedMedia[]> {
   if (
     (params.images.length === 0 && params.offloadedRefs.length === 0) ||
@@ -949,7 +951,7 @@ function extractTranscriptUserText(content: unknown): string | undefined {
   return textBlocks.length > 0 ? textBlocks.join("") : undefined;
 }
 
-async function rewriteChatSendUserTurnMediaPaths(params: {
+export async function rewriteChatSendUserTurnMediaPaths(params: {
   transcriptPath: string;
   sessionKey: string;
   message: string;
@@ -1234,7 +1236,7 @@ export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; max
   return { messages: [], placeholderCount: 0 };
 }
 
-function resolveTranscriptPath(params: {
+export function resolveTranscriptPath(params: {
   sessionId: string;
   storePath: string | undefined;
   sessionFile?: string;

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -16,6 +16,11 @@ export { deleteMediaBuffer } from "../media/store.js";
 export { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 export { defaultRuntime } from "../runtime.js";
 export { parseMessageWithAttachments, resolveChatAttachmentMaxBytes } from "./chat-attachments.js";
+export {
+  persistChatSendImages,
+  resolveTranscriptPath,
+  rewriteChatSendUserTurnMediaPaths,
+} from "./server-methods/chat.js";
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 export {
   loadSessionEntry,

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { SavedMedia } from "../media/store.js";
 import type { loadSessionEntry as loadSessionEntryType } from "./session-utils.js";
 
 const buildSessionLookup = (
@@ -90,6 +91,7 @@ const runtimeMocks = vi.hoisted(() => ({
   normalizeMainKey: vi.fn((key?: string | null) => key?.trim() || "agent:main:main"),
   normalizeRpcAttachmentsToChatAttachments: vi.fn((attachments?: unknown[]) => attachments ?? []),
   parseMessageWithAttachments: parseMessageWithAttachmentsMock,
+  persistChatSendImages: vi.fn(async (): Promise<SavedMedia[]> => []),
   registerApnsRegistration: registerApnsRegistrationMock,
   requestHeartbeatNow: vi.fn(),
   resolveChatAttachmentMaxBytes: vi.fn(() => 20 * 1024 * 1024),
@@ -123,6 +125,8 @@ const runtimeMocks = vi.hoisted(() => ({
       model: entry?.model ?? "default-model",
     }),
   ),
+  resolveTranscriptPath: vi.fn(() => null as string | null),
+  rewriteChatSendUserTurnMediaPaths: vi.fn(async () => {}),
   sanitizeInboundSystemTags: sanitizeInboundSystemTagsMock,
   scopedHeartbeatWakeOptions: vi.fn((sessionKey?: string, opts?: { reason: string }) => {
     const wakeOptions = { reason: opts?.reason };
@@ -1013,6 +1017,85 @@ describe("agent request events", () => {
     // dispatch, no crash, and the refusal reason bubbles up via logGateway.
     expect(agentCommandMock).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/attachment parse failed.*non-image/i));
+  });
+
+  it("persists offloaded image refs in transcript user turn for agent.request", async () => {
+    // Regression for #60339: iOS share / node ingress dispatches via
+    // agentCommandFromIngress and previously dropped parsed.offloadedRefs,
+    // leaving the transcript user turn without MediaPath/MediaPaths even
+    // though the media was already on disk. The fix mirrors chat.send's
+    // persistence + rewrite contract.
+    const persistChatSendImagesMock = runtimeMocks.persistChatSendImages;
+    const rewriteChatSendUserTurnMediaPathsMock = runtimeMocks.rewriteChatSendUserTurnMediaPaths;
+    const resolveTranscriptPathMock = runtimeMocks.resolveTranscriptPath;
+    persistChatSendImagesMock.mockClear();
+    rewriteChatSendUserTurnMediaPathsMock.mockClear();
+    resolveTranscriptPathMock.mockClear();
+
+    parseMessageWithAttachmentsMock.mockResolvedValueOnce({
+      message: "describe\n[media attached: media://inbound/img-1]",
+      images: [],
+      imageOrder: ["offloaded"],
+      offloadedRefs: [
+        {
+          id: "img-1",
+          path: "/media/inbound/img-1.jpg",
+          mimeType: "image/jpeg",
+          mediaRef: "media://inbound/img-1",
+          sizeBytes: 2_000_000,
+          label: "photo.jpg",
+        },
+      ],
+    });
+    const savedImage: SavedMedia = {
+      id: "img-1",
+      path: "/media/inbound/img-1.jpg",
+      size: 0,
+      contentType: "image/jpeg",
+    };
+    persistChatSendImagesMock.mockResolvedValueOnce([savedImage]);
+    resolveTranscriptPathMock.mockReturnValueOnce("/sessions/sid-x/session.jsonl");
+
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-ios-share", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main",
+        message: "describe",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/jpeg",
+            fileName: "photo.jpg",
+            content: "BIG_BASE64_PAYLOAD",
+          },
+        ],
+      }),
+    });
+
+    expect(persistChatSendImagesMock).toHaveBeenCalledTimes(1);
+    expect(persistChatSendImagesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        images: [],
+        imageOrder: ["offloaded"],
+        offloadedRefs: [expect.objectContaining({ id: "img-1" })],
+        client: null,
+      }),
+    );
+
+    // Wait for the fire-and-forget agentCommandFromIngress chain's
+    // .finally rewrite to settle.
+    await vi.waitFor(() => {
+      expect(rewriteChatSendUserTurnMediaPathsMock).toHaveBeenCalledTimes(1);
+    });
+    expect(rewriteChatSendUserTurnMediaPathsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcriptPath: "/sessions/sid-x/session.jsonl",
+        sessionKey: "agent:main:main",
+        message: "describe\n[media attached: media://inbound/img-1]",
+        savedImages: [savedImage],
+      }),
+    );
   });
 
   beforeEach(() => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -12,6 +12,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import type { OffloadedRef } from "./chat-attachments.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
 import {
   agentCommandFromIngress,
@@ -30,6 +31,7 @@ import {
   normalizeMainKey,
   normalizeRpcAttachmentsToChatAttachments,
   parseMessageWithAttachments,
+  persistChatSendImages,
   registerApnsRegistration,
   requestHeartbeatNow,
   resolveChatAttachmentMaxBytes,
@@ -37,6 +39,8 @@ import {
   resolveOutboundTarget,
   resolveSessionAgentId,
   resolveSessionModelRef,
+  resolveTranscriptPath,
+  rewriteChatSendUserTurnMediaPaths,
   sanitizeInboundSystemTags,
   scopedHeartbeatWakeOptions,
   updateSessionStore,
@@ -470,6 +474,7 @@ export const handleNodeEvent = async (
       );
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
       let imageOrder: PromptImageOrderEntry[] = [];
+      let offloadedImageRefs: OffloadedRef[] = [];
       if (!message && normalizedAttachments.length === 0) {
         return undefined;
       }
@@ -497,6 +502,7 @@ export const handleNodeEvent = async (
           message = parsed.message.trim();
           images = parsed.images;
           imageOrder = parsed.imageOrder;
+          offloadedImageRefs = parsed.offloadedRefs ?? [];
           if (message.length > 20_000) {
             ctx.logGateway.warn(
               `agent.request message exceeds limit after attachment parsing (length=${message.length})`,
@@ -576,6 +582,19 @@ export const handleNodeEvent = async (
         );
       }
 
+      // Mirror chat.send's media persistence contract: convert offloaded
+      // image refs (and inline images) into SavedMedia entries so the user
+      // turn in the session transcript carries MediaPath/MediaPaths. Without
+      // this, history replay loses the offloaded attachment link even though
+      // the media is already on disk.
+      const persistedImagesPromise = persistChatSendImages({
+        images,
+        imageOrder,
+        offloadedRefs: offloadedImageRefs,
+        client: null,
+        logGateway: ctx.logGateway,
+      });
+
       void agentCommandFromIngress(
         {
           runId: sessionId,
@@ -596,9 +615,47 @@ export const handleNodeEvent = async (
         },
         defaultRuntime,
         ctx.deps,
-      ).catch((err) => {
-        ctx.logGateway.warn(`agent failed node=${nodeId}: ${formatForLog(err)}`);
-      });
+      )
+        .catch((err) => {
+          ctx.logGateway.warn(`agent failed node=${nodeId}: ${formatForLog(err)}`);
+        })
+        .finally(async () => {
+          // Rewrite the user-turn entry once the agent run has completed so
+          // the transcript reflects the persisted media. Mirrors chat.send's
+          // rewriteChatSendUserTurnMediaPaths flow; safe no-op when no media
+          // was persisted or the target entry was never written.
+          try {
+            const savedImages = await persistedImagesPromise;
+            if (savedImages.length === 0) {
+              return;
+            }
+            const { storePath: latestStorePath, entry: latestEntry } =
+              loadSessionEntry(canonicalKey);
+            const resolvedSessionId = latestEntry?.sessionId ?? sessionId;
+            if (!resolvedSessionId) {
+              return;
+            }
+            const transcriptPath = resolveTranscriptPath({
+              sessionId: resolvedSessionId,
+              storePath: latestStorePath,
+              sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+              agentId: resolveSessionAgentId({ sessionKey: canonicalKey, config: cfg }),
+            });
+            if (!transcriptPath) {
+              return;
+            }
+            await rewriteChatSendUserTurnMediaPaths({
+              transcriptPath,
+              sessionKey: canonicalKey,
+              message,
+              savedImages,
+            });
+          } catch (err) {
+            ctx.logGateway.warn(
+              `agent.request transcript media rewrite failed node=${nodeId}: ${formatForLog(err)}`,
+            );
+          }
+        });
       return undefined;
     }
     case "notifications.changed": {


### PR DESCRIPTION
## Summary

- **Problem:** \`agent.request\` events arriving via the iOS Share extension and \`node.event\` ingress dropped \`parsed.offloadedRefs\` after \`parseMessageWithAttachments\` ran, so the user-turn entry of the session transcript was persisted without \`MediaPath\` / \`MediaPaths\` fields even though the media was already on disk.
- **Why it matters:** Downstream agents replaying history could not \"see\" the previously sent images during multi-turn conversations, so iOS share / node-ingress users effectively lost attachments from session memory.
- **What changed:** Reused the existing \`chat.send\` media-persistence contract — \`persistChatSendImages\` + \`rewriteChatSendUserTurnMediaPaths\` — by exporting those helpers (and \`resolveTranscriptPath\`) from \`server-methods/chat.ts\` and wiring them into the \`agent.request\` branch of \`server-node-events.ts\`. \`persistChatSendImages\`'s \`logGateway\` parameter was widened to \`Pick<..., \"warn\">\` since only \`.warn\` is consumed; existing call sites remain compatible.
- **What did NOT change (scope boundary):** No changes to \`chat.send\` behavior, \`agentCommandFromIngress\`, the agent runtime, or the parser. Non-image attachments on the node path remain rejected (\`acceptNonImage: false\`). The over-limit cleanup branch is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #60339
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** \`server-node-events.ts\` referenced \`parsed.offloadedRefs\` only inside the over-limit cleanup branch and never carried it through to a transcript media-field rewrite. \`chat.send\` already had a fix for this contract via \`persistChatSendImages\` + \`rewriteChatSendUserTurnMediaPaths\`, but those helpers were private to \`chat.ts\`, so the iOS share / node path could not reuse them.
- **Missing detection / guardrail:** No regression test asserted that \`agent.request\` with an offloaded image produced a transcript user turn with \`MediaPaths\`. Existing coverage for \`chat.send\`'s rewrite (\`chat.directive-tags.test.ts\` — \`preserves offloaded attachment media paths in transcript order\`) only locked in the web/chat path.
- **Contributing context:** Surfaced after PR #55513 introduced the claim-check offload pattern (per the issue discussion).

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** \`src/gateway/server-node-events.test.ts\` — new test \`persists offloaded image refs in transcript user turn for agent.request\`.
- **Scenario the test locks in:** When \`parseMessageWithAttachments\` returns \`offloadedRefs\`, \`agent.request\` invokes \`persistChatSendImages\` with those refs and then \`rewriteChatSendUserTurnMediaPaths\` with the resolved \`transcriptPath\` + persisted \`savedImages\`.
- **Why this is the smallest reliable guardrail:** Mocks at the same \`./server-node-events.runtime.js\` barrel boundary the existing test file already mocks, so failures in either the wire-up or the persistence-rewrite contract surface in the same lane as the other agent-request unit tests, without a full integration harness.
- **Existing test that already covers this (if any):** Only \`chat.send\` had similar coverage; that test continues to pass with this PR's logger-type widening.

## AI assistance

This PR was prepared with Claude (Opus 4.7).

- [x] AI-assisted (noted here per CONTRIBUTING.md)
- **Testing degree:** lightly tested locally:
  - \`pnpm tsgo\`: green
  - \`pnpm check\`: green
  - \`pnpm test src/gateway/server-node-events.test.ts\`: 37/37 passed (including the new regression)
  - \`pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -t \"preserves offloaded attachment media paths\"\`: green (sanity-check that the \`logGateway\` widening does not regress chat.send's path)
- I understand what the code does and the contract it mirrors from \`chat.send\`.