### PR TITLE
fix(agents): prevent zombie Agent loop when abort signal is pre-aborted (#74859)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2730,6 +2730,11 @@ export async function runEmbeddedAttempt(
               messages: btwSnapshotMessages,
               inFlightPrompt: promptSubmission.prompt,
             });
+            // Guard: skip prompt when already aborted to prevent starting a
+            // floating Agent loop that nobody would abort (#74859).
+            if (aborted || runAbortController.signal.aborted) {
+              throw makeAbortError(runAbortController.signal);
+            }
             if (promptSubmission.runtimeOnly) {
               await abortable(activeSession.prompt(promptSubmission.prompt));
             } else {
@@ -3087,6 +3092,12 @@ export async function runEmbeddedAttempt(
           log.debug(
             `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
           );
+        }
+        // Safety net: ensure any in-flight Agent loop is torn down when the
+        // attempt is cleaned up. Covers rare race windows where a prompt was
+        // started just before the pre-abort guard fires (#74859).
+        if (aborted || timedOut) {
+          void activeSession.abort();
         }
         try {
           unsubscribe();


### PR DESCRIPTION
## Summary

Prevents the embedded runner from starting a floating Agent loop when the abort signal is already aborted before `activeSession.prompt()` is called.

Closes #74859

## Root Cause

When `params.abortSignal` is pre-aborted (e.g. rapid consecutive messages with `messages.queue.mode: "interrupt"`):

1. `onAbort()` fires → `abortRun()` → `runAbortController.abort()` + `void activeSession.abort()`
2. Code still reaches `await abortable(activeSession.prompt(prompt))`
3. JavaScript evaluates `activeSession.prompt()` **first** (starts Agent `_runLoop` with a fresh internal `abortController`)
4. Then `abortable()` wraps/rejects immediately
5. The Agent loop runs with nobody to abort its internal controller → zombie

Observed: 2617 LLM calls over 103 minutes from a single zombie run.

## Fix

Two changes in `src/agents/pi-embedded-runner/run/attempt.ts`:

### 1. Pre-prompt abort guard

Before every `activeSession.prompt()` call, check if the run is already aborted. If so, throw `makeAbortError()` instead of starting a prompt that would create an unabortable Agent loop.

```typescript
if (aborted || runAbortController.signal.aborted) {
  throw makeAbortError(runAbortController.signal);
}
```

### 2. Finally-block safety net

Add `void activeSession.abort()` in the `finally` block when the run was aborted or timed out. This catches rare race windows where a prompt was started just before the pre-abort guard fires.

```typescript
if (aborted || timedOut) {
  void activeSession.abort();
}
```

Uses `void` (not `await`) to avoid blocking the cleanup path.

## Testing

All 127 existing tests in `attempt.test.ts` pass:

```
 Test Files  1 passed (1)
      Tests  127 passed (127)
```

## Risk Assessment

**Low risk.** Both changes are additive guards:
- The pre-prompt guard only fires when the run is already aborted — no change to the happy path
- The finally-block `activeSession.abort()` is best-effort fire-and-forget, same as the existing call in `abortRun()`
- The catch block at line 2768 correctly handles the thrown `AbortError` (existing `isRunnerAbortError` check)
