### PR TITLE
docs: recommend apple-notes-native as low-friction alternative (#75123)

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -350,7 +350,21 @@ lives on the [First-run FAQ](/help/faq-first-run).
   </Accordion>
 
   <Accordion title="Can I run Apple macOS-only skills from Linux?">
-    Not directly. macOS skills are gated by `metadata.openclaw.os` plus required binaries, and skills only appear in the system prompt when they are eligible on the **Gateway host**. On Linux, `darwin`-only skills (like `apple-notes`, `apple-reminders`, `things-mac`) will not load unless you override the gating.
+    Yes, if you have a **macOS node** connected to your Linux Gateway. The agent will execute the skill on the Mac node via the `exec` tool.
+  </Accordion>
+
+  <Accordion title="Is there a native Apple Notes skill that doesn't require extra CLI tools?">
+    Yes. While the default `apple-notes` skill requires the `memo` CLI, you can install the **`apple-notes-native`** skill (by `lishix520`) from ClawHub. It uses native macOS AppleScript (osascript) and has no external binary dependencies.
+
+    Install it via:
+    ```bash
+    openclaw skills install lishix520/apple-notes-native
+    ```
+
+  </Accordion>
+
+  <Accordion title="Gating macOS skills on Linux">
+    macOS skills are gated by `metadata.openclaw.os` plus required binaries, and skills only appear in the system prompt when they are eligible on the **Gateway host**. On Linux, `darwin`-only skills (like `apple-notes`, `apple-reminders`, `things-mac`) will not load unless you override the gating.
 
     You have three supported patterns:
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -354,12 +354,14 @@ lives on the [First-run FAQ](/help/faq-first-run).
   </Accordion>
 
   <Accordion title="Is there a native Apple Notes skill that doesn't require extra CLI tools?">
-    Yes. While the default `apple-notes` skill requires the `memo` CLI, you can install the **`apple-notes-native`** skill (by `lishix520`) from ClawHub. It uses native macOS AppleScript (osascript) and has no external binary dependencies.
+    Yes. While the default `apple-notes` skill requires the `memo` CLI, you can find native macOS alternatives on ClawHub that use `osascript` with no external binary dependencies.
 
-    Install it via:
+    Search for available options via:
     ```bash
-    openclaw skills install lishix520/apple-notes-native
+    openclaw skills search apple-notes
     ```
+
+    A common community choice is `apple-notes-native`.
 
   </Accordion>
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -60,10 +60,7 @@ The node reports a `permissions` map so agents can decide what’s allowed.
 
 ### Native productivity skills
 
-For macOS-only workflows, we recommend using native-first skills that leverage AppleScript (osascript) to avoid external CLI dependencies:
-
-- **Apple Notes:** Use `apple-notes-native` (by `lishix520`) for direct interaction with Notes.app without the `memo` CLI wrapper.
-- **Things 3:** Use the bundled `things-mac` skill.
+For macOS-only workflows, you can find native-first skills on ClawHub that leverage AppleScript (osascript) to avoid external CLI dependencies (e.g., searching for `apple-notes-native` to avoid the `memo` CLI wrapper).
 
 Node service + app IPC:
 

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -58,6 +58,13 @@ The macOS app presents itself as a node. Common commands:
 
 The node reports a `permissions` map so agents can decide what’s allowed.
 
+### Native productivity skills
+
+For macOS-only workflows, we recommend using native-first skills that leverage AppleScript (osascript) to avoid external CLI dependencies:
+
+- **Apple Notes:** Use `apple-notes-native` (by `lishix520`) for direct interaction with Notes.app without the `memo` CLI wrapper.
+- **Things 3:** Use the bundled `things-mac` skill.
+
 Node service + app IPC:
 
 - When the headless node host service is running (remote mode), it connects to the Gateway WS as a node.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -78,15 +78,16 @@ Notes
 
 ## Native Alternative (No `memo` dependency)
 
-If you want a lower-friction setup that doesn't require installing the `memo` CLI, we recommend the `apple-notes-native` skill by `lishix520`. It uses native macOS AppleScript (osascript) for automation.
+If you want a lower-friction setup that doesn't require installing the `memo` CLI, you can find native macOS AppleScript-based skills on ClawHub.
 
-**Install:**
+**Search and Install:**
 
 ```bash
-openclaw skills install lishix520/apple-notes-native
+openclaw skills search apple-notes
+openclaw skills install apple-notes-native
 ```
 
-Benefits:
+Benefits of native-first alternatives:
 
 - No third-party binary dependencies (no `memo` brew tap needed).
 - Direct interaction with Notes.app via official automation APIs.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -75,3 +75,25 @@ Notes
 - macOS-only.
 - Requires Apple Notes.app to be accessible.
 - For automation, grant permissions in System Settings > Privacy & Security > Automation.
+
+## Native Alternative (No `memo` dependency)
+
+If you want a lower-friction setup that doesn't require installing the `memo` CLI, we recommend the `apple-notes-native` skill by `lishix520`. It uses native macOS AppleScript (osascript) for automation.
+
+**Install:**
+
+```bash
+openclaw skills install lishix520/apple-notes-native
+```
+
+Benefits:
+
+- No third-party binary dependencies (no `memo` brew tap needed).
+- Direct interaction with Notes.app via official automation APIs.
+- Simpler setup for macOS-only environments.
+
+**Caveats:**
+
+- **Automation Permissions:** Requires "Automation" access for Notes.app in macOS System Settings.
+- **Reliability:** AppleScript (osascript) can occasionally be slower than direct binary access.
+- **UI Context:** Notes.app may need to be open or in a specific state for some operations.


### PR DESCRIPTION
## Summary

Guide macOS users to find native alternatives on ClawHub to reduce setup friction.

- **Problem:** The default Apple Notes skill depends on the `memo` CLI, which requires a third-party Homebrew tap.
- **Why it matters:** macOS users prefer native-first solutions with minimal dependencies.
- **What changed:** 
  - Updated documentation to explain how to search for native macOS skills on ClawHub.
  - Added instructions for the `apple-notes-native` community skill.
- **What did NOT change:** No core code was modified; follows `VISION.md` by documenting extension points while keeping skill discovery in ClawHub.

## Change Type
- [x] Docs

## Scope
- [x] Skills / tool execution
- [x] UI / DX

## Linked Issue/PR
- Closes #75123
