### PR TITLE
fix(gateway): snapshot all session-aborted runs

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1344,30 +1344,32 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           payload &&
           typeof payload === "object" &&
           Array.isArray((payload as { runIds?: unknown[] }).runIds)
-            ? (payload as { runIds: unknown[] }).runIds.filter((value): value is string =>
-                Boolean(normalizeOptionalString(value)),
-              )
+            ? (payload as { runIds: unknown[] }).runIds
+                .map((value) => normalizeOptionalString(value))
+                .filter((value): value is string => Boolean(value))
             : [];
         const firstAbortedRunId = runIds[0] ?? null;
         abortedRunId = firstAbortedRunId;
-        if (firstAbortedRunId) {
+        if (runIds.length > 0) {
           const endedAt = Date.now();
-          const runKind = preAbortRunKinds.get(firstAbortedRunId);
-          const dedupePrefix = runKind === "agent" ? "agent" : "chat";
-          setGatewayDedupeEntry({
-            dedupe: context.dedupe,
-            key: `${dedupePrefix}:${firstAbortedRunId}`,
-            entry: {
-              ts: endedAt,
-              ok: true,
-              payload: {
-                status: "timeout",
-                runId: firstAbortedRunId,
-                stopReason: "rpc",
-                endedAt,
+          for (const runId of runIds) {
+            const runKind = preAbortRunKinds.get(runId);
+            const dedupePrefix = runKind === "agent" ? "agent" : "chat";
+            setGatewayDedupeEntry({
+              dedupe: context.dedupe,
+              key: `${dedupePrefix}:${runId}`,
+              entry: {
+                ts: endedAt,
+                ok: true,
+                payload: {
+                  status: "timeout",
+                  runId,
+                  stopReason: "rpc",
+                  endedAt,
+                },
               },
-            },
-          });
+            });
+          }
         }
         respond(
           true,

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -329,6 +329,61 @@ describe("gateway server chat", () => {
     }
   });
 
+  test("sessions.abort writes wait snapshots for every session-wide aborted run", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-abort-all-"));
+    const sessionKey = "agent:main:dashboard:test-abort-all";
+    const runIds = ["idem-sessions-abort-all-1", "idem-sessions-abort-all-2"];
+    const releaseFirstReply = mockBlockedChatReply();
+    const releaseSecondReply = mockBlockedChatReply();
+    testState.sessionStorePath = path.join(dir, "sessions.json");
+    try {
+      await writeSessionStore({
+        entries: {
+          [sessionKey]: {
+            sessionId: "sess-dashboard-abort-all",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      for (const runId of runIds) {
+        const sendRes = await rpcReq(ws, "sessions.send", {
+          key: sessionKey,
+          message: "hello",
+          idempotencyKey: runId,
+          timeoutMs: 30_000,
+        });
+        expect(sendRes.ok).toBe(true);
+        expect(sendRes.payload?.status).toBe("started");
+      }
+
+      const abortRes = await rpcReq(ws, "sessions.abort", {
+        key: sessionKey,
+      });
+      expect(abortRes.ok).toBe(true);
+      expect(abortRes.payload?.status).toBe("aborted");
+      expect(runIds).toContain(abortRes.payload?.abortedRunId);
+
+      for (const runId of runIds) {
+        const waitRes = await rpcReq(ws, "agent.wait", {
+          runId,
+          timeoutMs: 0,
+        });
+        expect(waitRes.ok).toBe(true);
+        expect(waitRes.payload).toMatchObject({
+          runId,
+          status: "timeout",
+          stopReason: "rpc",
+        });
+      }
+    } finally {
+      releaseFirstReply();
+      releaseSecondReply();
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("sessions.abort resolves active runs by runId without a caller session key", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-abort-runid-"));
     testState.sessionStorePath = path.join(dir, "sessions.json");


### PR DESCRIPTION
Related https://github.com/openclaw/openclaw/issues/74704
## Summary

- Problem: #74751 records the terminal wait snapshot for only the first run returned by a session-wide `sessions.abort`.
- Why it matters: app clients that abort a session with multiple active runs can see only one run become terminal while the other aborted runs still wait or report stale state.
- What changed: normalize every returned run ID and write the RPC stop/timeout dedupe snapshot for each aborted run.
- What did NOT change: the existing `sessions.abort` response shape still reports the first `abortedRunId` for compatibility.

## Testing

- Not run locally, per request.
- `git diff --check HEAD~1..HEAD` passed.