### PR TITLE
fix(whatsapp): resolve outbound PN to LID via auth-dir forward mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 - Agents/subagents: have completed session-mode subagent registry rows honor `agents.defaults.subagents.archiveAfterMinutes` (default 60 minutes; same knob run-mode already uses for `archiveAtMs`) instead of a hardcoded 5-minute TTL, so `subagents list` and other registry-backed surfaces still show recently-completed runs and operators have one consistent retention knob across spawn modes. (#78263) Thanks @arniesaha.
 - Plugins/channel setup: fix `setChannelRuntime` being silently dropped from non-bundled external plugin setup entries — external channel plugins that export `{ plugin, setChannelRuntime }` from their setup entry now have the runtime setter invoked, so the runtime initializer the provider polls for is set before the channel starts, preventing a poll timeout and gateway crash loop when the plugin opts into deferred startup loading. Fixes #77779. (#77799) Thanks @openperf.
+- WhatsApp: route proactive phone-number sends through Baileys LID forward mappings when available, so LID-addressed contacts receive agent messages instead of creating sender-only ghost chats. Fixes #67378. (#74925) Thanks @edenfunf.
 
 ## 2026.5.3-1
 

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -918,6 +918,7 @@ export async function attachWebInboxToSocket(
     },
     defaultAccountId: options.accountId,
     resolveOutboundMentions: ({ jid, text }) => resolveOutboundMentionsForGroup(jid, text),
+    authDir: options.authDir,
   });
 
   return {

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -1,10 +1,13 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   AnyMessageContent,
   MiscMessageGenerationOptions,
   WAMessage,
 } from "@whiskeysockets/baileys";
 import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-message";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveWhatsAppOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
 
@@ -371,5 +374,88 @@ describe("createWebSendApi", () => {
         }),
       }),
     );
+  });
+});
+
+// Integration tests for issue #67378: createWebSendApi must route outbound
+// PN-only sends through the LID forward-mapping when authDir is provided,
+// otherwise messages going to LID-addressed contacts vanish into a
+// sender-only ghost chat.
+describe("createWebSendApi LID resolution (issue #67378)", () => {
+  const sendMessage = vi.fn(async () => ({ key: { id: "msg-1" } }));
+  const sendPresenceUpdate = vi.fn(async () => {});
+  let authDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-lid-"));
+    fs.writeFileSync(path.join(authDir, "lid-mapping-15555550000.json"), JSON.stringify("987654"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(authDir, { recursive: true, force: true });
+  });
+
+  it("resolves PN to LID for sendMessage when authDir is provided", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendMessage("+15555550000", "hello");
+    expect(sendMessage).toHaveBeenCalledWith("987654@lid", { text: "hello" });
+  });
+
+  it("falls back to PN s.whatsapp.net when no LID mapping exists", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendMessage("+33123456789", "hello");
+    expect(sendMessage).toHaveBeenCalledWith("33123456789@s.whatsapp.net", { text: "hello" });
+  });
+
+  it("resolves PN to LID for sendPoll", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendPoll("+15555550000", { question: "Q?", options: ["a", "b"] });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "987654@lid",
+      expect.objectContaining({ poll: expect.any(Object) }),
+    );
+  });
+
+  it("resolves PN to LID for sendComposingTo presence", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendComposingTo("+15555550000");
+    expect(sendPresenceUpdate).toHaveBeenCalledWith("composing", "987654@lid");
+  });
+
+  it("skips newsletter composing presence when authDir is provided", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      authDir,
+    });
+    await api.sendComposingTo("120363401234567890@newsletter");
+    expect(sendPresenceUpdate).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy behavior (no authDir → PN-only routing)", async () => {
+    const api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      // authDir intentionally omitted
+    });
+    await api.sendMessage("+15555550000", "hello");
+    expect(sendMessage).toHaveBeenCalledWith("15555550000@s.whatsapp.net", { text: "hello" });
   });
 });

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -7,7 +7,7 @@ import type {
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import { isWhatsAppNewsletterJid } from "../normalize.js";
 import { buildQuotedMessageOptions } from "../quoted-message.js";
-import { toWhatsappJid } from "../text-runtime.js";
+import { toWhatsappJid, toWhatsappJidWithLid } from "../text-runtime.js";
 import {
   addWhatsAppOutboundMentionsToContent,
   type WhatsAppOutboundMentionResolution,
@@ -41,7 +41,16 @@ export function createWebSendApi(params: {
     jid: string;
     text: string;
   }) => Promise<WhatsAppOutboundMentionResolution> | WhatsAppOutboundMentionResolution;
+  // When provided, lets outbound resolve `{phone}@s.whatsapp.net` to `{lid}@lid`
+  // via Baileys' lid-mapping-{phone-digits}.json files in the auth dir, so
+  // proactive sends to LID-addressed contacts reach the recipient instead of
+  // ending up in a sender-only ghost chat (#67378). Defaults to PN-only.
+  authDir?: string;
 }) {
+  const resolveOutboundJid = (recipient: string): string =>
+    params.authDir
+      ? toWhatsappJidWithLid(recipient, { authDir: params.authDir })
+      : toWhatsappJid(recipient);
   const resolveMentions = async (
     jid: string,
     text: string,
@@ -58,7 +67,7 @@ export function createWebSendApi(params: {
       mediaType?: string,
       sendOptions?: ActiveWebSendOptions,
     ): Promise<WhatsAppSendResult> => {
-      const jid = toWhatsappJid(to);
+      const jid = resolveOutboundJid(to);
       let payload: AnyMessageContent;
       if (mediaBuffer) {
         mediaType ??= "application/octet-stream";
@@ -129,7 +138,7 @@ export function createWebSendApi(params: {
       to: string,
       poll: { question: string; options: string[]; maxSelections?: number },
     ): Promise<WhatsAppSendResult> => {
-      const jid = toWhatsappJid(to);
+      const jid = resolveOutboundJid(to);
       const result = await params.sock.sendMessage(jid, {
         poll: {
           name: poll.question,
@@ -147,6 +156,9 @@ export function createWebSendApi(params: {
       fromMe: boolean,
       participant?: string,
     ): Promise<WhatsAppSendResult> => {
+      // chatJid is typically already a JID (group or DM); pass through
+      // unchanged. The participant is a sender id and stays PN-shaped to match
+      // how the existing inbound flow stores it.
       const jid = toWhatsappJid(chatJid);
       const result = await params.sock.sendMessage(jid, {
         react: {
@@ -162,7 +174,7 @@ export function createWebSendApi(params: {
       return normalizeWhatsAppSendResult(result, "reaction");
     },
     sendComposingTo: async (to: string): Promise<void> => {
-      const jid = toWhatsappJid(to);
+      const jid = resolveOutboundJid(to);
       if (isWhatsAppNewsletterJid(jid)) {
         return;
       }

--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -49,6 +49,22 @@ export function toWhatsappJid(number: string): string {
   return `${digits}@s.whatsapp.net`;
 }
 
+// LID-aware outbound JID resolver. When a forward mapping file
+// `lid-mapping-{phone-digits}.json` is present in any candidate dir, prefer
+// the `{lid}@lid` JID over `{phone-digits}@s.whatsapp.net`. This avoids the
+// ghost-chat failure mode where messages route to a sender-only thread that
+// never reaches recipients whose contact is internally LID-based (#67378).
+export function toWhatsappJidWithLid(number: string, opts?: JidToE164Options): string {
+  const stripped = number.replace(/^whatsapp:/i, "").trim();
+  if (stripped.includes("@")) {
+    return stripped;
+  }
+  const e164 = normalizeE164(stripped);
+  const phoneDigits = e164.replace(/\D/g, "");
+  const lid = readLidForwardMapping({ phoneDigits, opts });
+  return lid ? `${lid}@lid` : `${phoneDigits}@s.whatsapp.net`;
+}
+
 export type JidToE164Options = {
   authDir?: string;
   lidMappingDirs?: string[];
@@ -88,6 +104,31 @@ function readLidReverseMapping(params: { lid: string; opts?: JidToE164Options })
         continue;
       }
       return normalizeE164(String(phone));
+    } catch {
+      // next location
+    }
+  }
+  return null;
+}
+
+function readLidForwardMapping(params: {
+  phoneDigits: string;
+  opts?: JidToE164Options;
+}): string | null {
+  const mappingFilename = `lid-mapping-${params.phoneDigits}.json`;
+  const mappingDirs = resolveLidMappingDirs({ opts: params.opts });
+  for (const dir of mappingDirs) {
+    const mappingPath = path.join(dir, mappingFilename);
+    try {
+      const data = fs.readFileSync(mappingPath, "utf8");
+      const lid = JSON.parse(data) as string | number | null;
+      if (lid === null || lid === undefined) {
+        continue;
+      }
+      const digits = String(lid).replace(/\D/g, "");
+      if (digits) {
+        return digits;
+      }
     } catch {
       // next location
     }

--- a/extensions/whatsapp/src/text-runtime.test.ts
+++ b/extensions/whatsapp/src/text-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   markdownToWhatsApp,
   resolveJidToE164,
   toWhatsappJid,
+  toWhatsappJidWithLid,
 } from "./text-runtime.js";
 
 async function withTempDir<T>(
@@ -131,6 +132,43 @@ describe("jidToE164", () => {
         fs.writeFileSync(mappingPath, JSON.stringify("123321"));
         expect(jidToE164("321@lid", { lidMappingDirs: [first, second] })).toBe("+123321");
       });
+    });
+  });
+});
+
+describe("toWhatsappJidWithLid (issue #67378)", () => {
+  it("resolves PN to LID when forward mapping file exists in authDir", async () => {
+    await withTempDir("openclaw-fwd-", (authDir) => {
+      const mappingPath = path.join(authDir, "lid-mapping-15555550000.json");
+      fs.writeFileSync(mappingPath, JSON.stringify("987654"));
+      expect(toWhatsappJidWithLid("+15555550000", { authDir })).toBe("987654@lid");
+    });
+  });
+
+  it("falls back to PN s.whatsapp.net JID when no forward mapping exists", async () => {
+    await withTempDir("openclaw-fwd-", (authDir) => {
+      expect(toWhatsappJidWithLid("+33123456789", { authDir })).toBe("33123456789@s.whatsapp.net");
+    });
+  });
+
+  it("accepts numeric LID values in mapping files (Baileys writes either string or number)", async () => {
+    await withTempDir("openclaw-fwd-", (authDir) => {
+      const mappingPath = path.join(authDir, "lid-mapping-447700900123.json");
+      fs.writeFileSync(mappingPath, JSON.stringify(42424242));
+      expect(toWhatsappJidWithLid("+447700900123", { authDir })).toBe("42424242@lid");
+    });
+  });
+
+  it("preserves already-formed JIDs without consulting mapping", async () => {
+    await withTempDir("openclaw-fwd-", (authDir) => {
+      // Existing JIDs (group, s.whatsapp.net, lid) should pass through.
+      expect(toWhatsappJidWithLid("123456789-987654321@g.us", { authDir })).toBe(
+        "123456789-987654321@g.us",
+      );
+      expect(toWhatsappJidWithLid("1555123@s.whatsapp.net", { authDir })).toBe(
+        "1555123@s.whatsapp.net",
+      );
+      expect(toWhatsappJidWithLid("999@lid", { authDir })).toBe("999@lid");
     });
   });
 });

--- a/extensions/whatsapp/src/text-runtime.ts
+++ b/extensions/whatsapp/src/text-runtime.ts
@@ -6,6 +6,7 @@ export {
   markdownToWhatsApp,
   resolveJidToE164,
   toWhatsappJid,
+  toWhatsappJidWithLid,
   type JidToE164Options,
   type WebChannel,
 } from "./targets-runtime.js";


### PR DESCRIPTION
## Summary

- **Problem:** Proactive WhatsApp sends to phone numbers whose contact internally uses LID end up in a sender-only ghost chat. The message shows ✓✓ but never reaches the recipient (issue #67378).
- **Why it matters:** Silent data loss with a positive-success signal — agents report "sent" while users never see the message. Hard to debug for operators because the failure is invisible to the recipient and the gateway logs success.
- **What changed:** Outbound active-listener send paths (`sendMessage` / `sendPoll` / `sendComposingTo`) now resolve a phone number to `{lid}@lid` via `lid-mapping-{phoneDigits}.json` in the account auth dir when present, falling back to `{digits}@s.whatsapp.net` otherwise. New helpers `readLidForwardMapping` + `toWhatsappJidWithLid` are added beside the existing `readLidReverseMapping` / `jidToE164` to keep the LID handling symmetric.
- **What did NOT change (scope boundary):** `outbound-base.ts:131` and `send.ts` outer entries keep `toWhatsappJid` because those produce redacted log strings only; the actual delivery flows through `active.sendMessage(to, ...)`. `sendReaction`'s `chatJid` keeps `toWhatsappJid` because callers pass already-formed JIDs (group / DM / LID). The companion `lid-mapping-{lid}_reverse.json` regeneration after re-link, mentioned at the end of #67378, is left out as a separate fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #67378
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `toWhatsappJid` in `extensions/whatsapp/src/targets-runtime.ts` is purely lexical — it maps any phone number to `{digits}@s.whatsapp.net` with no awareness of LID. The reverse direction (LID JID → PN) was already wired through `readLidReverseMapping` reading `lid-mapping-{lid}_reverse.json`, but the forward direction (PN → LID) was missing entirely on the outbound path. When Baileys' contact uses LID internally, sending to `s.whatsapp.net` creates a separate sender-side thread.
- **Missing detection / guardrail:** No assertion that proactive sends route to a delivery-confirmable JID. WhatsApp Web does not surface the ghost-chat condition as an error.
- **Contributing context (if known):** Baileys 7.0 stores both directions under the `lid-mapping` keyspace — `[pnUser]: lidUser` and `[lidUser_reverse]: pnUser` — but only the reverse half had a code path here.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:**
  - `extensions/whatsapp/src/text-runtime.test.ts` — `describe("toWhatsappJidWithLid (issue #67378)", ...)`
  - `extensions/whatsapp/src/inbound/send-api.test.ts` — `describe("createWebSendApi LID resolution (issue #67378)", ...)`
- **Scenario the test should lock in:** Given a `lid-mapping-{phoneDigits}.json` containing a LID, outbound `sendMessage` / `sendPoll` / `sendComposingTo` must call `sock.sendMessage` (or `sendPresenceUpdate`) with `{lid}@lid`. With no forward mapping, the legacy `{digits}@s.whatsapp.net` JID must still be used. Without `authDir`, behavior must be identical to before this PR.
- **Why this is the smallest reliable guardrail:** The bug surfaces inside `createWebSendApi`, which is exactly where the new tests assert. The unit test on `toWhatsappJidWithLid` pins down the helper contract; the integration test confirms the `authDir` is threaded all the way through and that all three outbound entry points use it.
- **Existing test that already covers this (if any):** None — all prior `createWebSendApi` tests instantiate without `authDir`, so they never exercised LID resolution.
- **If no new test is added, why not:** N/A — both layers added.

## User-visible / Behavior Changes

- Proactive WhatsApp sends to LID-addressed contacts now actually reach the recipient. No config flag, no migration — behavior changes only for accounts whose Baileys auth dir already contains forward LID mappings (i.e., contacts have been observed at least once on inbound).
- Accounts with no LID mappings see no behavior change.

## Diagram (if applicable)

```text
Before:
  message tool ── "+15555550000" ──> toWhatsappJid ──> 15555550000@s.whatsapp.net
                                                       └─> WA Web ──> ghost chat (sender-only) ✗

After (with authDir + forward mapping present):
  message tool ── "+15555550000" ──> toWhatsappJidWithLid ──> reads lid-mapping-15555550000.json
                                                              └─> 987654@lid ──> WA Web ──> recipient ✓
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same Baileys send call, only the JID argument changes)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** (reads files already created and used by Baileys in the same auth dir)

## Repro + Verification

### Environment

- OS: Windows 11 (also reproducible on Linux/macOS by symptom report in #67378)
- Runtime/container: Node 22, OpenClaw `origin/main`
- Model/provider: not relevant (channel-side bug)
- Integration/channel: WhatsApp Web (Baileys 7.0)
- Relevant config: an account with at least one LID-using contact whose mapping is on disk

### Steps

1. Start with an OpenClaw account paired to WhatsApp Web; receive any message from a contact so Baileys writes the forward and reverse `lid-mapping-*.json` for them.
2. Have an agent invoke the `message` tool to send to that contact's phone number.
3. Observe the outbound JID Baileys is asked to send to and where the message lands.

### Expected

- Outbound JID: `{lid}@lid`. Message arrives in the recipient's existing thread on Android/iOS and on the recipient's WhatsApp.

### Actual (before this PR)

- Outbound JID: `{digits}@s.whatsapp.net`. A ghost chat appears only on the sender's WA Web; recipient never sees the message.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The new `text-runtime.test.ts` and `send-api.test.ts` LID describe blocks fail against `main` and pass against this branch.

## Human Verification (required)

- **Verified scenarios:** Helper-level (4 cases for `toWhatsappJidWithLid`) and integration-level (5 cases for `createWebSendApi`) covering: PN with mapping, PN without mapping, numeric LID values, already-formed JIDs (group, s.whatsapp.net, lid), legacy path with no `authDir`, and `sendPoll` / `sendComposingTo` parity with `sendMessage`.
- **Edge cases checked:** Forward file containing numeric vs string LID, `whatsapp:` prefix, group JIDs passing through unchanged, missing forward file falling back to PN, no-`authDir` regression guard.
- **What you did NOT verify:** Multi-device LID (`{lid}:N@lid`) — Baileys' on-disk format does not store device specificity for the forward direction, so the LID JID emitted is device-less, matching the working pattern the reporter applied to the compiled bundle. `@hosted.lid` outbound — same pattern would apply but was not in scope here.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**. No API change visible to callers; `authDir` is opt-in and defaults to legacy PN-only behavior.
- Config/env changes? **No**
- Migration needed? **No** — Baileys already writes the required mapping files; this PR only consumes them.

## Risks and Mitigations

- **Risk:** A forward mapping file might exist for a phone number whose LID is no longer the recipient's active LID (e.g., contact migrated devices). Sending to the stale LID could itself create a delivery hole.
  - **Mitigation:** This is no worse than the inbound behavior, which already trusts the same files for LID→PN. Baileys keeps the mapping in sync via `storeLIDPNMappings` whenever a fresh pair is observed. No new write path introduced here.
- **Risk:** Tests can race if multiple cases reuse a single tmp dir.
  - **Mitigation:** Each `withTempDir` / `beforeEach` creates a fresh `mkdtempSync` and the `afterEach` removes it.
