### PR TITLE
fix(telegram): remove strict SecretRef resolve in read-only token inspection

### DIFF
--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -83,13 +83,10 @@ function resolveRuntimeTokenValue(params: {
     }
     return { status: "configured_unavailable" };
   }
-  // Runtime resolution stays strict for non-env SecretRefs.
-  resolveSecretInputString({
-    value: params.value,
-    path: params.path,
-    defaults: params.cfg?.secrets?.defaults,
-    mode: "strict",
-  });
+  // Non-env SecretRefs (file, vault, etc.) cannot be resolved in read-only inspection
+  // paths such as `openclaw status`. Return configured_unavailable so the caller can
+  // surface a helpful status message. The previous strict-mode call here would throw
+  // "unresolved SecretRef" even when the gateway has the token available at runtime.
   return { status: "configured_unavailable" };
 }
 


### PR DESCRIPTION
## Summary

Targeted single-issue fix.

Closes #74832

🤖 Generated with [Claude Code](https://claude.ai/claude-code)