### PR TITLE
fix(gateway): raise default RPC timeout to 30s

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -634,7 +634,7 @@ describe("callGateway url resolution", () => {
     await vi.waitFor(() => {
       expect(eventLoopReadyState.calls).toHaveLength(1);
     });
-    expect(eventLoopReadyState.calls[0]?.maxWaitMs).toBe(10_000);
+    expect(eventLoopReadyState.calls[0]?.maxWaitMs).toBe(30_000);
     expect(lastClientOptions?.clientName).toBe(GATEWAY_CLIENT_NAMES.CLI);
     expect(startCalls).toBe(0);
 
@@ -965,6 +965,24 @@ describe("callGateway error details", () => {
     expect(eventLoopReadyState.calls[0]?.maxWaitMs).toBe(5);
     expect(lastClientOptions).not.toBeNull();
     expect(startCalls).toBe(0);
+  });
+
+  it("uses a 30s default wrapper timeout", async () => {
+    startMode = "silent";
+    setLocalLoopbackGatewayConfig();
+
+    vi.useFakeTimers();
+    let errMessage = "";
+    const promise = callGateway({ method: "health" }).catch((caught) => {
+      errMessage = caught instanceof Error ? caught.message : String(caught);
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(errMessage).toBe("");
+    await vi.advanceTimersByTimeAsync(20_000);
+    await promise;
+
+    expect(errMessage).toContain("gateway timeout after 30000ms");
   });
 
   it("keeps the default wrapper timeout aligned with configured handshake timeout", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -368,6 +368,8 @@ type ResolvedGatewayCallContext = {
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
 
+const DEFAULT_GATEWAY_CALL_TIMEOUT_MS = 30_000;
+
 function resolveGatewayCallTimeout(
   timeoutValue: unknown,
   configuredHandshakeTimeoutMs?: number | null,
@@ -389,9 +391,10 @@ function resolveGatewayCallTimeout(
   const timeoutMs =
     typeof timeoutValue === "number" && Number.isFinite(timeoutValue)
       ? timeoutValue
-      : typeof resolvedHandshakeTimeoutMs === "number" && resolvedHandshakeTimeoutMs > 10_000
+      : typeof resolvedHandshakeTimeoutMs === "number" &&
+          resolvedHandshakeTimeoutMs > DEFAULT_GATEWAY_CALL_TIMEOUT_MS
         ? resolvedHandshakeTimeoutMs
-        : 10_000;
+        : DEFAULT_GATEWAY_CALL_TIMEOUT_MS;
   const safeTimerTimeoutMs = resolveSafeTimeoutDelayMs(timeoutMs);
   return { timeoutMs, safeTimerTimeoutMs };
 }


### PR DESCRIPTION
## Summary
- raise the default Gateway RPC wrapper timeout from 10s to 30s
- keep explicit per-call `timeoutMs` behavior unchanged
- keep longer configured/env handshake timeouts overriding the 30s default

## Verification
- Hotfix applied separately to installed bundle on Clawdbot-1: `/usr/lib/node_modules/openclaw/dist/call-lSOkBlVy.js` now defaults to `3e4`; backup saved as `/usr/lib/node_modules/openclaw/dist/call-lSOkBlVy.js.pre-riley-gateway-timeout-30s-20260430`
- `node --check /usr/lib/node_modules/openclaw/dist/call-lSOkBlVy.js`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/call.test.ts --maxWorkers=1` → 79 passed
- `git diff --check`
- `pnpm exec oxfmt --check src/gateway/call.ts src/gateway/call.test.ts --threads=1`
- `pnpm exec oxlint src/gateway/call.ts src/gateway/call.test.ts`
- `pnpm exec tsx --no-cache -e "import('./src/gateway/call.ts').then(()=>console.log('call import ok'))"`

## Deploy
Do not deploy from this PR until reviewed/approved. Avi requested code only, no deployment.