### PR TITLE
docs(media): clarify provider credentials for media understanding

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -137,6 +137,41 @@ Each `models[]` entry can be **provider** or **CLI**:
   </Tab>
 </Tabs>
 
+### Provider credentials
+
+Provider model entries do **not** take an `apiKey` field inside `tools.media`. Media understanding uses the same provider credential sources as the rest of OpenClaw, so configure credentials before enabling provider-based image, audio, or video understanding.
+
+Use one of these credential sources:
+
+- Provider auth profiles created by `openclaw models auth login ...` when the provider supports them.
+- Provider environment variables such as `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `ANTHROPIC_API_KEY`, or the provider-specific key documented on that provider page.
+- `models.providers.<providerId>` entries for custom or OpenAI-compatible providers.
+
+For example, a custom provider referenced by a media model should define its key under `models.providers`:
+
+```json5
+{
+  models: {
+    providers: {
+      moonshot: {
+        apiKey: "${MOONSHOT_API_KEY}",
+        baseUrl: "https://api.moonshot.ai/v1",
+      },
+    },
+  },
+  tools: {
+    media: {
+      video: {
+        enabled: true,
+        models: [{ provider: "moonshot", model: "kimi-k2.5" }],
+      },
+    },
+  },
+}
+```
+
+If media understanding reports that an API key cannot be found, check the provider auth/profile or `models.providers.<providerId>` configuration first; adding `apiKey` to the `tools.media.*.models[]` entry will not be read.
+
 ## Defaults and limits
 
 Recommended defaults:


### PR DESCRIPTION
## Summary
- document that tools.media provider entries do not read apiKey directly
- point users to auth profiles, provider env vars, or models.providers.<providerId>
- add a working custom-provider config example for media understanding

Fixes #51054

## Verification
- pnpm dlx markdownlint-cli2 docs/nodes/media-understanding.md
- git diff --check