### PR TITLE
Handle undefined plugin command results without failing Telegram command dispatch

### DIFF
--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -27,7 +27,7 @@ type PlugCommandHarnessParams = {
   cfg?: OpenClawConfig;
   command?: Record<string, unknown>;
   args?: string;
-  result?: Record<string, unknown>;
+  result?: unknown;
   registerOverrides?: Partial<Parameters<typeof registerTelegramNativeCommands>[0]>;
 };
 
@@ -46,9 +46,8 @@ function primePlugCommand(params: PlugCommandHarnessParams = {}) {
     },
     args: params.args,
   } as never);
-  pluginCommandMocks.executePluginCommand.mockResolvedValue(
-    (params.result ?? { text: "ok" }) as never,
-  );
+  const result = Object.hasOwn(params, "result") ? params.result : { text: "ok" };
+  pluginCommandMocks.executePluginCommand.mockResolvedValue(result as never);
 }
 
 function registerPlugCommand(params: PlugCommandHarnessParams = {}) {
@@ -263,6 +262,21 @@ describe("registerTelegramNativeCommands", () => {
     expect(callbackData).toEqual(["tgcmd:/fast status", "tgcmd:/fast on", "tgcmd:/fast off"]);
     expect(parseTelegramNativeCommandCallbackData("tgcmd:/fast status")).toBe("/fast status");
     expect(parseTelegramNativeCommandCallbackData("tgcmd:fast status")).toBeNull();
+  });
+
+  it("treats undefined plugin command results as a no-op Telegram reply", async () => {
+    const { handler, sendMessage } = registerPlugCommand({
+      result: undefined,
+    });
+
+    await handler(createPrivateCommandContext());
+
+    expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{}],
+      }),
+    );
   });
 
   it("passes agent-scoped media roots for plugin command replies with media", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -147,6 +147,13 @@ function resolveTelegramProgressPlaceholder(command: {
   return text ? text : null;
 }
 
+function normalizeTelegramPluginCommandResult(result: unknown): TelegramNativeReplyPayload {
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return result as TelegramNativeReplyPayload;
+  }
+  return {};
+}
+
 function resolveTelegramCommandMenuModelContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -1193,21 +1200,23 @@ export const registerTelegramNativeCommands = ({
           }
         }
 
-        const result = await nativeCommandRuntime.executePluginCommand({
-          command: match.command,
-          args: match.args,
-          senderId,
-          channel: "telegram",
-          isAuthorizedSender: commandAuthorized,
-          senderIsOwner,
-          sessionKey: route.sessionKey,
-          commandBody,
-          config: runtimeCfg,
-          from,
-          to,
-          accountId,
-          messageThreadId: threadSpec.id,
-        });
+        const result = normalizeTelegramPluginCommandResult(
+          await nativeCommandRuntime.executePluginCommand({
+            command: match.command,
+            args: match.args,
+            senderId,
+            channel: "telegram",
+            isAuthorizedSender: commandAuthorized,
+            senderIsOwner,
+            sessionKey: route.sessionKey,
+            commandBody,
+            config: runtimeCfg,
+            from,
+            to,
+            accountId,
+            messageThreadId: threadSpec.id,
+          }),
+        );
 
         if (
           shouldSuppressLocalTelegramExecApprovalPrompt({

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -9,6 +9,8 @@ const executePluginCommandMock = vi.hoisted(() => vi.fn());
 vi.mock("../../plugins/commands.js", () => ({
   matchPluginCommand: matchPluginCommandMock,
   executePluginCommand: executePluginCommandMock,
+  normalizePluginCommandResult: (result: unknown) =>
+    result && typeof result === "object" && !Array.isArray(result) ? result : {},
 }));
 
 function buildPluginParams(
@@ -128,6 +130,27 @@ describe("handlePluginCommand", () => {
     expect(result).toEqual({
       shouldContinue: true,
       reply: { text: "from plugin" },
+    });
+  });
+
+  it("treats undefined plugin command results as a no-op reply", async () => {
+    matchPluginCommandMock.mockReturnValue({
+      command: { name: "noop" },
+      args: "",
+    });
+    executePluginCommandMock.mockResolvedValue(undefined);
+
+    const result = await handlePluginCommand(
+      buildPluginParams("/noop", {
+        commands: { text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig),
+      true,
+    );
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: undefined,
     });
   });
 

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -5,7 +5,11 @@
  * This handler is called before built-in command handlers.
  */
 
-import { matchPluginCommand, executePluginCommand } from "../../plugins/commands.js";
+import {
+  matchPluginCommand,
+  executePluginCommand,
+  normalizePluginCommandResult,
+} from "../../plugins/commands.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
 
@@ -56,8 +60,9 @@ export const handlePluginCommand: CommandHandler = async (
         : undefined,
     threadParentId: normalizeOptionalString(params.ctx.ThreadParentId),
   });
-  const shouldContinue = result.continueAgent === true;
-  const { continueAgent: _continueAgent, ...reply } = result;
+  const normalizedResult = normalizePluginCommandResult(result);
+  const shouldContinue = normalizedResult.continueAgent === true;
+  const { continueAgent: _continueAgent, ...reply } = normalizedResult;
   void _continueAgent;
 
   return {

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -836,6 +836,25 @@ describe("registerPluginCommand", () => {
     expectUnsupportedBindingApiResult(result);
   });
 
+  it("normalizes undefined plugin command results to an empty reply object", async () => {
+    const result = await executePluginCommand({
+      command: {
+        name: "noop",
+        description: "No-op command",
+        acceptsArgs: false,
+        handler: (async () => undefined) as never,
+        pluginId: "demo-plugin",
+      },
+      channel: "whatsapp",
+      senderId: "U123",
+      isAuthorizedSender: true,
+      commandBody: "/noop",
+      config: {} as never,
+    });
+
+    expect(result).toEqual({});
+  });
+
   it("passes host session identity through to the plugin command context", async () => {
     let receivedCtx:
       | {

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -339,7 +339,7 @@ export async function executePluginCommand(params: {
     logVerbose(
       `Plugin command /${command.name} executed successfully for ${senderId || "unknown"}`,
     );
-    return result;
+    return normalizePluginCommandResult(result);
   } catch (err) {
     const error = err as Error;
     logVerbose(`Plugin command /${command.name} error: ${error.message}`);
@@ -348,6 +348,13 @@ export async function executePluginCommand(params: {
   } finally {
     setPluginCommandRegistryLocked(false);
   }
+}
+
+export function normalizePluginCommandResult(result: unknown): PluginCommandResult {
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return result as PluginCommandResult;
+  }
+  return {};
 }
 
 /**


### PR DESCRIPTION
Fixes #74800.

This hardens plugin command result handling so command handlers that intentionally perform side effects and return no payload are treated as no-op replies instead of dispatch failures.

Changes:
- normalize nullish/non-object plugin command handler results at the shared `executePluginCommand` boundary
- defensively normalize plugin command results in the generic command reply path and Telegram native command path before reading result fields
- preserve existing `continueAgent: true` behavior and strip `continueAgent` from delivered reply payloads
- add regression coverage for undefined plugin command results in the central command executor, shared command dispatch, and Telegram native command handling

Validation:
- `pnpm test src/plugins/commands.test.ts src/auto-reply/reply/commands-plugin.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot-native-commands.registry.test.ts`
- `pnpm check:changed`
