### PR TITLE
chore(ci): add plugin trust CodeQL shard

### DIFF
--- a/.github/codeql/codeql-plugin-trust-boundary-critical-security.yml
+++ b/.github/codeql/codeql-plugin-trust-boundary-critical-security.yml
@@ -1,0 +1,89 @@
+name: openclaw-codeql-plugin-trust-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+  - exclude:
+      problem.severity:
+        - recommendation
+        - warning
+
+paths:
+  - src/cli/plugin-install-config-policy.ts
+  - src/cli/plugin-registry-loader.ts
+  - src/cli/plugins-command-helpers.ts
+  - src/cli/plugins-install-command.ts
+  - src/cli/plugins-install-record-commit.ts
+  - src/plugins/activation-planner.ts
+  - src/plugins/bundle-manifest.ts
+  - src/plugins/bundled-compat.ts
+  - src/plugins/bundled-dir.ts
+  - src/plugins/bundled-plugin-metadata.ts
+  - src/plugins/bundled-plugin-scan.ts
+  - src/plugins/bundled-runtime-deps*.ts
+  - src/plugins/bundled-runtime-root.ts
+  - src/plugins/cli-registry-loader.ts
+  - src/plugins/config-activation-shared.ts
+  - src/plugins/config-contracts.ts
+  - src/plugins/config-policy.ts
+  - src/plugins/config-schema.ts
+  - src/plugins/dependency-denylist.ts
+  - src/plugins/discovery.ts
+  - src/plugins/effective-plugin-ids.ts
+  - src/plugins/externalized-bundled-plugins.ts
+  - src/plugins/install.runtime.ts
+  - src/plugins/install-source-info.ts
+  - src/plugins/installed-plugin-index*.ts
+  - src/plugins/loader*.ts
+  - src/plugins/manifest*.ts
+  - src/plugins/marketplace.ts
+  - src/plugins/module-export.ts
+  - src/plugins/package-entrypoints.ts
+  - src/plugins/plugin-config-trust.ts
+  - src/plugins/plugin-origin.types.ts
+  - src/plugins/plugin-registry*.ts
+  - src/plugins/public-surface*.ts
+  - src/plugins/registry*.ts
+  - src/plugins/runtime
+  - src/plugins/runtime-state.ts
+  - src/plugins/runtime.ts
+  - src/plugins/source-loader.ts
+  - src/plugins/update.ts
+  - src/plugins/validation-diagnostics.ts
+  - src/plugin-sdk/*entry*.ts
+  - src/plugin-sdk/*facade*.ts
+  - src/plugin-sdk/api-baseline.ts
+  - src/plugin-sdk/config-schema.ts
+  - src/plugin-sdk/config-types.ts
+  - src/plugin-sdk/core.ts
+  - src/plugin-sdk/extension-shared.ts
+  - packages/plugin-package-contract/src
+  - packages/plugin-sdk/src/plugin-entry.ts
+  - packages/plugin-sdk/src/plugin-runtime.ts
+  - packages/plugin-sdk/src/runtime-env.ts
+  - packages/plugin-sdk/src/security-runtime.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,6 +56,11 @@ jobs:
             runs_on: blacksmith-4vcpu-ubuntu-2404
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
+          - language: javascript-typescript
+            category: plugin-trust-boundary
+            runs_on: blacksmith-4vcpu-ubuntu-2404
+            timeout_minutes: 25
+            config_file: ./.github/codeql/codeql-plugin-trust-boundary-critical-security.yml
           - language: actions
             category: actions
             runs_on: blacksmith-8vcpu-ubuntu-2404

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -272,7 +272,12 @@ The mcp-process-tool-boundary job scans MCP servers, process execution helpers,
 outbound delivery, and agent tool-execution gates under the
 `/codeql-critical-security/mcp-process-tool-boundary` category so command and
 tool boundary signal stays separate from both the auth/secrets baseline and
-the non-security MCP/process quality shard.
+the non-security MCP/process quality shard. The plugin-trust-boundary job scans
+plugin install, loader, manifest, registry, runtime-dependency staging,
+source-loading, public-surface, and Plugin SDK package contract trust surfaces
+under the `/codeql-critical-security/plugin-trust-boundary` category so plugin
+supply-chain and runtime-loading signal stays separate from both bundled plugin
+implementation code and the non-security plugin quality shard.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android
 security shard. It builds the Android app manually for CodeQL on the smallest


### PR DESCRIPTION
## Summary
- add a focused plugin-trust-boundary CodeQL security shard
- scope it to plugin install/load/manifest/registry/runtime-deps/source-loader/public-surface and Plugin SDK package contract trust surfaces
- keep it on `blacksmith-4vcpu-ubuntu-2404` with high/very-high precision security queries only

## Verification
- git diff --check
- ruby YAML parse for .github/workflows/codeql.yml and .github/codeql/codeql-plugin-trust-boundary-critical-security.yml
- pnpm check:workflows

## Notes
This does not scan bundled plugin implementation code or broaden default CodeQL. It isolates the plugin supply-chain/runtime-loading trust boundary as a separate critical security category.