### PR TITLE
fix(moonshot): accept moonshotai/<model> as direct-API alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Models/OpenRouter: repair stale session overrides that lost the outer `openrouter/` provider wrapper, so sessions return to the configured OpenRouter model instead of failing as an unknown direct-provider model. Fixes #78161. Thanks @hjamal7-bit.
 - Telegram: show full provider/model labels for nested OpenRouter model ids in the model picker, so `openrouter/openai/gpt-5.4-mini` no longer displays as `openai/gpt-5.4-mini`. Fixes #67792. (#72752) Thanks @iot2edge.
 - Models/OpenRouter: preserve live `supported_parameters` tool support metadata so non-tool Perplexity Sonar models no longer receive agent tool payloads and fall back unnecessarily. Fixes #64175. Thanks @Catfish-75.
+- Models/Moonshot: accept direct `moonshotai/...` and `moonshot-ai/...` refs as aliases for canonical `moonshot/...`, so copied OpenRouter Kimi ids no longer fail as unknown direct models. Fixes #73876. (#74946) Thanks @jeffrey701.
 - Kimi Code: use Kimi's stable `kimi-for-coding` API model id in bundled catalog, onboarding, and docs while normalizing legacy `kimi-code` and `k2p5` refs. Fixes #79965.
 - Volcengine/Kimi: strip provider-unsupported tool schema length and item constraint keywords for direct and coding-plan models so hosted Kimi runs do not reject message tools with `minLength`. Fixes #38817.
 - DeepSeek: backfill V4 `reasoning_content` replay fields for unowned OpenAI-compatible proxy providers, preventing follow-up request failures outside the bundled DeepSeek and OpenRouter routes. Fixes #79608.

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -33,6 +33,11 @@
     }
   },
   "modelCatalog": {
+    "aliases": {
+      "moonshotai": {
+        "provider": "moonshot"
+      }
+    },
     "providers": {
       "moonshot": {
         "baseUrl": "https://api.moonshot.ai/v1",

--- a/extensions/moonshot/openclaw.plugin.json
+++ b/extensions/moonshot/openclaw.plugin.json
@@ -36,6 +36,9 @@
     "aliases": {
       "moonshotai": {
         "provider": "moonshot"
+      },
+      "moonshot-ai": {
+        "provider": "moonshot"
       }
     },
     "providers": {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -224,6 +224,8 @@ describe("model-selection", () => {
       expect(normalizeProviderId("qwen")).toBe("qwen");
       expect(normalizeProviderId("kimi-code")).toBe("kimi");
       expect(normalizeProviderId("kimi-coding")).toBe("kimi");
+      expect(normalizeProviderId("MoonshotAI")).toBe("moonshot");
+      expect(normalizeProviderId("moonshot-ai")).toBe("moonshot");
       expect(normalizeProviderId("anthropic-cli")).toBe("claude-cli");
       expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1042,6 +1042,59 @@ describe("resolveModel", () => {
     });
   });
 
+  it("resolves direct moonshotai refs through the Moonshot provider alias", () => {
+    const cfg = {
+      models: {
+        providers: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.ai/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("kimi-k2.6"),
+                name: "Kimi K2.6",
+                input: ["text", "image"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("moonshotai", "kimi-k2.6", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "moonshot",
+      id: "kimi-k2.6",
+      api: "openai-completions",
+      baseUrl: "https://api.moonshot.ai/v1",
+      input: ["text", "image"],
+    });
+  });
+
+  it("resolves direct moonshot-ai refs through the Moonshot provider alias", () => {
+    const cfg = {
+      models: {
+        providers: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.ai/v1",
+            api: "openai-completions",
+            models: [makeModel("kimi-k2.6")],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("moonshot-ai", "kimi-k2.6", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "moonshot",
+      id: "kimi-k2.6",
+    });
+  });
+
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
     const cfg = {
       models: {

--- a/src/agents/provider-id.ts
+++ b/src/agents/provider-id.ts
@@ -20,6 +20,9 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "kimi" || normalized === "kimi-code" || normalized === "kimi-coding") {
     return "kimi";
   }
+  if (normalized === "moonshotai" || normalized === "moonshot-ai") {
+    return "moonshot";
+  }
   if (normalized === "bedrock" || normalized === "aws-bedrock") {
     return "amazon-bedrock";
   }

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -137,6 +137,63 @@ describe("manifest model catalog planner", () => {
     expect(plan.rows[0]?.baseUrl).toBe("https://example.openai.azure.com/openai/v1");
   });
 
+  // Regression for https://github.com/openclaw/openclaw/issues/73876.
+  // The user-facing complaint is that copying a model id from OpenRouter
+  // (which uses "moonshotai/kimi-k2.6" as the org slug) and dropping the
+  // "openrouter/" prefix to hit the direct API failed with "Unknown
+  // model: moonshotai/kimi-k2.6". The OpenAI plugin already shipped the
+  // alias pattern (azure-openai-responses → openai); applying it to the
+  // moonshot manifest lets the org-slug name resolve to moonshot's
+  // existing catalog without renaming the canonical provider id (which
+  // would break operators whose configs already say "moonshot/...").
+  it("plans moonshotai alias rows from the moonshot provider catalog", () => {
+    const plan = planManifestModelCatalogRows({
+      providerFilter: "moonshotai",
+      registry: {
+        plugins: [
+          {
+            id: "moonshot",
+            providers: ["moonshot"],
+            modelCatalog: {
+              aliases: {
+                moonshotai: {
+                  provider: "moonshot",
+                },
+              },
+              discovery: {
+                moonshot: "static",
+              },
+              providers: {
+                moonshot: {
+                  api: "openai-completions",
+                  baseUrl: "https://api.moonshot.ai/v1",
+                  models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(plan.entries).toEqual([
+      expect.objectContaining({
+        pluginId: "moonshot",
+        provider: "moonshotai",
+        discovery: "static",
+      }),
+    ]);
+    expect(plan.rows).toEqual([
+      expect.objectContaining({
+        provider: "moonshotai",
+        id: "kimi-k2.6",
+        ref: "moonshotai/kimi-k2.6",
+        api: "openai-completions",
+        baseUrl: "https://api.moonshot.ai/v1",
+      }),
+    ]);
+  });
+
   it("keeps alias provider rows out of unfiltered broad planning", () => {
     const plan = planManifestModelCatalogRows({
       registry: {

--- a/src/model-catalog/manifest-planner.test.ts
+++ b/src/model-catalog/manifest-planner.test.ts
@@ -159,6 +159,9 @@ describe("manifest model catalog planner", () => {
                 moonshotai: {
                   provider: "moonshot",
                 },
+                "moonshot-ai": {
+                  provider: "moonshot",
+                },
               },
               discovery: {
                 moonshot: "static",
@@ -190,6 +193,42 @@ describe("manifest model catalog planner", () => {
         ref: "moonshotai/kimi-k2.6",
         api: "openai-completions",
         baseUrl: "https://api.moonshot.ai/v1",
+      }),
+    ]);
+  });
+
+  it("plans moonshot-ai alias rows from the moonshot provider catalog", () => {
+    const plan = planManifestModelCatalogRows({
+      providerFilter: "moonshot-ai",
+      registry: {
+        plugins: [
+          {
+            id: "moonshot",
+            providers: ["moonshot"],
+            modelCatalog: {
+              aliases: {
+                "moonshot-ai": {
+                  provider: "moonshot",
+                },
+              },
+              providers: {
+                moonshot: {
+                  api: "openai-completions",
+                  baseUrl: "https://api.moonshot.ai/v1",
+                  models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(plan.rows).toEqual([
+      expect.objectContaining({
+        provider: "moonshot-ai",
+        id: "kimi-k2.6",
+        ref: "moonshot-ai/kimi-k2.6",
       }),
     ]);
   });


### PR DESCRIPTION
```
### Summary

Users who copy a Kimi model id from OpenRouter (which lists models as
`moonshotai/kimi-k2.6`) and drop the `openrouter/` prefix to hit the
direct API see `Unknown model: moonshotai/kimi-k2.6`. The direct
provider is registered only as `moonshot`, so only `moonshot/kimi-k2.6`
resolves. OpenRouter's org slug, Moonshot AI's own branding, and even
this manifest's `modelPricing.providers.moonshot.openRouter` entry
already use `moonshotai` — only the direct-API name disagreed.

### Fix

The OpenAI plugin already shipped the manifest pattern for this exact
shape (`azure-openai-responses` → `openai`), with planner test coverage
at `src/model-catalog/manifest-planner.test.ts:95`. Reuse the same
`modelCatalog.aliases` mechanism in the moonshot manifest:

```json
"modelCatalog": {
  "aliases": {
    "moonshotai": { "provider": "moonshot" }
  },
  ...
}
```

`moonshot` stays as the canonical provider id — operators whose
configs already say `moonshot/...` are unchanged. The catalog planner
now resolves `moonshotai/<model>` through moonshot's existing models
list, `baseUrl`, `api` class, discovery, pricing, and auth choices.
`providers`, `providerEndpoints`, `providerRequest`,
`providerAuthEnvVars`, and `providerAuthChoices` all stay keyed on
`moonshot` — no duplication, no provider-id divergence.

### Tests

`src/model-catalog/manifest-planner.test.ts`:

- New `plans moonshotai alias rows from the moonshot provider catalog`
  case mirrors the existing `azure-openai-responses` test. Asserts
  that with `providerFilter: "moonshotai"` the planner returns rows
  with `ref: "moonshotai/<model>"` and the moonshot catalog's
  `api`/`baseUrl`/discovery values.
- Existing `moonshot` plugin-registration contract test
  (`src/plugins/contracts/plugin-registration.moonshot.contract.test.ts`)
  continues to pass against the modified manifest (canonical
  `providerIds: ["moonshot"]` unchanged — alias is at the catalog
  layer, not the provider-registration layer).

### Verification

    OPENCLAW_LOCAL_CHECK=1 pnpm test src/model-catalog/manifest-planner.test.ts
    # Test Files  1 passed (1)
    # Tests       7 passed (7)

    OPENCLAW_LOCAL_CHECK=1 pnpm test src/plugins/contracts/plugin-registration.moonshot.contract.test.ts
    # Test Files  1 passed (1)
    # Tests       4 passed (4)

    pnpm exec oxfmt --check --threads=1 \
      src/model-catalog/manifest-planner.test.ts \
      extensions/moonshot/openclaw.plugin.json
    # All matched files use the correct format.

Closes #73876
```