### PR TITLE
fix(active-memory): rename command from active-memory to active_memory

### DIFF
--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -665,14 +665,14 @@ function resolveCommandSessionKey(params: {
 function formatActiveMemoryCommandHelp(): string {
   return [
     "Active Memory session toggle:",
-    "/active-memory status",
-    "/active-memory on",
-    "/active-memory off",
+    "/active_memory status",
+    "/active_memory on",
+    "/active_memory off",
     "",
     "Global config toggle:",
-    "/active-memory status --global",
-    "/active-memory on --global",
-    "/active-memory off --global",
+    "/active_memory status --global",
+    "/active_memory on --global",
+    "/active_memory off --global",
   ].join("\n");
 }
 
@@ -2462,7 +2462,7 @@ export default definePluginEntry({
       }
     };
     api.registerCommand({
-      name: "active-memory",
+      name: "active_memory",
       description: "Enable, disable, or inspect Active Memory for this session.",
       acceptsArgs: true,
       handler: async (ctx) => {


### PR DESCRIPTION
## Summary
Change the user-facing slash command from `/active-memory` to `/active_memory` for consistency (using underscore instead of hyphen in command name).

## Changes
- **Command registration**: Changed `name: "active-memory"` to `name: "active_memory"`
- **Help text**: Updated all occurrences in `formatActiveMemoryCommandHelp()` to show `/active_memory` instead of `/active-memory`

## Why
The command name in the help text was showing with a hyphen (`/active-memory`), but for consistency with typical CLI naming conventions, it should use underscore (`/active_memory`).

## Note
Internal identifiers (plugin ID, config keys, directory names) remain unchanged — only the user-facing slash command name was updated.