### PR TITLE
chore(ci): add provider runtime CodeQL quality shard

### DIFF
--- a/.github/codeql/codeql-provider-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-provider-runtime-boundary-critical-quality.yml
@@ -1,0 +1,44 @@
+name: openclaw-codeql-provider-runtime-boundary-critical-quality
+
+disable-default-queries: true
+
+queries:
+  - uses: security-and-quality
+
+query-filters:
+  - include:
+      problem.severity:
+        - error
+  - exclude:
+      tags:
+        - security
+
+paths:
+  - src/model-catalog
+  - src/plugins/provider-*.ts
+  - src/plugins/providers*.ts
+  - src/plugins/*provider*.ts
+  - src/plugins/capability-provider-runtime.ts
+  - src/plugins/compaction-provider.ts
+  - src/plugins/memory-embedding-provider*.ts
+  - src/plugins/memory-embedding-providers*.ts
+  - src/plugins/migration-provider-runtime.ts
+  - src/plugins/synthetic-auth.runtime.ts
+  - src/plugins/web-fetch-providers*.ts
+  - src/plugins/web-search-providers*.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -12,6 +12,7 @@ on:
           - all
           - plugin-sdk-package-contract
           - plugin-sdk-reply-runtime
+          - provider-runtime-boundary
           - session-diagnostics-boundary
   schedule:
     - cron: "30 6 * * *"
@@ -226,6 +227,28 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-critical-quality/plugin-sdk-reply-runtime"
+
+  provider-runtime-boundary:
+    name: Critical Quality (provider-runtime-boundary)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'provider-runtime-boundary' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-provider-runtime-boundary-critical-quality.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-critical-quality/provider-runtime-boundary"
 
   ui-control-plane:
     name: Critical Quality (ui-control-plane)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -294,7 +294,7 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 manual dispatch accepts
-`profile=all|plugin-sdk-package-contract|plugin-sdk-reply-runtime|session-diagnostics-boundary`;
+`profile=all|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
 the narrow profiles are teaching/iteration hooks for running one quality shard
 in isolation without dispatching the rest of the workflow.
 Its
@@ -325,6 +325,10 @@ plugin-sdk-reply-runtime job scans Plugin SDK inbound reply dispatch, reply
 payload/chunking/runtime helpers, channel reply options, delivery queues, and
 session/thread binding helpers under the separate
 `/codeql-critical-quality/plugin-sdk-reply-runtime` category. The
+provider-runtime-boundary job scans model catalog normalization, provider auth
+and discovery, provider runtime registration, provider defaults/catalogs, and
+web/search/fetch/embedding provider registries under the separate
+`/codeql-critical-quality/provider-runtime-boundary` category. The
 ui-control-plane job scans Control UI bootstrap, local persistence, gateway
 control flows, and task control-plane runtime contracts under the separate
 `/codeql-critical-quality/ui-control-plane` category. The


### PR DESCRIPTION
## Summary
- adds a focused CodeQL Critical Quality shard for provider runtime/model catalog contracts
- exposes `profile=provider-runtime-boundary` for single-shard manual runs
- documents the new category in CI docs

## Verification
- YAML parse for workflow + new CodeQL config
- new CodeQL path resolution check
- `git diff --check`
- `pnpm check:workflows`

## Notes
- no runtime code changes
- stays on `blacksmith-4vcpu-ubuntu-2404`
