### PR TITLE
fix(telegram): preserve audioAsVoice flag through all outbound send paths

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -170,6 +170,7 @@ function buildTelegramSendOptions(params: {
   threadId?: string | number | null;
   silent?: boolean | null;
   forceDocument?: boolean | null;
+  asVoice?: boolean | null;
   gatewayClientScopes?: readonly string[] | null;
 }): TelegramSendOptions {
   return {
@@ -182,6 +183,7 @@ function buildTelegramSendOptions(params: {
     accountId: params.accountId ?? undefined,
     silent: params.silent ?? undefined,
     forceDocument: params.forceDocument ?? undefined,
+    asVoice: params.asVoice ?? undefined,
     ...(Array.isArray(params.gatewayClientScopes)
       ? { gatewayClientScopes: [...params.gatewayClientScopes] }
       : {}),
@@ -1066,6 +1068,7 @@ export const telegramPlugin = createChatChannelPlugin({
         threadId,
         silent,
         forceDocument,
+        audioAsVoice,
         gatewayClientScopes,
       }) => {
         const send = await resolveTelegramSend(deps);
@@ -1081,6 +1084,7 @@ export const telegramPlugin = createChatChannelPlugin({
             threadId,
             silent,
             forceDocument,
+            asVoice: audioAsVoice,
             gatewayClientScopes,
           }),
         });

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -98,6 +98,73 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "12345" });
   });
 
+  it("preserves audioAsVoice flag as asVoice in sendMedia", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice" });
+
+    await telegramOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      mediaUrl: "https://example.com/note.ogg",
+      audioAsVoice: true,
+      accountId: "ops",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/note.ogg",
+        asVoice: true,
+      }),
+    );
+  });
+
+  it("preserves audioAsVoice flag as asVoice in sendPayload", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-voice", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: {
+        text: "voice message",
+        mediaUrls: ["https://example.com/note.ogg"],
+      },
+      audioAsVoice: true,
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      expect.any(String),
+      expect.objectContaining({
+        asVoice: true,
+      }),
+    );
+  });
+
+  it("defaults asVoice to false when audioAsVoice is not set", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-audio" });
+
+    await telegramOutbound.sendMedia!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      mediaUrl: "https://example.com/song.mp3",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "",
+      expect.objectContaining({
+        asVoice: false,
+      }),
+    );
+  });
+
   it("passes delivery pin notify requests to Telegram pinning", async () => {
     pinMessageTelegramMock.mockResolvedValueOnce({ ok: true, messageId: "tg-1", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -186,6 +186,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
       forceDocument,
+      audioAsVoice,
       gatewayClientScopes,
     }) => {
       const { send, baseOpts } = await resolveTelegramSendContext({
@@ -202,6 +203,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         mediaReadFile,
         forceDocument: forceDocument ?? false,
+        asVoice: audioAsVoice ?? false,
       });
     },
   }),
@@ -216,6 +218,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
     replyToId,
     threadId,
     forceDocument,
+    audioAsVoice,
     gatewayClientScopes,
   }) => {
     const { send, baseOpts } = await resolveTelegramSendContext({
@@ -235,6 +238,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         mediaReadFile,
         forceDocument: forceDocument ?? false,
+        asVoice: audioAsVoice ?? false,
       },
     });
     return attachChannelToResult("telegram", result);


### PR DESCRIPTION
## Summary

Wire the `audioAsVoice` context flag through both the legacy outbound adapter and the registered plugin `sendPayload` handler so that audio files tagged with `[[audio_as_voice]]` are consistently sent as Telegram voice messages regardless of which delivery path is used.

## Problem

The shared outbound delivery layer (`src/infra/outbound/deliver.ts:1112`) passes `audioAsVoice: true` in `sendOverrides` when the payload has the voice flag set. However, both the legacy adapter and registered plugin adapter silently dropped this flag:

- Legacy adapter (`outbound-adapter.ts`): `sendMedia` and `sendPayload` destructured `forceDocument` but not `audioAsVoice`
- Registered plugin (`channel.ts`): `sendPayload` handler and `buildTelegramSendOptions` had no `asVoice` parameter

Only the bot delivery path (`delivery.replies.ts:425`) properly honored the flag.

## Fix

- **outbound-adapter.ts**: Destructure `audioAsVoice` in both `sendMedia` and `sendPayload`, pass as `asVoice` to the Telegram send function
- **channel.ts**: Add `asVoice` param to `buildTelegramSendOptions` helper; destructure `audioAsVoice` in registered `sendPayload` handler and pass through
- **outbound-adapter.test.ts**: Add 3 regression tests verifying `asVoice` propagation in `sendMedia`, `sendPayload`, and default-false behavior

## Testing

```bash
pnpm test extensions/telegram/src/outbound-adapter.test.ts
pnpm test extensions/telegram/src/send.test.ts
```

## Related

- Supersedes #74663 (which only covered the legacy path and was flagged in review for missing the registered path)
- Fixes #42060

Closes #74663