### PR TITLE
chore(ci): add Plugin SDK reply CodeQL quality shard

### DIFF
--- a/.github/codeql/codeql-plugin-sdk-reply-runtime-critical-quality.yml
+++ b/.github/codeql/codeql-plugin-sdk-reply-runtime-critical-quality.yml
@@ -1,0 +1,44 @@
+name: openclaw-codeql-plugin-sdk-reply-runtime-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/plugin-sdk/inbound-envelope.ts
+  - src/plugin-sdk/inbound-reply-dispatch.ts
+  - src/plugin-sdk/reply-*.ts
+  - src/plugin-sdk/channel-reply-*.ts
+  - src/plugin-sdk/delivery-queue-runtime.ts
+  - src/plugin-sdk/outbound-runtime.ts
+  - src/plugin-sdk/outbound-send-deps.ts
+  - src/plugin-sdk/model-session-runtime.ts
+  - src/plugin-sdk/session-*.ts
+  - src/plugin-sdk/thread-bindings-runtime.ts
+  - src/plugin-sdk/thread-bindings-session-runtime.ts
+  - src/plugin-sdk/conversation-binding-runtime.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -11,6 +11,7 @@ on:
         options:
           - all
           - plugin-sdk-package-contract
+          - plugin-sdk-reply-runtime
           - session-diagnostics-boundary
   schedule:
     - cron: "30 6 * * *"
@@ -203,6 +204,28 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/session-diagnostics-boundary"
+
+  plugin-sdk-reply-runtime:
+    name: Critical Quality (plugin-sdk-reply-runtime)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-sdk-reply-runtime' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-plugin-sdk-reply-runtime-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/plugin-sdk-reply-runtime"
 
   ui-control-plane:
     name: Critical Quality (ui-control-plane)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -294,9 +294,9 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 manual dispatch accepts
-`profile=all|plugin-sdk-package-contract|session-diagnostics-boundary`; the
-narrow profiles are teaching/iteration hooks for running one quality shard in
-isolation without dispatching the rest of the workflow.
+`profile=all|plugin-sdk-package-contract|plugin-sdk-reply-runtime|session-diagnostics-boundary`;
+the narrow profiles are teaching/iteration hooks for running one quality shard
+in isolation without dispatching the rest of the workflow.
 Its
 core-auth-secrets job scans auth, secrets, sandbox, cron, and gateway security
 boundary code under the separate `/codeql-critical-quality/core-auth-secrets`
@@ -321,6 +321,10 @@ category. The session-diagnostics-boundary job scans reply queue internals,
 session delivery queues, outbound session binding/delivery helpers, diagnostic
 event/log bundle surfaces, and session doctor CLI contracts under the separate
 `/codeql-critical-quality/session-diagnostics-boundary` category. The
+plugin-sdk-reply-runtime job scans Plugin SDK inbound reply dispatch, reply
+payload/chunking/runtime helpers, channel reply options, delivery queues, and
+session/thread binding helpers under the separate
+`/codeql-critical-quality/plugin-sdk-reply-runtime` category. The
 ui-control-plane job scans Control UI bootstrap, local persistence, gateway
 control flows, and task control-plane runtime contracts under the separate
 `/codeql-critical-quality/ui-control-plane` category. The


### PR DESCRIPTION
## Summary
- add a focused CodeQL Critical Quality shard for Plugin SDK reply/runtime delivery contracts
- expose a narrow manual profile, `plugin-sdk-reply-runtime`, so the shard can run without dispatching the whole quality workflow
- document the new category in the CI guide

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/codeql-critical-quality.yml .github/codeql/codeql-plugin-sdk-reply-runtime-critical-quality.yml`
- path resolution check for every new CodeQL `paths` entry
- `git diff --check`
- `pnpm check:workflows`

## Notes
- This is non-security quality coverage only: error-severity quality queries with security-tagged findings excluded.
- The scope intentionally stays smaller than a broad `src/plugin-sdk` scan.
