### PR TITLE
chore(ci): add channel CodeQL PR quality guard

### DIFF
--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - channel-runtime-boundary
           - gateway-runtime-boundary
           - plugin-boundary
           - plugin-sdk-package-contract
@@ -23,6 +24,7 @@ on:
       - ".github/workflows/codeql-critical-quality.yml"
       - "packages/plugin-package-contract/**"
       - "packages/plugin-sdk/**"
+      - "src/channels/**"
       - "src/gateway/method-scopes.ts"
       - "src/gateway/protocol/**"
       - "src/gateway/server-methods/**"
@@ -53,6 +55,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 5
     outputs:
+      channel: ${{ steps.detect.outputs.channel }}
       gateway: ${{ steps.detect.outputs.gateway }}
       plugin: ${{ steps.detect.outputs.plugin }}
       plugin_sdk_package: ${{ steps.detect.outputs.plugin_sdk_package }}
@@ -68,12 +71,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          channel=false
           gateway=false
           plugin=false
           plugin_sdk_package=false
           provider=false
 
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            channel=true
             gateway=true
             plugin=true
             plugin_sdk_package=true
@@ -82,10 +87,14 @@ jobs:
             while IFS= read -r file; do
               case "${file}" in
                 .github/codeql/*|.github/workflows/codeql-critical-quality.yml)
+                  channel=true
                   gateway=true
                   plugin=true
                   plugin_sdk_package=true
                   provider=true
+                  ;;
+                src/channels/*)
+                  channel=true
                   ;;
                 src/gateway/method-scopes.ts|src/gateway/protocol/*|src/gateway/server-methods/*|src/gateway/server-methods.ts|src/gateway/server-methods-list.ts)
                   gateway=true
@@ -112,6 +121,7 @@ jobs:
           fi
 
           {
+            echo "channel=${channel}"
             echo "gateway=${gateway}"
             echo "plugin=${plugin}"
             echo "plugin_sdk_package=${plugin_sdk_package}"
@@ -187,7 +197,8 @@ jobs:
 
   channel-runtime-boundary:
     name: Critical Quality (channel-runtime-boundary)
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.channel == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'channel-runtime-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -299,12 +299,13 @@ The `CodeQL Critical Quality` workflow is the matching non-security shard. It
 runs only error-severity, non-security JavaScript/TypeScript quality queries
 over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its
 pull request guard is intentionally smaller than the scheduled profile: non-draft
-PRs only run the matching `gateway-runtime-boundary`, `provider-runtime-boundary`,
-`plugin-boundary`, and `plugin-sdk-package-contract` shards for gateway
+PRs only run the matching `channel-runtime-boundary`,
+`gateway-runtime-boundary`, `provider-runtime-boundary`, `plugin-boundary`, and
+`plugin-sdk-package-contract` shards for channel runtime, gateway
 protocol/server-method, provider runtime/model catalog, plugin loader, Plugin
 SDK, or package-contract changes. CodeQL config and quality workflow changes run
-all four PR quality shards. Its manual dispatch accepts
-`profile=all|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
+all five PR quality shards. Its manual dispatch accepts
+`profile=all|channel-runtime-boundary|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary`;
 the narrow profiles are teaching/iteration hooks for running one quality shard
 in isolation without dispatching the rest of the workflow.
 Its


### PR DESCRIPTION
## Summary
- adds `channel-runtime-boundary` to the CodeQL Critical Quality PR shard selector
- scopes channel PR triggering to `src/channels/**`
- documents the fifth lightweight PR quality shard and manual profile

## Verification
- `git diff --check`
- YAML parse for `.github/workflows/codeql-critical-quality.yml` and `.github/codeql/codeql-channel-runtime-boundary-critical-quality.yml`
- `pnpm check:workflows`
- selector simulation:
  - `src/channels/allow-from.ts` -> channel only
  - `src/channels/plugins/binding-routing.ts` -> channel only
  - `src/gateway/protocol/schema/channels.ts` -> gateway only
  - `src/plugins/provider-auth.ts` -> provider only
  - `src/plugins/loader.ts` -> plugin only
  - `src/plugin-sdk/core.ts` -> plugin + plugin-sdk-package
  - workflow changes -> all five PR quality shards
- `pnpm docs:check-mdx`

## Notes
This keeps the PR CodeQL quality guard small: channel implementation changes now get their own non-security error-severity quality shard without fanning out gateway/provider/plugin analysis.
