### PR TITLE
fix(feishu): media-aware dedupe key prevents dropping audio with reused message_id

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -3000,6 +3000,56 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 
+  it("processes same message_id with different audio file_key as distinct events (#75057)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const eventA: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-audio-dedupe",
+        },
+      },
+      message: {
+        message_id: "msg-audio-reuse-id",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "audio",
+        content: JSON.stringify({
+          file_key: "audio_file_key_aaa",
+        }),
+      },
+    };
+
+    const eventB: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-audio-dedupe",
+        },
+      },
+      message: {
+        message_id: "msg-audio-reuse-id",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "audio",
+        content: JSON.stringify({
+          file_key: "audio_file_key_bbb",
+        }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: eventA });
+    await dispatchMessage({ cfg, event: eventB });
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(2);
+  });
+
   it("skips empty-text messages with no media to prevent blank user turns in session (#74634)", async () => {
     // Feishu can deliver { "text": "" } events (empty-text or media-stripped
     // messages). Writing blank user content to the session causes downstream

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -25,7 +25,8 @@ import {
   normalizeFeishuCommandProbeBody,
   normalizeMentions,
   parseMergeForwardContent,
-  parseMessageContent,
+  parseMediaKeys,
+parseMessageContent,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
   toMessageResourceType,
@@ -380,6 +381,22 @@ function filterFetchedGroupContextMessages<
   }).items;
 }
 
+const MEDIA_TYPES_FOR_DEDUPE = new Set(["image", "audio", "file", "video", "media", "sticker"]);
+
+function computeMediaAwareDedupeKey(
+  messageId: string | undefined | null,
+  messageType: string | undefined | null,
+  content: string | undefined | null,
+): string | undefined {
+  const id = messageId?.trim();
+  if (!id) return undefined;
+  if (!messageType || !MEDIA_TYPES_FOR_DEDUPE.has(messageType)) return id;
+  if (!content) return id;
+  const keys = parseMediaKeys(content, messageType);
+  const mediaKey = keys.fileKey || keys.imageKey;
+  return mediaKey ? `${id}:${mediaKey}` : id;
+}
+
 export async function handleFeishuMessage(params: {
   cfg: ClawdbotConfig;
   event: FeishuMessageEvent;
@@ -409,15 +426,16 @@ export async function handleFeishuMessage(params: {
   const error = runtime?.error ?? console.error;
 
   const messageId = event.message.message_id;
+  const dedupeKey = computeMediaAwareDedupeKey(messageId, event.message.message_type, event.message.content);
   if (
     !(await finalizeFeishuMessageProcessing({
-      messageId,
+      messageId: dedupeKey,
       namespace: account.accountId,
       log,
       claimHeld: processingClaimHeld,
     }))
   ) {
-    log(`feishu: skipping duplicate message ${messageId}`);
+    log(`feishu: skipping duplicate message ${dedupeKey}`);
     return;
   }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -26,7 +26,7 @@ import {
   normalizeMentions,
   parseMergeForwardContent,
   parseMediaKeys,
-parseMessageContent,
+  parseMessageContent,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
   toMessageResourceType,
@@ -389,9 +389,15 @@ function computeMediaAwareDedupeKey(
   content: string | undefined | null,
 ): string | undefined {
   const id = messageId?.trim();
-  if (!id) return undefined;
-  if (!messageType || !MEDIA_TYPES_FOR_DEDUPE.has(messageType)) return id;
-  if (!content) return id;
+  if (!id) {
+    return undefined;
+  }
+  if (!messageType || !MEDIA_TYPES_FOR_DEDUPE.has(messageType)) {
+    return id;
+  }
+  if (!content) {
+    return id;
+  }
   const keys = parseMediaKeys(content, messageType);
   const mediaKey = keys.fileKey || keys.imageKey;
   return mediaKey ? `${id}:${mediaKey}` : id;
@@ -426,7 +432,11 @@ export async function handleFeishuMessage(params: {
   const error = runtime?.error ?? console.error;
 
   const messageId = event.message.message_id;
-  const dedupeKey = computeMediaAwareDedupeKey(messageId, event.message.message_type, event.message.content);
+  const dedupeKey = computeMediaAwareDedupeKey(
+    messageId,
+    event.message.message_type,
+    event.message.content,
+  );
   if (
     !(await finalizeFeishuMessageProcessing({
       messageId: dedupeKey,

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -1,6 +1,6 @@
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
-import type { FeishuMessageEvent } from "./event-types.js";
 import { parseMediaKeys } from "./bot-content.js";
+import type { FeishuMessageEvent } from "./event-types.js";
 import { isMentionForwardRequest } from "./mention.js";
 import {
   releaseFeishuMessageProcessing,
@@ -261,9 +261,7 @@ export function createFeishuMessageReceiveHandler({
       try {
         await recordProcessedMessage(key, accountId, log);
       } catch (err) {
-        error(
-          `feishu[${accountId}]: failed to record merged dedupe id ${key}: ${String(err)}`,
-        );
+        error(`feishu[${accountId}]: failed to record merged dedupe id ${key}: ${String(err)}`);
       }
     }
   };

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./event-types.js";
+import { parseMediaKeys } from "./bot-content.js";
 import { isMentionForwardRequest } from "./mention.js";
 import {
   releaseFeishuMessageProcessing,
@@ -10,6 +11,35 @@ import type { FeishuChatType } from "./types.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const MEDIA_MESSAGE_TYPES = new Set(["image", "audio", "file", "video", "media", "sticker"]);
+
+/**
+ * Compute a media-aware dedupe key. For media messages, includes the file_key
+ * or image_key so that the same message_id with different attachments is not
+ * incorrectly deduplicated. For text and other non-media types, returns the
+ * plain messageId (preserving existing behavior).
+ */
+function computeFeishuDedupeKey(event: FeishuMessageEvent): string | undefined {
+  const messageId = event.message.message_id?.trim();
+  if (!messageId) {
+    return undefined;
+  }
+  const messageType = event.message.message_type?.trim();
+  if (!messageType || !MEDIA_MESSAGE_TYPES.has(messageType)) {
+    return messageId;
+  }
+  const content = event.message.content;
+  if (!content) {
+    return messageId;
+  }
+  const keys = parseMediaKeys(content, messageType);
+  const mediaKey = keys.fileKey || keys.imageKey;
+  if (!mediaKey) {
+    return messageId;
+  }
+  return `${messageId}:${mediaKey}`;
 }
 
 function readString(value: unknown): string | undefined {
@@ -116,15 +146,15 @@ function dedupeFeishuDebounceEntriesByMessageId(
   const seen = new Set<string>();
   const deduped: FeishuMessageEvent[] = [];
   for (const entry of entries) {
-    const messageId = entry.message.message_id?.trim();
-    if (!messageId) {
+    const key = computeFeishuDedupeKey(entry);
+    if (!key) {
       deduped.push(entry);
       continue;
     }
-    if (seen.has(messageId)) {
+    if (seen.has(key)) {
       continue;
     }
-    seen.add(messageId);
+    seen.add(key);
     deduped.push(entry);
   }
   return deduped;
@@ -219,20 +249,20 @@ export function createFeishuMessageReceiveHandler({
 
   const recordSuppressedMessageIds = async (
     entries: FeishuMessageEvent[],
-    dispatchMessageId?: string,
+    dispatchDedupeKey?: string,
   ) => {
-    const keepMessageId = dispatchMessageId?.trim();
-    const suppressedIds = new Set(
+    const keepKey = dispatchDedupeKey?.trim();
+    const suppressedKeys = new Set(
       entries
-        .map((entry) => entry.message.message_id?.trim())
-        .filter((id): id is string => Boolean(id) && (!keepMessageId || id !== keepMessageId)),
+        .map((entry) => computeFeishuDedupeKey(entry))
+        .filter((key): key is string => Boolean(key) && (!keepKey || key !== keepKey)),
     );
-    for (const messageId of suppressedIds) {
+    for (const key of suppressedKeys) {
       try {
-        await recordProcessedMessage(messageId, accountId, log);
+        await recordProcessedMessage(key, accountId, log);
       } catch (err) {
         error(
-          `feishu[${accountId}]: failed to record merged dedupe id ${messageId}: ${String(err)}`,
+          `feishu[${accountId}]: failed to record merged dedupe id ${key}: ${String(err)}`,
         );
       }
     }
@@ -269,7 +299,8 @@ export function createFeishuMessageReceiveHandler({
       const dedupedEntries = dedupeFeishuDebounceEntriesByMessageId(entries);
       const freshEntries: FeishuMessageEvent[] = [];
       for (const entry of dedupedEntries) {
-        if (!(await hasProcessedMessage(entry.message.message_id, accountId, log))) {
+        const key = computeFeishuDedupeKey(entry);
+        if (!(await hasProcessedMessage(key, accountId, log))) {
           freshEntries.push(entry);
         }
       }
@@ -277,7 +308,7 @@ export function createFeishuMessageReceiveHandler({
       if (!dispatchEntry) {
         return;
       }
-      await recordSuppressedMessageIds(dedupedEntries, dispatchEntry.message.message_id);
+      await recordSuppressedMessageIds(dedupedEntries, computeFeishuDedupeKey(dispatchEntry));
       const combinedText = freshEntries
         .map((entry) => resolveDebounceText(entry))
         .filter(Boolean)
@@ -302,7 +333,7 @@ export function createFeishuMessageReceiveHandler({
     },
     onError: (err, entries) => {
       for (const entry of entries) {
-        releaseFeishuMessageProcessing(entry.message.message_id, accountId);
+        releaseFeishuMessageProcessing(computeFeishuDedupeKey(entry), accountId);
       }
       error(`feishu[${accountId}]: inbound debounce flush failed: ${String(err)}`);
     },
@@ -314,9 +345,9 @@ export function createFeishuMessageReceiveHandler({
       error(`feishu[${accountId}]: ignoring malformed message event payload`);
       return;
     }
-    const messageId = event.message?.message_id?.trim();
-    if (!tryBeginFeishuMessageProcessing(messageId, accountId)) {
-      log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);
+    const dedupeKey = computeFeishuDedupeKey(event);
+    if (!tryBeginFeishuMessageProcessing(dedupeKey, accountId)) {
+      log(`feishu[${accountId}]: dropping duplicate event for message ${dedupeKey}`);
       return;
     }
     const processMessage = async () => {
@@ -324,7 +355,7 @@ export function createFeishuMessageReceiveHandler({
     };
     if (fireAndForget) {
       void processMessage().catch((err) => {
-        releaseFeishuMessageProcessing(messageId, accountId);
+        releaseFeishuMessageProcessing(dedupeKey, accountId);
         error(`feishu[${accountId}]: error handling message: ${String(err)}`);
       });
       return;
@@ -332,7 +363,7 @@ export function createFeishuMessageReceiveHandler({
     try {
       await processMessage();
     } catch (err) {
-      releaseFeishuMessageProcessing(messageId, accountId);
+      releaseFeishuMessageProcessing(dedupeKey, accountId);
       error(`feishu[${accountId}]: error handling message: ${String(err)}`);
     }
   };


### PR DESCRIPTION
## Summary

Fixes #75057

## Root Cause

Feishu occasionally reuses the same `message_id` for different audio attachments sent in quick succession. The inbound dedupe logic (both the in-memory processing claim in `monitor.message-handler.ts` and the persistent finalize in `bot.ts`) keyed only on `message_id + account`, causing the second audio event to be silently dropped as a duplicate.

## Fix

Compute a composite dedupe key: `message_id:file_key` (or `message_id:image_key`) for media message types (audio, image, file, video, media, sticker). For text messages and true retries (same message_id + same media key), behavior is unchanged.

Affected paths:
- Early processing claim in `createFeishuMessageReceiveHandler`
- Batch debounce dedup in `dedupeFeishuDebounceEntriesByMessageId`
- Persistent finalize in `handleFeishuMessage`
- Suppressed message recording

## Test

Added regression test: same `message_id` with two different `file_key` values for audio messages → both are dispatched (not deduplicated).