### PR TITLE
fix(openai): remove incorrect gpt-5.4-mini suppression on openai-codex route

### DIFF
--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -688,11 +688,6 @@
         "provider": "openai-codex",
         "model": "gpt-5.3-codex-spark",
         "reason": "gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.4-mini",
-        "reason": "gpt-5.4-mini is not supported by the OpenAI Codex OAuth route. Use openai/gpt-5.4-mini with an OpenAI API key or openai-codex/gpt-5.5 with Codex OAuth."
       }
     ]
   },


### PR DESCRIPTION
## Summary

Removes the `modelCatalog.suppressions` entry that blocks `openai-codex/gpt-5.4-mini`. The model is available and works on the Codex OAuth route — the suppression is a regression introduced in 4.27.

Fixes #74451 — the original issue was that users got repeated runtime failures when switching to `openai-codex/gpt-5.4-mini`. #74655 improved suppression enforcement for stale inline entries, which is a valid resolver improvement, but it isn't the fix needed here. The underlying problem is that the suppression itself is incorrect — the model works on the Codex OAuth route and should not be suppressed.

## Context

- `openai-codex/gpt-5.4-mini` worked on 4.23 and earlier with no issues
- The 4.27 suppression blocks the model before the request reaches the API
- Verified the model works via the Codex app-server SDK (`codex/gpt-5.4-mini`) on a ChatGPT-backed OAuth account
- #74655's unconditional suppression code only fires when a manifest suppression entry exists — removing the entry makes it a no-op

## Test plan

- [ ] Verify `openai-codex/gpt-5.4-mini` resolves and completes requests on a ChatGPT-backed Codex OAuth account
- [ ] Verify existing `gpt-5.3-codex-spark` suppressions are unaffected
- [ ] `pnpm test src/agents/pi-embedded-runner/model.test.ts`