### PR TITLE
fix(agents): use resolved contextTokenBudget in tool-result context guard

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1476,7 +1476,10 @@ export async function runEmbeddedAttempt(
           contextWindowTokens: Math.max(
             1,
             Math.floor(
-              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+              params.contextTokenBudget ??
+                params.model.contextWindow ??
+                params.model.maxTokens ??
+                DEFAULT_CONTEXT_TOKENS,
             ),
           ),
         });


### PR DESCRIPTION
## Summary

When a model's `contextTokens` exceeds its `contextWindow`, the non-context-engine tool-result guard was incorrectly using the smaller `contextWindow` value to derive its overflow threshold. This caused premature tool-loop overflow/compaction even though the runtime budget (resolved from `contextTokens`) indicated available capacity.

## Root Cause

`installToolResultContextGuard` was installed with:
```ts
contextWindowTokens: params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS
```

But the rest of the attempt layer (session manager at line 1272, context-engine loop hook at line 1490) already uses `params.contextTokenBudget` — the resolved runtime budget from `resolveContextWindowInfo`.

## Fix

Add `params.contextTokenBudget` as the first fallback in the nullish coalescing chain:
```ts
contextWindowTokens: params.contextTokenBudget ?? params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS
```

When `contextTokenBudget` is defined (the common case — set from `ctxInfo.tokens` in `run.ts:988`), the guard now uses the same resolved budget as every other context-aware path. When undefined, behavior is unchanged.

## Testing

- TypeScript compilation passes cleanly
- Change is a single-line addition to the existing fallback chain
- Acceptance: `pnpm test src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`

Fixes #74917