### PR TITLE
fix(memory): mirror sqlite-vec into plugin runtime deps snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1754,6 +1754,7 @@
         "markdown-it",
         "openai",
         "semver",
+        "sqlite-vec",
         "tar",
         "tslog",
         "typebox",


### PR DESCRIPTION
Add `sqlite-vec` to `openclaw.bundle.mirroredRootRuntimeDependencies`. Without it, the plugin-runtime-deps snapshot ships without `sqlite-vec`, breaking builtin memory:

```
[memory] sqlite-vec unavailable: Cannot find package 'sqlite-vec' imported from .../engine-storage-*.js
```

`memory-host-sdk` imports `sqlite-vec` in the bundled `engine-storage` chunk; the root mirror is the only place that covers it. Platform binary (`sqlite-vec-darwin-arm64`) rides along as an optionalDependency.

Fixes #74692