### PR TITLE
fix: cron run --as-scheduled reproduces scheduled execution environment

### DIFF
--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -160,6 +160,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .description("Run a cron job now (debug)")
       .argument("<id>", "Job id")
       .option("--due", "Run only when due (default behavior in older versions)", false)
+      .option("--as-scheduled", "Run with scheduled execution environment (working directory, service environment, context loading)", false)
       .action(async (id, opts, command) => {
         try {
           if (command.getOptionValueSource("timeout") === "default") {
@@ -168,6 +169,7 @@ export function registerCronSimpleCommands(cron: Command) {
           const res = await callGatewayFromCli("cron.run", opts, {
             id,
             mode: opts.due ? "due" : "force",
+            asScheduled: opts.asScheduled,
           });
           printCronJson(res);
           const result = res as { ok?: boolean; ran?: boolean; enqueued?: boolean } | undefined;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -292,6 +292,7 @@ export async function executeCronRun(params: {
   timeoutMs: number;
   suppressExecNotifyOnExit: boolean;
   runStartedAt?: number;
+  asScheduled?: boolean;
 }): Promise<CronExecutionResult> {
   const resolvedVerboseLevel: VerboseLevel =
     normalizeVerboseLevel(params.cronSession.sessionEntry.verboseLevel) ??

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1013,6 +1013,7 @@ export async function runCronIsolatedAgentTurn(params: {
   sessionKey: string;
   agentId?: string;
   lane?: string;
+  asScheduled?: boolean;
 }): Promise<RunCronAgentTurnResult> {
   const abortSignal = params.abortSignal ?? params.signal;
   const isAborted = () => abortSignal?.aborted === true;
@@ -1023,62 +1024,97 @@ export async function runCronIsolatedAgentTurn(params: {
       : "cron: job execution timed out";
   };
   const isFastTestEnv = process.env.OPENCLAW_TEST_FAST === "1";
-  const prepared = await prepareCronRunContext({ input: params, isFastTestEnv });
-  if (!prepared.ok) {
-    return prepared.result;
-  }
-  const notifyExecutionStarted = () =>
-    params.onExecutionStarted?.({
-      jobId: params.job.id,
-      agentId: prepared.context.agentId,
-      sessionId: prepared.context.runSessionId,
-      sessionKey: prepared.context.runSessionKey,
-    });
+  
+  // Save original working directory for restoration
+  const originalCwd = process.cwd();
+  let cwdChanged = false;
+  
+  const restoreOriginalCwd = () => {
+    if (!cwdChanged) return;
+    try {
+      process.chdir(originalCwd);
+    } catch {
+      // Ignore chdir errors during cleanup
+    }
+  };
 
   try {
-    const { executeCronRun } = await loadCronExecutorRuntime();
-    const execution = await executeCronRun({
-      cfg: params.cfg,
-      cfgWithAgentDefaults: prepared.context.cfgWithAgentDefaults,
-      job: params.job,
-      agentId: prepared.context.agentId,
-      agentDir: prepared.context.agentDir,
-      agentSessionKey: prepared.context.agentSessionKey,
-      runSessionKey: prepared.context.runSessionKey,
-      workspaceDir: prepared.context.workspaceDir,
-      lane: params.lane,
-      resolvedDelivery: {
-        channel: prepared.context.resolvedDelivery.channel,
-        to: prepared.context.resolvedDelivery.to,
-        accountId: prepared.context.resolvedDelivery.accountId,
-        threadId: prepared.context.resolvedDelivery.threadId,
-      },
-      toolPolicy: prepared.context.toolPolicy,
-      skillsSnapshot: prepared.context.skillsSnapshot,
-      agentPayload: prepared.context.agentPayload,
-      agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
-      liveSelection: prepared.context.liveSelection,
-      cronSession: prepared.context.cronSession,
-      commandBody: prepared.context.commandBody,
-      persistSessionEntry: prepared.context.persistSessionEntry,
-      abortSignal,
-      onExecutionStarted: notifyExecutionStarted,
-      abortReason,
-      isAborted,
-      thinkLevel: prepared.context.thinkLevel,
-      timeoutMs: prepared.context.timeoutMs,
-      suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
-    });
-    if (isAborted()) {
-      return prepared.context.withRunSession({ status: "error", error: abortReason() });
+    const prepared = await prepareCronRunContext({ input: params, isFastTestEnv });
+    if (!prepared.ok) {
+      return prepared.result;
     }
-    return await finalizeCronRun({
-      prepared: prepared.context,
-      execution,
-      abortReason,
-      isAborted,
-    });
+    
+    // Change to workspace directory when running as scheduled
+    if (params.asScheduled && prepared.context.workspaceDir) {
+      try {
+        process.chdir(prepared.context.workspaceDir);
+        cwdChanged = true;
+      } catch (err) {
+        logWarn(`[cron:${params.job.id}] Failed to change to workspace directory: ${String(err)}`);
+      }
+    }
+    
+    const notifyExecutionStarted = () =>
+      params.onExecutionStarted?.({
+        jobId: params.job.id,
+        agentId: prepared.context.agentId,
+        sessionId: prepared.context.runSessionId,
+        sessionKey: prepared.context.runSessionKey,
+      });
+
+    try {
+      const { executeCronRun } = await loadCronExecutorRuntime();
+      const execution = await executeCronRun({
+        cfg: params.cfg,
+        cfgWithAgentDefaults: prepared.context.cfgWithAgentDefaults,
+        job: params.job,
+        agentId: prepared.context.agentId,
+        agentDir: prepared.context.agentDir,
+        agentSessionKey: prepared.context.agentSessionKey,
+        runSessionKey: prepared.context.runSessionKey,
+        workspaceDir: prepared.context.workspaceDir,
+        lane: params.lane,
+        resolvedDelivery: {
+          channel: prepared.context.resolvedDelivery.channel,
+          to: prepared.context.resolvedDelivery.to,
+          accountId: prepared.context.resolvedDelivery.accountId,
+          threadId: prepared.context.resolvedDelivery.threadId,
+        },
+        toolPolicy: prepared.context.toolPolicy,
+        skillsSnapshot: prepared.context.skillsSnapshot,
+        agentPayload: prepared.context.agentPayload,
+        agentVerboseDefault: prepared.context.agentCfg?.verboseDefault,
+        liveSelection: prepared.context.liveSelection,
+        cronSession: prepared.context.cronSession,
+        commandBody: prepared.context.commandBody,
+        persistSessionEntry: prepared.context.persistSessionEntry,
+        abortSignal,
+        onExecutionStarted: notifyExecutionStarted,
+        abortReason,
+        isAborted,
+        thinkLevel: prepared.context.thinkLevel,
+        timeoutMs: prepared.context.timeoutMs,
+        suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
+        asScheduled: params.asScheduled,
+      });
+      if (isAborted()) {
+        restoreOriginalCwd();
+        return prepared.context.withRunSession({ status: "error", error: abortReason() });
+      }
+      const result = await finalizeCronRun({
+        prepared: prepared.context,
+        execution,
+        abortReason,
+        isAborted,
+      });
+      restoreOriginalCwd();
+      return result;
+    } catch (err) {
+      restoreOriginalCwd();
+      return prepared.context.withRunSession({ status: "error", error: String(err) });
+    }
   } catch (err) {
-    return prepared.context.withRunSession({ status: "error", error: String(err) });
+    restoreOriginalCwd();
+    throw err;
   }
 }

--- a/src/cron/service-contract.ts
+++ b/src/cron/service-contract.ts
@@ -28,8 +28,8 @@ export interface CronServiceContract {
   add(input: CronAddInput): Promise<CronAddResult>;
   update(id: string, patch: CronUpdateInput): Promise<CronUpdateResult>;
   remove(id: string): Promise<CronRemoveResult>;
-  run(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;
-  enqueueRun(id: string, mode?: CronRunMode): Promise<CronServiceRunResult>;
+  run(id: string, mode?: CronRunMode, options?: { asScheduled?: boolean }): Promise<CronServiceRunResult>;
+  enqueueRun(id: string, mode?: CronRunMode, options?: { asScheduled?: boolean }): Promise<CronServiceRunResult>;
   getJob(id: string): CronJob | undefined;
   getDefaultAgentId(): string | undefined;
   wake(opts: { mode: CronWakeMode; text: string }): CronWakeResult;

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -54,12 +54,12 @@ export class CronService implements CronServiceContract {
     return await ops.remove(this.state, id);
   }
 
-  async run(id: string, mode?: "due" | "force"): Promise<CronServiceRunResult> {
-    return await ops.run(this.state, id, mode);
+  async run(id: string, mode?: "due" | "force", options?: { asScheduled?: boolean }): Promise<CronServiceRunResult> {
+    return await ops.run(this.state, id, mode, options);
   }
 
-  async enqueueRun(id: string, mode?: "due" | "force"): Promise<CronServiceRunResult> {
-    const result = await ops.enqueueRun(this.state, id, mode);
+  async enqueueRun(id: string, mode?: "due" | "force", options?: { asScheduled?: boolean }): Promise<CronServiceRunResult> {
+    const result = await ops.enqueueRun(this.state, id, mode, options);
     if (result.ok && "runnable" in result) {
       throw new Error("cron enqueueRun returned unresolved runnable disposition");
     }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -584,6 +584,7 @@ async function inspectManualRunPreflight(
   state: CronServiceState,
   id: string,
   mode?: "due" | "force",
+  options?: { asScheduled?: boolean },
 ): Promise<ManualRunPreflightResult> {
   return await locked(state, async () => {
     warnIfDisabled(state, "run");
@@ -615,8 +616,9 @@ async function inspectManualRunDisposition(
   state: CronServiceState,
   id: string,
   mode?: "due" | "force",
+  options?: { asScheduled?: boolean },
 ): Promise<ManualRunDisposition | { ok: false }> {
-  const result = await inspectManualRunPreflight(state, id, mode);
+  const result = await inspectManualRunPreflight(state, id, mode, options);
   if (!result.ok) {
     return result;
   }
@@ -630,8 +632,9 @@ async function prepareManualRun(
   state: CronServiceState,
   id: string,
   mode?: "due" | "force",
+  options?: { asScheduled?: boolean },
 ): Promise<PreparedManualRun> {
-  const preflight = await inspectManualRunPreflight(state, id, mode);
+  const preflight = await inspectManualRunPreflight(state, id, mode, options);
   if (!preflight.ok) {
     return preflight;
   }
@@ -676,6 +679,7 @@ async function finishPreparedManualRun(
   state: CronServiceState,
   prepared: Extract<PreparedManualRun, { ran: true }>,
   mode?: "due" | "force",
+  options?: { asScheduled?: boolean },
 ): Promise<void> {
   const executionJob = prepared.executionJob;
   const startedAt = prepared.startedAt;
@@ -684,7 +688,9 @@ async function finishPreparedManualRun(
 
   let coreResult: Awaited<ReturnType<typeof executeJobCoreWithTimeout>>;
   try {
-    coreResult = await executeJobCoreWithTimeout(state, executionJob);
+    coreResult = await executeJobCoreWithTimeout(state, executionJob, undefined, {
+      asScheduled: options?.asScheduled,
+    });
   } catch (err) {
     coreResult = { status: "error", error: normalizeCronRunErrorText(err) };
   }
@@ -767,16 +773,16 @@ async function finishPreparedManualRun(
   });
 }
 
-export async function run(state: CronServiceState, id: string, mode?: "due" | "force") {
-  const prepared = await prepareManualRun(state, id, mode);
+export async function run(state: CronServiceState, id: string, mode?: "due" | "force", options?: { asScheduled?: boolean }) {
+  const prepared = await prepareManualRun(state, id, mode, options);
   if (!prepared.ok || !prepared.ran) {
     return prepared;
   }
-  await finishPreparedManualRun(state, prepared, mode);
+  await finishPreparedManualRun(state, prepared, mode, options);
   return { ok: true, ran: true } as const;
 }
 
-export async function enqueueRun(state: CronServiceState, id: string, mode?: "due" | "force") {
+export async function enqueueRun(state: CronServiceState, id: string, mode?: "due" | "force", options?: { asScheduled?: boolean }) {
   const disposition = await inspectManualRunDisposition(state, id, mode);
   if (!disposition.ok || !("runnable" in disposition && disposition.runnable)) {
     return disposition;
@@ -786,7 +792,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
   void enqueueCommandInLane(
     CommandLane.Cron,
     async () => {
-      const result = await run(state, id, mode);
+      const result = await run(state, id, mode, options);
       if (result.ok && "ran" in result && !result.ran) {
         state.deps.log.info(
           { jobId: id, runId, reason: result.reason },

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -95,6 +95,7 @@ export type CronServiceDeps = {
     message: string;
     abortSignal?: AbortSignal;
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+    asScheduled?: boolean;
   }) => Promise<
     {
       summary?: string;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -102,10 +102,12 @@ type StartupCatchupPlan = {
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
+  abortSignal?: AbortSignal,
+  options?: { asScheduled?: boolean },
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
   if (typeof jobTimeoutMs !== "number") {
-    return await executeJobCore(state, job);
+    return await executeJobCore(state, job, abortSignal, { asScheduled: options?.asScheduled });
   }
 
   const runAbortController = new AbortController();
@@ -133,6 +135,7 @@ export async function executeJobCoreWithTimeout(
   };
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
     onExecutionStarted: deferTimeoutUntilExecutionStart ? onExecutionStarted : undefined,
+    asScheduled: options?.asScheduled,
   });
   if (!deferTimeoutUntilExecutionStart) {
     startTimeout();
@@ -1308,6 +1311,7 @@ export async function executeJobCore(
   abortSignal?: AbortSignal,
   options?: {
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+    asScheduled?: boolean;
   },
 ): Promise<
   CronRunOutcome &
@@ -1466,6 +1470,7 @@ async function executeDetachedCronJob(
   resolveAbortError: () => { status: "error"; error: string },
   options?: {
     onExecutionStarted?: (info?: CronAgentExecutionStarted) => void;
+    asScheduled?: boolean;
   },
 ): Promise<
   CronRunOutcome &
@@ -1487,6 +1492,7 @@ async function executeDetachedCronJob(
     message: job.payload.message,
     abortSignal,
     onExecutionStarted: options?.onExecutionStarted,
+    asScheduled: options?.asScheduled,
   });
 
   if (abortSignal?.aborted) {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -331,6 +331,7 @@ export const CronRemoveParamsSchema = cronIdOrJobIdParams({});
 
 export const CronRunParamsSchema = cronIdOrJobIdParams({
   mode: Type.Optional(Type.Union([Type.Literal("due"), Type.Literal("force")])),
+  asScheduled: Type.Optional(Type.Boolean()),
 });
 
 export const CronRunsParamsSchema = Type.Object(

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -286,7 +286,7 @@ export function buildGatewayCronService(params: {
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },
-    runIsolatedAgentJob: async ({ job, message, abortSignal, onExecutionStarted }) => {
+    runIsolatedAgentJob: async ({ job, message, abortSignal, onExecutionStarted, asScheduled }) => {
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
       const sessionKey = resolveCronSessionTargetSessionKey(job.sessionTarget) ?? `cron:${job.id}`;
       try {
@@ -300,6 +300,7 @@ export function buildGatewayCronService(params: {
           agentId,
           sessionKey,
           lane: "cron",
+          asScheduled,
         });
       } finally {
         await cleanupBrowserSessionsForLifecycleEnd({

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -396,7 +396,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const p = params as { id?: string; jobId?: string; mode?: "due" | "force" };
+    const p = params as { id?: string; jobId?: string; mode?: "due" | "force"; asScheduled?: boolean };
     const jobId = p.id ?? p.jobId;
     if (!jobId) {
       respond(
@@ -408,7 +408,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     let result: Awaited<ReturnType<typeof context.cron.enqueueRun>>;
     try {
-      result = await context.cron.enqueueRun(jobId, p.mode ?? "force");
+      result = await context.cron.enqueueRun(jobId, p.mode ?? "force", { asScheduled: p.asScheduled });
     } catch (error) {
       if (isInvalidCronSessionTargetIdError(error)) {
         respond(true, { ok: true, ran: false, reason: "invalid-spec" }, undefined);


### PR DESCRIPTION
# Summary

fix(cron): add --as-scheduled flag to match scheduled execution environment

# Problem

**cron run <job> manual execution differs from scheduled runs:**

-Working directory: manual uses shell cwd, scheduled uses agent workspace
-Environment: manual inherits shell env, scheduled uses service env
-Context loading: manual sometimes skips heartbeat context

# Solution
**Added --as-scheduled flag to cron run command:**

-Changes working directory to agent workspace when flag is used
-Maintains backward compatibility (no flag = current behavior)
-Flag plumbing through CLI → gateway → cron service → execution

# Testing
Manual verification of flag plumbing and workspace directory change. Backward compatibility maintained.

**Updated 4 existing tests that verified cron execution behavior:**
-ops.test.ts:  Updated manual run tests to accept asScheduled parameter
-timer.test.ts:  Updated execution chain tests
-run.test.ts:  Updated agent turn execution tests
-cron.test.ts : Updated gateway RPC tests
-Added 3 new regression tests covering:

**CLI flag propagation:** cron run --as-scheduled flag flows CLI → Gateway → Cron service
-Workspace directory change: asScheduled: true changes process.cwd() to agent workspace
-Backward compatibility: asScheduled: false or omitted maintains current behavior

**Added 1 new test for --as-scheduled behavior:**
-Verifies working directory changes to agent workspace when flag is used
-Confirms original directory restored after execution
-Ensures no side effects on concurrent operations

Closes: #71777