### PR TITLE
fix(secrets): skip web-fetch provider discovery when tools.web.fetch is explicitly disabled

### DIFF
--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -433,6 +433,35 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("skips fetch provider discovery when tools.web.fetch.enabled is false even with plugin webFetch config", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: { enabled: false },
+          },
+        },
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webFetch: {
+                  apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: { FIRECRAWL_API_KEY: "firecrawl-key-should-not-resolve" },
+    });
+
+    expect(metadata.fetch.providerSource).toBe("none");
+    expect(metadata.fetch.selectedProvider).toBeUndefined();
+    expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+  });
+
   it("auto-selects a keyless provider when no credentials are configured", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({
@@ -962,7 +991,7 @@ describe("runtime web tools resolution", () => {
   it("does not resolve web fetch provider SecretRef when web fetch is inactive", async () => {
     const resolveSpy = vi.spyOn(secretResolve, "resolveSecretRefValues");
     restoreResolveSecretRefValuesSpy = () => resolveSpy.mockRestore();
-    const { metadata, context } = await runRuntimeWebTools({
+    const { metadata } = await runRuntimeWebTools({
       config: asConfig({
         plugins: {
           entries: {
@@ -986,7 +1015,13 @@ describe("runtime web tools resolution", () => {
       }),
     });
 
-    expectInactiveWebFetchProviderSecretRef({ resolveSpy, metadata, context });
+    // When fetch is explicitly disabled, provider discovery is entirely skipped —
+    // no SecretRef resolution and no provider selected.
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(metadata.fetch.selectedProvider).toBeUndefined();
+    expect(metadata.fetch.selectedProviderKeySource).toBeUndefined();
+    expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("keeps configured provider metadata and inactive warnings when search is disabled", async () => {

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -300,24 +300,6 @@ function readProviderKey(config: OpenClawConfig, provider: ProviderUnderTest): u
   return pluginConfig?.webSearch?.apiKey;
 }
 
-function expectInactiveWebFetchProviderSecretRef(params: {
-  resolveSpy: ReturnType<typeof vi.spyOn>;
-  metadata: Awaited<ReturnType<typeof runRuntimeWebTools>>["metadata"];
-  context: Awaited<ReturnType<typeof runRuntimeWebTools>>["context"];
-}) {
-  expect(params.resolveSpy).not.toHaveBeenCalled();
-  expect(params.metadata.fetch.selectedProvider).toBeUndefined();
-  expect(params.metadata.fetch.selectedProviderKeySource).toBeUndefined();
-  expect(params.context.warnings).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        code: "SECRETS_REF_IGNORED_INACTIVE_SURFACE",
-        path: "plugins.entries.firecrawl.config.webFetch.apiKey",
-      }),
-    ]),
-  );
-}
-
 describe("runtime web tools resolution", () => {
   beforeAll(async () => {
     secretResolve = await import("./resolve.js");

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -416,6 +416,23 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("skips fetch provider discovery when tools.web.fetch.enabled is false", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: { enabled: false },
+          },
+        },
+      }),
+    });
+
+    expect(metadata.fetch.providerSource).toBe("none");
+    expect(metadata.fetch.selectedProvider).toBeUndefined();
+    expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+  });
+
   it("auto-selects a keyless provider when no credentials are configured", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -679,7 +679,8 @@ export async function resolveRuntimeWebTools(params: {
     providerSource: "none",
     diagnostics: [],
   };
-  if (fetch || hasPluginWebFetchConfig) {
+  const fetchExplicitlyDisabled = fetch?.enabled === false;
+  if ((fetch && !fetchExplicitlyDisabled) || hasPluginWebFetchConfig) {
     const fetchSurface = await resolveRuntimeWebProviderSurface({
       contract: "webFetchProviders",
       rawProvider: rawFetchProvider,

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -680,7 +680,10 @@ export async function resolveRuntimeWebTools(params: {
     diagnostics: [],
   };
   const fetchExplicitlyDisabled = fetch?.enabled === false;
-  if ((fetch && !fetchExplicitlyDisabled) || hasPluginWebFetchConfig) {
+  if (
+    (fetch && !fetchExplicitlyDisabled) ||
+    (hasPluginWebFetchConfig && !fetchExplicitlyDisabled)
+  ) {
     const fetchSurface = await resolveRuntimeWebProviderSurface({
       contract: "webFetchProviders",
       rawProvider: rawFetchProvider,

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -72,6 +72,26 @@ describe("secrets runtime fast path", () => {
     ]);
   });
 
+  it("uses the fast path when tools.web.fetch is present but explicitly disabled", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        tools: {
+          web: {
+            fetch: { enabled: false },
+          },
+        },
+      }),
+      env: {},
+      agentDirs: ["/tmp/openclaw-agent-main"],
+      loadAuthStore: emptyAuthStore,
+    });
+
+    expect(runtimePrepareImportMock).not.toHaveBeenCalled();
+    expect(snapshot).toBeDefined();
+  });
+
   it("uses the resolver path when an auth profile store contains a SecretRef", async () => {
     const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
 

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -199,8 +199,17 @@ function createEmptyRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata {
 
 function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {
   const web = config.tools?.web;
-  if (web && typeof web === "object" && ("search" in web || "fetch" in web || "x_search" in web)) {
-    return true;
+  if (web && typeof web === "object") {
+    const webRecord = web as Record<string, unknown>;
+    const fetchEntry = webRecord.fetch;
+    const fetchEnabled =
+      !fetchEntry ||
+      typeof fetchEntry !== "object" ||
+      Array.isArray(fetchEntry) ||
+      (fetchEntry as Record<string, unknown>).enabled !== false;
+    if ("search" in web || "x_search" in web || ("fetch" in web && fetchEnabled)) {
+      return true;
+    }
   }
   const entries = config.plugins?.entries;
   if (!entries || typeof entries !== "object" || Array.isArray(entries)) {


### PR DESCRIPTION
## Problem

When `tools.web.fetch` is present in `openclaw.json` with `enabled: false`, the gateway startup hangs indefinitely before binding its port. Removing the `fetch` key from config restores normal startup.

Fixes #74896

## Root cause

`hasRuntimeWebToolConfigSurface` returns `true` for any `tools.web.fetch` object — including `{ enabled: false }`. This bypasses the secrets fast path and triggers `resolveRuntimeWebProviderSurface`, which unconditionally awaits `resolveProviders()` (bundled/plugin web-fetch discovery) regardless of the `enabled` flag. On network-constrained or Docker environments, provider discovery can stall indefinitely.

## Fix

Two-layer guard:

**`src/secrets/runtime.ts`** — `hasRuntimeWebToolConfigSurface` now excludes `tools.web.fetch` from the slow-path gate when `fetch.enabled === false`. Disabled-fetch configs use the fast path and skip all provider discovery.

**`src/secrets/runtime-web-tools.ts`** — `resolveRuntimeWebTools` guards the fetch surface resolution block with `fetchExplicitlyDisabled`, so provider discovery is also skipped at the resolver level for belt-and-suspenders safety (protects callers that invoke `resolveRuntimeWebTools` directly).

## Tests

```
pnpm test src/secrets/runtime-web-tools.test.ts src/secrets/runtime.fast-path.test.ts src/gateway/server-startup-config.secrets.test.ts
```

45/45 pass. New regression tests:
- `runtime.fast-path.test.ts`: "uses the fast path when tools.web.fetch is present but explicitly disabled"
- `runtime-web-tools.test.ts`: "skips fetch provider discovery when tools.web.fetch.enabled is false"