### PR TITLE
Fix macOS LaunchAgent PATH canonicalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/sandbox: preserve existing workspace file modes when sandbox edits atomically replace files, so 0644 files do not collapse to 0600 after Write/Edit/apply_patch. Fixes #44077. Thanks @patosullivan.
-- Agents/models: keep legacy CLI runtime model refs such as `claude-cli/*` in the configured allowlist after canonical runtime migration, so cron `payload.model` overrides keep working. Fixes #75753. Thanks @RyanSandoval.
+- Gateway/macOS: write LaunchAgent services with a canonical system PATH and stop preserving old plist PATH entries, so Volta, asdf, fnm, and pnpm shell paths no longer affect gateway child-process Node resolution. Fixes #75233. Thanks @nphyde2.
+- # Agents/sandbox: preserve existing workspace file modes when sandbox edits atomically replace files, so 0644 files do not collapse to 0600 after Write/Edit/apply_patch. Fixes #44077. Thanks @patosullivan.
+  > > > > > > > 007574cee3 (fix: canonicalize macOS LaunchAgent PATH)
 - Gateway/watch: keep colored subsystem log prefixes in the managed tmux pane even when the parent shell exports `NO_COLOR`, while preserving explicit `FORCE_COLOR=0` opt-out. Thanks @vincentkoc.
 - Agents/compaction: submit a non-empty runtime-event marker for pre-compaction memory flush turns, so strict Anthropic providers no longer reject the silent flush as an empty user message. Fixes #75305. Thanks @sableassistant3777-source.
 - Plugin SDK: re-export `isPrivateIpAddress` from `plugin-sdk/ssrf-runtime`, restoring source-checkout builds for SearXNG and Firecrawl private-network guards. Thanks @vincentkoc.
@@ -285,6 +286,7 @@ Docs: https://docs.openclaw.ai
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.
 - Discord: report native slash-command deploy aborts as REST timeouts with method, path, timeout budget, and observed duration, so startup logs explain slow Discord API calls instead of showing a generic aborted operation. Thanks @discord.
 - Security/logging: redact payment credential field names such as card number, CVC/CVV, shared payment token, and payment credential across default log and tool-payload redaction patterns so wallet-style MCP tools do not expose raw payment credentials in UI events or transcripts. Thanks @stainlu.
+- Providers/OpenAI Codex: preserve existing wrapped Codex streams
 - Providers/OpenAI Codex: preserve existing wrapped Codex streams during OpenAI attribution so PI OAuth bearer injection reaches ChatGPT/Codex Responses, and strip native Codex-only unsupported payload fields without touching custom compatible endpoints. (#75111) Thanks @keshavbotagent.
 - Plugins/runtime-deps: materialize newly required bundled plugin packages after local `openclaw onboard` and `openclaw configure` config writes, while keeping remote setup read-only, so first Gateway startup no longer discovers missing channel/provider deps after setup claimed success. Fixes #75309; refs #75069. Thanks @scottgl9 and @xiaohuaxi.
 - Plugins/runtime-deps: expire stale legacy install locks whose live PID cannot be tied to the current process incarnation, so Docker PID reuse no longer leaves bundled dependency repair stuck behind old `.openclaw-runtime-deps.lock` directories. Fixes #74948; refs #74950 and #74346. Thanks @dchekmarev.

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -473,7 +473,7 @@ That stages grounded durable candidates into the short-term dreaming store while
   <Accordion title="17. Gateway runtime best practices">
     Doctor warns when the gateway service runs on Bun or a version-managed Node path (`nvm`, `fnm`, `volta`, `asdf`, etc.). WhatsApp + Telegram channels require Node, and version-manager paths can break after upgrades because the service does not load your shell init. Doctor offers to migrate to a system Node install when available (Homebrew/apt/choco).
 
-    Newly installed or repaired services keep explicit environment roots (`NVM_DIR`, `FNM_DIR`, `VOLTA_HOME`, `ASDF_DATA_DIR`, `BUN_INSTALL`, `PNPM_HOME`) and stable user-bin directories, but guessed version-manager fallback directories are only written to the service PATH when those directories exist on disk. This keeps the generated supervisor PATH aligned with the same minimal-PATH audit doctor runs later.
+    Newly installed or repaired macOS LaunchAgents use a canonical system PATH (`/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`) instead of copying the interactive shell PATH, so Volta, asdf, fnm, pnpm, and other version-manager directories do not change which Node child processes resolve. Linux services still keep explicit environment roots (`NVM_DIR`, `FNM_DIR`, `VOLTA_HOME`, `ASDF_DATA_DIR`, `BUN_INSTALL`, `PNPM_HOME`) and stable user-bin directories, but guessed version-manager fallback directories are only written to the service PATH when those directories exist on disk.
 
   </Accordion>
   <Accordion title="18. Config write + wizard metadata">

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -555,6 +555,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       env: { HOME: tmpDir },
       port: 3000,
       runtime: "node",
+      platform: "linux",
       existingEnvironment: {
         PATH: [
           ".",
@@ -611,6 +612,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
         env: { HOME: tmpDir },
         port: 3000,
         runtime: "node",
+        platform: "linux",
         existingEnvironment: {
           PATH: "/opt/safe/bin:/opt/safe/missing-bin:/custom/go/bin:/usr/bin",
         },
@@ -637,6 +639,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       env: { HOME: cwd },
       port: 3000,
       runtime: "node",
+      platform: "linux",
       existingEnvironment: {
         PATH: `${cwd}/evil-bin:/custom/go/bin:/usr/bin`,
       },
@@ -658,6 +661,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       env: { HOME: tmpDir },
       port: 3000,
       runtime: "node",
+      platform: "linux",
       existingEnvironment: {
         PATH: "/custom/go/bin:/usr/bin",
         GOBIN: "/Users/test/.local/gopath/bin",
@@ -672,6 +676,36 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     expect(plan.environment.BLOGWATCHER_HOME).toBe("/Users/test/.blogwatcher");
     expect(plan.environment.GOPATH).toBeUndefined();
     expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBeUndefined();
+  });
+
+  it("does not preserve existing PATH entries for macOS LaunchAgents", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        HOME: "/from-service",
+        OPENCLAW_PORT: "3000",
+        PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        TMPDIR: "/tmp",
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: { HOME: tmpDir },
+      port: 3000,
+      runtime: "node",
+      platform: "darwin",
+      existingEnvironment: {
+        PATH: [
+          "/Users/test/.volta/bin",
+          "/Users/test/.asdf/shims",
+          "/Users/test/Library/Application Support/fnm/aliases/default/bin",
+          "/Users/test/Library/pnpm",
+          "/custom/go/bin",
+          "/usr/bin",
+        ].join(path.delimiter),
+      },
+    });
+
+    expect(plan.environment.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
   });
 
   it("drops legacy inline env values when the key is now managed by .env", async () => {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -173,6 +173,7 @@ function mergeServicePath(
   nextPath: string | undefined,
   existingPath: string | undefined,
   tmpDir: string | undefined,
+  platform: NodeJS.Platform,
 ): string | undefined {
   const segments: string[] = [];
   const seen = new Set<string>();
@@ -257,7 +258,9 @@ function mergeServicePath(
     }
   };
   addPath(nextPath);
-  addPath(existingPath, { preserve: true });
+  if (platform !== "darwin") {
+    addPath(existingPath, { preserve: true });
+  }
   return segments.length > 0 ? segments.join(path.delimiter) : undefined;
 }
 
@@ -319,6 +322,7 @@ async function buildGatewayInstallEnvironment(params: {
   warn?: DaemonInstallWarnFn;
   serviceEnvironment: Record<string, string | undefined>;
   existingEnvironment?: Record<string, string | undefined>;
+  platform: NodeJS.Platform;
 }): Promise<Record<string, string | undefined>> {
   const durableEnvironment = collectDurableServiceEnvVars({
     env: params.env,
@@ -353,6 +357,7 @@ async function buildGatewayInstallEnvironment(params: {
     params.serviceEnvironment.PATH,
     params.existingEnvironment?.PATH,
     params.serviceEnvironment.TMPDIR,
+    params.platform,
   );
   if (mergedPath) {
     environment.PATH = mergedPath;
@@ -427,6 +432,7 @@ export async function buildGatewayInstallPlan(params: {
       warn: params.warn,
       serviceEnvironment,
       existingEnvironment: params.existingEnvironment,
+      platform,
     }),
   };
 }

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -111,36 +111,21 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/opt/fnm/current/bin");
   });
 
-  it("includes version manager directories on macOS when HOME is set", () => {
+  it("uses only canonical system directories on macOS by default", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
       existsSync: allExist,
     });
 
-    // Should include common user bin directories
-    expect(result).toContain("/Users/testuser/.local/bin");
-    expect(result).toContain("/Users/testuser/.npm-global/bin");
-    expect(result).toContain("/Users/testuser/bin");
-
-    // Should include version manager paths (macOS specific)
-    // Note: nvm has no stable default path, relies on user's shell config
-    expect(result).toContain("/Users/testuser/Library/Application Support/fnm/aliases/default/bin"); // fnm default on macOS
-    expect(result).toContain("/Users/testuser/.fnm/aliases/default/bin"); // fnm if customized to ~/.fnm
-    expect(result).toContain("/Users/testuser/.volta/bin");
-    expect(result).toContain("/Users/testuser/.asdf/shims");
-    expect(result).toContain("/Users/testuser/Library/pnpm"); // pnpm default on macOS
-    expect(result).toContain("/Users/testuser/.local/share/pnpm"); // pnpm XDG fallback
-    expect(result).toContain("/Users/testuser/.bun/bin");
-
-    // Should also include macOS system directories
-    expect(result).toContain("/opt/homebrew/bin");
-    expect(result).toContain("/usr/local/bin");
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result.some((entry) => entry.startsWith("/Users/testuser/"))).toBe(false);
   });
 
-  it("includes env-configured version manager dirs on macOS", () => {
+  it("can include env-configured version manager dirs on macOS when requested", () => {
     const result = getMinimalServicePathPartsFromEnv({
       platform: "darwin",
+      includeUserDirs: true,
       env: {
         HOME: "/Users/testuser",
         FNM_DIR: "/Users/testuser/Library/Application Support/fnm",
@@ -158,22 +143,18 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/Users/testuser/Library/pnpm");
   });
 
-  it("places version manager dirs before system dirs on macOS", () => {
+  it("does not let version manager dirs precede system dirs on macOS by default", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
       existsSync: allExist,
     });
 
-    // fnm on macOS defaults to ~/Library/Application Support/fnm
-    const fnmIndex = result.indexOf(
-      "/Users/testuser/Library/Application Support/fnm/aliases/default/bin",
-    );
-    const homebrewIndex = result.indexOf("/opt/homebrew/bin");
+    const fnmIndex = result.indexOf("/Users/testuser/.fnm/aliases/default/bin");
+    const systemIndex = result.indexOf("/usr/local/bin");
 
-    expect(fnmIndex).toBeGreaterThan(-1);
-    expect(homebrewIndex).toBeGreaterThan(-1);
-    expect(fnmIndex).toBeLessThan(homebrewIndex);
+    expect(fnmIndex).toBe(-1);
+    expect(systemIndex).toBe(0);
   });
 
   it("does not include Linux user directories on Windows", () => {
@@ -209,17 +190,18 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).not.toContain("/home/testuser/.local/share/pnpm");
   });
 
-  it("omits hard-coded version-manager fallbacks on macOS when missing", () => {
+  it("omits all user PATH fallbacks on macOS even when HOME is set", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
       existsSync: noneExist,
     });
 
-    expect(result).toContain("/Users/testuser/.local/bin");
-    expect(result).toContain("/Users/testuser/.npm-global/bin");
-    expect(result).toContain("/Users/testuser/bin");
-    expect(result).toContain("/Users/testuser/.nix-profile/bin");
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
+    expect(result).not.toContain("/Users/testuser/.local/bin");
+    expect(result).not.toContain("/Users/testuser/.npm-global/bin");
+    expect(result).not.toContain("/Users/testuser/bin");
+    expect(result).not.toContain("/Users/testuser/.nix-profile/bin");
     expect(result).not.toContain("/Users/testuser/.volta/bin");
     expect(result).not.toContain("/Users/testuser/.asdf/shims");
     expect(result).not.toContain("/Users/testuser/.bun/bin");
@@ -357,14 +339,15 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     expect(result).toContain("/home/testuser/.nix-profile/bin");
   });
 
-  it("falls back to default Nix profile when NIX_PROFILES is absent on macOS", () => {
+  it("omits the default Nix profile from macOS service PATH by default", () => {
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
       existsSync: () => true,
     });
 
-    expect(result).toContain("/Users/testuser/.nix-profile/bin");
+    expect(result).not.toContain("/Users/testuser/.nix-profile/bin");
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
   });
 
   it("places rightmost NIX_PROFILES entry before leftmost on Linux", () => {
@@ -384,7 +367,7 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     expect(userIdx).toBeLessThan(defaultIdx);
   });
 
-  it("places rightmost NIX_PROFILES entry before leftmost on macOS", () => {
+  it("ignores NIX_PROFILES on macOS service PATH by default", () => {
     const result = getMinimalServicePathPartsFromEnv({
       platform: "darwin",
       env: {
@@ -396,9 +379,9 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
 
     const userIdx = result.indexOf("/Users/testuser/.nix-profile/bin");
     const defaultIdx = result.indexOf("/nix/var/nix/profiles/default/bin");
-    expect(userIdx).toBeGreaterThan(-1);
-    expect(defaultIdx).toBeGreaterThan(-1);
-    expect(userIdx).toBeLessThan(defaultIdx);
+    expect(userIdx).toBe(-1);
+    expect(defaultIdx).toBe(-1);
+    expect(result).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
   });
 
   it("includes single Nix profile from NIX_PROFILES on Linux", () => {
@@ -414,9 +397,10 @@ describe("getMinimalServicePathParts - Nix Home Manager", () => {
     expect(result).toContain("/nix/var/nix/profiles/per-user/testuser/profile/bin");
   });
 
-  it("includes single Nix profile from NIX_PROFILES on macOS", () => {
+  it("can include single Nix profile from NIX_PROFILES on macOS when requested", () => {
     const result = getMinimalServicePathPartsFromEnv({
       platform: "darwin",
+      includeUserDirs: true,
       env: {
         HOME: "/Users/testuser",
         NIX_PROFILES: "/nix/var/nix/profiles/per-user/testuser/profile",
@@ -453,15 +437,12 @@ describe("buildMinimalServicePath", () => {
   const splitPath = (value: string, platform: NodeJS.Platform) =>
     value.split(platform === "win32" ? path.win32.delimiter : path.posix.delimiter);
 
-  it("includes Homebrew + system dirs on macOS", () => {
+  it("uses canonical launchd system dirs on macOS", () => {
     const result = buildMinimalServicePath({
       platform: "darwin",
     });
     const parts = splitPath(result, "darwin");
-    expect(parts).toContain("/opt/homebrew/bin");
-    expect(parts).toContain("/usr/local/bin");
-    expect(parts).toContain("/usr/bin");
-    expect(parts).toContain("/bin");
+    expect(parts).toEqual(["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"]);
   });
 
   it("returns PATH as-is on Windows", () => {
@@ -606,6 +587,22 @@ describe("buildServiceEnvironment", () => {
       platform: "darwin",
     });
     expect(env.TMPDIR).toBe(path.join("/Users/user", ".openclaw", "tmp"));
+  });
+
+  it("uses a canonical system PATH for macOS LaunchAgents", () => {
+    const env = buildServiceEnvironment({
+      env: {
+        HOME: "/Users/user",
+        FNM_DIR: "/Users/user/Library/Application Support/fnm",
+        PNPM_HOME: "/Users/user/Library/pnpm",
+        VOLTA_HOME: "/Users/user/.volta",
+        ASDF_DATA_DIR: "/Users/user/.asdf",
+      },
+      port: 18789,
+      platform: "darwin",
+    });
+
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
   });
 
   it("falls back to os.tmpdir when TMPDIR is not set on Linux", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -28,6 +28,7 @@ export { isNodeVersionManagerRuntime, resolveLinuxSystemCaBundle };
 type MinimalServicePathOptions = {
   platform?: NodeJS.Platform;
   extraDirs?: string[];
+  includeUserDirs?: boolean;
   home?: string;
   cwd?: string;
   env?: Record<string, string | undefined>;
@@ -209,7 +210,7 @@ function addNixProfileBinDirs(
 
 function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
   if (platform === "darwin") {
-    return ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
+    return ["/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
   }
   if (platform === "linux") {
     return ["/usr/local/bin", "/usr/bin", "/bin"];
@@ -316,15 +317,16 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   const parts: string[] = [];
   const extraDirs = options.extraDirs ?? [];
   const systemDirs = resolveSystemPathDirs(platform);
+  const includeUserDirs = options.includeUserDirs ?? platform !== "darwin";
 
-  // Add user bin directories for version managers (npm global, nvm, fnm, volta, etc.)
   const existsSync = options.existsSync ?? fs.existsSync;
-  const userDirs =
-    platform === "linux"
+  const userDirs = includeUserDirs
+    ? platform === "linux"
       ? resolveLinuxUserBinDirs(options.home, options.env, existsSync, options)
       : platform === "darwin"
         ? resolveDarwinUserBinDirs(options.home, options.env, existsSync, options)
-        : [];
+        : []
+    : [];
 
   const add = (dir: string) => {
     if (!dir) {
@@ -338,7 +340,6 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
   for (const dir of extraDirs) {
     add(dir);
   }
-  // User dirs first so user-installed binaries take precedence
   for (const dir of userDirs) {
     add(dir);
   }


### PR DESCRIPTION
## Summary

- Problem: macOS gateway LaunchAgent installs could persist an interactive-shell PATH containing Volta, asdf, fnm, pnpm, and other user toolchain directories.
- Why it matters: the supervised gateway and its children could resolve different Node binaries across install, doctor, and update flows.
- What changed: macOS service PATH generation now defaults to `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`, and macOS installs no longer merge old plist PATH entries back into the generated environment.
- What did NOT change (scope boundary): Linux service PATH keeps its existing user-bin/version-manager compatibility behavior, and runtime Node selection/warnings are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75233
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared minimal service PATH helper treated macOS version-manager and package-manager directories as expected service PATH entries, and the gateway install plan merged preserved existing PATH values back into rewritten service environments.
- Missing detection / guardrail: tests asserted the old macOS version-manager PATH policy rather than locking in a canonical launchd PATH.
- Contributing context (if known): Linux and macOS service PATH policy shared the same user-bin-first behavior even though launchd does not load the user's shell init.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/service-env.test.ts`, `src/commands/daemon-install-helpers.test.ts`
- Scenario the test should lock in: macOS service env ignores HOME/env version-manager roots by default and macOS install plans do not preserve existing plist PATH entries.
- Why this is the smallest reliable guardrail: the bug is in the service environment builder and install-plan merge seam, before launchd writes the plist.
- Existing test that already covers this (if any): service audit coverage still flags non-minimal version-manager PATH entries.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

macOS `openclaw gateway install`, onboarding service install, and doctor service repair now write a canonical LaunchAgent PATH instead of preserving shell/version-manager PATH entries. Users who intentionally need custom tools from the gateway service should configure explicit absolute paths or service-managed environment instead of relying on the interactive shell PATH.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS dev host
- Runtime/container: Node/pnpm repo test wrapper
- Model/provider: N/A
- Integration/channel (if any): macOS launchd Gateway service
- Relevant config (redacted): N/A

### Steps

1. Build a macOS gateway service environment with HOME plus FNM_DIR, PNPM_HOME, VOLTA_HOME, and ASDF_DATA_DIR.
2. Build a macOS gateway install plan with an existing PATH containing Volta, asdf, fnm, pnpm, a custom bin, and `/usr/bin`.
3. Audit the changed lanes and run the focused service env/install/service audit tests.

### Expected

- The macOS generated service PATH is `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`.
- Existing macOS plist PATH entries are not preserved into the rewritten install environment.
- Linux user-bin PATH compatibility tests continue to pass.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression assertions for the reported macOS PATH behavior and verified them with the focused test command below.

## Human Verification (required)

- Verified scenarios:
  - `pnpm docs:list`
  - `pnpm test src/daemon/service-env.test.ts src/daemon/service-audit.test.ts src/commands/daemon-install-helpers.test.ts src/commands/doctor-gateway-services.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/daemon/service-env.ts src/daemon/service-env.test.ts src/commands/daemon-install-helpers.ts src/commands/daemon-install-helpers.test.ts docs/gateway/doctor.md CHANGELOG.md`
  - `git diff --check HEAD~1..HEAD`
  - `pnpm changed:lanes --base upstream/main --json`
  - `pnpm check:changed --base upstream/main --dry-run`
- Edge cases checked: macOS ignores env-configured version-manager roots by default; explicit opt-in helper behavior remains covered; Linux user-bin/version-manager PATH behavior remains covered; macOS old plist PATH preservation is skipped.
- What you did **not** verify: no live launchd install/restart was performed. Blacksmith Testbox `pnpm check:changed` was attempted with `tbx_01kqfzcnffe6x8py5awx71t1tw`, but the box remained queued without a run URL and was stopped to avoid leaving resources active.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes, macOS generated LaunchAgent PATH is intentionally more restrictive
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a macOS gateway service that relied on shell PATH user directories for child tools may no longer find those tools by bare name.
  - Mitigation: this matches launchd's deterministic service model; use absolute tool paths or explicit service-managed environment for required custom tools. Linux PATH behavior is unchanged.
