### PR TITLE
fix(signal): keep SSE receive stream open

### DIFF
--- a/extensions/signal/src/client.test.ts
+++ b/extensions/signal/src/client.test.ts
@@ -202,6 +202,31 @@ describe("streamSignalEvents", () => {
     expect(events).toEqual([{ id: "42", event: "message", data: '{"group":true}' }]);
   });
 
+  it("does not apply the RPC default deadline to event streams", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const events: Array<import("./client.js").SignalSseEvent> = [];
+    let armedDefaultDeadline = false;
+    const baseUrl = await withSignalServer((req, res) => {
+      expect(req.url).toBe("/api/v1/events");
+      expect(req.headers.accept).toBe("text/event-stream");
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end('event: receive\ndata: {"message":"ping"}\n\n');
+    });
+
+    try {
+      await streamSignalEvents({
+        baseUrl,
+        onEvent: (event) => events.push(event),
+      });
+      armedDefaultDeadline = setTimeoutSpy.mock.calls.some(([, delay]) => delay === 10_000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(events).toEqual([{ event: "receive", data: '{"message":"ping"}' }]);
+    expect(armedDefaultDeadline).toBe(false);
+  });
+
   it("reports HTTP status failures from the event stream", async () => {
     const baseUrl = await withSignalServer((_req, res) => {
       res.writeHead(503, "Unavailable");
@@ -216,7 +241,7 @@ describe("streamSignalEvents", () => {
     ).rejects.toThrow("Signal SSE failed (503 Unavailable)");
   });
 
-  it("rejects event streams that do not send headers before the deadline", async () => {
+  it("honors explicit event stream deadlines before response headers arrive", async () => {
     const baseUrl = await withSignalServer(() => {
       // Leave the request open without response headers.
     });

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -235,7 +235,7 @@ export async function signalCheck(
 function openSignalEventStream(
   url: URL,
   abortSignal?: AbortSignal,
-  timeoutMs = DEFAULT_TIMEOUT_MS,
+  timeoutMs?: number,
 ): Promise<{ response: IncomingMessage; cleanup: () => void }> {
   assertSignalHttpProtocol(url, "SSE");
   if (abortSignal?.aborted) {
@@ -248,15 +248,20 @@ function openSignalEventStream(
     let response: IncomingMessage | undefined;
     let onAbort: () => void = () => {};
     let request: ClientRequest;
-    const headerDeadline = setTimeout(() => {
-      const error = new Error(`Signal SSE connection timed out after ${timeoutMs}ms`);
-      response?.destroy(error);
-      request.destroy(error);
-      rejectOnce(error);
-    }, timeoutMs);
-    headerDeadline.unref?.();
+    let headerDeadline: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutMs !== undefined) {
+      headerDeadline = setTimeout(() => {
+        const error = new Error(`Signal SSE connection timed out after ${timeoutMs}ms`);
+        response?.destroy(error);
+        request.destroy(error);
+        rejectOnce(error);
+      }, timeoutMs);
+      headerDeadline.unref?.();
+    }
     const cleanup = () => {
-      clearTimeout(headerDeadline);
+      if (headerDeadline) {
+        clearTimeout(headerDeadline);
+      }
       abortSignal?.removeEventListener("abort", onAbort);
     };
     const rejectOnce = (error: unknown) => {
@@ -284,7 +289,9 @@ function openSignalEventStream(
           res.destroy();
           return;
         }
-        clearTimeout(headerDeadline);
+        if (headerDeadline) {
+          clearTimeout(headerDeadline);
+        }
         settled = true;
         response = res;
         resolve({ response: res, cleanup });
@@ -318,7 +325,7 @@ export async function streamSignalEvents(params: {
   const { response, cleanup } = await openSignalEventStream(
     url,
     params.abortSignal,
-    params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    params.timeoutMs,
   );
   const decoder = new TextDecoder();
   let buffer = "";


### PR DESCRIPTION
## Summary

Fixes the native Signal `/api/v1/events` consumer so the long-lived SSE stream no longer inherits the bounded RPC/check 10s deadline by default.

## Root Cause

The Signal client used `DEFAULT_TIMEOUT_MS` for both bounded HTTP calls and the long-lived SSE receive stream. When `signal-cli` kept `/api/v1/events` quiet until the next inbound event, OpenClaw could abort the stream after 10 seconds and reconnect repeatedly before observing inbound activity.

## Linked Issue

Fixes #74741.

## Why This Is Safe

The change is scoped to the SSE event-stream opener. Explicit `timeoutMs` values are still honored for callers that need a bounded header wait, and the existing stream abort, HTTP status failure, buffer limit, parse, cleanup, and reconnect paths remain unchanged.

## Security / Runtime Controls Unchanged

This does not change Signal account selection, allowlists, DM/group policy, authentication, provider routing, secret handling, message parsing limits, network destinations, or command/tool execution policy. The fix relies on runtime HTTP stream lifecycle and abort handling, not prompt text.

## Tests Run

- `pnpm test extensions/signal/src/client.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 extensions/signal/src/client.ts extensions/signal/src/client.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

Note: I refreshed the local install with `pnpm install` before the final `pnpm check:changed` rerun because `node_modules` had stale `oxlint` 1.61.0 while current `package.json` requires 1.62.0. No tracked dependency files changed.

## Overlap

This overlaps #73086, which also addresses the idle Signal SSE timeout. Chosen path: keep this draft as the smaller issue-linked alternative for #74741; if #73086 lands first, this draft should be closed instead of merged.

## Out Of Scope

- No Signal send/RPC/check deadline changes.
- No reconnect/backoff policy changes.
- No config default, docs, generated artifact, or migration changes.
- No live Signal account or external `signal-cli` integration run in this PR.

## Contributing Note

AI-assisted change; reviewed against the final diff and validated with the focused checks above.

Made with [Cursor](https://cursor.com)