### PR TITLE
fix(config): include validation details in recovery notices

### DIFF
--- a/src/gateway/config-recovery-notice.test.ts
+++ b/src/gateway/config-recovery-notice.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../infra/system-events.js";
 import {
   enqueueConfigRecoveryNotice,
+  formatConfigRecoveryIssueSummary,
   formatConfigRecoveryNotice,
 } from "./config-recovery-notice.js";
 
@@ -26,6 +27,28 @@ describe("config recovery notice", () => {
     );
   });
 
+  it("formats validation details for recovered configs", () => {
+    expect(
+      formatConfigRecoveryIssueSummary([
+        { path: "agents.defaults.execution", message: "Unrecognized key: execution" },
+        { path: "gateway.auth.password.source", message: "Required" },
+      ]),
+    ).toBe(
+      " Validation issues: agents.defaults.execution: Unrecognized key: execution; gateway.auth.password.source: Required.",
+    );
+  });
+
+  it("includes validation details in prompt-facing warnings", () => {
+    expect(
+      formatConfigRecoveryNotice({
+        phase: "startup",
+        reason: "startup-invalid-config",
+        configPath: "/home/test/.openclaw/openclaw.json",
+        issues: [{ path: "agents.defaults.execution", message: "Unrecognized key: execution" }],
+      }),
+    ).toContain("Validation issues: agents.defaults.execution: Unrecognized key: execution.");
+  });
+
   it("queues the notice for the main agent session", () => {
     expect(
       enqueueConfigRecoveryNotice({
@@ -33,12 +56,15 @@ describe("config recovery notice", () => {
         phase: "reload",
         reason: "reload-invalid-config",
         configPath: "/home/test/.openclaw/openclaw.json",
+        issues: [{ path: "gateway.auth.password.source", message: "Required" }],
       }),
     ).toBe(true);
 
     expect(peekSystemEvents("agent:main:main")).toHaveLength(1);
-    expect(drainSystemEvents("agent:main:main")[0]).toContain(
+    const notice = drainSystemEvents("agent:main:main")[0];
+    expect(notice).toContain(
       "Do not write openclaw.json again unless you validate the full config first.",
     );
+    expect(notice).toContain("gateway.auth.password.source: Required");
   });
 });

--- a/src/gateway/config-recovery-notice.ts
+++ b/src/gateway/config-recovery-notice.ts
@@ -1,19 +1,42 @@
 import path from "node:path";
+import { formatConfigIssueLines } from "../config/issue-format.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 
 export type ConfigRecoveryNoticePhase = "startup" | "reload";
 
+type ConfigRecoveryIssue = {
+  path?: string | null;
+  message: string;
+};
+
+const MAX_RECOVERY_ISSUES = 5;
+
+export function formatConfigRecoveryIssueSummary(
+  issues: ReadonlyArray<ConfigRecoveryIssue> | undefined,
+): string {
+  if (!issues || issues.length === 0) {
+    return "";
+  }
+  const visible = formatConfigIssueLines(issues.slice(0, MAX_RECOVERY_ISSUES), "", {
+    normalizeRoot: true,
+  });
+  const hidden = issues.length - visible.length;
+  const suffix = hidden > 0 ? `; ...and ${hidden} more` : "";
+  return ` Validation issues: ${visible.join("; ")}${suffix}.`;
+}
+
 export function formatConfigRecoveryNotice(params: {
   phase: ConfigRecoveryNoticePhase;
   reason: string;
   configPath: string;
+  issues?: ReadonlyArray<ConfigRecoveryIssue>;
 }): string {
   const configName = path.basename(params.configPath) || "openclaw.json";
   return [
     `Config recovery warning: OpenClaw restored ${configName} from the last-known-good backup during ${params.phase} (${params.reason}).`,
-    "The rejected config was invalid and was preserved as a timestamped .clobbered.* file.",
+    `The rejected config was invalid and was preserved as a timestamped .clobbered.* file.${formatConfigRecoveryIssueSummary(params.issues)}`,
     `Do not write ${configName} again unless you validate the full config first.`,
   ].join(" ");
 }
@@ -23,6 +46,7 @@ export function enqueueConfigRecoveryNotice(params: {
   phase: ConfigRecoveryNoticePhase;
   reason: string;
   configPath: string;
+  issues?: ReadonlyArray<ConfigRecoveryIssue>;
 }): boolean {
   return enqueueSystemEvent(formatConfigRecoveryNotice(params), {
     sessionKey: resolveMainSessionKey(params.cfg),

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -748,7 +748,7 @@ describe("startGatewayConfigReloader", () => {
       "valid-config",
     );
     expect(log.warn).toHaveBeenCalledWith(
-      "config reload restored last-known-good config after invalid-config",
+      "config reload restored last-known-good config after invalid-config (gateway.mode: Expected string)",
     );
 
     await reloader.stop();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -271,7 +271,18 @@ export function startGatewayConfigReloader(opts: {
     if (!recovered) {
       return null;
     }
-    opts.log.warn(`config reload restored last-known-good config after ${reason}`);
+    const issueSummary = formatConfigIssueLines(
+      [...snapshot.issues, ...snapshot.legacyIssues],
+      "",
+      {
+        normalizeRoot: true,
+      },
+    ).join("; ");
+    opts.log.warn(
+      `config reload restored last-known-good config after ${reason}${
+        issueSummary ? ` (${issueSummary})` : ""
+      }`,
+    );
     const nextSnapshot = await opts.readSnapshot();
     if (!nextSnapshot.valid) {
       const issues = formatConfigIssueLines(nextSnapshot.issues, "").join(", ");

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -447,6 +447,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
         phase: "reload",
         reason: `reload-${reason}`,
         configPath: snapshot.path,
+        issues: [...snapshot.issues, ...snapshot.legacyIssues],
       });
     },
     subscribeToWrites: params.subscribeToWrites,

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -389,13 +389,14 @@ describe("gateway startup config recovery", () => {
       reason: "startup-invalid-config",
     });
     expect(log.warn).toHaveBeenCalledWith(
-      `gateway: invalid config was restored from last-known-good backup: ${configPath}`,
+      `gateway: invalid config was restored from last-known-good backup: ${configPath} (gateway.mode: Expected 'local' or 'remote')`,
     );
     expect(recoveryNotice.enqueueConfigRecoveryNotice).toHaveBeenCalledWith({
       cfg: recoveredSnapshot.config,
       phase: "startup",
       reason: "startup-invalid-config",
       configPath,
+      issues: invalidSnapshot.issues,
     });
   });
 

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -229,6 +229,7 @@ export async function loadGatewayStartupConfigSnapshot(params: {
       }
     }
     if (!configSnapshot.valid) {
+      const recoveryIssues = [...configSnapshot.issues, ...configSnapshot.legacyIssues];
       const canRecoverFromLastKnownGood = shouldAttemptLastKnownGoodRecovery(configSnapshot);
       const recovered = canRecoverFromLastKnownGood
         ? await recoverConfigFromLastKnownGood({
@@ -243,8 +244,13 @@ export async function loadGatewayStartupConfigSnapshot(params: {
       }
       if (recovered) {
         wroteConfig = true;
+        const issueSummary = formatConfigIssueLines(recoveryIssues, "", {
+          normalizeRoot: true,
+        }).join("; ");
         params.log.warn(
-          `gateway: invalid config was restored from last-known-good backup: ${configSnapshot.path}`,
+          `gateway: invalid config was restored from last-known-good backup: ${configSnapshot.path}${
+            issueSummary ? ` (${issueSummary})` : ""
+          }`,
         );
         snapshotRead = await measure("config.snapshot.recovery-read", () =>
           readConfigFileSnapshotWithPluginMetadata({ measure }),
@@ -257,6 +263,7 @@ export async function loadGatewayStartupConfigSnapshot(params: {
             phase: "startup",
             reason: "startup-invalid-config",
             configPath: configSnapshot.path,
+            issues: recoveryIssues,
           });
         }
       }


### PR DESCRIPTION
Fixes #75060.

## Summary

- Include the rejected config validation paths/messages in startup last-known-good recovery logs.
- Include the same validation details in reload recovery logs and the main-agent recovery notice.
- Keep the existing fail-closed recovery behavior unchanged: this does not add `agents.defaults.execution`, relax SecretRef validation, or change LAN/direct execution policy.

## Validation

- `pnpm test src/gateway/server-startup-config.recovery.test.ts src/gateway/config-recovery-notice.test.ts src/config/io.observe-recovery.test.ts src/gateway/config-reload.test.ts src/gateway/server-reload-handlers.test.ts src/config/config.secrets-schema.test.ts src/config/zod-schema.agent-defaults.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 src/gateway/config-recovery-notice.ts src/gateway/server-startup-config.ts src/gateway/config-reload.ts src/gateway/server-reload-handlers.ts src/gateway/config-recovery-notice.test.ts src/gateway/server-startup-config.recovery.test.ts src/gateway/config-reload.test.ts`
- `pnpm check:changed`
- `git diff --check`

## AI-assisted disclosure

AI-assisted PR prepared with Codex. I reviewed the touched recovery paths and kept the change scoped to diagnostics only.