### PR TITLE
chore(ci): add auth CodeQL PR quality guard

### DIFF
--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - all
+          - core-auth-secrets
           - channel-runtime-boundary
           - gateway-runtime-boundary
           - memory-runtime-boundary
@@ -27,6 +28,16 @@ on:
       - "packages/plugin-package-contract/**"
       - "packages/plugin-sdk/**"
       - "packages/memory-host-sdk/**"
+      - "src/agents/*auth*.ts"
+      - "src/agents/**/*auth*.ts"
+      - "src/agents/auth-health*.ts"
+      - "src/agents/auth-profiles"
+      - "src/agents/auth-profiles/**"
+      - "src/agents/bash-tools.exec-host-shared.ts"
+      - "src/agents/sandbox"
+      - "src/agents/sandbox/**"
+      - "src/agents/sandbox.ts"
+      - "src/agents/sandbox-*.ts"
       - "src/channels/**"
       - "src/auto-reply/reply/post-compaction-context.ts"
       - "src/auto-reply/reply/queue/**"
@@ -36,6 +47,16 @@ on:
       - "src/commands/doctor-session-*.ts"
       - "src/commands/session-store-targets.ts"
       - "src/commands/sessions*.ts"
+      - "src/cron/service/jobs.ts"
+      - "src/cron/stagger.ts"
+      - "src/gateway/*auth*.ts"
+      - "src/gateway/**/*auth*.ts"
+      - "src/gateway/*secret*.ts"
+      - "src/gateway/**/*secret*.ts"
+      - "src/gateway/protocol/**/*secret*.ts"
+      - "src/gateway/resolve-configured-secret-input-string*.ts"
+      - "src/gateway/security-path*.ts"
+      - "src/gateway/server-methods/secrets*.ts"
       - "src/gateway/server-startup-memory.ts"
       - "src/gateway/method-scopes.ts"
       - "src/gateway/protocol/**"
@@ -45,6 +66,7 @@ on:
       - "src/infra/diagnostic-*.ts"
       - "src/infra/diagnostics-timeline.ts"
       - "src/infra/outbound/**"
+      - "src/infra/secret-file*.ts"
       - "src/infra/session-delivery-queue*.ts"
       - "src/logging/diagnostic*.ts"
       - "src/memory/**"
@@ -54,6 +76,8 @@ on:
       - "src/plugin-sdk/**"
       - "src/plugins/**"
       - "src/process/**"
+      - "src/secrets/**"
+      - "src/security/**"
   schedule:
     - cron: "30 6 * * *"
 
@@ -77,6 +101,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       channel: ${{ steps.detect.outputs.channel }}
+      core_auth_secrets: ${{ steps.detect.outputs.core_auth_secrets }}
       gateway: ${{ steps.detect.outputs.gateway }}
       memory: ${{ steps.detect.outputs.memory }}
       mcp_process: ${{ steps.detect.outputs.mcp_process }}
@@ -97,6 +122,7 @@ jobs:
           set -euo pipefail
 
           channel=false
+          core_auth_secrets=false
           gateway=false
           memory=false
           mcp_process=false
@@ -108,6 +134,7 @@ jobs:
 
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
             channel=true
+            core_auth_secrets=true
             gateway=true
             memory=true
             mcp_process=true
@@ -121,6 +148,7 @@ jobs:
               case "${file}" in
                 .github/codeql/*|.github/workflows/codeql-critical-quality.yml)
                   channel=true
+                  core_auth_secrets=true
                   gateway=true
                   memory=true
                   mcp_process=true
@@ -135,6 +163,13 @@ jobs:
                   ;;
                 src/channels/*)
                   channel=true
+                  ;;
+                src/gateway/protocol/*secret*.ts|src/gateway/server-methods/secrets*.ts)
+                  core_auth_secrets=true
+                  gateway=true
+                  ;;
+                src/agents/*auth*.ts|src/agents/auth-health*.ts|src/agents/auth-profiles|src/agents/auth-profiles/*|src/agents/bash-tools.exec-host-shared.ts|src/agents/sandbox|src/agents/sandbox.ts|src/agents/sandbox-*.ts|src/agents/sandbox/*|src/cron/service/jobs.ts|src/cron/stagger.ts|src/gateway/*auth*.ts|src/gateway/*secret*.ts|src/gateway/resolve-configured-secret-input-string*.ts|src/gateway/security-path*.ts|src/infra/secret-file*.ts|src/secrets/*|src/security/*)
+                  core_auth_secrets=true
                   ;;
                 src/gateway/method-scopes.ts|src/gateway/protocol/*|src/gateway/server-methods/*|src/gateway/server-methods.ts|src/gateway/server-methods-list.ts)
                   gateway=true
@@ -189,6 +224,7 @@ jobs:
 
           {
             echo "channel=${channel}"
+            echo "core_auth_secrets=${core_auth_secrets}"
             echo "gateway=${gateway}"
             echo "memory=${memory}"
             echo "mcp_process=${mcp_process}"
@@ -201,7 +237,8 @@ jobs:
 
   core-auth-secrets:
     name: Critical Quality (core-auth-secrets)
-    if: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.profile == 'all') }}
+    needs: quality-shards
+    if: ${{ needs.quality-shards.outputs.core_auth_secrets == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request' || github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == 'core-auth-secrets') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -335,12 +335,12 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 
 ### Critical Quality categories
 
-`CodeQL Critical Quality` is the matching non-security shard. It runs only error-severity, non-security JavaScript/TypeScript quality queries over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its pull request guard is intentionally smaller than the scheduled profile: non-draft PRs only run the matching `channel-runtime-boundary`, `gateway-runtime-boundary`, `memory-runtime-boundary`, `mcp-process-runtime-boundary`, `provider-runtime-boundary`, `session-diagnostics-boundary`, `plugin-boundary`, `plugin-sdk-package-contract`, and `plugin-sdk-reply-runtime` shards for channel runtime, gateway protocol/server-method, memory runtime/SDK glue, MCP/process/outbound delivery, provider runtime/model catalog, session diagnostics/delivery queues, plugin loader, Plugin SDK/package-contract, or Plugin SDK reply runtime changes. CodeQL config and quality workflow changes run all nine PR quality shards.
+`CodeQL Critical Quality` is the matching non-security shard. It runs only error-severity, non-security JavaScript/TypeScript quality queries over narrow high-value surfaces on the smaller Blacksmith Linux runner. Its pull request guard is intentionally smaller than the scheduled profile: non-draft PRs only run the matching `core-auth-secrets`, `channel-runtime-boundary`, `gateway-runtime-boundary`, `memory-runtime-boundary`, `mcp-process-runtime-boundary`, `provider-runtime-boundary`, `session-diagnostics-boundary`, `plugin-boundary`, `plugin-sdk-package-contract`, and `plugin-sdk-reply-runtime` shards for auth/secrets/sandbox/security code, channel runtime, gateway protocol/server-method, memory runtime/SDK glue, MCP/process/outbound delivery, provider runtime/model catalog, session diagnostics/delivery queues, plugin loader, Plugin SDK/package-contract, or Plugin SDK reply runtime changes. CodeQL config and quality workflow changes run all ten PR quality shards.
 
 Manual dispatch accepts:
 
 ```
-profile=all|channel-runtime-boundary|gateway-runtime-boundary|memory-runtime-boundary|mcp-process-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary
+profile=all|core-auth-secrets|channel-runtime-boundary|gateway-runtime-boundary|memory-runtime-boundary|mcp-process-runtime-boundary|plugin-boundary|plugin-sdk-package-contract|plugin-sdk-reply-runtime|provider-runtime-boundary|session-diagnostics-boundary
 ```
 
 The narrow profiles are teaching/iteration hooks for running one quality shard in isolation.


### PR DESCRIPTION
## Summary
- add `core-auth-secrets` to the CodeQL Critical Quality PR/manual selector
- trigger the auth quality shard for auth profile, sandbox, cron, gateway auth/secret, infra secret-file, secrets, and security paths
- document the PR guard as ten narrow quality shards

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/codeql-critical-quality.yml` and `.github/codeql/codeql-core-auth-secrets-critical-quality.yml`
- selector probes for secrets/security/auth/sandbox/gateway secret/provider/channel/workflow paths
- `pnpm docs:check-mdx`
- `pnpm check:workflows`
