### PR TITLE
fix: preserve Codex OAuth stream auth

### DIFF
--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -300,4 +300,43 @@ describe("buildProviderStreamFamilyHooks", () => {
     expect(OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn).toBeTypeOf("function");
     expect(TOOL_STREAM_DEFAULT_ON_HOOKS.wrapStreamFn).toBeTypeOf("function");
   });
+
+  it("keeps Codex OAuth auth injection when adding OpenAI attribution headers", () => {
+    let called = false;
+    let capturedApiKey: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      called = true;
+      capturedApiKey = options?.apiKey;
+      capturedHeaders = options?.headers;
+      return {} as never;
+    };
+
+    const openAiHooks = OPENAI_RESPONSES_STREAM_HOOKS;
+    const wrapped = requireStreamFn(
+      requireWrapStreamFn(openAiHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        config: {},
+        agentDir: "/tmp/provider-stream-test",
+      } as never),
+    );
+
+    void wrapped(
+      {
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        id: "gpt-5.5",
+      } as never,
+      {} as never,
+      { apiKey: "oauth-access-token" },
+    );
+
+    expect(called).toBe(true);
+    expect(capturedApiKey).toBe("oauth-access-token");
+    expect(capturedHeaders).toMatchObject({
+      originator: "openclaw",
+      "User-Agent": expect.stringMatching(/^openclaw\//),
+    });
+  });
 });

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -103,7 +103,9 @@ export function buildProviderStreamFamilyHooks(
     case "openai-responses-defaults":
       return {
         wrapStreamFn: (ctx: ProviderWrapStreamFnContext) => {
-          let nextStreamFn = createOpenAIAttributionHeadersWrapper(ctx.streamFn);
+          let nextStreamFn = createOpenAIAttributionHeadersWrapper(ctx.streamFn, {
+            codexNativeTransportStreamFn: ctx.streamFn,
+          });
 
           if (resolveOpenAIFastMode(ctx.extraParams)) {
             nextStreamFn = createOpenAIFastModeWrapper(nextStreamFn);


### PR DESCRIPTION
## What
Preserve the authenticated OpenAI Codex stream function when OpenAI Responses provider hooks add attribution headers.

## Why
Codex OAuth credentials were resolving successfully, but the OpenAI Responses wrapper rebuilt the native Codex transport instead of wrapping the already-authenticated stream function. That bypassed the runner's OAuth injection and could send Codex requests with an invalid or missing bearer token, causing 401 responses even after a successful Codex login.

## Changes
- Preserve Codex stream auth
- Keep attribution headers
- Add regression coverage

## Testing
- `PATH=/Users/phaedrus/.local/share/mise/installs/node/22.17.0/bin:$PATH pnpm test src/plugin-sdk/provider-stream.test.ts`
- Live Telegram/Codex retry showed `embedded run agent end ... isError=false` and `telegram sendMessage ok chat=-1003774691294 message=14441`.
- Not run: `pnpm check:changed` in Blacksmith Testbox because `blacksmith testbox warmup ci-check-testbox.yml --ref main --idle-timeout 90` failed with `not authenticated` before provisioning a box.
