### PR TITLE
fix: tool-result context guard uses contextTokenBudget when available [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1476,7 +1476,10 @@ export async function runEmbeddedAttempt(
           contextWindowTokens: Math.max(
             1,
             Math.floor(
-              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+              params.contextTokenBudget ??
+                params.model.contextWindow ??
+                params.model.maxTokens ??
+                DEFAULT_CONTEXT_TOKENS,
             ),
           ),
         });


### PR DESCRIPTION
## Root Cause

`installToolResultContextGuard` in `src/agents/pi-embedded-runner/run/attempt.ts` (line ~1476) was installed with `params.model.contextWindow` as the token budget. However, the resolved runtime budget lives in `params.contextTokenBudget`, which can differ from `contextWindow` when the model metadata has `contextTokens > contextWindow`.

All other budget-sensitive paths in the same function (SessionManager at line 1272, context engine hooks at lines 2641/2648/2654) already use `params.contextTokenBudget`. The guard was the only path that diverged, causing premature tool-result compaction when `contextWindow < contextTokenBudget`.

## Fix

Prepend `params.contextTokenBudget ??` to the existing fallback chain so the guard uses the same resolved budget as every other path. When `contextTokenBudget` is undefined (legacy/unresolved cases), behavior is unchanged.

## Regression Test Plan

- Existing `tool-result-context-guard.test.ts` and `session-tool-result-guard.test.ts` cover guard installation and threshold behavior.
- The fix only changes which value is passed to an existing parameter; no new code paths are introduced.
- Manual verification: configure a model with `contextTokens: 1000000` and `contextWindow: 200000`, run a tool-heavy session, and confirm compaction threshold aligns with the 1M token budget rather than the 200K window.

## Security Impact

None. This change only affects which internally-resolved numeric budget value is passed to an existing guard. No new inputs, no authentication changes, no network surface changes.

Fixes #74917