### PR TITLE
fix(security): require pinned npm specs for trusted installs

### DIFF
--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -137,7 +137,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     );
   });
 
-  it("offers registry npm specs without requiring an exact version or integrity pin", async () => {
+  it("does not offer npm installs for unpinned or unverified registry specs", async () => {
     let captured:
       | {
           options: Array<{ value: "npm" | "local" | "skip"; label: string; hint?: string }>;
@@ -163,11 +163,31 @@ describe("ensureOnboardingPluginInstalled", () => {
       runtime: {} as never,
     });
 
-    expect(captured?.options).toEqual([
-      { value: "npm", label: "Download from npm (@demo/plugin)" },
-      { value: "skip", label: "Skip for now" },
-    ]);
-    expect(captured?.initialValue).toBe("npm");
+    expect(captured?.options).toEqual([{ value: "skip", label: "Skip for now" }]);
+    expect(captured?.initialValue).toBe("skip");
+    expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
+
+    await ensureOnboardingPluginInstalled({
+      cfg: {},
+      entry: {
+        pluginId: "demo-plugin",
+        label: "Demo Plugin",
+        install: {
+          npmSpec: "@demo/plugin@latest",
+          expectedIntegrity: "sha512-demo",
+        },
+      },
+      prompter: {
+        select: vi.fn(async (input) => {
+          captured = input;
+          return "skip";
+        }),
+      } as never,
+      runtime: {} as never,
+    });
+
+    expect(captured?.options).toEqual([{ value: "skip", label: "Skip for now" }]);
+    expect(captured?.initialValue).toBe("skip");
     expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
   });
 

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -196,8 +196,15 @@ function resolveNpmSpecForOnboarding(install: PluginPackageInstall): string | nu
   if (!npmSpec) {
     return null;
   }
+  const expectedIntegrity = install.expectedIntegrity?.trim();
+  if (!expectedIntegrity) {
+    return null;
+  }
   const parsed = parseRegistryNpmSpec(npmSpec);
-  return parsed ? npmSpec : null;
+  if (!parsed || parsed.selectorKind !== "exact-version") {
+    return null;
+  }
+  return npmSpec;
 }
 
 function resolveInstallDefaultChoice(params: {

--- a/src/plugins/provider-install-catalog.test.ts
+++ b/src/plugins/provider-install-catalog.test.ts
@@ -219,7 +219,7 @@ describe("provider install catalog", () => {
     });
   });
 
-  it("exposes trusted registry npm specs without requiring an exact version or integrity pin", () => {
+  it("does not expose unpinned or unverified trusted npm specs", () => {
     discoverOpenClawPlugins.mockReturnValue({
       candidates: [
         {
@@ -258,19 +258,29 @@ describe("provider install catalog", () => {
       },
     ]);
 
-    expect(resolveProviderInstallCatalogEntry("vllm")).toEqual({
-      pluginId: "vllm",
-      providerId: "vllm",
-      methodId: "server",
-      choiceId: "vllm",
-      choiceLabel: "vLLM",
-      label: "vLLM",
-      origin: "config",
-      install: {
-        npmSpec: "@openclaw/vllm",
-        defaultChoice: "npm",
-      },
+    expect(resolveProviderInstallCatalogEntry("vllm")).toBeUndefined();
+
+    discoverOpenClawPlugins.mockReturnValue({
+      candidates: [
+        {
+          idHint: "vllm",
+          origin: "config",
+          rootDir: "/Users/test/.openclaw/extensions/vllm",
+          source: "/Users/test/.openclaw/extensions/vllm/index.js",
+          packageName: "@openclaw/vllm",
+          packageDir: "/Users/test/.openclaw/extensions/vllm",
+          packageManifest: {
+            install: {
+              npmSpec: "@openclaw/vllm@latest",
+              expectedIntegrity: "sha512-vllm",
+            },
+          },
+        },
+      ],
+      diagnostics: [],
     });
+
+    expect(resolveProviderInstallCatalogEntry("vllm")).toBeUndefined();
   });
 
   it("does not expose npm install specs from untrusted package metadata", () => {

--- a/src/plugins/provider-install-catalog.ts
+++ b/src/plugins/provider-install-catalog.ts
@@ -64,8 +64,15 @@ function resolveTrustedNpmSpec(params: {
   if (!npmSpec) {
     return undefined;
   }
+  const expectedIntegrity = params.install?.expectedIntegrity?.trim();
+  if (!expectedIntegrity) {
+    return undefined;
+  }
   const parsed = parseRegistryNpmSpec(npmSpec);
-  return parsed ? npmSpec : undefined;
+  if (!parsed || parsed.selectorKind !== "exact-version") {
+    return undefined;
+  }
+  return npmSpec;
 }
 
 function resolveInstallInfo(params: {


### PR DESCRIPTION
### Motivation
- Prevent a supply-chain regression where onboarding or provider catalogs could offer unpinned registry installs (bare names or dist-tags) that execute unverified code with operator privileges.

### Description
- Require an `expectedIntegrity` pin and an exact-version registry selector before offering npm installs in onboarding by tightening `resolveNpmSpecForOnboarding` in `src/commands/onboarding-plugin-install.ts`.
- Apply the same gating in `resolveTrustedNpmSpec` in `src/plugins/provider-install-catalog.ts` so only `bundled`/`config` origins with exact-version + integrity are exposed as trusted installs.
- Update tests in `src/commands/onboarding-plugin-install.test.ts` and `src/plugins/provider-install-catalog.test.ts` to assert that bare package names, dist-tags, or missing integrity pins are rejected.

### Testing
- Ran `pnpm test src/commands/onboarding-plugin-install.test.ts src/plugins/provider-install-catalog.test.ts` and the updated unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d0c87c3c8320819ea06ed8bbdf3b)