### PR TITLE
fix(sdk): normalize run chat projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Channels/groups: preserve observe-only turn suppression for prepared dispatch paths and restore deprecated channel turn runtime aliases, so passive observer/group flows stay silent while older plugins keep compiling. Thanks @vincentkoc.
+- SDK/events: keep per-run SDK event streams from surfacing duplicate raw chat projection frames while still normalizing chat-only projection frames for app UI state. Refs #74704. Thanks @gazeatcode.
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
 - macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.
 - Plugin SDK: restore the deprecated `plugin-sdk/zalouser` command-auth facade so published Lark/Zalo plugins that import it load on current hosts. Fixes #74702. Thanks @Goron01.

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -163,6 +163,75 @@ function unsupportedGatewayApi(api: string): never {
   throw new Error(`${api} is not supported by the current OpenClaw Gateway yet`);
 }
 
+type ChatProjection = {
+  state: "delta" | "final";
+  payload: Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function readChatProjection(event: OpenClawEvent): ChatProjection | undefined {
+  if (event.type !== "raw" || event.raw?.event !== "chat") {
+    return undefined;
+  }
+  const payload = asRecord(event.raw.payload);
+  if (payload.state !== "delta" && payload.state !== "final") {
+    return undefined;
+  }
+  return { state: payload.state, payload };
+}
+
+function readChatProjectionText(payload: Record<string, unknown>): string | undefined {
+  const content = asRecord(payload.message).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .map((part) => {
+      const record = asRecord(part);
+      return record.type === "text" && typeof record.text === "string" ? record.text : "";
+    })
+    .join("");
+  return text.length > 0 ? text : undefined;
+}
+
+function isAssistantRunEvent(event: OpenClawEvent): boolean {
+  return event.type === "assistant.delta" || event.type === "assistant.message";
+}
+
+function isTerminalRunEvent(event: OpenClawEvent): boolean {
+  return (
+    event.type === "run.completed" ||
+    event.type === "run.failed" ||
+    event.type === "run.cancelled" ||
+    event.type === "run.timed_out"
+  );
+}
+
+function normalizeChatProjectionEvent(
+  event: OpenClawEvent,
+  projection: ChatProjection,
+): OpenClawEvent {
+  const text = readChatProjectionText(projection.payload);
+  if (projection.state === "delta") {
+    return {
+      ...event,
+      type: "assistant.delta",
+      data: text === undefined ? event.data : { delta: text },
+    };
+  }
+  return {
+    ...event,
+    type: "run.completed",
+    data: { phase: "end", ...(text === undefined ? {} : { outputText: text }) },
+  };
+}
+
 export class OpenClaw {
   readonly agents: AgentsNamespace;
   readonly sessions: SessionsNamespace;
@@ -262,23 +331,47 @@ export class OpenClaw {
     filter?: (event: OpenClawEvent) => boolean,
   ): AsyncIterable<OpenClawEvent> {
     await this.connect();
-    const matches = (event: OpenClawEvent) => {
-      if (event.runId !== runId) {
-        return false;
+    const replayEvents = this.replaySnapshot(runId);
+    let hasCanonicalAssistantEvent = replayEvents.some(isAssistantRunEvent);
+    let hasTerminalEvent = replayEvents.some(isTerminalRunEvent);
+    const toRunStreamEvent = (event: OpenClawEvent): OpenClawEvent | undefined => {
+      const projection = readChatProjection(event);
+      if (projection?.state === "delta") {
+        return hasCanonicalAssistantEvent
+          ? undefined
+          : normalizeChatProjectionEvent(event, projection);
       }
-      return filter ? filter(event) : true;
+      if (projection?.state === "final") {
+        if (hasTerminalEvent) {
+          return undefined;
+        }
+        hasTerminalEvent = true;
+        return normalizeChatProjectionEvent(event, projection);
+      }
+      if (isAssistantRunEvent(event)) {
+        hasCanonicalAssistantEvent = true;
+      }
+      if (isTerminalRunEvent(event)) {
+        hasTerminalEvent = true;
+      }
+      return event;
     };
+    const matches = (event: OpenClawEvent) => event.runId === runId;
     const liveSource = this.normalizedEvents.stream(matches, { replay: true });
     const live = liveSource[Symbol.asyncIterator]();
     let nextLive = live.next();
     const seen = new Set<string>();
     try {
-      for (const event of this.replaySnapshot(runId)) {
-        if (!matches(event) || seen.has(event.id)) {
+      for (const event of replayEvents) {
+        if (seen.has(event.id)) {
           continue;
         }
         seen.add(event.id);
-        yield event;
+        const runEvent = toRunStreamEvent(event);
+        if (!runEvent || (filter && !filter(runEvent))) {
+          continue;
+        }
+        yield runEvent;
       }
       while (true) {
         const next = await nextLive;
@@ -290,7 +383,11 @@ export class OpenClaw {
           continue;
         }
         seen.add(next.value.id);
-        yield next.value;
+        const runEvent = toRunStreamEvent(next.value);
+        if (!runEvent || (filter && !filter(runEvent))) {
+          continue;
+        }
+        yield runEvent;
       }
     } finally {
       await live.return?.();

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { EventHub, OpenClaw, normalizeGatewayEvent } from "./index.js";
-import type { GatewayEvent, GatewayRequestOptions, OpenClawTransport } from "./types.js";
+import type {
+  GatewayEvent,
+  GatewayRequestOptions,
+  OpenClawEvent,
+  OpenClawTransport,
+} from "./types.js";
 
 type RequestCall = {
   method: string;
@@ -353,6 +358,173 @@ describe("OpenClaw SDK", () => {
     }
 
     expect(seen).toEqual(["run.started", "assistant.delta", "run.completed"]);
+  });
+
+  it("suppresses duplicate raw chat projection events in per-run streams", async () => {
+    const ts = 1_777_000_000_100;
+    const transport = new FakeTransport({
+      agent: (
+        _params: unknown,
+        _options: GatewayRequestOptions | undefined,
+        fake: FakeTransport,
+      ) => {
+        fake.emit({
+          event: "agent",
+          seq: 1,
+          payload: {
+            runId: "run_chat_projection",
+            stream: "lifecycle",
+            ts,
+            data: { phase: "start" },
+          },
+        });
+        fake.emit({
+          event: "agent",
+          seq: 2,
+          payload: {
+            runId: "run_chat_projection",
+            stream: "assistant",
+            ts: ts + 1,
+            data: { delta: "hello" },
+          },
+        });
+        fake.emit({
+          event: "chat",
+          seq: 3,
+          payload: {
+            runId: "run_chat_projection",
+            sessionKey: "chat-projection",
+            state: "delta",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }],
+              timestamp: ts + 2,
+            },
+          },
+        });
+        fake.emit({
+          event: "agent",
+          seq: 4,
+          payload: {
+            runId: "run_chat_projection",
+            stream: "lifecycle",
+            ts: ts + 3,
+            data: { phase: "end" },
+          },
+        });
+        fake.emit({
+          event: "chat",
+          seq: 5,
+          payload: {
+            runId: "run_chat_projection",
+            sessionKey: "chat-projection",
+            state: "final",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }],
+              timestamp: ts + 4,
+            },
+          },
+        });
+        return {
+          status: "accepted",
+          runId: "run_chat_projection",
+          sessionKey: "chat-projection",
+        };
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const run = await oc.runs.create({
+      input: "stream with chat projection",
+      idempotencyKey: "chat-projection-events",
+      sessionKey: "chat-projection",
+    });
+    const seen: OpenClawEvent[] = [];
+
+    for await (const event of run.events()) {
+      seen.push(event);
+      if (event.type === "run.completed") {
+        break;
+      }
+    }
+
+    expect(seen.map((event) => event.type)).toEqual([
+      "run.started",
+      "assistant.delta",
+      "run.completed",
+    ]);
+    expect(seen.map((event) => event.raw?.event)).toEqual(["agent", "agent", "agent"]);
+  });
+
+  it("normalizes chat-only projection events in per-run streams", async () => {
+    const ts = 1_777_000_000_200;
+    const transport = new FakeTransport({
+      agent: (
+        _params: unknown,
+        _options: GatewayRequestOptions | undefined,
+        fake: FakeTransport,
+      ) => {
+        fake.emit({
+          event: "chat",
+          seq: 1,
+          payload: {
+            runId: "run_chat_only",
+            sessionKey: "chat-only",
+            state: "delta",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }],
+              timestamp: ts,
+            },
+          },
+        });
+        fake.emit({
+          event: "chat",
+          seq: 2,
+          payload: {
+            runId: "run_chat_only",
+            sessionKey: "chat-only",
+            state: "final",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hello" }],
+              timestamp: ts + 1,
+            },
+          },
+        });
+        return { status: "accepted", runId: "run_chat_only", sessionKey: "chat-only" };
+      },
+    });
+    const oc = new OpenClaw({ transport });
+
+    const run = await oc.runs.create({
+      input: "stream with chat-only projection",
+      idempotencyKey: "chat-only-events",
+      sessionKey: "chat-only",
+    });
+    const iterator = run.events()[Symbol.asyncIterator]();
+
+    try {
+      await expect(iterator.next()).resolves.toMatchObject({
+        done: false,
+        value: {
+          type: "assistant.delta",
+          data: { delta: "hello" },
+          raw: { event: "chat" },
+        },
+      });
+      await expect(iterator.next()).resolves.toMatchObject({
+        done: false,
+        value: {
+          type: "run.completed",
+          data: { phase: "end", outputText: "hello" },
+          raw: { event: "chat" },
+        },
+      });
+    } finally {
+      await iterator.return?.();
+    }
   });
 
   it("creates a session and sends a message as a run", async () => {


### PR DESCRIPTION
## Summary

- Problem: `Run.events()` can surface raw Gateway `chat` projection frames for SDK runs, which creates duplicate app-facing events instead of a stable normalized per-run stream.
- Why it matters: OpenMeow-style app clients need `Run.events()` for UI state, while raw Gateway frames should remain available through `rawEvents()`.
- What changed: per-run streams now suppress duplicate raw `chat` projection frames when canonical SDK run events exist, and normalize chat-only `delta` / `final` projections to stable SDK event types.
- What did NOT change (scope boundary): this does not change Gateway cancel/wait semantics and does not touch the separate #74751 abort/wait work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #74704
- Related #74750
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Gateway `chat` projection frames normalize to SDK `raw` events while retaining the same `runId`, so `Run.events()` treated them as part of the stable run event stream.
- Missing detection / guardrail: SDK tests covered fast replayed agent events, but not duplicate chat projection frames or chat-only projection fallback.
- Contributing context (if known): live #74704 dogfood evidence identified raw `chat` events leaking into `run.events()`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `packages/sdk/src/index.test.ts`
- Scenario the test should lock in: canonical agent stream events suppress duplicate raw `chat` projections, and chat-only projection streams still produce `assistant.delta` and `run.completed` events.
- Why this is the smallest reliable guardrail: the fake SDK transport exercises event normalization, replay, and per-run filtering without a live Gateway.
- Existing test that already covers this (if any): fast run replay coverage existed, but it did not include `chat` projection frames.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`Run.events()` no longer emits duplicate raw `chat` projection frames when stable SDK events already exist for the run. Chat-only streams still produce normalized SDK events. Raw Gateway event access remains available through `oc.rawEvents()`.

## Diagram (if applicable)

```text
Before:
Gateway agent/chat frames -> Run.events() -> SDK events + duplicate raw chat frames

After:
Gateway agent/chat frames -> Run.events() -> stable SDK events
Gateway chat-only frames -> Run.events() -> assistant.delta/run.completed fallback
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): SDK event stream
- Relevant config (redacted): fake SDK transport

### Steps

1. Start an SDK run where canonical `agent` frames and duplicate `chat` projection frames share a run id.
2. Iterate `run.events()`.
3. Start an SDK run where only `chat` projection frames are present.
4. Iterate `run.events()`.

### Expected

- Duplicate raw `chat` frames are suppressed when canonical SDK events exist.
- Chat-only projections normalize to `assistant.delta` and `run.completed`.
- `rawEvents()` remains the raw Gateway escape hatch.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: duplicate `chat` projection suppression, chat-only projection fallback normalization, fast replay path, formatting, whitespace, changelog attribution, and package test typecheck.
- Edge cases checked: array text content extraction from chat messages and terminal `chat` final fallback data.
- What you did **not** verify: full repo `pnpm check` / `pnpm test`, and live Gateway/OpenMeow adapter execution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a caller intentionally consumed raw `chat` projection frames from `Run.events()`.
  - Mitigation: raw Gateway frames remain available through `oc.rawEvents()`; `Run.events()` is the normalized app-client stream.
- Risk: this overlaps with #74750.
  - Mitigation: this is a single-commit, narrow patch for the same #74704 dogfood gap; maintainers can choose the cleaner branch.
