### PR TITLE
ci: shallow checkout OpenGrep PR scan

### DIFF
--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - ".github/actions/ensure-base-commit/**"
       - ".github/workflows/opengrep-precise.yml"
       - ".github/workflows/opengrep-precise-full.yml"
       - ".semgrepignore"
@@ -42,9 +43,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          fetch-tags: false
           persist-credentials: false
-          # `scripts/run-opengrep.sh --changed` diffs base...HEAD.
-          fetch-depth: 0
+          submodules: false
+
+      - name: Ensure PR base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install opengrep
         env:


### PR DESCRIPTION
## Summary
- use a shallow checkout for the OpenGrep PR diff workflow
- fetch only the PR base commit via the existing ensure-base-commit action
- trigger the workflow when that shared base-fetch action changes

## Test plan
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/opengrep-precise.yml")'
- bash -n scripts/run-opengrep.sh
