### PR TITLE
docs: use American "behavior" spelling per contribution guide

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -164,7 +164,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
     - `skipSignatureVerification` is for local testing only.
     - On ngrok free tier, set `publicUrl` to the exact ngrok URL; signature verification is always enforced.
     - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Local dev only.
-    - Ngrok free-tier URLs can change or add interstitial behaviour; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
+    - Ngrok free-tier URLs can change or add interstitial behavior; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
 
   </Accordion>
   <Accordion title="Streaming connection caps">
@@ -203,7 +203,7 @@ realtime transcription providers.
 audio mode per call.
 </Warning>
 
-Current runtime behaviour:
+Current runtime behavior:
 
 - `realtime.enabled` is supported for Twilio Media Streams.
 - `realtime.provider` is optional. If unset, Voice Call uses the first registered realtime voice provider.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -519,7 +519,7 @@ Two ways to start an ACP session:
 </ParamField>
 <ParamField path="mode" type='"run" | "session"' default="run">
   `"run"` is one-shot; `"session"` is persistent. If `thread: true` and
-  `mode` is omitted, OpenClaw may default to persistent behaviour per
+  `mode` is omitted, OpenClaw may default to persistent behavior per
   runtime path. `mode: "session"` requires `thread: true`.
 </ParamField>
 <ParamField path="cwd" type="string">


### PR DESCRIPTION
## What

Replaces the three remaining `behaviour` occurrences in `docs/` with `behavior`.

| File | Line | Context |
| --- | --- | --- |
| `docs/plugins/voice-call.md` | 167 | "interstitial behaviour" |
| `docs/plugins/voice-call.md` | 206 | "Current runtime behaviour:" |
| `docs/tools/acp-agents.md` | 522 | "default to persistent behaviour" |

## Why

[`CONTRIBUTING.md:126`](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md#L126) explicitly says:

> Use American English spelling and grammar in code, comments, docs, and UI strings

The rest of `docs/` already follows this — `behavior` appears in 252 files, `behaviour` in only these two.

## Coverage

`grep -rn "behaviour" docs/` after the change → 0 results. No code paths touched, no tests affected.

## Risk

None. Documentation prose only; no API names, UI strings, or external identifiers were renamed.