### PR TITLE
fix(plugins): restore active-registry check before globally-disabled guard in capability provider resolution

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -657,7 +657,7 @@ describe("resolvePluginCapabilityProviders", () => {
     });
   });
 
-  it("does not load bundled capability providers when plugins are globally disabled", () => {
+  it("returns active providers but skips compat loading when plugins are globally disabled", () => {
     const cfg = { plugins: { enabled: false, allow: ["custom-plugin"] } } as OpenClawConfig;
     const loaded = createEmptyPluginRegistry();
     loaded.mediaUnderstandingProviders.push({
@@ -671,18 +671,20 @@ describe("resolvePluginCapabilityProviders", () => {
     } as never);
     mocks.resolveRuntimePluginRegistry.mockReturnValue(loaded);
 
-    expectNoResolvedCapabilityProviders(
-      resolvePluginCapabilityProviders({
-        key: "mediaUnderstandingProviders",
-        cfg,
-      }),
-    );
+    const providers = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      cfg,
+    });
+
+    expect(providers).toHaveLength(1);
+    expect((providers[0] as { id: string }).id).toBe("openai");
 
     expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginAllowlistCompat).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginEnablementCompat).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginVitestCompat).not.toHaveBeenCalled();
-    expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -845,7 +847,7 @@ describe("resolvePluginCapabilityProviders", () => {
     });
   });
 
-  it("does not load targeted bundled capability providers when plugins are globally disabled", () => {
+  it("returns active provider but skips compat loading when plugins are globally disabled", () => {
     const cfg = { plugins: { enabled: false, allow: ["custom-plugin"] } } as OpenClawConfig;
     const loaded = createEmptyPluginRegistry();
     loaded.memoryEmbeddingProviders.push({
@@ -865,11 +867,13 @@ describe("resolvePluginCapabilityProviders", () => {
       cfg,
     });
 
-    expect(provider).toBeUndefined();
+    expect(provider).toBeDefined();
+    expect((provider as { id: string } | undefined)?.id).toBe("gemini");
     expect(mocks.loadPluginManifestRegistry).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginAllowlistCompat).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginEnablementCompat).not.toHaveBeenCalled();
     expect(mocks.withBundledPluginVitestCompat).not.toHaveBeenCalled();
-    expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -225,14 +225,14 @@ export function resolvePluginCapabilityProvider<K extends CapabilityProviderRegi
   cfg?: OpenClawConfig;
   installBundledRuntimeDeps?: boolean;
 }): CapabilityProviderForKey<K> | undefined {
-  if (arePluginsGloballyDisabled(params.cfg)) {
-    return undefined;
-  }
-
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProvider = findProviderById(activeRegistry?.[params.key] ?? [], params.providerId);
   if (activeProvider) {
     return activeProvider;
+  }
+
+  if (arePluginsGloballyDisabled(params.cfg)) {
+    return undefined;
   }
 
   const pluginIds = resolveBundledCapabilityCompatPluginIds({
@@ -263,10 +263,6 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   cfg?: OpenClawConfig;
   installBundledRuntimeDeps?: boolean;
 }): CapabilityProviderForKey<K>[] {
-  if (arePluginsGloballyDisabled(params.cfg)) {
-    return [];
-  }
-
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
   if (
@@ -277,6 +273,9 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
   if (activeProviders.length > 0 && params.key === "speechProviders" && !params.cfg) {
+    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  }
+  if (arePluginsGloballyDisabled(params.cfg)) {
     return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
   }
   const missingRequestedSpeechProviders =


### PR DESCRIPTION
## Problem

Commit `554b32feea` introduced `arePluginsGloballyDisabled()` early-return guards at the **top** of both `resolvePluginCapabilityProvider` and `resolvePluginCapabilityProviders`. When `cfg.plugins.enabled === false`, these short-circuited before checking the active runtime registry, completely breaking TTS (and other bundled capability providers) for users with that flag set.

### Failure trace

```
[MediaStream] TTS playback error: Error: TTS conversion failed: mistral: no provider registered
    at Object.synthesizeForTelephony (dist/runtime-entry-D6tt8oem.js:1116:76)
    at Object.playFn (dist/twilio-Cif2hRls.js:532:18)
    at MediaStreamHandler.processQueue (dist/runtime-entry-D6tt8oem.js:1879:5)
```

The single-error output (no fallbacks attempted) is the key signal. The full chain:

1. Config has `plugins.enabled: false`
2. TTS provider configured as `"mistral"` (not a registered speech provider — only an LLM/model provider)
3. `resolvePluginCapabilityProviders({ key: "speechProviders", cfg })` hits the `arePluginsGloballyDisabled` guard and returns `[]` immediately — **before checking the active registry**
4. `listSpeechProviders(cfg)` → `[]` → no fallbacks available
5. `resolveTtsProviderOrder("mistral", cfg)` → `["mistral"]` only
6. "mistral" has no entry in any plugin's `speechProviders` contracts → `resolvePluginCapabilityProvider` returns `undefined` → `no provider registered`
7. No fallback providers were in the list, so the error is a single entry and TTS fails unconditionally

### Why this is a regression

`withBundledPluginEnablementCompat` was explicitly designed to bypass `plugins.enabled: false` for bundled capability providers:

```typescript
// bundled-compat.ts
const forcePluginsEnabled = params.config?.plugins?.enabled === false;
// ...
...(forcePluginsEnabled ? { enabled: true } : {}),  // overrides the global disable
```

Commit `554b32feea` added early returns that fire **before** this compat path is reached, and also before the active runtime registry is checked. Providers already loaded during startup are therefore invisible to all capability lookups when `plugins.enabled: false`.

Before `6dbaa0a278` the fallback path worked correctly. `6dbaa0a278` correctly limited `installBundledRuntimeDeps` when globally disabled. `554b32feea` went too far and blocked all provider access.

## Fix

**`resolvePluginCapabilityProvider`** — move the `arePluginsGloballyDisabled` check **after** the active registry lookup. Already-loaded providers are always returned. Compat loading (which would install new deps) is still skipped when globally disabled.

```diff
-  if (arePluginsGloballyDisabled(params.cfg)) {
-    return undefined;
-  }
-
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProvider = findProviderById(activeRegistry?.[params.key] ?? [], params.providerId);
   if (activeProvider) {
     return activeProvider;
   }
+
+  if (arePluginsGloballyDisabled(params.cfg)) {
+    return undefined;
+  }
```

**`resolvePluginCapabilityProviders`** — replace `return []` with `return activeProviders.map(...)` so the active registry contents are surfaced. The compat load path is still skipped.

```diff
-  if (arePluginsGloballyDisabled(params.cfg)) {
-    return [];
-  }
-
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
   // ... existing fast paths ...
+  if (arePluginsGloballyDisabled(params.cfg)) {
+    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  }
```

## Test plan

- [x] Updated the two test cases that were asserting the (now-incorrect) behavior from `554b32feea`: they now assert that active-registry providers are returned and no compat/manifest loading happens
- [x] `pnpm test src/plugins/capability-provider-runtime.test.ts` — all 27 tests pass
- [x] `pnpm test extensions/speech-core/src/tts.test.ts` — all 268 tests pass
- [ ] Testbox `pnpm check:changed` for full changed-gate validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)