### PR TITLE
chore(barnacle): add false positive close label

### DIFF
--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -19,6 +19,12 @@ export const rules = [
       "Please use [our support server](https://discord.gg/clawd) and ask in #help or #users-helping-users to resolve this, or follow the stuck FAQ at https://docs.openclaw.ai/help/faq#im-stuck-whats-the-fastest-way-to-get-unstuck.",
   },
   {
+    label: "r: false-positive",
+    close: true,
+    message:
+      "Closing this because it looks like a false positive or reclassification-only report rather than an actionable OpenClaw bug. If this is still a real issue, please open a fresh report with concrete reproduction steps and current-version details.",
+  },
+  {
     label: "r: no-ci-pr",
     close: true,
     message:
@@ -63,6 +69,10 @@ export const managedLabelSpecs = {
   "r: support": {
     color: "0E8A16",
     description: "Auto-close: support requests belong in Discord or support docs.",
+  },
+  "r: false-positive": {
+    color: "D93F0B",
+    description: "Auto-close: false positive or reclassification-only report.",
   },
   "r: no-ci-pr": {
     color: "D93F0B",

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -192,6 +192,7 @@ describe("barnacle-auto-response", () => {
     expect(managedLabelSpecs["r: skill"].description).not.toContain("Clawdhub");
     expect(managedLabelSpecs.dirty.description).toContain("dirty/unrelated");
     expect(managedLabelSpecs["r: support"].description).toContain("support requests");
+    expect(managedLabelSpecs["r: false-positive"].description).toContain("false positive");
     expect(managedLabelSpecs["r: third-party-extension"].description).toContain("ClawHub");
     expect(managedLabelSpecs["r: too-many-prs"].description).toContain("ten active PRs");
 
@@ -392,6 +393,29 @@ describe("barnacle-auto-response", () => {
 
     expect(calls.createComment).toEqual([]);
     expect(calls.update).toEqual([]);
+  });
+
+  it("closes issues tagged as false positives", async () => {
+    const { calls, github } = barnacleGithub([]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleIssueContext({}, ["r: false-positive"], {
+        action: "labeled",
+        label: { name: "r: false-positive" },
+        sender: { login: "maintainer", type: "User" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.createComment).toContainEqual(
+      expect.objectContaining({
+        body: expect.stringContaining("false positive"),
+      }),
+    );
+    expect(calls.update).toContainEqual(expect.objectContaining({ state: "closed" }));
   });
 
   it("does not respond to maintainer comments on contributor items", async () => {


### PR DESCRIPTION
## Summary
- add managed `r: false-positive` Barnacle close label
- close false-positive/reclassification-only issues with a friendly reopen path
- cover the new label in Barnacle tests

## Tests
- `pnpm test:serial test/scripts/barnacle-auto-response.test.ts`
- `pnpm exec oxfmt --check --threads=1 scripts/github/barnacle-auto-response.mjs test/scripts/barnacle-auto-response.test.ts`
- `git diff --check`