### PR TITLE
fix(providers): enforce final output filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers: enforce tagged final-output filtering for MiniMax and OpenRouter channel replies so tool-call narration stays out of user-visible messages. Fixes #75077. Thanks @googlerest.
 - CLI/progress: suppress nested progress spinners and line clears while TUI input owns raw stdin, so Crestodian `/status` no longer disturbs the active input row. (#75003) Thanks @velvet-shark.
 - Telegram: use durable message edits for streaming previews instead of native draft state, so generated replies no longer flicker through draft-to-message transitions that look like duplicates. (#75073) Thanks @obviyus.
 

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -25,7 +25,7 @@ const minimaxProviderPlugin = {
 };
 
 describe("minimax provider hooks", () => {
-  it("keeps native reasoning mode for MiniMax transports", async () => {
+  it("uses tagged reasoning so user-visible streams keep the runtime final gate", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: minimaxProviderPlugin,
       id: "minimax",
@@ -41,7 +41,7 @@ describe("minimax provider hooks", () => {
         modelApi: "anthropic-messages",
         modelId: "MiniMax-M2.7",
       } as never),
-    ).toBe("native");
+    ).toBe("tagged");
 
     expect(portalProvider.hookAliases).toContain("minimax-portal-cn");
     expect(
@@ -50,7 +50,7 @@ describe("minimax provider hooks", () => {
         modelApi: "anthropic-messages",
         modelId: "MiniMax-M2.7",
       } as never),
-    ).toBe("native");
+    ).toBe("tagged");
   });
 
   it("keeps MiniMax auth setup metadata aligned across regions", async () => {

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -45,7 +45,7 @@ const HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
 const MINIMAX_PROVIDER_HOOKS = {
   ...HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS,
   ...MINIMAX_FAST_MODE_STREAM_HOOKS,
-  resolveReasoningOutputMode: () => "native" as const,
+  resolveReasoningOutputMode: () => "tagged" as const,
 };
 
 function getDefaultBaseUrl(region: MiniMaxRegion): string {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -58,7 +58,7 @@ describe("openrouter provider hooks", () => {
     });
   });
 
-  it("owns native reasoning output mode", async () => {
+  it("uses tagged reasoning so user-visible streams keep the runtime final gate", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
 
     expect(
@@ -67,7 +67,7 @@ describe("openrouter provider hooks", () => {
         modelApi: "openai-completions",
         modelId: "openai/gpt-5.4",
       } as never),
-    ).toBe("native");
+    ).toBe("tagged");
   });
 
   it("canonicalizes stale OpenRouter /v1 config and runtime metadata", async () => {

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -149,7 +149,7 @@ export default definePluginEntry({
           : undefined;
       },
       ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
-      resolveReasoningOutputMode: () => "native",
+      resolveReasoningOutputMode: () => "tagged",
       isModernModelRef: () => true,
       wrapStreamFn: wrapOpenRouterProviderStream,
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -43,14 +43,6 @@ async function expectInitialForumSend(
   );
 }
 
-function expectDmMessagePreviewViaSendMessage(
-  api: ReturnType<typeof createMockDraftApi>,
-  text = "Hello",
-): void {
-  expect(api.sendMessage).toHaveBeenCalledWith(123, text, { message_thread_id: 42 });
-  expect(api.editMessageText).not.toHaveBeenCalled();
-}
-
 function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
   const api = createMockDraftApi();
   api.sendMessage

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -137,10 +137,11 @@ describe("agent-runner-utils", () => {
     });
   });
 
-  it("does not force final-tag enforcement for minimax providers", () => {
+  it("forces final-tag enforcement when the provider requires tagged output", () => {
     const run = makeRun();
+    hoisted.isReasoningTagProviderMock.mockReturnValueOnce(true);
 
-    expect(resolveEnforceFinalTag(run, "minimax", "MiniMax-M2.7")).toBe(false);
+    expect(resolveEnforceFinalTag(run, "minimax", "MiniMax-M2.7")).toBe(true);
     expect(hoisted.isReasoningTagProviderMock).toHaveBeenCalledWith("minimax", {
       config: run.config,
       workspaceDir: run.workspaceDir,


### PR DESCRIPTION
## Summary
- Switch MiniMax and OpenRouter provider hooks to tagged reasoning output so auto-reply runs enable the existing runtime `<final>` gate.
- Update provider and auto-reply tests to cover the final-gate selection, and remove a stale Telegram test helper that blocked the required extension lint lane.
- Add a changelog fix entry for the reported channel-output leak.

## Root Cause
MiniMax and OpenRouter declared native reasoning output mode, so auto-reply runs did not enable `enforceFinalTag`. When models emitted tool-call narration or runtime context as ordinary assistant text, the subscriber treated it as user-visible text instead of discarding it outside `<final>`.

## Linked Issue
Fixes #75077.

## Why This Is Safe
This is a provider-policy change that reuses the existing runtime-enforced final-tag filter. It does not change tool execution, replay policy, stream wrappers, auth, model catalogs, or channel delivery contracts. Gemini-backed replay handling and MiniMax fast-mode stream wrapping remain in place.

## Security And Runtime Controls Unchanged
The existing runtime `<final>` extraction/suppression logic remains the enforcement point. Tool approval, provider replay sanitization, downgraded tool-call stripping, message delivery dedupe, and channel send permissions are unchanged.

## Tests Run
- `git diff --check`
- `pnpm test extensions/minimax/index.test.ts extensions/openrouter/index.test.ts src/auto-reply/reply/agent-runner-utils.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts -- --reporter=verbose`
- `pnpm check:changed`

## Out Of Scope
- Parsing arbitrary SOUL.md prose as a separate policy language.
- Changing provider model catalogs, fallback selection, or thinking-level defaults.
- Broadening final-tag enforcement to every provider.

Made with [Cursor](https://cursor.com)