### PR TITLE
fix(pi-embedded): strip [assistant copied inbound metadata omitted] placeholder from delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/output: strip internal `[assistant copied inbound metadata omitted]` replay placeholder from user-facing replies alongside `[tool calls omitted]`, so metadata-only assistant turns no longer leak the scaffolding label into Telegram and other channel outputs. Fixes #74745.
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
 - macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.
 - Plugin SDK: restore the deprecated `plugin-sdk/zalouser` command-auth facade so published Lark/Zalo plugins that import it load on current hosts. Fixes #74702. Thanks @Goron01.

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -223,6 +223,25 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("strips inbound-metadata replay placeholders without trimming visible text", () => {
+    expect(sanitizeUserFacingText("[assistant copied inbound metadata omitted]")).toBe("");
+    expect(sanitizeUserFacingText("  [assistant copied inbound metadata omitted]\t")).toBe("");
+    expect(
+      sanitizeUserFacingText("Hello\n\n[assistant copied inbound metadata omitted]\nWorld\n"),
+    ).toBe("Hello\n\nWorld\n");
+    expect(
+      sanitizeUserFacingText(
+        "A\n[assistant copied inbound metadata omitted]\n[tool calls omitted]\nB",
+      ),
+    ).toBe("A\nB");
+  });
+
+  it("keeps ordinary inline mentions of the inbound-metadata placeholder", () => {
+    expect(
+      sanitizeUserFacingText("What does [assistant copied inbound metadata omitted] mean?"),
+    ).toBe("What does [assistant copied inbound metadata omitted] mean?");
+  });
+
   it("strips marked internal runtime context blocks but keeps real reply text", () => {
     const input = [
       INTERNAL_RUNTIME_CONTEXT_BEGIN,

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -41,7 +41,8 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
-const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE =
+  /^[ \t]*\[(?:tool calls omitted|assistant copied inbound metadata omitted)\][ \t]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -400,8 +401,8 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   }
   const errorContext = opts?.errorContext ?? false;
   const stripped = stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw)));
-  // Replay repair may synthesize this placeholder to keep provider transcripts valid.
-  // It is internal scaffolding, so drop standalone placeholder lines before delivery
+  // Replay repair may synthesize these placeholders to keep provider transcripts valid.
+  // They are internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
   const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(stripped);
   const trimmed = withoutPlaceholder.trim();


### PR DESCRIPTION
## Problem

The internal replay placeholder `[assistant copied inbound metadata omitted]` is leaking into outbound Telegram (and other channel) messages after the 2026.4.27 update, appearing as the entire message body instead of the actual assistant reply.

Fixes #74745.

## Root cause

`sanitize-user-facing-text.ts` already strips `[tool calls omitted]` from user-facing output (landed in `d30b8dccfd`, fixing #74573). The same sentinel pattern `OMITTED_INBOUND_METADATA_TEXT = "[assistant copied inbound metadata omitted]"` synthesized by `normalizeAssistantReplayContent` in `replay-history.ts` was not covered by the stripping regex.

## Solution

Extend `TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE` to cover both placeholder variants using an alternation group:

```diff
-const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE =
+  /^[ \t]*\[(?:tool calls omitted|assistant copied inbound metadata omitted)\][ \t]*$/i;
```

Same standalone-line logic applies: only strip when the placeholder is the entire line content, so ordinary user discussion of the placeholder text is preserved.

## Tests

Added 4 test assertions mirroring the existing `[tool calls omitted]` coverage — standalone strip, whitespace strip, mid-text strip, and inline-mention preservation. All 90/90 tests pass.