### PR TITLE
fix(minimax): guard empty anthropic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Bonjour/Gateway: treat active ciao probing and fresh name-conflict renames as in-progress so the mDNS watchdog waits for probe settlement before retrying, preventing rapid re-advertise loops on Windows, WSL, and other multicast-hostile hosts. (#74778) Refs #74242. Thanks @fuller-stack-dev.
+- Providers/MiniMax: send a minimal Anthropic-compatible user fallback when message conversion filters a turn to an empty payload, so MiniMax M2.7 no longer returns `chat content is empty` after tool-heavy sessions. Fixes #74589. Thanks @neeravmakwana and @DerekEXS.
 - Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
 - Doctor/GitHub CLI: surface a `GH_CONFIG_DIR` hint when the GitHub skill is usable but `gh` auth lives under a different operator HOME than the agent process, without warning for disabled or filtered skills. Fixes #78063. (#78095) Thanks @tmimmanuel.
 - Gateway: dedupe concurrent `send`, `poll`, and `message.action` requests while delivery is still in flight, preventing duplicate outbound work for the same idempotency key. (#68341) Thanks @thesomewhatyou.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -719,6 +719,61 @@ describe("anthropic transport stream", () => {
   });
 
   it.each([
+    {
+      name: "empty history",
+      context: { messages: [] } as AnthropicStreamContext,
+    },
+    {
+      name: "blank user content",
+      context: {
+        messages: [
+          {
+            role: "user",
+            content: " \n\t ",
+            timestamp: 0,
+          },
+        ],
+      } as AnthropicStreamContext,
+    },
+  ])(
+    "sends a minimal user fallback when Anthropic message conversion has no content: $name",
+    async ({ context }) => {
+      await runTransportStream(
+        makeAnthropicTransportModel({
+          id: "MiniMax-M2.7",
+          name: "MiniMax M2.7",
+          provider: "minimax",
+          baseUrl: "https://api.minimax.io/anthropic",
+        }),
+        context,
+        {
+          apiKey: "sk-minimax-test",
+        } as AnthropicStreamOptions,
+      );
+
+      expect(latestAnthropicRequest().payload).toMatchObject({
+        model: "MiniMax-M2.7",
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: ".",
+                cache_control: { type: "ephemeral" },
+              },
+            ],
+          },
+        ],
+      });
+      expect(guardedFetchMock).toHaveBeenCalledWith(
+        "https://api.minimax.io/anthropic/v1/messages",
+        expect.objectContaining({ method: "POST" }),
+      );
+    },
+  );
+
+  it.each([
     ["empty", ""],
     ["whitespace-only", " \n\t "],
     ["invalid-surrogate-only", String.fromCharCode(0xd83d)],

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -108,6 +108,8 @@ type MutableAssistantOutput = {
   errorMessage?: string;
 };
 
+const EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT = ".";
+
 function isClaudeOpus47Model(modelId: string): boolean {
   return modelId.includes("opus-4-7") || modelId.includes("opus-4.7");
 }
@@ -423,6 +425,12 @@ function convertAnthropicMessages(
     }
   }
   return params;
+}
+
+function ensureNonEmptyAnthropicMessages(messages: Array<Record<string, unknown>>) {
+  return messages.length > 0
+    ? messages
+    : [{ role: "user", content: EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT }];
 }
 
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
@@ -754,7 +762,9 @@ function buildAnthropicParams(
   });
   const params: Record<string, unknown> = {
     model: model.id,
-    messages: convertAnthropicMessages(context.messages, model, isOAuthToken),
+    messages: ensureNonEmptyAnthropicMessages(
+      convertAnthropicMessages(context.messages, model, isOAuthToken),
+    ),
     max_tokens: maxTokens,
     stream: true,
   };


### PR DESCRIPTION
"\"## Root cause\\nMiniMax M2.7 uses the Anthropic-compatible transport. That transport filtered blank or unsupported replay content during `convertAnthropicMessages`, then sent the converted array directly. If the original session history was already empty, or every replay item was filtered out, the provider request could contain `messages: []` and MiniMax returned `chat content is empty`.\\n\\n## Linked issue\\nFixes #74589.\\n\\n## Why the fix is safe\\nThe change is limited to the final Anthropic-compatible payload boundary. Valid converted messages are preserved unchanged. Only the invalid zero-message case receives a minimal user fallback before the existing payload policy runs, so providers do not see an empty Anthropic Messages request.\\n\\n## Security and runtime controls unchanged\\nThis does not change auth, model routing, tool permissions, proxy/TLS policy, transcript persistence, or hook behavior. The guard is runtime-enforced in the transport payload builder rather than relying on prompt instructions.\\n\\n## Tests run\\n- `pnpm exec oxfmt --check --threads=1 src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts CHANGELOG.md`\\n- `git diff --check`\\n- `pnpm changed:lanes --json`\\n- `pnpm test src/agents/anthropic-transport-stream.test.ts -t \\\"minimal user fallback|replaces empty text-only tool results\\\"`\\n- `pnpm test src/agents/anthropic-transport-stream.test.ts`\\n- `pnpm test src/agents/anthropic-transport-stream.test.ts -t \\\"minimal user fallback\\\"`\\n- `pnpm check:changed`\\n\\n## Out of scope\\n- No embedded-run prompt guard changes; #73929 remains the separate blank replay-history guard for #73926.\\n- No MiniMax-specific retry/fallback policy changes.\\n- No transcript repair or session-store migration changes.\\n\\nAI-assisted: implemented and self-reviewed in Cursor.\\n\\nMade with [Cursor](https://cursor.com)\"\n\n\n## Real behavior proof\n- Behavior addressed: MiniMax M2.7 Anthropic-compatible requests no longer send an empty messages array after OpenClaw message conversion filters all content.\n- Real setup tested: local OpenClaw checkout using MINIMAX_API_KEY from the maintainer environment, MiniMax Anthropic-compatible endpoint https://api.minimax.io/anthropic, model MiniMax-M2.7.\n- Exact steps or command run after this patch: node/tsx live transport smoke that imports src/agents/anthropic-transport-stream.ts, calls createAnthropicMessagesTransportStreamFn(), and sends context.messages: [] to MiniMax-M2.7 with maxTokens 32.\n- Evidence after fix: copied live output from the real MiniMax endpoint: {\"ok\":true,\"stopReason\":\"length\",\"contentTypes\":[\"thinking\"],\"usage\":{\"input\":39,\"output\":32,\"totalTokens\":71},\"payloadSummary\":{\"model\":\"MiniMax-M2.7\",\"messageCount\":1,\"firstRole\":\"user\",\"firstContent\":[{\"type\":\"text\",\"text\":\".\",\"cache_control\":{\"type\":\"ephemeral\"}}],\"max_tokens\":32}}.\n- Observed result after fix: the request succeeded against MiniMax instead of returning the previous provider error {\"type\":\"invalid_request_error\",\"message\":\"invalid params, messages must not be empty (2013)\"}; outbound payload contained one minimal user fallback text block.\n- What was not tested: no additional gaps for this MiniMax empty-message regression.\n"
