### PR TITLE
codex: support native app-server background spawns for Codex harness agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
+- Agents/Codex: honor legacy `embeddedHarness` Codex runtime settings as fill-missing `agentRuntime` policy, so existing native app-server configurations keep selecting the Codex harness without switching to ACP. (#74768) Thanks @91wan.
 - Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging. Fixes #75283. Thanks @brokemac79.
 - TTS/providers: keep bundled speech-provider compat fallback available when plugins are globally disabled, so cold gateway and CLI startup can still resolve fallback speech providers instead of leaving explicit TTS provider selection with no registered providers. Refs #75265. Thanks @sliekens.
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.

--- a/src/agents/agent-runtime-policy.ts
+++ b/src/agents/agent-runtime-policy.ts
@@ -1,19 +1,54 @@
-import type { AgentRuntimePolicyConfig } from "../config/types.agents-shared.js";
+import type {
+  AgentEmbeddedHarnessConfig,
+  AgentRuntimePolicyConfig,
+} from "../config/types.agents-shared.js";
 
 type AgentRuntimePolicyContainer = {
   agentRuntime?: AgentRuntimePolicyConfig;
+  embeddedHarness?: AgentEmbeddedHarnessConfig;
 };
 
 export function resolveAgentRuntimePolicy(
   container: AgentRuntimePolicyContainer | undefined,
 ): AgentRuntimePolicyConfig | undefined {
   const preferred = container?.agentRuntime;
+  const legacy = normalizeLegacyEmbeddedHarnessPolicy(container?.embeddedHarness);
   if (hasAgentRuntimePolicy(preferred)) {
-    return preferred;
+    return mergeRuntimePolicy(preferred, legacy);
   }
-  return undefined;
+  return legacy;
 }
 
-function hasAgentRuntimePolicy(value: AgentRuntimePolicyConfig | undefined): boolean {
+function hasAgentRuntimePolicy(
+  value: AgentRuntimePolicyConfig | undefined,
+): value is AgentRuntimePolicyConfig {
   return Boolean(value?.id?.trim() || value?.fallback);
+}
+
+function normalizeLegacyEmbeddedHarnessPolicy(
+  value: AgentEmbeddedHarnessConfig | undefined,
+): AgentRuntimePolicyConfig | undefined {
+  const next: AgentRuntimePolicyConfig = {};
+  if (value?.runtime !== undefined) {
+    next.id = value.runtime;
+  }
+  if (value?.fallback !== undefined) {
+    next.fallback = value.fallback;
+  }
+  return hasAgentRuntimePolicy(next) ? next : undefined;
+}
+
+function mergeRuntimePolicy(
+  preferred: AgentRuntimePolicyConfig,
+  legacy: AgentRuntimePolicyConfig | undefined,
+): AgentRuntimePolicyConfig {
+  if (!legacy) {
+    return preferred;
+  }
+  return {
+    ...legacy,
+    ...preferred,
+    id: preferred.id ?? legacy.id,
+    fallback: preferred.fallback ?? legacy.fallback,
+  };
 }

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -411,6 +411,48 @@ describe("selectAgentHarness", () => {
     ).toThrow("PI fallback is disabled");
   });
 
+  it("honors legacy embeddedHarness as the default runtime policy source", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          embeddedHarness: { runtime: "auto", fallback: "none" },
+        },
+      },
+    };
+
+    expect(() =>
+      selectAgentHarness({
+        provider: "anthropic",
+        modelId: "sonnet-4.6",
+        config,
+      }),
+    ).toThrow("PI fallback is disabled");
+  });
+
+  it("honors legacy embeddedHarness as an agent runtime policy source", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          agentRuntime: { fallback: "pi" },
+        },
+        list: [
+          {
+            id: "codex",
+            embeddedHarness: { runtime: "codex", fallback: "none" },
+          },
+        ],
+      },
+    };
+
+    await expect(
+      runAgentHarnessAttemptWithFallback({
+        ...createAttemptParams(config),
+        sessionKey: "agent:codex:subagent:child",
+      }),
+    ).rejects.toThrow('Requested agent harness "codex" is not registered');
+    expect(piRunAttempt).not.toHaveBeenCalled();
+  });
+
   it("does not treat CLI runtime aliases as embedded harness ids", async () => {
     const config: OpenClawConfig = {
       agents: {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -230,6 +230,42 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
+  it("keeps configured Codex agents on the subagent route unless ACP is explicit", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "codex",
+              embeddedHarness: { runtime: "codex", fallback: "none" },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await tool.execute("call-codex-native", {
+      task: "background task",
+      agentId: "codex",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
+    });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "background task",
+        agentId: "codex",
+      }),
+      expect.any(Object),
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     { status: "error" as const, error: "spawn failed" },
     { status: "forbidden" as const, error: "not allowed" },

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -969,6 +969,27 @@ describe("resolveGatewayStartupPluginIds", () => {
     });
   });
 
+  it("includes required agent harness owner plugins when legacy embeddedHarness forces the runtime", () => {
+    expectStartupPluginIdsCase({
+      config: {
+        agents: {
+          list: [
+            {
+              id: "codex",
+              embeddedHarness: { runtime: "codex", fallback: "none" },
+            },
+          ],
+        },
+        plugins: {
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "codex", "memory-core"],
+    });
+  });
+
   it("includes required agent harness owner plugins when env forces the runtime", () => {
     expectStartupPluginIdsCase({
       config: createStartupConfig({


### PR DESCRIPTION
## Why

Codex app-server is the native Codex integration path; ACP/acpx remains the generic harness backend.

## What

- Allows the existing legacy `embeddedHarness: { runtime: "codex", fallback: "none" }` config shape to participate in agent runtime policy resolution when `agentRuntime` is not present.
- Keeps `sessions_spawn({ agentId: "codex", task: "..." })` on the normal OpenClaw child-session path, while the child agent can select the existing native Codex app-server harness through runtime policy.
- Starts the required Codex owner plugin when legacy `embeddedHarness` forces the Codex runtime.
- Preserves explicit `agentRuntime` precedence and only uses legacy `embeddedHarness` to fill missing runtime/fallback policy fields.

## What not

- Does not replace ACP/acpx.
- Does not change default agent routing.
- Does not touch Computer Use install behavior.
- Does not use WebSocket.
- Does not make Codex app-server a global default.

## Tests

- `pnpm exec oxfmt --check --threads=1 src/agents/agent-runtime-policy.ts src/agents/harness/selection.test.ts src/plugins/channel-plugin-ids.test.ts src/agents/tools/sessions-spawn-tool.test.ts` - PASS.
- `pnpm test src/agents/harness/selection.test.ts src/plugins/channel-plugin-ids.test.ts src/agents/tools/sessions-spawn-tool.test.ts -- --reporter=verbose` - PASS, 2 Vitest shards, 50 agent tests and 68 plugin tests.
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts src/agents/acp-spawn.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts -- --reporter=verbose` - PASS, 2 Vitest shards, 63 agent tests and 39 extension tests.
- `git diff --check` - PASS.
- `CI=true OPENCLAW_LOCAL_CHECK=0 pnpm check:changed` - PASS.

Note: broad changed-gate proof ran locally because the `blacksmith` Testbox CLI was unavailable in this checkout.
