### PR TITLE
fix(cron): validate cron expression before persisting to job state

### DIFF
--- a/src/cron/validate-cron-expression.test.ts
+++ b/src/cron/validate-cron-expression.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { validateCronExpression } from "./validate-cron-expression.js";
+
+describe("validateCronExpression", () => {
+  describe("valid expressions", () => {
+    it("accepts standard 5-field cron expression", () => {
+      const result = validateCronExpression("* * * * *");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts 6-field cron expression with seconds", () => {
+      const result = validateCronExpression("0 * * * * *");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts specific time expression", () => {
+      const result = validateCronExpression("0 0 * * *");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts expression with ranges", () => {
+      const result = validateCronExpression("0 9-17 * * 1-5");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts expression with timezone", () => {
+      const result = validateCronExpression("0 0 * * *", "America/New_York");
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe("invalid expressions", () => {
+    it("rejects empty expression", () => {
+      const result = validateCronExpression("");
+      expect(result).toEqual({
+        ok: false,
+        message: "cron expression cannot be empty",
+      });
+    });
+
+    it("rejects undefined expression", () => {
+      const result = validateCronExpression(undefined);
+      expect(result).toEqual({
+        ok: false,
+        message: "cron expression is required",
+      });
+    });
+
+    it("rejects invalid month value (13)", () => {
+      // Issue #74459: "* * * 13 *" should be rejected upfront
+      const result = validateCronExpression("* * * 13 *");
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("month");
+    });
+
+    it("rejects invalid day of week (8)", () => {
+      const result = validateCronExpression("* * * * 8");
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/day|week|range/i);
+    });
+
+    it("rejects invalid hour value (25)", () => {
+      const result = validateCronExpression("0 25 * * *");
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/hour|range/i);
+    });
+
+    it("rejects expression with too few fields", () => {
+      const result = validateCronExpression("* * *");
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles whitespace-only expression", () => {
+      const result = validateCronExpression("   ");
+      expect(result).toEqual({
+        ok: false,
+        message: "cron expression cannot be empty",
+      });
+    });
+
+    it("trims whitespace from valid expression", () => {
+      const result = validateCronExpression("  0 0 * * *  ");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts predefined alias @daily", () => {
+      const result = validateCronExpression("@daily");
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("accepts predefined alias @hourly", () => {
+      const result = validateCronExpression("@hourly");
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/src/cron/validate-cron-expression.ts
+++ b/src/cron/validate-cron-expression.ts
@@ -29,15 +29,14 @@ export function validateCronExpression(
   expr: unknown,
   tz?: unknown,
 ): CronExpressionValidationResult {
-  const exprRaw = normalizeOptionalString(expr) ?? "";
-  if (!exprRaw) {
+  if (typeof expr !== "string") {
     return {
       ok: false,
       message: "cron expression is required",
     };
   }
 
-  const exprTrimmed = exprRaw.trim();
+  const exprTrimmed = expr.trim();
   if (!exprTrimmed) {
     return {
       ok: false,
@@ -53,9 +52,7 @@ export function validateCronExpression(
     return { ok: true };
   } catch (error) {
     const errorMessage =
-      error instanceof Error
-        ? error.message
-        : `Invalid cron expression: ${String(error)}`;
+      error instanceof Error ? error.message : `Invalid cron expression: ${String(error)}`;
     return {
       ok: false,
       message: errorMessage,

--- a/src/cron/validate-cron-expression.ts
+++ b/src/cron/validate-cron-expression.ts
@@ -1,0 +1,64 @@
+import { Cron } from "croner";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export type CronExpressionValidationError = {
+  ok: false;
+  message: string;
+};
+
+export type CronExpressionValidationSuccess = {
+  ok: true;
+};
+
+export type CronExpressionValidationResult =
+  | CronExpressionValidationSuccess
+  | CronExpressionValidationError;
+
+/**
+ * Validates cron expression syntax before applying to job state.
+ * This prevents invalid cron expressions from being persisted in disabled jobs
+ * that would fail when enabled later.
+ *
+ * Uses croner library (same as computeNextRunAtMs) to validate the expression.
+ *
+ * @param expr - The cron expression to validate (e.g., "* * * * *" or "0 0 * * *")
+ * @param tz - Optional timezone (defaults to system timezone)
+ * @returns Validation result with ok boolean and error message if invalid
+ */
+export function validateCronExpression(
+  expr: unknown,
+  tz?: unknown,
+): CronExpressionValidationResult {
+  const exprRaw = normalizeOptionalString(expr) ?? "";
+  if (!exprRaw) {
+    return {
+      ok: false,
+      message: "cron expression is required",
+    };
+  }
+
+  const exprTrimmed = exprRaw.trim();
+  if (!exprTrimmed) {
+    return {
+      ok: false,
+      message: "cron expression cannot be empty",
+    };
+  }
+
+  const timezone = normalizeOptionalString(tz) ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  try {
+    // croner throws RangeError for invalid expressions like "* * * 13 *"
+    new Cron(exprTrimmed, { timezone, catch: false });
+    return { ok: true };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : `Invalid cron expression: ${String(error)}`;
+    return {
+      ok: false,
+      message: errorMessage,
+    };
+  }
+}

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -10,6 +10,7 @@ import { applyJobPatch } from "../../cron/service/jobs.js";
 import { isInvalidCronSessionTargetIdError } from "../../cron/session-target.js";
 import type { CronDelivery, CronJob, CronJobCreate, CronJobPatch } from "../../cron/types.js";
 import { validateScheduleTimestamp } from "../../cron/validate-timestamp.js";
+import { validateCronExpression } from "../../cron/validate-cron-expression.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { listConfiguredAnnounceChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -228,6 +229,21 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    // Also validate cron expression syntax on creation (issue #74459)
+    if (jobCreate.schedule.kind === "cron") {
+      const cronValidation = validateCronExpression(
+        jobCreate.schedule.expr,
+        jobCreate.schedule.tz,
+      );
+      if (!cronValidation.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, cronValidation.message),
+        );
+        return;
+      }
+    }
     try {
       assertValidCronCreateDelivery(cfg, jobCreate);
     } catch (err) {
@@ -316,6 +332,22 @@ export const cronHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.INVALID_REQUEST, timestampValidation.message),
         );
         return;
+      }
+      // Also validate cron expression syntax to prevent invalid schedules
+      // from being persisted in disabled jobs (issue #74459)
+      if (patch.schedule.kind === "cron") {
+        const cronValidation = validateCronExpression(
+          patch.schedule.expr,
+          patch.schedule.tz,
+        );
+        if (!cronValidation.ok) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, cronValidation.message),
+          );
+          return;
+        }
       }
     }
     try {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -380,3 +380,97 @@ describe("cron method validation", () => {
     expect(respond).not.toHaveBeenCalled();
   });
 });
+
+  // Issue #74459: Validate cron expression BEFORE applying to disabled jobs
+  it("rejects invalid cron expression on disabled job update BEFORE applying patch (#74459)", async () => {
+    const disabledJob = createCronJob({ enabled: false });
+    const context = createCronContext(disabledJob);
+    const respond = vi.fn();
+
+    await cronHandlers["cron.update"]({
+      req: {} as never,
+      params: {
+        id: disabledJob.id,
+        patch: {
+          schedule: { kind: "cron", expr: "* * * 13 *" },  // Invalid: month 13
+        },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    // Should reject BEFORE calling context.cron.update (not wait for runtime error)
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("month"),
+      }),
+    );
+    // Should NOT have called context.cron.update with invalid schedule
+    expect(context.cron.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid cron expression on cron.add with disabled flag (#74459)", async () => {
+    const context = createCronContext();
+    const respond = vi.fn();
+
+    await cronHandlers["cron.add"]({
+      req: {} as never,
+      params: {
+        name: "invalid-disabled-cron",
+        enabled: false,  // Creating disabled job with invalid cron
+        schedule: { kind: "cron", expr: "0 0 * * 8" },  // Invalid: day of week 8
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "ping" },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringMatching(/day|week|range/i),
+      }),
+    );
+    expect(context.cron.add).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid cron expression on disabled job update", async () => {
+    const disabledJob = createCronJob({ enabled: false });
+    const context = createCronContext(disabledJob);
+    const respond = vi.fn();
+
+    await cronHandlers["cron.update"]({
+      req: {} as never,
+      params: {
+        id: disabledJob.id,
+        patch: {
+          schedule: { kind: "cron", expr: "0 0 * * *" },  // Valid expression
+        },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    // Should accept and call context.cron.update
+    expect(context.cron.update).toHaveBeenCalledWith(
+      disabledJob.id,
+      expect.objectContaining({
+        schedule: { kind: "cron", expr: "0 0 * * *" },
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(true, { id: "cron-1" }, undefined);
+  });
+});

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -379,8 +379,6 @@ describe("cron method validation", () => {
     ).rejects.toThrow("DB write failed");
     expect(respond).not.toHaveBeenCalled();
   });
-});
-
   // Issue #74459: Validate cron expression BEFORE applying to disabled jobs
   it("rejects invalid cron expression on disabled job update BEFORE applying patch (#74459)", async () => {
     const disabledJob = createCronJob({ enabled: false });
@@ -392,7 +390,7 @@ describe("cron method validation", () => {
       params: {
         id: disabledJob.id,
         patch: {
-          schedule: { kind: "cron", expr: "* * * 13 *" },  // Invalid: month 13
+          schedule: { kind: "cron", expr: "* * * 13 *" }, // Invalid: month 13
         },
       } as never,
       respond: respond as never,
@@ -422,8 +420,8 @@ describe("cron method validation", () => {
       req: {} as never,
       params: {
         name: "invalid-disabled-cron",
-        enabled: false,  // Creating disabled job with invalid cron
-        schedule: { kind: "cron", expr: "0 0 * * 8" },  // Invalid: day of week 8
+        enabled: false, // Creating disabled job with invalid cron
+        schedule: { kind: "cron", expr: "0 0 * * 8" }, // Invalid: day of week 8
         sessionTarget: "isolated",
         wakeMode: "next-heartbeat",
         payload: { kind: "agentTurn", message: "ping" },
@@ -455,7 +453,7 @@ describe("cron method validation", () => {
       params: {
         id: disabledJob.id,
         patch: {
-          schedule: { kind: "cron", expr: "0 0 * * *" },  // Valid expression
+          schedule: { kind: "cron", expr: "0 0 * * *" }, // Valid expression
         },
       } as never,
       respond: respond as never,


### PR DESCRIPTION
## Summary

Fixes #74459: Prevents invalid cron expressions from being persisted in disabled jobs that would fail silently when enabled later.

## Problem

When a cron job is disabled, users can save invalid cron expressions (e.g., `* * * 13 *` - month 13 doesn not exist). The expression is stored without validation. When the job is enabled later, it fails at runtime with no clear error message.

## Solution

Add upfront cron expression validation using the `croner` library (same library used for computing next run times) in gateway handlers:

1. **cron.add**: Validate cron expressions before creating the job
2. **cron.update**: Validate cron expressions before applying the patch

This ensures invalid expressions are rejected with clear error messages BEFORE they are saved to job state, not at runtime.

## Implementation

- Create `validateCronExpression()` in `src/cron/validate-cron-expression.ts`
- Validate in both `cron.add` and `cron.update` gateway handlers
- Add comprehensive test coverage for valid/invalid expressions

## Testing

Added tests in:
- `src/cron/validate-cron-expression.test.ts` - unit tests for validation function
- `src/gateway/server-methods/cron.validation.test.ts` - integration tests for gateway handlers

Test cases include:
- Valid expressions: `* * * * *`, `0 0 * * *`, with timezone
- Invalid expressions: month 13, day of week 8, hour 25, empty/undefined
- Edge cases: whitespace, predefined aliases (`@daily`, `@hourly`)

## Checklist

- [x] Issue linked in title and body
- [x] Semantic commit message format
- [x] Test coverage added
- [x] No CHANGELOG update (maintainers handle this)