### PR TITLE
fix(memory): install local embedding runtime deps

### DIFF
--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -59,9 +59,9 @@ function formatLocalSetupError(err: unknown): string {
     "To enable local embeddings:",
     "1) Use Node 24 (recommended for installs/updates; Node 22 LTS, currently 22.14+, remains supported)",
     missing
-      ? `2) Install optional local embedding runtime next to OpenClaw: npm i -g ${NODE_LLAMA_CPP_INSTALL_SPEC}`
+      ? `2) Repair bundled runtime dependencies: openclaw doctor --fix (installs ${NODE_LLAMA_CPP_INSTALL_SPEC} for the managed memory runtime)`
       : null,
-    `3) If you use pnpm: pnpm approve-builds (select ${NODE_LLAMA_CPP_RUNTIME_PACKAGE}), then pnpm rebuild ${NODE_LLAMA_CPP_RUNTIME_PACKAGE}`,
+    `3) If you use pnpm/source installs: pnpm approve-builds (select ${NODE_LLAMA_CPP_RUNTIME_PACKAGE}), then pnpm rebuild ${NODE_LLAMA_CPP_RUNTIME_PACKAGE}`,
     ...listRemoteEmbeddingSetupHints(),
   ]
     .filter(Boolean)

--- a/src/plugins/bundled-runtime-deps-selection.ts
+++ b/src/plugins/bundled-runtime-deps-selection.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { resolveUserPath } from "../utils.js";
 import { readRuntimeDepsJsonObject, type JsonObject } from "./bundled-runtime-deps-json.js";
 import {
   collectPackageRuntimeDeps,
@@ -17,6 +18,12 @@ import {
 } from "./config-normalization-shared.js";
 
 const MIRRORED_PACKAGE_RUNTIME_DEP_PLUGIN_ID = "openclaw-core";
+const MEMORY_CORE_PLUGIN_ID = "memory-core";
+const LOCAL_MEMORY_EMBEDDING_RUNTIME_DEP: RuntimeDepEntry = {
+  name: "node-llama-cpp",
+  version: "3.18.1",
+  pluginIds: [MEMORY_CORE_PLUGIN_ID],
+};
 
 export type RuntimeDepConflict = {
   name: string;
@@ -463,6 +470,114 @@ function shouldIncludeBundledPluginRuntimeDeps(params: {
   });
 }
 
+function readConfiguredProviderApiId(
+  config: OpenClawConfig,
+  providerId: string,
+): string | undefined {
+  const providers = config.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const normalizedProviderId = normalizeProviderId(providerId);
+  const providerConfig =
+    providers[providerId] ??
+    Object.entries(providers).find(
+      ([candidateId]) => normalizeProviderId(candidateId) === normalizedProviderId,
+    )?.[1];
+  const api = providerConfig?.api?.trim();
+  if (!api) {
+    return undefined;
+  }
+  const normalizedApi = normalizeProviderId(api);
+  return normalizedApi && normalizedApi !== normalizedProviderId ? normalizedApi : undefined;
+}
+
+function memoryEmbeddingProviderResolvesToLocal(
+  config: OpenClawConfig,
+  providerId: unknown,
+): boolean {
+  if (typeof providerId !== "string") {
+    return false;
+  }
+  const normalizedProviderId = normalizeProviderId(providerId);
+  if (normalizedProviderId === "local") {
+    return true;
+  }
+  return readConfiguredProviderApiId(config, providerId) === "local";
+}
+
+function canAutoSelectLocalMemorySearch(value: Record<string, unknown>): boolean {
+  const local = value.local;
+  if (!isRecord(local) || typeof local.modelPath !== "string") {
+    return false;
+  }
+  const modelPath = local.modelPath.trim();
+  if (!modelPath || /^(hf:|https?:)/i.test(modelPath)) {
+    return false;
+  }
+  try {
+    return fs.statSync(resolveUserPath(modelPath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isLocalMemorySearchConfig(config: OpenClawConfig, value: unknown): boolean {
+  if (!isRecord(value) || value.enabled === false) {
+    return false;
+  }
+  if (memoryEmbeddingProviderResolvesToLocal(config, value.provider)) {
+    return true;
+  }
+  if (memoryEmbeddingProviderResolvesToLocal(config, value.fallback)) {
+    return true;
+  }
+  const provider = normalizeOptionalLowercaseString(value.provider);
+  return (!provider || provider === "auto") && canAutoSelectLocalMemorySearch(value);
+}
+
+function mergeMemorySearchConfig(defaults: unknown, override: unknown): unknown {
+  if (!isRecord(defaults) && !isRecord(override)) {
+    return undefined;
+  }
+  const defaultLocal = isRecord(defaults) && isRecord(defaults.local) ? defaults.local : {};
+  const overrideLocal = isRecord(override) && isRecord(override.local) ? override.local : {};
+  return {
+    ...(isRecord(defaults) ? defaults : {}),
+    ...(isRecord(override) ? override : {}),
+    local: {
+      ...defaultLocal,
+      ...overrideLocal,
+    },
+  };
+}
+
+function isLocalMemorySearchConfigured(config: OpenClawConfig | undefined): boolean {
+  if (!config) {
+    return false;
+  }
+  const defaults = config.agents?.defaults?.memorySearch;
+  if (isLocalMemorySearchConfig(config, defaults)) {
+    return true;
+  }
+  return (config.agents?.list ?? []).some((agent) =>
+    isLocalMemorySearchConfig(config, mergeMemorySearchConfig(defaults, agent.memorySearch)),
+  );
+}
+
+function addRuntimeDepEntry(
+  versionMap: Map<string, Map<string, Set<string>>>,
+  dep: RuntimeDepEntry,
+): void {
+  const byVersion = versionMap.get(dep.name) ?? new Map<string, Set<string>>();
+  const pluginIds = byVersion.get(dep.version) ?? new Set<string>();
+  for (const pluginId of dep.pluginIds) {
+    pluginIds.add(pluginId);
+  }
+  byVersion.set(dep.version, pluginIds);
+  versionMap.set(dep.name, byVersion);
+}
+
 export function collectBundledPluginRuntimeDeps(params: {
   extensionsDir: string;
   config?: OpenClawConfig;
@@ -522,12 +637,19 @@ export function collectBundledPluginRuntimeDeps(params: {
       if (!dep) {
         continue;
       }
-      const byVersion = versionMap.get(dep.name) ?? new Map<string, Set<string>>();
-      const pluginIds = byVersion.get(dep.version) ?? new Set<string>();
-      pluginIds.add(pluginId);
-      byVersion.set(dep.version, pluginIds);
-      versionMap.set(dep.name, byVersion);
+      addRuntimeDepEntry(versionMap, {
+        name: dep.name,
+        version: dep.version,
+        pluginIds: [pluginId],
+      });
     }
+  }
+
+  if (
+    includedPluginIds.has(MEMORY_CORE_PLUGIN_ID) &&
+    isLocalMemorySearchConfigured(params.config)
+  ) {
+    addRuntimeDepEntry(versionMap, LOCAL_MEMORY_EMBEDDING_RUNTIME_DEP);
   }
 
   const deps: RuntimeDepEntry[] = [];

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ModelProviderConfig } from "../config/types.models.js";
 import {
   __testing as bundledRuntimeDepsActivityTesting,
   getActiveBundledRuntimeDepsInstallCount,
@@ -1178,6 +1179,168 @@ describe("scanBundledPluginRuntimeDeps config policy", () => {
     });
 
     expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual(expectedDeps);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("adds local embedding runtime deps when scanning local memory search config", () => {
+    const packageRoot = makeTempDir();
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: "local",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "chokidar@^5.0.0",
+      "node-llama-cpp@3.18.1",
+    ]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("adds local embedding runtime deps for configured provider ids backed by local", () => {
+    const packageRoot = makeTempDir();
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {
+        models: {
+          providers: {
+            "local-gpu": {
+              api: "local",
+            } as unknown as ModelProviderConfig,
+          },
+        },
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: "local-gpu",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "chokidar@^5.0.0",
+      "node-llama-cpp@3.18.1",
+    ]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("adds local embedding runtime deps for auto provider with an existing local model file", () => {
+    const packageRoot = makeTempDir();
+    const modelPath = path.join(packageRoot, "embedding-model.gguf");
+    fs.writeFileSync(modelPath, "");
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: "auto",
+              local: {
+                modelPath,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "chokidar@^5.0.0",
+      "node-llama-cpp@3.18.1",
+    ]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("adds local embedding runtime deps for local fallback providers", () => {
+    const packageRoot = makeTempDir();
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: "openai",
+              fallback: "local",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "chokidar@^5.0.0",
+      "node-llama-cpp@3.18.1",
+    ]);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it("adds local embedding runtime deps for agent overrides that inherit local defaults", () => {
+    const packageRoot = makeTempDir();
+    writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+
+    const result = scanBundledPluginRuntimeDeps({
+      packageRoot,
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              enabled: false,
+              provider: "local",
+            },
+          },
+          list: [
+            {
+              id: "main",
+              memorySearch: {
+                enabled: true,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual([
+      "chokidar@^5.0.0",
+      "node-llama-cpp@3.18.1",
+    ]);
     expect(result.conflicts).toEqual([]);
   });
 
@@ -3230,6 +3393,73 @@ describe("ensureBundledPluginRuntimeDeps", () => {
       },
     ]);
     expect(installRoot).not.toBe(pluginRoot);
+  });
+
+  it("adds local embedding runtime deps when memory search uses the local provider", () => {
+    const packageRoot = makeTempDir();
+    const pluginRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+    const calls: BundledRuntimeDepsInstallParams[] = [];
+
+    const result = ensureBundledPluginRuntimeDeps({
+      env: {},
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              provider: "local",
+            },
+          },
+        },
+      },
+      installDeps: (params) => {
+        calls.push(params);
+      },
+      pluginId: "memory-core",
+      pluginRoot,
+    });
+
+    expect(result).toEqual({
+      installedSpecs: ["chokidar@^5.0.0", "node-llama-cpp@3.18.1"],
+    });
+    expect(calls[0]?.installSpecs).toEqual(["chokidar@^5.0.0", "node-llama-cpp@3.18.1"]);
+  });
+
+  it("does not add local embedding runtime deps when local memory search is disabled", () => {
+    const packageRoot = makeTempDir();
+    const pluginRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "^5.0.0" },
+    });
+    const calls: BundledRuntimeDepsInstallParams[] = [];
+
+    const result = ensureBundledPluginRuntimeDeps({
+      env: {},
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: {
+              enabled: false,
+              provider: "local",
+            },
+          },
+        },
+      },
+      installDeps: (params) => {
+        calls.push(params);
+      },
+      pluginId: "memory-core",
+      pluginRoot,
+    });
+
+    expect(result).toEqual({
+      installedSpecs: ["chokidar@^5.0.0"],
+    });
+    expect(calls[0]?.installSpecs).toEqual(["chokidar@^5.0.0"]);
   });
 
   it("repairs package-level mirrors when an installed package entry file is missing", () => {


### PR DESCRIPTION
## Summary

- Problem: local memory search can select the bundled memory-core runtime without installing `node-llama-cpp` into the managed plugin runtime dependency root.
- Why it matters: `agents.defaults.memorySearch.provider = "local"` can fail before indexing/search starts with `Cannot find package 'node-llama-cpp'` even when the model file exists or the package is installed globally.
- What changed: add `node-llama-cpp@3.18.1` to bundled runtime dependency selection when memory-core is included and local memory search is configured; update the local setup hint to use `openclaw doctor --fix`.
- What did NOT change (scope boundary): no root/package dependency is added for `node-llama-cpp`, preserving the release guardrail that keeps it operator-installed/managed runtime only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74777
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: local embeddings import `node-llama-cpp` from the managed plugin runtime, but runtime dependency selection did not include that package for local memory search.
- Missing detection / guardrail: bundled runtime dependency tests covered declared plugin package dependencies, but not config-gated optional local embedding runtime deps.
- Contributing context (if known): reproduced from a local memory_search failure where `plugin-runtime-deps` lacked `node-llama-cpp` despite global installation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/bundled-runtime-deps.test.ts`
- Scenario the test should lock in: scanning/ensuring bundled runtime deps includes `node-llama-cpp@3.18.1` only when local memory search is enabled.
- Why this is the smallest reliable guardrail: the bug is in runtime dependency selection, before embeddings execute.
- Existing test that already covers this (if any): none for the config-gated local embedding runtime dep.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw doctor --fix` and gateway startup can repair/install the local embedding runtime dependency into the managed runtime when local memory search is configured. The missing-runtime hint now points users to `openclaw doctor --fix` instead of global npm installation.

## Diagram (if applicable)

```text
Before:
[local memorySearch config] -> [memory-core runtime deps] -> [chokidar only] -> [node-llama-cpp import fails]

After:
[local memorySearch config] -> [memory-core runtime deps] -> [chokidar + node-llama-cpp] -> [local embeddings can load]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local pnpm workspace
- Model/provider: local memory search provider
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.memorySearch.provider = "local"`

### Steps

1. Configure local memory search.
2. Start or repair bundled memory-core runtime deps.
3. Exercise runtime dependency scan/ensure paths.

### Expected

- Managed runtime deps include `node-llama-cpp@3.18.1` for local memory search.

### Actual

- Before this fix, the managed runtime deps did not include `node-llama-cpp`, so bare import resolution failed from `plugin-runtime-deps`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec vitest run src/plugins/bundled-runtime-deps.test.ts --config test/vitest/vitest.plugins.config.ts`
  - `pnpm exec vitest run extensions/memory-core/src/memory/embeddings.test.ts extensions/memory-core/src/memory/search-manager.test.ts --config test/vitest/vitest.extension-memory.config.ts`
  - `pnpm exec vitest run test/openclaw-npm-release-check.test.ts --config test/vitest/vitest.tooling.config.ts`
  - `pnpm exec oxfmt --check --threads=1 src/plugins/bundled-runtime-deps-selection.ts src/plugins/bundled-runtime-deps.test.ts extensions/memory-core/src/memory/provider-adapters.ts`
  - `pnpm tsgo:core`
  - `pnpm check:changed`
- Edge cases checked: disabled local memory search does not add `node-llama-cpp`.
- What you did **not** verify: full end-to-end local embedding model load with native `node-llama-cpp` in the managed runtime.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `node-llama-cpp` native install can still fail on unsupported local toolchains.
  - Mitigation: dependency remains config-gated to local memory search and the setup hint points users to the managed repair path plus pnpm rebuild guidance.
