### PR TITLE
fix(acp): expose child process PID in sessions_spawn results #74684

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -517,6 +517,95 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(baseStore.load).toHaveBeenCalledOnce();
   });
 
+  it("extracts pid from the delegate ensureSession result", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude",
+      pid: 99_123,
+    } as never);
+
+    const result = await runtime.ensureSession({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "persistent",
+    });
+
+    expect(result.pid).toBe(99_123);
+    expect(result.sessionKey).toBe("agent:claude:acp:test");
+    expect(result.backend).toBe("acpx");
+    expect(result.runtimeSessionName).toBe("claude");
+  });
+
+  it("omits pid from ensureSession result when delegate does not expose one", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude",
+    });
+
+    const result = await runtime.ensureSession({
+      sessionKey: "agent:claude:acp:test",
+      agent: "claude",
+      mode: "persistent",
+    });
+
+    expect(result).not.toHaveProperty("pid");
+  });
+
+  it("extracts pid from the delegate getStatus result", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    vi.spyOn(delegate, "getStatus").mockResolvedValue({
+      summary: "running",
+      pid: 55_432,
+    } as never);
+    const handle: Parameters<NonNullable<AcpRuntime["getStatus"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude-session",
+    };
+
+    const status = await runtime.getStatus({ handle });
+
+    expect(status.pid).toBe(55_432);
+    expect(status.summary).toBe("running");
+  });
+
+  it("extracts pid from the delegate getStatus details when not at the top level", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    vi.spyOn(delegate, "getStatus").mockResolvedValue({
+      summary: "running",
+      details: { pid: 33_211 },
+    });
+    const handle: Parameters<NonNullable<AcpRuntime["getStatus"]>>[0]["handle"] = {
+      sessionKey: "agent:claude:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "claude-session",
+    };
+
+    const status = await runtime.getStatus({ handle });
+
+    expect(status.pid).toBe(33_211);
+  });
+
   it("routes openclaw ensureSession through the bridge-safe delegate when MCP servers are configured", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { AcpRuntimeHandle as CoreAcpRuntimeHandle, AcpRuntimeStatus as CoreAcpRuntimeStatus } from "openclaw/plugin-sdk/acp-runtime-backend";
 import {
   ACPX_BACKEND_ID,
   AcpxRuntime as BaseAcpxRuntime,
@@ -392,6 +393,31 @@ function shouldUseDistinctBridgeDelegate(options: AcpRuntimeOptions): boolean {
   return Array.isArray(mcpServers) && mcpServers.length > 0;
 }
 
+function resolvePidFromHandle(handle: AcpRuntimeHandle): CoreAcpRuntimeHandle {
+  const pid = resolvePidFromUnknown(handle);
+  return {
+    ...handle,
+    ...(typeof pid === "number" ? { pid } : {}),
+  };
+}
+
+function resolvePidFromStatus(status: AcpRuntimeStatus): CoreAcpRuntimeStatus {
+  const pid = resolvePidFromUnknown(status) ?? resolvePidFromUnknown(status.details);
+  return {
+    ...status,
+    ...(typeof pid === "number" ? { pid } : {}),
+  };
+}
+
+function resolvePidFromUnknown(value: unknown): number | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const obj = value as Record<string, unknown>;
+  const pid = obj["pid"];
+  return typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
 export class AcpxRuntime implements AcpRuntime {
   private readonly sessionStore: ResetAwareSessionStore;
   private readonly agentRegistry: AcpAgentRegistry;
@@ -491,7 +517,7 @@ export class AcpxRuntime implements AcpRuntime {
         : undefined;
 
     if (!codexModelOverride) {
-      return delegate.ensureSession(input);
+      return resolvePidFromHandle(await delegate.ensureSession(input));
     }
 
     const normalizedInput = {
@@ -500,8 +526,10 @@ export class AcpxRuntime implements AcpRuntime {
         ? { model: codexAcpSessionModelId(codexModelOverride) }
         : {}),
     };
-    return this.codexAcpModelOverrideScope.run(codexModelOverride, () =>
-      delegate.ensureSession(normalizedInput),
+    return resolvePidFromHandle(
+      await this.codexAcpModelOverrideScope.run(codexModelOverride, () =>
+        delegate.ensureSession(normalizedInput),
+      ),
     );
   }
 
@@ -517,7 +545,7 @@ export class AcpxRuntime implements AcpRuntime {
     input: Parameters<NonNullable<AcpRuntime["getStatus"]>>[0],
   ): Promise<AcpRuntimeStatus> {
     const delegate = await this.resolveDelegateForHandle(input.handle);
-    return delegate.getStatus(input);
+    return resolvePidFromStatus(await delegate.getStatus(input));
   }
 
   async setMode(input: Parameters<NonNullable<AcpRuntime["setMode"]>>[0]): Promise<void> {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -370,6 +370,7 @@ export class AcpSessionManager {
         cwd: effectiveCwd,
         state: "idle",
         lastActivityAt: Date.now(),
+        ...(typeof handle.pid === "number" ? { pid: handle.pid } : {}),
       };
 
       let persisted: SessionEntry | null = null;
@@ -497,6 +498,11 @@ export class AcpSessionManager {
           runtimeStatus,
           lastActivityAt: meta.lastActivityAt,
           lastError: meta.lastError,
+          ...(typeof runtimeStatus?.pid === "number"
+            ? { pid: runtimeStatus.pid }
+            : typeof meta.pid === "number"
+              ? { pid: meta.pid }
+              : {}),
         };
       },
       params.signal,
@@ -1509,6 +1515,11 @@ export class AcpSessionManager {
       state: previousMeta.state,
       lastActivityAt: now,
       ...(previousMeta.lastError ? { lastError: previousMeta.lastError } : {}),
+      ...(typeof ensured.pid === "number"
+        ? { pid: ensured.pid }
+        : typeof previousMeta.pid === "number"
+          ? { pid: previousMeta.pid }
+          : {}),
     };
     const shouldPersistMeta =
       previousMeta.backend !== nextMeta.backend ||
@@ -1517,6 +1528,7 @@ export class AcpSessionManager {
       previousMeta.agent !== nextMeta.agent ||
       previousMeta.cwd !== nextMeta.cwd ||
       !runtimeOptionsEqual(previousMeta.runtimeOptions, nextMeta.runtimeOptions) ||
+      previousMeta.pid !== nextMeta.pid ||
       hasLegacyAcpIdentityProjection(previousMeta);
     if (shouldPersistMeta) {
       await this.writeSessionMeta({
@@ -1617,6 +1629,7 @@ export class AcpSessionManager {
           state: base.state,
           lastActivityAt: Date.now(),
           ...(base.lastError ? { lastError: base.lastError } : {}),
+          ...(typeof base.pid === "number" ? { pid: base.pid } : {}),
         };
       },
       failOnError: true,
@@ -1773,6 +1786,7 @@ export class AcpSessionManager {
           state: base.state,
           lastActivityAt: now,
           ...(base.lastError ? { lastError: base.lastError } : {}),
+          ...(typeof base.pid === "number" ? { pid: base.pid } : {}),
         };
       },
     });
@@ -1822,6 +1836,7 @@ export class AcpSessionManager {
           ...(base.cwd ? { cwd: base.cwd } : {}),
           state: "idle",
           lastActivityAt: now,
+          ...(typeof base.pid === "number" ? { pid: base.pid } : {}),
         };
       },
       failOnError: true,
@@ -1920,6 +1935,7 @@ export class AcpSessionManager {
           state: params.state,
           lastActivityAt: Date.now(),
           ...(base.lastError ? { lastError: base.lastError } : {}),
+          ...(typeof base.pid === "number" ? { pid: base.pid } : {}),
         };
         const lastError = normalizeText(params.lastError);
         if (lastError) {

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -93,6 +93,8 @@ export type AcpSessionStatus = {
   runtimeStatus?: AcpRuntimeStatus;
   lastActivityAt: number;
   lastError?: string;
+  /** OS process PID of the ACP adapter/child agent process, if available. */
+  pid?: number;
 };
 
 export type AcpManagerObservabilitySnapshot = {

--- a/src/acp/runtime/types.ts
+++ b/src/acp/runtime/types.ts
@@ -29,6 +29,8 @@ export type AcpRuntimeHandle = {
   backendSessionId?: string;
   /** Upstream harness session identifier, if exposed by adapter/runtime. */
   agentSessionId?: string;
+  /** OS process PID of the ACP adapter/child agent process, if available. */
+  pid?: number;
 };
 
 export type AcpRuntimeEnsureInput = {
@@ -75,6 +77,8 @@ export type AcpRuntimeStatus = {
   backendSessionId?: string;
   /** Upstream harness session identifier, if known at status time. */
   agentSessionId?: string;
+  /** OS process PID of the ACP adapter/child agent process, if available. */
+  pid?: number;
   details?: Record<string, unknown>;
 };
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -2655,6 +2655,69 @@ describe("spawnAcpDirect", () => {
     );
   });
 
+  it("includes pid in spawn result when the runtime handle exposes one", async () => {
+    hoisted.initializeSessionMock.mockImplementationOnce(async (argsUnknown: unknown) => {
+      const args = argsUnknown as AcpInitializeSessionInput;
+      const runtimeSessionName = `${args.sessionKey}:runtime`;
+      return {
+        runtime: {
+          close: vi.fn().mockResolvedValue(undefined),
+        },
+        handle: {
+          sessionKey: args.sessionKey,
+          backend: "acpx",
+          runtimeSessionName,
+          agentSessionId: "codex-inner-1",
+          backendSessionId: "acpx-1",
+          pid: 42_789,
+        },
+        meta: {
+          backend: "acpx",
+          agent: args.agent,
+          runtimeSessionName,
+          identity: {
+            state: "pending",
+            source: "ensure",
+            acpxSessionId: "acpx-1",
+            agentSessionId: "codex-inner-1",
+            lastUpdatedAt: Date.now(),
+          },
+          mode: args.mode,
+          state: "idle",
+          lastActivityAt: Date.now(),
+        },
+      };
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.pid).toBe(42_789);
+  });
+
+  it("omits pid from spawn result when the runtime handle does not expose one", async () => {
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted).not.toHaveProperty("pid");
+  });
+
   it("disposes pre-registered parent relay when initial ACP dispatch fails", async () => {
     const relayHandle = createRelayHandle();
     hoisted.startAcpSpawnParentStreamRelayMock.mockReturnValueOnce(relayHandle);

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -148,6 +148,7 @@ type SpawnAcpResultFields = {
   inlineDelivery?: boolean;
   streamLogPath?: string;
   note?: string;
+  pid?: number;
 };
 
 type SpawnAcpAcceptedResult = SpawnAcpResultFields & {
@@ -1289,6 +1290,7 @@ export async function spawnAcpDirect(
   let binding: SessionBindingRecord | null = null;
   let sessionCreated = false;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let initializedPid: number | undefined;
   try {
     await callGateway({
       method: "sessions.patch",
@@ -1313,6 +1315,7 @@ export async function spawnAcpDirect(
       cwd: runtimeCwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;
+    initializedPid = initializedSession.initialized.handle.pid;
 
     if (preparedBinding) {
       ({ binding } = await bindPreparedAcpThread({
@@ -1463,6 +1466,7 @@ export async function spawnAcpDirect(
       runId: childRunId,
       mode: spawnMode,
       ...(streamLogPath ? { streamLogPath } : {}),
+      ...(typeof initializedPid === "number" ? { pid: initializedPid } : {}),
       note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
     };
   }
@@ -1496,6 +1500,7 @@ export async function spawnAcpDirect(
     runId: childRunId,
     mode: spawnMode,
     ...(deliveryPlan.useInlineDelivery ? { inlineDelivery: true } : {}),
+    ...(typeof initializedPid === "number" ? { pid: initializedPid } : {}),
     note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
   };
 }

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -49,6 +49,8 @@ export type SessionAcpMeta = {
   state: "idle" | "running" | "error";
   lastActivityAt: number;
   lastError?: string;
+  /** OS process PID of the ACP adapter/child agent process, if available. */
+  pid?: number;
 };
 
 export type AcpSessionRuntimeOptions = {


### PR DESCRIPTION
## Summary
Fixes #74684

### Issue
[sessions_spawn does not expose child process PID for running ACP sessions](https://github.com/openclaw/openclaw/issues/74684)

### Solution
Add optional `pid` field to `AcpRuntimeHandle`, `AcpRuntimeStatus`, `AcpSessionStatus`, and `SessionAcpMeta` types. Propagate the PID from the ACPX delegate through the control plane manager and acp-spawn result so callers can inspect the OS process ID of running ACP sessions.

### Testing
- Unit tests for PID extraction in `runtime.test.ts` (with and without PID)
- Unit tests for PID inclusion in spawn results in `acp-spawn.test.ts` (with and without PID)
- Defensive spread pattern ensures backward compatibility when PID is absent