### PR TITLE
fix(agents): use resolved budget for tool-result guard

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -199,6 +199,42 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     }
   });
 
+  it("uses the resolved context token budget for non-owner tool-result guard installs", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: createTestContextEngine({
+        assemble: async ({ messages }) => ({
+          messages,
+          estimatedTokens: 1,
+        }),
+        info: {
+          id: "non-owner-context-engine",
+          name: "Non-owner context engine",
+          version: "0.0.1",
+          ownsCompaction: false,
+        },
+      }),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        contextTokenBudget: 4096,
+        model: {
+          api: "openai-completions",
+          provider: "openai",
+          compat: {},
+          contextWindow: 128,
+          maxTokens: 64,
+          input: ["text"],
+        } as never,
+      },
+    });
+
+    expect(hoisted.installToolResultContextGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextWindowTokens: 4096,
+      }),
+    );
+  });
+
   it("marks inter-session transcriptPrompt before submitting the visible prompt", async () => {
     let seenPrompt: string | undefined;
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1476,7 +1476,10 @@ export async function runEmbeddedAttempt(
           contextWindowTokens: Math.max(
             1,
             Math.floor(
-              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+              params.contextTokenBudget ??
+                params.model.contextWindow ??
+                params.model.maxTokens ??
+                DEFAULT_CONTEXT_TOKENS,
             ),
           ),
         });


### PR DESCRIPTION
Fixes #74917.

## Summary
- Pass the resolved `contextTokenBudget` into the non-owner tool-result context guard.
- Add regression coverage where the resolved budget is smaller than the model-declared context window.

## Validation
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `git diff --check`

AI-assisted with OpenAI Codex.