### PR TITLE
fix(cli): avoid progress spinners in active TUI input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- CLI/progress: suppress nested progress spinners and line clears while TUI input owns raw stdin, so Crestodian `/status` no longer disturbs the active input row. (#75003) Thanks @velvet-shark.
+
 ## 2026.4.29
 
 ### Highlights

--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCliProgress } from "./progress.js";
+import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
 
 describe("cli progress", () => {
   it("logs progress when non-tty and fallback=log", () => {
@@ -42,5 +42,23 @@ describe("cli progress", () => {
     progress.done();
 
     expect(write).not.toHaveBeenCalled();
+  });
+
+  it("does not use readline-backed spinners while raw TUI input is active", () => {
+    expect(
+      shouldUseInteractiveProgressSpinner({
+        streamIsTty: true,
+        stdinIsRaw: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the normal interactive spinner for regular tty commands", () => {
+    expect(
+      shouldUseInteractiveProgressSpinner({
+        streamIsTty: true,
+        stdinIsRaw: false,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it, vi } from "vitest";
 import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
 
+function withStdinIsRaw<T>(isRaw: boolean, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process.stdin, "isRaw");
+  Object.defineProperty(process.stdin, "isRaw", {
+    configurable: true,
+    value: isRaw,
+  });
+  try {
+    return run();
+  } finally {
+    if (original) {
+      Object.defineProperty(process.stdin, "isRaw", original);
+    } else {
+      Reflect.deleteProperty(process.stdin, "isRaw");
+    }
+  }
+}
+
 describe("cli progress", () => {
   it("logs progress when non-tty and fallback=log", () => {
     const writes: string[] = [];
@@ -60,5 +77,28 @@ describe("cli progress", () => {
         stdinIsRaw: false,
       }),
     ).toBe(true);
+  });
+
+  it("does not write terminal controls when raw TUI input suppresses the default spinner", () => {
+    const writes: string[] = [];
+    const stream = {
+      isTTY: true,
+      write: vi.fn((chunk: string) => {
+        writes.push(chunk);
+      }),
+    } as unknown as NodeJS.WriteStream;
+
+    withStdinIsRaw(true, () => {
+      const progress = createCliProgress({
+        label: "Scanning",
+        total: 2,
+        stream,
+      });
+      progress.setLabel("Still scanning");
+      progress.tick();
+      progress.done();
+    });
+
+    expect(writes).toEqual([]);
   });
 });

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -66,7 +66,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
 
   const delayMs = typeof options.delayMs === "number" ? options.delayMs : DEFAULT_DELAY_MS;
   const canOsc = isTty && supportsOscProgress(process.env, isTty);
-  const stdinIsRaw = process.stdin.isRaw === true;
+  const stdinIsRaw = process.stdin.isRaw;
   const allowSpinner = shouldUseInteractiveProgressSpinner({
     fallback: options.fallback,
     streamIsTty: isTty,

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -66,12 +66,16 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
 
   const delayMs = typeof options.delayMs === "number" ? options.delayMs : DEFAULT_DELAY_MS;
   const canOsc = isTty && supportsOscProgress(process.env, isTty);
+  const stdinIsRaw = process.stdin.isRaw === true;
   const allowSpinner = shouldUseInteractiveProgressSpinner({
     fallback: options.fallback,
     streamIsTty: isTty,
-    stdinIsRaw: process.stdin.isRaw,
+    stdinIsRaw,
   });
   const allowLine = isTty && options.fallback === "line";
+  if (isTty && stdinIsRaw && (options.fallback === undefined || options.fallback === "spinner")) {
+    return noopReporter;
+  }
 
   let started = false;
   let label = options.label;

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -33,6 +33,15 @@ export type ProgressTotalsUpdate = {
   label?: string;
 };
 
+export function shouldUseInteractiveProgressSpinner(params: {
+  fallback?: ProgressOptions["fallback"];
+  streamIsTty?: boolean;
+  stdinIsRaw?: boolean;
+}): boolean {
+  const spinnerRequested = params.fallback === undefined || params.fallback === "spinner";
+  return spinnerRequested && params.streamIsTty === true && params.stdinIsRaw !== true;
+}
+
 const noopReporter: ProgressReporter = {
   setLabel: () => {},
   setPercent: () => {},
@@ -57,7 +66,11 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
 
   const delayMs = typeof options.delayMs === "number" ? options.delayMs : DEFAULT_DELAY_MS;
   const canOsc = isTty && supportsOscProgress(process.env, isTty);
-  const allowSpinner = isTty && (options.fallback === undefined || options.fallback === "spinner");
+  const allowSpinner = shouldUseInteractiveProgressSpinner({
+    fallback: options.fallback,
+    streamIsTty: isTty,
+    stdinIsRaw: process.stdin.isRaw,
+  });
   const allowLine = isTty && options.fallback === "line";
 
   let started = false;


### PR DESCRIPTION
## Summary

Crestodian's TUI can now finish `/status` without the nested CLI progress spinner taking over raw stdin. CLI progress skips readline-backed spinners when stdin is already raw, which preserves the TUI input loop while keeping normal interactive spinners for regular terminal commands.

## Testing

- `pnpm exec oxfmt --check --threads=1 src/cli/progress.ts src/cli/progress.test.ts`
- `pnpm test src/cli/progress.test.ts src/crestodian/crestodian.test.ts src/tui/tui-command-handlers.test.ts`
- `pnpm check:changed`
