### PR TITLE
fix(agents): allow gateway tool config.patch for messages.visibleReplies (#74876)

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -51,6 +51,10 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   "channels.*.*.*.requireMention",
   "channels.*.*.*.*.requireMention",
   "channels.*.*.*.*.*.requireMention",
+  // Visible reply delivery mode — operators can let agents self-configure
+  // group/channel reply visibility without hand-editing openclaw.json.
+  "messages.visibleReplies",
+  "messages.groupChat.visibleReplies",
 ] as const;
 
 /** @internal Exposed for regression tests only; do not import from runtime code. */


### PR DESCRIPTION
Relates to #74876

## Problem

`messages.groupChat.visibleReplies` is not in the gateway tool config.patch allowlist (`ALLOWED_GATEWAY_CONFIG_PATHS`). This means agents and Control UI cannot set the visible reply delivery mode via `config.patch` — users must manually edit `openclaw.json`.

From the issue: "Config path is protected: messages.groupChat.visibleReplies cannot be set via config.patch (it is a protected path)."

## Fix

Add `messages.visibleReplies` and `messages.groupChat.visibleReplies` to the allowlist. These are safe to allow:
- They are simple enum values (`automatic` | `message_tool`)
- No secrets or security-sensitive paths
- Messages config is hot-reloaded (no restart needed per config-reload-plan.ts)

## Testing

- Formatting check passes (oxfmt)
- All 6 existing tests in gateway-tool.test.ts pass
