### PR TITLE
fix(plugins-cli): reject `plugins enable/disable` for unknown ids before mutating config

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -79,7 +79,7 @@ export const recordHookInstall: UnknownMock = vi.fn();
 const { defaultRuntime, runtimeLogs, runtimeErrors, resetRuntimeCapture } =
   createCliRuntimeCapture();
 
-export { runtimeErrors, runtimeLogs };
+export { defaultRuntime, runtimeErrors, runtimeLogs };
 
 export function setInstalledPluginIndexInstallRecords(records: PluginInstallRecordMap): void {
   mockInstalledPluginIndexInstallRecords = clonePluginInstallRecords(records);

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -1,13 +1,25 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  buildPluginRegistrySnapshotReport,
+  defaultRuntime,
   enablePluginInConfig,
   loadConfig,
   refreshPluginRegistry,
   resetPluginsCliTestState,
   runPluginsCommand,
+  runtimeLogs,
   writeConfigFile,
 } from "./plugins-cli-test-helpers.js";
+
+function withDiscoveredPlugin(id: string) {
+  buildPluginRegistrySnapshotReport.mockReturnValue({
+    plugins: [{ id, name: id, enabled: false, status: "disabled" }],
+    diagnostics: [],
+    registrySource: "derived",
+    registryDiagnostics: [],
+  });
+}
 
 describe("plugins cli policy mutations", () => {
   beforeEach(() => {
@@ -23,6 +35,7 @@ describe("plugins cli policy mutations", () => {
       },
     } as OpenClawConfig;
     loadConfig.mockReturnValue({} as OpenClawConfig);
+    withDiscoveredPlugin("alpha");
     enablePluginInConfig.mockReturnValue({
       config: enabledConfig,
       enabled: true,
@@ -46,6 +59,7 @@ describe("plugins cli policy mutations", () => {
         },
       },
     } as OpenClawConfig);
+    withDiscoveredPlugin("alpha");
 
     await runPluginsCommand(["plugins", "disable", "alpha"]);
 
@@ -56,5 +70,37 @@ describe("plugins cli policy mutations", () => {
       installRecords: {},
       reason: "policy-changed",
     });
+  });
+
+  // Regression for #73551: enabling/disabling a plugin id that isn't in the
+  // discovered registry used to write `plugins.entries.<id>: { enabled: ... }`
+  // and exit 0 with a "success" message. The fix gates both subcommands on
+  // the registry and exits non-zero without touching config.
+  it("rejects `plugins enable` for an unknown plugin id without writing config", async () => {
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    // Default mock returns `plugins: []` — no discovered plugins.
+
+    await expect(
+      runPluginsCommand(["plugins", "enable", "totally-fake-plugin-xyz"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+    expect(enablePluginInConfig).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(runtimeLogs.join("\n")).toContain("Plugin not found: totally-fake-plugin-xyz");
+  });
+
+  it("rejects `plugins disable` for an unknown plugin id without writing config", async () => {
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+
+    await expect(
+      runPluginsCommand(["plugins", "disable", "totally-fake-plugin-xyz"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(refreshPluginRegistry).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(runtimeLogs.join("\n")).toContain("Plugin not found: totally-fake-plugin-xyz");
   });
 });

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -67,6 +67,17 @@ const quietPluginJsonLogger: PluginLogger = {
   error: () => undefined,
 };
 
+async function isKnownPluginId(cfg: OpenClawConfig, id: string): Promise<boolean> {
+  const { buildPluginRegistrySnapshotReport } = await import("../plugins/status.js");
+  const { normalizeChatChannelId } = await import("../channels/ids.js");
+  const report = buildPluginRegistrySnapshotReport({
+    config: cfg,
+    logger: quietPluginJsonLogger,
+  });
+  const resolvedId = normalizeChatChannelId(id) ?? id;
+  return report.plugins.some((plugin) => plugin.id === id || plugin.id === resolvedId);
+}
+
 function formatInspectSection(title: string, lines: string[]): string[] {
   if (lines.length === 0) {
     return [];
@@ -569,6 +580,19 @@ export function registerPluginsCli(program: Command) {
         await import("./plugins-registry-refresh.js");
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
+      // Reject unknown plugin ids before mutating config. The runtime config
+      // validator already filters stale entries with `warnOnly`, but the CLI
+      // is the surface where the user typed the id — failing there avoids
+      // accumulating phantom `plugins.entries.<id>: { enabled: true }`
+      // records that look successful but never load. See #73551.
+      if (!(await isKnownPluginId(cfg, id))) {
+        defaultRuntime.log(
+          theme.error(
+            `Plugin not found: ${id}. Run \`openclaw plugins list\` to see installed plugins.`,
+          ),
+        );
+        return defaultRuntime.exit(1);
+      }
       const enableResult = enablePluginInConfig(cfg, id);
       let next: OpenClawConfig = enableResult.config;
       const slotResult = applySlotSelectionForPlugin(next, id);
@@ -606,6 +630,17 @@ export function registerPluginsCli(program: Command) {
         await import("./plugins-registry-refresh.js");
       const snapshot = await readConfigFileSnapshot();
       const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
+      // Symmetric with `enable`: refuse to write `enabled: false` for an id
+      // that doesn't exist in the discovered registry, so `disable` cannot
+      // be used to seed a stale entry either. See #73551.
+      if (!(await isKnownPluginId(cfg, id))) {
+        defaultRuntime.log(
+          theme.error(
+            `Plugin not found: ${id}. Run \`openclaw plugins list\` to see installed plugins.`,
+          ),
+        );
+        return defaultRuntime.exit(1);
+      }
       const next = setPluginEnabledInConfig(cfg, id, false);
       await replaceConfigFile({
         nextConfig: next,


### PR DESCRIPTION
```
### What

`pnpm openclaw plugins enable <id>` and `plugins disable <id>` did not
validate the id against the discovered plugin registry. A nonexistent
id was written to `plugins.entries.<id>` with the requested enabled
state, the CLI printed a "success" message, and exited 0:

    $ pnpm openclaw plugins enable totally-fake-plugin-xyz
    Config warnings:
    - plugins.entries.totally-fake-plugin-xyz: plugin not found:
      totally-fake-plugin-xyz (stale config entry ignored; remove it
      from plugins config)

    Enabled plugin "totally-fake-plugin-xyz". Restart the gateway to apply.

    $ echo $?
    0

The next gateway start surfaced it as a `warnOnly` config validation
warning, but the stale entry stayed in `~/.openclaw/openclaw.json`
under `plugins.entries.<id>: { "enabled": true }` until the operator
removed it manually. Same shape on `plugins disable <id>`.

`models auth login` and `plugins uninstall` already exit non-zero on
similar input shapes (per #73646's note); `plugins enable/disable`
were the outliers.

### Fix

Add a small `isKnownPluginId(cfg, id)` helper in
`src/cli/plugins-cli.ts` that reads the same registry snapshot
`plugins list` uses (`buildPluginRegistrySnapshotReport`) and
normalizes channel-style ids via `normalizeChatChannelId`, so a
built-in channel id resolves correctly. Both `plugins enable` and
`plugins disable` now gate on it before any config mutation:

    if (!(await isKnownPluginId(cfg, id))) {
      defaultRuntime.log(theme.error(`Plugin not found: ${id}. ...`));
      return defaultRuntime.exit(1);
    }

Behaviour for known ids is unchanged. The runtime `warnOnly` path
on config load is intentionally kept so gateway startup stays
resilient when plugins are removed/renamed across upgrades — only
the CLI surface is stricter.

### Tests

`src/cli/plugins-cli.policy.test.ts`:

- existing `plugins enable/disable` policy tests now register the
  test plugin id `alpha` in
  `buildPluginRegistrySnapshotReport.mockReturnValue` (added via a
  small `withDiscoveredPlugin` helper) so they continue to pass.
- two new tests assert that an unknown id triggers
  `defaultRuntime.exit(1)`, leaves `writeConfigFile` /
  `refreshPluginRegistry` / `enablePluginInConfig` uncalled, and
  logs `Plugin not found: <id>`:

      it("rejects `plugins enable` for an unknown plugin id without writing config")
      it("rejects `plugins disable` for an unknown plugin id without writing config")

### Verification

    OPENCLAW_LOCAL_CHECK=1 pnpm test src/cli/plugins-cli.policy.test.ts
    # Test Files  1 passed (1)
    # Tests       4 passed (4)

    OPENCLAW_LOCAL_CHECK=1 pnpm test src/cli/plugins-cli.policy \
      src/cli/plugins-cli.list src/cli/plugins-cli.install \
      src/cli/plugins-cli.uninstall src/cli/plugins-cli.update
    # passed 74 Vitest shards in 85.29s

    pnpm exec oxfmt --check --threads=1 \
      src/cli/plugins-cli.ts src/cli/plugins-cli.policy.test.ts \
      src/cli/plugins-cli-test-helpers.ts
    # clean

### Refs

- `src/cli/plugins-cli.ts` — `isKnownPluginId` helper + guards in
  `plugins enable` and `plugins disable` action handlers.
- `src/cli/plugins-cli.policy.test.ts` — registry-aware existing
  tests + two new unknown-id rejection tests.
- `src/cli/plugins-cli-test-helpers.ts` — exports `defaultRuntime`
  for the new tests' `defaultRuntime.exit` assertions.

Closes #73551
```