### PR TITLE
Raise Barnacle active PR limit to 100

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -274,7 +274,7 @@ jobs:
 
             const activePrLimitLabel = "r: too-many-prs";
             const activePrLimitOverrideLabel = "r: too-many-prs-override";
-            const activePrLimit = 10;
+            const activePrLimit = 100;
             const labelColor = "B60205";
             const labelDescription = `Author has more than ${activePrLimit} active PRs in this repo`;
             const authorLogin = pullRequest.user?.login;

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -1,6 +1,6 @@
 // Barnacle owns deterministic GitHub triage and auto-response behavior.
 
-export const activePrLimit = 10;
+export const activePrLimit = 100;
 
 const thirdPartyExtensionMessage =
   "Please publish this as a third-party plugin on [ClawHub](https://clawhub.ai) instead of adding it to the core repo. Docs: https://docs.openclaw.ai/plugin and https://docs.openclaw.ai/tools/clawhub";
@@ -70,7 +70,7 @@ export const managedLabelSpecs = {
   },
   "r: too-many-prs": {
     color: "D93F0B",
-    description: "Auto-close: author has more than ten active PRs.",
+    description: "Auto-close: author has more than one hundred active PRs.",
   },
   "r: too-many-prs-override": {
     color: "C2E0C6",

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -193,7 +193,7 @@ describe("barnacle-auto-response", () => {
     expect(managedLabelSpecs.dirty.description).toContain("dirty/unrelated");
     expect(managedLabelSpecs["r: support"].description).toContain("support requests");
     expect(managedLabelSpecs["r: third-party-extension"].description).toContain("ClawHub");
-    expect(managedLabelSpecs["r: too-many-prs"].description).toContain("ten active PRs");
+    expect(managedLabelSpecs["r: too-many-prs"].description).toContain("one hundred active PRs");
 
     for (const label of Object.values(candidateLabels)) {
       expect(managedLabelSpecs[label]).toBeDefined();
@@ -461,7 +461,7 @@ describe("barnacle-auto-response", () => {
       );
       expect(calls.createComment).not.toContainEqual(
         expect.objectContaining({
-          body: expect.stringContaining("more than 10 active PRs"),
+          body: expect.stringContaining("more than 100 active PRs"),
         }),
       );
       expect(calls.update).not.toContainEqual(expect.objectContaining({ state: "closed" }));


### PR DESCRIPTION
## Summary
- Raise Barnacle active PR limit from 10 to 100
- Keep the workflow labeler and Barnacle auto-response script in sync
- Update Barnacle tests/messages for the new threshold

## Why
Martins approved increasing the cap to unblock the current OpenClaw reliability PR queue, including Discord session rollover guardrails.

## Verification
- `node --check scripts/github/barnacle-auto-response.mjs`
- ESM assertion verified `activePrLimit === 100`, the too-many-PR message says `more than 100 active PRs`, and the managed label description is updated
- `git diff --check`

Note: full Vitest run for `test/scripts/barnacle-auto-response.test.ts` was attempted in a temp worktree with symlinked node_modules but was SIGKILLed before completion on this host.
