### PR TITLE
fix(cli): exit with code 78 on EADDRINUSE to prevent systemd restart loop (#75115)

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -386,7 +386,7 @@ describe("gateway-cli coverage", () => {
         );
         await expect(
           runGatewayCommand(["gateway", "--token", "test-token", "--allow-unconfigured"]),
-        ).rejects.toThrow("__exit__:0");
+        ).rejects.toThrow("__exit__:78");
 
         expect(startGatewayServer).toHaveBeenCalled();
         expect(runtimeErrors.join("\n")).toContain("Gateway failed to start:");

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -850,7 +850,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       }
       const { maybeExplainGatewayServiceStop } = await import("./shared.js");
       await maybeExplainGatewayServiceStop();
-      defaultRuntime.exit(isHealthyGatewayLockError(err) ? 0 : 1);
+      defaultRuntime.exit(isHealthyGatewayLockError(err) ? EXIT_CONFIG_ERROR : 1);
       return;
     }
     await maybeWriteGatewayStartupFailureBundle(err);


### PR DESCRIPTION
## Summary

When `openclaw gateway` fails to bind due to EADDRINUSE (another instance already listening), it now exits with code 78 (EX_CONFIG) instead of 0.

Closes #75115

## Problem

When `openclaw gateway restart` is used with a systemd service configured with `Restart=always`:

1. `openclaw gateway restart` sends SIGTERM to the running gateway
2. systemd TimeoutStopSec fires → SIGKILL
3. systemd immediately spawns a new gateway (Restart=always)
4. `openclaw gateway restart` also spawns its own child process
5. Two processes race for port 18789
6. The loser gets EADDRINUSE, exits with code 0 (isHealthyGatewayLockError)
7. systemd sees exit 0 and restarts again (Restart=always restarts on ANY exit)
8. Loop continues with 19+ retry attempts, each burning CPU

## Fix

Change the exit code for healthy lock errors (EADDRINUSE / gateway already running) from 0 to 78 (`EXIT_CONFIG_ERROR`). This matches the existing `RestartPreventExitStatus=78` configuration in the systemd service file, which tells systemd to stop restarting.

Exit code 78 (`EX_CONFIG` from sysexits.h) is already used elsewhere in the codebase for configuration-related failures (lines 565, 706, 767, 797 of run.ts). The constant `EXIT_CONFIG_ERROR = 78` is defined at line 101.

## Testing

All related tests pass:
- `gateway-cli.coverage.test.ts` — 13 tests pass (updated expected exit code from 0 to 78)
- `run.supervised-lock.test.ts` — 4 tests pass
- `http-listen.test.ts` — 3 tests pass

## Risk Assessment

**Low risk.** The only behavior change is the exit code for a specific error path:
- Previously: exit 0 (success) — confused systemd into restarting
- Now: exit 78 (config error) — systemd respects RestartPreventExitStatus=78
- Non-systemd users: exit 78 instead of 0 on port conflict; no other behavioral impact
- The `isHealthyGatewayLockError` guard is unchanged — only the exit code differs



## Context vs. related PR

This change intentionally exits with `78` (EX_CONFIG) instead of `0`, which is a narrower and more systemd-safe fix than the existing #44476 approach.

- `Restart=always` + `RestartPreventExitStatus=78` stops the restart storm on port conflict.
- `Restart=on-failure` also stops the restart storm, because `RestartPreventExitStatus` takes precedence even though exit 78 is non-zero.
- Exit `0` can silently confuse lifecycle tooling: it looks like a clean successful run, even though startup failed.
- Exit `78` makes the failure explicit while still preventing restart loops, so it is safer for both systemd and launchd supervisors.

So this is a safer drop-in alternative to the exit-0 behavior described in #44476.
