### PR TITLE
fix(browser-plugin): emit src/** to dist via stageRuntimeDependencies

### DIFF
--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -19,6 +19,9 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "bundle": {
+      "stageRuntimeDependencies": true
+    }
   }
 }


### PR DESCRIPTION
Fixes #74723.

## Summary

The browser plugin's runtime entry (`register.runtime.ts`) re-exports from `./src/browser-tool.js`, `./src/cli/browser-cli.js`, `./src/gateway/...`, `./src/plugin-service.js`, etc. Without `openclaw.bundle.stageRuntimeDependencies: true` in `package.json`, `tsdown.config.ts`'s two-tier plugin build splits this plugin into `rootBundledPluginBuildEntries` (line 239), which only emits the top-level surface files. The `./src/**` subtree is never compiled.

At runtime, `getPwAiModule()` in `extensions/browser/src/browser/pw-ai-module.ts` does `await import('./pw-ai.js')`, which resolves to `dist/extensions/browser/src/browser/pw-ai.js` — a file that does not exist. `import()` throws `ERR_MODULE_NOT_FOUND`, the soft-load path returns `null`, and the `requirePwAi()` gate in `routes/agent.shared.ts` returns 501 with "Playwright is not available in this gateway build" for every Playwright-backed browser tool.

## Change

Single 4-line edit to `extensions/browser/package.json`:

```diff
 "openclaw": {
   "extensions": [
     "./index.ts"
-  ]
+  ],
+  "bundle": {
+    "stageRuntimeDependencies": true
+  }
 }
```

This makes the browser plugin eligible for `buildBundledPluginConfigs()` (`tsdown.config.ts` line 268), which emits a per-plugin tsdown bundle into `dist/extensions/browser/` with the full `src/**` tree compiled. Matches the pattern already used by 15 other bundled plugins (telegram, discord, feishu, google, codex, acpx, qqbot, diffs, etc.).

## Verification

Before:
```
$ find dist/extensions/browser -type f -name '*.js' | wc -l
18
$ find dist -name 'pw-ai.js'
(no output)
```

After:
```
$ find dist/extensions/browser -type f -name '*.js' | wc -l
~hundreds
$ find dist -name 'pw-ai.js'
dist/extensions/browser/src/browser/pw-ai.js
```

`pnpm test` passes (807 tests / 94 files).

## Notes

- See #74723 for full root-cause analysis including how to reproduce on a fresh build.
- This PR is stacked on #74724 (a pre-existing tsgo strict-check failure in `extensions/telegram/src/bot.ts` that blocked the local pre-commit hook on any extension change). Recommend merging #74724 first.