### PR TITLE
fix(telegram): preserve audioAsVoice flag through legacy outbound media sends

### DIFF
--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -43,6 +43,80 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media" });
   });
 
+  it("passes audioAsVoice as asVoice to sendMessageTelegram in sendMedia", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice" });
+
+    await telegramOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      mediaUrl: "https://example.com/tts.ogg",
+      audioAsVoice: true,
+      accountId: "ops",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/tts.ogg",
+        asVoice: true,
+      }),
+    );
+  });
+
+  it("passes audioAsVoice as asVoice to sendMessageTelegram in sendPayload", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-voice-payload",
+      chatId: "12345",
+    });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      audioAsVoice: true,
+      payload: {
+        text: "",
+        audioAsVoice: true,
+        mediaUrl: "https://example.com/tts.ogg",
+      },
+      accountId: "ops",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/tts.ogg",
+        asVoice: true,
+      }),
+    );
+  });
+
+  it("defaults asVoice to false when audioAsVoice is not set in sendMedia", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-audio" });
+
+    await telegramOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      mediaUrl: "https://example.com/song.mp3",
+      accountId: "ops",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "",
+      expect.objectContaining({
+        asVoice: false,
+      }),
+    );
+  });
+
   it("sends payload media in sequence and keeps buttons on the first message only", async () => {
     sendMessageTelegramMock
       .mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" })

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -157,6 +157,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       forceDocument,
+      audioAsVoice,
       gatewayClientScopes,
     }) => {
       const { send, baseOpts } = await resolveTelegramSendContext({
@@ -173,6 +174,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         mediaReadFile,
         forceDocument: forceDocument ?? false,
+        asVoice: audioAsVoice ?? false,
       });
     },
   }),
@@ -187,6 +189,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     replyToId,
     threadId,
     forceDocument,
+    audioAsVoice,
     gatewayClientScopes,
   }) => {
     const { send, baseOpts } = await resolveTelegramSendContext({
@@ -206,6 +209,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         mediaReadFile,
         forceDocument: forceDocument ?? false,
+        asVoice: audioAsVoice ?? payload.audioAsVoice ?? false,
       },
     });
     return attachChannelToResult("telegram", result);


### PR DESCRIPTION
## Summary

Fixes #42060

When a TTS audio reply carries `audioAsVoice: true`, the flag was being dropped in the Telegram outbound adapter, causing audio to be sent as a file attachment (`sendAudio`/`sendDocument`) instead of a voice note (`sendVoice`).

## Root Cause

The `sendMedia` and `sendPayload` handlers in `outbound-adapter.ts` destructured `forceDocument` from the `ChannelOutboundContext` but omitted `audioAsVoice`. The flag was available on the context (set correctly by the shared delivery infrastructure in `src/infra/outbound/deliver.ts`) but never forwarded as the `asVoice` option to `sendMessageTelegram`.

## Fix

- Extract `audioAsVoice` from the context in both the `sendMedia` and `sendPayload` handlers
- Pass it as `asVoice` to `sendMessageTelegram`
- For `sendPayload`, also fall back to `payload.audioAsVoice` (the ReplyPayload field) when the context-level flag isn't set

## Tests Added

3 new test cases in `outbound-adapter.test.ts`:
- `passes audioAsVoice as asVoice to sendMessageTelegram in sendMedia`
- `passes audioAsVoice as asVoice to sendMessageTelegram in sendPayload`
- `defaults asVoice to false when audioAsVoice is not set in sendMedia`

All existing tests continue to pass (80 in send.test.ts, 31 in delivery.test.ts).