### PR TITLE
chore(ci): add process CodeQL PR quality guard

### DIFF
--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -12,6 +12,7 @@ on:
           - all
           - channel-runtime-boundary
           - gateway-runtime-boundary
+          - mcp-process-runtime-boundary
           - plugin-boundary
           - plugin-sdk-package-contract
           - plugin-sdk-reply-runtime
@@ -30,9 +31,12 @@ on:
       - "src/gateway/server-methods/**"
       - "src/gateway/server-methods.ts"
       - "src/gateway/server-methods-list.ts"
+      - "src/infra/outbound/**"
+      - "src/mcp/**"
       - "src/model-catalog/**"
       - "src/plugin-sdk/**"
       - "src/plugins/**"
+      - "src/process/**"
   schedule:
     - cron: "30 6 * * *"
 
@@ -57,6 +61,7 @@ jobs:
     outputs:
       channel: ${{ steps.detect.outputs.channel }}
       gateway: ${{ steps.detect.outputs.gateway }}
+      mcp_process: ${{ steps.detect.outputs.mcp_process }}
       plugin: ${{ steps.detect.outputs.plugin }}
       plugin_sdk_package: ${{ steps.detect.outputs.plugin_sdk_package }}
       provider: ${{ steps.detect.outputs.provider }}
@@ -73,6 +78,7 @@ jobs:
 
           channel=false
           gateway=false
+          mcp_process=false
           plugin=false
           plugin_sdk_package=false
           provider=false
@@ -80,6 +86,7 @@ jobs:
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
             channel=true
             gateway=true
+            mcp_process=true
             plugin=true
             plugin_sdk_package=true
             provider=true
@@ -89,6 +96,7 @@ jobs:
                 .github/codeql/*|.github/workflows/codeql-critical-quality.yml)
                   channel=true
                   gateway=true
+                  mcp_process=true
                   plugin=true
                   plugin_sdk_package=true
                   provider=true
@@ -98,6 +106,9 @@ jobs:
                   ;;
                 src/gateway/method-scopes.ts|src/gateway/protocol/*|src/gateway/server-methods/*|src/gateway/server-methods.ts|src/gateway/server-methods-list.ts)
                   gateway=true
+                  ;;
+                src/infra/outbound/*|src/mcp/*|src/process/*)
+                  mcp_process=true
                   ;;
                 src/plugin-sdk/*)
                   plugin=true
@@ -123,6 +134,7 @@ jobs:
           {
             echo "channel=${channel}"
             echo "gateway=${gateway}"
+            echo "mcp_process=${mcp_process}"
             echo "plugin=${plugin}"
             echo "plugin_sdk_package=${plugin_sdk_package}"
             echo "provider=${provider}"
@@ -242,7 +254,8 @@ jobs:
 
   mcp-process-runtime-boundary:
     name: Critical Quality (mcp-process-runtime-boundary)
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.mcp_process == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'mcp-process-runtime-boundary') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -335,12 +335,12 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 
 ### Critical Quality categories
 
-`CodeQL Critical Quality` is the matching non-security shard. It runs only error-severity, non-security JavaScript/TypeScript quality queries over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its pull request guard is intentionally smaller than the scheduled profile: non-draft PRs only run the matching `channel-runtime-boundary`, `gateway-runtime-boundary`, `provider-runtime-boundary`, `plugin-boundary`, and `plugin-sdk-package-contract` shards for channel runtime, gateway protocol/server-method, provider runtime/model catalog, plugin loader, Plugin SDK, or package-contract changes. CodeQL config and quality workflow changes run all five PR quality shards.
+`CodeQL Critical Quality` is the matching non-security shard. It runs only error-severity, non-security JavaScript/TypeScript quality queries over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its pull request guard is intentionally smaller than the scheduled profile: non-draft PRs only run the matching `channel-runtime-boundary`, `gateway-runtime-boundary`, `mcp-process-runtime-boundary`, `provider-runtime-boundary`, `plugin-boundary`, and `plugin-sdk-package-contract` shards for channel runtime, gateway protocol/server-method, MCP/process/outbound delivery, provider runtime/model catalog, plugin loader, Plugin SDK, or package-contract changes. CodeQL config and quality workflow changes run all six PR quality shards.
 
 Manual dispatch accepts:
 
 ```
-profile=all|channel-runtime-boundary|gateway-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary
+profile=all|channel-runtime-boundary|gateway-runtime-boundary|mcp-process-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary
 ```
 
 The narrow profiles are teaching/iteration hooks for running one quality shard in isolation.


### PR DESCRIPTION
## Summary
- add `mcp-process-runtime-boundary` to the lightweight CodeQL Critical Quality PR selector
- trigger the process quality shard for `src/mcp/**`, `src/process/**`, and `src/infra/outbound/**`
- update CI docs for the sixth PR quality shard and manual profile

## Verification
- `git diff --check origin/main...HEAD`
- YAML parsed for `.github/workflows/codeql-critical-quality.yml` and `.github/codeql/codeql-mcp-process-runtime-boundary-critical-quality.yml`
- selector simulation: mcp/process/outbound paths select only the process shard; workflow/config changes select all six PR quality shards
- `pnpm docs:check-mdx`
- `pnpm check:workflows`

## Notes
This keeps the non-security quality guard narrow: process/MCP/outbound implementation changes get their own error-severity quality shard without pulling in unrelated UI/config/memory scheduled shards.
