### PR TITLE
fix(bedrock): expose xhigh + adaptive thinking for Claude Opus 4.7

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -253,6 +253,27 @@ describe("amazon-bedrock provider plugin", () => {
     });
   });
 
+  it("includes xhigh and adaptive for Claude Opus 4.7 Bedrock models", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    for (const modelId of [
+      "us.anthropic.claude-opus-4-7",
+      "us.anthropic.claude-opus-4.7-v1:0",
+      "eu.anthropic.claude-opus-4-7",
+      "arn:aws:bedrock:us-west-2:123456789012:inference-profile/us.anthropic.claude-opus-4-7",
+    ]) {
+      const profile = provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId,
+      } as never);
+      expect(profile).toMatchObject({
+        levels: expect.arrayContaining([{ id: "xhigh" }, { id: "adaptive" }]),
+      });
+      // Opus 4.7 should not auto-default to adaptive (matches native anthropic behavior).
+      expect(profile?.defaultLevel).toBeUndefined();
+    }
+  });
+
   it("owns Anthropic-style replay policy for Claude Bedrock models", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -290,6 +290,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
   // initialization during test bootstrap cannot trip TDZ reads.
   const providerId = "amazon-bedrock";
   const claude46ModelRe = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
+  const claudeOpus47ModelRe = /claude-opus-4(?:\.|-)7(?:$|[-.:])/i;
   // Match region from bedrock-runtime (Converse API) URLs.
   // e.g. https://bedrock-runtime.us-east-1.amazonaws.com
   const bedrockRegionRe = /bedrock-runtime\.([a-z0-9-]+)\.amazonaws\./;
@@ -521,16 +522,22 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
       }
       return undefined;
     },
-    resolveThinkingProfile: ({ modelId }) => ({
-      levels: [
-        { id: "off" },
-        { id: "minimal" },
-        { id: "low" },
-        { id: "medium" },
-        { id: "high" },
-        ...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
-      ],
-      defaultLevel: claude46ModelRe.test(modelId.trim()) ? "adaptive" : undefined,
-    }),
+    resolveThinkingProfile: ({ modelId }) => {
+      const trimmed = modelId.trim();
+      const isOpus47 = claudeOpus47ModelRe.test(trimmed);
+      const isClaude46 = claude46ModelRe.test(trimmed);
+      return {
+        levels: [
+          { id: "off" },
+          { id: "minimal" },
+          { id: "low" },
+          { id: "medium" },
+          { id: "high" },
+          ...(isOpus47 ? [{ id: "xhigh" as const }] : []),
+          ...(isOpus47 || isClaude46 ? [{ id: "adaptive" as const }] : []),
+        ],
+        defaultLevel: isClaude46 ? "adaptive" : undefined,
+      };
+    },
   });
 }


### PR DESCRIPTION
Fixes #74701.

## Problem

The `amazon-bedrock` provider's `resolveThinkingProfile` only exposed `off / minimal / low / medium / high` for Claude 4.7 models. Native Anthropic supports two extra levels for Opus 4.7 (`xhigh`, `adaptive`), so Bedrock users couldn't access them from the OpenClaw model picker.

## Fix

Detect Opus 4.7 model ids and append `xhigh` + `adaptive` to the levels list. Bedrock model ids for 4.7 take a few shapes — all matched by the new regex:

- `us.anthropic.claude-opus-4-7`
- `us.anthropic.claude-opus-4.7-v1:0`
- `eu.anthropic.claude-opus-4-7`
- inference-profile ARNs ending in `claude-opus-4-7`

`defaultLevel` stays `undefined` for 4.7 to mirror native Anthropic behaviour. Existing 4.6 adaptive default is preserved.

## Tests

Added a new `it("includes xhigh and adaptive for Claude Opus 4.7 Bedrock models", ...)` covering all 4 id shapes. All 59 tests in `extensions/amazon-bedrock` pass:

```
✓ extensions/amazon-bedrock/index.test.ts (30 tests)
✓ extensions/amazon-bedrock/discovery.test.ts (16 tests)
✓ extensions/amazon-bedrock/memory-embedding-adapter.test.ts (4 tests)
✓ extensions/amazon-bedrock/config-compat.test.ts (2 tests)
✓ extensions/amazon-bedrock/embedding-provider.test.ts (5 tests)
✓ extensions/amazon-bedrock/lazy-import.test.ts (2 tests)

Test Files  6 passed (6)
     Tests  59 passed (59)
```

Signed-off-by: Sanjay Santhanam &lt;51058514+Sanjays2402@users.noreply.github.com&gt;