### PR TITLE
fix(tts): respect trustedLocalMedia flag to unblock voice delivery when tts is absent from builtinToolNames

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -292,14 +292,25 @@ export function filterToolResultMediaUrls(
   if (mediaUrls.length === 0) {
     return mediaUrls;
   }
-  if (isToolResultMediaTrusted(toolName, result)) {
+  // When details.media.trustedLocalMedia is explicitly true the tool itself
+  // is vouching for the local file (e.g. the TTS tool after generating audio).
+  // Skip the builtinToolNames name-registration gate in that case — the
+  // semantic of trustedLocalMedia is exactly "this local path is safe to
+  // deliver" regardless of how the tool name was registered in this run.
+  const detailsMedia = (
+    result as { details?: { media?: { trustedLocalMedia?: unknown } } } | undefined
+  )?.details?.media;
+  const hasTrustedLocalMedia = detailsMedia?.trustedLocalMedia === true;
+
+  if (hasTrustedLocalMedia || isToolResultMediaTrusted(toolName, result)) {
     // When the current run provides its exact registered tool names (core
     // built-ins plus bundled/trusted plugin tools), require the raw emitted
     // tool name to match one of them before allowing local MEDIA: paths.
     // This blocks normalized aliases and case-variant collisions such as
     // "Bash" -> "bash" or "Web_Search" -> "web_search" from inheriting a
-    // registered tool's media trust.
-    if (builtinToolNames !== undefined) {
+    // registered tool's media trust. The trustedLocalMedia flag bypasses
+    // this gate because the tool explicitly opted in at result-construction time.
+    if (builtinToolNames !== undefined && !hasTrustedLocalMedia) {
       const registeredName = toolName?.trim();
       if (!registeredName || !builtinToolNames.has(registeredName)) {
         return mediaUrls.filter((url) => HTTP_URL_RE.test(url.trim()));


### PR DESCRIPTION
## Summary

The TTS tool was silently delivering a text message ("(spoken) …") instead of the audio voice note, because the local OGG file path was filtered out before reaching the Telegram send path.

**Root cause**: `filterToolResultMediaUrls` only allowed local paths when `builtinToolNames.has(toolName)` was true. When `builtinToolNames` was defined but did not contain `"tts"` (configuration-dependent), the `/tmp/…ogg` path was filtered to an empty array and delivery silently fell through to text only.

**Fix**: The TTS tool already sets `details.media.trustedLocalMedia: true` to signal the local audio path is safe for delivery. Added a check for this flag that bypasses the `builtinToolNames` name-registration gate — matching the intended semantics of `trustedLocalMedia`.

No behavioral change when `builtinToolNames` is undefined or already contains `"tts"`.

Closes #74752

🤖 Generated with [Claude Code](https://claude.ai/claude-code)