### PR TITLE
fix(security): emit QQBot debug logs as sanitized lines

### DIFF
--- a/extensions/qqbot/src/engine/utils/log.test.ts
+++ b/extensions/qqbot/src/engine/utils/log.test.ts
@@ -23,6 +23,6 @@ describe("QQBot debug logging", () => {
 
     debugLog("prefix", "line one\nline two");
 
-    expect(logSpy).toHaveBeenCalledWith("prefix", "line one line two");
+    expect(logSpy).toHaveBeenCalledWith("prefix line one line two");
   });
 });

--- a/extensions/qqbot/src/engine/utils/log.ts
+++ b/extensions/qqbot/src/engine/utils/log.ts
@@ -35,27 +35,27 @@ export function sanitizeDebugLogValue(value: unknown): string {
   return `${sanitized.slice(0, MAX_LOG_VALUE_CHARS)}...`;
 }
 
-function sanitizeDebugLogArgs(args: unknown[]): string[] {
-  return args.map(sanitizeDebugLogValue);
+function formatDebugLogArgs(args: unknown[]): string {
+  return args.map(sanitizeDebugLogValue).join(" ");
 }
 
 /** Debug-level log; only outputs when QQBOT_DEBUG is enabled. */
 export function debugLog(...args: unknown[]): void {
   if (isDebug()) {
-    console.log(...sanitizeDebugLogArgs(args));
+    console.log(formatDebugLogArgs(args).replace(/[\r\n]/g, " "));
   }
 }
 
 /** Debug-level warning; only outputs when QQBOT_DEBUG is enabled. */
 export function debugWarn(...args: unknown[]): void {
   if (isDebug()) {
-    console.warn(...sanitizeDebugLogArgs(args));
+    console.warn(formatDebugLogArgs(args).replace(/[\r\n]/g, " "));
   }
 }
 
 /** Debug-level error; only outputs when QQBOT_DEBUG is enabled. */
 export function debugError(...args: unknown[]): void {
   if (isDebug()) {
-    console.error(...sanitizeDebugLogArgs(args));
+    console.error(formatDebugLogArgs(args).replace(/[\r\n]/g, " "));
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up for the QQBot CodeQL log-injection remediation.
- Emits debug log arguments as one CRLF-neutralized log line so `console.*` sinks do not receive tainted varargs.
- Keeps the previous debug log value sanitization and tests.

## Code Scanning
- Remediates https://github.com/openclaw/openclaw/security/code-scanning/231.

## Validation
- `pnpm test:serial extensions/qqbot/src/engine/utils/log.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/qqbot/src/engine/utils/log.ts extensions/qqbot/src/engine/utils/log.test.ts`
- `OPENCLAW_TESTBOX=1 pnpm check:changed`
