### PR TITLE
feat(feishu): add segment streaming mode

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -272,14 +272,15 @@ Feishu/Lark supports streaming replies via interactive cards. When enabled, the 
 {
   channels: {
     feishu: {
-      streaming: true, // enable streaming card output (default: true)
+      streaming: true, // enable streaming delivery (default: true)
+      streamingMode: "card", // "card" (default) or "segment"
       blockStreaming: true, // enable block-level streaming (default: true)
     },
   },
 }
 ```
 
-Set `streaming: false` to send the complete reply in one message.
+Set `streaming: false` to send the complete reply in one message. Set `streamingMode: "segment"` to collect model text while it is actively streaming and flush each accumulated segment when the model pauses for a tool call, idle, blocking event, or final reply. Each segment still uses `renderMode: "auto"` independently, so plain text segments can be sent as text while markdown-heavy segments can be sent as cards.
 
 ### Quota optimization
 
@@ -427,7 +428,8 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 | `channels.feishu.groups.<chat_id>.enabled`        | Enable/disable a specific group                                                  | `true`           |
 | `channels.feishu.textChunkLimit`                  | Message chunk size                                                               | `2000`           |
 | `channels.feishu.mediaMaxMb`                      | Media size limit                                                                 | `30`             |
-| `channels.feishu.streaming`                       | Streaming card output                                                            | `true`           |
+| `channels.feishu.streaming`                       | Enable streaming delivery                                                        | `true`           |
+| `channels.feishu.streamingMode`                   | Streaming delivery mode (`card` or `segment`)                                    | `card`           |
 | `channels.feishu.blockStreaming`                  | Block-level streaming                                                            | `true`           |
 | `channels.feishu.typingIndicator`                 | Send typing reactions                                                            | `true`           |
 | `channels.feishu.resolveSenderNames`              | Resolve sender display names                                                     | `true`           |

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -220,6 +220,38 @@ describe("FeishuConfigSchema optimization flags", () => {
   });
 });
 
+describe("FeishuConfigSchema streaming delivery mode", () => {
+  it("accepts top-level segment streaming mode", () => {
+    const result = FeishuConfigSchema.parse({
+      streaming: true,
+      streamingMode: "segment",
+    });
+
+    expect(result.streamingMode).toBe("segment");
+  });
+
+  it("accepts account-level card streaming mode", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: {
+          streaming: true,
+          streamingMode: "card",
+        },
+      },
+    });
+
+    expect(result.accounts?.main?.streamingMode).toBe("card");
+  });
+
+  it("rejects invalid streaming delivery modes", () => {
+    const result = FeishuConfigSchema.safeParse({
+      streamingMode: "partial",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("FeishuConfigSchema TTS overrides", () => {
   it("accepts top-level and account-level TTS overrides", () => {
     const result = FeishuConfigSchema.parse({

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -65,9 +65,12 @@ const MarkdownConfigSchema = z
 // Message render mode: auto (default) = detect markdown, raw = plain text, card = always card
 const RenderModeSchema = z.enum(["auto", "raw", "card"]).optional();
 
-// Streaming card mode: when enabled, card replies use Feishu's Card Kit streaming API
-// for incremental text display with a "Thinking..." placeholder
+// Streaming toggle: when enabled, Feishu can use a streaming delivery strategy.
 const StreamingModeSchema = z.boolean().optional();
+// Streaming delivery mode:
+// - card (default): use Feishu's Card Kit streaming API for live card updates
+// - segment: collect model text between pause points, then send each segment
+const StreamingDeliveryModeSchema = z.enum(["card", "segment"]).optional();
 
 const BlockStreamingCoalesceSchema = z
   .object({
@@ -194,6 +197,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
+  streamingMode: StreamingDeliveryModeSchema,
   tools: FeishuToolsConfigSchema,
   actions: ChannelActionsSchema,
   replyInThread: ReplyInThreadSchema,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -424,6 +424,65 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("skips later final payloads already delivered by segment partial flushes", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "先查 session。" });
+    await result.replyOptions.onToolStart?.();
+    result.replyOptions.onPartialReply?.({ text: "先查 session。\n\n再看日志。" });
+    await result.replyOptions.onToolStart?.();
+
+    await options.deliver({ text: "查完了。" }, { kind: "final" });
+    await options.deliver({ text: "再看日志。" }, { kind: "final" });
+    await options.deliver({ text: "先查 session。" }, { kind: "final" });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(3);
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "先查 session。" }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "再看日志。" }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "查完了。" }),
+    );
+  });
+
+  it("keeps delivered segment state when reply start fires more than once in the same turn", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "先看日志。" });
+    await result.replyOptions.onToolStart?.();
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "先看日志。\n\n再看 session。" });
+    await result.replyOptions.onToolStart?.();
+
+    await options.deliver({ text: "总结。" }, { kind: "final" });
+    await options.deliver({ text: "再看 session。" }, { kind: "final" });
+    await options.deliver({ text: "先看日志。" }, { kind: "final" });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(3);
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "先看日志。" }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "再看 session。" }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "总结。" }),
+    );
+  });
+
   it("runs auto rendering independently for each segment", async () => {
     setupSegmentStreamingConfig();
     const { result, options } = createDispatcherHarness();

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -21,6 +21,16 @@ const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: 
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted((): StreamingSessionStub[] => []);
 
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
@@ -383,6 +393,34 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
     expect(sendMessageFeishuMock).toHaveBeenLastCalledWith(
       expect.objectContaining({ text: "今日热点新闻如下。" }),
+    );
+  });
+
+  it("serializes segment flushes so final text cannot overtake an in-flight partial", async () => {
+    setupSegmentStreamingConfig();
+    const firstSegmentSent = createDeferred();
+    sendMessageFeishuMock.mockImplementationOnce(async () => firstSegmentSent.promise);
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "第一段。" });
+    const toolStartFlush = result.replyOptions.onToolStart?.();
+    const finalDelivery = options.deliver({ text: "第一段。\n\n第二段。" }, { kind: "final" });
+    await vi.waitFor(() => expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1));
+
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "第一段。" }),
+    );
+
+    firstSegmentSent.resolve();
+    await toolStartFlush;
+    await finalDelivery;
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "第二段。" }),
     );
   });
 

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -52,6 +52,13 @@ vi.mock("./accounts.js", () => ({
   resolveFeishuAccount: resolveFeishuAccountMock,
   resolveFeishuRuntimeAccount: resolveFeishuAccountMock,
 }));
+vi.mock("./reply-dispatcher-runtime-api.js", () => ({
+  createReplyPrefixContext: vi.fn(() => ({
+    responsePrefix: undefined,
+    responsePrefixContextProvider: undefined,
+    prefixContext: {},
+  })),
+}));
 vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
@@ -159,6 +166,25 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     return createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+  }
+
+  function setFeishuAccountConfig(config: Record<string, unknown>) {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config,
+    });
+  }
+
+  function setupSegmentStreamingConfig(overrides: Record<string, unknown> = {}) {
+    setFeishuAccountConfig({
+      renderMode: "auto",
+      streaming: true,
+      streamingMode: "segment",
+      ...overrides,
+    });
   }
 
   function createRuntimeLogger() {
@@ -314,6 +340,145 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("uses streaming session when streamingMode is explicitly card", async () => {
+    setFeishuAccountConfig({
+      renderMode: "auto",
+      streaming: true,
+      streamingMode: "card",
+    });
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("segments partial text at tool start when streamingMode is segment", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "今天是 2026 年 4 月 30 日。" });
+    await result.replyOptions.onToolStart?.();
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: "今天是 2026 年 4 月 30 日。" }),
+    );
+
+    await options.deliver(
+      { text: "今天是 2026 年 4 月 30 日。\n\n今日热点新闻如下。" },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageFeishuMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: "今日热点新闻如下。" }),
+    );
+  });
+
+  it("runs auto rendering independently for each segment", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "先给一句普通说明。" });
+    await result.replyOptions.onToolStart?.();
+    await options.deliver(
+      {
+        text: "先给一句普通说明。\n\n```ts\nconst answer = 42\n```",
+      },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "先给一句普通说明。" }),
+    );
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "```ts\nconst answer = 42\n```" }),
+    );
+  });
+
+  it("flushes segment partial text on idle and suppresses an identical later final", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "idle streamed reply" });
+    await options.onIdle?.();
+    await options.deliver({ text: "idle streamed reply" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "idle streamed reply" }),
+    );
+  });
+
+  it("keeps segment tool payloads separate from assistant text segmentation", async () => {
+    setupSegmentStreamingConfig();
+    const { result, options } = createDispatcherHarness();
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "日期。" });
+    await options.deliver({ text: "Using web_search..." }, { kind: "tool" });
+    await options.deliver({ text: "日期。\n\n新闻。" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(3);
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "日期。" }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "Using web_search..." }),
+    );
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "新闻。" }),
+    );
+  });
+
+  it("sends segment mention targets only with the first text segment", async () => {
+    setupSegmentStreamingConfig();
+    const mentions = [{ openId: "ou_1", name: "User", key: "@_user_1" }];
+    const { result, options } = createDispatcherHarness({
+      mentionTargets: mentions,
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "第一段。" });
+    await result.replyOptions.onToolStart?.();
+    await options.deliver({ text: "第一段。\n\n第二段。" }, { kind: "final" });
+
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ mentions }));
+    expect(sendMessageFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ mentions: undefined }),
+    );
+  });
+
+  it("omits reasoning preview callbacks for segment streaming", () => {
+    setupSegmentStreamingConfig();
+    const { result } = createDispatcherHarness({
+      allowReasoningPreview: true,
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeUndefined();
+    expect(result.replyOptions.onReasoningEnd).toBeUndefined();
   });
 
   it("closes streaming with block text when final reply is missing", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -238,6 +238,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let segmentDeliveredText = "";
   let segmentLastPartial = "";
   let segmentMentionTargetsDelivered = false;
+  let segmentDeliveryQueue: Promise<void> = Promise.resolve();
 
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) {
@@ -553,7 +554,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     );
   };
 
-  const flushSegment = async (reason: string, nextText?: string): Promise<boolean> => {
+  const enqueueSegmentDelivery = <T>(operation: () => Promise<T>): Promise<T> => {
+    const queued = segmentDeliveryQueue.then(operation, operation);
+    segmentDeliveryQueue = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued;
+  };
+
+  const sendTextSegmentInOrder = (text: string, infoKind?: string) =>
+    enqueueSegmentDelivery(async () => {
+      await sendTextSegment(text, infoKind);
+    });
+
+  const flushSegmentNow = async (reason: string, nextText?: string): Promise<boolean> => {
     if (!segmentStreamingEnabled && reason !== "final" && reason !== "block") {
       return false;
     }
@@ -571,6 +586,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     return true;
   };
+
+  const flushSegment = (reason: string, nextText?: string): Promise<boolean> =>
+    enqueueSegmentDelivery(() => flushSegmentNow(reason, nextText));
 
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
@@ -617,7 +635,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           if (info?.kind === "tool") {
             await flushSegment("tool");
             if (shouldDeliverText) {
-              await sendTextSegment(text, "tool");
+              await sendTextSegmentInOrder(text, "tool");
             }
             if (hasMedia) {
               await sendMediaReplies(payload);

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -239,6 +239,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let segmentLastPartial = "";
   let segmentMentionTargetsDelivered = false;
   let segmentDeliveryQueue: Promise<void> = Promise.resolve();
+  let segmentReplyStarted = false;
 
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) {
@@ -596,13 +597,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: async () => {
-        deliveredFinalTexts.clear();
         streamingClosedForReply = false;
         streamingCloseErroredForReply = false;
-        segmentAccumulatedText = "";
-        segmentDeliveredText = "";
-        segmentLastPartial = "";
-        segmentMentionTargetsDelivered = false;
+        if (!segmentReplyStarted) {
+          segmentReplyStarted = true;
+          deliveredFinalTexts.clear();
+          segmentAccumulatedText = "";
+          segmentDeliveredText = "";
+          segmentLastPartial = "";
+          segmentMentionTargetsDelivered = false;
+          segmentDeliveryQueue = Promise.resolve();
+        }
         if (cardStreamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -617,6 +622,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           hasText && (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text)));
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
+        const skipTextForDeliveredSegmentFinal =
+          segmentStreamingEnabled &&
+          info?.kind === "final" &&
+          hasText &&
+          !resolveUndeliveredSegmentText(text);
         const skipTextForClosedStreamingFinal =
           info?.kind === "final" &&
           hasText &&
@@ -625,7 +635,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           cardStreamingEnabled &&
           useCard;
         const shouldDeliverText =
-          hasText && !skipTextForDuplicateFinal && !skipTextForClosedStreamingFinal;
+          hasText &&
+          !skipTextForDuplicateFinal &&
+          !skipTextForDeliveredSegmentFinal &&
+          !skipTextForClosedStreamingFinal;
 
         if (!shouldDeliverText && !hasMedia) {
           return;

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -216,7 +216,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
   const streamingEnabled = account.config?.streaming !== false && renderMode !== "raw";
-  const reasoningPreviewEnabled = streamingEnabled && params.allowReasoningPreview === true;
+  const streamingMode = account.config?.streamingMode ?? "card";
+  const segmentStreamingEnabled = streamingEnabled && streamingMode === "segment";
+  const cardStreamingEnabled = streamingEnabled && !segmentStreamingEnabled;
+  const reasoningPreviewEnabled = cardStreamingEnabled && params.allowReasoningPreview === true;
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
@@ -231,6 +234,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingClosedForReply = false;
   let streamingCloseErroredForReply = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
+  let segmentAccumulatedText = "";
+  let segmentDeliveredText = "";
+  let segmentLastPartial = "";
+  let segmentMentionTargetsDelivered = false;
 
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) {
@@ -318,7 +325,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const startStreaming = () => {
     if (
-      !streamingEnabled ||
+      !cardStreamingEnabled ||
       streamingStartPromise ||
       streaming ||
       isStreamingStartBackedOff(account.accountId)
@@ -449,6 +456,122 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     });
   };
 
+  const rememberSegmentPartialText = (nextText: string) => {
+    if (!nextText || nextText === segmentLastPartial) {
+      return;
+    }
+    segmentLastPartial = nextText;
+    segmentAccumulatedText = mergeStreamingText(segmentAccumulatedText, nextText);
+  };
+
+  const resolveUndeliveredSegmentText = (nextText: string): string => {
+    if (!nextText) {
+      return "";
+    }
+    if (!segmentDeliveredText) {
+      return nextText;
+    }
+    if (nextText === segmentDeliveredText || segmentDeliveredText.includes(nextText)) {
+      return "";
+    }
+    if (nextText.startsWith(segmentDeliveredText)) {
+      return nextText.slice(segmentDeliveredText.length).replace(/^\s+/, "");
+    }
+    const merged = mergeStreamingText(segmentDeliveredText, nextText);
+    if (merged && merged !== segmentDeliveredText && merged.startsWith(segmentDeliveredText)) {
+      return merged.slice(segmentDeliveredText.length).replace(/^\s+/, "");
+    }
+    return nextText;
+  };
+
+  const markSegmentTextDelivered = (fullText: string, segmentText: string) => {
+    if (fullText && (!segmentDeliveredText || fullText.startsWith(segmentDeliveredText))) {
+      segmentDeliveredText = fullText;
+      return;
+    }
+    segmentDeliveredText = mergeStreamingText(segmentDeliveredText, segmentText);
+  };
+
+  const takeMentionTargetsForSegment = (): MentionTarget[] | undefined => {
+    if (segmentMentionTargetsDelivered) {
+      return undefined;
+    }
+    segmentMentionTargetsDelivered = true;
+    return mentionTargets;
+  };
+
+  const sendTextSegment = async (text: string, infoKind?: string) => {
+    if (!text) {
+      return;
+    }
+    const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+    const segmentMentionTargets = takeMentionTargetsForSegment();
+
+    if (useCard) {
+      const cardHeader = resolveCardHeader(agentId, identity);
+      const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+      await sendChunkedTextReply({
+        text,
+        useCard: true,
+        infoKind,
+        sendChunk: async ({ chunk, isFirst }) => {
+          await sendStructuredCardFeishu({
+            cfg,
+            to: chatId,
+            text: chunk,
+            replyToMessageId: sendReplyToMessageId,
+            replyInThread: effectiveReplyInThread,
+            mentions: isFirst ? segmentMentionTargets : undefined,
+            accountId,
+            header: cardHeader,
+            note: cardNote,
+          });
+        },
+      });
+    } else {
+      await sendChunkedTextReply({
+        text,
+        useCard: false,
+        infoKind,
+        sendChunk: async ({ chunk, isFirst }) => {
+          await sendMessageFeishu({
+            cfg,
+            to: chatId,
+            text: chunk,
+            replyToMessageId: sendReplyToMessageId,
+            replyInThread: effectiveReplyInThread,
+            mentions: isFirst ? segmentMentionTargets : undefined,
+            accountId,
+          });
+        },
+      });
+    }
+    params.runtime.log?.(
+      `feishu[${account.accountId}] segment flush reason=${infoKind ?? "unknown"} mode=${
+        useCard ? "card" : "text"
+      } chars=${text.length}`,
+    );
+  };
+
+  const flushSegment = async (reason: string, nextText?: string): Promise<boolean> => {
+    if (!segmentStreamingEnabled && reason !== "final" && reason !== "block") {
+      return false;
+    }
+    if (nextText) {
+      segmentAccumulatedText = mergeStreamingText(segmentAccumulatedText, nextText);
+    }
+    const segmentText = resolveUndeliveredSegmentText(segmentAccumulatedText);
+    if (!segmentText) {
+      return false;
+    }
+    await sendTextSegment(segmentText, reason);
+    markSegmentTextDelivered(segmentAccumulatedText, segmentText);
+    if (reason === "final") {
+      deliveredFinalTexts.add(segmentAccumulatedText);
+    }
+    return true;
+  };
+
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       responsePrefix: prefixContext.responsePrefix,
@@ -458,7 +581,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         deliveredFinalTexts.clear();
         streamingClosedForReply = false;
         streamingCloseErroredForReply = false;
-        if (streamingEnabled && renderMode === "card") {
+        segmentAccumulatedText = "";
+        segmentDeliveredText = "";
+        segmentLastPartial = "";
+        segmentMentionTargetsDelivered = false;
+        if (cardStreamingEnabled && renderMode === "card") {
           startStreaming();
         }
         await typingCallbacks?.onReplyStart?.();
@@ -477,7 +604,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           hasText &&
           streamingClosedForReply &&
           !streamingCloseErroredForReply &&
-          streamingEnabled &&
+          cardStreamingEnabled &&
           useCard;
         const shouldDeliverText =
           hasText && !skipTextForDuplicateFinal && !skipTextForClosedStreamingFinal;
@@ -486,11 +613,33 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        if (segmentStreamingEnabled) {
+          if (info?.kind === "tool") {
+            await flushSegment("tool");
+            if (shouldDeliverText) {
+              await sendTextSegment(text, "tool");
+            }
+            if (hasMedia) {
+              await sendMediaReplies(payload);
+            }
+            return;
+          }
+
+          if (shouldDeliverText) {
+            await flushSegment(info?.kind ?? "final", text);
+          }
+
+          if (hasMedia) {
+            await sendMediaReplies(payload);
+          }
+          return;
+        }
+
         if (shouldDeliverText) {
           if (info?.kind === "block") {
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
+            if (!(cardStreamingEnabled && useCard)) {
               return;
             }
             startStreaming();
@@ -499,7 +648,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
 
-          if (info?.kind === "final" && streamingEnabled && useCard) {
+          if (info?.kind === "final" && cardStreamingEnabled && useCard) {
             startStreaming();
             if (streamingStartPromise) {
               await streamingStartPromise;
@@ -576,11 +725,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await closeStreaming({ markClosedForReply: false });
+        if (segmentStreamingEnabled) {
+          await flushSegment("error");
+        } else {
+          await closeStreaming({ markClosedForReply: false });
+        }
         typingCallbacks?.onIdle?.();
       },
       onIdle: async () => {
-        await closeStreaming();
+        if (segmentStreamingEnabled) {
+          await flushSegment("idle");
+        } else {
+          await closeStreaming();
+        }
         typingCallbacks?.onIdle?.();
       },
       onCleanup: () => {
@@ -606,6 +763,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (!cleaned) {
               return;
             }
+            if (segmentStreamingEnabled) {
+              rememberSegmentPartialText(cleaned);
+              return;
+            }
             queueStreamingUpdate(cleaned, {
               dedupeWithLastPartial: true,
               mode: "snapshot",
@@ -623,23 +784,27 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         : undefined,
       onReasoningEnd: reasoningPreviewEnabled ? () => {} : undefined,
       onToolStart: streamingEnabled
-        ? (payload: { name?: string; phase?: string }) => {
+        ? async (payload?: { name?: string; phase?: string }) => {
+            if (segmentStreamingEnabled) {
+              await flushSegment("toolStart");
+              return;
+            }
             updateStreamingStatusLine(
-              `🔧 **Using: ${payload.name ?? payload.phase ?? "tool"}...**`,
+              `🔧 **Using: ${payload?.name ?? payload?.phase ?? "tool"}...**`,
             );
           }
         : undefined,
-      onAssistantMessageStart: streamingEnabled
+      onAssistantMessageStart: cardStreamingEnabled
         ? () => {
             updateStreamingStatusLine("");
           }
         : undefined,
-      onCompactionStart: streamingEnabled
+      onCompactionStart: cardStreamingEnabled
         ? () => {
             updateStreamingStatusLine("📦 **Compacting context...**");
           }
         : undefined,
-      onCompactionEnd: streamingEnabled
+      onCompactionEnd: cardStreamingEnabled
         ? () => {
             updateStreamingStatusLine("");
           }

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -83,7 +83,7 @@ node_modules/.bin/vitest run --config test/vitest/vitest.extension-feishu.config
 Result:
 
 - 3 test files passed
-- 83 tests passed
+- 86 tests passed
 
 After fixing segment ordering/deduplication, also ran:
 

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -8,6 +8,8 @@ Feishu currently uses `channels.feishu.streaming` for CardKit live streaming. Th
 
 This PR keeps the existing `streaming: true` behavior unchanged and adds a new explicit mode for the new semantics.
 
+`streaming` remains the top-level enable/disable switch for Feishu streaming delivery. `streamingMode` only applies when `streaming` is enabled.
+
 ## Changes
 
 - Add `channels.feishu.streamingMode` with supported values:
@@ -28,6 +30,17 @@ This PR keeps the existing `streaming: true` behavior unchanged and adds a new e
 - Update Feishu config schema, generated config metadata, docs, and tests.
 
 ## Example
+
+Behavior by configuration:
+
+| `streaming` | `streamingMode` | Behavior                                                                                                                                                |
+| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `false`     | `"card"`        | Streaming is disabled. Feishu sends replies through the regular non-streaming path; the mode value is ignored.                                          |
+| `false`     | `"segment"`     | Streaming is disabled. Partial text is not accumulated and pause-point segment flushing is not enabled; the mode value is ignored.                      |
+| `true`      | `"card"`        | Existing CardKit streaming behavior. Feishu updates one live card and closes it with the final content.                                                 |
+| `true`      | `"segment"`     | New pause-point segment behavior. Feishu accumulates partial text and sends complete segments on tool start, idle, block, tool payload, or final reply. |
+
+Use segment delivery with:
 
 ```json5
 {

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -21,6 +21,7 @@ This PR keeps the existing `streaming: true` behavior unchanged and adds a new e
   - partial model output is accumulated
   - accumulated text is flushed on tool start, idle, block, tool payload, or final reply
   - duplicate final text after an idle flush is suppressed
+  - segment sends are serialized so final/tool payloads cannot overtake an in-flight partial flush
   - each flushed segment independently uses `renderMode: "auto"`
   - mentions are attached only to the first text segment
   - reasoning preview callbacks stay disabled because segment mode does not use live cards
@@ -62,6 +63,17 @@ Result:
 
 - 3 test files passed
 - 83 tests passed
+
+After fixing segment ordering/deduplication, also ran:
+
+```bash
+pnpm test extensions/feishu/src/reply-dispatcher.test.ts
+```
+
+Result:
+
+- 1 test file passed
+- 49 tests passed
 
 Also ran:
 

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -94,7 +94,7 @@ pnpm test extensions/feishu/src/reply-dispatcher.test.ts
 Result:
 
 - 1 test file passed
-- 49 tests passed
+- 51 tests passed
 
 Also ran:
 

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -1,14 +1,25 @@
 ## Summary
 
-Add an opt-in Feishu streaming delivery mode that flushes accumulated model output at pause points instead of changing the existing streaming card behavior.
+Add an opt-in Feishu streaming delivery mode that accumulates model output and flushes complete segments at pause points, without changing the existing CardKit streaming-card default.
 
 ## Motivation
 
-Feishu currently uses `channels.feishu.streaming` for CardKit live streaming. That behavior is useful, but some workflows need a different delivery style: collect text while the model is actively generating, then send a complete segment only when the model pauses for a tool call, idle event, block event, or final reply.
+Feishu currently uses `channels.feishu.streaming` for CardKit live streaming. That behavior is useful when users want one live card that updates as the model generates text.
 
-This PR keeps the existing `streaming: true` behavior unchanged and adds a new explicit mode for the new semantics.
+Some workflows need a different delivery style: show completed model text before a tool call, keep tool/status output in order, and then send the follow-up answer after the model resumes. Sending these boundaries as complete segments avoids sentence-by-sentence card updates while still giving users useful progress before the final reply.
+
+## Configuration Behavior
 
 `streaming` remains the top-level enable/disable switch for Feishu streaming delivery. `streamingMode` only applies when `streaming` is enabled.
+
+| `streaming` | `streamingMode` | Behavior                                                                                                                                                |
+| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `false`     | `"card"`        | Streaming is disabled. Feishu sends replies through the regular non-streaming path; the mode value is ignored.                                          |
+| `false`     | `"segment"`     | Streaming is disabled. Partial text is not accumulated and pause-point segment flushing is not enabled; the mode value is ignored.                      |
+| `true`      | `"card"`        | Existing CardKit streaming behavior. Feishu updates one live card and closes it with the final content. This remains the default.                       |
+| `true`      | `"segment"`     | New pause-point segment behavior. Feishu accumulates partial text and sends complete segments on tool start, idle, block, tool payload, or final reply. |
+
+`chunkMode` still applies after a reply or segment is ready to send. In segment mode, `streamingMode: "segment"` decides when to flush a semantic segment, then `chunkMode` decides whether that segment needs to be split by length or newline before sending to Feishu.
 
 ## Changes
 
@@ -30,15 +41,6 @@ This PR keeps the existing `streaming: true` behavior unchanged and adds a new e
 - Update Feishu config schema, generated config metadata, docs, and tests.
 
 ## Example
-
-Behavior by configuration:
-
-| `streaming` | `streamingMode` | Behavior                                                                                                                                                |
-| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `false`     | `"card"`        | Streaming is disabled. Feishu sends replies through the regular non-streaming path; the mode value is ignored.                                          |
-| `false`     | `"segment"`     | Streaming is disabled. Partial text is not accumulated and pause-point segment flushing is not enabled; the mode value is ignored.                      |
-| `true`      | `"card"`        | Existing CardKit streaming behavior. Feishu updates one live card and closes it with the final content.                                                 |
-| `true`      | `"segment"`     | New pause-point segment behavior. Feishu accumulates partial text and sends complete segments on tool start, idle, block, tool payload, or final reply. |
 
 Use segment delivery with:
 
@@ -65,6 +67,12 @@ Default behavior remains:
   },
 }
 ```
+
+## Compatibility
+
+- Existing configs that only set `channels.feishu.streaming` keep the same behavior because `streamingMode` defaults to `"card"`.
+- `streaming: false` continues to disable streaming delivery regardless of `streamingMode`.
+- Segment mode is opt-in and does not change CardKit streaming-card behavior.
 
 ## Tests
 

--- a/pr-feishu-segment-streaming-mode.md
+++ b/pr-feishu-segment-streaming-mode.md
@@ -1,0 +1,70 @@
+## Summary
+
+Add an opt-in Feishu streaming delivery mode that flushes accumulated model output at pause points instead of changing the existing streaming card behavior.
+
+## Motivation
+
+Feishu currently uses `channels.feishu.streaming` for CardKit live streaming. That behavior is useful, but some workflows need a different delivery style: collect text while the model is actively generating, then send a complete segment only when the model pauses for a tool call, idle event, block event, or final reply.
+
+This PR keeps the existing `streaming: true` behavior unchanged and adds a new explicit mode for the new semantics.
+
+## Changes
+
+- Add `channels.feishu.streamingMode` with supported values:
+  - `"card"`: default, existing CardKit streaming behavior
+  - `"segment"`: accumulate model text and flush at pause points
+- Preserve current `channels.feishu.streaming` semantics:
+  - `true` enables streaming delivery
+  - `false` disables streaming delivery
+  - default mode remains CardKit streaming
+- In segment mode:
+  - partial model output is accumulated
+  - accumulated text is flushed on tool start, idle, block, tool payload, or final reply
+  - duplicate final text after an idle flush is suppressed
+  - each flushed segment independently uses `renderMode: "auto"`
+  - mentions are attached only to the first text segment
+  - reasoning preview callbacks stay disabled because segment mode does not use live cards
+- Update Feishu config schema, generated config metadata, docs, and tests.
+
+## Example
+
+```json5
+{
+  channels: {
+    feishu: {
+      streaming: true,
+      streamingMode: "segment",
+    },
+  },
+}
+```
+
+Default behavior remains:
+
+```json5
+{
+  channels: {
+    feishu: {
+      streaming: true,
+      streamingMode: "card",
+    },
+  },
+}
+```
+
+## Tests
+
+```bash
+node_modules/.bin/vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/config-schema.test.ts --reporter=dot
+```
+
+Result:
+
+- 3 test files passed
+- 83 tests passed
+
+Also ran:
+
+```bash
+git diff --check -- extensions/feishu/src/config-schema.ts extensions/feishu/src/config-schema.test.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts src/config/bundled-channel-config-metadata.generated.ts docs/channels/feishu.md
+```

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -4112,6 +4112,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         streaming: {
           type: "boolean",
         },
+        streamingMode: {
+          type: "string",
+          enum: ["card", "segment"],
+        },
         tools: {
           type: "object",
           properties: {
@@ -4739,6 +4743,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               streaming: {
                 type: "boolean",
+              },
+              streamingMode: {
+                type: "string",
+                enum: ["card", "segment"],
               },
               tools: {
                 type: "object",


### PR DESCRIPTION
## Summary

Add an opt-in Feishu streaming delivery mode that accumulates model output and flushes complete segments at pause points, without changing the existing CardKit streaming-card default.

## Motivation

Feishu currently uses `channels.feishu.streaming` for CardKit live streaming. That behavior is useful when users want one live card that updates as the model generates text.

Some workflows need a different delivery style: show completed model text before a tool call, keep tool/status output in order, and then send the follow-up answer after the model resumes. Sending these boundaries as complete segments avoids sentence-by-sentence card updates while still giving users useful progress before the final reply.

## Configuration Behavior

`streaming` remains the top-level enable/disable switch for Feishu streaming delivery. `streamingMode` only applies when `streaming` is enabled.

| `streaming` | `streamingMode` | Behavior                                                                                                                                                |
| ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `false`     | `"card"`        | Streaming is disabled. Feishu sends replies through the regular non-streaming path; the mode value is ignored.                                          |
| `false`     | `"segment"`     | Streaming is disabled. Partial text is not accumulated and pause-point segment flushing is not enabled; the mode value is ignored.                      |
| `true`      | `"card"`        | Existing CardKit streaming behavior. Feishu updates one live card and closes it with the final content. This remains the default.                       |
| `true`      | `"segment"`     | New pause-point segment behavior. Feishu accumulates partial text and sends complete segments on tool start, idle, block, tool payload, or final reply. |

`chunkMode` still applies after a reply or segment is ready to send. In segment mode, `streamingMode: "segment"` decides when to flush a semantic segment, then `chunkMode` decides whether that segment needs to be split by length or newline before sending to Feishu.

## Changes

- Add `channels.feishu.streamingMode` with supported values:
  - `"card"`: default, existing CardKit streaming behavior
  - `"segment"`: accumulate model text and flush at pause points
- Preserve current `channels.feishu.streaming` semantics:
  - `true` enables streaming delivery
  - `false` disables streaming delivery
  - default mode remains CardKit streaming
- In segment mode:
  - partial model output is accumulated
  - accumulated text is flushed on tool start, idle, block, tool payload, or final reply
  - duplicate final text after an idle flush is suppressed
  - segment sends are serialized so final/tool payloads cannot overtake an in-flight partial flush
  - each flushed segment independently uses `renderMode: "auto"`
  - mentions are attached only to the first text segment
  - reasoning preview callbacks stay disabled because segment mode does not use live cards
- Update Feishu config schema, generated config metadata, docs, and tests.

## Example

Use segment delivery with:

```json5
{
  channels: {
    feishu: {
      streaming: true,
      streamingMode: "segment",
    },
  },
}
```

Default behavior remains:

```json5
{
  channels: {
    feishu: {
      streaming: true,
      streamingMode: "card",
    },
  },
}
```

## Compatibility

- Existing configs that only set `channels.feishu.streaming` keep the same behavior because `streamingMode` defaults to `"card"`.
- `streaming: false` continues to disable streaming delivery regardless of `streamingMode`.
- Segment mode is opt-in and does not change CardKit streaming-card behavior.

## Tests

```bash
node_modules/.bin/vitest run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/config-schema.test.ts --reporter=dot
```

Result:

- 3 test files passed
- 86 tests passed

After fixing segment ordering/deduplication, also ran:

```bash
pnpm test extensions/feishu/src/reply-dispatcher.test.ts
```

Result:

- 1 test file passed
- 51 tests passed

Also ran:

```bash
git diff --check -- extensions/feishu/src/config-schema.ts extensions/feishu/src/config-schema.test.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts src/config/bundled-channel-config-metadata.generated.ts docs/channels/feishu.md
```
