### PR TITLE
fix(gateway): surface unreachable status diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Status: show the `openai-codex` OAuth profile for `openai/gpt-*` sessions running through the native Codex runtime instead of reporting auth as unknown. (#76197) Thanks @mbelinky.
 - Plugins/externalization: keep diagnostics ClawHub packages and persisted bundled-plugin relocation on npm-first install metadata for launch, and omit Discord from the core package now that its external package is published. Thanks @vincentkoc.
 - Plugins/Codex: allow the official npm Codex plugin to install without the unsafe-install override, keep `/codex` command ownership, and cover the real npm Docker live path through managed `.openclaw/npm` dependencies plus uninstall failure proof.
+- Gateway/status: add concrete service, config, listener-owner, and log collection next steps when gateway probes fail and Bonjour finds no local gateway, so frozen or port-conflict reports include the data needed for root-cause triage. Refs #49012. Thanks @vincentkoc.
 
 ## 2026.5.2
 

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -312,6 +312,46 @@ describe("gateway-status command", () => {
     expect(targets[0]?.summary).toBeTruthy();
   });
 
+  it("includes diagnostic next steps when no gateway is reachable or discoverable", async () => {
+    const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
+    const defaultProbeGateway = probeGateway.getMockImplementation();
+    try {
+      probeGateway.mockImplementation(async (opts: { url: string }) => ({
+        ok: false,
+        url: opts.url,
+        connectLatencyMs: null,
+        error: "connection refused",
+        close: null,
+        auth: {
+          role: null,
+          scopes: [],
+          capability: "unknown",
+        },
+        health: null,
+        status: null,
+        presence: null,
+        configSnapshot: null,
+      }));
+
+      await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
+        "__exit__:1",
+      );
+    } finally {
+      probeGateway.mockReset();
+      if (defaultProbeGateway) {
+        probeGateway.mockImplementation(defaultProbeGateway);
+      }
+    }
+
+    expect(runtimeErrors).toHaveLength(0);
+    const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+      warnings?: Array<{ code?: string; message?: string }>;
+    };
+    const warning = parsed.warnings?.find((entry) => entry.code === "no_gateway_reachable");
+    expect(warning?.message).toContain("openclaw gateway status --deep --require-rpc");
+    expect(warning?.message).toContain("ss -ltnp");
+  });
+
   it("omits discovery wsUrl when only TXT hints are present", async () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
     discoverGatewayBeacons.mockResolvedValueOnce([

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -121,6 +121,7 @@ export async function gatewayStatusCommand(
     sshTarget: probePass.sshTarget,
     sshTunnelStarted: probePass.sshTunnelStarted,
     sshTunnelError: probePass.sshTunnelError,
+    discoveryCount: probePass.discovery.length,
     localTlsLoadError:
       localTlsRuntime && !localTlsRuntime.enabled && localTlsRuntime.required
         ? (localTlsRuntime.error ?? "gateway tls is enabled but local TLS runtime could not load")

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -18,7 +18,8 @@ vi.mock("../../terminal/theme.js", async () => {
   };
 });
 
-const { writeGatewayStatusJson, writeGatewayStatusText } = await import("./output.js");
+const { buildGatewayStatusWarnings, writeGatewayStatusJson, writeGatewayStatusText } =
+  await import("./output.js");
 
 function createRuntimeCapture(): RuntimeEnv {
   return {
@@ -78,6 +79,34 @@ function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbe
 describe("gateway status output", () => {
   beforeEach(() => {
     writeRuntimeJson.mockReset();
+  });
+
+  it("warns with diagnostic next steps when no probes or Bonjour discovery find a gateway", () => {
+    const warnings = buildGatewayStatusWarnings({
+      probed: [
+        createTarget(
+          "localLoopback",
+          createProbe("unknown", {
+            ok: false,
+            connectLatencyMs: null,
+            error: "connection refused",
+          }),
+        ),
+      ],
+      sshTarget: null,
+      sshTunnelStarted: false,
+      sshTunnelError: null,
+      discoveryCount: 0,
+    });
+
+    expect(warnings).toContainEqual(
+      expect.objectContaining({
+        code: "no_gateway_reachable",
+        message: expect.stringContaining("openclaw gateway status --deep --require-rpc"),
+        targetIds: ["localLoopback"],
+      }),
+    );
+    expect(warnings.at(0)?.message).toContain("lsof -nP -iTCP:<port>");
   });
 
   it("derives summary capability from reachable probes only in json output", () => {

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -3,10 +3,12 @@ import type { GatewayProbeResult } from "../../gateway/probe.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { GatewayStatusProbedTarget } from "./probe-run.js";
 
-const writeRuntimeJson = vi.fn();
+const mocks = vi.hoisted(() => ({
+  writeRuntimeJson: vi.fn(),
+}));
 
 vi.mock("../../runtime.js", () => ({
-  writeRuntimeJson: (...args: unknown[]) => writeRuntimeJson(...args),
+  writeRuntimeJson: (...args: unknown[]) => mocks.writeRuntimeJson(...args),
 }));
 
 vi.mock("../../terminal/theme.js", async () => {
@@ -78,7 +80,7 @@ function createTarget(id: string, probe: GatewayProbeResult): GatewayStatusProbe
 
 describe("gateway status output", () => {
   beforeEach(() => {
-    writeRuntimeJson.mockReset();
+    mocks.writeRuntimeJson.mockReset();
   });
 
   it("warns with diagnostic next steps when no probes or Bonjour discovery find a gateway", () => {
@@ -143,7 +145,7 @@ describe("gateway status output", () => {
       primaryTargetId: "reachable-read",
     });
 
-    expect(writeRuntimeJson).toHaveBeenCalledWith(
+    expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(
       runtime,
       expect.objectContaining({
         ok: true,
@@ -217,7 +219,7 @@ describe("gateway status output", () => {
       primaryTargetId: "detail-timeout",
     });
 
-    expect(writeRuntimeJson).toHaveBeenCalledWith(
+    expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(
       runtime,
       expect.objectContaining({
         ok: true,

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -18,6 +18,9 @@ export type GatewayStatusWarning = {
   targetIds?: string[];
 };
 
+const noReachableGatewayDiagnostic =
+  "No gateway answered any probe and Bonjour discovery returned no local gateways. Run `openclaw gateway status --deep --require-rpc` to inspect service state, config paths, listener owners, and logs; include `ss -ltnp` or `lsof -nP -iTCP:<port> -sTCP:LISTEN` for the configured port when filing a report.";
+
 export function pickPrimaryProbedTarget(probed: GatewayStatusProbedTarget[]) {
   const reachable = probed.filter((entry) => isProbeReachable(entry.probe));
   return (
@@ -35,6 +38,7 @@ export function buildGatewayStatusWarnings(params: {
   sshTunnelStarted: boolean;
   sshTunnelError: string | null;
   localTlsLoadError?: string | null;
+  discoveryCount?: number;
 }): GatewayStatusWarning[] {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const degradedScopeLimited = params.probed.filter((entry) =>
@@ -57,6 +61,13 @@ export function buildGatewayStatusWarnings(params: {
       code: "local_tls_runtime_unavailable",
       message: `Local gateway TLS is enabled but OpenClaw could not load the local certificate fingerprint: ${params.localTlsLoadError}`,
       targetIds: ["localLoopback"],
+    });
+  }
+  if (reachable.length === 0 && params.discoveryCount === 0) {
+    warnings.push({
+      code: "no_gateway_reachable",
+      message: noReachableGatewayDiagnostic,
+      targetIds: params.probed.map((entry) => entry.target.id),
     });
   }
   if (reachable.length > 1) {


### PR DESCRIPTION
## Summary

- add a `no_gateway_reachable` Gateway status warning when every probe is unreachable and Bonjour discovers no local gateways
- wire discovery count into the status warning builder so JSON and human output request service, config, listener-owner, and log diagnostics
- cover the warning builder and the command JSON path for the exact frozen/unreachable symptom

Refs #49012. This is a diagnostic/remediation-data fix, not a root-cause closure.

## Validation

- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_ID=tbx_01kqdttjtb1nnj92za0mka8032 pnpm testbox:run --id tbx_01kqdttjtb1nnj92za0mka8032 -- pnpm test:serial src/commands/gateway-status/output.test.ts src/commands/gateway-status.test.ts` — passed, 27 tests
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_ID=tbx_01kqdttjtb1nnj92za0mka8032 pnpm testbox:run --id tbx_01kqdttjtb1nnj92za0mka8032 -- node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.core.json src/commands/gateway-status.ts src/commands/gateway-status/output.ts src/commands/gateway-status/output.test.ts src/commands/gateway-status.test.ts` — passed
- `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_ID=tbx_01kqdttjtb1nnj92za0mka8032 pnpm testbox:run --id tbx_01kqdttjtb1nnj92za0mka8032 -- pnpm check:changed -- CHANGELOG.md src/commands/gateway-status.ts src/commands/gateway-status/output.ts src/commands/gateway-status/output.test.ts src/commands/gateway-status.test.ts` — blocked by unrelated `packages/sdk/src/index.test.ts` oxlint `typescript-eslint(no-redundant-type-constituents)` errors after conflict-marker, changelog-attribution, typecheck core, and typecheck core test steps passed

AI-assisted: yes; diff reviewed before opening.
