### PR TITLE
fix(tui): skip eager context warmup during startup

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -158,6 +158,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "secrets",
   "sessions",
   "status",
+  "tui",
   "update",
   "webhooks",
 ]);


### PR DESCRIPTION
## Summary

- add `tui` to the eager context-window warmup skip list
- prevent TUI startup from kicking off expensive model/provider/context discovery on the UI process
- keep context/model discovery available lazily when actually needed

## Why

`openclaw tui --local ...` can render as ready while eager context/model warmup continues in the same Node process. On my setup this starved PTY stdin for many seconds after first render, so the TUI looked ready but keyboard input appeared frozen.

The warmup path includes provider/model discovery, auth/env discovery, plugin compatibility, and context-window cache population. This metadata work can be useful, but it should not run eagerly in an interactive TUI immediately after startup.

## Validation

- `pnpm install`
- `pnpm build`
- `pnpm check`
- `pnpm test` attempted; no assertion failure found, but the monorepo run was interrupted on this VPS after `test/vitest/vitest.extension-discord.config.ts` exited by `SIGKILL` / overall `SIGTERM`
- `pnpm vitest run --config test/vitest/vitest.extension-discord.config.ts` passed when rerun alone: 134 files / 1187 tests

Local behavior validation:

Before:
- TUI rendered ready, but keypresses were delayed by seconds.
- Tracing showed `ensureContextWindowCacheLoaded()` continuing for ~43s after first render.

After applying the same skip-list change to the installed dist file:
- automated PTY probe showed input read delays of ~0ms for real local TUI scenarios
- normal TUI chat remained usable

AI-assisted: yes. I understand the change: it only skips eager startup warmup for the `tui` command; on-demand context lookup remains intact.
