### PR TITLE
fix: 5 targeted bug fixes (gemini-cli, plugin commands, openrouter thinking, cron summary, LLM-only tools)

### DIFF
--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -27,16 +27,8 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
     bundleMcpMode: "gemini-system-settings",
     config: {
       command: "gemini",
-      args: ["--skip-trust", "--output-format", "json", "--prompt", "{prompt}"],
-      resumeArgs: [
-        "--skip-trust",
-        "--resume",
-        "{sessionId}",
-        "--output-format",
-        "json",
-        "--prompt",
-        "{prompt}",
-      ],
+      args: ["--output-format", "json", "--prompt", "{prompt}"],
+      resumeArgs: ["--resume", "{sessionId}", "--output-format", "json", "--prompt", "{prompt}"],
       output: "json",
       input: "arg",
       imageArg: "@",

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -149,6 +149,24 @@ export default definePluginEntry({
           : undefined;
       },
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      resolveThinkingProfile: (ctx) => {
+        const capabilities = getOpenRouterModelCapabilities(ctx.modelId);
+        const hasReasoning =
+          (capabilities?.reasoning ?? false) &&
+          !isOpenRouterProxyReasoningUnsupportedModel(ctx.modelId);
+        if (!hasReasoning) {
+          return null;
+        }
+        return {
+          levels: [
+            { id: "off" as const },
+            { id: "low" as const },
+            { id: "medium" as const },
+            { id: "high" as const },
+            { id: "xhigh" as const },
+          ],
+        };
+      },
       resolveReasoningOutputMode: () => "native",
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -327,16 +327,8 @@ beforeEach(() => {
       bundleMcpMode: "gemini-system-settings",
       config: {
         command: "gemini",
-        args: ["--skip-trust", "--output-format", "json", "--prompt", "{prompt}"],
-        resumeArgs: [
-          "--skip-trust",
-          "--resume",
-          "{sessionId}",
-          "--output-format",
-          "json",
-          "--prompt",
-          "{prompt}",
-        ],
+        args: ["--output-format", "json", "--prompt", "{prompt}"],
+        resumeArgs: ["--resume", "{sessionId}", "--output-format", "json", "--prompt", "{prompt}"],
         imageArg: "@",
         imagePathScope: "workspace",
         modelArg: "--model",

--- a/src/agents/tool-allowlist-guard.ts
+++ b/src/agents/tool-allowlist-guard.ts
@@ -20,6 +20,10 @@ export function buildEmptyExplicitToolAllowlistError(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
 }): Error | null {
+  // LLM-only runs intentionally disable tools; an empty callable set is expected, not an error.
+  if (params.disableTools === true) {
+    return null;
+  }
   const callableToolNames = params.callableToolNames.map(normalizeToolName).filter(Boolean);
   if (params.sources.length === 0 || callableToolNames.length > 0) {
     return null;

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -258,9 +258,17 @@ export function resolveCronPayloadOutcome(params: {
   preferFinalAssistantVisibleText?: boolean;
 }): CronPayloadOutcome {
   const firstText = params.payloads[0]?.text ?? "";
+  const normalizedFinalAssistantVisibleTextEarly = normalizeOptionalString(
+    params.finalAssistantVisibleText,
+  );
   const fallbackSummary =
-    pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
-  const fallbackOutputText = pickLastNonEmptyTextFromPayloads(params.payloads);
+    pickSummaryFromPayloads(params.payloads) ??
+    (normalizedFinalAssistantVisibleTextEarly
+      ? pickSummaryFromOutput(normalizedFinalAssistantVisibleTextEarly)
+      : undefined) ??
+    pickSummaryFromOutput(firstText);
+  const fallbackOutputText =
+    pickLastNonEmptyTextFromPayloads(params.payloads) ?? normalizedFinalAssistantVisibleTextEarly;
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
   const deliveryPayloadHasStructuredContent = payloadHasStructuredDeliveryContent(deliveryPayload);

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -339,7 +339,7 @@ export async function executePluginCommand(params: {
     logVerbose(
       `Plugin command /${command.name} executed successfully for ${senderId || "unknown"}`,
     );
-    return result;
+    return result ?? {};
   } catch (err) {
     const error = err as Error;
     logVerbose(`Plugin command /${command.name} error: ${error.message}`);


### PR DESCRIPTION
## Summary

Five independent targeted fixes, each addressing a distinct bug:

### 1. fix(google): remove unsupported `--skip-trust` flag from gemini-cli backend (#74749)
`gemini-cli >= 0.38.x` dropped `--skip-trust`. Passing it causes yargs to exit non-zero on every call, resulting in 100% failure rate for the gemini CLI backend. Removed from both `args` and `resumeArgs`.

### 2. fix(plugins): guard against undefined plugin command handler result (#74800)
Plugin command handlers typed as `Promise<PluginCommandResult>` can return `undefined` at runtime. The caller in `commands-plugin.ts` immediately destructures `result.continueAgent`, crashing with `Cannot read properties of undefined`. Added a `?? {}` fallback at the execution boundary.

### 3. fix(openrouter): add `resolveThinkingProfile` with `xhigh` for reasoning models (#74788)
OpenRouter had no `resolveThinkingProfile`, so `/think xhigh` was rejected for all models including `openrouter/deepseek/deepseek-v4-pro`. Added a profile that exposes `xhigh` for models with `reasoning: true` (unless explicitly excluded via `isOpenRouterProxyReasoningUnsupportedModel`).

### 4. fix(cron): prefer `finalAssistantVisibleText` over raw error text in task summary (#74807)
When a cron `agentTurn` run had only error payloads (tool call failed, agent self-corrected but never sent an explicit reply via messaging tool), `fallbackSummary` fell through to `pickSummaryFromOutput(firstText)` where `firstText` was the tool error. Now prefers `finalAssistantVisibleText` as an intermediate fallback before resorting to raw payload text.

### 5. fix(agents): skip tool allowlist guard for LLM-only runs (#74810)
`buildEmptyExplicitToolAllowlistError` raised an error when `callableToolNames` was empty, even when `disableTools: true`. LLM-only runs intentionally disable tools, so an empty callable set is expected. Added early return when `disableTools === true`.

## Testing

Each fix is independently testable:
- **#74749**: `pnpm test -- src/agents/cli-backends.test.ts`
- **#74800**: Trigger any plugin command whose handler returns `undefined`
- **#74788**: `pnpm test -- src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts`
- **#74807**: `pnpm test -- src/cron/isolated-agent`
- **#74810**: `pnpm test -- src/agents/tool-allowlist-guard`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)