### PR TITLE
fix(feishu): skip empty text messages to avoid downstream LLM 'messages must not be empty' (#74634)

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -497,6 +497,28 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(mockTouchBinding).toHaveBeenCalledWith("default:oc_group_chat:topic:om_topic_root");
   });
 
+  it("skips empty text messages without invoking the agent route resolver", async () => {
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-empty",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "" }),
+        },
+      },
+    });
+
+    expect(mockResolveAgentRoute).not.toHaveBeenCalled();
+    expect(mockSendMessageFeishu).not.toHaveBeenCalled();
+  });
+
   it("passes reasoning preview permission from session state into the dispatcher", async () => {
     mockResolveFeishuReasoningPreviewEnabled.mockReturnValue(true);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -422,6 +422,17 @@ export async function handleFeishuMessage(params: {
   }
 
   let ctx = parseFeishuMessageEvent(event, botOpenId, botName);
+
+  // Skip empty text messages (no content, no media possible). Without this guard
+  // the empty string flows into the session/transcript and downstream LLM
+  // requests reject the message list as empty (see issue #74634).
+  if (event.message.message_type === "text" && !ctx.content.trim()) {
+    log(
+      `feishu[${account.accountId}]: skipping empty text message ${messageId} from ${ctx.senderOpenId}`,
+    );
+    return;
+  }
+
   const isGroup = isFeishuGroupChatType(ctx.chatType);
   const isDirect = !isGroup;
   const senderUserId = normalizeOptionalString(event.sender.sender_id.user_id);


### PR DESCRIPTION
## Summary

Fixes #74634.

When a Feishu user sends a message whose text payload is empty (`{"text": ""}` or a media-only message that resolves to no content), `parseMessageContent` returned an empty string and the empty `ctx.content` flowed all the way through `handleFeishuMessage` into the session transcript. The next LLM request then failed with errors like `messages must not be empty (2013)` on MiniMax, forcing fallback failovers and noisy gateway error logs.

## Fix

Add an early guard in `handleFeishuMessage` (`extensions/feishu/src/bot.ts`): for `message_type === "text"` with no trimmed content, log and return before any agent route resolution or session write happens. This matches the suggested fix in the issue and is the narrowest layer that still keeps richer-content messages (post / media / share_chat / merge_forward) untouched.

## Test

Added `extensions/feishu/src/bot.test.ts` case `"skips empty text messages without invoking the agent route resolver"` that dispatches an empty-text payload through `handleFeishuMessage` and asserts neither `resolveAgentRoute` nor `sendMessageFeishu` is invoked.

```
✓ extensions/feishu/src/bot.test.ts (58 tests) 700ms
Test Files  1 passed (1)
     Tests  58 passed (58)
```

## Notes

- Non-text messages (image/file/audio/video/sticker/post/share_chat/merge_forward) are unaffected — the guard is gated on `message_type === "text"`.
- A user-visible reply is intentionally not sent for empty text events; the original message is just dropped (matches the issue's "skip entirely" suggestion).