### PR TITLE
fix(plugins): always include dependencies field in isolated package.json for npm v11 compatibility

### DIFF
--- a/src/plugins/bundled-runtime-deps-materialization.ts
+++ b/src/plugins/bundled-runtime-deps-materialization.ts
@@ -166,7 +166,7 @@ function createNpmInstallExecutionManifest(installSpecs: readonly string[]): Jso
   return {
     name: "openclaw-runtime-deps-install",
     private: true,
-    ...(Object.keys(sortedDependencies).length > 0 ? { dependencies: sortedDependencies } : {}),
+    dependencies: sortedDependencies,
   };
 }
 

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -10,7 +10,10 @@ import {
   getActiveBundledRuntimeDepsInstallCount,
   waitForBundledRuntimeDepsInstallIdle,
 } from "./bundled-runtime-deps-activity.js";
-import { assertBundledRuntimeDepsInstalled } from "./bundled-runtime-deps-materialization.js";
+import {
+  assertBundledRuntimeDepsInstalled,
+  ensureNpmInstallExecutionManifest,
+} from "./bundled-runtime-deps-materialization.js";
 import {
   __testing as bundledRuntimeDepsTesting,
   createBundledRuntimeDependencyAliasMap,
@@ -543,6 +546,16 @@ describe("installBundledRuntimeDeps", () => {
         cwd: installRoot,
       }),
     );
+  });
+
+  it("always includes a dependencies field in the install manifest, even when specs are empty", () => {
+    const installRoot = makeTempDir();
+    ensureNpmInstallExecutionManifest(installRoot, []);
+    const written = JSON.parse(fs.readFileSync(path.join(installRoot, "package.json"), "utf8")) as {
+      dependencies?: unknown;
+    };
+    expect(written).toHaveProperty("dependencies");
+    expect(written.dependencies).toEqual({});
   });
 
   it("repairs external install roots from the complete generated dependency plan", async () => {


### PR DESCRIPTION
## Summary

Fixes #74949

`npm v11`'s arborist fails with `TypeError: Invalid Version` when the staging `package.json` has no `dependencies` field and specs are passed only via CLI arguments. The root cause is in `createNpmInstallExecutionManifest`: the `dependencies` object was conditionally omitted when `installSpecs` is empty.

**Before:**
```ts
...(Object.keys(sortedDependencies).length > 0 ? { dependencies: sortedDependencies } : {}),
```

**After:**
```ts
dependencies: sortedDependencies,
```

This ensures arborist always finds a `dependencies` field to parse, even when empty, avoiding the `Invalid Version` crash loop.

## Files changed

- `src/plugins/bundled-runtime-deps-materialization.ts` — always emit `dependencies` (1 line)
- `src/plugins/bundled-runtime-deps.test.ts` — regression test for empty-spec manifest

## Test plan

- [ ] `pnpm vitest run src/plugins/bundled-runtime-deps.test.ts` — 114/114 pass
- [ ] New regression test: `always includes a dependencies field in the install manifest, even when specs are empty`