### PR TITLE
fix(feishu): include audio file_key in dedupe key for distinct uploads (#75057)

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -42,6 +42,7 @@ import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sende
 import { getChatInfo } from "./chat.js";
 import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
+import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
 import {
@@ -408,16 +409,16 @@ export async function handleFeishuMessage(params: {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
 
-  const messageId = event.message.message_id;
+  const dedupeKey = resolveFeishuMessageDedupeKey(event);
   if (
     !(await finalizeFeishuMessageProcessing({
-      messageId,
+      messageId: dedupeKey,
       namespace: account.accountId,
       log,
       claimHeld: processingClaimHeld,
     }))
   ) {
-    log(`feishu: skipping duplicate message ${messageId}`);
+    log(`feishu: skipping duplicate message ${dedupeKey}`);
     return;
   }
 

--- a/extensions/feishu/src/dedupe-key.test.ts
+++ b/extensions/feishu/src/dedupe-key.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
+import type { FeishuMessageEvent } from "./event-types.js";
+
+function makeEvent(params: {
+  messageId: string;
+  messageType: string;
+  content: string;
+}): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: { open_id: "ou_sender" },
+      sender_type: "user",
+    },
+    message: {
+      message_id: params.messageId,
+      chat_id: "oc_chat",
+      chat_type: "p2p",
+      message_type: params.messageType,
+      content: params.content,
+    },
+  };
+}
+
+describe("resolveFeishuMessageDedupeKey", () => {
+  it("returns the bare message_id for text messages", () => {
+    const event = makeEvent({
+      messageId: "om_text",
+      messageType: "text",
+      content: JSON.stringify({ text: "hi" }),
+    });
+    expect(resolveFeishuMessageDedupeKey(event)).toBe("om_text");
+  });
+
+  it("returns the bare message_id for image messages even when a file_key field is present", () => {
+    // Only audio is affected by the upstream message_id reuse bug (#75057).
+    // Other media types stay on plain message_id dedupe to preserve existing
+    // behavior.
+    const event = makeEvent({
+      messageId: "om_image",
+      messageType: "image",
+      content: JSON.stringify({ image_key: "img_key", file_key: "ignored" }),
+    });
+    expect(resolveFeishuMessageDedupeKey(event)).toBe("om_image");
+  });
+
+  it("folds file_key into the dedupe key for audio messages", () => {
+    const event = makeEvent({
+      messageId: "om_dup",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "audio_alpha", duration: 1234 }),
+    });
+    expect(resolveFeishuMessageDedupeKey(event)).toBe("om_dup:audio:audio_alpha");
+  });
+
+  it("yields distinct dedupe keys when the same message_id is reused for different audio uploads (#75057)", () => {
+    const first = makeEvent({
+      messageId: "om_dup",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "audio_alpha" }),
+    });
+    const second = makeEvent({
+      messageId: "om_dup",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "audio_beta" }),
+    });
+    expect(resolveFeishuMessageDedupeKey(first)).not.toBe(resolveFeishuMessageDedupeKey(second));
+  });
+
+  it("yields the same dedupe key for an audio repeat with identical message_id and file_key", () => {
+    const first = makeEvent({
+      messageId: "om_dup",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "audio_alpha" }),
+    });
+    const second = makeEvent({
+      messageId: "om_dup",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "audio_alpha" }),
+    });
+    expect(resolveFeishuMessageDedupeKey(first)).toBe(resolveFeishuMessageDedupeKey(second));
+  });
+
+  it("falls back to message_id when audio content is missing or unparseable", () => {
+    const noFileKey = makeEvent({
+      messageId: "om_audio_partial",
+      messageType: "audio",
+      content: JSON.stringify({ duration: 500 }),
+    });
+    expect(resolveFeishuMessageDedupeKey(noFileKey)).toBe("om_audio_partial");
+
+    const malformed = makeEvent({
+      messageId: "om_audio_bad",
+      messageType: "audio",
+      content: "not json",
+    });
+    expect(resolveFeishuMessageDedupeKey(malformed)).toBe("om_audio_bad");
+
+    const blankFileKey = makeEvent({
+      messageId: "om_audio_blank",
+      messageType: "audio",
+      content: JSON.stringify({ file_key: "   " }),
+    });
+    expect(resolveFeishuMessageDedupeKey(blankFileKey)).toBe("om_audio_blank");
+  });
+});

--- a/extensions/feishu/src/dedupe-key.ts
+++ b/extensions/feishu/src/dedupe-key.ts
@@ -1,0 +1,40 @@
+import type { FeishuMessageEvent } from "./event-types.js";
+
+/**
+ * Resolve a stable dedupe key for a Feishu inbound message event.
+ *
+ * Most events are uniquely identified by `message_id` alone. However, Feishu
+ * has been observed reusing the same `message_id` across distinct audio
+ * uploads (issue #75057). When that happens, keying dedupe purely on
+ * `message_id` silently drops the second voice note before its content is
+ * parsed.
+ *
+ * For audio events with a parsable `file_key`, fold that key into the dedupe
+ * identity so each distinct upload is processed exactly once while same-id
+ * repeats are still suppressed. Other message types are unaffected.
+ */
+export function resolveFeishuMessageDedupeKey(event: FeishuMessageEvent): string {
+  const messageId = event.message.message_id;
+  if (event.message.message_type !== "audio") {
+    return messageId;
+  }
+  const fileKey = parseFeishuAudioFileKey(event.message.content);
+  return fileKey ? `${messageId}:audio:${fileKey}` : messageId;
+}
+
+function parseFeishuAudioFileKey(content: string | undefined | null): string | undefined {
+  if (!content) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(content) as { file_key?: unknown };
+    const raw = parsed?.file_key;
+    if (typeof raw !== "string") {
+      return undefined;
+    }
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/feishu/src/monitor.message-handler.audio-dedupe.test.ts
+++ b/extensions/feishu/src/monitor.message-handler.audio-dedupe.test.ts
@@ -1,0 +1,126 @@
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
+
+function buildCfg(): ClawdbotConfig {
+  return {
+    messages: { inbound: { debounceMs: 0 } },
+    channels: { feishu: { enabled: true } },
+  } as ClawdbotConfig;
+}
+
+function buildCore(): PluginRuntime {
+  return {
+    channel: {
+      debounce: { createInboundDebouncer, resolveInboundDebounceMs },
+      text: { hasControlCommand },
+    },
+  } as unknown as PluginRuntime;
+}
+
+function createAudioEvent(params: { messageId: string; fileKey: string }): FeishuMessageEvent {
+  return {
+    sender: { sender_id: { open_id: "ou_sender" }, sender_type: "user" },
+    message: {
+      message_id: params.messageId,
+      chat_id: "oc_chat",
+      chat_type: "p2p",
+      message_type: "audio",
+      content: JSON.stringify({ file_key: params.fileKey, duration: 1000 }),
+    },
+  };
+}
+
+function createTextEvent(messageId: string, text = "hi"): FeishuMessageEvent {
+  return {
+    sender: { sender_id: { open_id: "ou_sender" }, sender_type: "user" },
+    message: {
+      message_id: messageId,
+      chat_id: "oc_chat",
+      chat_type: "p2p",
+      message_type: "text",
+      content: JSON.stringify({ text }),
+    },
+  };
+}
+
+type Recorded = { messageId: string; namespace: string };
+
+function buildHandlerHarness() {
+  const handleMessage = vi.fn(async (_params: { event: FeishuMessageEvent }) => {});
+  const recorded: Recorded[] = [];
+  const processedSet = new Set<string>();
+  const hasProcessedMessage = vi.fn(async (messageId: string | undefined | null) => {
+    return Boolean(messageId) && processedSet.has(String(messageId));
+  });
+  const recordProcessedMessage = vi.fn(
+    async (messageId: string | undefined | null, namespace: string) => {
+      if (messageId) {
+        processedSet.add(messageId);
+        recorded.push({ messageId, namespace });
+      }
+      return true;
+    },
+  );
+  const handler = createFeishuMessageReceiveHandler({
+    cfg: buildCfg(),
+    core: buildCore(),
+    accountId: "default",
+    chatHistories: new Map(),
+    handleMessage,
+    resolveDebounceText: ({ event, botOpenId, botName }) =>
+      parseFeishuMessageEvent(event, botOpenId, botName).content,
+    hasProcessedMessage,
+    recordProcessedMessage,
+  });
+  return { handler, handleMessage, recordProcessedMessage, recorded };
+}
+
+describe("createFeishuMessageReceiveHandler audio dedupe (#75057)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("dispatches both audios when the same message_id is reused for distinct uploads", async () => {
+    const { handler, handleMessage } = buildHandlerHarness();
+
+    await handler(createAudioEvent({ messageId: "om_dup_distinct", fileKey: "audio_alpha" }));
+    await handler(createAudioEvent({ messageId: "om_dup_distinct", fileKey: "audio_beta" }));
+
+    expect(handleMessage).toHaveBeenCalledTimes(2);
+    const dispatched = handleMessage.mock.calls.map((call) => {
+      const params = call[0] as { event: FeishuMessageEvent };
+      const parsed = JSON.parse(params.event.message.content) as { file_key?: string };
+      return parsed.file_key;
+    });
+    expect(dispatched).toEqual(["audio_alpha", "audio_beta"]);
+  });
+
+  it("still drops a true repeat (same message_id and same file_key)", async () => {
+    const { handler, handleMessage } = buildHandlerHarness();
+
+    await handler(createAudioEvent({ messageId: "om_dup_repeat", fileKey: "audio_gamma" }));
+    await handler(createAudioEvent({ messageId: "om_dup_repeat", fileKey: "audio_gamma" }));
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("still drops duplicate text events with the same message_id", async () => {
+    const { handler, handleMessage } = buildHandlerHarness();
+
+    await handler(createTextEvent("om_text_dup_unique"));
+    await handler(createTextEvent("om_text_dup_unique"));
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -1,4 +1,5 @@
 import type { ClawdbotConfig, HistoryEntry, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
 import type { FeishuMessageEvent } from "./event-types.js";
 import { isMentionForwardRequest } from "./mention.js";
 import {
@@ -116,15 +117,15 @@ function dedupeFeishuDebounceEntriesByMessageId(
   const seen = new Set<string>();
   const deduped: FeishuMessageEvent[] = [];
   for (const entry of entries) {
-    const messageId = entry.message.message_id?.trim();
-    if (!messageId) {
+    const dedupeKey = resolveFeishuMessageDedupeKey(entry).trim();
+    if (!dedupeKey) {
       deduped.push(entry);
       continue;
     }
-    if (seen.has(messageId)) {
+    if (seen.has(dedupeKey)) {
       continue;
     }
-    seen.add(messageId);
+    seen.add(dedupeKey);
     deduped.push(entry);
   }
   return deduped;
@@ -219,20 +220,20 @@ export function createFeishuMessageReceiveHandler({
 
   const recordSuppressedMessageIds = async (
     entries: FeishuMessageEvent[],
-    dispatchMessageId?: string,
+    dispatchDedupeKey?: string,
   ) => {
-    const keepMessageId = dispatchMessageId?.trim();
-    const suppressedIds = new Set(
+    const keepKey = dispatchDedupeKey?.trim();
+    const suppressedKeys = new Set(
       entries
-        .map((entry) => entry.message.message_id?.trim())
-        .filter((id): id is string => Boolean(id) && (!keepMessageId || id !== keepMessageId)),
+        .map((entry) => resolveFeishuMessageDedupeKey(entry).trim())
+        .filter((key): key is string => Boolean(key) && (!keepKey || key !== keepKey)),
     );
-    for (const messageId of suppressedIds) {
+    for (const dedupeKey of suppressedKeys) {
       try {
-        await recordProcessedMessage(messageId, accountId, log);
+        await recordProcessedMessage(dedupeKey, accountId, log);
       } catch (err) {
         error(
-          `feishu[${accountId}]: failed to record merged dedupe id ${messageId}: ${String(err)}`,
+          `feishu[${accountId}]: failed to record merged dedupe id ${dedupeKey}: ${String(err)}`,
         );
       }
     }
@@ -269,7 +270,7 @@ export function createFeishuMessageReceiveHandler({
       const dedupedEntries = dedupeFeishuDebounceEntriesByMessageId(entries);
       const freshEntries: FeishuMessageEvent[] = [];
       for (const entry of dedupedEntries) {
-        if (!(await hasProcessedMessage(entry.message.message_id, accountId, log))) {
+        if (!(await hasProcessedMessage(resolveFeishuMessageDedupeKey(entry), accountId, log))) {
           freshEntries.push(entry);
         }
       }
@@ -277,7 +278,10 @@ export function createFeishuMessageReceiveHandler({
       if (!dispatchEntry) {
         return;
       }
-      await recordSuppressedMessageIds(dedupedEntries, dispatchEntry.message.message_id);
+      await recordSuppressedMessageIds(
+        dedupedEntries,
+        resolveFeishuMessageDedupeKey(dispatchEntry),
+      );
       const combinedText = freshEntries
         .map((entry) => resolveDebounceText(entry))
         .filter(Boolean)
@@ -302,7 +306,7 @@ export function createFeishuMessageReceiveHandler({
     },
     onError: (err, entries) => {
       for (const entry of entries) {
-        releaseFeishuMessageProcessing(entry.message.message_id, accountId);
+        releaseFeishuMessageProcessing(resolveFeishuMessageDedupeKey(entry), accountId);
       }
       error(`feishu[${accountId}]: inbound debounce flush failed: ${String(err)}`);
     },
@@ -314,9 +318,9 @@ export function createFeishuMessageReceiveHandler({
       error(`feishu[${accountId}]: ignoring malformed message event payload`);
       return;
     }
-    const messageId = event.message?.message_id?.trim();
-    if (!tryBeginFeishuMessageProcessing(messageId, accountId)) {
-      log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);
+    const dedupeKey = resolveFeishuMessageDedupeKey(event).trim();
+    if (!tryBeginFeishuMessageProcessing(dedupeKey, accountId)) {
+      log(`feishu[${accountId}]: dropping duplicate event for message ${dedupeKey}`);
       return;
     }
     const processMessage = async () => {
@@ -324,7 +328,7 @@ export function createFeishuMessageReceiveHandler({
     };
     if (fireAndForget) {
       void processMessage().catch((err) => {
-        releaseFeishuMessageProcessing(messageId, accountId);
+        releaseFeishuMessageProcessing(dedupeKey, accountId);
         error(`feishu[${accountId}]: error handling message: ${String(err)}`);
       });
       return;
@@ -332,7 +336,7 @@ export function createFeishuMessageReceiveHandler({
     try {
       await processMessage();
     } catch (err) {
-      releaseFeishuMessageProcessing(messageId, accountId);
+      releaseFeishuMessageProcessing(dedupeKey, accountId);
       error(`feishu[${accountId}]: error handling message: ${String(err)}`);
     }
   };


### PR DESCRIPTION
## What

Fixes #75057.

Feishu's inbound dedupe was keyed on `(account, message_id)` before media content was parsed, so when Feishu reused the same `message_id` across two distinct voice notes (observed in the wild on `2026.4.27`, macOS, with `minimax/m2.7`), the second voice note was silently dropped before reaching the agent.

## Why

`clawsweeper`'s triage on the issue confirmed the root cause: dedupe sees the event before media content is parsed, so it cannot tell two distinct `audio` payloads apart when the upstream `message_id` is reused. Telegram does not exhibit this because each Telegram message gets a unique id.

## How

Introduce a small helper `resolveFeishuMessageDedupeKey(event)` in a new `extensions/feishu/src/dedupe-key.ts`:

- Non-audio events: returns `message_id` unchanged (zero behavior change).
- Audio events with a parsable `file_key` in `event.message.content`: returns `${message_id}:audio:${file_key}` so each distinct upload is processed exactly once.
- Audio events without a parsable `file_key` (malformed JSON, missing/empty `file_key`): falls back to bare `message_id` to preserve existing behavior.

All four call sites in `extensions/feishu/src/monitor.message-handler.ts` were migrated to the helper:

1. `dedupeFeishuDebounceEntriesByMessageId` (in-flight debounce dedupe)
2. `recordSuppressedMessageIds` (persisting merged-flush dedupe ids)
3. `hasProcessedMessage` lookup in the debounce flush path
4. `tryBeginFeishuMessageProcessing` / `releaseFeishuMessageProcessing` in the synchronous receive path

`extensions/feishu/src/bot.ts` was updated to pass the same helper through to the inbound debounce supervisor so receive and dispatch paths agree on the key.

## Coverage

Two new test files (232 lines):

- `extensions/feishu/src/dedupe-key.test.ts` — 6 unit tests covering text/post/audio/audio-without-content/malformed-content/empty-file_key.
- `extensions/feishu/src/monitor.message-handler.audio-dedupe.test.ts` — 3 integration tests asserting:
  - Same `message_id` + **different** `file_key` → both audio events delivered (the bug).
  - Same `message_id` + **same** `file_key` → second event still dropped (regression guard).
  - Same `message_id` + text → second event still dropped (no behavior change for non-audio).

Verified locally:

\`\`\`
node scripts/run-vitest.mjs run extensions/feishu/
# → 63 files, 701 tests, all passing
npx oxlint extensions/feishu/src/{dedupe-key,monitor.message-handler,bot}.ts <new test files>
# → 0 warnings, 0 errors
\`\`\`

## Risk

- Behavior change is scoped to audio events with a parseable `file_key`. Every other message type takes exactly the same code path as before.
- Persisted dedupe records: the on-disk dedupe store now sees `${message_id}:audio:${file_key}` keys for new audio events. Existing entries from before this change remain valid (still bare `message_id`), so a deployed-during-flight audio with a reused id will be slightly more permissive across the upgrade boundary — acceptable because the buggy behavior was to drop, not double-deliver.
- `file_key` is a stable Feishu storage identifier, so two voice notes with the same id and same file_key are genuinely the same upload and should still dedupe.

## Out of scope

This PR only addresses the audio case from #75057. Image/file/sticker payloads also have `file_key`-style identifiers but are not part of the reported regression and are left unchanged to keep this fix minimal. If the same `message_id`-reuse symptom is observed on those types later, the helper is the obvious place to extend.