### PR TITLE
perf(agents): skip idle wait on abort to release session lock synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: stop Gateway-originated outbound echoes from advancing inbound activity in `openclaw channels status`, so outbound self-sends no longer look like handled inbound messages. Fixes #79056. (#79057) Thanks @ai-hpc and @bittoby.
 - Gateway/nodes: preserve the live node registry session and invoke ownership when an older same-node WebSocket closes after reconnecting. (#78351) Thanks @samzong.
 - Browser/downloads: route explicit and managed browser download output directories through `fs-safe` validation before staging final files, so symlinked output roots are rejected before writes. (#78780) Thanks @jesse-merhi.
+- Agents/PI: skip the idle wait during aborted embedded-run cleanup, so stopped or timed-out runs clear pending tool state and release the session lock promptly. (#74919) Thanks @medns.
 
 ## 2026.5.3-1
 

--- a/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
+++ b/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
@@ -138,4 +138,43 @@ describe("flushPendingToolResultsAfterIdle", () => {
     });
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it("immediately clears pending tool results without waiting when timeoutMs is 0 or less", async () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+    
+    // Agent that never resolves idle
+    const idle = deferred<void>();
+    const waitForIdleSpy = vi.fn(() => idle.promise);
+    const agent = { waitForIdle: waitForIdleSpy };
+
+    appendMessage(assistantToolCall("call_orphan_immediate"));
+
+    // Should resolve immediately without advancing timers
+    await flushPendingToolResultsAfterIdle({
+      agent,
+      sessionManager: sm,
+      timeoutMs: 0,
+      clearPendingOnTimeout: true,
+    });
+
+    // Verify waitForIdle was completely bypassed
+    expect(waitForIdleSpy).not.toHaveBeenCalled();
+
+    // The pending tool result should be cleared immediately.
+    expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant"]);
+
+    // Test negative timeout as well
+    appendMessage(assistantToolCall("call_orphan_negative"));
+    await flushPendingToolResultsAfterIdle({
+      agent,
+      sessionManager: sm,
+      timeoutMs: -100,
+      clearPendingOnTimeout: true,
+    });
+    
+    // Verify waitForIdle was still bypassed
+    expect(waitForIdleSpy).not.toHaveBeenCalled();
+    expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant", "assistant"]);
+  });
 });

--- a/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
+++ b/src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts
@@ -142,7 +142,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
   it("immediately clears pending tool results without waiting when timeoutMs is 0 or less", async () => {
     const sm = guardSessionManager(SessionManager.inMemory());
     const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
-    
+
     // Agent that never resolves idle
     const idle = deferred<void>();
     const waitForIdleSpy = vi.fn(() => idle.promise);
@@ -172,7 +172,7 @@ describe("flushPendingToolResultsAfterIdle", () => {
       timeoutMs: -100,
       clearPendingOnTimeout: true,
     });
-    
+
     // Verify waitForIdle was still bypassed
     expect(waitForIdleSpy).not.toHaveBeenCalled();
     expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant", "assistant"]);

--- a/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
@@ -30,6 +30,7 @@ export async function cleanupEmbeddedAttemptResources(params: {
   bundleMcpRuntime?: { dispose(): Promise<void> | void };
   bundleLspRuntime?: { dispose(): Promise<void> | void };
   sessionLock: { release(): Promise<void> | void };
+  aborted?: boolean;
 }): Promise<void> {
   try {
     try {
@@ -37,11 +38,15 @@ export async function cleanupEmbeddedAttemptResources(params: {
     } catch {
       /* best-effort */
     }
+    // PERF: When the run was aborted (user stop / timeout), skip the expensive
+    // waitForIdle (up to 30 s) and just clear pending tool results synchronously
+    // so the session write-lock is released ASAP and the next message is not blocked.
     try {
       await params.flushPendingToolResultsAfterIdle({
         agent: params.session?.agent as IdleAwareAgent | null | undefined,
         sessionManager: params.sessionManager as ToolResultFlushManager | null | undefined,
         clearPendingOnTimeout: true,
+        ...(params.aborted ? { timeoutMs: 0 } : {}),
       });
     } catch {
       /* best-effort */

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2345,6 +2345,10 @@ export async function runEmbeddedAttempt(
           agent: activeSession?.agent,
           sessionManager,
           clearPendingOnTimeout: true,
+          // PERF: If the run was aborted during the setup,
+          // skip the idle wait and clear pending results synchronously so we can
+          // immediately dispose the session and throw the error without blocking.
+          ...(params.abortSignal?.aborted ? { timeoutMs: 0 } : {}),
         });
         activeSession.dispose();
         throw err;
@@ -3845,6 +3849,14 @@ export async function runEmbeddedAttempt(
           bundleMcpRuntime,
           bundleLspRuntime,
           sessionLock,
+          // PERF: If the run was aborted (user stop, timeout, etc.), skip the idle wait
+          // and clear pending results synchronously so we can release the session lock ASAP.
+          aborted:
+            Boolean(params.abortSignal?.aborted) ||
+            aborted ||
+            timedOut ||
+            idleTimedOut ||
+            timedOutDuringCompaction,
         });
       } catch (err) {
         cleanupError = err;

--- a/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
+++ b/src/agents/pi-embedded-runner/wait-for-idle-before-flush.ts
@@ -46,10 +46,14 @@ export async function flushPendingToolResultsAfterIdle(opts: {
   timeoutMs?: number;
   clearPendingOnTimeout?: boolean;
 }): Promise<void> {
-  const timedOut = await waitForAgentIdleBestEffort(
-    opts.agent,
-    opts.timeoutMs ?? DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS,
-  );
+  const isImmediateTimeout = opts.timeoutMs !== undefined && opts.timeoutMs <= 0;
+  const timedOut =
+    isImmediateTimeout ||
+    (await waitForAgentIdleBestEffort(
+      opts.agent,
+      opts.timeoutMs ?? DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS,
+    ));
+
   if (timedOut && opts.clearPendingOnTimeout && opts.sessionManager?.clearPendingToolResults) {
     opts.sessionManager.clearPendingToolResults();
     return;


### PR DESCRIPTION
## Summary
When an agent run is aborted (e.g., user stop or timeout), the cleanup process previously waited for the agent to become idle (up to 30s) before clearing pending tool results. This held the session write-lock and blocked subsequent messages.

This PR introduces a fast-path for abort scenarios:
- `flushPendingToolResultsAfterIdle` now treats `timeoutMs <= 0` as an immediate timeout, skipping the `waitForIdle` promise via short-circuit evaluation.
- `cleanupEmbeddedAttemptResources` and the early-abort `catch` block in `runEmbeddedAttempt` now pass `timeoutMs: 0` when `abortSignal.aborted` is true.
- Added unit tests to verify the immediate flush behavior.

## Test plan
- [x] Tested locally via `pnpm test src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts`
- [x] Verified `pnpm check:changed` passes.

## AI-Assisted
- [x] This PR was authored with the assistance of an AI coding agent.
- Degree of testing: Fully tested (unit tests added).
- I confirm I understand what the code does.