### PR TITLE
fix(infra): honor OPENCLAW_STATE_DIR for exec-approvals.json (#75204)

### DIFF
--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -197,8 +198,8 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const DEFAULT_SOCKET_FILENAME = "exec-approvals.sock";
+const DEFAULT_FILENAME = "exec-approvals.json";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -208,11 +209,13 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  // Honor OPENCLAW_STATE_DIR so the approvals file lands in the configured
+  // state directory rather than the legacy ~/.openclaw default (#75204).
+  return path.join(resolveStateDir(), DEFAULT_FILENAME);
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), DEFAULT_SOCKET_FILENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
## Summary

- **Problem:** with `OPENCLAW_STATE_DIR=~/openclaw`, exec-approvals.json (and its IPC socket) still landed in `~/.openclaw/`. `openclaw doctor` then warned 'Multiple state directories detected' because two roots existed for one install. Reported in #75204.
- **Root cause:** `resolveExecApprovalsPath()` and `resolveExecApprovalsSocketPath()` in `src/infra/exec-approvals.ts` hard-coded `~/.openclaw/...` and called `expandHomePrefix()`, which doesn't honor `OPENCLAW_STATE_DIR`. Other infra paths (`device-auth-store.ts`, `restart-sentinel.ts`, `push-web.ts`, `allow-from-store-file.ts`) already route through `resolveStateDir()`.
- **What changed:** the two resolver functions now `path.join(resolveStateDir(), ...)` so `OPENCLAW_STATE_DIR` is consistently honored alongside the rest of openclaw's persistent state layout.

## Linked Issue

- Closes #75204
- [x] This PR fixes a bug or regression

## Test Plan

- [x] `pnpm tsgo:core` — clean
- [x] `pnpm exec oxfmt --check --threads=1 src/infra/exec-approvals.ts` — clean