### PR TITLE
fix(build): preserve native crypto binaries in staged runtime deps

### DIFF
--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -104,6 +104,52 @@ export function writeLegacyCliExitCompatChunks(params = {}) {
   }
 }
 
+/**
+ * Copy native platform binaries that are downloaded at install time by
+ * postinstall scripts. The staged runtime dep install runs with
+ * --ignore-scripts, so postinstall hooks (e.g. native crypto downloads)
+ * never execute. After staging completes, copy the native artifacts from
+ * the source node_modules into the staged dist tree so they remain
+ * available at runtime.
+ */
+export function copyNativeRuntimeDepBinaries(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const fsImpl = params.fs ?? fs;
+  const warn = params.warn ?? console.warn;
+
+  const nativeArtifacts = [
+    {
+      // @matrix-org/matrix-sdk-crypto-nodejs downloads a platform-specific
+      // .node binary via postinstall (download-lib.js). The staged install
+      // uses --ignore-scripts, so we must copy this manually.
+      src: "node_modules/@matrix-org/matrix-sdk-crypto-nodejs",
+      destDir: "dist/extensions/matrix/node_modules/@matrix-org/matrix-sdk-crypto-nodejs",
+      match: (name) => name.endsWith(".node"),
+      label: "matrix-sdk-crypto (native binary)",
+    },
+  ];
+
+  for (const { src, destDir, match, label } of nativeArtifacts) {
+    const srcDir = path.join(rootDir, src);
+    const targetDir = path.join(rootDir, destDir);
+    if (!fsImpl.existsSync(srcDir)) {
+      warn(`[runtime-postbuild] native artifact source not found, skipping: ${label}`);
+      continue;
+    }
+    if (!fsImpl.existsSync(targetDir)) {
+      warn(`[runtime-postbuild] native artifact dest not found, skipping: ${label}`);
+      continue;
+    }
+    const entries = fsImpl.readdirSync(srcDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (match(entry.name)) {
+        fsImpl.copyFileSync(path.join(srcDir, entry.name), path.join(targetDir, entry.name));
+      }
+    }
+  }
+}
+
 export function runRuntimePostBuild(params = {}) {
   const timingsEnabled = params.timings ?? process.env.OPENCLAW_RUNTIME_POSTBUILD_TIMINGS !== "0";
   const runPhase = (label, action) => {
@@ -121,6 +167,7 @@ export function runRuntimePostBuild(params = {}) {
   runPhase("bundled plugin metadata", () => copyBundledPluginMetadata(params));
   runPhase("official channel catalog", () => writeOfficialChannelCatalog(params));
   runPhase("bundled plugin runtime deps", () => stageBundledPluginRuntimeDeps(params));
+  runPhase("native runtime dep binaries", () => copyNativeRuntimeDepBinaries(params));
   runPhase("bundled plugin runtime overlay", () => stageBundledPluginRuntime(params));
   runPhase("stable root runtime aliases", () => writeStableRootRuntimeAliases(params));
   runPhase("legacy CLI exit compat chunks", () => writeLegacyCliExitCompatChunks(params));


### PR DESCRIPTION
## Problem

Matrix connectivity breaks after every `pnpm build` / gateway update because the native crypto binary is missing from the dist tree.

**Root cause:** `@matrix-org/matrix-sdk-crypto-nodejs` downloads its platform-specific `.node` binary (12MB) via a `postinstall` script. The build's runtime dependency staging runs `npm install --ignore-scripts`, which skips postinstall entirely. The dist tree gets JS wrappers but no native binary.

## Fix

Adds `copyNativeRuntimeDepBinaries()` — a new phase in `runtime-postbuild` that runs after staged dep install. It copies native `.node` binaries from source `node_modules` into the staged dist tree. Currently covers `matrix-sdk-crypto-nodejs`; structured so additional native deps can be added via the config array.

## Testing

- Unit tested: normal copy, idempotent re-run, missing source (warns), missing dest (warns)
- Integration tested: full `pnpm build` verified native binary present in dist
- Edge cases: all handled with warnings, no crashes

## Related

- `--ignore-scripts` is in `scripts/lib/bundled-runtime-deps-install.mjs` — this fix works with it rather than removing it (removing `--ignore-scripts` would be risky for other deps)
- The prune config in `bundled-runtime-deps-prune.mjs` only removes docs/types from matrix-sdk-crypto, not the binary — the binary was never being placed, not being pruned