### PR TITLE
fix(bonjour): auto-disable mDNS in WSL2 environments

### DIFF
--- a/docs/gateway/bonjour.md
+++ b/docs/gateway/bonjour.md
@@ -162,7 +162,7 @@ The log includes browser state transitions and result‑set changes.
 ## When to disable Bonjour
 
 Disable Bonjour only when LAN multicast advertising is unavailable or harmful.
-The common case is a Gateway running behind Docker bridge networking, WSL, or a
+The common case is a Gateway running behind Docker bridge networking, WSL2, or a
 network policy that drops mDNS multicast. In those environments the Gateway is
 still reachable through its published URL, SSH, Tailnet, or wide-area DNS-SD,
 but LAN auto-discovery is not reliable.
@@ -248,6 +248,9 @@ If a node no longer auto-discovers the Gateway after Docker setup:
 - **Docker bridge networking**: Bonjour auto-disables in detected containers.
   Set `OPENCLAW_DISABLE_BONJOUR=0` only for host, macvlan, or another
   mDNS-capable network.
+- **WSL2**: Bonjour auto-disables inside WSL2 because its virtualized network
+  stack does not forward mDNS multicast to the Windows host. Use
+  `OPENCLAW_DISABLE_BONJOUR=0` only if you have configured a multicast bridge.
 - **Sleep / interface churn**: macOS may temporarily drop mDNS results; retry.
 - **Browse works but resolve fails**: keep machine names simple (avoid emojis or
   punctuation), then restart the Gateway. The service instance name derives from
@@ -267,7 +270,7 @@ sequences (e.g. spaces become `\032`).
 - `openclaw plugins enable bonjour` restores the default LAN discovery plugin.
 - `OPENCLAW_DISABLE_BONJOUR=1` disables LAN multicast advertising without changing plugin config; accepted truthy values are `1`, `true`, `yes`, and `on` (legacy: `OPENCLAW_DISABLE_BONJOUR`).
 - `OPENCLAW_DISABLE_BONJOUR=0` forces LAN multicast advertising on, including inside detected containers; accepted falsy values are `0`, `false`, `no`, and `off`.
-- When `OPENCLAW_DISABLE_BONJOUR` is unset, Bonjour advertises on normal hosts and auto-disables inside detected containers.
+- When `OPENCLAW_DISABLE_BONJOUR` is unset, Bonjour advertises on normal hosts and auto-disables inside detected containers and WSL2.
 - `gateway.bind` in `~/.openclaw/openclaw.json` controls the Gateway bind mode.
 - `OPENCLAW_SSH_PORT` overrides the SSH port when `sshPort` is advertised (legacy: `OPENCLAW_SSH_PORT`).
 - `OPENCLAW_TAILNET_DNS` publishes a MagicDNS hint in TXT when mDNS full mode is enabled (legacy: `OPENCLAW_TAILNET_DNS`).

--- a/docs/gateway/discovery.md
+++ b/docs/gateway/discovery.md
@@ -87,8 +87,8 @@ Disable/override:
 
 - `OPENCLAW_DISABLE_BONJOUR=1` disables advertising.
 - When `OPENCLAW_DISABLE_BONJOUR` is unset, Bonjour advertises on normal hosts
-  and auto-disables inside detected containers. Use `0` only on host, macvlan,
-  or another mDNS-capable network; use `1` to force-disable.
+  and auto-disables inside detected containers and WSL2. Use `0` only on host,
+  macvlan, or another mDNS-capable network; use `1` to force-disable.
 - `gateway.bind` in `~/.openclaw/openclaw.json` controls the Gateway bind mode.
 - `OPENCLAW_SSH_PORT` overrides the SSH port advertised when `sshPort` is emitted.
 - `OPENCLAW_TAILNET_DNS` publishes a `tailnetDns` hint (MagicDNS).

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
     warn: vi.fn(),
     debug: vi.fn(),
   },
+  isWSL2Sync: vi.fn().mockReturnValue(false),
 }));
 const {
   createService,
@@ -48,6 +49,10 @@ function enableAdvertiserUnitMode(hostname = "test-host") {
   process.env.NODE_ENV = "development";
   vi.spyOn(os, "hostname").mockReturnValue(hostname);
   process.env.OPENCLAW_MDNS_HOSTNAME = hostname;
+  // Clear WSL env vars so tests run consistently regardless of host environment
+  delete process.env.WSL_DISTRO_NAME;
+  delete process.env.WSL_INTEROP;
+  delete process.env.WSLENV;
 }
 
 function mockCiaoService(params?: {
@@ -85,6 +90,14 @@ function mockCiaoService(params?: {
   getResponder.mockReturnValue(params?.responder ?? { createService, shutdown });
   return { advertise, destroy, on };
 }
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual("openclaw/plugin-sdk/runtime-env");
+  return {
+    ...actual,
+    isWSL2Sync: mocks.isWSL2Sync,
+  };
+});
 
 vi.mock("@homebridge/ciao", () => {
   return {
@@ -239,7 +252,7 @@ describe("gateway bonjour advertiser", () => {
 
   it("auto-disables Bonjour in WSL2", async () => {
     enableAdvertiserUnitMode();
-    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    mocks.isWSL2Sync.mockReturnValue(true);
 
     const started = await startAdvertiser({
       gatewayPort: 18789,
@@ -249,12 +262,12 @@ describe("gateway bonjour advertiser", () => {
     expect(createService).not.toHaveBeenCalled();
     await expect(started.stop()).resolves.toBeUndefined();
 
-    delete process.env.WSL_DISTRO_NAME;
+    mocks.isWSL2Sync.mockReturnValue(false);
   });
 
   it("honors explicit Bonjour opt-in inside WSL2", async () => {
     enableAdvertiserUnitMode();
-    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    mocks.isWSL2Sync.mockReturnValue(true);
     process.env.OPENCLAW_DISABLE_BONJOUR = "0";
 
     const destroy = vi.fn().mockResolvedValue(undefined);
@@ -270,7 +283,7 @@ describe("gateway bonjour advertiser", () => {
 
     await started.stop();
 
-    delete process.env.WSL_DISTRO_NAME;
+    mocks.isWSL2Sync.mockReturnValue(false);
     delete process.env.OPENCLAW_DISABLE_BONJOUR;
   });
 

--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -237,6 +237,43 @@ describe("gateway bonjour advertiser", () => {
     await expect(started.stop()).resolves.toBeUndefined();
   });
 
+  it("auto-disables Bonjour in WSL2", async () => {
+    enableAdvertiserUnitMode();
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).not.toHaveBeenCalled();
+    await expect(started.stop()).resolves.toBeUndefined();
+
+    delete process.env.WSL_DISTRO_NAME;
+  });
+
+  it("honors explicit Bonjour opt-in inside WSL2", async () => {
+    enableAdvertiserUnitMode();
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    process.env.OPENCLAW_DISABLE_BONJOUR = "0";
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    expect(createService).toHaveBeenCalledTimes(1);
+
+    await started.stop();
+
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.OPENCLAW_DISABLE_BONJOUR;
+  });
+
   it("honors explicit Bonjour opt-in inside detected containers", async () => {
     enableAdvertiserUnitMode();
     process.env.OPENCLAW_DISABLE_BONJOUR = "0";

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
-import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
+import { isTruthyEnvValue, isWSL2Sync } from "openclaw/plugin-sdk/runtime-env";
 import { classifyCiaoProcessError, type CiaoProcessErrorClassification } from "./ciao.js";
 import { formatBonjourError } from "./errors.js";
 
@@ -166,6 +166,9 @@ function isDisabledByEnv() {
     return envOverride;
   }
   if (isContainerEnvironment()) {
+    return true;
+  }
+  if (isWSL2Sync()) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Problem

In WSL2, the Bonjour/mDNS advertiser repeatedly fails because WSL2's virtualized network stack isolates the Linux guest from the host's multicast domain. This causes `@homebridge/ciao` to get stuck in the `unannounced` state and eventually exhaust its restart limit, producing warnings like:

```
bonjour: disabling advertiser after 3 failed restarts (service stuck in unannounced ...)
set discovery.mdns.mode=\"off\" or OPENCLAW_DISABLE_BONJOUR=1 to disable mDNS discovery
```

While c39ca49 (merged) and #74778 (pending) address the symptoms by limiting restart loops, they do not prevent the unnecessary churn in environments where multicast is fundamentally unsupported.

## Solution

Automatically skip Bonjour advertisement when running in WSL2, using the existing `isWSL2Sync()` utility from `plugin-sdk/runtime-env`. This mirrors the existing behavior for container environments and avoids wasting resources on doomed advertisement attempts.

Users can still explicitly opt-in via `OPENCLAW_DISABLE_BONJOUR=0` if they have a working multicast bridge setup.

## How This Complements Existing Fixes

- **c39ca49**: Caps restart loops (symptom mitigation) — still valuable for other constrained environments
- **#74778**: Fixes probing state handling (bug fix) — orthogonal to this change
- **This PR**: Prevents WSL2 from entering the failure path entirely (environment-aware optimization)

## Changes

- `extensions/bonjour/src/advertiser.ts`: Added WSL2 detection to `isDisabledByEnv()`
- `extensions/bonjour/src/advertiser.test.ts`: 
  - Added tests for auto-disable and explicit opt-in in WSL2
  - Mocked `isWSL2Sync` so tests pass consistently regardless of host environment
  - Cleared WSL env vars in `enableAdvertiserUnitMode()` for test isolation

## Testing

- [x] All 28 bonjour advertiser tests pass
- [x] New WSL2 auto-disable test verifies `createService` is not called
- [x] New WSL2 opt-in test verifies `OPENCLAW_DISABLE_BONJOUR=0` overrides detection
- [x] Existing container tests still pass
- [x] Code formatting verified with `oxfmt`

## Related

Refs #74209
