### PR TITLE
docs(changelog): note outbound CodeQL remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/outbound: strip re-formed HTML tags during plain-text sanitization so nested tag fragments cannot leave a CodeQL-detected `<script>` sequence behind. Thanks @vincentkoc.
 - CLI/agents/status: keep `openclaw agents`, text `agents list`, and plain text `status` on read-only metadata paths so human output no longer preloads plugin runtimes or live channel scans before printing. Fixes #74195. Thanks @NianJiuZst.
 - Media: treat legacy Word/OLE attachments with `application/msword` or `application/x-cfb` MIME as binary so printable-looking `.doc` files are not embedded into prompts as text. Fixes #54176; carries forward #54380. Thanks @andyliu.
 - Config: accept documented `browser.tabCleanup` keys in strict root config validation, so configured tab cleanup no longer fails before runtime reads it. Fixes #74577. Thanks @lonexreb and @ezdlp.


### PR DESCRIPTION
## Summary
- Add the requested changelog attribution for the outbound plain-text sanitizer CodeQL remediation.
- Tracks alert https://github.com/openclaw/openclaw/security/code-scanning/228.
- Runtime remediation is already present on main in 7c5bf1c675742a488402cd8d06c2c476a76145f2.

## Validation
- `git diff --check`
- `pnpm test:serial src/infra/outbound/sanitize-text.test.ts src/security/audit-extra.sync.test.ts`
