### PR TITLE
fix(gateway): preserve err.stack when chat.send/agent attachment parsing fails

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -633,12 +633,23 @@ export const agentHandlers: GatewayRequestHandlers = {
         // etc.). Map it to UNAVAILABLE so clients can retry without treating it as
         // a bad request. All other errors are input-validation failures → 4xx.
         const isServerFault = err instanceof MediaOffloadError;
+        // String(err) drops err.stack, leaving operators with no way to locate
+        // a synchronous Error thrown deep inside parseMessageWithAttachments
+        // (e.g. RangeError "Maximum call stack size exceeded"). Log the full
+        // stack here; keep the response surface minimal.
+        const stackText =
+          err instanceof Error ? (err.stack ?? `${err.name}: ${err.message}`) : String(err);
+        context.logGateway.error(
+          `agent: parseMessageWithAttachments failed (kind=${
+            isServerFault ? "media-offload" : "invalid"
+          }): ${stackText}`,
+        );
         respond(
           false,
           undefined,
           errorShape(
             isServerFault ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
+            err instanceof Error ? `${err.name}: ${err.message}` : String(err),
           ),
         );
         return;

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -415,7 +415,9 @@ function createChatContext(): Pick<
       ],
     registerToolEventRecipient: vi.fn(),
     logGateway: {
+      info: vi.fn(),
       warn: vi.fn(),
+      error: vi.fn(),
       debug: vi.fn(),
     } as unknown as GatewayRequestContext["logGateway"],
   };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2021,12 +2021,25 @@ export const chatHandlers: GatewayRequestHandlers = {
           agentId,
         }));
       } catch (err) {
+        const isServerFault = err instanceof MediaOffloadError;
+        // String(err) drops err.stack, so a synchronous RangeError ("Maximum
+        // call stack size exceeded") or any other Error thrown deep inside
+        // parseMessageWithAttachments / prestageMediaPathOffloads becomes
+        // unattributable in production. Log the full stack here so operators
+        // can find the recursing frame; keep the response surface minimal.
+        const stackText =
+          err instanceof Error ? (err.stack ?? `${err.name}: ${err.message}`) : String(err);
+        context.logGateway.error(
+          `chat.send: parseMessageWithAttachments failed (kind=${
+            isServerFault ? "media-offload" : "invalid"
+          }): ${stackText}`,
+        );
         respond(
           false,
           undefined,
           errorShape(
-            err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
+            isServerFault ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+            err instanceof Error ? `${err.name}: ${err.message}` : String(err),
           ),
         );
         return;


### PR DESCRIPTION
## Summary

- **Problem:** Webchat \`chat.send\` (and the \`agent\` handler) wraps \`parseMessageWithAttachments\` in \`catch (err) { respond(..., String(err)) }\`. \`String(err)\` discards \`err.stack\`, so any synchronous Error thrown deep inside the attachment-parse pipeline (\`parseMessageWithAttachments\` → \`prestageMediaPathOffloads\` → \`saveMediaBuffer\` → \`detectMime\`/\`fileTypeFromBuffer\`, etc.) becomes unattributable in production logs.
- **Why it matters:** Live failures show up as \`INVALID_REQUEST: RangeError: Maximum call stack size exceeded\` returned to the UI with **no matching gateway log line carrying the originating frames**. Operators have no way to find the recursing function. Issue #63432 reports this exact pattern for image sends from iPad/Tailscale; the same code path is hit by every non-image attachment too (PDF uploads, etc.).
- **What changed:** In both catch blocks, log the full \`err.stack\` (or \`name: message\` fallback) via \`context.logGateway.error(...)\` before responding. The response message becomes \`\${err.name}: \${err.message}\` for Error instances.
- **What did NOT change (scope boundary):** Protocol classification (\`UNAVAILABLE\` for \`MediaOffloadError\`, \`INVALID_REQUEST\` otherwise), best-effort orphan cleanup, \`acceptNonImage\` semantics, sandbox staging, dispatcher wiring — all untouched. Strictly a diagnostics + response-text refinement.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #63432 (Control UI on iPad/Tailscale fails on image send with \`RangeError: Maximum call stack size exceeded\`)
- [x] This PR fixes a bug or regression

This PR does **not** \`Closes #63432\` because it does not eliminate the underlying RangeError — it makes the underlying RangeError diagnosable (you'll get the full stack in \`gateway.err.log\`) so the next PR can target the actual recursing frame.

## Root Cause (if applicable)

- **Root cause:** \`String(err)\` on an \`Error\` returns \`\"<Name>: <message>\"\` and silently drops \`err.stack\`. The handler also never logs the error — only the response carries it. So a \`RangeError\` produced by, e.g., a regex with deep backtracking, a recursive \`structuredClone\`, or a recursive parser inside a sniff library leaves no trace.
- **Missing detection / guardrail:** No structured logging at the handler boundary for the attachment-parse failure path. Other catch blocks in the same files do call \`context.logGateway.warn/info\`; only this one is silent.
- **Contributing context (if known):** The same \`String(err)\` pattern exists in **both** \`chat.send\` (chat.ts:2023) and the \`agent\` handler (agent.ts:631). Patching one but not the other would leave a parallel blind spot.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: \`src/gateway/server-methods/chat.directive-tags.test.ts\` already exercises the catch path for \`MediaOffloadError → UNAVAILABLE\` with the \`/ENOSPC|non-image attachments/i\` regex (line ~2768). The existing assertion still passes after this change because \`String(new MediaOffloadError(\"ENOSPC ...\"))\` and \`\${err.name}: \${err.message}\` produce identical output for native Error subclasses. No new test added in this PR.
- Scenario the test should lock in (for the follow-up PR that targets the actual RangeError): assert that when \`parseMessageWithAttachments\` throws a synchronous \`RangeError\`, the gateway logs the stack at \`error\` level. That requires injecting a stub that throws — a small new test with a mocked \`parseMessageWithAttachments\` would do it. Out of scope here (this PR is the diagnostic enabler).
- Why this is the smallest reliable guardrail: The bug surfaces only with specific attachment payloads, so a unit test would need a contrived stub. The seam-level assertion on logged \`error\` is the more durable contract.
- Existing test that already covers this (if any): The existing \`MediaOffloadError\` case at chat.directive-tags.test.ts:~2740 covers the response-shape side; this PR keeps that contract stable.
- If no new test is added, why not: Keeping the change minimal and behavior-preserving. The next PR (root-cause fix once the stack is captured) will land the regression test for whichever recursing frame turns out to be at fault.

## User-visible / Behavior Changes

- The error \`message\` field on the JSON-RPC response goes from \`\"Error: foo\"\` (\`String(err)\`) to \`\"Error: foo\"\` (\`\${err.name}: \${err.message}\`) — **identical output** for native \`Error\`/subclass instances, because \`Error.prototype.toString\` already returns \`\"Name: message\"\`. Non-Error throws (\`throw \"x\"\`, \`throw 42\`) still surface as \`String(err)\`. No behavior change for clients.
- New log lines at \`error\` level, in \`gateway.err.log\`:
  - \`chat.send: parseMessageWithAttachments failed (kind=invalid|media-offload): <stack>\`
  - \`agent: parseMessageWithAttachments failed (kind=invalid|media-offload): <stack>\`

## Diagram (if applicable)

\`\`\`text
Before:
[bad attachment] -> parseMessageWithAttachments throws RangeError
                 -> catch (err) { respond(\"RangeError: Maximum call stack size exceeded\") }
                 -> client sees terse string; gateway log has nothing.

After:
[bad attachment] -> parseMessageWithAttachments throws RangeError
                 -> catch (err) { logGateway.error(<full stack>); respond(<terse string>) }
                 -> operator can grep gateway.err.log and find the recursing frame.
\`\`\`

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** (the attachment label/filename was already inside the response message via \`String(err)\`; logging it to the error log does not expand its blast radius)

## Repro + Verification

### Environment

- OS: macOS 15.3 (Darwin 25.3.0)
- Runtime/container: Node.js v24.8.0 via nvm; openclaw 2026.4.26 (be8c246) installed via \`npm i -g openclaw\`
- Model/provider: bailian/glm-5.1 (text-only)
- Integration/channel (if any): webchat (Control UI)
- Relevant config (redacted): default gateway on 127.0.0.1:18789, single \`agent:main:main\` session

### Steps

1. Drag a 4.3 MB PDF (e.g. \`DeepSeek_V4.pdf\`) into the Control UI chat composer.
2. Send any prompt referring to the PDF.
3. Observe \`chat.send\` returns \`INVALID_REQUEST: RangeError: Maximum call stack size exceeded\`.

### Expected

After this patch, \`gateway.err.log\` contains a stack-bearing line:
\`\`\`
chat.send: parseMessageWithAttachments failed (kind=invalid): RangeError: Maximum call stack size exceeded
    at <recursing frame>
    at ...
\`\`\`

### Actual

Confirmed locally by patching the equivalent dist file and triggering the same catch with deliberately invalid base64. Output:
\`\`\`
RESPONSE: {\"ok\":false,\"error\":{\"code\":\"INVALID_REQUEST\",\"message\":\"Error: attachment bad.pdf: invalid base64 content\"}}
=== logGateway.error calls ===
chat.send: parseMessageWithAttachments failed (kind=invalid): Error: attachment bad.pdf: invalid base64 content
    at parseMessageWithAttachments (.../attachment-normalize-Bl3b9I5G.js:175:35)
    at chat.send (.../chat-CTjpvvH8.js:1841:26)
    at ...
=== Verdict ===
PASS: stack-bearing log captured
\`\`\`

## Evidence

- [x] Failing test/log before + passing after (offline trigger output above)
- [x] Trace/log snippets (see \"Actual\")
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Patched the equivalent code in the locally installed dist file and confirmed the new \`logGateway.error\` line appears with full stack.
  - Confirmed the response \`error.message\` for an \`Error\` instance is byte-identical to the previous \`String(err)\` output.
  - Confirmed both files (\`chat.ts\`, \`agent.ts\`) compile via \`node --check\` against the equivalent post-build dist.
- Edge cases checked:
  - Non-Error throws (\`throw \"x\"\`) still produce \`String(err)\` in the response.
  - \`MediaOffloadError\` continues to map to \`UNAVAILABLE\`.
  - The existing best-effort \`savedMediaIds\` cleanup inside \`parseMessageWithAttachments\` is unchanged.
- What I did **not** verify:
  - Did not run \`pnpm build && pnpm check && pnpm test\` (would require the full ~742 MB checkout and dependency install). The change is mechanical and behavior-preserving on the response path; CI on the PR will exercise the existing tests.
  - Did not yet identify the actual recursing frame causing the original RangeError — that is the explicit purpose of this PR (enable diagnosis), and the follow-up PR will target it.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: \`err.stack\` for a deeply chained internal Error could include long paths and noise.
  - Mitigation: Only logged at \`error\` level (already the gateway's noisiest channel); not surfaced to clients; trimmed implicitly by node's default V8 stack-trace limit.
- Risk: A future change adds a \`toString\` override on a custom Error subclass and starts producing different text from \`name: message\`.
  - Mitigation: Native \`Error.prototype.toString\` is exactly \`name: message\`. Any subclass that depends on a custom \`toString\` for the response text would already be a poor fit for \`String(err)\` semantics; falling through this branch is acceptable.