### PR TITLE
fix(google-vertex): support authorized_user ADC credentials

### DIFF
--- a/extensions/google/adc-credentials.test.ts
+++ b/extensions/google/adc-credentials.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type AdcCredentials,
+  type FetchLike,
+  clearAdcTokenCache,
+  getAuthorizedUserAccessToken,
+  loadAdcCredentials,
+  mintAccessTokenFromAuthorizedUser,
+} from "./adc-credentials.js";
+
+type AuthorizedUserCred = Extract<AdcCredentials, { type: "authorized_user" }>;
+
+async function writeTempJson(content: unknown): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openclaw-adc-"));
+  const file = path.join(dir, "adc.json");
+  await writeFile(file, JSON.stringify(content), "utf8");
+  return file;
+}
+
+describe("loadAdcCredentials", () => {
+  afterEach(() => {
+    clearAdcTokenCache();
+  });
+
+  it("parses authorized_user ADC", async () => {
+    const file = await writeTempJson({
+      type: "authorized_user",
+      client_id: "cid",
+      client_secret: "csec",
+      refresh_token: "rt",
+      quota_project_id: "qproj",
+    });
+    const cred = await loadAdcCredentials(file);
+    expect(cred.type).toBe("authorized_user");
+    if (cred.type === "authorized_user") {
+      expect(cred.clientId).toBe("cid");
+      expect(cred.clientSecret).toBe("csec");
+      expect(cred.refreshToken).toBe("rt");
+      expect(cred.quotaProjectId).toBe("qproj");
+    }
+  });
+
+  it("rejects authorized_user missing required fields", async () => {
+    const file = await writeTempJson({ type: "authorized_user", client_id: "cid" });
+    await expect(loadAdcCredentials(file)).rejects.toThrow(/missing client_id/);
+  });
+
+  it("parses service_account ADC", async () => {
+    const file = await writeTempJson({
+      type: "service_account",
+      project_id: "p",
+      private_key: "k",
+      client_email: "e",
+    });
+    const cred = await loadAdcCredentials(file);
+    expect(cred.type).toBe("service_account");
+  });
+
+  it("returns 'other' for unknown ADC types so callers can fall through", async () => {
+    const file = await writeTempJson({ type: "external_account", audience: "x" });
+    const cred = await loadAdcCredentials(file);
+    expect(cred.type).toBe("other");
+    if (cred.type === "other") {
+      expect(cred.rawType).toBe("external_account");
+    }
+  });
+});
+
+describe("mintAccessTokenFromAuthorizedUser", () => {
+  it("POSTs refresh_token grant and returns access token", async () => {
+    const fetchMock: FetchLike = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ access_token: "AT", expires_in: 3600 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const cred: AuthorizedUserCred = {
+      type: "authorized_user",
+      clientId: "cid",
+      clientSecret: "csec",
+      refreshToken: "rt",
+      raw: {},
+    };
+    const minted = await mintAccessTokenFromAuthorizedUser(cred, {
+      fetch: fetchMock,
+      now: () => 1_000_000,
+    });
+    expect(minted.accessToken).toBe("AT");
+    expect(minted.expiresAt).toBe(1_000_000 + 3600 * 1000 - 60_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("grant_type=refresh_token"),
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        body: expect.stringContaining("refresh_token=rt"),
+      }),
+    );
+  });
+
+  it("throws on non-OK response", async () => {
+    const fetchMock: FetchLike = vi.fn(
+      async () => new Response("invalid_grant", { status: 400, statusText: "Bad Request" }),
+    );
+    const cred: AuthorizedUserCred = {
+      type: "authorized_user",
+      clientId: "cid",
+      clientSecret: "csec",
+      refreshToken: "rt",
+      raw: {},
+    };
+    await expect(mintAccessTokenFromAuthorizedUser(cred, { fetch: fetchMock })).rejects.toThrow(
+      /token refresh failed: 400/,
+    );
+  });
+});
+
+describe("getAuthorizedUserAccessToken cache", () => {
+  afterEach(() => {
+    clearAdcTokenCache();
+  });
+
+  it("reuses cached token while not expired", async () => {
+    let now = 1_000_000;
+    const fetchMock: FetchLike = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ access_token: "AT", expires_in: 3600 }), {
+          status: 200,
+        }),
+    );
+    const cred: AuthorizedUserCred = {
+      type: "authorized_user",
+      clientId: "cid",
+      clientSecret: "csec",
+      refreshToken: "rt",
+      raw: {},
+    };
+    const t1 = await getAuthorizedUserAccessToken(cred, { fetch: fetchMock, now: () => now });
+    now += 1000;
+    const t2 = await getAuthorizedUserAccessToken(cred, { fetch: fetchMock, now: () => now });
+    expect(t1).toBe("AT");
+    expect(t2).toBe("AT");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-mints after expiry", async () => {
+    let now = 1_000_000;
+    let calls = 0;
+    const fetchMock: FetchLike = vi.fn(async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ access_token: `AT${calls}`, expires_in: 1 }), {
+        status: 200,
+      });
+    });
+    const cred: AuthorizedUserCred = {
+      type: "authorized_user",
+      clientId: "cid",
+      clientSecret: "csec",
+      refreshToken: "rt",
+      raw: {},
+    };
+    const t1 = await getAuthorizedUserAccessToken(cred, { fetch: fetchMock, now: () => now });
+    now += 5 * 60_000;
+    const t2 = await getAuthorizedUserAccessToken(cred, { fetch: fetchMock, now: () => now });
+    expect(t1).toBe("AT1");
+    expect(t2).toBe("AT2");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/google/adc-credentials.ts
+++ b/extensions/google/adc-credentials.ts
@@ -1,0 +1,119 @@
+import { readFile } from "node:fs/promises";
+
+export type AdcCredentials =
+  | {
+      type: "service_account";
+      raw: Record<string, unknown>;
+    }
+  | {
+      type: "authorized_user";
+      clientId: string;
+      clientSecret: string;
+      refreshToken: string;
+      quotaProjectId?: string;
+      raw: Record<string, unknown>;
+    }
+  | {
+      type: "other";
+      rawType: string;
+      raw: Record<string, unknown>;
+    };
+
+export type MintedToken = {
+  accessToken: string;
+  expiresAt: number;
+};
+
+const OAUTH2_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SAFETY_SKEW_MS = 60_000;
+
+export async function loadAdcCredentials(path: string): Promise<AdcCredentials> {
+  const raw = await readFile(path, "utf8");
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const type = typeof parsed.type === "string" ? parsed.type : "";
+  if (type === "service_account") {
+    return { type: "service_account", raw: parsed };
+  }
+  if (type === "authorized_user") {
+    const clientId = readString(parsed.client_id);
+    const clientSecret = readString(parsed.client_secret);
+    const refreshToken = readString(parsed.refresh_token);
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new Error(
+        `authorized_user ADC at ${path} missing client_id, client_secret, or refresh_token`,
+      );
+    }
+    return {
+      type: "authorized_user",
+      clientId,
+      clientSecret,
+      refreshToken,
+      quotaProjectId: readString(parsed.quota_project_id) || undefined,
+      raw: parsed,
+    };
+  }
+  return { type: "other", rawType: type, raw: parsed };
+}
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export async function mintAccessTokenFromAuthorizedUser(
+  cred: Extract<AdcCredentials, { type: "authorized_user" }>,
+  deps: { fetch?: FetchLike; now?: () => number } = {},
+): Promise<MintedToken> {
+  const fetchImpl = deps.fetch ?? globalThis.fetch;
+  const now = deps.now ?? Date.now;
+  const body = new URLSearchParams({
+    client_id: cred.clientId,
+    client_secret: cred.clientSecret,
+    refresh_token: cred.refreshToken,
+    grant_type: "refresh_token",
+  });
+  const res = await fetchImpl(OAUTH2_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `authorized_user ADC token refresh failed: ${res.status} ${res.statusText} ${text}`,
+    );
+  }
+  const json = (await res.json()) as { access_token?: unknown; expires_in?: unknown };
+  const accessToken = readString(json.access_token);
+  const expiresIn = typeof json.expires_in === "number" ? json.expires_in : 3600;
+  if (!accessToken) {
+    throw new Error("authorized_user ADC token refresh response missing access_token");
+  }
+  return {
+    accessToken,
+    expiresAt: now() + expiresIn * 1000 - SAFETY_SKEW_MS,
+  };
+}
+
+type CacheKey = string;
+const tokenCache = new Map<CacheKey, MintedToken>();
+
+export function clearAdcTokenCache(): void {
+  tokenCache.clear();
+}
+
+export async function getAuthorizedUserAccessToken(
+  cred: Extract<AdcCredentials, { type: "authorized_user" }>,
+  deps: { fetch?: FetchLike; now?: () => number } = {},
+): Promise<string> {
+  const now = deps.now ?? Date.now;
+  const key = `${cred.clientId}:${cred.refreshToken}`;
+  const cached = tokenCache.get(key);
+  if (cached && cached.expiresAt > now()) {
+    return cached.accessToken;
+  }
+  const minted = await mintAccessTokenFromAuthorizedUser(cred, deps);
+  tokenCache.set(key, minted);
+  return minted.accessToken;
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/extensions/google/google-genai-runtime.ts
+++ b/extensions/google/google-genai-runtime.ts
@@ -1,8 +1,75 @@
 import { GoogleGenAI } from "@google/genai";
+import {
+  getAuthorizedUserAccessToken,
+  loadAdcCredentials,
+  type AdcCredentials,
+} from "./adc-credentials.js";
 
 export type GoogleGenAIClient = InstanceType<typeof GoogleGenAI>;
 export type GoogleGenAIOptions = ConstructorParameters<typeof GoogleGenAI>[0];
 
 export function createGoogleGenAI(options: GoogleGenAIOptions): GoogleGenAIClient {
   return new GoogleGenAI(options);
+}
+
+export type CreateVertexClientDeps = {
+  loadCredentials?: (path: string) => Promise<AdcCredentials>;
+  mintToken?: (cred: Extract<AdcCredentials, { type: "authorized_user" }>) => Promise<string>;
+  env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * Build a Vertex-mode GoogleGenAI client that tolerates `authorized_user` ADC.
+ *
+ * The bundled `@google/genai` SDK only handles `service_account` ADC cleanly; an
+ * `authorized_user` ADC file (the default for `gcloud auth application-default
+ * login`) makes the SDK throw `TypeError: Cannot convert undefined or null to
+ * object` because it iterates fields that only exist on service-account creds.
+ *
+ * For `authorized_user`, exchange the refresh token at the OAuth2 token endpoint
+ * and inject the resulting Bearer token via `httpOptions.headers.Authorization`,
+ * bypassing the SDK's own credential resolver.
+ */
+export async function createGoogleVertexGenAI(
+  options: GoogleGenAIOptions & { vertexai: true; project?: string; location?: string },
+  deps: CreateVertexClientDeps = {},
+): Promise<GoogleGenAIClient> {
+  const env = deps.env ?? process.env;
+  const credPath = env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  if (!credPath) {
+    return new GoogleGenAI(options);
+  }
+  const load = deps.loadCredentials ?? loadAdcCredentials;
+  const cred = await load(credPath);
+  if (cred.type !== "authorized_user") {
+    return new GoogleGenAI(options);
+  }
+
+  const project =
+    options.project ??
+    env.GOOGLE_CLOUD_PROJECT?.trim() ??
+    env.GCLOUD_PROJECT?.trim() ??
+    cred.quotaProjectId;
+  if (!project) {
+    throw new Error(
+      "google-vertex: authorized_user ADC has no project_id; set GOOGLE_CLOUD_PROJECT",
+    );
+  }
+
+  const mint = deps.mintToken ?? ((c) => getAuthorizedUserAccessToken(c));
+  const accessToken = await mint(cred);
+
+  const existingHeaders = options.httpOptions?.headers ?? {};
+  return new GoogleGenAI({
+    ...options,
+    project,
+    location: options.location ?? env.GOOGLE_CLOUD_LOCATION?.trim() ?? "global",
+    httpOptions: {
+      ...options.httpOptions,
+      headers: {
+        ...existingHeaders,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  });
 }

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -564,4 +564,83 @@ describe("google transport stream", () => {
 
     expect(params.contents).toEqual([{ role: "user", parts: [{ text: " " }] }]);
   });
+
+  it("regression #74628: exchanges authorized_user ADC for a Bearer token on google-vertex chat", async () => {
+    const { mkdtemp, writeFile } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const path = await import("node:path");
+    const { clearAdcTokenCache } = await import("./adc-credentials.js");
+    clearAdcTokenCache();
+
+    const dir = await mkdtemp(path.join(tmpdir(), "openclaw-vertex-regression-"));
+    const credPath = path.join(dir, "adc.json");
+    await writeFile(
+      credPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "cid",
+        client_secret: "csec",
+        refresh_token: "rt",
+      }),
+      "utf8",
+    );
+
+    const originalEnv = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    const originalFetch = globalThis.fetch;
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = credPath;
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ access_token: "ya29.minted", expires_in: 3600 }), {
+          status: 200,
+        }),
+    ) as typeof fetch;
+
+    try {
+      guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+
+      const model = attachModelProviderRequestTransport(
+        {
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+          api: "google-generative-ai",
+          provider: "google-vertex",
+          baseUrl: "https://global-aiplatform.googleapis.com/v1beta1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128000,
+          maxTokens: 8192,
+        } satisfies Model<"google-generative-ai">,
+        {},
+      );
+
+      const streamFn = createGoogleGenerativeAiTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          model,
+          {
+            messages: [{ role: "user", content: "hi", timestamp: 0 }],
+          } as unknown as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "gcp-vertex-credentials",
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      await stream.result();
+
+      const headers = (guardedFetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.headers as
+        | Record<string, string>
+        | undefined;
+      expect(headers).toBeDefined();
+      expect(headers?.Authorization).toBe("Bearer ya29.minted");
+      expect(headers?.["x-goog-api-key"]).toBeUndefined();
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+      } else {
+        process.env.GOOGLE_APPLICATION_CREDENTIALS = originalEnv;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -33,6 +33,7 @@ import {
   type GoogleThinkingInputLevel,
   type GoogleThinkingLevel,
 } from "./thinking-api.js";
+import { resolveGoogleVertexAuthHeaders } from "./vertex-adc-auth.js";
 
 type GoogleTransportModel = Model<"google-generative-ai"> & {
   headers?: Record<string, string>;
@@ -506,12 +507,24 @@ export function buildGoogleGenerativeAiParams(
   return params;
 }
 
+async function resolveGoogleAuthHeaders(
+  apiKey: string | undefined,
+): Promise<Record<string, string> | undefined> {
+  if (!apiKey) {
+    return undefined;
+  }
+  const adcHeaders = await resolveGoogleVertexAuthHeaders(apiKey);
+  if (adcHeaders.kind === "bearer") {
+    return { ...adcHeaders.headers, "Content-Type": "application/json" };
+  }
+  return parseGeminiAuth(apiKey).headers;
+}
+
 function buildGoogleHeaders(
   model: GoogleTransportModel,
-  apiKey: string | undefined,
+  authHeaders: Record<string, string> | undefined,
   optionHeaders: Record<string, string> | undefined,
 ): Record<string, string> {
-  const authHeaders = apiKey ? parseGeminiAuth(apiKey).headers : undefined;
   return (
     mergeTransportHeaders(
       {
@@ -639,6 +652,7 @@ export function createGoogleGenerativeAiTransportStreamFn(): StreamFn {
       };
       try {
         const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? undefined;
+        const authHeaders = await resolveGoogleAuthHeaders(apiKey);
         const guardedFetch = buildGuardedModelFetch(model);
         let params = buildGoogleGenerativeAiParams(model, context, options);
         const nextParams = await options?.onPayload?.(params, model);
@@ -647,7 +661,7 @@ export function createGoogleGenerativeAiTransportStreamFn(): StreamFn {
         }
         const response = await guardedFetch(buildGoogleRequestUrl(model), {
           method: "POST",
-          headers: buildGoogleHeaders(model, apiKey, options?.headers),
+          headers: buildGoogleHeaders(model, authHeaders, options?.headers),
           body: JSON.stringify(params),
           signal: options?.signal,
         });

--- a/extensions/google/vertex-adc-auth.test.ts
+++ b/extensions/google/vertex-adc-auth.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearAdcTokenCache } from "./adc-credentials.js";
+import { resolveGoogleVertexAuthHeaders } from "./vertex-adc-auth.js";
+
+async function writeTempJson(content: unknown): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "openclaw-vertex-auth-"));
+  const file = path.join(dir, "adc.json");
+  await writeFile(file, JSON.stringify(content), "utf8");
+  return file;
+}
+
+describe("resolveGoogleVertexAuthHeaders", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    clearAdcTokenCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns fallback for non-marker apiKey", async () => {
+    const result = await resolveGoogleVertexAuthHeaders("AIza-real-key", {});
+    expect(result.kind).toBe("fallback");
+  });
+
+  it("returns fallback when GOOGLE_APPLICATION_CREDENTIALS is unset", async () => {
+    const result = await resolveGoogleVertexAuthHeaders("gcp-vertex-credentials", {});
+    expect(result.kind).toBe("fallback");
+  });
+
+  it("returns fallback for service_account ADC (preserves existing behavior)", async () => {
+    const file = await writeTempJson({
+      type: "service_account",
+      project_id: "p",
+      private_key: "k",
+      client_email: "e",
+    });
+    const result = await resolveGoogleVertexAuthHeaders("gcp-vertex-credentials", {
+      GOOGLE_APPLICATION_CREDENTIALS: file,
+    });
+    expect(result.kind).toBe("fallback");
+  });
+
+  it("mints a Bearer token for authorized_user ADC", async () => {
+    const file = await writeTempJson({
+      type: "authorized_user",
+      client_id: "cid",
+      client_secret: "csec",
+      refresh_token: "rt",
+    });
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ access_token: "AT", expires_in: 3600 }), {
+          status: 200,
+        }),
+    ) as typeof fetch;
+    const result = await resolveGoogleVertexAuthHeaders("gcp-vertex-credentials", {
+      GOOGLE_APPLICATION_CREDENTIALS: file,
+    });
+    expect(result.kind).toBe("bearer");
+    if (result.kind === "bearer") {
+      expect(result.headers.Authorization).toBe("Bearer AT");
+    }
+  });
+
+  it("returns fallback when ADC parsing throws", async () => {
+    const file = await writeTempJson({ type: "authorized_user", client_id: "cid" });
+    const result = await resolveGoogleVertexAuthHeaders("gcp-vertex-credentials", {
+      GOOGLE_APPLICATION_CREDENTIALS: file,
+    });
+    expect(result.kind).toBe("fallback");
+  });
+});

--- a/extensions/google/vertex-adc-auth.ts
+++ b/extensions/google/vertex-adc-auth.ts
@@ -1,0 +1,41 @@
+import { getAuthorizedUserAccessToken, loadAdcCredentials } from "./adc-credentials.js";
+
+const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
+
+export type VertexAuthResolution =
+  | { kind: "bearer"; headers: Record<string, string> }
+  | { kind: "fallback" };
+
+/**
+ * Resolve auth headers for the google-vertex chat path when the upstream
+ * apiKey is the synthetic ADC marker. Only `authorized_user` ADC files are
+ * exchanged here (the @google/genai SDK can't handle them — see #74628).
+ *
+ * For service_account or unknown ADC shapes we return `fallback` so the
+ * caller can keep its existing behavior (current main forwards the marker
+ * through `parseGeminiAuth`, which is broken for non-API-key creds but is
+ * preserved here to avoid a wider refactor).
+ */
+export async function resolveGoogleVertexAuthHeaders(
+  apiKey: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<VertexAuthResolution> {
+  if (apiKey !== GCP_VERTEX_CREDENTIALS_MARKER) {
+    return { kind: "fallback" };
+  }
+  const credPath = env.GOOGLE_APPLICATION_CREDENTIALS?.trim();
+  if (!credPath) {
+    return { kind: "fallback" };
+  }
+  const cred = await loadAdcCredentials(credPath).catch(() => null);
+  if (!cred || cred.type !== "authorized_user") {
+    return { kind: "fallback" };
+  }
+  const token = await getAuthorizedUserAccessToken(cred);
+  return {
+    kind: "bearer",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #74628.

The `@google/genai` SDK (v1.50.1) only handles service-account ADC cleanly. When `GOOGLE_APPLICATION_CREDENTIALS` points to an `authorized_user` JSON (the default produced by `gcloud auth application-default login`, common in Docker dev setups), the SDK throws:

```
TypeError: Cannot convert undefined or null to object
    at createClient (google-vertex.js)
```

…because it iterates fields that only exist on service-account credentials.

This PR adds first-class support for `authorized_user` ADC by minting a short-lived Bearer token via the OAuth2 `refresh_token` grant and injecting it as an `Authorization` header on the GoogleGenAI client, bypassing the SDK's broken credential resolver for this case.

## Changes

- `extensions/google/adc-credentials.ts` (new) — load + parse ADC JSON, mint access tokens via `https://oauth2.googleapis.com/token`, in-memory cache with 60 s safety skew.
- `extensions/google/google-genai-runtime.ts` — new `createGoogleVertexGenAI()` async helper that detects `authorized_user`, mints a token, and injects `httpOptions.headers.Authorization`. Service-account and "no creds" paths are unchanged.
- `extensions/google/adc-credentials.test.ts` (new) — vitest covering shape detection, missing-field errors, token POST body, error responses, cache hit/expiry.

## Behavior

| ADC `type`         | Before                                              | After                                       |
|--------------------|-----------------------------------------------------|---------------------------------------------|
| `service_account`  | Works                                               | Unchanged                                   |
| `authorized_user`  | Crash on startup (`TypeError`)                      | Token minted + injected; client initializes |
| missing / no path  | SDK default behavior                                | Unchanged                                   |

`GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`, or `quota_project_id` in the JSON) is now required for `authorized_user` since the JSON has no `project_id`. A clear error is thrown if absent.

## Follow-up (not in this PR)

`createGoogleVertexGenAI` needs to be wired into the chat-completion code path that produces the stack trace in #74628. Current `createGoogleGenAI` callers (video / realtime / music) don't pass `vertexai: true`, so the crashing call site lives elsewhere — happy to extend in a follow-up once a maintainer points to it, or in this PR if preferred.

## Test plan

- [x] `pnpm -C extensions/google test adc-credentials` (unit tests)
- [ ] Manual: Docker container, authorized_user ADC mounted at `/run/secrets/gcloud-adc.json`, `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION=global` set — confirm OpenClaw initializes against `gemini-3.1-pro-preview`
- [ ] Manual: same flow with a service-account ADC — confirm unchanged behavior
- [ ] Manual: authorized_user ADC without `GOOGLE_CLOUD_PROJECT` — confirm the new error is raised