### PR TITLE
fix(memory): share plugin state across runtime mirrors

### DIFF
--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -10,12 +10,23 @@ import {
   appendMemoryHostEvent,
   resolveMemoryHostEventLogPath,
 } from "openclaw/plugin-sdk/memory-host-events";
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { syncMemoryWikiBridgeSources } from "./bridge.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createVault } = createMemoryWikiTestHarness();
+
+let bridgeMirrorImportId = 0;
+
+async function importMirroredBridgeModule(): Promise<typeof import("./bridge.js")> {
+  bridgeMirrorImportId += 1;
+  return await importFreshModule<typeof import("./bridge.js")>(
+    import.meta.url,
+    `./bridge.js?runtimeMirror=${bridgeMirrorImportId}`,
+  );
+}
 
 describe("syncMemoryWikiBridgeSources", () => {
   let fixtureRoot = "";
@@ -196,6 +207,45 @@ describe("syncMemoryWikiBridgeSources", () => {
       workspaces: 0,
       pagePaths: [],
     });
+  });
+
+  it("imports canonical memory artifacts when loaded from a mirrored runtime module instance", async () => {
+    const workspaceDir = await createBridgeWorkspace("mirrored-workspace");
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("mirrored-vault"),
+      config: {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+          indexMemoryRoot: true,
+        },
+      },
+    });
+    const memoryPath = path.join(workspaceDir, "MEMORY.md");
+    await fs.writeFile(memoryPath, "# Durable Memory\n", "utf8");
+    registerBridgeArtifacts([
+      {
+        kind: "memory-root",
+        workspaceDir,
+        relativePath: "MEMORY.md",
+        absolutePath: memoryPath,
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+    const appConfig: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true, workspace: workspaceDir }],
+      },
+    };
+    const mirroredBridge = await importMirroredBridgeModule();
+
+    const result = await mirroredBridge.syncMemoryWikiBridgeSources({ config, appConfig });
+
+    expect(result.artifactCount).toBe(1);
+    expect(result.importedCount).toBe(1);
+    expect(result.pagePaths).toHaveLength(1);
   });
 
   it("imports the public memory event journal when followMemoryEvents is enabled", async () => {

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import {
+  clearMemoryPluginState,
+  type MemoryPluginPublicArtifact,
+  registerMemoryCapability,
+} from "openclaw/plugin-sdk/memory-host-core";
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { resolveMemoryWikiConfig } from "./config.js";
 import { renderWikiMarkdown } from "./markdown.js";
@@ -13,6 +19,16 @@ import {
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const { createVault } = createMemoryWikiTestHarness();
+
+let statusMirrorImportId = 0;
+
+async function importMirroredStatusModule(): Promise<typeof import("./status.js")> {
+  statusMirrorImportId += 1;
+  return await importFreshModule<typeof import("./status.js")>(
+    import.meta.url,
+    `./status.js?runtimeMirror=${statusMirrorImportId}`,
+  );
+}
 
 async function resolveBridgeMissingArtifactsStatus() {
   const config = resolveMemoryWikiConfig(
@@ -39,6 +55,10 @@ async function resolveBridgeMissingArtifactsStatus() {
 }
 
 describe("resolveMemoryWikiStatus", () => {
+  afterEach(() => {
+    clearMemoryPluginState();
+  });
+
   it("reports missing vault and missing requested obsidian cli", async () => {
     const config = resolveMemoryWikiConfig(
       {
@@ -89,6 +109,50 @@ describe("resolveMemoryWikiStatus", () => {
 
     expect(status.bridgePublicArtifactCount).toBe(0);
     expect(status.warnings.map((warning) => warning.code)).toContain("bridge-artifacts-missing");
+  });
+
+  it("counts canonical bridge artifacts when loaded from a mirrored runtime module instance", async () => {
+    const artifact: MemoryPluginPublicArtifact = {
+      kind: "memory-root",
+      workspaceDir: "workspace",
+      relativePath: "MEMORY.md",
+      absolutePath: "workspace/MEMORY.md",
+      agentIds: ["main"],
+      contentType: "markdown",
+    };
+    registerMemoryCapability("memory-core", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [artifact];
+        },
+      },
+    });
+    const config = resolveMemoryWikiConfig(
+      {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: true,
+        },
+      },
+      { homedir: "openclaw-test-home" },
+    );
+    const mirroredStatus = await importMirroredStatusModule();
+
+    const status = await mirroredStatus.resolveMemoryWikiStatus(config, {
+      appConfig: {
+        agents: {
+          list: [{ id: "main", default: true, workspace: "workspace" }],
+        },
+      } as OpenClawConfig,
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(status.bridgePublicArtifactCount).toBe(1);
+    expect(status.warnings.map((warning) => warning.code)).not.toContain(
+      "bridge-artifacts-missing",
+    );
   });
 
   it("counts source provenance from the vault", async () => {

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import {
   _resetMemoryPluginState,
   buildMemoryPromptSection,
@@ -76,6 +77,16 @@ function registerMemoryState(params: {
   if (params.runtime) {
     registerMemoryRuntime(params.runtime);
   }
+}
+
+let memoryStateMirrorImportId = 0;
+
+async function importMirroredMemoryStateModule(): Promise<typeof import("./memory-state.js")> {
+  memoryStateMirrorImportId += 1;
+  return await importFreshModule<typeof import("./memory-state.js")>(
+    import.meta.url,
+    `./memory-state.js?runtimeMirror=${memoryStateMirrorImportId}`,
+  );
 }
 
 describe("memory plugin state", () => {
@@ -179,6 +190,33 @@ describe("memory plugin state", () => {
         contentType: "markdown",
       },
     ]);
+  });
+
+  it("shares active public artifacts across mirrored runtime module instances", async () => {
+    const artifact = {
+      kind: "memory-root",
+      workspaceDir: "workspace",
+      relativePath: "MEMORY.md",
+      absolutePath: "workspace/MEMORY.md",
+      agentIds: ["main"],
+      contentType: "markdown" as const,
+    };
+    registerMemoryCapability("memory-core", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [artifact];
+        },
+      },
+    });
+
+    const mirroredMemoryState = await importMirroredMemoryStateModule();
+
+    await expect(
+      mirroredMemoryState.listActiveMemoryPublicArtifacts({ cfg: {} as never }),
+    ).resolves.toEqual([artifact]);
+
+    mirroredMemoryState.clearMemoryPluginState();
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([]);
   });
 
   it("passes citations mode through to the prompt builder", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -1,4 +1,5 @@
 import type { MemoryCitationsMode } from "../config/types.memory.js";
+import { createPluginRuntimeStore } from "../plugin-sdk/runtime-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MemorySearchManager } from "../memory-host-sdk/host/types.js";
 
@@ -152,10 +153,22 @@ type MemoryPluginState = {
   runtime?: MemoryPluginRuntime;
 };
 
-const memoryPluginState: MemoryPluginState = {
-  corpusSupplements: [],
-  promptSupplements: [],
-};
+function createEmptyMemoryPluginState(): MemoryPluginState {
+  return {
+    corpusSupplements: [],
+    promptSupplements: [],
+  };
+}
+
+// Runtime dependency mirrors can load a second copy of this module in the same
+// Gateway process. Store the mutable registry through the shared plugin runtime
+// store so mirrored chunks observe the same memory capability state.
+const memoryPluginStateStore = createPluginRuntimeStore<MemoryPluginState>({
+  key: "memory-plugin-state",
+  errorMessage: "memory plugin state has not been initialized",
+});
+const memoryPluginState = memoryPluginStateStore.tryGetRuntime() ?? createEmptyMemoryPluginState();
+memoryPluginStateStore.setRuntime(memoryPluginState);
 
 export function registerMemoryCorpusSupplement(
   pluginId: string,


### PR DESCRIPTION
## Summary

Refs #74981.

Memory plugin state was module-local, so mirrored runtime chunks in the same Gateway process could observe different memory capability registries. Memory Wiki bridge/status can then see zero public artifacts even after memory-core registered them.

This moves the existing memory plugin state object into OpenClaw's shared `createPluginRuntimeStore` mechanism so duplicate module instances observe the same in-process registry.

## Changes

- Reuse `createPluginRuntimeStore` for `memory-state` registry storage.
- Preserve the existing memory plugin SDK API and in-place clear/restore behavior.
- Add mirrored-runtime regression coverage for memory-state, Memory Wiki bridge import, and Memory Wiki status artifact counting.

## Validation

Local validation was intentionally light on this constrained VPS:

- `git diff --check`

Please rely on CI/Testbox for full test/typecheck validation.

## Possible durable follow-up

A broader follow-up could move memory capabilities behind a canonical host-owned capability service so plugin registration and artifact reads never depend on which SDK/runtime chunk imported `memory-state`.

Suggested prompt for a coding agent:

```md
# Task
Design and implement a durable host-owned memory capability registry for OpenClaw plugin runtime boundaries.

## Goal
Memory plugins should register capabilities through one canonical host-owned service, and all consumers should read active memory capabilities/artifacts through that service. The result should not depend on whether code is loaded from canonical dist, plugin-runtime-deps, a runtime mirror, or an extension bundle.

## Constraints
- Keep the existing public plugin SDK API backward compatible unless a small documented migration is clearly necessary.
- Avoid broad refactors. Prefer a narrow host capability seam with focused adapter changes.
- Do not special-case Memory Wiki, memory-core, or any local filesystem path.
- Preserve plugin disablement, memory-slot selection, and dual-kind memory plugin guardrails.
- Do not expand filesystem, network, or secret access.
- Add regression coverage for canonical-vs-mirrored runtime module instances.

## Starting points
- `src/plugins/memory-state.ts`
- `src/plugins/registry.ts`
- `src/plugin-sdk/memory-core-host-runtime-core.ts`
- `src/plugin-sdk/runtime-store.ts`
- `extensions/memory-wiki/src/bridge.ts`
- `extensions/memory-wiki/src/status.ts`
- plugin/runtime mirror tests around `src/plugins/loader.test.ts` and `src/plugin-sdk/runtime-store.test.ts`

## Acceptance criteria
1. A memory capability registered by the selected memory plugin is visible to all host and extension consumers in the same Gateway process, even when they load through mirrored runtime chunks.
2. Memory Wiki bridge/status read artifacts through the canonical host-owned seam, not incidental module-local state.
3. Existing memory plugin APIs remain source-compatible.
4. Tests cover duplicate module instance behavior and the Memory Wiki bridge/status artifact-count regression.
5. Full changed-surface validation passes in CI/Testbox.

## Output
Return a concise summary of the architecture, files changed, compatibility notes, and verification evidence.
```
