### PR TITLE
fix: default missing model costs

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -283,6 +283,43 @@ describe("resolveModel", () => {
     expect(result.model?.api).toBe("openai-completions");
   });
 
+  it("fills zero cost for configured provider models that omit cost", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "sider-litellm-messages": {
+            baseUrl: "https://meter.example/llm",
+            api: "anthropic-messages",
+            models: [
+              {
+                id: "bothyouandme/claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
+                reasoning: true,
+                input: ["text", "image"],
+                contextWindow: 1_050_000,
+                maxTokens: 128_000,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "sider-litellm-messages",
+      "bothyouandme/claude-sonnet-4-6",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "sider-litellm-messages",
+      id: "bothyouandme/claude-sonnet-4-6",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
   it("defaults baseUrl-only local custom fallback models to chat completions", () => {
     const cfg = {
       agents: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -111,7 +111,7 @@ function createEmptyPiDiscoveryStores(): {
     typeof PiAuthStorageClass.inMemory === "function"
       ? PiAuthStorageClass.inMemory({})
       : PiAuthStorageClass.create();
-  const modelRegistry = new PiModelRegistryClass(authStorage, "");
+  const modelRegistry = PiModelRegistryClass.inMemory(authStorage);
   return { authStorage, modelRegistry };
 }
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -111,10 +111,7 @@ function createEmptyPiDiscoveryStores(): {
     typeof PiAuthStorageClass.inMemory === "function"
       ? PiAuthStorageClass.inMemory({})
       : PiAuthStorageClass.create();
-  const modelRegistry =
-    typeof PiModelRegistryClass.inMemory === "function"
-      ? PiModelRegistryClass.inMemory(authStorage)
-      : PiModelRegistryClass.create(authStorage);
+  const modelRegistry = new PiModelRegistryClass(authStorage, "");
   return { authStorage, modelRegistry };
 }
 
@@ -183,6 +180,54 @@ function applyResolvedTransportFallback(params: {
   };
 }
 
+const ZERO_MODEL_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} satisfies Model<Api>["cost"];
+
+function isCostNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function normalizeModelCost(cost: unknown): Model<Api>["cost"] {
+  if (!cost || typeof cost !== "object" || Array.isArray(cost)) {
+    return { ...ZERO_MODEL_COST };
+  }
+  const raw = cost as Record<string, unknown>;
+  const input = isCostNumber(raw.input) ? raw.input : 0;
+  const output = isCostNumber(raw.output) ? raw.output : 0;
+  const cacheRead = isCostNumber(raw.cacheRead) ? raw.cacheRead : 0;
+  const cacheWrite = isCostNumber(raw.cacheWrite) ? raw.cacheWrite : 0;
+  if (
+    raw.input === input &&
+    raw.output === output &&
+    raw.cacheRead === cacheRead &&
+    raw.cacheWrite === cacheWrite
+  ) {
+    return cost as Model<Api>["cost"];
+  }
+  return {
+    ...raw,
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+  } as Model<Api>["cost"];
+}
+
+function normalizeResolvedModelCost<T extends Model<Api>>(model: T): T {
+  const normalizedCost = normalizeModelCost((model as { cost?: unknown }).cost);
+  if (normalizedCost === model.cost) {
+    return model;
+  }
+  return {
+    ...model,
+    cost: normalizedCost,
+  };
+}
+
 function normalizeResolvedModel(params: {
   provider: string;
   model: Model<Api>;
@@ -241,7 +286,7 @@ function normalizeResolvedModel(params: {
       runtimeHooks,
       model: compatNormalized ?? pluginNormalized ?? normalizedInputModel,
     });
-  return canonicalizeLegacyResolvedModel({
+  const resolvedModel = canonicalizeLegacyResolvedModel({
     provider: params.provider,
     model: normalizeResolvedProviderModel({
       provider: params.provider,
@@ -249,6 +294,7 @@ function normalizeResolvedModel(params: {
         fallbackTransportNormalized ?? compatNormalized ?? pluginNormalized ?? normalizedInputModel,
     }),
   });
+  return normalizeResolvedModelCost(resolvedModel);
 }
 
 function resolveProviderTransport(params: {


### PR DESCRIPTION
## Summary
- default resolved model cost metadata to zero when a configured/custom model omits it
- preserve existing cost objects and fill only missing/non-numeric cost fields
- use the current ModelRegistry constructor for skipPiDiscovery's empty registry path

## Test plan
- `pnpm test src/agents/pi-embedded-runner/model.test.ts -- -t "fills zero cost for configured provider models that omit cost"` (red before fix, green after fix)
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/model.ts src/agents/pi-embedded-runner/model.test.ts`
- `pnpm test src/agents/pi-embedded-runner/model.test.ts`
- `pnpm check:changed --staged` *(fails in local workspace during `tsgo:core` on existing dependency/typecheck issues such as missing `typebox` and pi-ai compat type mismatches; targeted tests pass)*
