### PR TITLE
chore: ignore OAuth client secret files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,7 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 /local/
-client_secret_*.json
+/client_secret_*.json
 package-lock.json
 .claude/
 .agent/

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ USER.md
 .agent/*.json
 !.agent/workflows/
 /local/
+client_secret_*.json
 package-lock.json
 .claude/
 .agent/


### PR DESCRIPTION
## Summary

- Ignore root-level `client_secret_*.json` files so local OAuth client-secret downloads do not appear as commit candidates.

## Verification

Repo-native checks passed locally with Node 22.22.0:

- `pnpm build`
- `pnpm tsgo`
- `pnpm lint`
- `pnpm test -- --changed origin/main` (no changed test targets; skipped)

Additional local gate:

- `bash /Users/jdlee100/.claude/verify-codex.sh pre-pr` was run and reported `FAIL` because the user-level verifier falls back to `npx tsc`, strict-parses JSONC tsconfig files, and runs global `pnpm test:coverage` thresholds. Build/lint/security passed in that run; the failures are tracked locally as a verifier/repo-policy mismatch rather than a change in this PR.
