### PR TITLE
fix(discord): avoid resolving tokens for read-only accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Discord: keep read-only allowlist/default-target accessors from resolving SecretRef-backed bot tokens, so status and channel summaries no longer fail when tokens are only available in gateway runtime. (#74737) Thanks @eusine.
 - Channels/groups: preserve observe-only turn suppression for prepared dispatch paths and restore deprecated channel turn runtime aliases, so passive observer/group flows stay silent while older plugins keep compiling. Thanks @vincentkoc.
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
 - macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.

--- a/extensions/discord/src/shared.test.ts
+++ b/extensions/discord/src/shared.test.ts
@@ -128,4 +128,32 @@ describe("discordConfigAdapter", () => {
       "123456789",
     ]);
   });
+
+  it("keeps read-only accessors from resolving token SecretRefs", () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          discord_token: {
+            source: "file",
+            path: "/tmp/openclaw-missing-discord-token",
+            mode: "singleValue",
+          },
+        },
+      },
+      channels: {
+        discord: {
+          token: { source: "file", provider: "discord_token", id: "value" },
+          allowFrom: ["1128540374256849009"],
+          defaultTo: "1498959610751750304",
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(discordConfigAdapter.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
+      "1128540374256849009",
+    ]);
+    expect(discordConfigAdapter.resolveDefaultTo?.({ cfg, accountId: "default" })).toBe(
+      "1498959610751750304",
+    );
+  });
 });

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -1,4 +1,5 @@
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createScopedChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
@@ -7,6 +8,7 @@ import { inspectDiscordAccount } from "./account-inspect.js";
 import {
   isDiscordAccountEnabledForRuntime,
   listDiscordAccountIds,
+  mergeDiscordAccountConfig,
   resolveDefaultDiscordAccountId,
   resolveDiscordAccount,
   resolveDiscordAccountAllowFrom,
@@ -66,10 +68,13 @@ function resolveDiscordConfigAccessorAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
 }): DiscordConfigAccessorAccount {
-  const account = resolveDiscordAccount(params);
+  const accountId = normalizeAccountId(
+    params.accountId ?? resolveDefaultDiscordAccountId(params.cfg),
+  );
+  const config = mergeDiscordAccountConfig(params.cfg, accountId);
   return {
-    allowFrom: resolveDiscordAccountAllowFrom({ cfg: params.cfg, accountId: account.accountId }),
-    defaultTo: account.config.defaultTo,
+    allowFrom: resolveDiscordAccountAllowFrom({ cfg: params.cfg, accountId }),
+    defaultTo: config.defaultTo,
   };
 }
 


### PR DESCRIPTION
## Summary
- avoid resolving Discord bot tokens when read-only config accessors only need allowFrom/defaultTo
- keep SecretRef-backed tokens from throwing during status/channel summary paths
- add regression coverage for Discord read-only accessors with file SecretRefs

## Test plan
- bunx oxfmt --check extensions/discord/src/shared.ts extensions/discord/src/shared.test.ts
- bunx vitest run extensions/discord/src/shared.test.ts extensions/discord/src/account-inspect.test.ts extensions/discord/src/token.test.ts src/commands/channels.config-only-status-output.test.ts
- node --import tsx --eval "import { buildChannelsTable } from './src/commands/status-all/channels.ts'; const cfg={channels:{discord:{enabled:true,token:{source:'file',provider:'discord_token',id:'value'},allowFrom:['1128540374256849009'],defaultTo:'1498959610751750304'}},secrets:{providers:{discord_token:{source:'file',path:'/tmp/nope',mode:'singleValue'}}}}; buildChannelsTable(cfg,{sourceConfig:cfg,showSecrets:false,includeSetupRuntimeFallback:true}).then(r=>console.log(JSON.stringify(r.rows))).catch(e=>{console.error(e.stack); process.exit(1);});"

Note: `bun run start status --timeout 5000` could not run in this clone because the source build script shells out to `pnpm`, which is not installed in this environment (`spawn pnpm ENOENT`).