### PR TITLE
fix(security): remediate CodeQL alerts

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -63,6 +63,15 @@ describe("sanitizeForPlainText", () => {
     expect(sanitizeForPlainText('<a href="https://example.com">link</a>')).toBe("link");
   });
 
+  it("keeps stripping tags exposed by malformed tag text", () => {
+    const sanitized = sanitizeForPlainText(
+      "before <<script>script>alert(1)</<script>script> after",
+    );
+
+    expect(sanitized).toBe("before alert(1) after");
+    expect(sanitized).not.toContain("<script");
+  });
+
   it("strips known internal runtime scaffolding tags including underscore names", () => {
     expect(sanitizeForPlainText("ok <previous_response>null</previous_response> done")).toBe(
       "ok  done",

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -25,6 +25,17 @@ const INTERNAL_RUNTIME_SCAFFOLDING_TAG_RE = new RegExp(
   `<\\s*\\/?\\s*(?:${INTERNAL_RUNTIME_SCAFFOLDING_TAG_PATTERN})\\b[^>]*>`,
   "gi",
 );
+const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
+
+function stripRemainingHtmlTags(text: string): string {
+  let previous: string;
+  let current = text;
+  do {
+    previous = current;
+    current = current.replace(HTML_TAG_RE, "");
+  } while (current !== previous);
+  return current;
+}
 
 export function stripInternalRuntimeScaffolding(text: string): string {
   return text
@@ -42,29 +53,25 @@ export function stripInternalRuntimeScaffolding(text: string): string {
  * prose (e.g. `a < b`).
  */
 export function sanitizeForPlainText(text: string): string {
-  return (
-    stripInternalRuntimeScaffolding(text)
-      // Preserve angle-bracket autolinks as plain URLs before tag stripping.
-      .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
-      // Line breaks
-      .replace(/<br\s*\/?>/gi, "\n")
-      // Block elements → newlines
-      .replace(/<\/?(p|div)>/gi, "\n")
-      // Bold → WhatsApp/Signal bold
-      .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
-      // Italic → WhatsApp/Signal italic
-      .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
-      // Strikethrough → WhatsApp/Signal strikethrough
-      .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
-      // Inline code
-      .replace(/<code>(.*?)<\/code>/gi, "`$1`")
-      // Headings → bold text with newline
-      .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
-      // List items → bullet points
-      .replace(/<li[^>]*>(.*?)<\/li>/gi, "• $1\n")
-      // Strip remaining HTML tags (require tag-like structure: <word...>)
-      .replace(/<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi, "")
-      // Collapse 3+ consecutive newlines into 2
-      .replace(/\n{3,}/g, "\n\n")
-  );
+  const converted = stripInternalRuntimeScaffolding(text)
+    // Preserve angle-bracket autolinks as plain URLs before tag stripping.
+    .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
+    // Line breaks
+    .replace(/<br\s*\/?>/gi, "\n")
+    // Block elements → newlines
+    .replace(/<\/?(p|div)>/gi, "\n")
+    // Bold → WhatsApp/Signal bold
+    .replace(/<(b|strong)>(.*?)<\/\1>/gi, "*$2*")
+    // Italic → WhatsApp/Signal italic
+    .replace(/<(i|em)>(.*?)<\/\1>/gi, "_$2_")
+    // Strikethrough → WhatsApp/Signal strikethrough
+    .replace(/<(s|strike|del)>(.*?)<\/\1>/gi, "~$2~")
+    // Inline code
+    .replace(/<code>(.*?)<\/code>/gi, "`$1`")
+    // Headings → bold text with newline
+    .replace(/<h[1-6][^>]*>(.*?)<\/h[1-6]>/gi, "\n*$1*\n")
+    // List items → bullet points
+    .replace(/<li[^>]*>(.*?)<\/li>/gi, "• $1\n");
+
+  return stripRemainingHtmlTags(converted).replace(/\n{3,}/g, "\n\n");
 }

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -52,6 +52,8 @@ describe("safeEqualSecret", () => {
     ["secret-token", "secret-token", true],
     ["secret-token", "secret-tokEn", false],
     ["short", "much-longer", false],
+    ["", "", true],
+    ["", "secret", false],
     [undefined, "secret", false],
     ["secret", undefined, false],
     [null, "secret", false],

--- a/src/security/secret-equal.ts
+++ b/src/security/secret-equal.ts
@@ -1,4 +1,13 @@
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
+
+function padSecretBytes(bytes: Buffer, length: number): Buffer {
+  if (bytes.length === length) {
+    return bytes;
+  }
+  const padded = Buffer.alloc(length);
+  bytes.copy(padded);
+  return padded;
+}
 
 export function safeEqualSecret(
   provided: string | undefined | null,
@@ -7,6 +16,16 @@ export function safeEqualSecret(
   if (typeof provided !== "string" || typeof expected !== "string") {
     return false;
   }
-  const hash = (s: string) => createHash("sha256").update(s).digest();
-  return timingSafeEqual(hash(provided), hash(expected));
+  const providedBytes = Buffer.from(provided, "utf8");
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const byteLength = Math.max(providedBytes.length, expectedBytes.length);
+  if (byteLength === 0) {
+    return true;
+  }
+  return (
+    timingSafeEqual(
+      padSecretBytes(providedBytes, byteLength),
+      padSecretBytes(expectedBytes, byteLength),
+    ) && providedBytes.length === expectedBytes.length
+  );
 }


### PR DESCRIPTION
## Summary

- Problem: CodeQL security-high is flagging two main-branch alerts: insecure password hashing in secret comparison and incomplete multi-character sanitization in outbound plain-text cleanup.
- Why it matters: these are exactly the high-signal PR guard alerts we want to keep actionable instead of letting alert debt pile up.
- What changed: remove hash-based secret normalization in favor of padded `timingSafeEqual`, and repeatedly strip remaining HTML tags exposed by malformed tag text.
- What did NOT change (scope boundary): no auth config changes, no new outbound formatting surface, no workflow changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/security/code-scanning/228
- Related https://github.com/openclaw/openclaw/security/code-scanning/229
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `safeEqualSecret` used `createHash("sha256")` to normalize string lengths before `timingSafeEqual`, which CodeQL treats as insecure password hashing; outbound sanitization stripped remaining HTML tags only once, leaving a second tag-like payload possible when malformed text exposed it after the first replacement.
- Missing detection / guardrail: the new CodeQL PR guard caught both on main; the sanitizer lacked a malformed nested-tag regression case.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/security/audit-extra.sync.test.ts`, `src/infra/outbound/sanitize-text.test.ts`
- Scenario the test should lock in: empty/non-empty secret comparisons, and malformed text that exposes `<script` after one tag-strip pass.
- Why this is the smallest reliable guardrail: both fixes are pure helper behavior with no runtime service dependency.
- Existing test that already covers this (if any): existing equal/different/undefined secret cases and HTML-to-plain-text conversion cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: secret comparison still uses `timingSafeEqual`; this removes hash-based normalization while preserving equal/different/null behavior coverage.

## Repro + Verification

### Environment

- OS: macOS local, Blacksmith Testbox CI environment
- Runtime/container: Node 22 / repo pnpm scripts
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect open CodeQL alerts 228 and 229 on main.
2. Apply the two helper fixes.
3. Run targeted unit coverage and changed gate.

### Expected

- Secret comparison keeps expected equality behavior without hash-based normalization.
- Plain-text sanitization removes malformed tag payloads exposed across replacement passes.
- CodeQL PR checks close the branch findings.

### Actual

- Targeted tests pass.
- Blacksmith `check:changed` passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test:serial src/security/audit-extra.sync.test.ts src/infra/outbound/sanitize-text.test.ts`; `pnpm exec oxfmt --check --threads=1 src/security/secret-equal.ts src/security/audit-extra.sync.test.ts src/infra/outbound/sanitize-text.ts src/infra/outbound/sanitize-text.test.ts`; `git diff --check`; Blacksmith `OPENCLAW_TESTBOX=1 pnpm check:changed` on `tbx_01kqekfx55tn3drkww316hca09`.
- Edge cases checked: empty secrets, missing secrets, unequal length secrets, malformed nested tag text exposing `<script`.
- What you did **not** verify: main-branch alert closure, because that requires PR CodeQL then post-merge CodeQL on main.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
