### PR TITLE
ci: right-size OpenGrep PR scan

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -11,6 +11,9 @@ concurrency:
   group: opengrep-full-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -53,7 +53,7 @@ jobs:
           scripts/run-opengrep.sh --sarif --error
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         # Only upload if the scan actually produced a SARIF file.
         if: always() && hashFiles('.opengrep-out/precise.sarif') != ''
         with:

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
           # `scripts/run-opengrep.sh --changed` diffs base...HEAD.
@@ -74,7 +74,7 @@ jobs:
           scripts/run-opengrep.sh --changed --sarif --error
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         # Only upload if the scan actually produced a SARIF file.
         if: always() && hashFiles('.opengrep-out/precise.sarif') != ''
         with:

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -25,6 +25,9 @@ concurrency:
   group: opengrep-pr-diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -9,6 +9,17 @@ name: OpenGrep — PR Diff
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/opengrep-precise.yml"
+      - ".github/workflows/opengrep-precise-full.yml"
+      - ".semgrepignore"
+      - "apps/**"
+      - "extensions/**"
+      - "packages/**"
+      - "scripts/**"
+      - "security/opengrep/**"
+      - "src/**"
 
 concurrency:
   group: opengrep-pr-diff-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -21,7 +32,8 @@ permissions:
 jobs:
   scan:
     name: Scan changed paths (precise)
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/scripts/run-opengrep.sh
+++ b/scripts/run-opengrep.sh
@@ -127,7 +127,9 @@ if (( PATHS_PASSED == 0 )); then
       } | awk '/^(security\/opengrep\/|scripts\/run-opengrep\.sh$|\.semgrepignore$|\.github\/workflows\/opengrep-)/ { print }' | sort -u
     )
     if (( ${#SCAN_PATHS[@]} == 0 && ${#RULEPACK_CHANGED_PATHS[@]} > 0 )); then
-      SCAN_PATHS=( "security/opengrep/precise.yml" )
+      # Exercise rulepack loading without scanning the compiled YAML, which contains
+      # rule pattern literals that can match themselves.
+      SCAN_PATHS=( "scripts/run-opengrep.sh" )
     fi
     if (( ${#SCAN_PATHS[@]} == 0 )); then
       echo "→ No changed first-party paths for opengrep." >&2


### PR DESCRIPTION
## Summary
- restrict OpenGrep PR scanning to relevant changed-path surfaces
- skip draft PRs until ready for review
- downsize the PR diff runner from Blacksmith 16vcpu to 4vcpu

## Evidence
- recent OpenGrep PR diff runs average ~77s across 27 completed runs; install is usually 3-10s and checkout/SARIF upload dominate
- no binary cache added: the pinned install is cheap, and caching an executable scanner adds avoidable cache-trust risk

## Testing
- git diff --check
- ruby YAML parse for .github/workflows/opengrep-precise.yml

## Notes
- full manual OpenGrep scan stays on 16vcpu because it can scan the whole first-party surface
