### PR TITLE
fix(channels): structured warn for bundled lock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ Docs: https://docs.openclaw.ai
 - Commands: keep channel-prefixed owner allowlist entries scoped to matching providers so webchat command contexts cannot inherit external channel owners. Thanks @zsxsoft.
 - Auth/device pairing: bound bootstrap handoff token issuance, redemption, and approved pairing baselines to the documented per-role scope allowlist, so bootstrap approvals cannot persistently grant `operator.admin`, `operator.pairing`, or `node.exec` scopes. Thanks @eleqtrizit.
 - Providers/GitHub Copilot: support the GUI/RPC wizard device-code auth flow so onboarding from non-TTY clients (gateway RPC bridge, GUI wizards) completes instead of returning empty profiles. Dangerous-state handling now distinguishes `access_denied` and `expired_token` from transport errors. (#73290) Thanks @indierawk2k2.
+- Channels/runtime-deps: emit structured warn metadata (`failureReason`, `lockDir`, `waitedMs`) when bundled channel runtime-deps lock acquisition times out, so JSON and file log consumers can route lock-timeout failures without parsing free-form messages, and derive `lockDir` from the stable ` (waited=` marker so paths that contain ` (` segments are preserved intact. (#74736) Thanks @masatohoshino.
 
 ## 2026.4.27
 

--- a/src/channels/plugins/bundled.test.ts
+++ b/src/channels/plugins/bundled.test.ts
@@ -112,6 +112,42 @@ describe("loadGeneratedBundledChannelEntry: structured warn for lock timeout", (
     });
   });
 
+  it("preserves lockDir for paths that contain ` (` segments", async () => {
+    const fakeModulePath = path.join("/tmp", "openclaw-alpha", "index.js");
+    const lockDirWithParen = "/tmp/OpenClaw (prod)/.openclaw-runtime-deps.lock";
+    const messageWithParen =
+      `Timed out waiting for bundled runtime deps lock at ${lockDirWithParen} ` +
+      `(waited=300000ms, ownerFile=present, ownerFileSymlink=false, pid=12345 alive=false, ` +
+      `ownerAge=300001ms, ownerFileAge=300001ms, lockAge=300001ms, ` +
+      `ownerFilePath=${lockDirWithParen}/owner.json). ` +
+      `If no OpenClaw/npm install is running, remove the lock directory and retry.`;
+
+    mockBundledChannelRuntime(fakeModulePath);
+    vi.doMock("./module-loader.js", () => ({
+      isJavaScriptModulePath: () => false,
+      loadChannelPluginModule: () => {
+        throw new Error(messageWithParen);
+      },
+    }));
+
+    const bundled = await importFreshModule<typeof import("./bundled.js")>(
+      import.meta.url,
+      "./bundled.js?scope=lock-timeout-paren-path",
+    );
+
+    const result = bundled.getBundledChannelPlugin("alpha");
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [, meta] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(meta).toMatchObject({
+      failureReason: "lock_timeout",
+      bundledChannelId: "alpha",
+      lockDir: lockDirWithParen,
+      waitedMs: 300000,
+    });
+  });
+
   it("emits flat string warn for non-lock-timeout module import errors", async () => {
     const fakeModulePath = path.join("/tmp", "openclaw-alpha", "index.js");
 

--- a/src/channels/plugins/bundled.test.ts
+++ b/src/channels/plugins/bundled.test.ts
@@ -96,15 +96,20 @@ describe("loadGeneratedBundledChannelEntry: structured warn for lock timeout", (
 
     expect(result).toBeUndefined();
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining("lock timeout"),
-      expect.objectContaining({
-        failureReason: "lock_timeout",
-        bundledChannelId: "alpha",
-        lockDir: FAKE_LOCK_DIR,
-        waitedMs: 300000,
-      }),
-    );
+    const [message, meta] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    // The message preserves the upstream lock-timeout detail so pretty/compact
+    // console renderers (which drop structured meta) still see the diagnostic.
+    expect(message).toContain("failed to load bundled channel alpha");
+    expect(message).toContain("Timed out waiting for bundled runtime deps lock at");
+    expect(message).toContain(FAKE_LOCK_DIR);
+    expect(message).toContain("waited=300000ms");
+    expect(message).toContain("remove the lock directory and retry");
+    expect(meta).toMatchObject({
+      failureReason: "lock_timeout",
+      bundledChannelId: "alpha",
+      lockDir: FAKE_LOCK_DIR,
+      waitedMs: 300000,
+    });
   });
 
   it("emits flat string warn for non-lock-timeout module import errors", async () => {

--- a/src/channels/plugins/bundled.test.ts
+++ b/src/channels/plugins/bundled.test.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Capture the warn fn before module mocking so we can inspect calls.
+const warn = vi.hoisted(() => vi.fn());
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    warn,
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+    subsystem: "channels",
+    isEnabled: vi.fn(() => false),
+  })),
+}));
+
+vi.mock("../../plugins/bundled-dir.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../plugins/bundled-dir.js")>();
+  return {
+    ...actual,
+    resolveBundledPluginsDir: (env: NodeJS.ProcessEnv = process.env) =>
+      env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? actual.resolveBundledPluginsDir(env),
+  };
+});
+
+const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+
+afterEach(() => {
+  warn.mockClear();
+  if (originalBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
+  }
+  vi.resetModules();
+  vi.doUnmock("../../plugins/bundled-channel-runtime.js");
+  vi.doUnmock("./module-loader.js");
+});
+
+const FAKE_LOCK_DIR = "/tmp/openclaw-stage/.openclaw-runtime-deps.lock";
+
+const LOCK_TIMEOUT_MESSAGE =
+  `Timed out waiting for bundled runtime deps lock at ${FAKE_LOCK_DIR} ` +
+  `(waited=300000ms, ownerFile=present, ownerFileSymlink=false, pid=12345 alive=false, ` +
+  `ownerAge=300001ms, ownerFileAge=300001ms, lockAge=300001ms, ` +
+  `ownerFilePath=${FAKE_LOCK_DIR}/owner.json). ` +
+  `If no OpenClaw/npm install is running, remove the lock directory and retry.`;
+
+const ALPHA_METADATA = {
+  dirName: "alpha",
+  manifest: {
+    id: "alpha",
+    channels: ["alpha"],
+  },
+  source: {
+    source: "./index.js",
+    built: "./index.js",
+  },
+};
+
+function mockBundledChannelRuntime(modulePath: string) {
+  vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
+    listBundledChannelPluginMetadata: () => [ALPHA_METADATA],
+    resolveBundledChannelGeneratedPath: () => modulePath,
+  }));
+}
+
+describe("loadGeneratedBundledChannelEntry: structured warn for lock timeout", () => {
+  it("emits structured warn with failureReason=lock_timeout when a lock timeout error is thrown", async () => {
+    const fakeModulePath = path.join("/tmp", "openclaw-alpha", "index.js");
+
+    mockBundledChannelRuntime(fakeModulePath);
+
+    // Mock loadChannelPluginModule to throw a lock timeout error directly.
+    // This bypasses file-system checks while exercising the catch branch in bundled.ts.
+    vi.doMock("./module-loader.js", () => ({
+      isJavaScriptModulePath: () => false,
+      loadChannelPluginModule: () => {
+        throw new Error(LOCK_TIMEOUT_MESSAGE);
+      },
+    }));
+
+    const bundled = await importFreshModule<typeof import("./bundled.js")>(
+      import.meta.url,
+      "./bundled.js?scope=lock-timeout-structured-warn",
+    );
+
+    // getBundledChannelPlugin internally calls loadGeneratedBundledChannelEntry.
+    const result = bundled.getBundledChannelPlugin("alpha");
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("lock timeout"),
+      expect.objectContaining({
+        failureReason: "lock_timeout",
+        bundledChannelId: "alpha",
+        lockDir: FAKE_LOCK_DIR,
+        waitedMs: 300000,
+      }),
+    );
+  });
+
+  it("emits flat string warn for non-lock-timeout module import errors", async () => {
+    const fakeModulePath = path.join("/tmp", "openclaw-alpha", "index.js");
+
+    mockBundledChannelRuntime(fakeModulePath);
+
+    // Mock loadChannelPluginModule to throw a regular module-not-found error.
+    vi.doMock("./module-loader.js", () => ({
+      isJavaScriptModulePath: () => false,
+      loadChannelPluginModule: () => {
+        throw new Error("Cannot find module 'nostr-tools'");
+      },
+    }));
+
+    const bundled = await importFreshModule<typeof import("./bundled.js")>(
+      import.meta.url,
+      "./bundled.js?scope=import-error-flat-warn",
+    );
+
+    const result = bundled.getBundledChannelPlugin("alpha");
+
+    expect(result).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    // Flat string warn — no structured meta object as second argument.
+    const [message, meta] = warn.mock.calls[0] as [string, unknown];
+    expect(message).toContain("failed to load bundled channel alpha");
+    expect(message).toContain("nostr-tools");
+    expect(meta).toBeUndefined();
+  });
+});

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -295,8 +295,10 @@ function parseLockTimeoutErrorMeta(error: unknown): {
     return { lockDir: undefined, waitedMs: undefined };
   }
   const afterPrefix = error.message.slice(LOCK_TIMEOUT_MESSAGE_PREFIX.length);
-  const parenIdx = afterPrefix.indexOf(" (");
-  const lockDir = parenIdx >= 0 ? afterPrefix.slice(0, parenIdx) : undefined;
+  // Use the stable ` (waited=` marker emitted by formatRuntimeDepsLockTimeoutMessage
+  // so paths containing ` (` like `/tmp/OpenClaw (prod)/...` are not truncated.
+  const markerIdx = afterPrefix.indexOf(" (waited=");
+  const lockDir = markerIdx >= 0 ? afterPrefix.slice(0, markerIdx) : undefined;
   const waitedMatch = /waited=(\d+)ms/.exec(error.message);
   const waitedMs = waitedMatch ? Number(waitedMatch[1]) : undefined;
   return { lockDir, waitedMs };

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -260,8 +260,11 @@ function loadGeneratedBundledChannelEntry(params: {
     const detail = formatErrorMessage(error);
     if (isRuntimeDepsLockTimeoutError(error)) {
       const lockTimeoutMeta = parseLockTimeoutErrorMeta(error);
+      // Keep the upstream detail (lockDir, owner, waited, recovery hint) in the
+      // message so pretty/compact console renderers — which drop structured meta —
+      // still surface the diagnostic context.
       log.warn(
-        `[channels] failed to load bundled channel ${params.metadata.manifest.id}: lock timeout`,
+        `[channels] failed to load bundled channel ${params.metadata.manifest.id}: ${detail}`,
         {
           failureReason: "lock_timeout",
           bundledChannelId: params.metadata.manifest.id,

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -258,9 +258,45 @@ function loadGeneratedBundledChannelEntry(params: {
     };
   } catch (error) {
     const detail = formatErrorMessage(error);
-    log.warn(`[channels] failed to load bundled channel ${params.metadata.manifest.id}: ${detail}`);
+    if (isRuntimeDepsLockTimeoutError(error)) {
+      const lockTimeoutMeta = parseLockTimeoutErrorMeta(error);
+      log.warn(
+        `[channels] failed to load bundled channel ${params.metadata.manifest.id}: lock timeout`,
+        {
+          failureReason: "lock_timeout",
+          bundledChannelId: params.metadata.manifest.id,
+          lockDir: lockTimeoutMeta.lockDir,
+          waitedMs: lockTimeoutMeta.waitedMs,
+        },
+      );
+    } else {
+      log.warn(
+        `[channels] failed to load bundled channel ${params.metadata.manifest.id}: ${detail}`,
+      );
+    }
     return null;
   }
+}
+
+const LOCK_TIMEOUT_MESSAGE_PREFIX = "Timed out waiting for bundled runtime deps lock at ";
+
+function isRuntimeDepsLockTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(LOCK_TIMEOUT_MESSAGE_PREFIX);
+}
+
+function parseLockTimeoutErrorMeta(error: unknown): {
+  lockDir: string | undefined;
+  waitedMs: number | undefined;
+} {
+  if (!(error instanceof Error)) {
+    return { lockDir: undefined, waitedMs: undefined };
+  }
+  const afterPrefix = error.message.slice(LOCK_TIMEOUT_MESSAGE_PREFIX.length);
+  const parenIdx = afterPrefix.indexOf(" (");
+  const lockDir = parenIdx >= 0 ? afterPrefix.slice(0, parenIdx) : undefined;
+  const waitedMatch = /waited=(\d+)ms/.exec(error.message);
+  const waitedMs = waitedMatch ? Number(waitedMatch[1]) : undefined;
+  return { lockDir, waitedMs };
 }
 
 function loadGeneratedBundledChannelSetupEntry(params: {


### PR DESCRIPTION
## Summary

- Problem: when `loadGeneratedBundledChannelEntry` (`src/channels/plugins/bundled.ts`) catches a `formatRuntimeDepsLockTimeoutMessage` lock-timeout error, it emits a single flat-string `log.warn` and returns `null`, so structured logging cannot distinguish "channel disabled because the bundled runtime-deps lock timed out" from "channel disabled because the module import failed".
- Why it matters: gs1 production hit `v2026.4.26` with all channels (LINE / Telegram / WhatsApp / Slack) silently disabled, and operators had to grep gateway logs by hand to confirm the lock-timeout origin before applying the stale-lock removal workaround. The same flat-string warn shape is still on `main`.
- What changed: the catch branch now detects lock-timeout origin via a file-local helper and, on hit, emits one structured `log.warn` with `failureReason`, `bundledChannelId`, `lockDir`, `waitedMs`. Non-lock-timeout errors keep the existing flat-string warn and `return null` shape.
- What did NOT change (scope boundary): the silent-skip behavior (`return null` to disable the channel entry) is preserved; no retry/backoff is introduced; the throw side (`bundled-runtime-deps.ts`) is untouched; no public SDK helper is added (the lock-timeout detector and the meta parser are file-local, not exported).

## Change Type (select all)

- [x] Bug fix — observability fix scoped to the catch block
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations — `src/channels/plugins/bundled.ts` (bundled channel loader, catch branch only)

## Linked Issue/PR

- Related #73874 (operator-visible regression whose recovery path the missing structured signal lengthens)
- Related: commit `830bd2e236` (`fix: recover stale runtime deps locks`) and follow-up #74291 (dead-PID test backfill on the same lock surface)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `loadGeneratedBundledChannelEntry` collapses all load failures into the same flat-string `log.warn` before returning `null`, so downstream structured logging has no `failureReason` key for the lock-timeout path.
- Missing detection / guardrail: no `failureReason` field on the bundled channel load path.
- Contributing context: lock-timeout messages already share a stable prefix from `formatRuntimeDepsLockTimeoutMessage`, but the prefix was only used on the throw side, not the catch side.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/channels/plugins/bundled.test.ts`
- Scenario the test should lock in: when the bundled-channel loader catches a lock-timeout error (message starts with `LOCK_TIMEOUT_MESSAGE_PREFIX`), it emits one structured warn with `failureReason: "lock_timeout"` plus `bundledChannelId` / `lockDir` / `waitedMs`; when it catches any other error, it keeps the existing flat-string warn and returns `null`.
- Why this is the smallest reliable guardrail: the catch branch is the only place in the loader that translates a thrown error into operator-visible logging, so a small set of `it` blocks (lock-timeout vs. non-lock-timeout) covers the entire decision.
- Existing test that already covers this (if any): none — `bundled.test.ts` did not previously assert on the catch branch's logging shape.
- If no new test is added, why not: N/A; new tests are added.

## User-visible / Behavior Changes

None for end users. Operator-visible logging gains a `failureReason: "lock_timeout"` field on the bundled-channel load failure path. The silent-skip behavior (channel disabled when load fails) is unchanged.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.8 (Ubuntu 22.04, Node v22.x, pnpm 10.x)
- Runtime/container: Node, pnpm
- Model/provider: N/A
- Integration/channel (if any): bundled channels (LINE / Telegram / WhatsApp / Slack) — load path only
- Relevant config (redacted): N/A

### Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm test src/channels/plugins/bundled.test.ts`

### Expected

- New tests pass, covering: (a) lock-timeout error → structured warn with `failureReason: "lock_timeout"` and parsed `lockDir` / `waitedMs`; (b) non-lock-timeout error → existing flat-string warn, `null` return preserved.

### Actual

- New tests pass.

## Evidence

- [x] Passing targeted test output — see below.
- [x] Regression coverage added — `bundled.test.ts` previously had no catch-branch logging-shape assertions; the new `it` blocks lock in the lock-timeout and non-lock-timeout branches.

```
Test Files  1 passed (1)
Tests  2 passed (2)
```

Locally also verified via `pnpm check:changed` (lanes: core, coreTests, extensions, extensionTests — lint 0/0, typecheck pass, import cycles 0).

## Human Verification (required)

- Verified scenarios: lock-timeout error path emits the structured warn with `failureReason: "lock_timeout"`, `bundledChannelId`, `lockDir`, `waitedMs`; non-lock-timeout error path keeps the existing flat-string warn and `null` return.
- Edge cases checked: a lock-timeout-like error whose message does not start with `LOCK_TIMEOUT_MESSAGE_PREFIX` falls through to the existing flat-string branch, avoiding false positives on the structured field.
- What I did not verify: end-to-end gateway-side observability assertion (the structured field reaches a real downstream sink). Out of scope for this catch-branch-local fix.

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address in this PR.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — additive structured field on an existing warn; flat-string fallback is preserved for non-lock-timeout errors and the silent-skip behavior is unchanged.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: the metadata parser is intentionally coupled to the current `formatRuntimeDepsLockTimeoutMessage` shape.
  - Mitigation: classification depends only on the stable prefix; `lockDir` / `waitedMs` are best-effort fields and fall back to `undefined` if parsing fails. The loader behavior still returns `null` as before.
- Risk: maintainers may prefer a typed error or `cause`-based classification.
  - Mitigation: this PR keeps the change file-local and catch-side only. A typed error can be introduced later on the throw side without changing the operator-visible `failureReason` contract.
