### PR TITLE
fix(agents): strip replay metadata placeholder from user-facing text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -217,10 +217,26 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("A\n[tool calls omitted]\n[tool calls omitted]\nB")).toBe("A\nB");
   });
 
+  it("strips copied inbound metadata replay placeholders without trimming visible text", () => {
+    expect(sanitizeUserFacingText("[assistant copied inbound metadata omitted]")).toBe("");
+    expect(sanitizeUserFacingText("  [assistant copied inbound metadata omitted]\t")).toBe("");
+    expect(
+      sanitizeUserFacingText("Hello\n\n[assistant copied inbound metadata omitted]\nWorld\n"),
+    ).toBe("Hello\n\nWorld\n");
+    expect(
+      sanitizeUserFacingText(
+        "A\n[assistant copied inbound metadata omitted]\n[assistant copied inbound metadata omitted]\nB",
+      ),
+    ).toBe("A\nB");
+  });
+
   it("keeps ordinary inline mentions of the replay placeholder", () => {
     expect(sanitizeUserFacingText("What does [tool calls omitted] mean?")).toBe(
       "What does [tool calls omitted] mean?",
     );
+    expect(
+      sanitizeUserFacingText("What does [assistant copied inbound metadata omitted] mean?"),
+    ).toBe("What does [assistant copied inbound metadata omitted] mean?");
   });
 
   it("strips marked internal runtime context blocks but keeps real reply text", () => {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -41,7 +41,8 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
-const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const REPLAY_PLACEHOLDER_LINE_RE =
+  /^[ \t]*\[(?:tool calls omitted|assistant copied inbound metadata omitted)\][ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -333,7 +334,7 @@ function stripFinalTagsFromText(text: unknown): string {
   return normalized.replace(FINAL_TAG_RE, "");
 }
 
-function stripToolCallsOmittedPlaceholderLines(text: string): string {
+function stripReplayPlaceholderLines(text: string): string {
   let result = "";
   let start = 0;
   while (start < text.length) {
@@ -341,7 +342,7 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
     const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const chunk = text.slice(start, end);
     const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
-    if (!TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line)) {
+    if (!REPLAY_PLACEHOLDER_LINE_RE.test(line)) {
       result += chunk;
     }
     start = end;
@@ -403,7 +404,7 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
-  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(stripped);
+  const withoutPlaceholder = stripReplayPlaceholderLines(stripped);
   const trimmed = withoutPlaceholder.trim();
   if (!trimmed) {
     return "";

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -112,6 +112,22 @@ describe("normalizeReplyPayload", () => {
     }
   });
 
+  it("strips replay metadata placeholder from outbound replies (#74745)", () => {
+    const result = normalizeReplyPayload({
+      text: "Hello\n[assistant copied inbound metadata omitted]\nWorld",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Hello\nWorld");
+    expect(result!.text).not.toContain("assistant copied inbound metadata omitted");
+  });
+
+  it("strips standalone replay metadata placeholder (#74745)", () => {
+    const result = normalizeReplyPayload({
+      text: "[assistant copied inbound metadata omitted]",
+    });
+    expect(result).toBeNull(); // Empty after stripping
+  });
+
   it("strips NO_REPLY from mixed emoji message (#30916)", () => {
     const result = normalizeReplyPayload({ text: "😄 NO_REPLY" });
     expect(result).not.toBeNull();


### PR DESCRIPTION
## Summary

- Problem: Internal replay placeholder `[assistant copied inbound metadata omitted]` is leaking into outbound Telegram messages after 2026.4.27
- Why it matters: Users see internal scaffolding text instead of (or in addition to) the actual assistant response
- What changed: Extended the existing replay placeholder stripping to also filter this metadata placeholder
- What did NOT change: Inline mentions of the placeholder (e.g. user asking "what does this mean?") are preserved

**Regression**: Introduced in `ee8f41f56e` (2026-04-26) which added the placeholder in `replay-history.ts` but did not add corresponding filtering in `sanitize-user-facing-text.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74745
- Related to `ee8f41f56e` (commit that introduced the placeholder)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `normalizeAssistantReplayContent` in `replay-history.ts` synthesizes `[assistant copied inbound metadata omitted]` when stripped assistant replay text becomes empty, but `sanitizeUserFacingText` only stripped `[tool calls omitted]` placeholder lines
- Missing detection / guardrail: The new placeholder was not added to the outbound sanitizer
- Contributing context: If LLM echoes the replay history or certain edge cases occur, the placeholder leaks to user-facing delivery

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- Target test file: `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Scenario the test should lock in: Standalone `[assistant copied inbound metadata omitted]` lines are stripped, inline mentions are preserved
- Why this is the smallest reliable guardrail: Tests the central sanitizer that all outbound paths use
- Existing test that already covers this: None for this specific placeholder

## User-visible / Behavior Changes

- Internal placeholder text no longer appears in delivered messages
- Users receive actual assistant responses instead of scaffolding text

## Diagram (if applicable)

```text
Before:
[replay-history synthesizes placeholder] -> [sanitizer misses it] -> [user sees "[assistant copied inbound metadata omitted]"]

After:
[replay-history synthesizes placeholder] -> [sanitizer strips it] -> [user sees actual response or empty string]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js v22.22.0
- Model/provider: Any
- Integration/channel: Telegram (reported), affects all channels

### Steps

1. Trigger a session where replay-history synthesizes the metadata placeholder
2. Observe outbound message delivery

### Expected

- Placeholder is stripped; user sees actual response

### Actual

- Works as expected after fix

## Evidence

- [x] Failing test/log before + passing after

```
pnpm test src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
# All tests pass including new regression tests
```

New tests verify:
```ts
expect(sanitizeUserFacingText("[assistant copied inbound metadata omitted]")).toBe("");
expect(sanitizeUserFacingText("Hello\n\n[assistant copied inbound metadata omitted]\nWorld\n")).toBe("Hello\n\nWorld\n");
// Inline mentions preserved
expect(sanitizeUserFacingText("What does [assistant copied inbound metadata omitted] mean?"))
  .toBe("What does [assistant copied inbound metadata omitted] mean?");
```

## Human Verification (required)

- Verified scenarios: Unit tests pass, code review, regex logic inspection
- Edge cases checked: Standalone line, multiple lines, inline mention preservation
- What you did NOT verify: E2E session replay (unit tests cover the sanitizer path)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Regex could over-match and strip legitimate user content
  - Mitigation: Only matches exact standalone placeholder lines (with optional whitespace); inline mentions are preserved by design and tested