### PR TITLE
fix(plugins): normalize undefined handler return to prevent TypeError on Telegram plugin commands

### DIFF
--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -585,4 +585,11 @@ describe("registerTelegramNativeCommands", () => {
       }),
     );
   });
+
+  it("does not throw when a plugin handler returns undefined", async () => {
+    const { handler } = registerPlugCommand();
+    pluginCommandMocks.executePluginCommand.mockResolvedValue(undefined as never);
+
+    await expect(handler(createPrivateCommandContext())).resolves.not.toThrow();
+  });
 });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1193,21 +1193,22 @@ export const registerTelegramNativeCommands = ({
           }
         }
 
-        const result = await nativeCommandRuntime.executePluginCommand({
-          command: match.command,
-          args: match.args,
-          senderId,
-          channel: "telegram",
-          isAuthorizedSender: commandAuthorized,
-          senderIsOwner,
-          sessionKey: route.sessionKey,
-          commandBody,
-          config: runtimeCfg,
-          from,
-          to,
-          accountId,
-          messageThreadId: threadSpec.id,
-        });
+        const result =
+          (await nativeCommandRuntime.executePluginCommand({
+            command: match.command,
+            args: match.args,
+            senderId,
+            channel: "telegram",
+            isAuthorizedSender: commandAuthorized,
+            senderIsOwner,
+            sessionKey: route.sessionKey,
+            commandBody,
+            config: runtimeCfg,
+            from,
+            to,
+            accountId,
+            messageThreadId: threadSpec.id,
+          })) ?? {};
 
         if (
           shouldSuppressLocalTelegramExecApprovalPrompt({

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -131,6 +131,24 @@ describe("handlePluginCommand", () => {
     });
   });
 
+  it("does not throw when plugin handler returns undefined", async () => {
+    matchPluginCommandMock.mockReturnValue({
+      command: { name: "silent" },
+      args: "",
+    });
+    executePluginCommandMock.mockResolvedValue(undefined);
+
+    const result = await handlePluginCommand(
+      buildPluginParams("/silent", {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig),
+      true,
+    );
+
+    expect(result).toEqual({ shouldContinue: false, reply: undefined });
+  });
+
   it("enforces requiredScopes through the command handler path", async () => {
     const actualCommands = await vi.importActual<typeof import("../../plugins/commands.js")>(
       "../../plugins/commands.js",

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -56,8 +56,9 @@ export const handlePluginCommand: CommandHandler = async (
         : undefined,
     threadParentId: normalizeOptionalString(params.ctx.ThreadParentId),
   });
-  const shouldContinue = result.continueAgent === true;
-  const { continueAgent: _continueAgent, ...reply } = result;
+  const safeResult = result ?? {};
+  const shouldContinue = safeResult.continueAgent === true;
+  const { continueAgent: _continueAgent, ...reply } = safeResult;
   void _continueAgent;
 
   return {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -335,11 +335,13 @@ export async function executePluginCommand(params: {
   // Lock registry during execution to prevent concurrent modifications
   setPluginCommandRegistryLocked(true);
   try {
-    const result = await command.handler(ctx);
+    const rawResult = await command.handler(ctx);
     logVerbose(
       `Plugin command /${command.name} executed successfully for ${senderId || "unknown"}`,
     );
-    return result;
+    // Plugins are third-party JS and may omit an explicit return; coerce nullish to
+    // an empty reply so callers can safely destructure without a TypeError.
+    return rawResult ?? {};
   } catch (err) {
     const error = err as Error;
     logVerbose(`Plugin command /${command.name} error: ${error.message}`);


### PR DESCRIPTION
## Problem

Plugin command handlers are third-party JS — they can omit an explicit `return` statement, causing `executePluginCommand` to resolve to `undefined`. Two downstream callers read properties immediately without a null guard:

- `commands-plugin.ts:59`: `result.continueAgent` → `TypeError: Cannot read properties of undefined (reading 'continueAgent')`
- `bot-native-commands.ts:1213`: `result.channelData` (via `shouldSuppressLocalTelegramExecApprovalPrompt`) → same TypeError

The user sees: `Something went wrong while processing your request. Please try again.`

Fixes #74800

## Solution

**Normalize at the executor boundary** (`commands.ts`): coerce nullish handler return to `{}` so all callers are protected without individual null guards at every call site.

**Add defensive null guard** in `commands-plugin.ts` and `bot-native-commands.ts` for belt-and-suspenders safety (protects against mocked/wrapped executors that bypass the central normalization).

## Files changed

- `src/plugins/commands.ts` — `rawResult ?? {}` at executor return
- `src/auto-reply/reply/commands-plugin.ts` — `const safeResult = result ?? {}`
- `extensions/telegram/src/bot-native-commands.ts` — `?? {}` on `executePluginCommand` result
- `src/auto-reply/reply/commands-plugin.test.ts` — regression test: undefined handler result → no throw
- `extensions/telegram/src/bot-native-commands.test.ts` — regression test: Telegram native path with undefined result → no throw

## Test

```
pnpm test src/auto-reply/reply/commands-plugin.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot-native-commands.registry.test.ts
```

All 29 tests pass (5 + 24).