### PR TITLE
fix(sandbox): build image with python3 instead of tagging bare debian

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -261,8 +261,17 @@ export async function ensureDockerImage(image: string) {
     return;
   }
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    await execDocker(["pull", "debian:bookworm-slim"]);
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
+    // Build from debian:bookworm-slim with python3 included.
+    // The sandbox write/edit tools use python3 as a pinned mutation helper;
+    // the bare debian image does not include it, causing those tools to fail.
+    const dockerfile = [
+      "FROM debian:bookworm-slim",
+      "RUN apt-get update -qq \\",
+      "    && apt-get install -y --no-install-recommends python3 \\",
+      "    && apt-get clean \\",
+      "    && rm -rf /var/lib/apt/lists/*",
+    ].join("\n");
+    await execDocker(["build", "-t", DEFAULT_SANDBOX_IMAGE, "-"], { input: dockerfile });
     return;
   }
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);


### PR DESCRIPTION
## Problem

The sandbox `write` and `edit` tools use `python3` internally as a pinned mutation helper inside the container. The previous `ensureDockerImage` implementation pulled `debian:bookworm-slim` and re-tagged it as `openclaw-sandbox:bookworm-slim` without any modifications, leaving `python3` absent from the container.

This caused all `write`/`edit` tool calls to silently fail with:
```
sandbox pinned mutation helper requires python3 or python
```

This is a first-run regression for any new install or after a sandbox image rebuild — the agent appears to work but file mutation tools do nothing.

## Fix

Replace the `pull` + `tag` approach with a `docker build` that installs `python3` via `apt-get` on top of `debian:bookworm-slim`. The Dockerfile is inline and minimal:

```dockerfile
FROM debian:bookworm-slim
RUN apt-get update -qq \\
    && apt-get install -y --no-install-recommends python3 \\
    && apt-get clean \\
    && rm -rf /var/lib/apt/lists/*
```

The resulting image adds ~35MB but makes all sandbox file tools functional.

## Testing

Verified on macOS arm64 (Apple Silicon) — after applying this fix and recreating the sandbox container, `write`/`edit` tools work correctly:
```
Successfully wrote 241 bytes to memory/domains/hosting-migration-index.md
```

Previously both tools would fail immediately with the python3 missing error.