### PR TITLE
fix(bonjour): auto-disable mDNS in WSL2 environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Bonjour/Gateway: auto-disable mDNS advertisement on WSL2, where virtualized networking isolates multicast traffic and causes repeated advertiser restart failures. Users can still opt in via `OPENCLAW_DISABLE_BONJOUR=0`. Refs #74209. Thanks @DhtIsCoding.
 - Channels/groups: preserve observe-only turn suppression for prepared dispatch paths and restore deprecated channel turn runtime aliases, so passive observer/group flows stay silent while older plugins keep compiling. Thanks @vincentkoc.
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
 - macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
     warn: vi.fn(),
     debug: vi.fn(),
   },
+  isWSL2Sync: vi.fn().mockReturnValue(false),
 }));
 const {
   createService,
@@ -48,6 +49,10 @@ function enableAdvertiserUnitMode(hostname = "test-host") {
   process.env.NODE_ENV = "development";
   vi.spyOn(os, "hostname").mockReturnValue(hostname);
   process.env.OPENCLAW_MDNS_HOSTNAME = hostname;
+  // Clear WSL env vars so tests run consistently regardless of host environment
+  delete process.env.WSL_DISTRO_NAME;
+  delete process.env.WSL_INTEROP;
+  delete process.env.WSLENV;
 }
 
 function mockCiaoService(params?: {
@@ -85,6 +90,14 @@ function mockCiaoService(params?: {
   getResponder.mockReturnValue(params?.responder ?? { createService, shutdown });
   return { advertise, destroy, on };
 }
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual("openclaw/plugin-sdk/runtime-env");
+  return {
+    ...actual,
+    isWSL2Sync: mocks.isWSL2Sync,
+  };
+});
 
 vi.mock("@homebridge/ciao", () => {
   return {
@@ -239,7 +252,7 @@ describe("gateway bonjour advertiser", () => {
 
   it("auto-disables Bonjour in WSL2", async () => {
     enableAdvertiserUnitMode();
-    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    mocks.isWSL2Sync.mockReturnValue(true);
 
     const started = await startAdvertiser({
       gatewayPort: 18789,
@@ -249,12 +262,12 @@ describe("gateway bonjour advertiser", () => {
     expect(createService).not.toHaveBeenCalled();
     await expect(started.stop()).resolves.toBeUndefined();
 
-    delete process.env.WSL_DISTRO_NAME;
+    mocks.isWSL2Sync.mockReturnValue(false);
   });
 
   it("honors explicit Bonjour opt-in inside WSL2", async () => {
     enableAdvertiserUnitMode();
-    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    mocks.isWSL2Sync.mockReturnValue(true);
     process.env.OPENCLAW_DISABLE_BONJOUR = "0";
 
     const destroy = vi.fn().mockResolvedValue(undefined);
@@ -270,7 +283,7 @@ describe("gateway bonjour advertiser", () => {
 
     await started.stop();
 
-    delete process.env.WSL_DISTRO_NAME;
+    mocks.isWSL2Sync.mockReturnValue(false);
     delete process.env.OPENCLAW_DISABLE_BONJOUR;
   });
 

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -237,6 +237,43 @@ describe("gateway bonjour advertiser", () => {
     await expect(started.stop()).resolves.toBeUndefined();
   });
 
+  it("auto-disables Bonjour in WSL2", async () => {
+    enableAdvertiserUnitMode();
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).not.toHaveBeenCalled();
+    await expect(started.stop()).resolves.toBeUndefined();
+
+    delete process.env.WSL_DISTRO_NAME;
+  });
+
+  it("honors explicit Bonjour opt-in inside WSL2", async () => {
+    enableAdvertiserUnitMode();
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    process.env.OPENCLAW_DISABLE_BONJOUR = "0";
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).toHaveBeenCalledTimes(1);
+
+    await started.stop();
+
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.OPENCLAW_DISABLE_BONJOUR;
+  });
+
   it("honors explicit Bonjour opt-in inside detected containers", async () => {
     enableAdvertiserUnitMode();
     process.env.OPENCLAW_DISABLE_BONJOUR = "0";

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
-import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { isTruthyEnvValue, isWSL2Sync } from "openclaw/plugin-sdk/runtime-env";
 import { classifyCiaoProcessError, type CiaoProcessErrorClassification } from "./ciao.js";
 import { formatBonjourError } from "./errors.js";
 
@@ -166,6 +166,9 @@ function isDisabledByEnv() {
     return envOverride;
   }
   if (isContainerEnvironment()) {
+    return true;
+  }
+  if (isWSL2Sync()) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Problem

In WSL2, the Bonjour/mDNS advertiser repeatedly fails because WSL2's virtualized network stack isolates the Linux guest from the host's multicast domain. This causes `@homebridge/ciao` to get stuck in the `unannounced` state and eventually exhaust its restart limit, producing warnings like:

```
bonjour: disabling advertiser after 3 failed restarts (service stuck in unannounced ...)
set discovery.mdns.mode=\"off\" or OPENCLAW_DISABLE_BONJOUR=1 to disable mDNS discovery
```

This is a common issue in WSL2 environments where multicast traffic cannot reach the Windows host network.

## Solution

Automatically skip Bonjour advertisement when running in WSL2, using the existing `isWSL2Sync()` utility from `plugin-sdk/runtime-env`. This mirrors the existing behavior for container environments.

Users can still explicitly opt-in via `OPENCLAW_DISABLE_BONJOUR=0` if they have a working multicast bridge setup.

## Changes

- `extensions/bonjour/src/advertiser.ts`: Added WSL2 detection to `isDisabledByEnv()`
- `extensions/bonjour/src/advertiser.test.ts`: 
  - Added tests for auto-disable and explicit opt-in in WSL2
  - Mocked `isWSL2Sync` so tests pass consistently regardless of host environment
  - Cleared WSL env vars in `enableAdvertiserUnitMode()` for test isolation
- `CHANGELOG.md`: Added entry under Unreleased/Fixes

## Testing

- [x] All 28 bonjour advertiser tests pass
- [x] New WSL2 auto-disable test verifies `createService` is not called
- [x] New WSL2 opt-in test verifies `OPENCLAW_DISABLE_BONJOUR=0` overrides detection
- [x] Existing container tests still pass
- [x] Code formatting verified with `oxfmt`

## Related

Refs #74209 (Bonjour can block gateway startup after 2026.4.26 upgrade)
