### PR TITLE
fix(agents): initialize context engines before cli-compaction resolves

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -167,4 +167,84 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(updatedEntry?.cliSessionIds?.["claude-cli"]).toBeUndefined();
     expect(updatedEntry?.claudeCliSessionId).toBeUndefined();
   });
+
+  it("initializes built-in context engines before resolving compaction context engine", async () => {
+    // Regression test for the cli-compaction equivalent of #73095.
+    // ensureContextEnginesInitialized must be called before resolveContextEngine
+    // or the resolver throws: 'Context engine "legacy" is not registered. Available engines: (none)'.
+    const sessionId = "init-order-session";
+    const sessionFile = path.join(tmpDir, `${sessionId}.jsonl`);
+    await writeSessionFile({ sessionFile, sessionId });
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      sessionFile,
+      contextTokens: 1_000,
+      currentTokenCount: 950,
+    };
+    const sessionKey = "agent:main";
+    const storePath = path.join(tmpDir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({ [sessionKey]: sessionEntry }, null, 2),
+      "utf-8",
+    );
+
+    let initialized = false;
+    const ensureContextEnginesInitializedMock = vi.fn(() => {
+      initialized = true;
+    });
+    const resolveContextEngineMock = vi.fn(async () => {
+      if (!initialized) {
+        throw new Error(
+          'Context engine "legacy" is not registered. Available engines: (none)',
+        );
+      }
+      return buildContextEngine({ compactCalls: [] });
+    });
+
+    setCliCompactionTestDeps({
+      ensureContextEnginesInitialized: ensureContextEnginesInitializedMock,
+      resolveContextEngine: resolveContextEngineMock,
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      })),
+    });
+
+    await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(ensureContextEnginesInitializedMock).toHaveBeenCalledTimes(1);
+    expect(resolveContextEngineMock).toHaveBeenCalledTimes(1);
+    expect(
+      ensureContextEnginesInitializedMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(resolveContextEngineMock.mock.invocationCallOrder[0]);
+  });
 });

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { ensureContextEnginesInitialized as ensureContextEnginesInitializedImpl } from "../../context-engine/init.js";
 import { resolveContextEngine as resolveContextEngineImpl } from "../../context-engine/registry.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -28,6 +29,7 @@ type SettingsManagerLike = {
 };
 type CliCompactionDeps = {
   openSessionManager: (sessionFile: string) => SessionManagerLike;
+  ensureContextEnginesInitialized: () => void;
   resolveContextEngine: (cfg: OpenClawConfig) => Promise<ContextEngine>;
   createPreparedEmbeddedPiSettingsManager: (params: {
     cwd: string;
@@ -49,6 +51,7 @@ const log = createSubsystemLogger("agents/cli-compaction");
 
 const cliCompactionDeps: CliCompactionDeps = {
   openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+  ensureContextEnginesInitialized: ensureContextEnginesInitializedImpl,
   resolveContextEngine: resolveContextEngineImpl,
   createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
   applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
@@ -65,6 +68,7 @@ export function setCliCompactionTestDeps(overrides: Partial<typeof cliCompaction
 export function resetCliCompactionTestDeps(): void {
   Object.assign(cliCompactionDeps, {
     openSessionManager: (sessionFile: string) => SessionManager.open(sessionFile),
+    ensureContextEnginesInitialized: ensureContextEnginesInitializedImpl,
     resolveContextEngine: resolveContextEngineImpl,
     createPreparedEmbeddedPiSettingsManager: createPreparedEmbeddedPiSettingsManagerImpl,
     applyPiAutoCompactionGuard: applyPiAutoCompactionGuardImpl,
@@ -195,6 +199,7 @@ export async function runCliTurnCompactionLifecycle(params: {
     return params.sessionEntry;
   }
 
+  cliCompactionDeps.ensureContextEnginesInitialized();
   const contextEngine = await cliCompactionDeps.resolveContextEngine(params.cfg);
   const sessionManager = cliCompactionDeps.openSessionManager(sessionFile);
   const settingsManager = await cliCompactionDeps.createPreparedEmbeddedPiSettingsManager({


### PR DESCRIPTION
## Summary

Mirrors PR #73904's init-order fix for the CLI compaction lane. Same bug class, second site, additive only (+85/-0).

PR #73904 added `ensureContextEnginesInitialized()` before `resolveContextEngine` in `prepareContextEngineSubagentSpawn` (subagent-spawn lane). The same `resolveContextEngine`-without-init pattern still exists in `cli-compaction.ts:198`, so the same `Context engine "legacy" is not registered. Available engines: (none)` error reproduces on cold CLI compaction runs.

## Why this exists separately

I flagged the second site in a review comment on #73904. Filing the follow-up here so #73904 stays focused on the subagent-spawn fix and this PR can be reviewed independently.

## What changes

- `src/agents/command/cli-compaction.ts`
  - Imports `ensureContextEnginesInitialized` from `context-engine/init.js`
  - Adds it to the `CliCompactionDeps` type, default deps object, and `resetCliCompactionTestDeps` reset object
  - Calls `cliCompactionDeps.ensureContextEnginesInitialized()` immediately before the existing `resolveContextEngine` call inside `runCliTurnCompactionLifecycle`

- `src/agents/command/cli-compaction.test.ts`
  - New test: `initializes built-in context engines before resolving compaction context engine`
  - Pattern mirrors the test added in #73904: `resolveContextEngine` mock throws the exact production error string when init wasn't called first, then asserts call ordering via `mock.invocationCallOrder`

## Verification

Local reproduction: openclaw 2026.4.25, claude-cli backend, OAuth-mode auth profile (matches issue #73095 install pattern). Tested via the new vitest case — fails on main, passes with the fix.

## Refs

- Fixes the cli-compaction half of #73095
- Companion to #73904 (subagent-spawn half)
