### PR TITLE
fix(plugins): canonicalize packageRoot before hashing runtime-deps stage key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: add an opt-in `agents.defaults.compaction.midTurnPrecheck` mid-turn precheck that detects tool-loop context pressure and triggers compaction before the next tool call instead of waiting for end-of-turn. (#73499) Thanks @marchpure and @haoxingjun.
 - Gateway/approvals: let loopback token/password-backed native approval clients resolve exec approvals without attaching stale paired Gateway identities, while remote and unauthenticated approval clients keep normal device identity behavior. (#74472)
 - Gateway/config: include rejected validation paths in foreground and service last-known-good recovery logs plus main-agent notices, so unsupported direct edits explain which key caused restore instead of looking like silent reversion. Fixes #75060. Thanks @amknight.
+- Plugins/runtime-deps: hash the OS-canonical `packageRoot` via `fs.realpathSync.native` (with `path.resolve` fallback) when computing the bundled runtime-deps stage key, so loader and channel `bundled-root` callers no longer derive divergent stage directories under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/` and bundled channels stop failing with `ENOENT` on shared dist chunks under Windows npm symlinks, junctions, or PM2 multi-instance worker layouts. Fixes #74963. (#75048) Thanks @openperf and @vincentkoc.
 
 ## 2026.4.29
 
@@ -377,7 +378,6 @@ Docs: https://docs.openclaw.ai
 - Installer/Linux: warn before switching an unwritable npm global prefix to `~/.npm-global`, then tell users to run future global updates with `npm i -g openclaw@latest` without `sudo` so npm keeps using the redirected user prefix. Fixes #44365; carries forward #50479. Thanks @Sayeem3051.
 - Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 - macOS app: detect stale Gateway TLS certificate pins, automatically repair trusted Tailscale Serve rotations, and surface paired-but-disconnected Mac companion nodes so partial Gateway connections no longer look healthy. Thanks @guti.
-- Plugins/runtime-deps: hash the OS-canonical `packageRoot` via `fs.realpathSync.native` (with `path.resolve` fallback) when computing the bundled runtime-deps stage key, so loader and channel `bundled-root` callers no longer derive divergent stage directories under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/` and bundled channels stop failing with `ENOENT` on shared dist chunks under Windows npm symlinks, junctions, or PM2 multi-instance worker layouts. Fixes #74963. (#75048) Thanks @openperf and @vincentkoc.
 
 ## 2026.4.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,7 @@ Docs: https://docs.openclaw.ai
 - Installer/Linux: warn before switching an unwritable npm global prefix to `~/.npm-global`, then tell users to run future global updates with `npm i -g openclaw@latest` without `sudo` so npm keeps using the redirected user prefix. Fixes #44365; carries forward #50479. Thanks @Sayeem3051.
 - Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 - macOS app: detect stale Gateway TLS certificate pins, automatically repair trusted Tailscale Serve rotations, and surface paired-but-disconnected Mac companion nodes so partial Gateway connections no longer look healthy. Thanks @guti.
+- Plugins/bundled runtime: fix bundled channels failing with ENOENT on Windows when npm symlinks, junctions, or PM2 multi-instance deployments expose multiple lexical paths to the same install. Fixes #74963. (#75048) Thanks @vincentkoc, @openperf.
 
 ## 2026.4.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,7 +377,7 @@ Docs: https://docs.openclaw.ai
 - Installer/Linux: warn before switching an unwritable npm global prefix to `~/.npm-global`, then tell users to run future global updates with `npm i -g openclaw@latest` without `sudo` so npm keeps using the redirected user prefix. Fixes #44365; carries forward #50479. Thanks @Sayeem3051.
 - Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 - macOS app: detect stale Gateway TLS certificate pins, automatically repair trusted Tailscale Serve rotations, and surface paired-but-disconnected Mac companion nodes so partial Gateway connections no longer look healthy. Thanks @guti.
-- Plugins/bundled runtime: fix bundled channels failing with ENOENT on Windows when npm symlinks, junctions, or PM2 multi-instance deployments expose multiple lexical paths to the same install. Fixes #74963. (#75048) Thanks @vincentkoc, @openperf.
+- Plugins/runtime-deps: hash the OS-canonical `packageRoot` via `fs.realpathSync.native` (with `path.resolve` fallback) when computing the bundled runtime-deps stage key, so loader and channel `bundled-root` callers no longer derive divergent stage directories under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/` and bundled channels stop failing with `ENOENT` on shared dist chunks under Windows npm symlinks, junctions, or PM2 multi-instance worker layouts. Fixes #74963. (#75048) Thanks @openperf and @vincentkoc.
 
 ## 2026.4.27
 

--- a/src/plugins/bundled-runtime-deps-roots.ts
+++ b/src/plugins/bundled-runtime-deps-roots.ts
@@ -53,7 +53,9 @@ function isPackagedBundledPluginRoot(pluginRoot: string): boolean {
 }
 
 function createPathHash(value: string): string {
-  return createHash("sha256").update(path.resolve(value)).digest("hex").slice(0, 12);
+  // Hash the OS-canonical (realpath) form so symlinked / junctioned
+  // packageRoots converge on a single staging directory across call sites.
+  return createHash("sha256").update(realpathOrResolve(value)).digest("hex").slice(0, 12);
 }
 
 function sanitizePathSegment(value: string): string {

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -2645,6 +2645,41 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     expect(path.basename(resolved).startsWith("openclaw-unknown-")).toBe(false);
   });
 
+  const itSupportsPackageRootSymlinks = process.platform === "win32" ? it.skip : it;
+  itSupportsPackageRootSymlinks(
+    "stages bundled runtime deps to the same root for symlinked packageRoot views (issue #74963)",
+    () => {
+      const realParent = makeTempDir();
+      const stageDir = makeTempDir();
+      const realPackageRoot = path.join(realParent, "openclaw-real");
+      fs.mkdirSync(realPackageRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(realPackageRoot, "package.json"),
+        JSON.stringify({ name: "openclaw", version: "2026.4.27" }),
+      );
+      const realPluginRoot = path.join(realPackageRoot, "dist", "extensions", "discord");
+      fs.mkdirSync(realPluginRoot, { recursive: true });
+      fs.writeFileSync(
+        path.join(realPluginRoot, "package.json"),
+        JSON.stringify({ dependencies: {} }),
+      );
+      const linkedPackageRoot = path.join(realParent, "openclaw-linked");
+      fs.symlinkSync(realPackageRoot, linkedPackageRoot, "dir");
+      const linkedPluginRoot = path.join(linkedPackageRoot, "dist", "extensions", "discord");
+      const env = { OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+
+      const installRootViaReal = resolveBundledRuntimeDependencyInstallRoot(realPluginRoot, {
+        env,
+      });
+      const installRootViaLink = resolveBundledRuntimeDependencyInstallRoot(linkedPluginRoot, {
+        env,
+      });
+
+      expect(installRootViaLink).toBe(installRootViaReal);
+      expect(path.basename(installRootViaReal)).toMatch(/^openclaw-2026\.4\.27-[0-9a-f]{12}$/);
+    },
+  );
+
   it("prunes stale unknown external runtime roots while keeping newest and locked roots", () => {
     const stageDir = makeTempDir();
     const nowMs = Date.parse("2026-04-29T08:00:00.000Z");

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -918,13 +918,25 @@ describe("bundledRuntimeDependencySentinelCandidates", () => {
         "playwright-core",
         { HOME: homeRoot } as NodeJS.ProcessEnv,
       );
+      const realRootCandidates = bundledRuntimeDependencySentinelCandidates(
+        packageRoot,
+        "browser",
+        "playwright-core",
+        { HOME: homeRoot } as NodeJS.ProcessEnv,
+      );
       const externalCandidates = candidates.filter(
         (candidate) =>
           candidate.startsWith(join(homeRoot, ".openclaw", "plugin-runtime-deps")) &&
           candidate.endsWith(join("node_modules", "playwright-core", "package.json")),
       );
+      const realRootExternalCandidates = realRootCandidates.filter(
+        (candidate) =>
+          candidate.startsWith(join(homeRoot, ".openclaw", "plugin-runtime-deps")) &&
+          candidate.endsWith(join("node_modules", "playwright-core", "package.json")),
+      );
 
-      expect(externalCandidates.length).toBeGreaterThanOrEqual(2);
+      expect(externalCandidates).toEqual(realRootExternalCandidates);
+      expect(externalCandidates).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
### Summary

- **Problem**: On Windows multi-instance deployments (5x PM2 workers, OpenClaw 2026.4.27, Node v22.x), bundled channels fail to load with `ENOENT` on shared dist chunks under `~/.openclaw/plugin-runtime-deps/openclaw-2026.4.27-<hash>/dist/*.js` (e.g. `channel-reply-pipeline-DIVeGRyD.js`, `channel-options-UH47ik5d.js`, `cache-controls-DyMccij0.js`). Different processes — and even different code paths inside the *same* process — derive different `<hash>` values for the same physical install, so loaders look up files in a stage directory that was populated under a different key. Site of the divergence: `src/plugins/bundled-runtime-deps-roots.ts:55-57`, `createPathHash`, which hashes `path.resolve(value)` instead of the canonical filesystem path.
- **Root Cause**: `createPathHash` did **not** canonicalize the `packageRoot` to its OS-real path before hashing — it only normalized lexically via `path.resolve`. The two consumers of this hash arrive with different lexical forms of the same physical directory:
  - **Loader path**: `src/plugins/loader.ts:1419` produces `pluginRoot = safeRealpathOrResolve(candidate.rootDir)` which already resolves symlinks via `fs.realpathSync`. Walking up to `packageRoot` yields the realpath form (e.g. `C:\Users\<u>\.npm\node_modules\openclaw`).
  - **Bundled-channel path**: `src/channels/plugins/bundled.ts:206-211` calls `resolveBundledChannelBoundaryRoot` with `params.rootScope.packageRoot`, which originates from `OPENCLAW_PACKAGE_ROOT` in `src/channels/plugins/bundled-root.ts` and is **not** realpath-normalized. Walking up yields the symlinked form (e.g. `C:\Users\<u>\AppData\Roaming\npm\node_modules\openclaw`).
  Because `path.resolve` only normalizes path components — it does not resolve symlinks, junctions, or drive-letter casing — the same physical install hashes to two different 12-char keys (matching the two values reported in #74963: `5f4e2e59ed9a` and `456555aaef5c`). The loader stages dist chunks into hash-A's directory; the channel loader then opens hash-B and gets `ENOENT`. PM2 multi-instance amplifies the symptom because each worker can independently produce a third lexical form via its argv1/cwd context, but the bug also reproduces single-instance whenever an npm symlink, Windows junction, or drive-letter casing variant is in play.
- **Fix**: Hash the OS-canonical (realpath) form of `packageRoot` instead of the lexical form. `createPathHash` now delegates path normalization to the file-local `realpathOrResolve` helper (`src/plugins/bundled-runtime-deps-roots.ts:240`), which calls `fs.realpathSync.native(value)` and falls back to `path.resolve(value)` only when the path does not yet exist. This is the same canonicalization already used by `resolveExistingExternalBundledRuntimeDepsRoots` to detect already-staged package roots, so the file's two normalization sites are now consistent. Side-effect surface stays small: `createPathHash` is reachable from exactly one caller (`resolveExternalBundledRuntimeDepsInstallRoots`, line 213); no other call site re-implements the hash format. Existing 4.27 stage directories created with the old (lexical) hash become orphaned on disk after upgrade — they are not referenced by the new key but cause no functional regression; first start after upgrade re-stages once into the canonical directory and all subsequent starts (including all PM2 workers) share it. The fallback to `path.resolve` preserves the old behavior in the degenerate case where the package root has been deleted between resolution and hashing.
- **What changed**:
  - `src/plugins/bundled-runtime-deps-roots.ts`: `createPathHash` now hashes `realpathOrResolve(value)` instead of `path.resolve(value)`; one-line behavioral change plus a two-line comment explaining why.
  - `src/plugins/bundled-runtime-deps.test.ts`: new regression test `stages bundled runtime deps to the same root for symlinked packageRoot views (issue #74963)` — creates a real package root and a sibling symlink to it, calls `resolveBundledRuntimeDependencyInstallRoot` via both views, and asserts the two install roots are byte-equal and match the `openclaw-<version>-<12-hex>` shape. Skipped on `win32` to follow the existing `itSupportsSymlinks` precedent at line 2938 (Windows symlink creation requires admin in CI).
- **What did NOT change (scope boundary)**:
  - No `CHANGELOG.md` entry — left for maintainers to place under the active release section per their preferred phrasing/credit format.
  - No change to `realpathOrResolve` itself, the file lock implementation (`bundled-runtime-deps-lock.ts`), the dist-mirror cache (`bundled-runtime-dist-mirror-cache.ts`), the channel loader (`src/channels/plugins/bundled.ts`), or the manifest discovery flow (`src/plugins/loader.ts`). The fix is intentionally confined to the hashing seam; it does not also "fix" the lexical inconsistency between the loader and channel call sites because doing so would broaden the surface (hot import paths per `src/channels/CLAUDE.md`) without changing the observable outcome — converging the hash already converges the stage directory.
  - No change to the existing `path.resolve(installRoot)` hash construction inside the test at `bundled-runtime-deps.test.ts:2444`. That value is computed only as the right-hand side of a `.not.toBe` assertion (line 2450), so the assertion still holds: the resolver returns the canonical `installRoot`, which is not equal to any hypothetical fallback root — regardless of whether the fallback is computed lexically or canonically.
  - No new env vars, no new public API, no new types, no `any`, no behavioral change for source-checkout layouts (the source-checkout branch in `resolveBundledRuntimeDependencyInstallRootPlan`/`resolveBundledRuntimeDependencyPackageInstallRootPlan` short-circuits before reaching `createPathHash`).
  - No deprecation, no migration shim. Existing stage dirs from the buggy hash become disk-resident orphans; they are version-prefixed (`openclaw-2026.4.27-*`) so the existing prune logic at `pruneUnknownBundledRuntimeDepsRoots` (which targets `openclaw-unknown-*`) leaves them alone — same as any prior version's stage directory. Disk cost is bounded and one-time.

### Reproduction

1. On Windows, run 5 OpenClaw 2026.4.27 gateway instances under PM2 against the same install (or, simpler, expose the install via two paths — one canonical and one through an npm/Windows junction).
2. Boot the gateway; observe `[channels] failed to load bundled channel <id>: ENOENT` for several channels (Discord, Feishu, Google Chat, iMessage, LINE, IRC).
3. Inspect `~/.openclaw/plugin-runtime-deps/`: two or more directories named `openclaw-2026.4.27-<12-hex>` exist with the same version prefix but different hashes. The chunks named in the ENOENT messages exist under one hash but the failing process is reading from the other.

After applying this PR, only one such directory exists per version and all instances/call sites resolve to it.

Equivalent unit-level reproduction (already wired in this PR): `pnpm test src/plugins/bundled-runtime-deps.test.ts -t "issue #74963"` — fails on `main` (two install roots), passes after the fix.

### Risk / Mitigation

- **Risk** — *Stage-directory churn on upgrade*: existing 2026.4.27 deployments will create one new realpath-keyed stage directory on first run and leave the old lexical-keyed directory(ies) behind. This is a one-time disk cost (single-digit GB at worst, dependent on the bundled plugin runtime-deps tree size); subsequent starts share the new directory.
  **Mitigation**: behavior is identical to any major version's stage directory rotation, no operator action is required. The orphaned directory is version-prefixed so it does not collide with any future hash and does not get pruned by the `openclaw-unknown-*` cleanup; operators who care about disk usage can `rm -rf` it manually or wait for the next major version's natural rotation.
- **Risk** — *`realpathSync.native` failing on a path that does exist*: would silently fall back to `path.resolve`, reproducing the old (buggy) hash. In practice `realpathSync.native` only fails on ENOENT/EACCES/loop-detection; the `packageRoot` here is the parent of the dist tree we just enumerated, so it is guaranteed to exist at this point in the flow.
  **Mitigation**: the fallback preserves the pre-fix behavior, so failure mode is "no improvement", not "new regression". The added regression test exercises the realpath path on Linux/macOS; the Windows-skipped path still benefits from realpath's native libuv resolver in production where `realpathSync.native` is the canonical Windows realpath.
- **Risk** — *Test flakiness on macOS due to `/tmp` → `/private/tmp` symlinking*: the new test creates its own intra-tempdir symlink (`linkedPackageRoot` → `realPackageRoot`), so it does not rely on `/tmp` being or not being a symlink — both sides go through the same `realpathSync.native`.
  **Mitigation**: tested mentally against macOS `/var/folders/.../T` (`os.tmpdir()` default) and Linux `/tmp`; the test asserts equality between two resolver calls, both of which canonicalize identically.
- **Risk** — *Performance regression*: one `fs.realpathSync.native` stat per `createPathHash` call.
  **Mitigation**: `createPathHash` is invoked only inside `resolveExternalBundledRuntimeDepsInstallRoots`, which runs at plugin discovery time (cold start), not on the hot request path. Negligible measured impact.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Plugins
- [x] Bundled runtime deps
- [x] Channels (downstream consumer of the converged stage directory)

### Linked Issue/PR

Fixes #74963