### PR TITLE
Add Google Meet space access controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/beta: prepare diagnostics OpenTelemetry, Discord, Diffs, Lobster, Memory LanceDB, Microsoft Teams, QQ Bot, Voice Call, and WhatsApp for `2026.5.1-beta.1` npm and ClawHub publishing. Thanks @vincentkoc.
 - Plugins/beta: prepare Brave, Codex, Feishu, Synology Chat, Tlon, and Twitch for `2026.5.1-beta.1` npm and ClawHub publishing. Thanks @vincentkoc.
 - Providers/xAI: add Grok 4.3 to the bundled catalog and make it the default xAI chat model.
+- Google Meet: let API-created rooms set `accessType` and `entryPointAccess`, and add `googlemeet end-active-conference` for closing managed spaces after a call. (#74824) Thanks @BsnizND.
 - Plugins/ClawHub: prefer versioned ClawPack artifacts when ClawHub publishes digest metadata, verifying the ClawPack response header and downloaded bytes before installing. Thanks @vincentkoc.
 - Plugins/ClawHub: persist ClawPack digest metadata on ClawHub plugin install and update records so registry refreshes and download verification can reuse stored artifact facts. Thanks @vincentkoc.
 - Plugins/ClawHub: allow official bundled-plugin cutovers to prefer ClawHub installs with npm fallback only when the ClawHub package or version is absent. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/beta: prepare Brave, Codex, Feishu, Synology Chat, Tlon, and Twitch for `2026.5.1-beta.1` npm and ClawHub publishing. Thanks @vincentkoc.
 - Providers/xAI: add Grok 4.3 to the bundled catalog and make it the default xAI chat model.
 - Google Meet: let API-created rooms set `accessType` and `entryPointAccess`, and add `googlemeet end-active-conference` for closing managed spaces after a call. (#74824) Thanks @BsnizND.
+- Google Meet: add `googlemeet test-listen` and the matching `google_meet` `test_listen` action so transcribe-mode joins wait for real caption or transcript movement before reporting listen-first health. Refs #72478. Thanks @DougButdorf.
 - Plugins/ClawHub: prefer versioned ClawPack artifacts when ClawHub publishes digest metadata, verifying the ClawPack response header and downloaded bytes before installing. Thanks @vincentkoc.
 - Plugins/ClawHub: persist ClawPack digest metadata on ClawHub plugin install and update records so registry refreshes and download verification can reuse stored artifact facts. Thanks @vincentkoc.
 - Plugins/ClawHub: allow official bundled-plugin cutovers to prefer ClawHub installs with npm fallback only when the ClawHub package or version is absent. Thanks @vincentkoc.

--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -125,6 +125,24 @@ Create a new meeting and join it:
 openclaw googlemeet create --transport chrome-node --mode realtime
 ```
 
+For API-created rooms, use Google Meet `SpaceConfig.accessType` when you want
+the room's no-knock policy to be explicit instead of inherited from the Google
+account defaults:
+
+```bash
+openclaw googlemeet create --access-type OPEN --transport chrome-node --mode realtime
+```
+
+`OPEN` lets anyone with the Meet URL join without knocking. `TRUSTED` lets the
+host organization's trusted users, invited external users, and dial-in users
+join without knocking. `RESTRICTED` limits no-knock entry to invitees. These
+settings only apply to the official Google Meet API creation path, so OAuth
+credentials must be configured.
+
+If you authenticated Google Meet before this option was available, rerun
+`openclaw googlemeet auth login --json` after adding the
+`meetings.space.settings` scope to your Google OAuth consent screen.
+
 Create only the URL without joining:
 
 ```bash
@@ -504,6 +522,7 @@ In Google Cloud Console:
 4. Add the scopes OpenClaw requests:
    - `https://www.googleapis.com/auth/meetings.space.created`
    - `https://www.googleapis.com/auth/meetings.space.readonly`
+   - `https://www.googleapis.com/auth/meetings.space.settings`
    - `https://www.googleapis.com/auth/meetings.conference.media.readonly`
 5. Create an OAuth client ID.
    - Application type: **Web application**.
@@ -517,6 +536,8 @@ In Google Cloud Console:
 
 `meetings.space.created` is required by Google Meet `spaces.create`.
 `meetings.space.readonly` lets OpenClaw resolve Meet URLs/codes to spaces.
+`meetings.space.settings` lets OpenClaw pass `SpaceConfig` settings such as
+`accessType` during API room creation.
 `meetings.conference.media.readonly` is for Meet Media API preflight and media
 work; Google may require Developer Preview enrollment for actual Media API use.
 If you only need browser-based Chrome joins, skip OAuth entirely.
@@ -708,6 +729,21 @@ openclaw googlemeet artifacts --conference-record conferenceRecords/abc123 --jso
 openclaw googlemeet attendance --conference-record conferenceRecords/abc123 --json
 ```
 
+End an active conference for an API-created space when you want to close the
+room after the call:
+
+```bash
+openclaw googlemeet end-active-conference https://meet.google.com/abc-defg-hij
+```
+
+This calls Google Meet `spaces.endActiveConference` and requires OAuth with the
+`meetings.space.created` scope for a space the authorized account can manage.
+OpenClaw accepts a Meet URL, meeting code, or `spaces/{id}` input and resolves it
+to the API space resource before ending the active conference.
+It is separate from `googlemeet leave`: `leave` stops OpenClaw's local/session
+participation, while `end-active-conference` asks Google Meet to end the active
+conference for the space.
+
 Write a readable report:
 
 ```bash
@@ -763,6 +799,26 @@ Agents can also create the same bundle through the `google_meet` tool:
 ```
 
 Set `"dryRun": true` to return only the export manifest and skip file writes.
+
+Agents can also create an API-backed room with an explicit access policy:
+
+```json
+{
+  "action": "create",
+  "transport": "chrome-node",
+  "mode": "realtime",
+  "accessType": "OPEN"
+}
+```
+
+And they can end the active conference for a known room:
+
+```json
+{
+  "action": "end_active_conference",
+  "meeting": "https://meet.google.com/abc-defg-hij"
+}
+```
 
 Run the guarded live smoke against a real retained meeting:
 
@@ -1502,6 +1558,8 @@ argument list, and do not point it at scripts from untrusted locations.
 `googlemeet speak` triggers the active realtime audio bridge for a Chrome
 session. `googlemeet leave` stops that bridge. For Twilio sessions delegated
 through the Voice Call plugin, `leave` also hangs up the underlying voice call.
+Use `googlemeet end-active-conference` when you also want to close the active
+Google Meet conference for an API-managed space.
 
 ## Related
 

--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -193,6 +193,10 @@ a best-effort Meet caption observer. `googlemeet status --json` and
 `transcriptLines`, `lastCaptionAt`, `lastCaptionSpeaker`, `lastCaptionText`,
 and a short `recentTranscript` tail so operators can tell whether the browser
 joined the call and whether Meet captions are producing text.
+Use `openclaw googlemeet test-listen <meet-url> --transport chrome-node` when
+you need a yes/no probe: it joins in transcribe mode, waits for fresh caption or
+transcript movement, and returns `listenVerified`, `listenTimedOut`, manual
+action fields, and the latest caption health.
 
 During realtime sessions, `google_meet` status includes browser and audio bridge
 health such as `inCall`, `manualActionRequired`, `providerConnected`,
@@ -820,12 +824,32 @@ And they can end the active conference for a known room:
 }
 ```
 
+For listen-first validation, agents should use `test_listen` before claiming the
+meeting is useful:
+
+```json
+{
+  "action": "test_listen",
+  "url": "https://meet.google.com/abc-defg-hij",
+  "transport": "chrome-node",
+  "timeoutMs": 30000
+}
+```
+
 Run the guarded live smoke against a real retained meeting:
 
 ```bash
 OPENCLAW_LIVE_TEST=1 \
 OPENCLAW_GOOGLE_MEET_LIVE_MEETING=https://meet.google.com/abc-defg-hij \
 pnpm test:live -- extensions/google-meet/google-meet.live.test.ts
+```
+
+Run the live listen-first browser probe against a meeting where someone will
+speak with Meet captions available:
+
+```bash
+openclaw googlemeet setup --transport chrome-node --mode transcribe
+openclaw googlemeet test-listen https://meet.google.com/abc-defg-hij --transport chrome-node --timeout-ms 30000
 ```
 
 Live smoke environment:
@@ -1297,7 +1321,8 @@ openclaw nodes status --connected
 
 ### Browser opens but agent cannot join
 
-Run `googlemeet test-speech` and inspect the returned Chrome health. If it
+Run `googlemeet test-listen` for observe-only joins or `googlemeet test-speech`
+for realtime joins, then inspect the returned Chrome health. If either probe
 reports `manualActionRequired: true`, show `manualActionMessage` to the operator
 and stop retrying until the browser action is complete.
 

--- a/extensions/google-meet/index.create.test.ts
+++ b/extensions/google-meet/index.create.test.ts
@@ -108,7 +108,7 @@ describe("google-meet create flow", () => {
     googleMeetPluginTesting.setCallGatewayFromCliForTests();
   });
 
-  it("CLI create prints the new meeting URL", async () => {
+  it("CLI create can configure API-created space access", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
       const url = input instanceof Request ? input.url : input.toString();
       if (url.includes("oauth2.googleapis.com")) {
@@ -142,9 +142,27 @@ describe("google-meet create flow", () => {
     });
 
     try {
-      await program.parseAsync(["googlemeet", "create", "--no-join"], { from: "user" });
+      await program.parseAsync(
+        [
+          "googlemeet",
+          "create",
+          "--no-join",
+          "--access-type",
+          "OPEN",
+          "--entry-point-access",
+          "ALL",
+        ],
+        { from: "user" },
+      );
       expect(stdout.output()).toContain("meeting uri: https://meet.google.com/new-abcd-xyz");
       expect(stdout.output()).toContain("space: spaces/new-space");
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://meet.googleapis.com/v2/spaces",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ config: { accessType: "OPEN", entryPointAccess: "ALL" } }),
+        }),
+      );
     } finally {
       stdout.restore();
     }
@@ -218,6 +236,27 @@ describe("google-meet create flow", () => {
         }),
       }),
     );
+  });
+
+  it("rejects access policy flags when tool create would use browser fallback", async () => {
+    const { methods } = setup(
+      {
+        defaultTransport: "chrome-node",
+        chromeNode: { node: "parallels-macos" },
+      },
+      {
+        nodesInvokeHandler: async () => {
+          throw new Error("browser fallback should not run");
+        },
+      },
+    );
+
+    await expect(
+      invokeGoogleMeetGatewayMethodForTest(methods, "googlemeet.create", {
+        join: false,
+        accessType: "OPEN",
+      }),
+    ).rejects.toThrow("access policy options require OAuth/API room creation");
   });
 
   it("reports structured manual action when browser creation needs Google login", async () => {

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -560,6 +560,7 @@ describe("google-meet plugin", () => {
             "end_active_conference",
             "speak",
             "test_speech",
+            "test_listen",
           ],
           description: expect.stringContaining("recover_current_tab"),
         },
@@ -2395,6 +2396,52 @@ describe("google-meet plugin", () => {
     expect(result.details).toMatchObject({ createdSession: true });
   });
 
+  it("exposes a test-listen action that proves transcript movement", async () => {
+    const { tools, nodesInvoke } = setup(
+      {
+        defaultTransport: "chrome-node",
+      },
+      {
+        browserActResult: {
+          inCall: true,
+          captioning: true,
+          transcriptLines: 1,
+          lastCaptionText: "hello from the meeting",
+          title: "Meet call",
+          url: "https://meet.google.com/abc-defg-hij",
+        },
+        nodesInvokeResult: {
+          payload: {
+            launched: true,
+          },
+        },
+      },
+    );
+    const tool = tools[0] as {
+      execute: (
+        id: string,
+        params: unknown,
+      ) => Promise<{ details: { listenVerified?: boolean; transcriptLines?: number } }>;
+    };
+
+    const result = await tool.execute("id", {
+      action: "test_listen",
+      url: "https://meet.google.com/abc-defg-hij",
+      timeoutMs: 100,
+    });
+
+    expect(nodesInvoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "googlemeet.chrome",
+        params: expect.objectContaining({
+          action: "start",
+          mode: "transcribe",
+        }),
+      }),
+    );
+    expect(result.details).toMatchObject({ listenVerified: true, transcriptLines: 1 });
+  });
+
   it("does not start a second realtime response for test speech", async () => {
     const runtime = new GoogleMeetRuntime({
       config: resolveGoogleMeetConfig({}),
@@ -2454,6 +2501,29 @@ describe("google-meet plugin", () => {
         mode: "transcribe",
       }),
     ).rejects.toThrow("test_speech requires mode: realtime");
+  });
+
+  it("rejects realtime and Twilio modes for test listen", async () => {
+    const runtime = new GoogleMeetRuntime({
+      config: resolveGoogleMeetConfig({}),
+      fullConfig: {} as never,
+      runtime: {} as never,
+      logger: noopLogger,
+    });
+
+    await expect(
+      runtime.testListen({
+        url: "https://meet.google.com/abc-defg-hij",
+        mode: "realtime",
+      }),
+    ).rejects.toThrow("test_listen requires mode: transcribe");
+
+    await expect(
+      runtime.testListen({
+        url: "https://meet.google.com/abc-defg-hij",
+        transport: "twilio",
+      }),
+    ).rejects.toThrow("test_listen supports chrome or chrome-node");
   });
 
   it("reports manual action when the browser profile needs Google login", async () => {

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -557,6 +557,7 @@ describe("google-meet plugin", () => {
             "export",
             "recover_current_tab",
             "leave",
+            "end_active_conference",
             "speak",
             "test_speech",
           ],

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -22,6 +22,7 @@ import {
 } from "./src/config.js";
 import {
   buildGoogleMeetPreflightReport,
+  endGoogleMeetActiveConference,
   fetchGoogleMeetArtifacts,
   fetchGoogleMeetAttendance,
   fetchLatestGoogleMeetConferenceRecord,
@@ -201,6 +202,7 @@ const GoogleMeetToolSchema = Type.Object({
       "export",
       "recover_current_tab",
       "leave",
+      "end_active_conference",
       "speak",
       "test_speech",
     ],
@@ -210,6 +212,19 @@ const GoogleMeetToolSchema = Type.Object({
   join: Type.Optional(
     Type.Boolean({
       description: "For action=create, set false to create the URL without joining.",
+    }),
+  ),
+  accessType: Type.Optional(
+    Type.String({
+      enum: ["OPEN", "TRUSTED", "RESTRICTED"],
+      description:
+        "For action=create with Google Meet OAuth, configure who can join without knocking.",
+    }),
+  ),
+  entryPointAccess: Type.Optional(
+    Type.String({
+      enum: ["ALL", "CREATOR_APP_ONLY"],
+      description: "For action=create with Google Meet OAuth, configure allowed join entry points.",
     }),
   ),
   url: Type.Optional(Type.String({ description: "Explicit https://meet.google.com/... URL" })),
@@ -343,6 +358,7 @@ type GoogleMeetGatewayToolAction =
   | "recover_current_tab"
   | "setup_status"
   | "leave"
+  | "end_active_conference"
   | "speak"
   | "test_speech";
 
@@ -354,6 +370,8 @@ function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolActio
       return "googlemeet.setup";
     case "test_speech":
       return "googlemeet.testSpeech";
+    case "end_active_conference":
+      return "googlemeet.endActiveConference";
     default:
       return `googlemeet.${action}`;
   }
@@ -843,6 +861,25 @@ export default definePluginEntry({
     );
 
     api.registerGatewayMethod(
+      "googlemeet.endActiveConference",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const raw = asParamRecord(params);
+          const token = await resolveGoogleMeetTokenFromParams(config, raw);
+          respond(
+            true,
+            await endGoogleMeetActiveConference({
+              accessToken: token.accessToken,
+              meeting: resolveMeetingInput(config, raw.meeting),
+            }),
+          );
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
+    api.registerGatewayMethod(
       "googlemeet.speak",
       async ({ params, respond }: GatewayRequestHandlerOptions) => {
         try {
@@ -998,6 +1035,15 @@ export default definePluginEntry({
                 throw new Error("sessionId required");
               }
               return json(await callGoogleMeetGatewayFromTool({ config, action: "leave", raw }));
+            }
+            case "end_active_conference": {
+              return json(
+                await callGoogleMeetGatewayFromTool({
+                  config,
+                  action: "end_active_conference",
+                  raw,
+                }),
+              );
             }
             case "speak": {
               const sessionId = normalizeOptionalString(raw.sessionId);

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -205,6 +205,7 @@ const GoogleMeetToolSchema = Type.Object({
       "end_active_conference",
       "speak",
       "test_speech",
+      "test_listen",
     ],
     description:
       "Google Meet action to run. create creates and joins by default; pass join=false to only mint a URL. After a timeout or unclear browser state, call recover_current_tab before retrying join.",
@@ -243,6 +244,7 @@ const GoogleMeetToolSchema = Type.Object({
   dtmfSequence: Type.Optional(Type.String({ description: "Explicit DTMF sequence for Twilio" })),
   sessionId: Type.Optional(Type.String({ description: "Meet session ID" })),
   message: Type.Optional(Type.String({ description: "Realtime instructions to speak now" })),
+  timeoutMs: Type.Optional(Type.Number({ description: "Probe timeout in milliseconds" })),
   meeting: Type.Optional(Type.String({ description: "Meet URL, meeting code, or spaces/{id}" })),
   today: Type.Optional(
     Type.Boolean({
@@ -360,7 +362,8 @@ type GoogleMeetGatewayToolAction =
   | "leave"
   | "end_active_conference"
   | "speak"
-  | "test_speech";
+  | "test_speech"
+  | "test_listen";
 
 function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolAction): string {
   switch (action) {
@@ -370,6 +373,8 @@ function googleMeetGatewayMethodForToolAction(action: GoogleMeetGatewayToolActio
       return "googlemeet.setup";
     case "test_speech":
       return "googlemeet.testSpeech";
+    case "test_listen":
+      return "googlemeet.testListen";
     case "end_active_conference":
       return "googlemeet.endActiveConference";
     default:
@@ -917,11 +922,29 @@ export default definePluginEntry({
       },
     );
 
+    api.registerGatewayMethod(
+      "googlemeet.testListen",
+      async ({ params, respond }: GatewayRequestHandlerOptions) => {
+        try {
+          const rt = await ensureRuntime();
+          const result = await rt.testListen({
+            url: resolveMeetingInput(config, params?.url),
+            transport: normalizeTransport(params?.transport),
+            mode: normalizeMode(params?.mode),
+            timeoutMs: typeof params?.timeoutMs === "number" ? params.timeoutMs : undefined,
+          });
+          respond(true, result);
+        } catch (err) {
+          sendError(respond, err);
+        }
+      },
+    );
+
     api.registerTool({
       name: "google_meet",
       label: "Google Meet",
       description:
-        "Join and track Google Meet sessions through Chrome or Twilio. Call setup_status before join/create/test_speech; if it reports a Chrome node offline or local audio missing, surface that blocker instead of retrying or switching transports. Offline nodes are diagnostics only, not usable candidates. If a Meet tab is already open after a timeout, call recover_current_tab before retrying join to report login, permission, or admission blockers without opening another tab.",
+        "Join and track Google Meet sessions through Chrome or Twilio. Call setup_status before join/create/test_listen/test_speech; if it reports a Chrome node offline or local audio missing, surface that blocker instead of retrying or switching transports. Offline nodes are diagnostics only, not usable candidates. If a Meet tab is already open after a timeout, call recover_current_tab before retrying join to report login, permission, or admission blockers without opening another tab.",
       parameters: GoogleMeetToolSchema,
       async execute(_toolCallId, params) {
         const raw = asParamRecord(params);
@@ -936,6 +959,11 @@ export default definePluginEntry({
             case "test_speech": {
               return json(
                 await callGoogleMeetGatewayFromTool({ config, action: "test_speech", raw }),
+              );
+            }
+            case "test_listen": {
+              return json(
+                await callGoogleMeetGatewayFromTool({ config, action: "test_listen", raw }),
               );
             }
             case "status": {

--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -698,9 +698,9 @@ describe("google-meet CLI", () => {
       session: {
         id: "meet_1",
         url: "https://meet.google.com/abc-defg-hij",
-        state: "active",
-        transport: "chrome-node",
-        mode: "transcribe",
+        state: "active" as const,
+        transport: "chrome-node" as const,
+        mode: "transcribe" as const,
         participantIdentity: "signed-in Google Chrome profile on a paired node",
         createdAt: "2026-04-25T00:00:00.000Z",
         updatedAt: "2026-04-25T00:00:01.000Z",

--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -689,6 +689,55 @@ describe("google-meet CLI", () => {
     }
   });
 
+  it("runs a listen-first health probe", async () => {
+    const testListen = vi.fn(async () => ({
+      createdSession: true,
+      listenVerified: true,
+      listenTimedOut: false,
+      transcriptLines: 1,
+      session: {
+        id: "meet_1",
+        url: "https://meet.google.com/abc-defg-hij",
+        state: "active",
+        transport: "chrome-node",
+        mode: "transcribe",
+        participantIdentity: "signed-in Google Chrome profile on a paired node",
+        createdAt: "2026-04-25T00:00:00.000Z",
+        updatedAt: "2026-04-25T00:00:01.000Z",
+        realtime: { enabled: false, provider: "openai", toolPolicy: "safe-read-only" },
+        notes: [],
+      },
+    }));
+    const stdout = captureStdout();
+    try {
+      await setupCli({
+        runtime: { testListen },
+      }).parseAsync(
+        [
+          "googlemeet",
+          "test-listen",
+          "https://meet.google.com/abc-defg-hij",
+          "--transport",
+          "chrome-node",
+          "--timeout-ms",
+          "30000",
+        ],
+        { from: "user" },
+      );
+      expect(testListen).toHaveBeenCalledWith({
+        url: "https://meet.google.com/abc-defg-hij",
+        transport: "chrome-node",
+        timeoutMs: 30000,
+      });
+      expect(JSON.parse(stdout.output())).toMatchObject({
+        listenVerified: true,
+        transcriptLines: 1,
+      });
+    } finally {
+      stdout.restore();
+    }
+  });
+
   it("prints a dry-run export manifest without writing files", async () => {
     stubMeetArtifactsApi();
     const stdout = captureStdout();

--- a/extensions/google-meet/src/cli.test.ts
+++ b/extensions/google-meet/src/cli.test.ts
@@ -324,6 +324,64 @@ describe("google-meet CLI", () => {
     }
   });
 
+  it("ends an active conference for a Meet space", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = requestUrl(input);
+      if (url.pathname === "/v2/spaces/abc-defg-hij") {
+        return jsonResponse({
+          name: "spaces/space-resource-123",
+          meetingCode: "abc-defg-hij",
+          meetingUri: "https://meet.google.com/abc-defg-hij",
+        });
+      }
+      if (url.pathname === "/v2/spaces/space-resource-123:endActiveConference") {
+        return jsonResponse({});
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stdout = captureStdout();
+    try {
+      await setupCli({}).parseAsync(
+        [
+          "googlemeet",
+          "end-active-conference",
+          "https://meet.google.com/abc-defg-hij",
+          "--access-token",
+          "token",
+          "--expires-at",
+          String(Date.now() + 120_000),
+          "--json",
+        ],
+        { from: "user" },
+      );
+      expect(JSON.parse(stdout.output())).toMatchObject({
+        space: "spaces/space-resource-123",
+        ended: true,
+        tokenSource: "cached-access-token",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://meet.googleapis.com/v2/spaces/space-resource-123:endActiveConference",
+        expect.objectContaining({ method: "POST", body: "{}" }),
+      );
+    } finally {
+      stdout.restore();
+    }
+  });
+
+  it("rejects access policy flags when create would use browser fallback", async () => {
+    await expect(
+      setupCli({
+        runtime: {
+          createViaBrowser: vi.fn(async () => {
+            throw new Error("browser fallback should not run");
+          }),
+        },
+      }).parseAsync(["googlemeet", "create", "--access-type", "OPEN"], { from: "user" }),
+    ).rejects.toThrow("access policy options require OAuth/API room creation");
+  });
+
   it("prints the latest conference record", async () => {
     stubMeetArtifactsApi();
     const stdout = captureStdout();

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -37,6 +37,7 @@ type JoinOptions = {
   transport?: GoogleMeetTransport;
   mode?: GoogleMeetMode;
   message?: string;
+  timeoutMs?: string;
   dialInNumber?: string;
   pin?: string;
   dtmfSequence?: string;
@@ -226,6 +227,17 @@ function formatBoolean(value: boolean | undefined): string {
 
 function formatOptional(value: unknown): string {
   return typeof value === "string" && value.trim() ? value : "n/a";
+}
+
+function parsePositiveNumber(value: string | undefined, label: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive number`);
+  }
+  return parsed;
 }
 
 function formatDuration(value: number | undefined): string {
@@ -1563,6 +1575,22 @@ export function registerGoogleMeetCli(params: {
           transport: options.transport,
           mode: options.mode,
           message: options.message,
+        }),
+      );
+    });
+
+  root
+    .command("test-listen")
+    .argument("[url]", "Explicit https://meet.google.com/... URL")
+    .option("--transport <transport>", "Transport: chrome or chrome-node")
+    .option("--timeout-ms <ms>", "How long to wait for fresh captions/transcript movement")
+    .action(async (url: string | undefined, options: JoinOptions) => {
+      const rt = await params.ensureRuntime();
+      writeStdoutJson(
+        await rt.testListen({
+          url: resolveMeetingInput(params.config, url),
+          transport: options.transport,
+          timeoutMs: parsePositiveNumber(options.timeoutMs, "timeout-ms"),
         }),
       );
     });

--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -10,9 +10,11 @@ import {
   type GoogleMeetCalendarLookupResult,
 } from "./calendar.js";
 import type { GoogleMeetConfig, GoogleMeetMode, GoogleMeetTransport } from "./config.js";
+import { hasCreateSpaceConfigInput, resolveCreateSpaceConfig } from "./create.js";
 import {
   buildGoogleMeetPreflightReport,
   createGoogleMeetSpace,
+  endGoogleMeetActiveConference,
   fetchGoogleMeetArtifacts,
   fetchGoogleMeetAttendance,
   fetchLatestGoogleMeetConferenceRecord,
@@ -159,6 +161,8 @@ type CreateOptions = {
   clientId?: string;
   clientSecret?: string;
   expiresAt?: string;
+  accessType?: string;
+  entryPointAccess?: string;
   join?: boolean;
   transport?: GoogleMeetTransport;
   mode?: GoogleMeetMode;
@@ -1367,6 +1371,14 @@ export function registerGoogleMeetCli(params: {
     .option("--client-id <id>", "OAuth client id override")
     .option("--client-secret <secret>", "OAuth client secret override")
     .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+    .option(
+      "--access-type <type>",
+      "Google Meet SpaceConfig accessType for API create: OPEN, TRUSTED, or RESTRICTED",
+    )
+    .option(
+      "--entry-point-access <type>",
+      "Google Meet SpaceConfig entryPointAccess for API create: ALL or CREATOR_APP_ONLY",
+    )
     .option("--no-join", "Only create the meeting URL; do not join it")
     .option("--transport <transport>", "Join transport: chrome, chrome-node, or twilio")
     .option(
@@ -1380,6 +1392,11 @@ export function registerGoogleMeetCli(params: {
     .option("--json", "Print JSON output", false)
     .action(async (options: CreateOptions) => {
       if (!hasCreateOAuth(params.config, options)) {
+        if (hasCreateSpaceConfigInput(options as Record<string, unknown>)) {
+          throw new Error(
+            "Google Meet access policy options require OAuth/API room creation. Configure Google Meet OAuth or remove --access-type/--entry-point-access.",
+          );
+        }
         const rt = await params.ensureRuntime();
         const result = await rt.createViaBrowser();
         const join =
@@ -1423,7 +1440,10 @@ export function registerGoogleMeetCli(params: {
       const token = await resolveGoogleMeetAccessToken(
         resolveCreateTokenOptions(params.config, options),
       );
-      const result = await createGoogleMeetSpace({ accessToken: token.accessToken });
+      const result = await createGoogleMeetSpace({
+        accessToken: token.accessToken,
+        config: resolveCreateSpaceConfig(options as Record<string, unknown>),
+      });
       const join =
         options.join !== false
           ? await (
@@ -1461,6 +1481,39 @@ export function registerGoogleMeetCli(params: {
       } else {
         writeStdoutLine("joined: no (run `openclaw googlemeet join %s`)", result.meetingUri);
       }
+    });
+
+  root
+    .command("end-active-conference")
+    .description("End the active conference for a Google Meet space")
+    .argument("[meeting]", "Meet URL, meeting code, or spaces/{id}")
+    .option("--access-token <token>", "Access token override")
+    .option("--refresh-token <token>", "Refresh token override")
+    .option("--client-id <id>", "OAuth client id override")
+    .option("--client-secret <secret>", "OAuth client secret override")
+    .option("--expires-at <ms>", "Cached access token expiry as unix epoch milliseconds")
+    .option("--json", "Print JSON output", false)
+    .action(async (meeting: string | undefined, options: ResolveSpaceOptions & JsonOptions) => {
+      const token = await resolveGoogleMeetAccessToken(
+        resolveOAuthTokenOptions(params.config, options),
+      );
+      const result = await endGoogleMeetActiveConference({
+        accessToken: token.accessToken,
+        meeting: resolveMeetingInput(params.config, meeting ?? options.meeting),
+      });
+      if (options.json) {
+        writeStdoutJson({
+          ...result,
+          tokenSource: token.refreshed ? "refresh-token" : "cached-access-token",
+        });
+        return;
+      }
+      writeStdoutLine("space: %s", result.space);
+      writeStdoutLine("ended: yes");
+      writeStdoutLine(
+        "token source: %s",
+        token.refreshed ? "refresh-token" : "cached-access-token",
+      );
     });
 
   root

--- a/extensions/google-meet/src/create.ts
+++ b/extensions/google-meet/src/create.ts
@@ -1,7 +1,12 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import type { GoogleMeetConfig, GoogleMeetMode, GoogleMeetTransport } from "./config.js";
-import { createGoogleMeetSpace } from "./meet.js";
+import {
+  createGoogleMeetSpace,
+  type GoogleMeetAccessType,
+  type GoogleMeetEntryPointAccess,
+  type GoogleMeetSpaceConfig,
+} from "./meet.js";
 import { resolveGoogleMeetAccessToken } from "./oauth.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
 import { createMeetWithBrowserProxyOnNode } from "./transports/chrome-create.js";
@@ -14,6 +19,47 @@ function normalizeMode(value: unknown): GoogleMeetMode | undefined {
   return value === "realtime" || value === "transcribe" ? value : undefined;
 }
 
+export function normalizeGoogleMeetAccessType(value: unknown): GoogleMeetAccessType | undefined {
+  const normalized = normalizeOptionalString(value)?.toUpperCase().replaceAll("-", "_");
+  return normalized === "OPEN" || normalized === "TRUSTED" || normalized === "RESTRICTED"
+    ? normalized
+    : undefined;
+}
+
+export function normalizeGoogleMeetEntryPointAccess(
+  value: unknown,
+): GoogleMeetEntryPointAccess | undefined {
+  const normalized = normalizeOptionalString(value)?.toUpperCase().replaceAll("-", "_");
+  return normalized === "ALL" || normalized === "CREATOR_APP_ONLY" ? normalized : undefined;
+}
+
+export function resolveCreateSpaceConfig(
+  raw: Record<string, unknown>,
+): GoogleMeetSpaceConfig | undefined {
+  const rawAccessType = normalizeOptionalString(raw.accessType);
+  const rawEntryPointAccess = normalizeOptionalString(raw.entryPointAccess);
+  const accessType = normalizeGoogleMeetAccessType(raw.accessType);
+  const entryPointAccess = normalizeGoogleMeetEntryPointAccess(raw.entryPointAccess);
+  if (rawAccessType !== undefined && !accessType) {
+    throw new Error("Invalid Google Meet accessType. Expected OPEN, TRUSTED, or RESTRICTED.");
+  }
+  if (rawEntryPointAccess !== undefined && !entryPointAccess) {
+    throw new Error("Invalid Google Meet entryPointAccess. Expected ALL or CREATOR_APP_ONLY.");
+  }
+  const config = {
+    ...(accessType ? { accessType } : {}),
+    ...(entryPointAccess ? { entryPointAccess } : {}),
+  };
+  return Object.keys(config).length > 0 ? config : undefined;
+}
+
+export function hasCreateSpaceConfigInput(raw: Record<string, unknown>): boolean {
+  return (
+    normalizeOptionalString(raw.accessType) !== undefined ||
+    normalizeOptionalString(raw.entryPointAccess) !== undefined
+  );
+}
+
 async function createSpaceFromParams(config: GoogleMeetConfig, raw: Record<string, unknown>) {
   const token = await resolveGoogleMeetAccessToken({
     clientId: normalizeOptionalString(raw.clientId) ?? config.oauth.clientId,
@@ -22,7 +68,10 @@ async function createSpaceFromParams(config: GoogleMeetConfig, raw: Record<strin
     accessToken: normalizeOptionalString(raw.accessToken) ?? config.oauth.accessToken,
     expiresAt: typeof raw.expiresAt === "number" ? raw.expiresAt : config.oauth.expiresAt,
   });
-  const result = await createGoogleMeetSpace({ accessToken: token.accessToken });
+  const result = await createGoogleMeetSpace({
+    accessToken: token.accessToken,
+    config: resolveCreateSpaceConfig(raw),
+  });
   return { source: "api" as const, token, ...result };
 }
 
@@ -52,6 +101,11 @@ export async function createMeetFromParams(params: {
       nextAction:
         "URL-only creation was requested. Call google_meet with action=join and url=meetingUri to enter the meeting.",
     };
+  }
+  if (hasCreateSpaceConfigInput(params.raw)) {
+    throw new Error(
+      "Google Meet access policy options require OAuth/API room creation. Configure Google Meet OAuth or remove accessType/entryPointAccess.",
+    );
   }
   const browser = await createMeetWithBrowserProxyOnNode({
     runtime: params.runtime,

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -9,16 +9,26 @@ const GOOGLE_MEET_API_HOST = "meet.googleapis.com";
 const GOOGLE_MEET_MEDIA_SCOPE =
   "https://www.googleapis.com/auth/meetings.conference.media.readonly";
 const GOOGLE_MEET_SPACE_SCOPE = "https://www.googleapis.com/auth/meetings.space.readonly";
+const GOOGLE_MEET_SPACE_CREATED_SCOPE = "https://www.googleapis.com/auth/meetings.space.created";
+const GOOGLE_MEET_SPACE_SETTINGS_SCOPE = "https://www.googleapis.com/auth/meetings.space.settings";
 
-type GoogleMeetSpace = {
+export type GoogleMeetAccessType = "OPEN" | "TRUSTED" | "RESTRICTED";
+export type GoogleMeetEntryPointAccess = "ALL" | "CREATOR_APP_ONLY";
+
+export type GoogleMeetSpaceConfig = {
+  accessType?: GoogleMeetAccessType;
+  entryPointAccess?: GoogleMeetEntryPointAccess;
+};
+
+export type GoogleMeetSpace = {
   name: string;
   meetingCode?: string;
   meetingUri?: string;
   activeConference?: Record<string, unknown>;
-  config?: Record<string, unknown>;
+  config?: GoogleMeetSpaceConfig & Record<string, unknown>;
 };
 
-type GoogleMeetPreflightReport = {
+export type GoogleMeetPreflightReport = {
   input: string;
   resolvedSpaceName: string;
   meetingCode?: string;
@@ -29,12 +39,17 @@ type GoogleMeetPreflightReport = {
   blockers: string[];
 };
 
-type GoogleMeetCreateSpaceResult = {
+export type GoogleMeetCreateSpaceResult = {
   space: GoogleMeetSpace;
   meetingUri: string;
 };
 
-type GoogleMeetConferenceRecord = {
+export type GoogleMeetEndActiveConferenceResult = {
+  space: string;
+  ended: true;
+};
+
+export type GoogleMeetConferenceRecord = {
   name: string;
   space?: string;
   startTime?: string;
@@ -353,7 +368,12 @@ export async function fetchGoogleMeetSpace(params: {
 
 export async function createGoogleMeetSpace(params: {
   accessToken: string;
+  config?: GoogleMeetSpaceConfig;
 }): Promise<GoogleMeetCreateSpaceResult> {
+  const body =
+    params.config && Object.keys(params.config).length > 0
+      ? JSON.stringify({ config: params.config })
+      : "{}";
   const { response, release } = await fetchWithSsrFGuard({
     url: `${GOOGLE_MEET_API_BASE_URL}/spaces`,
     init: {
@@ -363,7 +383,7 @@ export async function createGoogleMeetSpace(params: {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: "{}",
+      body,
     },
     policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
     auditContext: "google-meet.spaces.create",
@@ -375,7 +395,10 @@ export async function createGoogleMeetSpace(params: {
         response,
         detail,
         prefix: "Google Meet spaces.create",
-        scopes: ["https://www.googleapis.com/auth/meetings.space.created"],
+        scopes:
+          params.config && Object.keys(params.config).length > 0
+            ? [GOOGLE_MEET_SPACE_CREATED_SCOPE, GOOGLE_MEET_SPACE_SETTINGS_SCOPE]
+            : [GOOGLE_MEET_SPACE_CREATED_SCOPE],
       });
     }
     const payload = (await response.json()) as GoogleMeetSpace;
@@ -392,7 +415,46 @@ export async function createGoogleMeetSpace(params: {
   }
 }
 
-async function fetchGoogleMeetConferenceRecord(params: {
+export async function endGoogleMeetActiveConference(params: {
+  accessToken: string;
+  meeting: string;
+}): Promise<GoogleMeetEndActiveConferenceResult> {
+  const resolved = await fetchGoogleMeetSpace({
+    accessToken: params.accessToken,
+    meeting: params.meeting,
+  });
+  const space = resolved.name;
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${GOOGLE_MEET_API_BASE_URL}/${encodeSpaceNameForPath(space)}:endActiveConference`,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    },
+    policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
+    auditContext: "google-meet.spaces.endActiveConference",
+  });
+  try {
+    if (!response.ok) {
+      const detail = await response.text();
+      throw await googleApiError({
+        response,
+        detail,
+        prefix: "Google Meet spaces.endActiveConference",
+        scopes: [GOOGLE_MEET_SPACE_CREATED_SCOPE],
+      });
+    }
+    return { space, ended: true };
+  } finally {
+    await release();
+  }
+}
+
+export async function fetchGoogleMeetConferenceRecord(params: {
   accessToken: string;
   conferenceRecord: string;
 }): Promise<GoogleMeetConferenceRecord> {

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -13,6 +13,7 @@ const GOOGLE_MEET_TOKEN_HOST = "oauth2.googleapis.com";
 export const GOOGLE_MEET_SCOPES = [
   "https://www.googleapis.com/auth/meetings.space.created",
   "https://www.googleapis.com/auth/meetings.space.readonly",
+  "https://www.googleapis.com/auth/meetings.space.settings",
   "https://www.googleapis.com/auth/meetings.conference.media.readonly",
   "https://www.googleapis.com/auth/calendar.events.readonly",
   "https://www.googleapis.com/auth/drive.meet.readonly",

--- a/extensions/google-meet/src/runtime.ts
+++ b/extensions/google-meet/src/runtime.ts
@@ -66,6 +66,43 @@ function hasRealtimeAudioOutputAdvanced(
   return (health?.lastOutputBytes ?? 0) > startOutputBytes;
 }
 
+type TranscriptCheckpoint = {
+  lines: number;
+  lastCaptionAt?: string;
+  lastCaptionText?: string;
+};
+
+function transcriptCheckpoint(health: GoogleMeetChromeHealth | undefined): TranscriptCheckpoint {
+  return {
+    lines: health?.transcriptLines ?? 0,
+    lastCaptionAt: health?.lastCaptionAt,
+    lastCaptionText: health?.lastCaptionText,
+  };
+}
+
+function hasTranscriptAdvanced(
+  health: GoogleMeetChromeHealth | undefined,
+  start: TranscriptCheckpoint,
+): boolean {
+  if ((health?.transcriptLines ?? 0) > start.lines) {
+    return true;
+  }
+  if (health?.lastCaptionAt && health.lastCaptionAt !== start.lastCaptionAt) {
+    return true;
+  }
+  return Boolean(health?.lastCaptionText && health.lastCaptionText !== start.lastCaptionText);
+}
+
+function resolveProbeTimeoutMs(input: number | undefined, fallback: number): number {
+  if (input === undefined) {
+    return Math.min(Math.max(fallback, 1), 120_000);
+  }
+  if (!Number.isFinite(input) || input <= 0) {
+    throw new Error("timeoutMs must be a positive number");
+  }
+  return Math.min(Math.trunc(input), 120_000);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -593,6 +630,88 @@ export class GoogleMeetRuntime {
       speechBlockedMessage: health?.speechBlockedMessage,
       audioOutputActive: health?.audioOutputActive,
       lastOutputBytes: health?.lastOutputBytes,
+      session: result.session,
+    };
+  }
+
+  async testListen(request: GoogleMeetJoinRequest): Promise<{
+    createdSession: boolean;
+    inCall?: boolean;
+    manualActionRequired?: boolean;
+    manualActionReason?: GoogleMeetChromeHealth["manualActionReason"];
+    manualActionMessage?: string;
+    listenVerified: boolean;
+    listenTimedOut: boolean;
+    captioning?: boolean;
+    captionsEnabledAttempted?: boolean;
+    transcriptLines?: number;
+    lastCaptionAt?: string;
+    lastCaptionSpeaker?: string;
+    lastCaptionText?: string;
+    recentTranscript?: GoogleMeetChromeHealth["recentTranscript"];
+    session: GoogleMeetSession;
+  }> {
+    if (request.mode === "realtime") {
+      throw new Error(
+        "test_listen requires mode: transcribe; use test_speech for realtime talk-back.",
+      );
+    }
+    const url = normalizeMeetUrl(request.url);
+    const transport = resolveTransport(request.transport, this.params.config);
+    if (transport === "twilio") {
+      throw new Error("test_listen supports chrome or chrome-node transports");
+    }
+    const beforeSessions = this.list();
+    const before = new Set(beforeSessions.map((session) => session.id));
+    const existingSession = beforeSessions.find(
+      (session) =>
+        session.state === "active" &&
+        isSameMeetUrlForReuse(session.url, url) &&
+        session.transport === transport &&
+        session.mode === "transcribe",
+    );
+    const start = transcriptCheckpoint(existingSession?.chrome?.health);
+    const result = await this.join({
+      ...request,
+      transport,
+      url,
+      mode: "transcribe",
+      message: undefined,
+    });
+    let health = result.session.chrome?.health;
+    const timeoutMs = resolveProbeTimeoutMs(
+      request.timeoutMs,
+      this.params.config.chrome.joinTimeoutMs,
+    );
+    const shouldWait =
+      health?.manualActionRequired !== true && isManagedChromeBrowserSession(result.session);
+    if (shouldWait && !hasTranscriptAdvanced(health, start)) {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        await sleep(250);
+        await this.#refreshCaptionHealthForSession(result.session);
+        health = result.session.chrome?.health;
+        if (health?.manualActionRequired || hasTranscriptAdvanced(health, start)) {
+          break;
+        }
+      }
+    }
+    const listenVerified = hasTranscriptAdvanced(health, start);
+    return {
+      createdSession: !before.has(result.session.id),
+      inCall: health?.inCall,
+      manualActionRequired: health?.manualActionRequired,
+      manualActionReason: health?.manualActionReason,
+      manualActionMessage: health?.manualActionMessage,
+      listenVerified,
+      listenTimedOut: shouldWait && !listenVerified && health?.manualActionRequired !== true,
+      captioning: health?.captioning,
+      captionsEnabledAttempted: health?.captionsEnabledAttempted,
+      transcriptLines: health?.transcriptLines,
+      lastCaptionAt: health?.lastCaptionAt,
+      lastCaptionSpeaker: health?.lastCaptionSpeaker,
+      lastCaptionText: health?.lastCaptionText,
+      recentTranscript: health?.recentTranscript,
       session: result.session,
     };
   }

--- a/extensions/google-meet/src/transports/types.ts
+++ b/extensions/google-meet/src/transports/types.ts
@@ -7,6 +7,7 @@ export type GoogleMeetJoinRequest = {
   transport?: GoogleMeetTransport;
   mode?: GoogleMeetMode;
   message?: string;
+  timeoutMs?: number;
   dialInNumber?: string;
   pin?: string;
   dtmfSequence?: string;


### PR DESCRIPTION
## Summary

- add Google Meet API room access controls (`accessType`, `entryPointAccess`) to `googlemeet create` and the `google_meet` tool
- add OAuth scope coverage for `meetings.space.settings` when a create request includes `SpaceConfig`
- add `googlemeet end-active-conference` and the matching `google_meet` tool action for closing an API-managed active conference
- document the new room access flags, required reauth/scope, and end-active-conference behavior

## Why

Google Meet API-created spaces can set `SpaceConfig.accessType` so callers can choose whether participants join without knocking instead of inheriting account defaults. This is useful for agent-created private rooms where the agent needs predictable admission behavior. `spaces.endActiveConference` also gives API-managed flows a clean way to close the active conference after local participation ends.

Official Google docs used while implementing:

- `spaces.create` / `SpaceConfig`: https://developers.google.com/workspace/meet/api/reference/rest/v2/spaces
- Meeting space configuration guide: https://developers.google.com/workspace/meet/api/guides/meeting-spaces-configuration

## Tests

- `pnpm format:docs`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/google-meet/index.create.test.ts extensions/google-meet/src/cli.test.ts`
- `pnpm tsgo:extensions`
