### PR TITLE
fix: avoid replaying channel restart recovery turns

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -157,6 +157,37 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
   });
 
+  it("fails channel-backed sessions instead of replaying a restart-recovery turn", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:discord:channel:123": {
+        sessionId: "discord-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        channel: "discord",
+        lastTo: "channel:123",
+        origin: {
+          provider: "discord",
+          surface: "channel",
+        },
+      },
+    });
+    await writeTranscript(sessionsDir, "discord-session", [
+      { role: "user", content: "do the thing" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
+    expect(callGateway).not.toHaveBeenCalled();
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:discord:channel:123"]?.status).toBe("failed");
+    expect(store["agent:main:discord:channel:123"]?.abortedLastRun).toBe(true);
+  });
+
   it("does not scan ordinary running sessions without the restart-aborted marker", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -32,6 +32,17 @@ function shouldSkipMainRecovery(entry: SessionEntry, sessionKey: string): boolea
   );
 }
 
+function isChannelBackedMainSession(entry: SessionEntry): boolean {
+  return Boolean(
+    entry.channel ||
+    entry.deliveryContext ||
+    entry.lastChannel ||
+    entry.lastTo ||
+    entry.origin?.surface ||
+    entry.origin?.provider,
+  );
+}
+
 function sessionIdFromLockPath(lockPath: string): string | undefined {
   const fileName = path.basename(lockPath);
   if (!fileName.endsWith(".jsonl.lock")) {
@@ -221,6 +232,16 @@ async function recoverStore(params: {
     }
     if (params.resumedSessionKeys.has(sessionKey)) {
       result.skipped++;
+      continue;
+    }
+
+    if (isChannelBackedMainSession(entry)) {
+      await markSessionFailed({
+        storePath: params.storePath,
+        sessionKey,
+        reason: "channel-backed session requires manual restart recovery",
+      });
+      result.failed++;
       continue;
     }
 


### PR DESCRIPTION
## Summary

Closing this copy in favor of a replacement PR with a neutral branch name and the repository's full PR template. The code change itself is being preserved; only the public submission metadata is being cleaned up.
