### PR TITLE
chore(ci): add gateway CodeQL PR quality guard

### DIFF
--- a/.github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
+++ b/.github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
@@ -14,8 +14,11 @@ query-filters:
         - security
 
 paths:
+  - src/gateway/method-scopes.ts
   - src/gateway/protocol
   - src/gateway/server-methods
+  - src/gateway/server-methods.ts
+  - src/gateway/server-methods-list.ts
 
 paths-ignore:
   - "**/node_modules"

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -43,9 +43,64 @@ env:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
+  quality-shards:
+    name: Select Critical Quality shards
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    outputs:
+      gateway: ${{ steps.detect.outputs.gateway }}
+      plugin: ${{ steps.detect.outputs.plugin }}
+      plugin_sdk_package: ${{ steps.detect.outputs.plugin_sdk_package }}
+    steps:
+      - name: Detect PR shard paths
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          gateway=false
+          plugin=false
+          plugin_sdk_package=false
+
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            gateway=true
+            plugin=true
+            plugin_sdk_package=true
+          else
+            while IFS= read -r file; do
+              case "${file}" in
+                .github/codeql/*|.github/workflows/codeql-critical-quality.yml)
+                  gateway=true
+                  plugin=true
+                  plugin_sdk_package=true
+                  ;;
+                src/gateway/method-scopes.ts|src/gateway/protocol/*|src/gateway/server-methods/*|src/gateway/server-methods.ts|src/gateway/server-methods-list.ts)
+                  gateway=true
+                  ;;
+                src/plugin-sdk/*|src/plugins/*)
+                  plugin=true
+                  ;;
+                packages/plugin-package-contract/*|packages/plugin-sdk/*|src/plugin-sdk/*)
+                  plugin_sdk_package=true
+                  ;;
+              esac
+            done < <(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          fi
+
+          {
+            echo "gateway=${gateway}"
+            echo "plugin=${plugin}"
+            echo "plugin_sdk_package=${plugin_sdk_package}"
+          } >> "${GITHUB_OUTPUT}"
+
   core-auth-secrets:
     name: Critical Quality (core-auth-secrets)
     if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all') }}
@@ -92,7 +147,8 @@ jobs:
 
   gateway-runtime-boundary:
     name: Critical Quality (gateway-runtime-boundary)
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'gateway-runtime-boundary') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.gateway == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'gateway-runtime-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -312,7 +368,8 @@ jobs:
 
   plugin-boundary:
     name: Critical Quality (plugin-boundary)
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-boundary') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.plugin == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -334,7 +391,8 @@ jobs:
 
   plugin-sdk-package-contract:
     name: Critical Quality (plugin-sdk-package-contract)
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-sdk-package-contract') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.plugin_sdk_package == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'plugin-sdk-package-contract') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - gateway-runtime-boundary
           - plugin-boundary
           - plugin-sdk-package-contract
           - plugin-sdk-reply-runtime
@@ -22,6 +23,11 @@ on:
       - ".github/workflows/codeql-critical-quality.yml"
       - "packages/plugin-package-contract/**"
       - "packages/plugin-sdk/**"
+      - "src/gateway/method-scopes.ts"
+      - "src/gateway/protocol/**"
+      - "src/gateway/server-methods/**"
+      - "src/gateway/server-methods.ts"
+      - "src/gateway/server-methods-list.ts"
       - "src/plugin-sdk/**"
       - "src/plugins/**"
   schedule:
@@ -86,7 +92,7 @@ jobs:
 
   gateway-runtime-boundary:
     name: Critical Quality (gateway-runtime-boundary)
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all') }}
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'gateway-runtime-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -299,10 +299,11 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 pull request guard is intentionally smaller than the scheduled profile: non-draft
-PRs only run the `plugin-boundary` and `plugin-sdk-package-contract` shards when
-plugin loader, Plugin SDK, package-contract, CodeQL config, or quality workflow
-files change. Its manual dispatch accepts
-`profile=all|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
+PRs only run the `gateway-runtime-boundary`, `plugin-boundary`, and
+`plugin-sdk-package-contract` shards when gateway protocol/server-method, plugin
+loader, Plugin SDK, package-contract, CodeQL config, or quality workflow files
+change. Its manual dispatch accepts
+`profile=all|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
 the narrow profiles are teaching/iteration hooks for running one quality shard
 in isolation without dispatching the rest of the workflow.
 Its

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -299,10 +299,10 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 pull request guard is intentionally smaller than the scheduled profile: non-draft
-PRs only run the `gateway-runtime-boundary`, `plugin-boundary`, and
-`plugin-sdk-package-contract` shards when gateway protocol/server-method, plugin
-loader, Plugin SDK, package-contract, CodeQL config, or quality workflow files
-change. Its manual dispatch accepts
+PRs only run the matching `gateway-runtime-boundary`, `plugin-boundary`, and
+`plugin-sdk-package-contract` shards for gateway protocol/server-method, plugin
+loader, Plugin SDK, or package-contract changes. CodeQL config and quality
+workflow changes run all three PR quality shards. Its manual dispatch accepts
 `profile=all|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
 the narrow profiles are teaching/iteration hooks for running one quality shard
 in isolation without dispatching the rest of the workflow.


### PR DESCRIPTION
## Summary

- Problem: the new PR quality guard only covered plugin/package-contract surfaces, while gateway protocol/server-method PRs were still skipping non-security CodeQL quality.
- Why it matters: gateway protocol and server methods are hot PR surfaces and high-leverage places for error-severity quality findings.
- What changed: enable `gateway-runtime-boundary` on non-draft PRs touching gateway method/protocol files, expose it as a manual dispatch profile, and include the top-level gateway method dispatch files in that shard.
- What did NOT change (scope boundary): no broad quality expansion, no scheduled/security behavior change, no runtime code change.

## Change Type (select all)

- [x] Docs
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/74771
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, repo workflow tooling
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions / CodeQL
- Relevant config (redacted): N/A

### Steps

1. Parse the edited workflow and CodeQL config as YAML.
2. Run workflow sanity.
3. Open PR and verify `Critical Quality (gateway-runtime-boundary)` runs for this workflow/config change.

### Expected

- Workflow syntax is valid.
- Workflow sanity passes.
- PR CodeQL quality runs the gateway shard instead of skipping it.

### Actual

- YAML parse passed locally.
- `pnpm check:workflows` passed locally.
- PR-run proof pending on this PR.

## Evidence

- [x] Trace/log snippets

Local evidence:

```text
ok .github/workflows/codeql-critical-quality.yml
ok .github/codeql/codeql-gateway-runtime-boundary-critical-quality.yml
No direct inputs interpolation found in composite run blocks.
```

## Human Verification (required)

- Verified scenarios: YAML syntax, whitespace, workflow sanity, diff scoped to three files after rebase onto current `origin/main`.
- Edge cases checked: manual dispatch now accepts `gateway-runtime-boundary`; draft PRs still skip the PR quality jobs.
- What you did **not** verify: PR CodeQL runtime result before opening this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: one additional CodeQL quality job on gateway PRs increases CI work.
  - Mitigation: path-gated to gateway protocol/server-method files and kept on the small Blacksmith runner.
