### PR TITLE
fix(gateway): filter transcript-only assistant messages from chat.history

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -11,6 +11,7 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { coerceChatContentText } from "../shared/chat-content.js";
 import {
+  isTranscriptOnlyOpenClawAssistantMessage,
   parseAssistantTextSignature,
   resolveAssistantMessagePhase,
   type AssistantPhase,
@@ -40,15 +41,6 @@ import {
 
 function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
   return resolveAssistantMessagePhase(message) === "commentary";
-}
-
-function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage | undefined): boolean {
-  if (!message || message.role !== "assistant") {
-    return false;
-  }
-  const provider = normalizeOptionalString(message.provider) ?? "";
-  const model = normalizeOptionalString(message.model) ?? "";
-  return provider === "openclaw" && (model === "delivery-mirror" || model === "gateway-injected");
 }
 
 function isOpenAiResponsesAssistantMessage(message: AgentMessage | undefined): boolean {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -37,6 +37,7 @@ import { normalizeInputProvenance, type InputProvenance } from "../../sessions/i
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/chat-message-content.js";
 import {
   stripInlineDirectiveTagsForDisplay,
   sanitizeReplyDirectiveId,
@@ -1664,11 +1665,15 @@ export const chatHandlers: GatewayRequestHandlers = {
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const localMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+    // Filter out transcript-only assistant messages (delivery-mirror,
+    // gateway-injected). They are bookkeeping entries appended to the JSONL
+    // after a successful delivery; surfacing them to chat clients renders
+    // verbatim duplicates of the real assistant turn.
     const rawMessages = augmentChatHistoryWithCliSessionImports({
       entry,
       provider: resolvedSessionModel.provider,
       localMessages,
-    });
+    }).filter((message) => !isTranscriptOnlyOpenClawAssistantMessage(message));
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -3,6 +3,7 @@ import {
   extractAssistantTextForPhase,
   extractAssistantVisibleText,
   extractFirstTextBlock,
+  isTranscriptOnlyOpenClawAssistantMessage,
   resolveAssistantMessagePhase,
 } from "./chat-message-content.js";
 
@@ -195,5 +196,125 @@ describe("resolveAssistantMessagePhase", () => {
         ],
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("isTranscriptOnlyOpenClawAssistantMessage", () => {
+  it("returns true for delivery-mirror assistant messages", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "hey" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for gateway-injected assistant messages", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "gateway-injected",
+        content: [{ type: "text", text: "synthetic" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("trims whitespace around provider and model before comparing", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "  openclaw  ",
+        model: " delivery-mirror ",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for real assistant messages from real providers", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        content: [{ type: "text", text: "hey" }],
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.4",
+        content: [{ type: "text", text: "hey" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when provider is openclaw but model is not a transcript-only marker", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "some-other-model",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user messages even when shaped like a transcript-only marker", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "user",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "hi" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for tool, system, and other roles", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "tool",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "system",
+        provider: "openclaw",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null, undefined, and non-object inputs", () => {
+    expect(isTranscriptOnlyOpenClawAssistantMessage(null)).toBe(false);
+    expect(isTranscriptOnlyOpenClawAssistantMessage(undefined)).toBe(false);
+    expect(isTranscriptOnlyOpenClawAssistantMessage("delivery-mirror")).toBe(false);
+    expect(isTranscriptOnlyOpenClawAssistantMessage(42)).toBe(false);
+  });
+
+  it("returns false when provider or model fields are missing or non-string", () => {
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: "openclaw",
+      }),
+    ).toBe(false);
+    expect(
+      isTranscriptOnlyOpenClawAssistantMessage({
+        role: "assistant",
+        provider: 123,
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -205,3 +205,31 @@ export function extractAssistantVisibleText(message: unknown): string | undefine
   }
   return extractAssistantTextForPhase(message);
 }
+
+/**
+ * OpenClaw appends "transcript-only" assistant messages to the session JSONL as
+ * bookkeeping after a successful delivery (`delivery-mirror`) or when the
+ * gateway synthesizes a placeholder turn (`gateway-injected`). Both are tagged
+ * with provider `"openclaw"` and a reserved model id.
+ *
+ * Chat-surface consumers (TUI, web chat, `chat.history` responses) must filter
+ * these out before rendering. Otherwise they appear as duplicate assistant
+ * turns immediately after the real reply, since the mirror copies the visible
+ * text verbatim. Pi-embedded subscribers already use this discriminator at
+ * three call sites; this helper is the shared canonical home.
+ */
+export function isTranscriptOnlyOpenClawAssistantMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const record = message as { role?: unknown; provider?: unknown; model?: unknown };
+  if (record.role !== "assistant") {
+    return false;
+  }
+  const provider = typeof record.provider === "string" ? record.provider.trim() : "";
+  if (provider !== "openclaw") {
+    return false;
+  }
+  const model = typeof record.model === "string" ? record.model.trim() : "";
+  return model === "delivery-mirror" || model === "gateway-injected";
+}


### PR DESCRIPTION
## What this fixes

`chat.history` currently returns `delivery-mirror` and `gateway-injected` assistant messages alongside real assistant turns. These are transcript-only bookkeeping entries appended after a successful delivery, not user-visible turns. Chat-surface consumers that render every assistant-role message (the TUI on every `loadHistory` after a run, web chat on history reload, anything similar) display them as verbatim duplicates of the real reply.

Observed in the TUI: every iMessage round-trip rendered the assistant text twice, immediately back-to-back, even though the actual messaging channel (iPhone iMessage) only received one message. The transcript on disk is correct; the user-facing duplication comes from chat-surface consumers re-rendering the mirror.

## Why this fix point

OpenClaw already documents and tests the contract that these messages are transcript-only:

- `src/agents/pi-embedded-subscribe.handlers.messages.ts` had a private `isTranscriptOnlyOpenClawAssistantMessage` helper used at three call sites in agent-end handling.
- `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts` has a passing test asserting "ignores delivery-mirror assistant messages".
- `src/gateway/session-utils.fs.ts` already does a parallel `isDeliveryMirror` check when computing usage stats so they aren't double-counted.

The contract was just missing one consumer: the `chat.history` server method that surfaces transcript messages to clients. Fixing it there means TUI, web chat, and any future client get the same view without each having to repeat the filter, which keeps the contract enforced at the gateway boundary.

## Change shape

- Promotes `isTranscriptOnlyOpenClawAssistantMessage` to `src/shared/chat-message-content.ts` as an exported, `unknown`-input predicate. It now lives next to `extractAssistantVisibleText` and friends.
- Replaces the local function in `src/agents/pi-embedded-subscribe.handlers.messages.ts` with the imported one. Three existing call sites continue to work unchanged.
- Adds one `.filter(...)` call in `chat.history` (`src/gateway/server-methods/chat.ts`) right after `augmentChatHistoryWithCliSessionImports`. Filter runs before slice/sanitize/cap so existing budget logic is unaffected.

Net: +156 / -10 across four files. Behavior change is scoped to `chat.history` consumers; agent-end handling, transcript persistence, and usage stats are unchanged.

## Tests

Added 9 unit tests in `src/shared/chat-message-content.test.ts` covering:

- `delivery-mirror` and `gateway-injected` both classified as transcript-only.
- Whitespace tolerance on provider/model.
- Real provider/model pairs (`anthropic/claude-opus-4-7`, `openai/gpt-5.4`) classified as visible.
- Role mismatches (user/tool/system) not classified as transcript-only even with matching provider/model.
- Null, undefined, primitive, and shape-mismatched inputs.

Existing 5 tests in `pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts` continue to pass, confirming the refactor preserves agent-end behavior.

## Gates

- `pnpm check:changed`: clean. Lint + runtime import cycles green.
- `pnpm test:changed`: 925 + 21 + 12 + 93 test files green across the touched lanes. The single failure is `test/scripts/run-opengrep.test.ts` failing on `mapfile: command not found` (macOS bash 3.2 vs `mapfile` requirement) which is unrelated to this change and reproduces on `origin/main`.
- `pnpm build`: clean.

## Is this the best possible fix?

Yes, with high confidence:

1. The contract is already in core (helper + tests + 3 existing call sites). This change closes the consumer gap, it doesn't introduce new policy.
2. Server-side filter beats per-client filter: TUI is one consumer, but web chat and any future client benefit from the same gateway-boundary guarantee. No need to repeat the filter in each client.
3. The discriminator (`provider === "openclaw" && model === "delivery-mirror" | "gateway-injected"`) is precise; misclassification risk is near zero. Real assistant turns carry their own provider/model identity (anthropic/claude-opus-4-7, openai/gpt-5.4, etc.) and never match.
4. Mirror entries remain in the JSONL on disk regardless; the filter only affects what `chat.history` sends to clients. No data loss, easy rollback (revert the commit).

## Rollback

If a regression appears: revert this commit. The mirror entries are preserved in the session JSONL (transcript bookkeeping unchanged), so no data is lost. Reverting just restores the prior behavior of `chat.history` returning them in the response.
