### PR TITLE
fix(ollama): add remote-ollama as provider alias

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -147,6 +147,7 @@ export default definePluginEntry({
     api.registerWebSearchProvider(createOllamaWebSearchProvider());
     api.registerProvider({
       id: OLLAMA_PROVIDER_ID,
+      aliases: ["remote-ollama"],
       label: "Ollama",
       docsPath: "/providers/ollama",
       envVars: ["OLLAMA_API_KEY"],

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -4,7 +4,10 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["ollama"],
+  "providers": [
+    "ollama",
+    "remote-ollama"
+  ],
   "providerDiscoveryEntry": "./provider-discovery.ts",
   "providerRequest": {
     "providers": {
@@ -20,10 +23,19 @@
       }
     }
   },
-  "syntheticAuthRefs": ["ollama"],
-  "nonSecretAuthMarkers": ["ollama-local"],
+  "syntheticAuthRefs": [
+    "ollama"
+  ],
+  "nonSecretAuthMarkers": [
+    "ollama-local"
+  ],
   "providerAuthEnvVars": {
-    "ollama": ["OLLAMA_API_KEY"]
+    "ollama": [
+      "OLLAMA_API_KEY"
+    ],
+    "remote-ollama": [
+      "OLLAMA_API_KEY"
+    ]
   },
   "providerAuthChoices": [
     {
@@ -38,8 +50,12 @@
     }
   ],
   "contracts": {
-    "memoryEmbeddingProviders": ["ollama"],
-    "webSearchProviders": ["ollama"]
+    "memoryEmbeddingProviders": [
+      "ollama"
+    ],
+    "webSearchProviders": [
+      "ollama"
+    ]
   },
   "configSchema": {
     "type": "object",
@@ -49,7 +65,9 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "enabled": { "type": "boolean" }
+          "enabled": {
+            "type": "boolean"
+          }
         }
       }
     }


### PR DESCRIPTION
## Problem

When configuring an alternate Ollama provider (e.g. `remote-ollama` pointing to a LAN machine), requests fail with:

```
No API provider registered for api: ollama
```

Root cause: the plugin manifest lists `"ollama"` as the only provider, and the `registerProvider()` call inside the plugin does not include aliases. The runtime loader (`normalizeProviderRegistration`) only reads `aliases` from the `registerProvider` argument, not from the plugin entry — so `matchesProviderId(provider, "remote-ollama")` never matches the ollama plugin. This means `resolveProviderRuntimePlugin` returns `undefined`, no streamFn is registered, and pi-ai throws the error.

## Fix

Two changes:

1. **`extensions/ollama/index.ts`**: add `aliases: ["remote-ollama"]` to the `api.registerProvider({...})` call, so the runtime can match `remote-ollama` to the ollama plugin.

2. **`extensions/ollama/openclaw.plugin.json`**: add `"remote-ollama"` to `providers[]` and `providerAuthEnvVars`, so `resolveOwningPluginIdsForProvider` can find the ollama plugin when a user configures a `remote-ollama` provider.

## Reproduction

Config snippet that triggers the bug:

```json
{
  "models": {
    "providers": {
      "remote-ollama": {
        "baseUrl": "http://192.168.1.50:11434/v1",
        "apiKey": "lan-ollama-noauth",
        "api": "ollama",
        "models": [{ "id": "qwen3:8b", "api": "ollama" }]
      }
    }
  }
}
```

Without this fix, pinning an agent to `providerOverride: "remote-ollama"` fails. With it, the ollama plugin correctly resolves and streamFn registration succeeds.

## Testing

- Verified on a live OpenClaw gateway: `remote-ollama` provider config routes requests to the LAN Ollama at `192.168.5.155:11434`.
- Existing `ollama` (cloud) provider continues to work independently.
- Both providers can coexist (cloud ollama + LAN remote-ollama).
