### PR TITLE
active-memory: clarify modelFallback semantics in deprecation warning (#74587)

### DIFF
--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2432,7 +2432,7 @@ export default definePluginEntry({
     const warnDeprecatedModelFallbackPolicy = (pluginConfig: unknown) => {
       if (hasDeprecatedModelFallbackPolicy(pluginConfig)) {
         api.logger.warn?.(
-          "active-memory: config.modelFallbackPolicy is deprecated and no longer changes runtime behavior; set config.modelFallback explicitly if you want a fallback model",
+          "active-memory: config.modelFallbackPolicy is deprecated and no longer changes runtime behavior; set config.modelFallback explicitly to choose the last-resort model used when no other model (config.model, current run model, or the configured default model) resolves. Note: modelFallback is not runtime failover.",
         );
       }
     };


### PR DESCRIPTION
## Summary

- Problem: The `active-memory` deprecation warning printed when `config.modelFallbackPolicy` is set says "set config.modelFallback explicitly if you want a fallback model". That phrasing reads as runtime failover (fall back to model B when model A errors/times out), but `modelFallback` is actually the last-resort step in chain resolution inside `getModelRef` (only consulted when `config.model`, current run model, and configured default model all fail to resolve).
- Why it matters: As reported in #74587, users debug sessions for hours assuming `modelFallback` provides runtime failover before reading source reveals the mismatch.
- What changed: One-line text change to the deprecation warning to spell out chain-resolution semantics and add an explicit "not runtime failover" note. This is Option A from the issue.
- What did NOT change (scope boundary): No runtime behavior, no schema, no docs. The existing `docs/concepts/active-memory.md` "Model fallback policy" section already documents the resolution order correctly.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74587
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The deprecation warning was written in terms of "fallback model" without distinguishing chain-resolution last-resort from runtime failover. The implementation in `getModelRef` (`extensions/active-memory/index.ts:2031-2044`) treats `config.modelFallback` as the 4th candidate in a first-non-null-wins chain, with no error-recovery substitution.
- Missing detection / guardrail: Existing test only asserts on `expect.stringContaining("config.modelFallbackPolicy is deprecated")`, which does not pin the explanatory tail of the message — so the misleading phrasing was never caught by tests.
- Contributing context: The naming `modelFallback` is overloaded across the broader product, and the original deprecation note inherited that overload without disambiguating.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/active-memory/index.test.ts` ("uses config.modelFallback when no session or agent model resolves")
- Scenario the test should lock in: Warning is emitted when `modelFallbackPolicy` is set; this PR keeps the existing assertion green (it matches the unchanged prefix substring).
- Why this is the smallest reliable guardrail: The user-visible behavior is the warning text itself; the test pins the prefix substring, leaving the explanatory tail editable without churn. Tightening the assertion to the full string would couple tests to copy and add maintenance cost without catching real regressions.
- Existing test that already covers this: Yes (above).
- If no new test is added, why not: Pure copy change to a single user-facing string with no behavior change. Existing assertion remains green.

## Test Plan

- [x] `pnpm test extensions/active-memory/index.test.ts` — 94/94 pass
- [x] `pnpm check:changed` — clean (typecheck, oxlint, runtime sidecar guard, import-cycle guard)
- [x] `pnpm exec oxfmt --write --threads=1 extensions/active-memory/index.ts` — clean