### PR TITLE
chore(ci): add session diagnostics CodeQL quality shard

### DIFF
--- a/.github/codeql/codeql-session-diagnostics-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-session-diagnostics-boundary-critical-quality.yml
@@ -1,0 +1,48 @@
+name: openclaw-codeql-session-diagnostics-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/auto-reply/reply/queue
+  - src/auto-reply/reply/post-compaction-context.ts
+  - src/auto-reply/reply/startup-context.ts
+  - src/infra/diagnostic-*.ts
+  - src/infra/diagnostics-timeline.ts
+  - src/infra/session-delivery-queue*.ts
+  - src/infra/outbound/base-session-key.ts
+  - src/infra/outbound/delivery-queue*.ts
+  - src/infra/outbound/outbound-session.ts
+  - src/infra/outbound/session-binding*.ts
+  - src/infra/outbound/session-context.ts
+  - src/infra/outbound/targets-session.ts
+  - src/logging/diagnostic*.ts
+  - src/commands/doctor-session-*.ts
+  - src/commands/session-store-targets.ts
+  - src/commands/sessions*.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -11,6 +11,7 @@ on:
         options:
           - all
           - plugin-sdk-package-contract
+          - session-diagnostics-boundary
   schedule:
     - cron: "30 6 * * *"
 
@@ -180,6 +181,28 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/memory-runtime-boundary"
+
+  session-diagnostics-boundary:
+    name: Critical Quality (session-diagnostics-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'session-diagnostics-boundary' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-session-diagnostics-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/session-diagnostics-boundary"
 
   ui-control-plane:
     name: Critical Quality (ui-control-plane)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -293,8 +293,9 @@ default workflow because the macOS build dominates runtime even when clean.
 The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
-manual dispatch accepts `profile=all|plugin-sdk-package-contract`; the narrow
-profile is the first teaching/iteration hook for running one quality shard in
+manual dispatch accepts
+`profile=all|plugin-sdk-package-contract|session-diagnostics-boundary`; the
+narrow profiles are teaching/iteration hooks for running one quality shard in
 isolation without dispatching the rest of the workflow.
 Its
 core-auth-secrets job scans auth, secrets, sandbox, cron, and gateway security
@@ -316,7 +317,10 @@ supervision helpers, and outbound delivery contracts under the separate
 memory-runtime-boundary job scans the memory host SDK, memory runtime facades,
 memory Plugin SDK aliases, memory runtime activation glue, and memory doctor
 commands under the separate `/codeql-critical-quality/memory-runtime-boundary`
-category. The
+category. The session-diagnostics-boundary job scans reply queue internals,
+session delivery queues, outbound session binding/delivery helpers, diagnostic
+event/log bundle surfaces, and session doctor CLI contracts under the separate
+`/codeql-critical-quality/session-diagnostics-boundary` category. The
 ui-control-plane job scans Control UI bootstrap, local persistence, gateway
 control flows, and task control-plane runtime contracts under the separate
 `/codeql-critical-quality/ui-control-plane` category. The


### PR DESCRIPTION
## Summary
- add a focused `session-diagnostics-boundary` CodeQL Critical Quality shard
- scope it to reply queue internals, session delivery/outbound session helpers, diagnostics/log bundles, and session doctor CLI contracts
- document the new shard and manual narrow profile in CI docs

## Verification
- `git diff --check`
- Ruby YAML parse for `.github/workflows/codeql-critical-quality.yml` and `.github/codeql/codeql-session-diagnostics-boundary-critical-quality.yml`
- CodeQL config path resolution check
- `pnpm check:workflows`

## Notes
- This is the separate non-security critical issues lane.
- It intentionally avoids widening security CodeQL and avoids duplicating the existing agent-runtime shard's core agent/session runner coverage.
