### PR TITLE
fix(amazon-bedrock): expose xhigh thinking level for Claude Opus 4.7 inference profiles (#74701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Amazon Bedrock: expose `xhigh` thinking level for Claude Opus 4.7 inference profiles (`us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4.7`, etc.) so the `/think xhigh` autocomplete matches the native Anthropic provider behaviour. Fixes #74701.
 - CLI/update: scope packaged Node compile caches by OpenClaw version and install metadata, so global installs no longer reuse stale compiled chunks after package updates. Thanks @pashpashpash.
 - Plugin SDK/testing: lazy-load TypeScript from the plugin test-contract runtime and add release checks for critical SDK contract entrypoint imports and bundle size, so published packages fail preflight before shipping ESM-incompatible or oversized contract helpers. Thanks @vincentkoc.
 - Channels/Microsoft Teams: treat configured `19:...@thread.tacv2` and legacy `19:...@thread.skype` team/channel IDs as already resolved during startup, avoiding false `channels unresolved` warnings while preserving Graph name lookup for display-name entries. Fixes #74683. Thanks @dseravalli.

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -253,6 +253,26 @@ describe("amazon-bedrock provider plugin", () => {
     });
   });
 
+  it("exposes xhigh thinking for Claude Opus 4.7 Bedrock inference profiles", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    for (const modelId of [
+      "us.anthropic.claude-opus-4-7",
+      "eu.anthropic.claude-opus-4.7",
+      "anthropic.claude-opus-4-7-20260219",
+    ]) {
+      expect(
+        provider.resolveThinkingProfile?.({ provider: "amazon-bedrock", modelId } as never),
+      ).toMatchObject({ levels: expect.arrayContaining([{ id: "xhigh" }]) });
+    }
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId: "us.anthropic.claude-opus-4-6-v1",
+      } as never),
+    ).toMatchObject({ levels: expect.not.arrayContaining([{ id: "xhigh" }]) });
+  });
+
   it("owns Anthropic-style replay policy for Claude Bedrock models", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -528,6 +528,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         { id: "low" },
         { id: "medium" },
         { id: "high" },
+        ...(isOpus47BedrockModelRef(modelId.trim()) ? [{ id: "xhigh" as const }] : []),
         ...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
       ],
       defaultLevel: claude46ModelRe.test(modelId.trim()) ? "adaptive" : undefined,


### PR DESCRIPTION
## Root cause

`resolveThinkingProfile` in the Amazon Bedrock plugin never included `xhigh` for Claude Opus 4.7 inference profiles (`us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4.7`, etc.). The downstream stream runtime already maps `xhigh→xhigh` for these models, so the backend supports it — only the profile exposure was missing.

## Fix

Add `xhigh` to the levels array using the existing `isOpus47BedrockModelRef` guard (already in the file), alongside the existing `claude46ModelRe` adaptive branch. Two-line delta, no new regex.

```ts
// Before:
...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),

// After:
...(isOpus47BedrockModelRef(modelId.trim()) ? [{ id: "xhigh" as const }] : []),
...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
```

The `isOpus47BedrockModelRef` regex already handles the region-prefixed Bedrock model ID format (`us.anthropic.*`, `eu.anthropic.*`, etc.) that `resolveClaudeThinkingProfile` from provider-model-shared does not match.

## Test

Added `exposes xhigh thinking for Claude Opus 4.7 Bedrock inference profiles` covering:
- `us.anthropic.claude-opus-4-7` → has xhigh ✓
- `eu.anthropic.claude-opus-4.7` → has xhigh ✓
- `anthropic.claude-opus-4-7-20260219` → has xhigh ✓
- `us.anthropic.claude-opus-4-6-v1` → no xhigh ✓

30/30 tests pass.

Fixes #74701.