### PR TITLE
chore(ci): add provider CodeQL PR quality guard

### DIFF
--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -28,6 +28,7 @@ on:
       - "src/gateway/server-methods/**"
       - "src/gateway/server-methods.ts"
       - "src/gateway/server-methods-list.ts"
+      - "src/model-catalog/**"
       - "src/plugin-sdk/**"
       - "src/plugins/**"
   schedule:
@@ -55,6 +56,7 @@ jobs:
       gateway: ${{ steps.detect.outputs.gateway }}
       plugin: ${{ steps.detect.outputs.plugin }}
       plugin_sdk_package: ${{ steps.detect.outputs.plugin_sdk_package }}
+      provider: ${{ steps.detect.outputs.provider }}
     steps:
       - name: Detect PR shard paths
         id: detect
@@ -69,11 +71,13 @@ jobs:
           gateway=false
           plugin=false
           plugin_sdk_package=false
+          provider=false
 
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
             gateway=true
             plugin=true
             plugin_sdk_package=true
+            provider=true
           else
             while IFS= read -r file; do
               case "${file}" in
@@ -81,14 +85,26 @@ jobs:
                   gateway=true
                   plugin=true
                   plugin_sdk_package=true
+                  provider=true
                   ;;
                 src/gateway/method-scopes.ts|src/gateway/protocol/*|src/gateway/server-methods/*|src/gateway/server-methods.ts|src/gateway/server-methods-list.ts)
                   gateway=true
                   ;;
-                src/plugin-sdk/*|src/plugins/*)
+                src/plugin-sdk/*)
+                  plugin=true
+                  plugin_sdk_package=true
+                  ;;
+                src/plugins/provider-contract-public-artifacts.ts|src/plugins/provider-public-artifacts.ts|src/plugins/web-provider-public-artifacts*.ts)
+                  plugin=true
+                  provider=true
+                  ;;
+                src/model-catalog/*|src/plugins/*provider*.ts|src/plugins/capability-provider-runtime.ts|src/plugins/compaction-provider.ts|src/plugins/memory-embedding-provider*.ts|src/plugins/memory-embedding-providers*.ts|src/plugins/migration-provider-runtime.ts|src/plugins/synthetic-auth.runtime.ts|src/plugins/web-fetch-providers*.ts|src/plugins/web-search-providers*.ts)
+                  provider=true
+                  ;;
+                src/plugins/activation-planner.ts|src/plugins/api-builder.ts|src/plugins/bundled-*.ts|src/plugins/captured-registration.ts|src/plugins/config-*.ts|src/plugins/discovery.ts|src/plugins/effective-plugin-ids.ts|src/plugins/externalized-bundled-plugins.ts|src/plugins/installed-plugin-index*.ts|src/plugins/loader*.ts|src/plugins/manifest*.ts|src/plugins/module-export.ts|src/plugins/package-entrypoints.ts|src/plugins/plugin-registry*.ts|src/plugins/public-surface*.ts|src/plugins/registry.ts|src/plugins/registry-types.ts|src/plugins/runtime|src/plugins/runtime/*|src/plugins/runtime-state.ts|src/plugins/runtime.ts|src/plugins/sdk-alias.ts|src/plugins/source-loader.ts|src/plugins/types.ts|src/plugins/validation-diagnostics.ts)
                   plugin=true
                   ;;
-                packages/plugin-package-contract/*|packages/plugin-sdk/*|src/plugin-sdk/*)
+                packages/plugin-package-contract/*|packages/plugin-sdk/*)
                   plugin_sdk_package=true
                   ;;
               esac
@@ -99,6 +115,7 @@ jobs:
             echo "gateway=${gateway}"
             echo "plugin=${plugin}"
             echo "plugin_sdk_package=${plugin_sdk_package}"
+            echo "provider=${provider}"
           } >> "${GITHUB_OUTPUT}"
 
   core-auth-secrets:
@@ -302,7 +319,8 @@ jobs:
 
   provider-runtime-boundary:
     name: Critical Quality (provider-runtime-boundary)
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'provider-runtime-boundary') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.provider == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'provider-runtime-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -299,10 +299,11 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 pull request guard is intentionally smaller than the scheduled profile: non-draft
-PRs only run the matching `gateway-runtime-boundary`, `plugin-boundary`, and
-`plugin-sdk-package-contract` shards for gateway protocol/server-method, plugin
-loader, Plugin SDK, or package-contract changes. CodeQL config and quality
-workflow changes run all three PR quality shards. Its manual dispatch accepts
+PRs only run the matching `gateway-runtime-boundary`, `provider-runtime-boundary`,
+`plugin-boundary`, and `plugin-sdk-package-contract` shards for gateway
+protocol/server-method, provider runtime/model catalog, plugin loader, Plugin
+SDK, or package-contract changes. CodeQL config and quality workflow changes run
+all four PR quality shards. Its manual dispatch accepts
 `profile=all|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
 the narrow profiles are teaching/iteration hooks for running one quality shard
 in isolation without dispatching the rest of the workflow.


### PR DESCRIPTION
## Summary

- Problem: PR CodeQL quality coverage still skipped provider runtime/model-catalog changes.
- Why it matters: provider auth, discovery, catalogs, and fetch/search/embedding registries are critical runtime wiring, but the full scheduled quality profile is too broad for every PR.
- What changed: added provider runtime/model-catalog path selection to the existing CodeQL Critical Quality PR guard and tightened the selector so provider-only changes do not fan out to generic plugin shards unless they touch plugin public-surface provider artifacts.
- What did NOT change (scope boundary): no CodeQL query set expansion beyond the existing provider shard, no runtime code changes, no security-severity threshold changes.

## Change Type (select all)

- [x] Chore/infra
- [x] Docs

## Scope (select all touched areas)

- [x] CI/CD / infra
- [x] API / contracts

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/74821
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: provider quality had a manual/scheduled shard but no PR path selection.
- Contributing context (if known): the PR quality guard is being rolled out incrementally by surface area to avoid the old all-default CodeQL runtime cost.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
provider PR -> CodeQL Critical Quality trigger -> no provider quality shard

After:
provider PR -> Select Critical Quality shards -> provider-runtime-boundary only
workflow/config PR -> Select Critical Quality shards -> all PR quality shards
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22 via repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions / Blacksmith
- Relevant config (redacted): N/A

### Steps

1. Parsed `.github/workflows/codeql-critical-quality.yml` and `.github/codeql/codeql-provider-runtime-boundary-critical-quality.yml` as YAML.
2. Ran `git diff --check`.
3. Simulated the shard selector for provider-only, provider public-artifact, plugin-only, plugin-sdk, package-contract, gateway-only, and workflow/config changes.
4. Ran `pnpm check:workflows`.

### Expected

- Provider-only paths select provider quality only.
- Provider public-artifact paths select provider + plugin quality.
- `src/plugin-sdk/*` selects plugin + package-contract quality.
- Workflow/config changes select all PR quality shards.

### Actual

- Matches expected locally. Live PR workflow run will provide the GitHub Actions proof.

## Evidence

- [x] Trace/log snippets

Local proof:

- YAML parse: passed
- `git diff --check`: passed
- selector simulation: passed
- `pnpm check:workflows`: passed

## Human Verification (required)

- Verified scenarios: provider-only, provider public-artifact overlap, plugin-only, `src/plugin-sdk/*`, package-contract, gateway-only, workflow/config selector cases.
- Edge cases checked: bash `case` no-fallthrough behavior; this PR fixes `src/plugin-sdk/*` to select both plugin and package-contract shards.
- What you did **not** verify: live GitHub Actions result before opening this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: selector paths drift from CodeQL config paths.
  - Mitigation: docs call out the PR selector behavior; local selector simulation covers the critical path classes touched here.
