### PR TITLE
fix(web_fetch): resolve external webFetchProviders

### DIFF
--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -201,7 +201,7 @@ describe("web fetch runtime", () => {
     expect(resolved?.provider.id).toBe("firecrawl");
   });
 
-  it("keeps non-sandboxed web fetch on bundled providers even when runtime providers are preferred", () => {
+  it("uses runtime providers for non-sandboxed web fetch when runtime providers are preferred", () => {
     const bundled = createFirecrawlProvider({
       getConfiguredCredentialValue: () => "bundled-key",
     });
@@ -215,6 +215,24 @@ describe("web fetch runtime", () => {
       preferRuntimeProviders: true,
     });
 
-    expect(resolved?.provider.id).toBe("firecrawl");
+    expect(resolved?.provider.id).toBe("thirdparty");
+  });
+
+  it("resolves an explicitly configured non-bundled provider from plugin providers", () => {
+    const bundled = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "bundled-key",
+    });
+    const external = createThirdPartyFetchProvider();
+    resolvePluginWebFetchProvidersMock.mockReturnValue([bundled, external]);
+
+    const resolved = resolveWebFetchDefinition({
+      config: {
+        tools: { web: { fetch: { provider: "thirdparty" } } },
+      } as OpenClawConfig,
+      sandboxed: false,
+      preferRuntimeProviders: false,
+    });
+
+    expect(resolved?.provider.id).toBe("thirdparty");
   });
 });

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -4,7 +4,10 @@ import type {
   PluginWebFetchProviderEntry,
   WebFetchProviderToolDefinition,
 } from "../plugins/types.js";
-import { resolvePluginWebFetchProviders } from "../plugins/web-fetch-providers.runtime.js";
+import {
+  resolvePluginWebFetchProviders,
+  resolveRuntimeWebFetchProviders,
+} from "../plugins/web-fetch-providers.runtime.js";
 import { sortWebFetchProvidersForAutoDetect } from "../plugins/web-fetch-providers.shared.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebFetchMetadata } from "../secrets/runtime-web-tools.types.js";
@@ -81,7 +84,6 @@ export function listWebFetchProviders(params?: {
   return resolvePluginWebFetchProviders({
     config: params?.config,
     bundledAllowlistCompat: true,
-    origin: "bundled",
   });
 }
 
@@ -104,7 +106,6 @@ export function resolveWebFetchProviderId(params: {
       resolvePluginWebFetchProviders({
         config: params.config,
         bundledAllowlistCompat: true,
-        origin: "bundled",
       }),
   );
   const raw =
@@ -146,11 +147,21 @@ export function resolveWebFetchDefinition(
     | undefined;
   const runtimeWebFetch = options?.runtimeWebFetch ?? getActiveRuntimeWebToolsMetadata()?.fetch;
   const providers = sortWebFetchProvidersForAutoDetect(
-    resolvePluginWebFetchProviders({
-      config: options?.config,
-      bundledAllowlistCompat: true,
-      origin: "bundled",
-    }),
+    options?.sandboxed
+      ? resolvePluginWebFetchProviders({
+          config: options?.config,
+          bundledAllowlistCompat: true,
+          origin: "bundled",
+        })
+      : options?.preferRuntimeProviders
+        ? resolveRuntimeWebFetchProviders({
+            config: options?.config,
+            bundledAllowlistCompat: true,
+          })
+        : resolvePluginWebFetchProviders({
+            config: options?.config,
+            bundledAllowlistCompat: true,
+          }),
   );
   return resolveWebProviderDefinition({
     config: options?.config,


### PR DESCRIPTION
## Summary
- Fix web_fetch provider resolution to honor explicitly configured and runtime-selected providers across non-bundled plugin origins.
- Keep sandboxed web_fetch restricted to bundled providers.

## Test plan
- pnpm test src/web-fetch/runtime.test.ts
- pnpm test src/agents/tools/web-tools.fetch.test.ts

Fixes #74915