### PR TITLE
feat(qqbot): resolve clientSecret SecretRefs and add secret contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Plugins/tools: keep disabled bundled tool plugins out of explicit runtime allowlist ownership and fall back from loaded-but-empty channel registries to tool-bearing plugin registries, so Active Memory can use bundled `memory-core` search/get tools even when `memory-lancedb` is disabled. Fixes #76603. Thanks @jwong-art.
+- Channels/QQ Bot: resolve structured `clientSecret` SecretRefs before QQ token exchange, expose the QQ Bot secret contract to secrets tooling, and reject legacy `secretref:/...` marker strings. (#74772) Thanks @xialonglee.
 - Plugins/externalization: keep official ACPX, Google Chat, and LINE install specs on production package names, leaving beta-tag probing to the explicit OpenClaw beta update channel. Thanks @vincentkoc.
 - CLI/doctor: keep missing-plugin repair from overriding official catalog metadata with runtime fallbacks, so ACPX repairs preserve the official npm spec during the externalization rollout. Thanks @vincentkoc.
 - Plugins/catalog: preserve ClawHub install specs when generating the packaged channel catalog so future storepack-first channel plugins keep their remote source instead of becoming npm-only. Thanks @vincentkoc.

--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -82,6 +82,20 @@ File-backed AppSecret:
 }
 ```
 
+Env SecretRef AppSecret:
+
+```json5
+{
+  channels: {
+    qqbot: {
+      enabled: true,
+      appId: "YOUR_APP_ID",
+      clientSecret: { source: "env", provider: "default", id: "QQBOT_CLIENT_SECRET" },
+    },
+  },
+}
+```
+
 Notes:
 
 - Env fallback applies to the default QQ Bot account only.

--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -102,6 +102,8 @@ Notes:
 - `openclaw channels add --channel qqbot --token-file ...` provides the
   AppSecret only; the AppID must already be set in config or `QQBOT_APP_ID`.
 - `clientSecret` also accepts SecretRef input, not just a plaintext string.
+- Legacy `secretref:/...` marker strings are not valid `clientSecret` values;
+  use structured SecretRef objects like the example above.
 
 ### Multi-account setup
 

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -90,6 +90,8 @@ Scope intent:
 - `channels.feishu.accounts.*.appSecret`
 - `channels.feishu.accounts.*.encryptKey`
 - `channels.feishu.accounts.*.verificationToken`
+- `channels.qqbot.clientSecret`
+- `channels.qqbot.accounts.*.clientSecret`
 - `channels.msteams.appPassword`
 - `channels.mattermost.botToken`
 - `channels.mattermost.accounts.*.botToken`

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -90,8 +90,6 @@ Scope intent:
 - `channels.feishu.accounts.*.appSecret`
 - `channels.feishu.accounts.*.encryptKey`
 - `channels.feishu.accounts.*.verificationToken`
-- `channels.qqbot.clientSecret`
-- `channels.qqbot.accounts.*.clientSecret`
 - `channels.msteams.appPassword`
 - `channels.mattermost.botToken`
 - `channels.mattermost.accounts.*.botToken`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -282,6 +282,20 @@
       "optIn": true
     },
     {
+      "id": "channels.qqbot.accounts.*.clientSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.qqbot.accounts.*.clientSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.qqbot.clientSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.qqbot.clientSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.slack.accounts.*.appToken",
       "configFile": "openclaw.json",
       "path": "channels.slack.accounts.*.appToken",

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -282,20 +282,6 @@
       "optIn": true
     },
     {
-      "id": "channels.qqbot.accounts.*.clientSecret",
-      "configFile": "openclaw.json",
-      "path": "channels.qqbot.accounts.*.clientSecret",
-      "secretShape": "secret_input",
-      "optIn": true
-    },
-    {
-      "id": "channels.qqbot.clientSecret",
-      "configFile": "openclaw.json",
-      "path": "channels.qqbot.clientSecret",
-      "secretShape": "secret_input",
-      "optIn": true
-    },
-    {
       "id": "channels.slack.accounts.*.appToken",
       "configFile": "openclaw.json",
       "path": "channels.slack.accounts.*.appToken",

--- a/extensions/qqbot/index.ts
+++ b/extensions/qqbot/index.ts
@@ -21,6 +21,10 @@ export default defineBundledChannelEntry({
     specifier: "./channel-plugin-api.js",
     exportName: "qqbotPlugin",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
   runtime: {
     specifier: "./runtime-api.js",
     exportName: "setQQBotRuntime",

--- a/extensions/qqbot/secret-contract-api.ts
+++ b/extensions/qqbot/secret-contract-api.ts
@@ -1,0 +1,5 @@
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/qqbot/setup-entry.ts
+++ b/extensions/qqbot/setup-entry.ts
@@ -6,4 +6,8 @@ export default defineBundledChannelSetupEntry({
     specifier: "./setup-plugin-api.js",
     exportName: "qqbotSetupPlugin",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
 });

--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -19,6 +19,16 @@ interface QQBotChannelConfig extends QQBotAccountConfig {
   defaultAccount?: string;
 }
 
+function assertNotLegacySecretRefMarker(value: unknown, path: string): void {
+  const normalized = normalizeSecretInputString(value);
+  if (!normalized || !/^secretref(?:-env)?:/i.test(normalized)) {
+    return;
+  }
+  throw new Error(
+    `${path}: legacy SecretRef marker strings are not valid QQ Bot clientSecret values; use a structured SecretRef object instead.`,
+  );
+}
+
 function resolveEnvSecretRefValue(params: {
   cfg: OpenClawConfig;
   value: unknown;
@@ -55,6 +65,8 @@ function resolveQQBotClientSecretInput(params: {
   value: unknown;
   path: string;
 }): string | undefined {
+  assertNotLegacySecretRefMarker(params.value, params.path);
+
   const envSecret = resolveEnvSecretRefValue({
     cfg: params.cfg,
     value: params.value,

--- a/extensions/qqbot/src/bridge/config.ts
+++ b/extensions/qqbot/src/bridge/config.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
+import { coerceSecretRef, normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { getPlatformAdapter } from "../engine/adapter/index.js";
 import {
   DEFAULT_ACCOUNT_ID as ENGINE_DEFAULT_ACCOUNT_ID,
@@ -15,6 +17,56 @@ export const DEFAULT_ACCOUNT_ID = ENGINE_DEFAULT_ACCOUNT_ID;
 interface QQBotChannelConfig extends QQBotAccountConfig {
   accounts?: Record<string, QQBotAccountConfig>;
   defaultAccount?: string;
+}
+
+function resolveEnvSecretRefValue(params: {
+  cfg: OpenClawConfig;
+  value: unknown;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const ref = coerceSecretRef(params.value, params.cfg.secrets?.defaults);
+  if (!ref || ref.source !== "env") {
+    return undefined;
+  }
+
+  const providerConfig = params.cfg.secrets?.providers?.[ref.provider];
+  if (providerConfig) {
+    if (providerConfig.source !== "env") {
+      throw new Error(
+        `Secret provider "${ref.provider}" has source "${providerConfig.source}" but ref requests "env".`,
+      );
+    }
+    if (providerConfig.allowlist && !providerConfig.allowlist.includes(ref.id)) {
+      throw new Error(
+        `Environment variable "${ref.id}" is not allowlisted in secrets.providers.${ref.provider}.allowlist.`,
+      );
+    }
+  } else if (ref.provider !== resolveDefaultSecretProviderAlias(params.cfg, "env")) {
+    throw new Error(
+      `Secret provider "${ref.provider}" is not configured (ref: env:${ref.provider}:${ref.id}).`,
+    );
+  }
+
+  return normalizeSecretInputString((params.env ?? process.env)[ref.id]);
+}
+
+function resolveQQBotClientSecretInput(params: {
+  cfg: OpenClawConfig;
+  value: unknown;
+  path: string;
+}): string | undefined {
+  const envSecret = resolveEnvSecretRefValue({
+    cfg: params.cfg,
+    value: params.value,
+  });
+  if (envSecret) {
+    return envSecret;
+  }
+
+  return getPlatformAdapter().resolveSecretInputString({
+    value: params.value,
+    path: params.path,
+  });
 }
 
 /** List all configured QQBot account IDs. */
@@ -62,7 +114,8 @@ export function resolveQQBotAccount(
   if (adapter.hasConfiguredSecret(accountConfig.clientSecret)) {
     clientSecret = opts?.allowUnresolvedSecretRef
       ? (adapter.normalizeSecretInputString(accountConfig.clientSecret) ?? "")
-      : (adapter.resolveSecretInputString({
+      : (resolveQQBotClientSecretInput({
+          cfg,
           value: accountConfig.clientSecret,
           path: clientSecretPath,
         }) ?? "");

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -214,6 +214,21 @@ describe("qqbot config", () => {
     );
   });
 
+  it("rejects legacy SecretRef marker strings before QQ token exchange", () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          appId: "123456",
+          clientSecret: "secretref:/QQBOT_CLIENT_SECRET",
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(() => resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID)).toThrow(
+      "channels.qqbot.clientSecret: legacy SecretRef marker strings are not valid QQ Bot clientSecret values; use a structured SecretRef object instead.",
+    );
+  });
+
   it("allows unresolved SecretRefs for setup/status flows", () => {
     const cfg = makeQqbotSecretRefConfig();
 

--- a/extensions/qqbot/src/config.test.ts
+++ b/extensions/qqbot/src/config.test.ts
@@ -176,11 +176,41 @@ describe("qqbot config", () => {
     expect(resolved.name).toBe("Bot Two");
   });
 
-  it("rejects unresolved SecretRefs on runtime resolution", () => {
+  it("resolves env SecretRefs on runtime resolution", () => {
     const cfg = makeQqbotSecretRefConfig();
+    const previous = process.env.QQBOT_CLIENT_SECRET;
+
+    process.env.QQBOT_CLIENT_SECRET = "resolved-secret";
+    try {
+      const resolved = resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID);
+
+      expect(resolved.clientSecret).toBe("resolved-secret");
+      expect(resolved.secretSource).toBe("config");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.QQBOT_CLIENT_SECRET;
+      } else {
+        process.env.QQBOT_CLIENT_SECRET = previous;
+      }
+    }
+  });
+
+  it("rejects unresolved non-env SecretRefs on runtime resolution", () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          appId: "123456",
+          clientSecret: {
+            source: "file",
+            provider: "default",
+            id: "/qqbot/clientSecret",
+          },
+        },
+      },
+    } as OpenClawConfig;
 
     expect(() => resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID)).toThrow(
-      'channels.qqbot.clientSecret: unresolved SecretRef "env:default:QQBOT_CLIENT_SECRET"',
+      'channels.qqbot.clientSecret: unresolved SecretRef "file:default:/qqbot/clientSecret"',
     );
   });
 

--- a/extensions/qqbot/src/secret-contract.test.ts
+++ b/extensions/qqbot/src/secret-contract.test.ts
@@ -1,0 +1,110 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import {
+  applyResolvedAssignments,
+  createResolverContext,
+  resolveSecretRefValues,
+} from "openclaw/plugin-sdk/runtime-secret-resolution";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments } from "./secret-contract.js";
+
+async function resolveQqbotSecretAssignments(
+  sourceConfig: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<OpenClawConfig> {
+  const resolvedConfig: OpenClawConfig = structuredClone(sourceConfig);
+  const context = createResolverContext({ sourceConfig, env });
+
+  collectRuntimeConfigAssignments({
+    config: resolvedConfig,
+    defaults: sourceConfig.secrets?.defaults,
+    context,
+  });
+
+  const resolved = await resolveSecretRefValues(
+    context.assignments.map((assignment) => assignment.ref),
+    {
+      config: sourceConfig,
+      env: context.env,
+      cache: context.cache,
+    },
+  );
+  applyResolvedAssignments({ assignments: context.assignments, resolved });
+
+  expect(context.warnings).toEqual([]);
+  return resolvedConfig;
+}
+
+describe("qqbot secret contract", () => {
+  it("resolves top-level clientSecret SecretRefs even when clientSecretFile is configured", async () => {
+    const resolvedConfig = await resolveQqbotSecretAssignments(
+      {
+        channels: {
+          qqbot: {
+            enabled: true,
+            appId: "123456",
+            clientSecret: { source: "env", provider: "default", id: "QQBOT_CLIENT_SECRET" },
+            clientSecretFile: "/ignored/by/runtime",
+          },
+        },
+      } as OpenClawConfig,
+      { QQBOT_CLIENT_SECRET: "resolved-top-level-secret" },
+    );
+
+    expect(resolvedConfig.channels?.qqbot?.clientSecret).toBe("resolved-top-level-secret");
+  });
+
+  it("resolves account clientSecret SecretRefs even when account clientSecretFile is configured", async () => {
+    const resolvedConfig = await resolveQqbotSecretAssignments(
+      {
+        channels: {
+          qqbot: {
+            enabled: true,
+            accounts: {
+              bot2: {
+                enabled: true,
+                appId: "654321",
+                clientSecret: { source: "env", provider: "default", id: "QQBOT_BOT2_SECRET" },
+                clientSecretFile: "/ignored/by/runtime",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      { QQBOT_BOT2_SECRET: "resolved-bot2-secret" },
+    );
+
+    expect(resolvedConfig.channels?.qqbot?.accounts?.bot2?.clientSecret).toBe(
+      "resolved-bot2-secret",
+    );
+  });
+
+  it("keeps the implicit default account top-level clientSecret active with named accounts", async () => {
+    const resolvedConfig = await resolveQqbotSecretAssignments(
+      {
+        channels: {
+          qqbot: {
+            enabled: true,
+            appId: "123456",
+            clientSecret: { source: "env", provider: "default", id: "QQBOT_DEFAULT_SECRET" },
+            accounts: {
+              bot2: {
+                enabled: true,
+                appId: "654321",
+                clientSecret: { source: "env", provider: "default", id: "QQBOT_BOT2_SECRET" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        QQBOT_DEFAULT_SECRET: "resolved-default-secret",
+        QQBOT_BOT2_SECRET: "resolved-bot2-secret",
+      },
+    );
+
+    expect(resolvedConfig.channels?.qqbot?.clientSecret).toBe("resolved-default-secret");
+    expect(resolvedConfig.channels?.qqbot?.accounts?.bot2?.clientSecret).toBe(
+      "resolved-bot2-secret",
+    );
+  });
+});

--- a/extensions/qqbot/src/secret-contract.ts
+++ b/extensions/qqbot/src/secret-contract.ts
@@ -2,11 +2,12 @@ import {
   collectConditionalChannelFieldAssignments,
   getChannelSurface,
   hasConfiguredSecretInputValue,
-  normalizeSecretStringValue,
   type ResolverContext,
   type SecretDefaults,
   type SecretTargetRegistryEntry,
 } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+const DEFAULT_ACCOUNT_ID = "default";
 
 export const secretTargetRegistryEntries = [
   {
@@ -33,8 +34,11 @@ export const secretTargetRegistryEntries = [
   },
 ] satisfies SecretTargetRegistryEntry[];
 
-function hasClientSecretFile(value: unknown): boolean {
-  return normalizeSecretStringValue(value).length > 0;
+function hasTopLevelAppId(qqbot: Record<string, unknown>): boolean {
+  if (typeof qqbot.appId === "string") {
+    return qqbot.appId.trim().length > 0;
+  }
+  return typeof qqbot.appId === "number";
 }
 
 export function collectRuntimeConfigAssignments(params: {
@@ -48,9 +52,9 @@ export function collectRuntimeConfigAssignments(params: {
   }
 
   const { channel: qqbot, surface } = resolved;
-  const baseClientSecretFile = hasClientSecretFile(qqbot.clientSecretFile);
-  const accountClientSecretFile = (account: Record<string, unknown>) =>
-    hasClientSecretFile(account.clientSecretFile);
+  const hasExplicitDefaultAccount = surface.accounts.some(
+    ({ accountId }) => accountId === DEFAULT_ACCOUNT_ID,
+  );
 
   collectConditionalChannelFieldAssignments({
     channelKey: "qqbot",
@@ -59,20 +63,16 @@ export function collectRuntimeConfigAssignments(params: {
     surface,
     defaults: params.defaults,
     context: params.context,
-    topLevelActiveWithoutAccounts: !baseClientSecretFile,
-    topLevelInheritedAccountActive: ({ account, enabled }) => {
-      if (!enabled || baseClientSecretFile) {
-        return false;
+    topLevelActiveWithoutAccounts: true,
+    topLevelInheritedAccountActive: ({ accountId, account, enabled }) => {
+      if (accountId === DEFAULT_ACCOUNT_ID) {
+        return enabled && !hasConfiguredSecretInputValue(account.clientSecret, params.defaults);
       }
-      return (
-        !hasConfiguredSecretInputValue(account.clientSecret, params.defaults) &&
-        !accountClientSecretFile(account)
-      );
+      return !hasExplicitDefaultAccount && hasTopLevelAppId(qqbot);
     },
-    accountActive: ({ account, enabled }) => enabled && !accountClientSecretFile(account),
-    topInactiveReason:
-      "no enabled QQBot surface inherits this top-level clientSecret (clientSecretFile is configured).",
-    accountInactiveReason: "QQBot account is disabled or clientSecretFile is configured.",
+    accountActive: ({ enabled }) => enabled,
+    topInactiveReason: "no enabled QQ Bot default surface uses this top-level clientSecret.",
+    accountInactiveReason: "QQ Bot account is disabled.",
   });
 }
 

--- a/extensions/qqbot/src/secret-contract.ts
+++ b/extensions/qqbot/src/secret-contract.ts
@@ -1,0 +1,82 @@
+import {
+  collectConditionalChannelFieldAssignments,
+  getChannelSurface,
+  hasConfiguredSecretInputValue,
+  normalizeSecretStringValue,
+  type ResolverContext,
+  type SecretDefaults,
+  type SecretTargetRegistryEntry,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+export const secretTargetRegistryEntries = [
+  {
+    id: "channels.qqbot.accounts.*.clientSecret",
+    targetType: "channels.qqbot.accounts.*.clientSecret",
+    configFile: "openclaw.json",
+    pathPattern: "channels.qqbot.accounts.*.clientSecret",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.qqbot.clientSecret",
+    targetType: "channels.qqbot.clientSecret",
+    configFile: "openclaw.json",
+    pathPattern: "channels.qqbot.clientSecret",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+] satisfies SecretTargetRegistryEntry[];
+
+function hasClientSecretFile(value: unknown): boolean {
+  return normalizeSecretStringValue(value).length > 0;
+}
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, "qqbot");
+  if (!resolved) {
+    return;
+  }
+
+  const { channel: qqbot, surface } = resolved;
+  const baseClientSecretFile = hasClientSecretFile(qqbot.clientSecretFile);
+  const accountClientSecretFile = (account: Record<string, unknown>) =>
+    hasClientSecretFile(account.clientSecretFile);
+
+  collectConditionalChannelFieldAssignments({
+    channelKey: "qqbot",
+    field: "clientSecret",
+    channel: qqbot,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topLevelActiveWithoutAccounts: !baseClientSecretFile,
+    topLevelInheritedAccountActive: ({ account, enabled }) => {
+      if (!enabled || baseClientSecretFile) {
+        return false;
+      }
+      return (
+        !hasConfiguredSecretInputValue(account.clientSecret, params.defaults) &&
+        !accountClientSecretFile(account)
+      );
+    },
+    accountActive: ({ account, enabled }) => enabled && !accountClientSecretFile(account),
+    topInactiveReason:
+      "no enabled QQBot surface inherits this top-level clientSecret (clientSecretFile is configured).",
+    accountInactiveReason: "QQBot account is disabled or clientSecretFile is configured.",
+  });
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};

--- a/src/secrets/credential-matrix.ts
+++ b/src/secrets/credential-matrix.ts
@@ -1,4 +1,4 @@
-import { listSecretTargetRegistryEntries } from "./target-registry.js";
+import { getSourceSecretTargetRegistry } from "./target-registry-data.js";
 import { getUnsupportedSecretRefSurfacePatterns } from "./unsupported-surface-policy.js";
 
 type CredentialMatrixEntry = {
@@ -22,7 +22,7 @@ export type SecretRefCredentialMatrixDocument = {
 };
 
 export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocument {
-  const entries: CredentialMatrixEntry[] = listSecretTargetRegistryEntries()
+  const entries: CredentialMatrixEntry[] = getSourceSecretTargetRegistry()
     .map((entry) => {
       const isCanonicalFirecrawlWebFetchEntry =
         entry.id === "plugins.entries.firecrawl.config.webFetch.apiKey";

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -441,6 +441,25 @@ const CORE_SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
 
 let cachedSecretTargetRegistry: SecretTargetRegistryEntry[] | null = null;
 
+function loadSecretTargetRegistryFromPluginMetadata(params: {
+  env: NodeJS.ProcessEnv;
+  preferPersisted?: boolean;
+}): SecretTargetRegistryEntry[] {
+  const plugins = loadPluginMetadataSnapshot({
+    config: {},
+    env: params.env,
+    ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
+  }).plugins;
+  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
+  const channelPlugins = plugins.filter((record) => record.channels.length > 0);
+  return [
+    ...CORE_SECRET_TARGET_REGISTRY,
+    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
+    ...listBundledPluginConfigSecretTargetRegistryEntries(bundledPlugins),
+    ...listChannelSecretTargetRegistryEntries(channelPlugins),
+  ];
+}
+
 export function getCoreSecretTargetRegistry(): SecretTargetRegistryEntry[] {
   return CORE_SECRET_TARGET_REGISTRY;
 }
@@ -449,17 +468,18 @@ export function getSecretTargetRegistry(): SecretTargetRegistryEntry[] {
   if (cachedSecretTargetRegistry) {
     return cachedSecretTargetRegistry;
   }
-  const plugins = loadPluginMetadataSnapshot({
-    config: {},
+  cachedSecretTargetRegistry = loadSecretTargetRegistryFromPluginMetadata({
     env: process.env,
-  }).plugins;
-  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
-  const channelPlugins = plugins.filter((record) => record.channels.length > 0);
-  cachedSecretTargetRegistry = [
-    ...CORE_SECRET_TARGET_REGISTRY,
-    ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
-    ...listBundledPluginConfigSecretTargetRegistryEntries(bundledPlugins),
-    ...listChannelSecretTargetRegistryEntries(channelPlugins),
-  ];
+  });
   return cachedSecretTargetRegistry;
+}
+
+export function getSourceSecretTargetRegistry(): SecretTargetRegistryEntry[] {
+  return loadSecretTargetRegistryFromPluginMetadata({
+    env: {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: process.env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? "extensions",
+    },
+    preferPersisted: false,
+  });
 }


### PR DESCRIPTION
# feat(qqbot): resolve clientSecret SecretRefs and add secret contract

## Summary

The QQ Bot channel can now use structured **SecretRef** values for `channels.qqbot.clientSecret` (and per-account `channels.qqbot.accounts.*.clientSecret`), including the common env form:

`{ "source": "env", "provider": "default", "id": "QQBOT_CLIENT_SECRET" }`.

Runtime resolution reads env-backed refs during account resolution, and the plugin exposes a **secret contract** so the gateway runtime snapshot can materialize these surfaces like other channels.

## What changed

- **`extensions/qqbot/src/bridge/config.ts`**: Resolve `env` SecretRefs for `clientSecret` (with provider / allowlist semantics aligned with other channels); fall through to the existing platform adapter path for other ref kinds.
- **`extensions/qqbot/src/secret-contract.ts`** + **`extensions/qqbot/secret-contract-api.ts`**: Register SecretRef targets and runtime assignment collection for top-level and account-level `clientSecret`.
- **`extensions/qqbot/index.ts`** and **`extensions/qqbot/setup-entry.ts`**: Wire `secrets` into bundled channel entrypoints (consistent with Feishu/Telegram).
- **Docs**: QQ Bot channel doc example for env SecretRef; canonical SecretRef credential surface list updated for QQ Bot paths.
- **Tests**: `extensions/qqbot/src/config.test.ts` — env SecretRef resolves when the env var is set; non-env refs still fail closed when unresolved.

## Validation

- `pnpm exec oxfmt --check --threads=1` (touched sources/docs)
- `pnpm test extensions/qqbot/src/config.test.ts`
- `pnpm test src/secrets/target-registry.test.ts`
- `pnpm test test/scripts/bundled-plugin-build-entries.test.ts`
- `pnpm test src/plugin-sdk/channel-entry-contract.test.ts`

## Related docs

- [QQ Bot channel](https://docs.openclaw.ai/channels/qqbot)
- [SecretRef credential surface](https://docs.openclaw.ai/reference/secretref-credential-surface)
