### PR TITLE
fix(bonjour): avoid probing watchdog repair loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Bonjour/Gateway: treat active ciao probing and fresh name-conflict renames as in-progress so the mDNS watchdog waits for probe settlement before retrying, preventing rapid re-advertise loops on Windows, WSL, and other multicast-hostile hosts. (#74778) Refs #74242. Thanks @fuller-stack-dev.
 - Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
 - Doctor/GitHub CLI: surface a `GH_CONFIG_DIR` hint when the GitHub skill is usable but `gh` auth lives under a different operator HOME than the agent process, without warning for disabled or filtered skills. Fixes #78063. (#78095) Thanks @tmimmanuel.
 - Gateway: dedupe concurrent `send`, `poll`, and `message.action` requests while delivery is still in flight, preventing duplicate outbound work for the same idempotency key. (#68341) Thanks @thesomewhatyou.

--- a/docs/gateway/bonjour.md
+++ b/docs/gateway/bonjour.md
@@ -141,6 +141,11 @@ The Gateway writes a rolling log file (printed on startup as
 - `bonjour: watchdog detected non-announced service ...`
 - `bonjour: disabling advertiser after ... failed restarts ...`
 
+The watchdog treats active `probing`, `announcing`, and fresh conflict-renames as
+in-progress states. If the service never reaches `announced`, OpenClaw eventually
+recreates the advertiser and, after repeated failures, disables Bonjour for that
+Gateway process instead of re-advertising forever.
+
 Bonjour uses the system hostname for the advertised `.local` host when it is a
 valid DNS label. If the system hostname contains spaces, underscores, or another
 invalid DNS-label character, OpenClaw falls back to `openclaw.local`. Set

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -64,11 +64,16 @@ function mockCiaoService(params?: {
   serviceState?: string;
   stateRef?: { value: string };
   on?: ReturnType<typeof vi.fn>;
+  listenerMap?: Map<string, (value: unknown) => void>;
   responder?: Record<string, unknown>;
 }) {
   const advertise = params?.advertise ?? vi.fn().mockResolvedValue(undefined);
   const destroy = params?.destroy ?? vi.fn().mockResolvedValue(undefined);
-  const on = params?.on ?? vi.fn();
+  const on =
+    params?.on ??
+    vi.fn((event: string, listener: (value: unknown) => void) => {
+      params?.listenerMap?.set(event, listener);
+    });
   createService.mockImplementation((options: Record<string, unknown>) => {
     const service = {
       advertise,
@@ -695,18 +700,8 @@ describe("gateway bonjour advertiser", () => {
     vi.useFakeTimers();
 
     const stateRef = { value: "probing" };
-    let advertiseCount = 0;
     const destroy = vi.fn().mockResolvedValue(undefined);
-    const advertise = vi.fn().mockImplementation(() => {
-      advertiseCount += 1;
-      if (advertiseCount === 2) {
-        stateRef.value = "announcing";
-      }
-      if (advertiseCount >= 3) {
-        stateRef.value = "announced";
-      }
-      return Promise.resolve();
-    });
+    const advertise = vi.fn().mockResolvedValue(undefined);
     mockCiaoService({ advertise, destroy, stateRef });
 
     const started = await startAdvertiser({
@@ -717,16 +712,85 @@ describe("gateway bonjour advertiser", () => {
     expect(createService).toHaveBeenCalledTimes(1);
     expect(advertise).toHaveBeenCalledTimes(1);
 
+    setTimeout(() => {
+      stateRef.value = "announcing";
+    }, 10_000);
+
     await vi.advanceTimersByTimeAsync(25_000);
 
     expectWarnContaining("service stuck in announcing");
     expect(createService).toHaveBeenCalledTimes(2);
-    expect(advertise).toHaveBeenCalledTimes(3);
+    expect(advertise).toHaveBeenCalledTimes(2);
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(shutdown).not.toHaveBeenCalled();
 
     await started.stop();
     expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-advertise while ciao is still probing", async () => {
+    enableAdvertiserUnitMode();
+    vi.useFakeTimers();
+
+    const stateRef = { value: "probing" };
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy, stateRef });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(advertise).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(advertise).toHaveBeenCalledTimes(1);
+    expect(createService).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("watchdog detected non-announced service; attempting re-advertise"),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("service stuck in probing"));
+    expect(createService).toHaveBeenCalledTimes(2);
+
+    await started.stop();
+  });
+
+  it("defers probing recovery while a name conflict is still settling", async () => {
+    enableAdvertiserUnitMode();
+    vi.useFakeTimers();
+
+    const stateRef = { value: "probing" };
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    const listenerMap = new Map<string, (value: unknown) => void>();
+    mockCiaoService({ advertise, destroy, stateRef, listenerMap });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    listenerMap.get("name-change")?.("test-host (OpenClaw) (2)");
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(createService).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('name conflict resolved; newName="test-host (OpenClaw) (2)"'),
+    );
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("service stuck in probing"));
+    expect(createService).toHaveBeenCalledTimes(2);
+
+    await started.stop();
   });
 
   it("disables bonjour for the process after repeated stuck advertiser restarts", async () => {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -81,6 +81,7 @@ type BonjourAdvertiserDeps = {
 
 const WATCHDOG_INTERVAL_MS = 5_000;
 const REPAIR_DEBOUNCE_MS = 30_000;
+const CONFLICT_SETTLE_MS = 30_000;
 // Real-world LAN announce phase typically takes 12-13s on Mac/iOS networks. The
 // previous 8s threshold was triggering false-positive teardowns on every gateway
 // restart in such environments. 20s gives healthy networks plenty of room while
@@ -252,6 +253,10 @@ function serviceSummary(label: string, svc: BonjourService): string {
 
 function isAnnouncedState(state: string) {
   return state === BONJOUR_ANNOUNCED_STATE;
+}
+
+function isAdvertisingInProgressState(state: string) {
+  return state === "probing" || state === "announcing";
 }
 
 function shouldSuppressCiaoConsoleLog(args: unknown[]): boolean {
@@ -510,12 +515,14 @@ export async function startGatewayBonjourAdvertiser(
       for (const { label, svc } of services) {
         try {
           svc.on("name-change", (name: unknown) => {
+            markConflictObserved(label, svc);
             const next = typeof name === "string" ? name : String(name);
             logger.warn(
               `bonjour: ${label} name conflict resolved; newName=${JSON.stringify(next)}`,
             );
           });
           svc.on("hostname-change", (nextHostname: unknown) => {
+            markConflictObserved(label, svc);
             const next = typeof nextHostname === "string" ? nextHostname : String(nextHostname);
             logger.warn(
               `bonjour: ${label} hostname conflict resolved; newHostname=${JSON.stringify(next)}`,
@@ -580,6 +587,14 @@ export async function startGatewayBonjourAdvertiser(
     const restartTimestamps: number[] = [];
     let cycle: BonjourCycle | null = createCycle();
     const stateTracker = new Map<string, ServiceStateTracker>();
+    const conflictTracker = new Map<string, number>();
+
+    const markConflictObserved = (label: string, svc: BonjourService) => {
+      const now = Date.now();
+      conflictTracker.set(label, now);
+      const nextState = typeof svc.serviceState === "string" ? svc.serviceState : "unknown";
+      stateTracker.set(label, { state: nextState, sinceMs: now });
+    };
 
     const updateStateTrackers = (services: Array<{ label: string; svc: BonjourService }>) => {
       const now = Date.now();
@@ -633,6 +648,7 @@ export async function startGatewayBonjourAdvertiser(
           const previous = cycle;
           cycle = null;
           stateTracker.clear();
+          conflictTracker.clear();
           await stopCycle(previous, { shutdownResponder: true });
           restoreConsoleLog();
           restoreCiaoExecHidePatch();
@@ -643,6 +659,7 @@ export async function startGatewayBonjourAdvertiser(
         await stopCycle(previous);
         cycle = createCycle();
         stateTracker.clear();
+        conflictTracker.clear();
         attachConflictListeners(cycle.services);
         startAdvertising(cycle.services);
       })().finally(() => {
@@ -666,6 +683,7 @@ export async function startGatewayBonjourAdvertiser(
       }
       updateStateTrackers(cycle.services);
       for (const { label, svc } of cycle.services) {
+        const now = Date.now();
         const stateUnknown = (svc as { serviceState?: unknown }).serviceState;
         if (typeof stateUnknown !== "string") {
           continue;
@@ -673,15 +691,23 @@ export async function startGatewayBonjourAdvertiser(
         if (stateUnknown === "announced") {
           consecutiveRestarts = 0;
           consecutiveStuckStateRestarts = 0;
+          conflictTracker.delete(label);
+        }
+        const lastConflictAt = conflictTracker.get(label);
+        if (lastConflictAt !== undefined && now - lastConflictAt >= CONFLICT_SETTLE_MS) {
+          conflictTracker.delete(label);
+        }
+        if (lastConflictAt !== undefined && now - lastConflictAt < CONFLICT_SETTLE_MS) {
+          continue;
         }
         const tracked = stateTracker.get(label);
         if (
           stateUnknown !== "announced" &&
           tracked &&
-          Date.now() - tracked.sinceMs >= STUCK_ANNOUNCING_MS
+          now - tracked.sinceMs >= STUCK_ANNOUNCING_MS
         ) {
           void recreateAdvertiser(
-            `service stuck in ${stateUnknown} for ${Date.now() - tracked.sinceMs}ms (${serviceSummary(
+            `service stuck in ${stateUnknown} for ${now - tracked.sinceMs}ms (${serviceSummary(
               label,
               svc,
             )})`,
@@ -689,7 +715,7 @@ export async function startGatewayBonjourAdvertiser(
           );
           return;
         }
-        if (stateUnknown === "announced" || stateUnknown === "announcing") {
+        if (stateUnknown === "announced" || isAdvertisingInProgressState(stateUnknown)) {
           continue;
         }
 
@@ -699,7 +725,6 @@ export async function startGatewayBonjourAdvertiser(
         } catch {
           // ignore
         }
-        const now = Date.now();
         const last = lastRepairAttempt.get(key) ?? 0;
         if (now - last < REPAIR_DEBOUNCE_MS) {
           continue;


### PR DESCRIPTION
## Summary
- treat ciao `probing` as an in-progress state so the Bonjour watchdog stops calling `advertise()` again while the service is still negotiating
- reset the unhealthy window and add a conflict-settle grace period after `name-change` and `hostname-change` events so ciao can resolve duplicate names before OpenClaw tries to recycle the advertiser
- add targeted advertiser regressions for probing and name-conflict loops, plus docs for the new watchdog behavior

## Testing
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/gateway/bonjour.md extensions/bonjour/src/advertiser.ts extensions/bonjour/src/advertiser.test.ts`
- `pnpm test extensions/bonjour/src/advertiser.test.ts`
- `pnpm build`
- `pnpm check:changed`