### PR TITLE
fix(exec-approvals): honor OPENCLAW_STATE_DIR for exec-approvals.json and .sock

### DIFF
--- a/src/infra/exec-approvals-effective.ts
+++ b/src/infra/exec-approvals-effective.ts
@@ -3,6 +3,7 @@ import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   DEFAULT_EXEC_APPROVAL_ASK_FALLBACK,
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalsPath,
   type ExecApprovalDecision,
   maxAsk,
   minSecurity,
@@ -15,7 +16,6 @@ import {
 
 const DEFAULT_REQUESTED_SECURITY: ExecSecurity = "full";
 const DEFAULT_REQUESTED_ASK: ExecAsk = "off";
-const DEFAULT_HOST_PATH = "~/.openclaw/exec-approvals.json";
 const REQUESTED_DEFAULT_LABEL = {
   security: DEFAULT_REQUESTED_SECURITY,
   ask: DEFAULT_REQUESTED_ASK,
@@ -234,7 +234,7 @@ export function resolveExecPolicyScopeSnapshot(params: {
       ask: requestedAsk.value,
     },
   });
-  const hostPath = params.hostPath ?? DEFAULT_HOST_PATH;
+  const hostPath = params.hostPath ?? resolveExecApprovalsPath();
   const effectiveSecurity = minSecurity(requestedSecurity.value, resolved.agent.security);
   const effectiveAsk = maxAsk(requestedAsk.value, resolved.agent.ask);
   const effectiveAskFallback = minSecurity(effectiveSecurity, resolved.agent.askFallback);

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -21,7 +21,10 @@ import {
   normalizeExecTarget,
   normalizeExecSecurity,
   requiresExecApproval,
+  resolveExecApprovalsPath,
 } from "./exec-approvals.js";
+
+const APPROVALS_PATH = resolveExecApprovalsPath();
 
 function expectMalformedAgentAskUsesDefaults(agentAsk: unknown): void {
   const approvals = {
@@ -48,7 +51,7 @@ function expectMalformedAgentAskUsesDefaults(agentAsk: unknown): void {
   expect(summary.ask).toMatchObject({
     requested: "off",
     host: "always",
-    hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+    hostSource: `${APPROVALS_PATH} defaults.ask`,
     effective: "always",
     note: "more aggressive ask wins",
   });
@@ -276,19 +279,19 @@ describe("exec approvals policy helpers", () => {
       requested: "full",
       host: "allowlist",
       effective: "allowlist",
-      hostSource: "~/.openclaw/exec-approvals.json defaults.security",
+      hostSource: `${APPROVALS_PATH} defaults.security`,
       note: "stricter host security wins",
     });
     expect(summary.ask).toMatchObject({
       requested: "off",
       host: "always",
       effective: "always",
-      hostSource: "~/.openclaw/exec-approvals.json defaults.ask",
+      hostSource: `${APPROVALS_PATH} defaults.ask`,
       note: "more aggressive ask wins",
     });
     expect(summary.askFallback).toEqual({
       effective: "deny",
-      source: "~/.openclaw/exec-approvals.json defaults.askFallback",
+      source: `${APPROVALS_PATH} defaults.askFallback`,
     });
   });
 
@@ -362,7 +365,7 @@ describe("exec approvals policy helpers", () => {
 
     expect(summary.askFallback).toEqual({
       effective: "allowlist",
-      source: "~/.openclaw/exec-approvals.json defaults.askFallback",
+      source: `${APPROVALS_PATH} defaults.askFallback`,
     });
   });
 
@@ -406,15 +409,15 @@ describe("exec approvals policy helpers", () => {
 
     expect(summary.security).toMatchObject({
       host: "allowlist",
-      hostSource: "~/.openclaw/exec-approvals.json agents.*.security",
+      hostSource: `${APPROVALS_PATH} agents.*.security`,
     });
     expect(summary.ask).toMatchObject({
       host: "always",
-      hostSource: "~/.openclaw/exec-approvals.json agents.*.ask",
+      hostSource: `${APPROVALS_PATH} agents.*.ask`,
     });
     expect(summary.askFallback).toEqual({
       effective: "deny",
-      source: "~/.openclaw/exec-approvals.json agents.*.askFallback",
+      source: `${APPROVALS_PATH} agents.*.askFallback`,
     });
   });
 
@@ -537,11 +540,11 @@ describe("exec approvals policy helpers", () => {
     expect(snapshots.map((snapshot) => snapshot.scopeLabel)).toEqual(["tools.exec"]);
     expect(snapshots[0]?.security).toMatchObject({
       host: "allowlist",
-      hostSource: "~/.openclaw/exec-approvals.json agents.main.security",
+      hostSource: `${APPROVALS_PATH} agents.main.security`,
     });
     expect(snapshots[0]?.ask).toMatchObject({
       host: "always",
-      hostSource: "~/.openclaw/exec-approvals.json agents.main.ask",
+      hostSource: `${APPROVALS_PATH} agents.main.ask`,
     });
   });
 

--- a/src/infra/exec-approvals.test.ts
+++ b/src/infra/exec-approvals.test.ts
@@ -1,9 +1,11 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { normalizeSafeBins } from "./exec-approvals-allowlist.js";
 import {
   makeMockCommandResolution,
   makeMockExecutableResolution,
 } from "./exec-approvals-test-helpers.js";
+import { resolveExecApprovalsPath, resolveExecApprovalsSocketPath } from "./exec-approvals.js";
 import { evaluateExecAllowlist, type ExecAllowlistEntry } from "./exec-approvals.js";
 
 describe("exec approvals allowlist evaluation", () => {
@@ -233,5 +235,24 @@ describe("exec approvals allowlist evaluation", () => {
     expect(result.allowlistSatisfied).toBe(true);
     expect(result.allowlistMatches.map((entry) => entry.pattern)).toEqual(["/usr/bin/tool"]);
     expect(result.segmentSatisfiedBy).toEqual(["allowlist", "safeBins"]);
+  });
+});
+
+describe("resolveExecApprovalsPath / resolveExecApprovalsSocketPath", () => {
+  it("honors OPENCLAW_STATE_DIR override (regression #75204)", () => {
+    const original = process.env.OPENCLAW_STATE_DIR;
+    try {
+      process.env.OPENCLAW_STATE_DIR = "/custom/state";
+      expect(resolveExecApprovalsPath()).toBe(path.join("/custom/state", "exec-approvals.json"));
+      expect(resolveExecApprovalsSocketPath()).toBe(
+        path.join("/custom/state", "exec-approvals.sock"),
+      );
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = original;
+      }
+    }
   });
 });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -197,8 +198,8 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const EXEC_APPROVALS_FILENAME = "exec-approvals.json";
+const EXEC_APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -208,11 +209,11 @@ function hashExecApprovalsRaw(raw: string | null): string {
 }
 
 export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_FILENAME);
 }
 
 export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+  return path.join(resolveStateDir(), EXEC_APPROVALS_SOCKET_FILENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
## Summary

`exec-approvals.json` and `exec-approvals.sock` were hardcoded to `~/.openclaw` regardless of `OPENCLAW_STATE_DIR`, creating a split-state condition when the env var is set. Users with `OPENCLAW_STATE_DIR=~/openclaw` saw the active state dir used for sessions and config, but `exec-approvals.json` still written to `~/.openclaw` — triggering `openclaw doctor` warnings about multiple state directories.

**Root cause:** `DEFAULT_FILE = "~/.openclaw/exec-approvals.json"` and `DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock"` were expanded with `expandHomePrefix` rather than `resolveStateDir()`. Other infra files (`device-identity.ts`, `voicewake.ts`, `push-web.ts`) already correctly use `resolveStateDir()`.

**Fix:**
- Replace hardcoded constants with `path.join(resolveStateDir(), filename)` in `resolveExecApprovalsPath()` and `resolveExecApprovalsSocketPath()`
- Remove now-unused `DEFAULT_FILE` / `DEFAULT_SOCKET` constants
- Update `exec-approvals-effective.ts` `DEFAULT_HOST_PATH` to use `resolveExecApprovalsPath()` instead

**Test:**
- New regression test: `OPENCLAW_STATE_DIR=/custom/state` → both paths resolve under `/custom/state`
- Updated 10 policy test expectations to derive `hostSource` from `resolveExecApprovalsPath()` rather than the literal `~/.openclaw` string (so tests work on any machine/config)
- 49/49 tests pass

Fixes #75204.