### PR TITLE
chore(ci): add CodeQL PR security guard

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,12 +11,20 @@ on:
         options:
           - all
           - security
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/actions/**"
+      - ".github/codeql/**"
+      - ".github/workflows/**"
+      - "packages/**"
+      - "src/**"
   schedule:
     - cron: "0 6 * * *"
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.sha }}
-  cancel-in-progress: false
+  group: codeql-${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -29,7 +37,7 @@ permissions:
 jobs:
   critical-security:
     name: Critical Security (${{ matrix.category }})
-    if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'security' }}
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'security') }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -256,10 +256,10 @@ landed PR is merged and that each duplicate has either a shared referenced issue
 or overlapping changed hunks.
 
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner,
-not the full repository sweep. Daily and manual runs scan Actions workflow code
-plus the highest-risk JavaScript/TypeScript auth, secrets, sandbox, cron, and
-gateway surfaces with high-precision security queries under the
-`/codeql-critical-security/core-auth-secrets` category. The
+not the full repository sweep. Daily, manual, and non-draft pull request guard
+runs scan Actions workflow code plus the highest-risk JavaScript/TypeScript
+auth, secrets, sandbox, cron, and gateway surfaces with high-precision security
+queries under the `/codeql-critical-security/core-auth-secrets` category. The
 channel-runtime-boundary job separately scans core channel implementation
 contracts plus the channel plugin runtime, gateway, Plugin SDK, secrets, and
 audit touchpoints under the `/codeql-critical-security/channel-runtime-boundary`
@@ -278,6 +278,10 @@ source-loading, public-surface, and Plugin SDK package contract trust surfaces
 under the `/codeql-critical-security/plugin-trust-boundary` category so plugin
 supply-chain and runtime-loading signal stays separate from both bundled plugin
 implementation code and the non-security plugin quality shard.
+The pull request guard stays light: it only starts for changes under
+`.github/actions`, `.github/codeql`, `.github/workflows`, `packages`, or `src`,
+and it runs the same critical-security matrix as the scheduled workflow. Android,
+macOS, and non-security quality CodeQL stay out of PR defaults.
 
 The `CodeQL Android Critical Security` workflow is the scheduled Android
 security shard. It builds the Android app manually for CodeQL on the smallest


### PR DESCRIPTION
## Summary
- runs the existing narrow CodeQL critical-security matrix on non-draft pull requests
- keeps PR triggering path-scoped to `.github/actions`, `.github/codeql`, `.github/workflows`, `packages`, and `src`
- keeps Android, macOS, and non-security quality CodeQL out of PR defaults

## Verification
- YAML parse for `.github/workflows/codeql.yml`
- `git diff --check`
- `pnpm check:workflows`
