### PR TITLE
Add Vesicle native OpenClaw channel

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -21,11 +21,12 @@ Text is supported everywhere; media and reactions vary by channel.
 
 ## Supported channels
 
-- [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (bundled plugin; edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
+- [Vesicle](/channels/vesicle) — Native iMessage bridge via Vesicle's REST API (bundled plugin; text send/probe first, native inbound webhook in progress).
+- [BlueBubbles](/channels/bluebubbles) — iMessage via the BlueBubbles macOS server REST API with full feature support (bundled plugin; edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
 - [Discord](/channels/discord) — Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (bundled plugin).
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.
-- [iMessage (legacy)](/channels/imessage) — Legacy macOS integration via imsg CLI (deprecated, use BlueBubbles for new setups).
+- [iMessage (legacy)](/channels/imessage) — Legacy macOS integration via imsg CLI (deprecated; use Vesicle or BlueBubbles for new setups).
 - [IRC](/channels/irc) — Classic IRC servers; channels + DMs with pairing/allowlist controls.
 - [LINE](/channels/line) — LINE Messaging API bot (bundled plugin).
 - [Matrix](/channels/matrix) — Matrix protocol (bundled plugin).

--- a/docs/channels/vesicle.md
+++ b/docs/channels/vesicle.md
@@ -1,0 +1,67 @@
+---
+summary: "iMessage via Vesicle's native REST API."
+read_when:
+  - Setting up Vesicle native iMessage support
+  - Migrating away from BlueBubbles compatibility
+  - Debugging Vesicle send/probe behavior
+title: "Vesicle"
+sidebarTitle: "Vesicle"
+---
+
+Status: bundled channel for Vesicle's native API. The first native surface supports
+health probes and text sends to existing Messages chats. Native inbound webhooks are
+the next migration step.
+
+## Quick start
+
+Configure OpenClaw with the Vesicle server URL and bearer token:
+
+```json5
+{
+  channels: {
+    vesicle: {
+      enabled: true,
+      serverUrl: "http://127.0.0.1:1234",
+      authToken: "example-token",
+    },
+  },
+}
+```
+
+Then start the gateway and verify channel status:
+
+```bash
+openclaw gateway
+openclaw status channels vesicle
+```
+
+## Sending
+
+The initial native send route targets existing chats by Messages chat GUID:
+
+```bash
+openclaw deliver --channel vesicle --to "chat_guid:iMessage;-;+15551234567" "hello"
+openclaw deliver --channel vesicle --to "chat_guid:iMessage;+;chat123" "hello group"
+```
+
+Plain phone-number or email targets are intentionally rejected until Vesicle exposes
+a native chat lookup/create route. Use `chat_guid:<GUID>` during the migration window.
+
+## Native API
+
+OpenClaw uses:
+
+- `GET /api/v1/vesicle/health`
+- `GET /api/v1/vesicle/capabilities`
+- `POST /api/v1/vesicle/message/text`
+
+Requests use `Authorization: Bearer <authToken>`.
+
+Unsupported BlueBubbles-only features remain disabled on this channel: reactions,
+edits, unsend, effects, attachments, and group management.
+
+## Migration Notes
+
+`channels.bluebubbles` can continue to run against Vesicle's compatibility routes
+while `channels.vesicle` is introduced. To remove BlueBubbles from the required stack,
+finish the native webhook path and cut over inbound routing to `channels.vesicle`.

--- a/docs/channels/vesicle.md
+++ b/docs/channels/vesicle.md
@@ -8,9 +8,8 @@ title: "Vesicle"
 sidebarTitle: "Vesicle"
 ---
 
-Status: bundled channel for Vesicle's native API. The first native surface supports
-health probes and text sends to existing Messages chats. Native inbound webhooks are
-the next migration step.
+Status: bundled channel for Vesicle's native API. The native surface supports
+health probes, text sends to existing Messages chats, and inbound message webhooks.
 
 ## Quick start
 
@@ -23,6 +22,7 @@ Configure OpenClaw with the Vesicle server URL and bearer token:
       enabled: true,
       serverUrl: "http://127.0.0.1:1234",
       authToken: "example-token",
+      webhookSecret: "shared-hmac-secret",
     },
   },
 }
@@ -57,6 +57,28 @@ OpenClaw uses:
 
 Requests use `Authorization: Bearer <authToken>`.
 
+## Inbound Webhooks
+
+When `webhookSecret` is configured, OpenClaw starts a native Vesicle webhook
+listener at `/vesicle-webhook` by default. Set `webhookPath` to use a different
+route.
+
+Vesicle should `POST` JSON to the OpenClaw gateway with
+`X-Vesicle-Signature: sha256=<hex hmac>`, where the HMAC is SHA-256 over the raw
+request body using `webhookSecret`.
+
+```json
+{
+  "messageGuid": "msg-1",
+  "chatGuid": "iMessage;-;+15551234567",
+  "isGroup": false,
+  "sender": "+15551234567",
+  "service": "iMessage",
+  "date": 1777000000,
+  "text": "hello"
+}
+```
+
 Unsupported BlueBubbles-only features remain disabled on this channel: reactions,
 edits, unsend, effects, attachments, and group management.
 
@@ -64,4 +86,5 @@ edits, unsend, effects, attachments, and group management.
 
 `channels.bluebubbles` can continue to run against Vesicle's compatibility routes
 while `channels.vesicle` is introduced. To remove BlueBubbles from the required stack,
-finish the native webhook path and cut over inbound routing to `channels.vesicle`.
+cut over inbound routing to the native Vesicle webhook and remove the compatibility
+channel once all send targets use `chat_guid:<GUID>`.

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -82,6 +82,10 @@ Scope intent:
 - `channels.irc.accounts.*.nickserv.password`
 - `channels.bluebubbles.password`
 - `channels.bluebubbles.accounts.*.password`
+- `channels.vesicle.authToken`
+- `channels.vesicle.webhookSecret`
+- `channels.vesicle.accounts.*.authToken`
+- `channels.vesicle.accounts.*.webhookSecret`
 - `channels.feishu.appSecret`
 - `channels.feishu.encryptKey`
 - `channels.feishu.verificationToken`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -366,6 +366,34 @@
       "optIn": true
     },
     {
+      "id": "channels.vesicle.accounts.*.authToken",
+      "configFile": "openclaw.json",
+      "path": "channels.vesicle.accounts.*.authToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.vesicle.accounts.*.webhookSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.vesicle.accounts.*.webhookSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.vesicle.authToken",
+      "configFile": "openclaw.json",
+      "path": "channels.vesicle.authToken",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
+      "id": "channels.vesicle.webhookSecret",
+      "configFile": "openclaw.json",
+      "path": "channels.vesicle.webhookSecret",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.zalo.accounts.*.botToken",
       "configFile": "openclaw.json",
       "path": "channels.zalo.accounts.*.botToken",

--- a/extensions/vesicle/.npmignore
+++ b/extensions/vesicle/.npmignore
@@ -1,0 +1,8 @@
+dist/
+node_modules/
+*.log
+src/**/*.test.ts
+src/**/test-*.ts
+src/**/*test-helpers.ts
+src/**/*test-harness.ts
+src/**/*test-support.ts

--- a/extensions/vesicle/README.md
+++ b/extensions/vesicle/README.md
@@ -1,0 +1,34 @@
+# OpenClaw Vesicle Channel
+
+Vesicle is an OpenClaw channel plugin for sending and receiving iMessage traffic through the Vesicle native macOS bridge.
+
+## Install
+
+From a local checkout:
+
+```sh
+openclaw plugins install -l ./extensions/vesicle
+```
+
+From a packed tarball:
+
+```sh
+openclaw plugins install ./openclaw-vesicle-2026.4.25.tgz
+```
+
+Configure the channel under `channels.vesicle`:
+
+```json5
+{
+  channels: {
+    vesicle: {
+      enabled: true,
+      serverUrl: "http://127.0.0.1:1234",
+      authToken: "vesicle-auth-token",
+      webhookSecret: "shared-webhook-secret",
+    },
+  },
+}
+```
+
+The default webhook path is `/vesicle-webhook`.

--- a/extensions/vesicle/README.md
+++ b/extensions/vesicle/README.md
@@ -16,6 +16,12 @@ From a packed tarball:
 openclaw plugins install ./openclaw-vesicle-2026.4.25.tgz
 ```
 
+For a fast local install smoke from the OpenClaw checkout:
+
+```sh
+pnpm test:plugins:vesicle-install
+```
+
 Configure the channel under `channels.vesicle`:
 
 ```json5

--- a/extensions/vesicle/api.ts
+++ b/extensions/vesicle/api.ts
@@ -9,6 +9,15 @@ export { vesiclePlugin } from "./src/channel.js";
 export { type VesicleProbe, probeVesicle } from "./src/probe.js";
 export { type VesicleSendResult, sendMessageVesicle } from "./src/send.js";
 export {
+  handleVesicleWebhookRequest,
+  parseVesicleWebhookPayload,
+  registerVesicleWebhookTarget,
+  resolveConfiguredVesicleWebhookSecret,
+  resolveVesicleWebhookPath,
+  signVesicleWebhookBody,
+  verifyVesicleWebhookSignature,
+} from "./src/webhook.js";
+export {
   inferVesicleTargetChatType,
   looksLikeVesicleExplicitTargetId,
   normalizeVesicleMessagingTarget,

--- a/extensions/vesicle/api.ts
+++ b/extensions/vesicle/api.ts
@@ -1,0 +1,19 @@
+export {
+  listEnabledVesicleAccounts,
+  listVesicleAccountIds,
+  resolveDefaultVesicleAccountId,
+  type ResolvedVesicleAccount,
+  resolveVesicleAccount,
+} from "./src/accounts.js";
+export { vesiclePlugin } from "./src/channel.js";
+export { type VesicleProbe, probeVesicle } from "./src/probe.js";
+export { type VesicleSendResult, sendMessageVesicle } from "./src/send.js";
+export {
+  inferVesicleTargetChatType,
+  looksLikeVesicleExplicitTargetId,
+  normalizeVesicleMessagingTarget,
+  parseVesicleTarget,
+  resolveVesicleOutboundSessionRoute,
+  type VesicleTarget,
+} from "./src/targets.js";
+export { getVesicleRuntime, setVesicleRuntime } from "./src/runtime.js";

--- a/extensions/vesicle/channel-config-api.ts
+++ b/extensions/vesicle/channel-config-api.ts
@@ -1,0 +1,1 @@
+export { VesicleChannelConfigSchema } from "./src/config-schema.js";

--- a/extensions/vesicle/channel-plugin-api.ts
+++ b/extensions/vesicle/channel-plugin-api.ts
@@ -1,0 +1,1 @@
+export { vesiclePlugin } from "./src/channel.js";

--- a/extensions/vesicle/index.ts
+++ b/extensions/vesicle/index.ts
@@ -1,0 +1,20 @@
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelEntry({
+  id: "vesicle",
+  name: "Vesicle",
+  description: "Vesicle native iMessage channel plugin",
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./channel-plugin-api.js",
+    exportName: "vesiclePlugin",
+  },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
+  runtime: {
+    specifier: "./runtime-api.js",
+    exportName: "setVesicleRuntime",
+  },
+});

--- a/extensions/vesicle/openclaw.plugin.json
+++ b/extensions/vesicle/openclaw.plugin.json
@@ -4,6 +4,142 @@
     "onStartup": false
   },
   "channels": ["vesicle"],
+  "channelConfigs": {
+    "vesicle": {
+      "label": "Vesicle",
+      "description": "iMessage via Vesicle's native REST API.",
+      "preferOver": ["bluebubbles", "imessage"],
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "definitions": {
+          "allowFrom": {
+            "type": "array",
+            "items": {
+              "anyOf": [{ "type": "string" }, { "type": "number" }]
+            }
+          },
+          "markdown": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tables": {
+                "type": "string",
+                "enum": ["off", "bullets", "code", "block"]
+              }
+            }
+          },
+          "network": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dangerouslyAllowPrivateNetwork": { "type": "boolean" }
+            }
+          },
+          "secretInput": {
+            "anyOf": [{ "type": "string" }, { "type": "object" }]
+          },
+          "account": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string" },
+              "enabled": { "type": "boolean" },
+              "markdown": { "$ref": "#/definitions/markdown" },
+              "serverUrl": { "type": "string" },
+              "authToken": { "$ref": "#/definitions/secretInput" },
+              "webhookPath": { "type": "string" },
+              "webhookSecret": { "$ref": "#/definitions/secretInput" },
+              "dmPolicy": {
+                "type": "string",
+                "enum": ["pairing", "allowlist", "open", "disabled"]
+              },
+              "allowFrom": { "$ref": "#/definitions/allowFrom" },
+              "groupAllowFrom": { "$ref": "#/definitions/allowFrom" },
+              "groupPolicy": {
+                "type": "string",
+                "enum": ["open", "disabled", "allowlist"]
+              },
+              "defaultTo": { "type": "string" },
+              "sendTimeoutMs": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "probeTimeoutMs": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "textChunkLimit": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "network": { "$ref": "#/definitions/network" }
+            }
+          }
+        },
+        "properties": {
+          "name": { "type": "string" },
+          "enabled": { "type": "boolean" },
+          "markdown": { "$ref": "#/definitions/markdown" },
+          "serverUrl": { "type": "string" },
+          "authToken": { "$ref": "#/definitions/secretInput" },
+          "webhookPath": { "type": "string" },
+          "webhookSecret": { "$ref": "#/definitions/secretInput" },
+          "dmPolicy": {
+            "type": "string",
+            "enum": ["pairing", "allowlist", "open", "disabled"]
+          },
+          "allowFrom": { "$ref": "#/definitions/allowFrom" },
+          "groupAllowFrom": { "$ref": "#/definitions/allowFrom" },
+          "groupPolicy": {
+            "type": "string",
+            "enum": ["open", "disabled", "allowlist"]
+          },
+          "defaultTo": { "type": "string" },
+          "sendTimeoutMs": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "probeTimeoutMs": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "textChunkLimit": {
+            "type": "integer",
+            "exclusiveMinimum": 0
+          },
+          "network": { "$ref": "#/definitions/network" },
+          "accounts": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/definitions/account" }
+          },
+          "defaultAccount": { "type": "string" }
+        }
+      },
+      "uiHints": {
+        "serverUrl": {
+          "label": "Server URL",
+          "placeholder": "http://127.0.0.1:1234"
+        },
+        "authToken": {
+          "label": "Auth token",
+          "secret": true
+        },
+        "webhookPath": {
+          "label": "Webhook path",
+          "placeholder": "/vesicle-webhook"
+        },
+        "webhookSecret": {
+          "label": "Webhook secret",
+          "secret": true
+        },
+        "defaultTo": {
+          "label": "Default chat",
+          "placeholder": "chat_guid:<GUID>"
+        }
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/vesicle/openclaw.plugin.json
+++ b/extensions/vesicle/openclaw.plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "vesicle",
+  "activation": {
+    "onStartup": false
+  },
+  "channels": ["vesicle"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/vesicle/package.json
+++ b/extensions/vesicle/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@openclaw/vesicle",
+  "version": "2026.4.25",
+  "description": "OpenClaw Vesicle native iMessage channel plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*",
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.4.25"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "setupEntry": "./setup-entry.ts",
+    "channel": {
+      "id": "vesicle",
+      "label": "Vesicle",
+      "selectionLabel": "Vesicle (native iMessage bridge)",
+      "detailLabel": "Vesicle",
+      "docsPath": "/channels/vesicle",
+      "docsLabel": "vesicle",
+      "blurb": "iMessage via Vesicle's native REST API.",
+      "aliases": [
+        "vsl"
+      ],
+      "preferOver": [
+        "bluebubbles",
+        "imessage"
+      ],
+      "systemImage": "message.badge.waveform",
+      "order": 70,
+      "cliAddOptions": [
+        {
+          "flags": "--server-url <url>",
+          "description": "Vesicle server URL"
+        },
+        {
+          "flags": "--auth-token <token>",
+          "description": "Vesicle bearer auth token"
+        },
+        {
+          "flags": "--webhook-path <path>",
+          "description": "Vesicle native webhook path"
+        },
+        {
+          "flags": "--webhook-secret <secret>",
+          "description": "Vesicle native webhook HMAC secret"
+        }
+      ]
+    },
+    "install": {
+      "npmSpec": "@openclaw/vesicle",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.4.25"
+    },
+    "compat": {
+      "pluginApi": ">=2026.4.25"
+    },
+    "build": {
+      "openclawVersion": "2026.4.25"
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/vesicle/runtime-api.ts
+++ b/extensions/vesicle/runtime-api.ts
@@ -1,0 +1,1 @@
+export { setVesicleRuntime } from "./src/runtime.js";

--- a/extensions/vesicle/secret-contract-api.ts
+++ b/extensions/vesicle/secret-contract-api.ts
@@ -1,0 +1,5 @@
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/vesicle/setup-entry.ts
+++ b/extensions/vesicle/setup-entry.ts
@@ -1,0 +1,17 @@
+import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+
+export default defineBundledChannelSetupEntry({
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./channel-plugin-api.js",
+    exportName: "vesiclePlugin",
+  },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
+  runtime: {
+    specifier: "./runtime-api.js",
+    exportName: "setVesicleRuntime",
+  },
+});

--- a/extensions/vesicle/src/accounts.test.ts
+++ b/extensions/vesicle/src/accounts.test.ts
@@ -1,0 +1,38 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { describe, expect, it } from "vitest";
+import { resolveVesicleAccount, resolveVesicleServerAccount } from "./accounts.js";
+
+describe("Vesicle accounts", () => {
+  it("marks accounts configured when serverUrl and authToken are present", () => {
+    const cfg = {
+      channels: {
+        vesicle: {
+          serverUrl: "127.0.0.1:1234/",
+          authToken: "token",
+        },
+      },
+    } as OpenClawConfig;
+    const account = resolveVesicleAccount({ cfg });
+    expect(account.configured).toBe(true);
+    expect(account.baseUrl).toBe("http://127.0.0.1:1234");
+  });
+
+  it("merges per-account overrides", () => {
+    const cfg = {
+      channels: {
+        vesicle: {
+          serverUrl: "http://base.local",
+          authToken: "base-token",
+          accounts: {
+            work: {
+              serverUrl: "http://work.local",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const account = resolveVesicleServerAccount({ cfg, accountId: "work" });
+    expect(account.baseUrl).toBe("http://work.local");
+    expect(account.authToken).toBe("base-token");
+  });
+});

--- a/extensions/vesicle/src/accounts.ts
+++ b/extensions/vesicle/src/accounts.ts
@@ -1,0 +1,132 @@
+import {
+  createAccountListHelpers,
+  normalizeAccountId,
+  resolveMergedAccountConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/account-resolution";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { hasConfiguredSecretInput, normalizeSecretInputString } from "./secret-input.js";
+import {
+  DEFAULT_PROBE_TIMEOUT_MS,
+  DEFAULT_SEND_TIMEOUT_MS,
+  type CoreConfig,
+  type ResolvedVesicleAccount,
+  type VesicleAccountConfig,
+} from "./types.js";
+import { normalizeVesicleServerUrl } from "./url.js";
+
+const {
+  listAccountIds: listVesicleAccountIds,
+  resolveDefaultAccountId: resolveDefaultVesicleAccountId,
+} = createAccountListHelpers("vesicle");
+
+export { listVesicleAccountIds, resolveDefaultVesicleAccountId };
+export type { ResolvedVesicleAccount } from "./types.js";
+
+function mergeVesicleAccountConfig(cfg: OpenClawConfig, accountId: string): VesicleAccountConfig {
+  const coreCfg = cfg as CoreConfig;
+  return resolveMergedAccountConfig<VesicleAccountConfig>({
+    channelConfig: coreCfg.channels?.vesicle as VesicleAccountConfig | undefined,
+    accounts: coreCfg.channels?.vesicle?.accounts,
+    accountId,
+    omitKeys: ["defaultAccount"],
+    normalizeAccountId,
+    nestedObjectKeys: ["network"],
+  });
+}
+
+export function resolveVesicleAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedVesicleAccount {
+  const accountId = normalizeAccountId(
+    params.accountId ?? resolveDefaultVesicleAccountId(params.cfg),
+  );
+  const coreCfg = params.cfg as CoreConfig;
+  const baseEnabled = coreCfg.channels?.vesicle?.enabled !== false;
+  const merged = mergeVesicleAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const serverUrl = normalizeSecretInputString(merged.serverUrl);
+  const configured = Boolean(serverUrl && hasConfiguredSecretInput(merged.authToken));
+  const baseUrl = serverUrl ? normalizeVesicleServerUrl(serverUrl) : undefined;
+  return {
+    accountId,
+    enabled: baseEnabled && accountEnabled,
+    name: normalizeOptionalString(merged.name),
+    config: merged,
+    configured,
+    baseUrl,
+  };
+}
+
+export function listEnabledVesicleAccounts(cfg: OpenClawConfig): ResolvedVesicleAccount[] {
+  return listVesicleAccountIds(cfg)
+    .map((accountId) => resolveVesicleAccount({ cfg, accountId }))
+    .filter((account) => account.enabled);
+}
+
+export function resolveVesicleEffectiveAllowPrivateNetwork(params: {
+  baseUrl?: string;
+  config?: VesicleAccountConfig | null;
+}): boolean {
+  const config = params.config as
+    | (VesicleAccountConfig & { dangerouslyAllowPrivateNetwork?: boolean })
+    | null
+    | undefined;
+  return (
+    config?.network?.dangerouslyAllowPrivateNetwork === true ||
+    config?.dangerouslyAllowPrivateNetwork === true
+  );
+}
+
+export function resolveVesicleServerAccount(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
+  serverUrl?: string | null;
+  authToken?: string | null;
+  allowPrivateNetwork?: boolean;
+}): {
+  accountId: string;
+  baseUrl: string;
+  authToken: string;
+  sendTimeoutMs: number;
+  probeTimeoutMs: number;
+  allowPrivateNetwork: boolean;
+  allowPrivateNetworkConfig?: boolean;
+} {
+  const cfg = (params.cfg ?? {}) as CoreConfig;
+  const account = resolveVesicleAccount({
+    cfg,
+    accountId: params.accountId,
+  });
+  const serverUrl =
+    normalizeSecretInputString(params.serverUrl) ??
+    normalizeSecretInputString(account.config.serverUrl) ??
+    account.baseUrl;
+  const authToken =
+    normalizeSecretInputString(params.authToken) ??
+    normalizeSecretInputString(account.config.authToken);
+  if (!serverUrl) {
+    throw new Error("Vesicle serverUrl is required");
+  }
+  if (!authToken) {
+    throw new Error("Vesicle authToken is required");
+  }
+  const allowPrivateNetworkConfig =
+    account.config.network?.dangerouslyAllowPrivateNetwork ??
+    (account.config as { dangerouslyAllowPrivateNetwork?: boolean }).dangerouslyAllowPrivateNetwork;
+  return {
+    accountId: account.accountId,
+    baseUrl: normalizeVesicleServerUrl(serverUrl),
+    authToken,
+    sendTimeoutMs: account.config.sendTimeoutMs ?? DEFAULT_SEND_TIMEOUT_MS,
+    probeTimeoutMs: account.config.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS,
+    allowPrivateNetwork:
+      params.allowPrivateNetwork ??
+      resolveVesicleEffectiveAllowPrivateNetwork({
+        baseUrl: account.baseUrl,
+        config: account.config,
+      }),
+    allowPrivateNetworkConfig,
+  };
+}

--- a/extensions/vesicle/src/channel.ts
+++ b/extensions/vesicle/src/channel.ts
@@ -14,6 +14,7 @@ import {
   type ResolvedVesicleAccount,
 } from "./accounts.js";
 import { VesicleChannelConfigSchema } from "./config-schema.js";
+import { startVesicleGatewayAccount } from "./gateway.js";
 import type { VesicleProbe } from "./probe.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { sendMessageVesicle } from "./send.js";
@@ -98,6 +99,9 @@ export const vesiclePlugin = createChatChannelPlugin<ResolvedVesicleAccount, Ves
       },
     },
     status: vesicleStatus,
+    gateway: {
+      startAccount: startVesicleGatewayAccount,
+    },
   },
   outbound: {
     base: {

--- a/extensions/vesicle/src/channel.ts
+++ b/extensions/vesicle/src/channel.ts
@@ -28,7 +28,18 @@ import {
 } from "./targets.js";
 
 const CHANNEL_ID = "vesicle" as const;
-const meta = { ...getChatChannelMeta(CHANNEL_ID) };
+const meta = {
+  ...getChatChannelMeta(CHANNEL_ID),
+  label: "Vesicle",
+  selectionLabel: "Vesicle (native iMessage bridge)",
+  docsPath: "/channels/vesicle",
+  docsLabel: "vesicle",
+  blurb: "iMessage via Vesicle's native REST API.",
+  aliases: ["vsl"],
+  preferOver: ["bluebubbles", "imessage"],
+  systemImage: "message.badge.waveform",
+  order: 70,
+};
 
 const vesicleConfigAdapter = createScopedChannelConfigAdapter<ResolvedVesicleAccount>({
   sectionKey: CHANNEL_ID,

--- a/extensions/vesicle/src/channel.ts
+++ b/extensions/vesicle/src/channel.ts
@@ -1,0 +1,134 @@
+import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
+import {
+  adaptScopedAccountAccessor,
+  createScopedChannelConfigAdapter,
+  formatTrimmedAllowFromEntries,
+} from "openclaw/plugin-sdk/channel-config-helpers";
+import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import {
+  listVesicleAccountIds,
+  resolveDefaultVesicleAccountId,
+  resolveVesicleAccount,
+  type ResolvedVesicleAccount,
+} from "./accounts.js";
+import { VesicleChannelConfigSchema } from "./config-schema.js";
+import type { VesicleProbe } from "./probe.js";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
+import { sendMessageVesicle } from "./send.js";
+import { applyVesicleSetup } from "./setup.js";
+import { vesicleStatus } from "./status.js";
+import {
+  inferVesicleTargetChatType,
+  looksLikeVesicleExplicitTargetId,
+  normalizeVesicleMessagingTarget,
+  resolveVesicleOutboundSessionRoute,
+} from "./targets.js";
+
+const CHANNEL_ID = "vesicle" as const;
+const meta = { ...getChatChannelMeta(CHANNEL_ID) };
+
+const vesicleConfigAdapter = createScopedChannelConfigAdapter<ResolvedVesicleAccount>({
+  sectionKey: CHANNEL_ID,
+  listAccountIds: listVesicleAccountIds,
+  resolveAccount: adaptScopedAccountAccessor(resolveVesicleAccount),
+  defaultAccountId: resolveDefaultVesicleAccountId,
+  clearBaseFields: ["serverUrl", "authToken", "webhookPath", "webhookSecret", "name"],
+  resolveAllowFrom: (account) => account.config.allowFrom,
+  formatAllowFrom: (allowFrom) => formatTrimmedAllowFromEntries(allowFrom),
+  resolveDefaultTo: (account) => account.config.defaultTo,
+});
+
+export const vesiclePlugin = createChatChannelPlugin<ResolvedVesicleAccount, VesicleProbe>({
+  base: {
+    id: CHANNEL_ID,
+    meta,
+    capabilities: {
+      chatTypes: ["direct", "group"],
+    },
+    reload: { configPrefixes: ["channels.vesicle"] },
+    configSchema: VesicleChannelConfigSchema,
+    config: {
+      ...vesicleConfigAdapter,
+      isConfigured: (account) => account.configured,
+      describeAccount: (account) =>
+        describeWebhookAccountSnapshot({
+          account,
+          configured: account.configured,
+          extra: {
+            baseUrl: account.baseUrl,
+          },
+        }),
+    },
+    setup: {
+      applyAccountConfig: ({ cfg, accountId, input }) =>
+        applyVesicleSetup({
+          cfg,
+          accountId,
+          input: input as Record<string, unknown>,
+        }),
+    },
+    secrets: {
+      secretTargetRegistryEntries,
+      collectRuntimeConfigAssignments,
+    },
+    messaging: {
+      normalizeTarget: normalizeVesicleMessagingTarget,
+      inferTargetChatType: ({ to }) => inferVesicleTargetChatType(to),
+      resolveOutboundSessionRoute: (params) => resolveVesicleOutboundSessionRoute(params),
+      targetResolver: {
+        looksLikeId: looksLikeVesicleExplicitTargetId,
+        hint: "<chat_guid:GUID>",
+        resolveTarget: async ({ normalized }) => {
+          const to = normalizeOptionalString(normalized);
+          if (!to || !looksLikeVesicleExplicitTargetId(to)) {
+            return null;
+          }
+          const chatType = inferVesicleTargetChatType(to);
+          if (!chatType) {
+            return null;
+          }
+          return {
+            to,
+            kind: chatType === "direct" ? "user" : "group",
+            source: "normalized" as const,
+          };
+        },
+      },
+    },
+    status: vesicleStatus,
+  },
+  outbound: {
+    base: {
+      deliveryMode: "direct",
+      textChunkLimit: 4000,
+      resolveTarget: ({ to }) => {
+        const trimmed = normalizeOptionalString(to);
+        if (!trimmed) {
+          return {
+            ok: false,
+            error: new Error("Delivering to Vesicle requires --to <chat_guid:GUID>"),
+          };
+        }
+        if (!looksLikeVesicleExplicitTargetId(trimmed)) {
+          return {
+            ok: false,
+            error: new Error(
+              "Vesicle currently sends only to existing chats; use --to chat_guid:<GUID>",
+            ),
+          };
+        }
+        return { ok: true, to: trimmed };
+      },
+    },
+    attachedResults: {
+      channel: CHANNEL_ID,
+      sendText: async ({ cfg, to, text, accountId }) =>
+        await sendMessageVesicle(to, text, {
+          cfg,
+          accountId: accountId ?? undefined,
+        }),
+    },
+  },
+});

--- a/extensions/vesicle/src/client.ts
+++ b/extensions/vesicle/src/client.ts
@@ -1,0 +1,290 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { fetchWithRuntimeDispatcherOrMockedGlobal } from "openclaw/plugin-sdk/runtime-fetch";
+import {
+  fetchWithSsrFGuard,
+  isBlockedHostnameOrIp,
+  type SsrFPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import { resolveVesicleServerAccount } from "./accounts.js";
+import type { VesicleCapabilities, VesicleHealthResponse } from "./types.js";
+import { normalizeVesicleServerUrl } from "./url.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function safeExtractHostname(baseUrl: string): string | undefined {
+  try {
+    const hostname = new URL(normalizeVesicleServerUrl(baseUrl)).hostname.trim();
+    return hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveVesicleClientSsrfPolicy(params: {
+  baseUrl: string;
+  allowPrivateNetwork: boolean;
+  allowPrivateNetworkConfig?: boolean;
+}): {
+  ssrfPolicy: SsrFPolicy;
+  trustedHostname?: string;
+  trustedHostnameIsPrivate: boolean;
+} {
+  const trustedHostname = safeExtractHostname(params.baseUrl);
+  const trustedHostnameIsPrivate = trustedHostname ? isBlockedHostnameOrIp(trustedHostname) : false;
+
+  if (params.allowPrivateNetwork) {
+    return {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      trustedHostname,
+      trustedHostnameIsPrivate,
+    };
+  }
+
+  if (
+    trustedHostname &&
+    (params.allowPrivateNetworkConfig !== false || !trustedHostnameIsPrivate)
+  ) {
+    return {
+      ssrfPolicy: { allowedHostnames: [trustedHostname] },
+      trustedHostname,
+      trustedHostnameIsPrivate,
+    };
+  }
+
+  return { ssrfPolicy: {}, trustedHostname, trustedHostnameIsPrivate };
+}
+
+async function vesicleFetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  ssrfPolicy: SsrFPolicy,
+): Promise<Response> {
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init,
+    timeoutMs,
+    policy: ssrfPolicy,
+    auditContext: "vesicle-api",
+  });
+  const isNullBody =
+    response.status === 101 ||
+    response.status === 204 ||
+    response.status === 205 ||
+    response.status === 304;
+  try {
+    const bodyBytes = isNullBody ? null : await response.arrayBuffer();
+    return new Response(bodyBytes, { status: response.status, headers: response.headers });
+  } finally {
+    await release();
+  }
+}
+
+export type VesicleClientOptions = {
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
+  serverUrl?: string | null;
+  authToken?: string | null;
+  timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
+};
+
+type VesicleClientConstructorParams = {
+  accountId: string;
+  baseUrl: string;
+  authToken: string;
+  defaultTimeoutMs: number;
+  ssrfPolicy: SsrFPolicy;
+  trustedHostname?: string;
+  trustedHostnameIsPrivate: boolean;
+};
+
+export class VesicleClient {
+  readonly accountId: string;
+  readonly baseUrl: string;
+  readonly trustedHostname: string | undefined;
+  readonly trustedHostnameIsPrivate: boolean;
+
+  private readonly authToken: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly ssrfPolicy: SsrFPolicy;
+
+  constructor(params: VesicleClientConstructorParams) {
+    this.accountId = params.accountId;
+    this.baseUrl = params.baseUrl;
+    this.authToken = params.authToken;
+    this.defaultTimeoutMs = params.defaultTimeoutMs;
+    this.ssrfPolicy = params.ssrfPolicy;
+    this.trustedHostname = params.trustedHostname;
+    this.trustedHostnameIsPrivate = params.trustedHostnameIsPrivate;
+  }
+
+  getSsrfPolicy(): SsrFPolicy {
+    return this.ssrfPolicy;
+  }
+
+  private buildRequest(params: { path: string; method: string; init?: RequestInit }): {
+    url: string;
+    init: RequestInit;
+  } {
+    const normalized = normalizeVesicleServerUrl(this.baseUrl);
+    const url = new URL(params.path, `${normalized}/`);
+    const headers = new Headers(params.init?.headers ?? undefined);
+    headers.set("Authorization", `Bearer ${this.authToken}`);
+    return {
+      url: url.toString(),
+      init: {
+        ...params.init,
+        method: params.method,
+        headers,
+      },
+    };
+  }
+
+  async request(params: {
+    method: string;
+    path: string;
+    body?: unknown;
+    headers?: Record<string, string>;
+    timeoutMs?: number;
+  }): Promise<Response> {
+    const init: RequestInit = {};
+    if (params.headers) {
+      init.headers = { ...params.headers };
+    }
+    if (params.body !== undefined) {
+      init.headers = {
+        "Content-Type": "application/json",
+        ...(init.headers as Record<string, string> | undefined),
+      };
+      init.body = JSON.stringify(params.body);
+    }
+    const prepared = this.buildRequest({
+      path: params.path,
+      method: params.method,
+      init,
+    });
+    return await vesicleFetchWithTimeout(
+      prepared.url,
+      prepared.init,
+      params.timeoutMs ?? this.defaultTimeoutMs,
+      this.ssrfPolicy,
+    );
+  }
+
+  async requestJson(params: {
+    method: string;
+    path: string;
+    body?: unknown;
+    timeoutMs?: number;
+  }): Promise<{ response: Response; data: unknown }> {
+    const response = await this.request(params);
+    const data: unknown = await response.json().catch(() => null);
+    return { response, data };
+  }
+
+  async health(params: { timeoutMs?: number } = {}): Promise<{
+    response: Response;
+    data: VesicleHealthResponse | null;
+  }> {
+    const { response, data } = await this.requestJson({
+      method: "GET",
+      path: "/api/v1/vesicle/health",
+      timeoutMs: params.timeoutMs,
+    });
+    return {
+      response,
+      data: typeof data === "object" && data !== null ? (data as VesicleHealthResponse) : null,
+    };
+  }
+
+  async capabilities(params: { timeoutMs?: number } = {}): Promise<{
+    response: Response;
+    data: VesicleCapabilities | null;
+  }> {
+    const { response, data } = await this.requestJson({
+      method: "GET",
+      path: "/api/v1/vesicle/capabilities",
+      timeoutMs: params.timeoutMs,
+    });
+    return {
+      response,
+      data: typeof data === "object" && data !== null ? (data as VesicleCapabilities) : null,
+    };
+  }
+
+  async sendText(params: {
+    chatGuid: string;
+    text: string;
+    timeoutMs?: number;
+  }): Promise<{ response: Response; data: unknown }> {
+    return await this.requestJson({
+      method: "POST",
+      path: "/api/v1/vesicle/message/text",
+      body: {
+        chatGuid: params.chatGuid,
+        text: params.text,
+      },
+      timeoutMs: params.timeoutMs,
+    });
+  }
+}
+
+export function createVesicleClientFromParts(params: {
+  baseUrl: string;
+  authToken: string;
+  accountId?: string;
+  timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
+  allowPrivateNetworkConfig?: boolean;
+}): VesicleClient {
+  const policyResult = resolveVesicleClientSsrfPolicy({
+    baseUrl: params.baseUrl,
+    allowPrivateNetwork: params.allowPrivateNetwork === true,
+    allowPrivateNetworkConfig: params.allowPrivateNetworkConfig,
+  });
+  return new VesicleClient({
+    accountId: params.accountId ?? "default",
+    baseUrl: normalizeVesicleServerUrl(params.baseUrl),
+    authToken: params.authToken,
+    defaultTimeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    ssrfPolicy: policyResult.ssrfPolicy,
+    trustedHostname: policyResult.trustedHostname,
+    trustedHostnameIsPrivate: policyResult.trustedHostnameIsPrivate,
+  });
+}
+
+export function createVesicleClient(opts: VesicleClientOptions = {}): VesicleClient {
+  const resolved = resolveVesicleServerAccount({
+    cfg: opts.cfg,
+    accountId: opts.accountId,
+    serverUrl: opts.serverUrl,
+    authToken: opts.authToken,
+    allowPrivateNetwork: opts.allowPrivateNetwork,
+  });
+  return createVesicleClientFromParts({
+    accountId: resolved.accountId,
+    baseUrl: resolved.baseUrl,
+    authToken: resolved.authToken,
+    timeoutMs: opts.timeoutMs,
+    allowPrivateNetwork: resolved.allowPrivateNetwork,
+    allowPrivateNetworkConfig: resolved.allowPrivateNetworkConfig,
+  });
+}
+
+export async function unguardedVesicleFetchForTests(
+  url: string,
+  init: RequestInit,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchWithRuntimeDispatcherOrMockedGlobal(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/extensions/vesicle/src/config-schema.ts
+++ b/extensions/vesicle/src/config-schema.ts
@@ -1,0 +1,63 @@
+import {
+  AllowFromListSchema,
+  buildCatchallMultiAccountChannelSchema,
+  buildChannelConfigSchema,
+  DmPolicySchema,
+  GroupPolicySchema,
+  MarkdownConfigSchema,
+} from "openclaw/plugin-sdk/channel-config-schema";
+import { z } from "openclaw/plugin-sdk/zod";
+import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
+
+const vesicleNetworkSchema = z
+  .object({
+    /** Dangerous opt-in for trusted private/internal Vesicle deployments. */
+    dangerouslyAllowPrivateNetwork: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
+const vesicleAccountSchema = z
+  .object({
+    name: z.string().optional(),
+    enabled: z.boolean().optional(),
+    markdown: MarkdownConfigSchema,
+    serverUrl: z.string().optional(),
+    authToken: buildSecretInputSchema().optional(),
+    webhookPath: z.string().optional(),
+    webhookSecret: buildSecretInputSchema().optional(),
+    dmPolicy: DmPolicySchema.optional(),
+    allowFrom: AllowFromListSchema,
+    groupAllowFrom: AllowFromListSchema,
+    groupPolicy: GroupPolicySchema.optional(),
+    defaultTo: z.string().optional(),
+    sendTimeoutMs: z.number().int().positive().optional(),
+    probeTimeoutMs: z.number().int().positive().optional(),
+    textChunkLimit: z.number().int().positive().optional(),
+    network: vesicleNetworkSchema,
+  })
+  .superRefine((value, ctx) => {
+    const serverUrl = value.serverUrl?.trim() ?? "";
+    const authTokenConfigured = hasConfiguredSecretInput(value.authToken);
+    if (serverUrl && !authTokenConfigured) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["authToken"],
+        message: "authToken is required when serverUrl is configured",
+      });
+    }
+
+    const webhookPath = value.webhookPath?.trim() ?? "";
+    const webhookSecretConfigured = hasConfiguredSecretInput(value.webhookSecret);
+    if (webhookPath && !webhookSecretConfigured) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["webhookSecret"],
+        message: "webhookSecret is required when webhookPath is configured",
+      });
+    }
+  });
+
+export const VesicleConfigSchema = buildCatchallMultiAccountChannelSchema(vesicleAccountSchema);
+
+export const VesicleChannelConfigSchema = buildChannelConfigSchema(VesicleConfigSchema);

--- a/extensions/vesicle/src/gateway.ts
+++ b/extensions/vesicle/src/gateway.ts
@@ -1,0 +1,54 @@
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { createAccountStatusSink } from "openclaw/plugin-sdk/channel-lifecycle";
+import type { ResolvedVesicleAccount } from "./accounts.js";
+import {
+  registerVesicleWebhookTarget,
+  resolveConfiguredVesicleWebhookSecret,
+  resolveVesicleWebhookPath,
+} from "./webhook.js";
+
+type VesicleGatewayStart = NonNullable<
+  NonNullable<ChannelPlugin<ResolvedVesicleAccount>["gateway"]>["startAccount"]
+>;
+
+export const startVesicleGatewayAccount: VesicleGatewayStart = async (ctx) => {
+  const secret = resolveConfiguredVesicleWebhookSecret(ctx.account);
+  if (!secret) {
+    ctx.log?.info?.(
+      `[${ctx.account.accountId}] Vesicle native webhook disabled (webhookSecret not configured)`,
+    );
+    return;
+  }
+
+  const path = resolveVesicleWebhookPath(ctx.account);
+  const statusSink = createAccountStatusSink({
+    accountId: ctx.account.accountId,
+    setStatus: ctx.setStatus,
+  });
+  statusSink({
+    baseUrl: ctx.account.baseUrl,
+    webhookPath: path,
+  });
+  ctx.log?.info?.(`[${ctx.account.accountId}] Vesicle webhook listening on ${path}`);
+
+  const unregister = registerVesicleWebhookTarget({
+    account: ctx.account,
+    config: ctx.cfg,
+    runtime: ctx.runtime,
+    path,
+    secret,
+    statusSink,
+  });
+
+  await new Promise<void>((resolve) => {
+    const stop = () => {
+      unregister();
+      resolve();
+    };
+    if (ctx.abortSignal.aborted) {
+      stop();
+      return;
+    }
+    ctx.abortSignal.addEventListener("abort", stop, { once: true });
+  });
+};

--- a/extensions/vesicle/src/inbound-core.test.ts
+++ b/extensions/vesicle/src/inbound-core.test.ts
@@ -1,0 +1,95 @@
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { dispatchInboundReplyWithBase } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+import { describe, expect, it, vi } from "vitest";
+import { handleVesicleInboundMessage } from "./inbound-core.js";
+import type { ResolvedVesicleAccount } from "./types.js";
+
+const cfg = {
+  channels: {
+    vesicle: {
+      serverUrl: "http://127.0.0.1:1234",
+      authToken: "token",
+    },
+  },
+} as OpenClawConfig;
+
+const account: ResolvedVesicleAccount = {
+  accountId: "default",
+  enabled: true,
+  configured: true,
+  baseUrl: "http://127.0.0.1:1234",
+  config: {
+    serverUrl: "http://127.0.0.1:1234",
+    authToken: "token",
+  },
+};
+
+describe("handleVesicleInboundMessage", () => {
+  it("routes direct messages through the native chat GUID target and sends replies there", async () => {
+    const runtime = createPluginRuntimeMock();
+    const sendText = vi.fn(async () => undefined);
+    const dispatch = vi.fn(async (params: Parameters<typeof dispatchInboundReplyWithBase>[0]) => {
+      await params.deliver({ text: "pong" });
+    }) as typeof dispatchInboundReplyWithBase;
+
+    await handleVesicleInboundMessage({
+      account,
+      config: cfg,
+      runtime,
+      dispatchInboundReplyWithBase: dispatch,
+      sendText,
+      message: {
+        messageGuid: "msg-1",
+        chatGuid: "iMessage;-;+15551234567",
+        sender: "+15551234567",
+        text: "ping",
+        date: 1_777_000_000,
+      },
+    });
+
+    expect(runtime.channel.routing.resolveAgentRoute).toHaveBeenCalledWith({
+      cfg,
+      channel: "vesicle",
+      accountId: "default",
+      peer: {
+        kind: "direct",
+        id: "+15551234567",
+      },
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0]?.[0].ctxPayload).toMatchObject({
+      BodyForAgent: "ping",
+      To: "chat_guid:iMessage;-;+15551234567",
+      From: "vesicle:+15551234567",
+      ChatType: "direct",
+      MessageSid: "msg-1",
+      Timestamp: 1_777_000_000_000,
+    });
+    expect(sendText).toHaveBeenCalledWith({
+      to: "chat_guid:iMessage;-;+15551234567",
+      text: "pong",
+    });
+  });
+
+  it("drops messages sent by the local Vesicle account", async () => {
+    const dispatch = vi.fn() as typeof dispatchInboundReplyWithBase;
+
+    await handleVesicleInboundMessage({
+      account,
+      config: cfg,
+      runtime: createPluginRuntimeMock(),
+      dispatchInboundReplyWithBase: dispatch,
+      sendText: vi.fn(),
+      message: {
+        messageGuid: "msg-1",
+        chatGuid: "iMessage;-;+15551234567",
+        sender: "+15551234567",
+        text: "ping",
+        isFromMe: true,
+      },
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/vesicle/src/inbound-core.test.ts
+++ b/extensions/vesicle/src/inbound-core.test.ts
@@ -29,9 +29,12 @@ describe("handleVesicleInboundMessage", () => {
   it("routes direct messages through the native chat GUID target and sends replies there", async () => {
     const runtime = createPluginRuntimeMock();
     const sendText = vi.fn(async () => undefined);
-    const dispatch = vi.fn(async (params: Parameters<typeof dispatchInboundReplyWithBase>[0]) => {
-      await params.deliver({ text: "pong" });
-    }) as typeof dispatchInboundReplyWithBase;
+    const dispatchMock = vi.fn(
+      async (params: Parameters<typeof dispatchInboundReplyWithBase>[0]) => {
+        await params.deliver({ text: "pong" });
+      },
+    );
+    const dispatch = dispatchMock as unknown as typeof dispatchInboundReplyWithBase;
 
     await handleVesicleInboundMessage({
       account,
@@ -57,8 +60,8 @@ describe("handleVesicleInboundMessage", () => {
         id: "+15551234567",
       },
     });
-    expect(dispatch).toHaveBeenCalledTimes(1);
-    expect(dispatch.mock.calls[0]?.[0].ctxPayload).toMatchObject({
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock.mock.calls[0]?.[0].ctxPayload).toMatchObject({
       BodyForAgent: "ping",
       To: "chat_guid:iMessage;-;+15551234567",
       From: "vesicle:+15551234567",
@@ -73,7 +76,8 @@ describe("handleVesicleInboundMessage", () => {
   });
 
   it("drops messages sent by the local Vesicle account", async () => {
-    const dispatch = vi.fn() as typeof dispatchInboundReplyWithBase;
+    const dispatchMock = vi.fn();
+    const dispatch = dispatchMock as unknown as typeof dispatchInboundReplyWithBase;
 
     await handleVesicleInboundMessage({
       account,
@@ -90,6 +94,6 @@ describe("handleVesicleInboundMessage", () => {
       },
     });
 
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/vesicle/src/inbound-core.ts
+++ b/extensions/vesicle/src/inbound-core.ts
@@ -1,0 +1,150 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { extractHandleFromVesicleChatGuid } from "./targets.js";
+import type { ResolvedVesicleAccount, VesicleInboundMessage } from "./types.js";
+
+const APPLE_ABSOLUTE_EPOCH_MS = Date.UTC(2001, 0, 1);
+
+type DispatchInboundReplyWithBase =
+  typeof import("openclaw/plugin-sdk/inbound-reply-dispatch").dispatchInboundReplyWithBase;
+
+function resolveVesicleTimestamp(raw: number | undefined): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) {
+    return Date.now();
+  }
+  if (raw > 1_000_000_000_000_000) {
+    return APPLE_ABSOLUTE_EPOCH_MS + Math.floor(raw / 1_000_000);
+  }
+  if (raw > 1_000_000_000_000) {
+    return raw;
+  }
+  if (raw > 1_000_000_000) {
+    return raw * 1000;
+  }
+  return Date.now();
+}
+
+function resolveInboundChatType(message: VesicleInboundMessage): "direct" | "group" {
+  if (typeof message.isGroup === "boolean") {
+    return message.isGroup ? "group" : "direct";
+  }
+  return message.chatGuid.includes(";+;") ? "group" : "direct";
+}
+
+function resolveDirectPeerId(message: VesicleInboundMessage): string {
+  return (
+    message.sender.trim() || extractHandleFromVesicleChatGuid(message.chatGuid) || message.chatGuid
+  );
+}
+
+function readReplyText(payload: unknown): string {
+  if (!payload || typeof payload !== "object" || !("text" in payload)) {
+    return "";
+  }
+  const text = (payload as { text?: unknown }).text;
+  return typeof text === "string" ? text : "";
+}
+
+export async function handleVesicleInboundMessage(params: {
+  account: ResolvedVesicleAccount;
+  config: OpenClawConfig;
+  message: VesicleInboundMessage;
+  runtime: PluginRuntime;
+  dispatchInboundReplyWithBase: DispatchInboundReplyWithBase;
+  sendText: (params: { to: string; text: string }) => Promise<void>;
+}): Promise<void> {
+  if (params.message.isFromMe === true) {
+    return;
+  }
+  if (!params.message.text.trim()) {
+    return;
+  }
+
+  const chatType = resolveInboundChatType(params.message);
+  const isGroup = chatType === "group";
+  const peerId = isGroup ? params.message.chatGuid : resolveDirectPeerId(params.message);
+  const target = `chat_guid:${params.message.chatGuid}`;
+  const timestamp = resolveVesicleTimestamp(params.message.date);
+  const route = params.runtime.channel.routing.resolveAgentRoute({
+    cfg: params.config,
+    channel: "vesicle",
+    accountId: params.account.accountId,
+    peer: {
+      kind: isGroup ? "group" : "direct",
+      id: peerId,
+    },
+  });
+  const wasMentioned = isGroup
+    ? params.runtime.channel.mentions.matchesMentionPatterns(
+        params.message.text,
+        params.runtime.channel.mentions.buildMentionRegexes(params.config, route.agentId),
+      )
+    : undefined;
+  const storePath = params.runtime.channel.session.resolveStorePath(params.config.session?.store, {
+    agentId: route.agentId,
+  });
+  const previousTimestamp = params.runtime.channel.session.readSessionUpdatedAt({
+    storePath,
+    sessionKey: route.sessionKey,
+  });
+  const body = params.runtime.channel.reply.formatAgentEnvelope({
+    channel: "Vesicle",
+    from: params.message.sender || peerId,
+    timestamp,
+    previousTimestamp,
+    envelope: params.runtime.channel.reply.resolveEnvelopeFormatOptions(params.config),
+    body: params.message.text,
+  });
+
+  const ctxPayload = params.runtime.channel.reply.finalizeInboundContext({
+    Body: body,
+    BodyForAgent: params.message.text,
+    RawBody: params.message.text,
+    CommandBody: params.message.text,
+    From: `vesicle:${params.message.sender || peerId}`,
+    To: target,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId ?? params.account.accountId,
+    ChatType: chatType,
+    WasMentioned: wasMentioned,
+    ConversationLabel: isGroup ? params.message.chatGuid : params.message.sender || peerId,
+    GroupSubject: isGroup ? params.message.chatGuid : undefined,
+    GroupChannel: isGroup ? params.message.chatGuid : undefined,
+    NativeChannelId: params.message.chatGuid,
+    SenderName: params.message.sender,
+    SenderId: params.message.sender,
+    Provider: "vesicle",
+    Surface: "vesicle",
+    MessageSid: params.message.messageGuid,
+    MessageSidFull: params.message.messageGuid,
+    Timestamp: timestamp,
+    OriginatingChannel: "vesicle",
+    OriginatingTo: target,
+    CommandAuthorized: true,
+  });
+
+  await params.dispatchInboundReplyWithBase({
+    cfg: params.config,
+    channel: "vesicle",
+    accountId: params.account.accountId,
+    route,
+    storePath,
+    ctxPayload,
+    core: params.runtime,
+    deliver: async (payload) => {
+      const text = readReplyText(payload);
+      if (!text.trim()) {
+        return;
+      }
+      await params.sendText({ to: target, text });
+    },
+    onRecordError: (error) => {
+      throw error instanceof Error
+        ? error
+        : new Error(`Vesicle session record failed: ${String(error)}`);
+    },
+    onDispatchError: (error) => {
+      throw error instanceof Error ? error : new Error(`Vesicle dispatch failed: ${String(error)}`);
+    },
+  });
+}

--- a/extensions/vesicle/src/inbound.ts
+++ b/extensions/vesicle/src/inbound.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { dispatchInboundReplyWithBase } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+import { handleVesicleInboundMessage } from "./inbound-core.js";
+import { getVesicleRuntime } from "./runtime.js";
+import { sendMessageVesicle } from "./send.js";
+import type { ResolvedVesicleAccount, VesicleInboundMessage } from "./types.js";
+
+export async function handleVesicleInbound(params: {
+  account: ResolvedVesicleAccount;
+  config: OpenClawConfig;
+  message: VesicleInboundMessage;
+}): Promise<void> {
+  await handleVesicleInboundMessage({
+    ...params,
+    runtime: getVesicleRuntime(),
+    dispatchInboundReplyWithBase,
+    sendText: async ({ to, text }) => {
+      await sendMessageVesicle(to, text, {
+        cfg: params.config,
+        accountId: params.account.accountId,
+      });
+    },
+  });
+}

--- a/extensions/vesicle/src/probe.ts
+++ b/extensions/vesicle/src/probe.ts
@@ -1,0 +1,64 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createVesicleClientFromParts } from "./client.js";
+import { normalizeSecretInputString } from "./secret-input.js";
+import { DEFAULT_PROBE_TIMEOUT_MS, type VesicleHealthResponse } from "./types.js";
+
+export type VesicleProbe = {
+  ok: boolean;
+  error?: string | null;
+  status?: number | null;
+  service?: string;
+  version?: string;
+  nativeStatus?: string;
+  capabilities?: VesicleHealthResponse["capabilities"];
+};
+
+export async function probeVesicle(params: {
+  baseUrl?: string | null;
+  authToken?: string | null;
+  timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
+}): Promise<VesicleProbe> {
+  const baseUrl = normalizeSecretInputString(params.baseUrl);
+  const authToken = normalizeSecretInputString(params.authToken);
+  if (!baseUrl) {
+    return { ok: false, error: "serverUrl not configured", status: null };
+  }
+  if (!authToken) {
+    return { ok: false, error: "authToken not configured", status: null };
+  }
+
+  const timeoutMs = params.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const client = createVesicleClientFromParts({
+    baseUrl,
+    authToken,
+    timeoutMs,
+    allowPrivateNetwork: params.allowPrivateNetwork === true,
+  });
+  try {
+    const { response, data } = await client.health({ timeoutMs });
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: `HTTP ${response.status}` };
+    }
+    if (!data) {
+      return { ok: false, status: response.status, error: "invalid health response" };
+    }
+    const nativeStatus = typeof data.status === "string" ? data.status : undefined;
+    const ok = nativeStatus === "running";
+    return {
+      ok,
+      status: response.status,
+      service: data.service,
+      version: data.version,
+      nativeStatus,
+      capabilities: data.capabilities,
+      error: ok ? null : (data.detail ?? nativeStatus ?? "Vesicle is not running"),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      error: formatErrorMessage(err),
+    };
+  }
+}

--- a/extensions/vesicle/src/runtime.ts
+++ b/extensions/vesicle/src/runtime.ts
@@ -1,0 +1,10 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+const { setRuntime: setVesicleRuntime, getRuntime: getVesicleRuntime } =
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "vesicle",
+    errorMessage: "Vesicle runtime not initialized",
+  });
+
+export { getVesicleRuntime, setVesicleRuntime };

--- a/extensions/vesicle/src/secret-contract.ts
+++ b/extensions/vesicle/src/secret-contract.ts
@@ -1,0 +1,91 @@
+import {
+  collectSimpleChannelFieldAssignments,
+  getChannelSurface,
+  type ResolverContext,
+  type SecretDefaults,
+  type SecretTargetRegistryEntry,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+export const secretTargetRegistryEntries = [
+  {
+    id: "channels.vesicle.accounts.*.authToken",
+    targetType: "channels.vesicle.accounts.*.authToken",
+    configFile: "openclaw.json",
+    pathPattern: "channels.vesicle.accounts.*.authToken",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.vesicle.authToken",
+    targetType: "channels.vesicle.authToken",
+    configFile: "openclaw.json",
+    pathPattern: "channels.vesicle.authToken",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.vesicle.accounts.*.webhookSecret",
+    targetType: "channels.vesicle.accounts.*.webhookSecret",
+    configFile: "openclaw.json",
+    pathPattern: "channels.vesicle.accounts.*.webhookSecret",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.vesicle.webhookSecret",
+    targetType: "channels.vesicle.webhookSecret",
+    configFile: "openclaw.json",
+    pathPattern: "channels.vesicle.webhookSecret",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+] satisfies SecretTargetRegistryEntry[];
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, "vesicle");
+  if (!resolved) {
+    return;
+  }
+  const { channel: vesicle, surface } = resolved;
+  collectSimpleChannelFieldAssignments({
+    channelKey: "vesicle",
+    field: "authToken",
+    channel: vesicle,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topInactiveReason: "no enabled account inherits this top-level Vesicle authToken.",
+    accountInactiveReason: "Vesicle account is disabled.",
+  });
+  collectSimpleChannelFieldAssignments({
+    channelKey: "vesicle",
+    field: "webhookSecret",
+    channel: vesicle,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topInactiveReason: "no enabled account inherits this top-level Vesicle webhookSecret.",
+    accountInactiveReason: "Vesicle account is disabled.",
+  });
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};

--- a/extensions/vesicle/src/secret-input.ts
+++ b/extensions/vesicle/src/secret-input.ts
@@ -1,0 +1,5 @@
+export {
+  buildSecretInputSchema,
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+} from "openclaw/plugin-sdk/secret-input";

--- a/extensions/vesicle/src/send.test.ts
+++ b/extensions/vesicle/src/send.test.ts
@@ -1,0 +1,58 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { describe, expect, it, vi } from "vitest";
+import { sendMessageVesicle } from "./send.js";
+
+const cfg = {
+  channels: {
+    vesicle: {
+      serverUrl: "http://127.0.0.1:1234",
+      authToken: "token",
+    },
+  },
+} as OpenClawConfig;
+
+describe("sendMessageVesicle", () => {
+  it("sends native text to a chat GUID target", async () => {
+    const client = {
+      sendText: vi.fn(async () => ({
+        response: new Response(JSON.stringify({ message: { messageGuid: "msg-1" } }), {
+          status: 200,
+        }),
+        data: { message: { messageGuid: "msg-1" } },
+      })),
+    };
+
+    await expect(
+      sendMessageVesicle("chat_guid:iMessage;-;+15551234567", "hello", { cfg, client }),
+    ).resolves.toEqual({
+      to: "chat_guid:iMessage;-;+15551234567",
+      messageId: "msg-1",
+    });
+    expect(client.sendText).toHaveBeenCalledWith({
+      chatGuid: "iMessage;-;+15551234567",
+      text: "hello",
+      timeoutMs: 30_000,
+    });
+  });
+
+  it("rejects handle targets until native chat lookup exists", async () => {
+    await expect(sendMessageVesicle("+15551234567", "hello", { cfg })).rejects.toThrow(
+      /chat_guid:<GUID>/,
+    );
+  });
+
+  it("surfaces native error envelopes", async () => {
+    const client = {
+      sendText: vi.fn(async () => ({
+        response: new Response(JSON.stringify({ code: "chat_not_found", message: "missing" }), {
+          status: 404,
+        }),
+        data: { code: "chat_not_found", message: "missing" },
+      })),
+    };
+
+    await expect(
+      sendMessageVesicle("chat_guid:iMessage;+;chat123", "hello", { cfg, client }),
+    ).rejects.toThrow("Vesicle send failed (404): chat_not_found: missing");
+  });
+});

--- a/extensions/vesicle/src/send.ts
+++ b/extensions/vesicle/src/send.ts
@@ -1,0 +1,93 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-runtime";
+import { resolveVesicleAccount, type ResolvedVesicleAccount } from "./accounts.js";
+import { createVesicleClient, type VesicleClient } from "./client.js";
+import { parseVesicleTarget } from "./targets.js";
+import {
+  DEFAULT_SEND_TIMEOUT_MS,
+  type VesicleErrorEnvelope,
+  type VesicleMessageTextResponse,
+} from "./types.js";
+
+export type VesicleSendResult = {
+  messageId: string;
+  to: string;
+};
+
+export type VesicleSendOpts = {
+  accountId?: string | null;
+  timeoutMs?: number;
+  cfg?: OpenClawConfig;
+  account?: ResolvedVesicleAccount;
+  client?: Pick<VesicleClient, "sendText">;
+};
+
+function readErrorMessage(data: unknown, status: number): string {
+  if (data && typeof data === "object") {
+    const envelope = data as VesicleErrorEnvelope;
+    if (typeof envelope.message === "string" && envelope.message.trim()) {
+      return envelope.code && envelope.code.trim()
+        ? `${envelope.code}: ${envelope.message}`
+        : envelope.message;
+    }
+  }
+  return `HTTP ${status}`;
+}
+
+function readMessageId(data: unknown): string {
+  if (!data || typeof data !== "object") {
+    return "unknown";
+  }
+  const response = data as VesicleMessageTextResponse;
+  const messageGuid = response.message?.messageGuid;
+  return typeof messageGuid === "string" && messageGuid.trim() ? messageGuid.trim() : "unknown";
+}
+
+export async function sendMessageVesicle(
+  to: string,
+  text: string,
+  opts: VesicleSendOpts = {},
+): Promise<VesicleSendResult> {
+  const cfg = requireRuntimeConfig(opts.cfg ?? {}, "Vesicle send");
+  const account =
+    opts.account ??
+    resolveVesicleAccount({
+      cfg,
+      accountId: opts.accountId,
+    });
+  const target = parseVesicleTarget(to);
+  if (target.kind !== "chat_guid") {
+    throw new Error(
+      "Vesicle send requires an existing chat target: use chat_guid:<GUID> until native chat lookup is available.",
+    );
+  }
+
+  const stripped = stripInlineDirectiveTagsForDelivery(text ?? "").text;
+  if (!stripped.trim()) {
+    throw new Error("Vesicle send requires text");
+  }
+
+  const timeoutMs = opts.timeoutMs ?? account.config.sendTimeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+  const client =
+    opts.client ??
+    createVesicleClient({
+      cfg,
+      accountId: account.accountId,
+      timeoutMs,
+    });
+  const { response, data } = await client.sendText({
+    chatGuid: target.chatGuid,
+    text: stripped,
+    timeoutMs,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Vesicle send failed (${response.status}): ${readErrorMessage(data, response.status)}`,
+    );
+  }
+  return {
+    to: `chat_guid:${target.chatGuid}`,
+    messageId: readMessageId(data),
+  };
+}

--- a/extensions/vesicle/src/setup.ts
+++ b/extensions/vesicle/src/setup.ts
@@ -1,0 +1,57 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { CoreConfig, VesicleAccountConfig } from "./types.js";
+
+function readString(input: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function applyVesicleSetup(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: Record<string, unknown>;
+}): OpenClawConfig {
+  const nextCfg = structuredClone(params.cfg) as CoreConfig;
+  const section = nextCfg.channels?.vesicle ?? {};
+  const accounts = { ...section.accounts };
+  const target: Partial<VesicleAccountConfig> =
+    params.accountId === DEFAULT_ACCOUNT_ID ? { ...section } : { ...accounts[params.accountId] };
+
+  const serverUrl = readString(params.input, ["serverUrl", "baseUrl", "url"]);
+  if (serverUrl) {
+    target.serverUrl = serverUrl;
+  }
+  const authToken = readString(params.input, ["authToken", "token", "secret", "password"]);
+  if (authToken) {
+    target.authToken = authToken;
+  }
+  const webhookPath = readString(params.input, ["webhookPath"]);
+  if (webhookPath) {
+    target.webhookPath = webhookPath;
+  }
+  const webhookSecret = readString(params.input, ["webhookSecret"]);
+  if (webhookSecret) {
+    target.webhookSecret = webhookSecret;
+  }
+
+  nextCfg.channels ??= {};
+  if (params.accountId === DEFAULT_ACCOUNT_ID) {
+    nextCfg.channels.vesicle = {
+      ...section,
+      ...target,
+    };
+  } else {
+    accounts[params.accountId] = target;
+    nextCfg.channels.vesicle = {
+      ...section,
+      accounts,
+    };
+  }
+  return nextCfg as OpenClawConfig;
+}

--- a/extensions/vesicle/src/status.ts
+++ b/extensions/vesicle/src/status.ts
@@ -1,0 +1,44 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { buildProbeChannelStatusSummary } from "openclaw/plugin-sdk/channel-status";
+import {
+  createComputedAccountStatusAdapter,
+  createDefaultChannelRuntimeState,
+} from "openclaw/plugin-sdk/status-helpers";
+import {
+  resolveVesicleEffectiveAllowPrivateNetwork,
+  type ResolvedVesicleAccount,
+} from "./accounts.js";
+import { probeVesicle, type VesicleProbe } from "./probe.js";
+
+export const vesicleStatus = createComputedAccountStatusAdapter<
+  ResolvedVesicleAccount,
+  VesicleProbe
+>({
+  defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
+  buildChannelSummary: ({ snapshot }) =>
+    buildProbeChannelStatusSummary(snapshot, { baseUrl: snapshot.baseUrl ?? null }),
+  probeAccount: async ({ account, timeoutMs }) =>
+    await probeVesicle({
+      baseUrl: account.baseUrl,
+      authToken: account.config.authToken ?? null,
+      timeoutMs: timeoutMs ?? account.config.probeTimeoutMs,
+      allowPrivateNetwork: resolveVesicleEffectiveAllowPrivateNetwork({
+        baseUrl: account.baseUrl,
+        config: account.config,
+      }),
+    }),
+  resolveAccountSnapshot: ({ account, runtime, probe }) => {
+    const running = runtime?.running ?? false;
+    return {
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: account.configured,
+      extra: {
+        baseUrl: account.baseUrl,
+        connected: probe?.ok ?? running,
+        nativeStatus: probe?.nativeStatus ?? null,
+      },
+    };
+  },
+});

--- a/extensions/vesicle/src/targets.test.ts
+++ b/extensions/vesicle/src/targets.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  inferVesicleTargetChatType,
+  looksLikeVesicleExplicitTargetId,
+  normalizeVesicleMessagingTarget,
+  parseVesicleTarget,
+  resolveVesicleOutboundSessionRoute,
+} from "./targets.js";
+
+describe("Vesicle targets", () => {
+  it("parses prefixed and raw chat GUID targets", () => {
+    expect(parseVesicleTarget("chat_guid:iMessage;-;+15551234567")).toEqual({
+      kind: "chat_guid",
+      chatGuid: "iMessage;-;+15551234567",
+    });
+    expect(parseVesicleTarget("vesicle:iMessage;+;chat123")).toEqual({
+      kind: "chat_guid",
+      chatGuid: "iMessage;+;chat123",
+    });
+  });
+
+  it("keeps handles parseable but not explicit send targets", () => {
+    expect(parseVesicleTarget("+15551234567")).toEqual({
+      kind: "handle",
+      to: "+15551234567",
+    });
+    expect(looksLikeVesicleExplicitTargetId("+15551234567")).toBe(false);
+  });
+
+  it("normalizes explicit chat GUID targets", () => {
+    expect(normalizeVesicleMessagingTarget("vesicle:guid:iMessage;+;chat123")).toBe(
+      "chat_guid:iMessage;+;chat123",
+    );
+    expect(looksLikeVesicleExplicitTargetId("iMessage;+;chat123")).toBe(true);
+  });
+
+  it("infers chat type from the Vesicle chat GUID separator", () => {
+    expect(inferVesicleTargetChatType("chat_guid:iMessage;-;+15551234567")).toBe("direct");
+    expect(inferVesicleTargetChatType("chat_guid:iMessage;+;chat123")).toBe("group");
+    expect(inferVesicleTargetChatType("+15551234567")).toBeUndefined();
+  });
+
+  it("builds direct outbound session routes using the DM handle as peer id", () => {
+    const route = resolveVesicleOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "chat_guid:iMessage;-;+15551234567",
+    });
+    expect(route?.chatType).toBe("direct");
+    expect(route?.peer).toEqual({ kind: "direct", id: "+15551234567" });
+    expect(route?.to).toBe("vesicle:chat_guid:iMessage;-;+15551234567");
+  });
+});

--- a/extensions/vesicle/src/targets.ts
+++ b/extensions/vesicle/src/targets.ts
@@ -1,0 +1,178 @@
+import {
+  buildChannelOutboundSessionRoute,
+  stripChannelTargetPrefix,
+  type ChannelOutboundSessionRouteParams,
+} from "openclaw/plugin-sdk/channel-core";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/text-runtime";
+
+export type VesicleTarget =
+  | { kind: "chat_guid"; chatGuid: string }
+  | { kind: "handle"; to: string };
+
+const CHAT_GUID_PREFIXES = ["chat_guid:", "chatguid:", "guid:"];
+
+function stripPrefix(value: string, prefix: string): string {
+  return value.slice(prefix.length).trim();
+}
+
+function stripVesiclePrefix(value: string): string {
+  const trimmed = normalizeOptionalString(value) ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("vesicle:")) {
+    return trimmed;
+  }
+  return trimmed.slice("vesicle:".length).trim();
+}
+
+function parseRawChatGuid(value: string): string | null {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return null;
+  }
+  const parts = trimmed.split(";");
+  if (parts.length !== 3) {
+    return null;
+  }
+  const service = normalizeOptionalString(parts[0]);
+  const separator = normalizeOptionalString(parts[1]);
+  const identifier = normalizeOptionalString(parts[2]);
+  if (!service || !identifier) {
+    return null;
+  }
+  if (separator !== "+" && separator !== "-") {
+    return null;
+  }
+  return `${service};${separator};${identifier}`;
+}
+
+export function extractHandleFromVesicleChatGuid(chatGuid: string): string | null {
+  const parts = chatGuid.split(";");
+  if (parts.length === 3 && parts[1] === "-") {
+    return normalizeOptionalString(parts[2]) ?? null;
+  }
+  return null;
+}
+
+export function parseVesicleTarget(raw: string): VesicleTarget {
+  const trimmed = stripVesiclePrefix(raw);
+  if (!trimmed) {
+    throw new Error("Vesicle target is required");
+  }
+  const lower = normalizeLowercaseStringOrEmpty(trimmed);
+
+  for (const prefix of CHAT_GUID_PREFIXES) {
+    if (lower.startsWith(prefix)) {
+      const value = stripPrefix(trimmed, prefix);
+      if (!value) {
+        throw new Error("Vesicle chat_guid target is required");
+      }
+      return { kind: "chat_guid", chatGuid: value };
+    }
+  }
+
+  if (lower.startsWith("group:")) {
+    const value = stripPrefix(trimmed, "group:");
+    if (!value) {
+      throw new Error("Vesicle group target is required");
+    }
+    return { kind: "chat_guid", chatGuid: value };
+  }
+
+  const rawChatGuid = parseRawChatGuid(trimmed);
+  if (rawChatGuid) {
+    return { kind: "chat_guid", chatGuid: rawChatGuid };
+  }
+
+  return { kind: "handle", to: trimmed };
+}
+
+export function normalizeVesicleMessagingTarget(raw: string): string | undefined {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = parseVesicleTarget(trimmed);
+    if (parsed.kind === "chat_guid") {
+      return `chat_guid:${parsed.chatGuid}`;
+    }
+  } catch {
+    return trimmed;
+  }
+  return trimmed;
+}
+
+export function looksLikeVesicleExplicitTargetId(raw: string, normalized?: string): boolean {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return false;
+  }
+  const candidate = stripVesiclePrefix(trimmed);
+  if (!candidate) {
+    return false;
+  }
+  if (parseRawChatGuid(candidate)) {
+    return true;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(candidate);
+  if (CHAT_GUID_PREFIXES.some((prefix) => lowered.startsWith(prefix))) {
+    return true;
+  }
+  if (lowered.startsWith("group:")) {
+    return true;
+  }
+  const normalizedTrimmed = normalizeOptionalString(normalized);
+  if (!normalizedTrimmed) {
+    return false;
+  }
+  const normalizedLower = normalizeLowercaseStringOrEmpty(normalizedTrimmed);
+  return CHAT_GUID_PREFIXES.some((prefix) => normalizedLower.startsWith(prefix));
+}
+
+export function inferVesicleTargetChatType(raw: string): "direct" | "group" | undefined {
+  try {
+    const parsed = parseVesicleTarget(raw);
+    if (parsed.kind !== "chat_guid") {
+      return undefined;
+    }
+    if (parsed.chatGuid.includes(";-;")) {
+      return "direct";
+    }
+    return "group";
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveVesicleOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
+  const stripped = stripChannelTargetPrefix(params.target, "vesicle");
+  if (!stripped) {
+    return null;
+  }
+  const parsed = parseVesicleTarget(stripped);
+  if (parsed.kind !== "chat_guid") {
+    return null;
+  }
+  const isGroup = parsed.chatGuid.includes(";+;") || !parsed.chatGuid.includes(";-;");
+  const peerId = isGroup
+    ? parsed.chatGuid
+    : (extractHandleFromVesicleChatGuid(parsed.chatGuid) ?? parsed.chatGuid);
+  return buildChannelOutboundSessionRoute({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    channel: "vesicle",
+    accountId: params.accountId,
+    peer: {
+      kind: isGroup ? "group" : "direct",
+      id: peerId,
+    },
+    chatType: isGroup ? "group" : "direct",
+    from: isGroup ? `group:${peerId}` : `vesicle:${peerId}`,
+    to: `vesicle:chat_guid:${parsed.chatGuid}`,
+  });
+}

--- a/extensions/vesicle/src/types.ts
+++ b/extensions/vesicle/src/types.ts
@@ -62,6 +62,18 @@ export type ResolvedVesicleAccount = {
   baseUrl?: string;
 };
 
+export type VesicleInboundMessage = {
+  messageGuid: string;
+  chatGuid: string;
+  isGroup?: boolean;
+  sender: string;
+  service?: string;
+  date?: number;
+  text: string;
+  isFromMe?: boolean;
+  rowId?: number | null;
+};
+
 export type VesicleCapabilities = {
   text?: boolean;
   attachments?: boolean;
@@ -103,3 +115,4 @@ export type VesicleErrorEnvelope = {
 
 export const DEFAULT_SEND_TIMEOUT_MS = 30_000;
 export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+export const DEFAULT_WEBHOOK_PATH = "/vesicle-webhook";

--- a/extensions/vesicle/src/types.ts
+++ b/extensions/vesicle/src/types.ts
@@ -1,0 +1,105 @@
+import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
+
+export type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
+
+export type VesicleNetworkConfig = {
+  /** Dangerous opt-in for trusted private/internal Vesicle deployments. */
+  dangerouslyAllowPrivateNetwork?: boolean;
+};
+
+export type VesicleAccountConfig = {
+  /** Optional display name for this account. */
+  name?: string;
+  /** If false, do not start this Vesicle account. Default: true. */
+  enabled?: boolean;
+  /** Base URL for the Vesicle API, for example http://127.0.0.1:1234. */
+  serverUrl?: string;
+  /** Bearer token accepted by Vesicle's API middleware. */
+  authToken?: string;
+  /** Native inbound webhook path exposed by OpenClaw. */
+  webhookPath?: string;
+  /** HMAC secret used to verify X-Vesicle-Signature on native webhooks. */
+  webhookSecret?: string;
+  /** Direct message access policy for inbound webhooks. */
+  dmPolicy?: DmPolicy;
+  allowFrom?: Array<string | number>;
+  /** Optional allowlist for group senders. */
+  groupAllowFrom?: Array<string | number>;
+  /** Group message handling policy. */
+  groupPolicy?: GroupPolicy;
+  /** Default delivery target for CLI --deliver when no explicit --reply-to is provided. */
+  defaultTo?: string;
+  /** Per-request timeout for outbound text sends. Default: 30000. */
+  sendTimeoutMs?: number;
+  /** Per-request timeout for status probes. Default: 10000. */
+  probeTimeoutMs?: number;
+  /** Outbound text chunk size. Default: 4000. */
+  textChunkLimit?: number;
+  /** Network policy overrides for same-host or trusted private/internal Vesicle deployments. */
+  network?: VesicleNetworkConfig;
+};
+
+export type VesicleConfig = VesicleAccountConfig & {
+  accounts?: Record<string, Partial<VesicleAccountConfig>>;
+  defaultAccount?: string;
+};
+
+export type CoreConfig = {
+  channels?: {
+    vesicle?: VesicleConfig;
+  };
+  session?: {
+    store?: string;
+  };
+};
+
+export type ResolvedVesicleAccount = {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  config: VesicleAccountConfig;
+  configured: boolean;
+  baseUrl?: string;
+};
+
+export type VesicleCapabilities = {
+  text?: boolean;
+  attachments?: boolean;
+  reactions?: boolean;
+  edits?: boolean;
+  unsend?: boolean;
+  groupManagement?: boolean;
+  facetime?: boolean;
+};
+
+export type VesicleHealthResponse = {
+  service?: string;
+  version?: string;
+  status?: string;
+  detail?: string;
+  capabilities?: VesicleCapabilities;
+};
+
+export type VesicleMessage = {
+  messageGuid?: string;
+  chatGuid?: string;
+  isGroup?: boolean;
+  sender?: string;
+  service?: string;
+  date?: number;
+  text?: string;
+  isFromMe?: boolean;
+  rowId?: number | null;
+};
+
+export type VesicleMessageTextResponse = {
+  message?: VesicleMessage;
+};
+
+export type VesicleErrorEnvelope = {
+  code?: string;
+  message?: string;
+};
+
+export const DEFAULT_SEND_TIMEOUT_MS = 30_000;
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;

--- a/extensions/vesicle/src/url.ts
+++ b/extensions/vesicle/src/url.ts
@@ -1,0 +1,8 @@
+export function normalizeVesicleServerUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Vesicle serverUrl is required");
+  }
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  return withScheme.replace(/\/+$/, "");
+}

--- a/extensions/vesicle/src/webhook.test.ts
+++ b/extensions/vesicle/src/webhook.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseVesicleWebhookPayload,
+  signVesicleWebhookBody,
+  verifyVesicleWebhookSignature,
+} from "./webhook.js";
+
+describe("Vesicle webhook security", () => {
+  it("verifies Vesicle HMAC signatures with and without the sha256 prefix", () => {
+    const body = JSON.stringify({
+      messageGuid: "msg-1",
+      chatGuid: "iMessage;-;+15551234567",
+      sender: "+15551234567",
+      text: "hello",
+    });
+    const signature = signVesicleWebhookBody(body, "secret");
+
+    expect(verifyVesicleWebhookSignature({ body, secret: "secret", signature })).toBe(true);
+    expect(
+      verifyVesicleWebhookSignature({
+        body,
+        secret: "secret",
+        signature: signature.replace(/^sha256=/, ""),
+      }),
+    ).toBe(true);
+    expect(verifyVesicleWebhookSignature({ body, secret: "wrong", signature })).toBe(false);
+  });
+});
+
+describe("parseVesicleWebhookPayload", () => {
+  it("parses the native Vesicle inbound envelope", () => {
+    const parsed = parseVesicleWebhookPayload(
+      JSON.stringify({
+        messageGuid: "msg-1",
+        chatGuid: "iMessage;+;chat123",
+        isGroup: true,
+        sender: "+15551234567",
+        service: "iMessage",
+        date: 1_777_000_000,
+        text: "hello",
+        isFromMe: false,
+        rowId: 42,
+      }),
+    );
+
+    expect(parsed).toEqual({
+      ok: true,
+      message: {
+        messageGuid: "msg-1",
+        chatGuid: "iMessage;+;chat123",
+        isGroup: true,
+        sender: "+15551234567",
+        service: "iMessage",
+        date: 1_777_000_000,
+        text: "hello",
+        isFromMe: false,
+        rowId: 42,
+      },
+    });
+  });
+
+  it("rejects payloads without required message identity fields", () => {
+    expect(parseVesicleWebhookPayload(JSON.stringify({ text: "hello" }))).toEqual({
+      ok: false,
+      error: "missing required message fields",
+    });
+  });
+});

--- a/extensions/vesicle/src/webhook.ts
+++ b/extensions/vesicle/src/webhook.ts
@@ -1,0 +1,247 @@
+import crypto from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import {
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  createFixedWindowRateLimiter,
+  createWebhookInFlightLimiter,
+  readWebhookBodyOrReject,
+  registerWebhookTargetWithPluginRoute,
+  resolveRequestClientIp,
+  withResolvedWebhookRequestPipeline,
+} from "openclaw/plugin-sdk/webhook-ingress";
+import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-path";
+import { handleVesicleInbound } from "./inbound.js";
+import { normalizeSecretInputString } from "./secret-input.js";
+import {
+  DEFAULT_WEBHOOK_PATH,
+  type ResolvedVesicleAccount,
+  type VesicleInboundMessage,
+} from "./types.js";
+
+type VesicleRuntimeEnv = {
+  log?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+export type VesicleWebhookTarget = {
+  account: ResolvedVesicleAccount;
+  config: Parameters<typeof handleVesicleInbound>[0]["config"];
+  runtime: VesicleRuntimeEnv;
+  path: string;
+  secret: string;
+  statusSink?: (patch: { lastInboundAt?: number }) => void;
+};
+
+const webhookTargets = new Map<string, VesicleWebhookTarget[]>();
+const webhookRateLimiter = createFixedWindowRateLimiter({
+  windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
+  maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+});
+const webhookInFlightLimiter = createWebhookInFlightLimiter();
+
+export function clearVesicleWebhookSecurityStateForTest(): void {
+  webhookRateLimiter.clear();
+  webhookInFlightLimiter.clear();
+}
+
+export function resolveVesicleWebhookPath(account: ResolvedVesicleAccount): string {
+  const raw = account.config.webhookPath?.trim();
+  return normalizeWebhookPath(raw || DEFAULT_WEBHOOK_PATH);
+}
+
+function normalizeSignature(raw: string | string[] | undefined): string {
+  const value = (Array.isArray(raw) ? raw[0] : raw)?.trim() ?? "";
+  if (!value) {
+    return "";
+  }
+  return value.toLowerCase().startsWith("sha256=") ? value.slice("sha256=".length).trim() : value;
+}
+
+export function signVesicleWebhookBody(body: string | Buffer, secret: string): string {
+  return `sha256=${crypto.createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+export function verifyVesicleWebhookSignature(params: {
+  body: string;
+  secret: string;
+  signature: string | string[] | undefined;
+}): boolean {
+  const supplied = normalizeSignature(params.signature);
+  if (!supplied || !params.secret) {
+    return false;
+  }
+  const expected = normalizeSignature(signVesicleWebhookBody(params.body, params.secret));
+  return safeEqualSecret(supplied, expected);
+}
+
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function parseVesicleWebhookPayload(
+  rawBody: string,
+): { ok: true; message: VesicleInboundMessage } | { ok: false; error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody) as unknown;
+  } catch {
+    return { ok: false, error: "invalid json" };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "invalid payload" };
+  }
+  const record = parsed as Record<string, unknown>;
+  const messageGuid = readString(record.messageGuid);
+  const chatGuid = readString(record.chatGuid);
+  const sender = readString(record.sender);
+  const text = readString(record.text);
+  if (!messageGuid || !chatGuid || !sender || !text) {
+    return { ok: false, error: "missing required message fields" };
+  }
+  return {
+    ok: true,
+    message: {
+      messageGuid,
+      chatGuid,
+      sender,
+      text,
+      isGroup: typeof record.isGroup === "boolean" ? record.isGroup : undefined,
+      service: readString(record.service) || undefined,
+      date: readNumber(record.date),
+      isFromMe: typeof record.isFromMe === "boolean" ? record.isFromMe : undefined,
+      rowId: readNumber(record.rowId) ?? null,
+    },
+  };
+}
+
+function collectTrustedProxies(targets: readonly VesicleWebhookTarget[]): string[] {
+  const proxies = new Set<string>();
+  for (const target of targets) {
+    for (const proxy of target.config.gateway?.trustedProxies ?? []) {
+      const normalized = proxy.trim();
+      if (normalized) {
+        proxies.add(normalized);
+      }
+    }
+  }
+  return [...proxies];
+}
+
+function resolveWebhookClientIp(
+  req: IncomingMessage,
+  targets: readonly VesicleWebhookTarget[],
+): string {
+  const trustedProxies = collectTrustedProxies(targets);
+  const allowRealIpFallback = targets.some(
+    (target) => target.config.gateway?.allowRealIpFallback === true,
+  );
+  if (!req.headers["x-forwarded-for"] && !(allowRealIpFallback && req.headers["x-real-ip"])) {
+    return req.socket.remoteAddress ?? "unknown";
+  }
+  return (
+    resolveRequestClientIp(req, trustedProxies, allowRealIpFallback) ??
+    req.socket.remoteAddress ??
+    "unknown"
+  );
+}
+
+export function registerVesicleWebhookTarget(target: VesicleWebhookTarget): () => void {
+  return registerWebhookTargetWithPluginRoute({
+    targetsByPath: webhookTargets,
+    target,
+    route: {
+      auth: "plugin",
+      match: "exact",
+      pluginId: "vesicle",
+      source: "vesicle-webhook",
+      accountId: target.account.accountId,
+      log: target.runtime.log,
+      handler: async (req, res) => {
+        const handled = await handleVesicleWebhookRequest(req, res);
+        if (!handled && !res.headersSent) {
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "text/plain; charset=utf-8");
+          res.end("Not Found");
+        }
+      },
+    },
+  }).unregister;
+}
+
+export async function handleVesicleWebhookRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+  const normalizedPath = normalizeWebhookPath(requestUrl.pathname);
+  const pathTargets = webhookTargets.get(normalizedPath) ?? [];
+  const clientIp = resolveWebhookClientIp(req, pathTargets);
+  return await withResolvedWebhookRequestPipeline({
+    req,
+    res,
+    targetsByPath: webhookTargets,
+    allowMethods: ["POST"],
+    requireJsonContentType: true,
+    rateLimiter: webhookRateLimiter,
+    rateLimitKey: `${normalizedPath}:${clientIp}`,
+    inFlightLimiter: webhookInFlightLimiter,
+    inFlightKey: `${normalizedPath}:${clientIp}`,
+    handle: async ({ targets }) => {
+      const body = await readWebhookBodyOrReject({
+        req,
+        res,
+        profile: "pre-auth",
+        invalidBodyMessage: "invalid payload",
+      });
+      if (!body.ok) {
+        return true;
+      }
+      const signature = req.headers["x-vesicle-signature"];
+      const target = targets.find((entry) =>
+        verifyVesicleWebhookSignature({
+          body: body.value,
+          secret: entry.secret,
+          signature,
+        }),
+      );
+      if (!target) {
+        res.statusCode = 401;
+        res.end("unauthorized");
+        return true;
+      }
+      const parsed = parseVesicleWebhookPayload(body.value);
+      if (!parsed.ok) {
+        res.statusCode = 400;
+        res.end(parsed.error);
+        return true;
+      }
+
+      target.statusSink?.({ lastInboundAt: Date.now() });
+      handleVesicleInbound({
+        account: target.account,
+        config: target.config,
+        message: parsed.message,
+      }).catch((error) => {
+        target.runtime.error?.(
+          `[${target.account.accountId}] Vesicle webhook failed: ${String(error)}`,
+        );
+      });
+
+      res.statusCode = 200;
+      res.end("ok");
+      return true;
+    },
+  });
+}
+
+export function resolveConfiguredVesicleWebhookSecret(
+  account: ResolvedVesicleAccount,
+): string | undefined {
+  return normalizeSecretInputString(account.config.webhookSecret) ?? undefined;
+}

--- a/extensions/vesicle/tsconfig.json
+++ b/extensions/vesicle/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1562,6 +1562,7 @@
     "test:perf:profile:main": "node scripts/run-vitest-profile.mjs main",
     "test:perf:profile:runner": "node scripts/run-vitest-profile.mjs runner",
     "test:plugins:gateway-gauntlet": "node scripts/check-plugin-gateway-gauntlet.mjs",
+    "test:plugins:vesicle-install": "bash scripts/e2e/vesicle-plugin-install-smoke.sh",
     "test:sectriage": "OPENCLAW_GATEWAY_PROJECT_SHARDS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts && node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts --exclude src/daemon/launchd.integration.test.ts --exclude src/process/exec.test.ts",
     "test:serial": "OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs",
     "test:stability:gateway": "OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/gateway-stability.test.ts && OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic-stability-bundle.test.ts && OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/fatal-error-hooks.test.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,6 +1379,15 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/vesicle:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/video-generation-core:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/e2e/vesicle-plugin-install-smoke.sh
+++ b/scripts/e2e/vesicle-plugin-install-smoke.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Fast local smoke test for the installable Vesicle channel plugin package.
+#
+# This intentionally disables bundled plugin discovery so the smoke only tests
+# Vesicle packaging/install behavior and does not stage unrelated bundled
+# runtime dependencies.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+TMP_ROOT="${OPENCLAW_VESICLE_PLUGIN_TMP_ROOT:-${TMPDIR:-/tmp}}"
+mkdir -p "$TMP_ROOT"
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
+
+PACK_DEST="${OPENCLAW_VESICLE_PLUGIN_PACK_DEST:-/tmp}"
+mkdir -p "$PACK_DEST"
+PACK_DEST="$(cd "$PACK_DEST" && pwd -P)"
+
+NPM_CACHE="${OPENCLAW_VESICLE_PLUGIN_NPM_CACHE:-${npm_config_cache:-${NPM_CONFIG_CACHE:-$TMP_ROOT/openclaw-npm-cache}}}"
+STATE_DIR_CREATED=0
+if [[ -n "${OPENCLAW_VESICLE_PLUGIN_STATE_DIR:-}" ]]; then
+  STATE_DIR="$OPENCLAW_VESICLE_PLUGIN_STATE_DIR"
+  mkdir -p "$STATE_DIR"
+else
+  STATE_DIR="$(mktemp -d "$TMP_ROOT/openclaw-vesicle-plugin-smoke.XXXXXX")"
+  STATE_DIR_CREATED=1
+fi
+STATE_DIR="$(cd "$STATE_DIR" && pwd -P)"
+KEEP_STATE="${OPENCLAW_VESICLE_PLUGIN_KEEP_STATE:-$((1 - STATE_DIR_CREATED))}"
+
+cleanup() {
+  if [[ "$KEEP_STATE" != "1" ]]; then
+    rm -rf "$STATE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "$ROOT_DIR/dist/entry.js" && ! -f "$ROOT_DIR/dist/entry.mjs" ]]; then
+  echo "==> dist/entry.js missing; running fast CLI bundle"
+  (cd "$ROOT_DIR" && node scripts/tsdown-build.mjs)
+fi
+
+echo "==> OpenClaw CLI"
+node "$ROOT_DIR/openclaw.mjs" --version
+
+echo "==> Packing @openclaw/vesicle"
+pack_name="$(
+  cd "$ROOT_DIR"
+  env npm_config_cache="$NPM_CACHE" npm pack --silent --ignore-scripts ./extensions/vesicle --pack-destination "$PACK_DEST"
+)"
+pack_name="$(printf "%s\n" "$pack_name" | tail -n 1)"
+pack_path="$PACK_DEST/$pack_name"
+if [[ ! -f "$pack_path" ]]; then
+  echo "Packed tarball not found: $pack_path" >&2
+  exit 1
+fi
+echo "Packed $pack_path"
+
+run_openclaw() {
+  env \
+    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
+    OPENCLAW_STATE_DIR="$STATE_DIR" \
+    OPENCLAW_CONFIG_PATH="$STATE_DIR/openclaw.json" \
+    npm_config_cache="$NPM_CACHE" \
+    node "$ROOT_DIR/openclaw.mjs" "$@"
+}
+
+echo "==> Installing packed Vesicle plugin"
+run_openclaw plugins install "$pack_path"
+
+echo "==> Listing plugins"
+run_openclaw plugins list
+
+inspect_json="$STATE_DIR/vesicle-inspect.json"
+run_openclaw plugins inspect vesicle --json >"$inspect_json"
+node -e '
+const fs = require("node:fs");
+const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const plugin = data.plugin ?? {};
+const diagnostics = Array.isArray(data.diagnostics) ? data.diagnostics : [];
+const channelIds = Array.isArray(plugin.channelIds) ? plugin.channelIds : [];
+const errors = [];
+if (plugin.id !== "vesicle") {
+  errors.push(`expected plugin id vesicle, got ${JSON.stringify(plugin.id)}`);
+}
+if (plugin.status !== "loaded") {
+  errors.push(`expected plugin status loaded, got ${JSON.stringify(plugin.status)}`);
+}
+if (!channelIds.includes("vesicle")) {
+  errors.push(`expected channelIds to include vesicle, got ${JSON.stringify(channelIds)}`);
+}
+if (data.install?.source !== "archive") {
+  errors.push(`expected archive install source, got ${JSON.stringify(data.install?.source)}`);
+}
+if (diagnostics.length > 0) {
+  errors.push(`expected no diagnostics, got ${JSON.stringify(diagnostics)}`);
+}
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+' "$inspect_json"
+
+echo "Vesicle plugin install smoke passed."

--- a/scripts/lib/bundled-runtime-sidecar-paths.json
+++ b/scripts/lib/bundled-runtime-sidecar-paths.json
@@ -34,6 +34,7 @@
   "dist/extensions/tlon/runtime-api.js",
   "dist/extensions/tokenjuice/runtime-api.js",
   "dist/extensions/twitch/runtime-api.js",
+  "dist/extensions/vesicle/runtime-api.js",
   "dist/extensions/voice-call/runtime-api.js",
   "dist/extensions/webhooks/runtime-api.js",
   "dist/extensions/whatsapp/light-runtime-api.js",

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -15705,6 +15705,462 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
     },
   },
   {
+    pluginId: "vesicle",
+    channelId: "vesicle",
+    label: "Vesicle",
+    description: "iMessage via Vesicle's native REST API.",
+    schema: {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+        },
+        enabled: {
+          type: "boolean",
+        },
+        markdown: {
+          type: "object",
+          properties: {
+            tables: {
+              type: "string",
+              enum: ["off", "bullets", "code", "block"],
+            },
+          },
+          additionalProperties: false,
+        },
+        serverUrl: {
+          type: "string",
+        },
+        authToken: {
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "env",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                      pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "file",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "exec",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          ],
+        },
+        webhookPath: {
+          type: "string",
+        },
+        webhookSecret: {
+          anyOf: [
+            {
+              type: "string",
+            },
+            {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "env",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                      pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "file",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+                {
+                  type: "object",
+                  properties: {
+                    source: {
+                      type: "string",
+                      const: "exec",
+                    },
+                    provider: {
+                      type: "string",
+                      pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                    },
+                    id: {
+                      type: "string",
+                    },
+                  },
+                  required: ["source", "provider", "id"],
+                  additionalProperties: false,
+                },
+              ],
+            },
+          ],
+        },
+        dmPolicy: {
+          type: "string",
+          enum: ["pairing", "allowlist", "open", "disabled"],
+        },
+        allowFrom: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
+        },
+        groupAllowFrom: {
+          type: "array",
+          items: {
+            anyOf: [
+              {
+                type: "string",
+              },
+              {
+                type: "number",
+              },
+            ],
+          },
+        },
+        groupPolicy: {
+          type: "string",
+          enum: ["open", "disabled", "allowlist"],
+        },
+        defaultTo: {
+          type: "string",
+        },
+        sendTimeoutMs: {
+          type: "integer",
+          exclusiveMinimum: 0,
+          maximum: 9007199254740991,
+        },
+        probeTimeoutMs: {
+          type: "integer",
+          exclusiveMinimum: 0,
+          maximum: 9007199254740991,
+        },
+        textChunkLimit: {
+          type: "integer",
+          exclusiveMinimum: 0,
+          maximum: 9007199254740991,
+        },
+        network: {
+          type: "object",
+          properties: {
+            dangerouslyAllowPrivateNetwork: {
+              type: "boolean",
+            },
+          },
+          additionalProperties: false,
+        },
+        accounts: {
+          type: "object",
+          properties: {},
+          additionalProperties: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+              },
+              enabled: {
+                type: "boolean",
+              },
+              markdown: {
+                type: "object",
+                properties: {
+                  tables: {
+                    type: "string",
+                    enum: ["off", "bullets", "code", "block"],
+                  },
+                },
+                additionalProperties: false,
+              },
+              serverUrl: {
+                type: "string",
+              },
+              authToken: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "env",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                            pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "file",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "exec",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+              webhookPath: {
+                type: "string",
+              },
+              webhookSecret: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    oneOf: [
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "env",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                            pattern: "^[A-Z][A-Z0-9_]{0,127}$",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "file",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                      {
+                        type: "object",
+                        properties: {
+                          source: {
+                            type: "string",
+                            const: "exec",
+                          },
+                          provider: {
+                            type: "string",
+                            pattern: "^[a-z][a-z0-9_-]{0,63}$",
+                          },
+                          id: {
+                            type: "string",
+                          },
+                        },
+                        required: ["source", "provider", "id"],
+                        additionalProperties: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+              dmPolicy: {
+                type: "string",
+                enum: ["pairing", "allowlist", "open", "disabled"],
+              },
+              allowFrom: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+              groupAllowFrom: {
+                type: "array",
+                items: {
+                  anyOf: [
+                    {
+                      type: "string",
+                    },
+                    {
+                      type: "number",
+                    },
+                  ],
+                },
+              },
+              groupPolicy: {
+                type: "string",
+                enum: ["open", "disabled", "allowlist"],
+              },
+              defaultTo: {
+                type: "string",
+              },
+              sendTimeoutMs: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
+              probeTimeoutMs: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
+              textChunkLimit: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
+              network: {
+                type: "object",
+                properties: {
+                  dangerouslyAllowPrivateNetwork: {
+                    type: "boolean",
+                  },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+        defaultAccount: {
+          type: "string",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
     pluginId: "whatsapp",
     channelId: "whatsapp",
     label: "WhatsApp",


### PR DESCRIPTION
## Summary
- add a Vesicle native iMessage channel plugin
- add native signed webhook ingress and Vesicle REST client wiring
- document plugin install/setup and add install smoke coverage

## Verification
- pnpm test:plugins:vesicle-install
- node scripts/check-extension-package-tsc-boundary.mjs --mode=compile
- installed and inspected the packed plugin on Rocky OpenClaw 2026.4.27
- verified Forge Vesicle native health/capability routes and signed /vesicle-webhook smoke