### PR TITLE
fix(secrets): skip web tool discovery when surface is explicitly disabled (#74896)

### DIFF
--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -416,6 +416,86 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("skips fetch provider discovery when tools.web.fetch is explicitly disabled and has no credentials", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: {
+              enabled: false,
+              maxChars: 200_000,
+              maxCharsCap: 2_000_000,
+            },
+          },
+        },
+        plugins: {
+          enabled: true,
+          allow: [],
+          entries: {},
+        },
+      }),
+    });
+
+    expect(metadata.fetch.providerSource).toBe("none");
+    expect(metadata.fetch.selectedProvider).toBeUndefined();
+    expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("skips search provider discovery when tools.web.search is explicitly disabled and has no credentials", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+            },
+          },
+        },
+        plugins: {
+          enabled: true,
+          allow: [],
+          entries: {},
+        },
+      }),
+    });
+
+    expect(metadata.search.providerSource).toBe("none");
+    expect(metadata.search.selectedProvider).toBeUndefined();
+    expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("still runs fetch provider discovery when tools.web.fetch is disabled but has nested credential config", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: {
+              enabled: false,
+              firecrawl: {
+                apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY_REF" },
+              },
+            },
+          },
+        },
+        plugins: { enabled: true, allow: [], entries: {} },
+      }),
+      env: { FIRECRAWL_API_KEY_REF: "firecrawl-key" }, // pragma: allowlist secret
+    });
+
+    // Discovery still runs so SecretRef resolution happens; metadata reflects the disabled
+    // surface but plugin discovery was reached.
+    expect(
+      resolveBundledWebFetchProvidersFromPublicArtifactsMock.mock.calls.length +
+        resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock.mock.calls.length +
+        resolvePluginWebFetchProvidersMock.mock.calls.length,
+    ).toBeGreaterThan(0);
+    expect(metadata.fetch.providerSource).toBeDefined();
+  });
+
   it("auto-selects a keyless provider when no credentials are configured", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -496,6 +496,80 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.providerSource).toBeDefined();
   });
 
+  it("skips fetch discovery when disabled fetch only has non-credential nested config (ssrfPolicy)", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: {
+              enabled: false,
+              ssrfPolicy: {
+                allowRfc2544BenchmarkRange: true,
+                allowIpv6UniqueLocalRange: false,
+              },
+            },
+          },
+        },
+        plugins: { enabled: true, allow: [], entries: {} },
+      }),
+    });
+
+    expect(metadata.fetch.providerSource).toBe("none");
+    expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("skips search discovery when disabled search only has non-credential nested config (openaiCodex/userLocation)", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+              openaiCodex: {
+                enabled: true,
+                mode: "auto",
+                userLocation: { country: "US", region: "CA" },
+              },
+            },
+          },
+        },
+        plugins: { enabled: true, allow: [], entries: {} },
+      }),
+    });
+
+    expect(metadata.search.providerSource).toBe("none");
+    expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("still runs search discovery when disabled search has a literal apiKey", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: false,
+              apiKey: { source: "env", provider: "default", id: "DISABLED_SEARCH_API_KEY" },
+            },
+          },
+        },
+        plugins: { enabled: true, allow: [], entries: {} },
+      }),
+    });
+
+    // SecretRef'd apiKey on a disabled tool should still trigger discovery
+    // so the inactive-surface warning fires accurately.
+    expect(
+      resolveBundledWebSearchProvidersFromPublicArtifactsMock.mock.calls.length +
+        resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock.mock.calls.length +
+        resolvePluginWebSearchProvidersMock.mock.calls.length,
+    ).toBeGreaterThan(0);
+    expect(metadata.search.providerSource).toBeDefined();
+  });
+
   it("auto-selects a keyless provider when no credentials are configured", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -66,6 +66,15 @@ type SecretResolutionSource =
   | WebSearchCredentialResolutionSource
   | WebFetchCredentialResolutionSource;
 
+function hasNestedObjectFields(record: Record<string, unknown>): boolean {
+  for (const value of Object.values(record)) {
+    if (value !== null && typeof value === "object") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function hasPluginScopedWebToolConfig(
   config: OpenClawConfig,
   key: "webSearch" | "webFetch",
@@ -549,6 +558,21 @@ export async function resolveRuntimeWebTools(params: {
   }
   const search = isRecord(sourceWeb?.search) ? sourceWeb.search : undefined;
   const fetch = isRecord(sourceWeb?.fetch) ? (sourceWeb.fetch as FetchConfig) : undefined;
+  // Provider discovery must not block gateway startup when a tool surface is
+  // explicitly disabled and has nothing to resolve. We still run discovery
+  // when the tool config carries credentials (nested objects such as
+  // `firecrawl: { apiKey: ... }`) so SecretRef warnings remain accurate, and
+  // when any plugin owns a scoped config for that surface.
+  const searchSurfaceCanSkip =
+    isRecord(search) &&
+    search.enabled === false &&
+    !hasPluginWebSearchConfig &&
+    !hasNestedObjectFields(search);
+  const fetchSurfaceCanSkip =
+    isRecord(fetch) &&
+    fetch.enabled === false &&
+    !hasPluginWebFetchConfig &&
+    !hasNestedObjectFields(fetch);
   if (!search && !fetch && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
     return {
       search: {
@@ -581,7 +605,7 @@ export async function resolveRuntimeWebTools(params: {
     providerSource: "none",
     diagnostics: [],
   };
-  if (search || hasPluginWebSearchConfig) {
+  if ((search || hasPluginWebSearchConfig) && !searchSurfaceCanSkip) {
     const searchSurface = await resolveRuntimeWebProviderSurface({
       contract: "webSearchProviders",
       rawProvider,
@@ -679,7 +703,7 @@ export async function resolveRuntimeWebTools(params: {
     providerSource: "none",
     diagnostics: [],
   };
-  if (fetch || hasPluginWebFetchConfig) {
+  if ((fetch || hasPluginWebFetchConfig) && !fetchSurfaceCanSkip) {
     const fetchSurface = await resolveRuntimeWebProviderSurface({
       contract: "webFetchProviders",
       rawProvider: rawFetchProvider,

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -66,10 +66,29 @@ type SecretResolutionSource =
   | WebSearchCredentialResolutionSource
   | WebFetchCredentialResolutionSource;
 
-function hasNestedObjectFields(record: Record<string, unknown>): boolean {
-  for (const value of Object.values(record)) {
-    if (value !== null && typeof value === "object") {
+// Field-name allowlist used by the disabled-tool fast path. Matches keys that
+// commonly hold credentials so we still run discovery (and emit inactive
+// SecretRef warnings) when a disabled tool surface still references one.
+// Keep narrow: SSRF policy, location, mode, etc. are non-credential nested
+// objects and must not block the fast path.
+const CREDENTIAL_FIELD_NAMES = new Set(["apikey", "key", "token", "secret", "password"]);
+
+function hasCredentialBearingValue(
+  record: Record<string, unknown>,
+  defaults: SecretDefaults | undefined,
+): boolean {
+  for (const [rawKey, value] of Object.entries(record)) {
+    const key = rawKey.toLowerCase();
+    if (CREDENTIAL_FIELD_NAMES.has(key) && value != null && value !== "") {
       return true;
+    }
+    if (hasConfiguredSecretRef(value, defaults)) {
+      return true;
+    }
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      if (hasCredentialBearingValue(value as Record<string, unknown>, defaults)) {
+        return true;
+      }
     }
   }
   return false;
@@ -560,19 +579,21 @@ export async function resolveRuntimeWebTools(params: {
   const fetch = isRecord(sourceWeb?.fetch) ? (sourceWeb.fetch as FetchConfig) : undefined;
   // Provider discovery must not block gateway startup when a tool surface is
   // explicitly disabled and has nothing to resolve. We still run discovery
-  // when the tool config carries credentials (nested objects such as
-  // `firecrawl: { apiKey: ... }`) so SecretRef warnings remain accurate, and
-  // when any plugin owns a scoped config for that surface.
+  // when the tool config carries a credential field (`apiKey`, `token`, ...) or
+  // a SecretRef-shaped value so the inactive-surface SecretRef warnings
+  // remain accurate, and when any plugin owns a scoped config for that
+  // surface. Non-credential nested options (e.g. `ssrfPolicy`,
+  // `openaiCodex`, `userLocation`) do not need provider discovery.
   const searchSurfaceCanSkip =
     isRecord(search) &&
     search.enabled === false &&
     !hasPluginWebSearchConfig &&
-    !hasNestedObjectFields(search);
+    !hasCredentialBearingValue(search, defaults);
   const fetchSurfaceCanSkip =
     isRecord(fetch) &&
     fetch.enabled === false &&
     !hasPluginWebFetchConfig &&
-    !hasNestedObjectFields(fetch);
+    !hasCredentialBearingValue(fetch, defaults);
   if (!search && !fetch && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
     return {
       search: {


### PR DESCRIPTION
## Summary

- **Symptom:** OpenClaw 2026.4.26 gateway starts but never binds its port when `tools.web.fetch` is present in `openclaw.json`. With `OPENCLAW_GATEWAY_STARTUP_TRACE=1`, the trace stops after `config.snapshot` and never reaches `config.auth`. Setting `tools.web.fetch.enabled=false` does **not** fix it; only removing the `tools.web.fetch` key entirely lets startup proceed. Reported as a regression on 2026.4.26 in #74896.
- **Why it matters:** the gateway looks alive but is unreachable. Health checks and local clients can't connect, and the user's "Expected behavior" explicitly asks for `enabled=false` to be a real escape hatch: *"If `tools.web.fetch.enabled=false`, fetch provider discovery should not block gateway startup."*
- **What changed:** `resolveRuntimeWebTools` (`src/secrets/runtime-web-tools.ts`) now short-circuits the search and fetch discovery branches when the tool surface is explicitly `enabled: false`, has no plugin-scoped config (`plugins.entries.<id>.config.web{Search,Fetch}`), and carries no nested object fields (no credential subkeys like `firecrawl: { apiKey: ... }`). The empty-config fast-path early return that already existed for the no-key case is now mirrored at the per-surface granularity.
- **What did NOT change:** disabled tools that DO carry credential subkeys still run discovery so inactive-surface SecretRef warnings remain accurate (the existing test "keeps configured provider metadata and inactive warnings when search is disabled" still passes). The full root-cause investigation of why bundled manifest discovery stalls on Linux/Docker on this code path is left as a separate concern; this PR delivers the user's explicit `enabled: false` workaround.

## Change Type

- [x] Bug fix

## Scope

- [x] API / contracts (config behavior)
- [x] Gateway / orchestration (startup path)

## Linked Issue/PR

- Closes #74896
- [x] This PR fixes a bug or regression

## Root Cause

`resolveRuntimeWebTools` reached `resolveRuntimeWebProviderSurface` → bundled-plugin manifest scan whenever a tool surface had any object in config, regardless of `enabled`. On affected Linux/Docker environments, that manifest scan during startup secrets activation does not return promptly, so `prepareGatewayStartupConfig` never resolves and the gateway never reaches the HTTP bind step.

Code flow that hangs (current `main`):
- `prepareSecretsRuntimeSnapshot` → `resolveRuntimeWebTools` ([`src/secrets/runtime.ts:362`](https://github.com/openclaw/openclaw/blob/main/src/secrets/runtime.ts#L362))
- `resolveRuntimeWebTools` enters the `if (fetch || hasPluginWebFetchConfig)` branch even when `fetch.enabled === false` ([`src/secrets/runtime-web-tools.ts:682`](https://github.com/openclaw/openclaw/blob/main/src/secrets/runtime-web-tools.ts#L682))
- That branch awaits `resolveRuntimeWebProviderSurface` → `resolveBundledWebFetchProviders` → bundled manifest registry load.

This regressed in `74059aaa29 fix(secrets): honor plugin install ledger for web fetch discovery` (Apr 25), which threaded `await getHasCustomWebFetchRisk()` into the fetch resolveProviders callback and added a load to `loadRuntimeWebToolsManifest()`.

## Regression Test Plan

3 new tests in `src/secrets/runtime-web-tools.test.ts`:

- **disabled credential-free fetch skips fetch discovery** — mirrors the user's exact reproducer config (`tools.web.fetch: { enabled: false, maxChars, maxCharsCap }`, empty `plugins.entries`); asserts none of the bundled-public-artifacts mocks or the plugin fallback mock are called.
- **disabled credential-free search skips search discovery** — same shape on the search side.
- **disabled fetch with nested credential block still runs discovery** — guards against regressing the "inactive surface SecretRef warning" contract: when `fetch.firecrawl.apiKey` is a SecretRef, discovery still happens even with `enabled: false`.

## Test Plan

- [x] `pnpm test src/secrets/runtime-web-tools.test.ts` — 36/36 pass (33 existing + 3 new)
- [x] `pnpm tsgo:core` — clean
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm exec oxfmt --write --threads=1 …` — clean

## Notes

- Honest scope acknowledgment: I do not have a Linux/Docker repro of the deeper hang, so the underlying manifest-scan stall is not addressed here. This PR ships the user's explicit `enabled: false` escape hatch and tightens the fast-path to match the no-key case. Full root-cause investigation of the manifest-scan stall (likely in `loadRuntimeWebToolsManifest()` → bundled plugin discovery on slow filesystems) should land in a follow-up after a maintainer with the affected environment can profile the stall.
- The optimization also incidentally helps users who simply do not need the web fetch tool but want to keep the config key present for documentation/policy reasons.