### PR TITLE
fix(protocol): allow paperclip field in AgentParamsSchema

### DIFF
--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -173,6 +173,9 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    // Allow Paperclip and other third-party integrations to pass runtime context
+    // without breaking gateway validation. Gateway accepts but ignores this field.
+    paperclip: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Summary

Paperclip agent injects a `paperclip` property into agent invocation payloads when using the openclaw_gateway adapter, but the gateway validation rejects it with:

```
invalid agent params: at root: unexpected property 'paperclip'
```

AgentParamsSchema has `additionalProperties: false`, so any unknown field fails validation.

## Fix

Add `paperclip: Type.Optional(Type.Unknown())` to AgentParamsSchema to allow Paperclip and other third-party integrations to pass runtime context without breaking gateway validation. The gateway accepts but ignores this field.

## Test Plan

- [x] Schema modification compiles without TypeScript errors
- [ ] Gateway accepts agent requests with `paperclip` field
- [ ] Paperclip agent can successfully invoke OpenClaw gateway

Fixes #74635