### PR TITLE
Feat/main session durable delivery pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/externalization: keep ACPX, Google Chat, and LINE publishable plugin dist trees out of the core npm package file list.
 - Plugins/ClawHub: fall back to version metadata when the artifact resolver route is missing and keep the Docker ClawHub fixture aligned with npm-pack artifact resolution, avoiding false version-not-found failures during plugin install validation. Thanks @vincentkoc.
 - Status/channels: show configured channels in `openclaw status` and config-only `openclaw channels status` output even when the Gateway is unreachable, avoiding empty Channels tables on WSL and other no-Gateway paths. Thanks @vincentkoc.
+- Agents/main-session: keep pending final delivery markers until the final reply is actually routed or queued, so restart and heartbeat recovery can retry failed delivery. Refs #65037.
 - Plugins/ClawHub: explain unavailable explicit ClawHub ClawPack artifact downloads with a temporary npm install hint while ClawHub artifact routing rolls out. Thanks @vincentkoc.
 - Media: accept home-relative `MEDIA:~/...` attachment paths while preserving existing file-read policy, traversal checks, and media type validation. Fixes #73796. Thanks @fabkury.
 - Onboarding/search: install official external web-search plugins such as Brave before saving provider config, and make doctor repair reconcile selected external search providers whose npm payload is missing. Thanks @vincentkoc.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1247,7 +1247,13 @@ async function agentCommandInternal(
 
     // Phase 2: Persist pending final delivery for main sessions before attempting delivery.
     // This ensures that if the process restarts during delivery, the payload is durable.
-    if (sessionStore && sessionKey && payloads.length > 0 && !isSubagentSessionKey(sessionKey)) {
+    if (
+      opts.deliver === true &&
+      sessionStore &&
+      sessionKey &&
+      payloads.length > 0 &&
+      !isSubagentSessionKey(sessionKey)
+    ) {
       const now = Date.now();
       const combinedPayload = payloads
         .map((p) => (typeof p.text === "string" ? p.text : ""))
@@ -1286,7 +1292,12 @@ async function agentCommandInternal(
     });
 
     // Phase 2: Clear pending delivery payload after successful delivery.
-    if (sessionStore && sessionKey && !isSubagentSessionKey(sessionKey)) {
+    if (
+      deliveryResult?.deliverySucceeded === true &&
+      sessionStore &&
+      sessionKey &&
+      !isSubagentSessionKey(sessionKey)
+    ) {
       const entry = sessionStore[sessionKey] ?? sessionEntry;
       const next: SessionEntry = {
         ...entry,

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -17,8 +17,11 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import {
+  isSubagentSessionKey,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
@@ -1241,8 +1244,37 @@ async function agentCommandInternal(
     }
 
     const payloads = result.payloads ?? [];
+
+    // Phase 2: Persist pending final delivery for main sessions before attempting delivery.
+    // This ensures that if the process restarts during delivery, the payload is durable.
+    if (sessionStore && sessionKey && payloads.length > 0 && !isSubagentSessionKey(sessionKey)) {
+      const now = Date.now();
+      const combinedPayload = payloads
+        .map((p) => (typeof p.text === "string" ? p.text : ""))
+        .filter(Boolean)
+        .join("\n\n");
+
+      if (combinedPayload) {
+        const entry = sessionStore[sessionKey] ?? sessionEntry;
+        const next: SessionEntry = {
+          ...entry,
+          pendingFinalDelivery: true,
+          pendingFinalDeliveryText: combinedPayload,
+          pendingFinalDeliveryCreatedAt: now,
+          updatedAt: now,
+        };
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: next,
+        });
+        sessionEntry = next;
+      }
+    }
+
     const { deliverAgentCommandResult } = await loadDeliveryRuntime();
-    return await deliverAgentCommandResult({
+    const deliveryResult = await deliverAgentCommandResult({
       cfg,
       deps: resolvedDeps,
       runtime,
@@ -1252,6 +1284,27 @@ async function agentCommandInternal(
       result,
       payloads,
     });
+
+    // Phase 2: Clear pending delivery payload after successful delivery.
+    if (sessionStore && sessionKey && !isSubagentSessionKey(sessionKey)) {
+      const entry = sessionStore[sessionKey] ?? sessionEntry;
+      const next: SessionEntry = {
+        ...entry,
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        updatedAt: Date.now(),
+      };
+      await persistSessionEntry({
+        sessionStore,
+        sessionKey,
+        storePath,
+        entry: next,
+      });
+      sessionEntry = next;
+    }
+
+    return deliveryResult;
   } finally {
     clearAgentRunContext(runId);
   }

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -215,6 +215,52 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     });
   });
 
+  it("reports successful requested delivery", async () => {
+    deliverOutboundPayloadsMock.mockResolvedValue([]);
+
+    const delivered = await deliverMediaReplyForTest({
+      key: "agent:tester:slack:direct:alice",
+      agentId: "tester",
+    } as never);
+
+    expect(delivered.deliverySucceeded).toBe(true);
+  });
+
+  it("does not report success when best-effort delivery records an error", async () => {
+    deliverOutboundPayloadsMock.mockImplementationOnce(async (params: unknown) => {
+      (params as { onError?: (err: unknown) => void }).onError?.(new Error("send failed"));
+      return [];
+    });
+
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    const delivered = await deliverAgentCommandResult({
+      cfg: {
+        agents: {
+          list: [{ id: "tester", workspace: "/tmp/agent-workspace" }],
+        },
+      } as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "go",
+        deliver: true,
+        bestEffortDeliver: true,
+        replyChannel: "slack",
+        replyTo: "#general",
+      } as AgentCommandOpts,
+      outboundSession: {
+        key: "agent:tester:slack:direct:alice",
+        agentId: "tester",
+      } as never,
+      sessionEntry: undefined,
+      payloads: [{ text: "here you go" }],
+      result: createResult(),
+    });
+
+    expect(delivered.deliverySucceeded).toBe(false);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("send failed"));
+  });
+
   it("threads agentId into the normalizer when sessionKey is unresolved", async () => {
     createReplyMediaPathNormalizerMock.mockReturnValue(async (payload: ReplyPayload) => payload);
     deliverOutboundPayloadsMock.mockResolvedValue([]);

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -355,6 +355,8 @@ export async function deliverAgentCommandResult(params: {
   }
 
   const deliveryPayloads = projectOutboundPayloadPlanForOutbound(outboundPayloadPlan);
+  let deliverySucceeded = false;
+  let deliveryHadError = false;
   const logPayload = (payload: NormalizedOutboundPayload) => {
     if (opts.json) {
       return;
@@ -368,6 +370,10 @@ export async function deliverAgentCommandResult(params: {
       return;
     }
     runtime.log(output);
+  };
+  const markDeliveryError = (err: unknown) => {
+    deliveryHadError = true;
+    logDeliveryError(err);
   };
   if (!deliver) {
     for (const payload of deliveryPayloads) {
@@ -386,12 +392,13 @@ export async function deliverAgentCommandResult(params: {
         replyToId: resolvedReplyToId ?? null,
         threadId: resolvedThreadTarget ?? null,
         bestEffort: bestEffortDeliver,
-        onError: (err) => logDeliveryError(err),
+        onError: markDeliveryError,
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
       });
+      deliverySucceeded = !deliveryHadError;
     }
   }
 
-  return { payloads: normalizedPayloads, meta: resultMeta };
+  return { payloads: normalizedPayloads, meta: resultMeta, deliverySucceeded };
 }

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -307,9 +307,12 @@ describe("main-session-restart-recovery", () => {
 
     const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
-    expect(store["agent:main:main"]?.pendingFinalDelivery).toBeUndefined();
-    expect(store["agent:main:main"]?.pendingFinalDeliveryText).toBeUndefined();
-    expect(store["agent:main:main"]?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(store["agent:main:main"]?.pendingFinalDelivery).toBe(true);
+    expect(store["agent:main:main"]?.pendingFinalDeliveryText).toBe(pendingPayload);
+    expect(store["agent:main:main"]?.pendingFinalDeliveryCreatedAt).toBeDefined();
+    expect(store["agent:main:main"]?.pendingFinalDeliveryAttemptCount).toBe(1);
+    expect(store["agent:main:main"]?.pendingFinalDeliveryLastAttemptAt).toBeDefined();
+    expect(store["agent:main:main"]?.pendingFinalDeliveryLastError).toBeNull();
   });
 
   it("does not scan ordinary running sessions without the restart-aborted marker", async () => {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -278,6 +278,40 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
   });
 
+  it("resumes marked sessions with a durable pending final delivery payload (Phase 2)", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const pendingPayload = "The final answer is 42.";
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: pendingPayload,
+        pendingFinalDeliveryCreatedAt: Date.now() - 5_000,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "calculate the answer" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "calc" }] },
+      { role: "toolResult", content: "42" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    const callParams = vi.mocked(callGateway).mock.calls[0]?.[0].params as { message?: string };
+    expect(callParams.message).toContain(pendingPayload);
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
+    expect(store["agent:main:main"]?.pendingFinalDelivery).toBeUndefined();
+    expect(store["agent:main:main"]?.pendingFinalDeliveryText).toBeUndefined();
+    expect(store["agent:main:main"]?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+  });
+
   it("does not scan ordinary running sessions without the restart-aborted marker", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -116,12 +116,15 @@ function resolveMainSessionResumeBlockReason(messages: unknown[]): string | null
   return null;
 }
 
-function buildResumeMessage(): string {
-  return (
+function buildResumeMessage(pendingFinalDeliveryText?: string | null): string {
+  const base =
     "[System] Your previous turn was interrupted by a gateway restart while " +
     "OpenClaw was waiting on tool/model work. Continue from the existing " +
-    "transcript and finish the interrupted response."
-  );
+    "transcript and finish the interrupted response.";
+  if (pendingFinalDeliveryText) {
+    return `${base}\n\nNote: The interrupted final reply was captured: "${pendingFinalDeliveryText}"`;
+  }
+  return base;
 }
 
 async function markSessionFailed(params: {
@@ -140,6 +143,13 @@ async function markSessionFailed(params: {
       entry.abortedLastRun = true;
       entry.endedAt = Date.now();
       entry.updatedAt = entry.endedAt;
+      entry.pendingFinalDelivery = undefined;
+      entry.pendingFinalDeliveryText = undefined;
+      entry.pendingFinalDeliveryCreatedAt = undefined;
+      entry.pendingFinalDeliveryLastAttemptAt = undefined;
+      entry.pendingFinalDeliveryAttemptCount = undefined;
+      entry.pendingFinalDeliveryLastError = undefined;
+      entry.pendingFinalDeliveryContext = undefined;
       store[params.sessionKey] = entry;
     },
     { skipMaintenance: true },
@@ -150,12 +160,13 @@ async function markSessionFailed(params: {
 async function resumeMainSession(params: {
   storePath: string;
   sessionKey: string;
+  pendingFinalDeliveryText?: string | null;
 }): Promise<boolean> {
   try {
     await callGateway<{ runId: string }>({
       method: "agent",
       params: {
-        message: buildResumeMessage(),
+        message: buildResumeMessage(params.pendingFinalDeliveryText),
         sessionKey: params.sessionKey,
         idempotencyKey: crypto.randomUUID(),
         deliver: false,
@@ -172,11 +183,22 @@ async function resumeMainSession(params: {
         }
         entry.abortedLastRun = false;
         entry.updatedAt = Date.now();
+        entry.pendingFinalDelivery = undefined;
+        entry.pendingFinalDeliveryText = undefined;
+        entry.pendingFinalDeliveryCreatedAt = undefined;
+        entry.pendingFinalDeliveryLastAttemptAt = undefined;
+        entry.pendingFinalDeliveryAttemptCount = undefined;
+        entry.pendingFinalDeliveryLastError = undefined;
+        entry.pendingFinalDeliveryContext = undefined;
         store[params.sessionKey] = entry;
       },
       { skipMaintenance: true },
     );
-    log.info(`resumed interrupted main session: ${params.sessionKey}`);
+    log.info(
+      `resumed interrupted main session: ${params.sessionKey}${
+        params.pendingFinalDeliveryText ? " (with pending payload)" : ""
+      }`,
+    );
     return true;
   } catch (err) {
     log.warn(`failed to resume interrupted main session ${params.sessionKey}: ${String(err)}`);
@@ -290,6 +312,7 @@ async function recoverStore(params: {
     const resumed = await resumeMainSession({
       storePath: params.storePath,
       sessionKey,
+      pendingFinalDeliveryText: entry.pendingFinalDeliveryText,
     });
     if (resumed) {
       params.resumedSessionKeys.add(sessionKey);

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -181,15 +181,15 @@ async function resumeMainSession(params: {
         if (!entry) {
           return;
         }
+        const now = Date.now();
         entry.abortedLastRun = false;
-        entry.updatedAt = Date.now();
-        entry.pendingFinalDelivery = undefined;
-        entry.pendingFinalDeliveryText = undefined;
-        entry.pendingFinalDeliveryCreatedAt = undefined;
-        entry.pendingFinalDeliveryLastAttemptAt = undefined;
-        entry.pendingFinalDeliveryAttemptCount = undefined;
-        entry.pendingFinalDeliveryLastError = undefined;
-        entry.pendingFinalDeliveryContext = undefined;
+        entry.updatedAt = now;
+        if (entry.pendingFinalDelivery || entry.pendingFinalDeliveryText) {
+          entry.pendingFinalDeliveryLastAttemptAt = now;
+          entry.pendingFinalDeliveryAttemptCount =
+            (entry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+          entry.pendingFinalDeliveryLastError = null;
+        }
         store[params.sessionKey] = entry;
       },
       { skipMaintenance: true },

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -34,7 +34,7 @@ import {
   resolveAnnounceRetryDelayMs,
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
 
 type CaptureSubagentCompletionReply =
@@ -315,11 +315,64 @@ export function createSubagentRegistryLifecycleController(params: {
     }
   };
 
+  const clearPendingFinalDelivery = (entry: SubagentRunRecord) => {
+    entry.pendingFinalDelivery = undefined;
+    entry.pendingFinalDeliveryCreatedAt = undefined;
+    entry.pendingFinalDeliveryLastAttemptAt = undefined;
+    entry.pendingFinalDeliveryAttemptCount = undefined;
+    entry.pendingFinalDeliveryLastError = undefined;
+    entry.pendingFinalDeliveryPayload = undefined;
+  };
+
+  const loadPendingFinalDeliveryPayload = (
+    entry: SubagentRunRecord,
+  ): PendingFinalDeliveryPayload => {
+    return {
+      requesterSessionKey:
+        entry.pendingFinalDeliveryPayload?.requesterSessionKey ?? entry.requesterSessionKey,
+      requesterOrigin: entry.pendingFinalDeliveryPayload?.requesterOrigin ?? entry.requesterOrigin,
+      requesterDisplayKey:
+        entry.pendingFinalDeliveryPayload?.requesterDisplayKey ?? entry.requesterDisplayKey,
+      childSessionKey: entry.pendingFinalDeliveryPayload?.childSessionKey ?? entry.childSessionKey,
+      childRunId: entry.pendingFinalDeliveryPayload?.childRunId ?? entry.runId,
+      task: entry.pendingFinalDeliveryPayload?.task ?? entry.task,
+      label: entry.pendingFinalDeliveryPayload?.label ?? entry.label,
+      startedAt: entry.pendingFinalDeliveryPayload?.startedAt ?? entry.startedAt,
+      endedAt: entry.pendingFinalDeliveryPayload?.endedAt ?? entry.endedAt,
+      outcome: entry.pendingFinalDeliveryPayload?.outcome ?? entry.outcome,
+      expectsCompletionMessage:
+        entry.pendingFinalDeliveryPayload?.expectsCompletionMessage ??
+        entry.expectsCompletionMessage,
+      spawnMode: entry.pendingFinalDeliveryPayload?.spawnMode ?? entry.spawnMode,
+      frozenResultText:
+        entry.pendingFinalDeliveryPayload?.frozenResultText ?? entry.frozenResultText,
+      fallbackFrozenResultText:
+        entry.pendingFinalDeliveryPayload?.fallbackFrozenResultText ??
+        entry.fallbackFrozenResultText,
+      wakeOnDescendantSettle:
+        entry.pendingFinalDeliveryPayload?.wakeOnDescendantSettle ?? entry.wakeOnDescendantSettle,
+    };
+  };
+
+  const markPendingFinalDelivery = (args: { entry: SubagentRunRecord; error?: string }) => {
+    const now = Date.now();
+    const payload: PendingFinalDeliveryPayload = loadPendingFinalDeliveryPayload(args.entry);
+
+    args.entry.pendingFinalDelivery = true;
+    args.entry.pendingFinalDeliveryCreatedAt ??= now;
+    args.entry.pendingFinalDeliveryLastAttemptAt = now;
+    args.entry.pendingFinalDeliveryAttemptCount =
+      (args.entry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+    args.entry.pendingFinalDeliveryLastError = args.error ?? null;
+    args.entry.pendingFinalDeliveryPayload = payload;
+  };
+
   const finalizeResumedAnnounceGiveUp = async (giveUpParams: {
     runId: string;
     entry: SubagentRunRecord;
     reason: "retry-limit" | "expiry";
   }) => {
+    clearPendingFinalDelivery(giveUpParams.entry);
     safeSetSubagentTaskDeliveryStatus({
       runId: giveUpParams.runId,
       childSessionKey: giveUpParams.entry.childSessionKey,
@@ -486,6 +539,7 @@ export function createSubagentRegistryLifecycleController(params: {
         entry.completionAnnouncedAt = Date.now();
         params.persist();
       }
+      clearPendingFinalDelivery(entry);
       if (!options?.skipDeliveryStatus) {
         safeSetSubagentTaskDeliveryStatus({
           runId,
@@ -544,6 +598,7 @@ export function createSubagentRegistryLifecycleController(params: {
     }
 
     if (deferredDecision.kind === "give-up") {
+      clearPendingFinalDelivery(entry);
       safeSetSubagentTaskDeliveryStatus({
         runId,
         childSessionKey: entry.childSessionKey,
@@ -571,6 +626,10 @@ export function createSubagentRegistryLifecycleController(params: {
       return;
     }
 
+    markPendingFinalDelivery({
+      entry,
+      error: didAnnounce ? undefined : "announce deferred or direct delivery failed",
+    });
     entry.cleanupHandled = false;
     params.resumedRuns.delete(runId);
     params.persist();
@@ -631,7 +690,8 @@ export function createSubagentRegistryLifecycleController(params: {
       });
       return true;
     }
-    const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+    const pendingPayload = loadPendingFinalDeliveryPayload(entry);
+    const requesterOrigin = normalizeDeliveryContext(pendingPayload.requesterOrigin);
     let latestDeliveryError = entry.lastAnnounceDeliveryError;
     const finalizeAnnounceCleanup = (didAnnounce: boolean) => {
       if (!didAnnounce && latestDeliveryError) {
@@ -650,24 +710,24 @@ export function createSubagentRegistryLifecycleController(params: {
 
     void params
       .runSubagentAnnounceFlow({
-        childSessionKey: entry.childSessionKey,
-        childRunId: entry.runId,
-        requesterSessionKey: entry.requesterSessionKey,
+        childSessionKey: pendingPayload.childSessionKey,
+        childRunId: pendingPayload.childRunId,
+        requesterSessionKey: pendingPayload.requesterSessionKey,
         requesterOrigin,
-        requesterDisplayKey: entry.requesterDisplayKey,
-        task: entry.task,
+        requesterDisplayKey: pendingPayload.requesterDisplayKey,
+        task: pendingPayload.task,
         timeoutMs: params.subagentAnnounceTimeoutMs,
         cleanup: entry.cleanup,
-        roundOneReply: entry.frozenResultText ?? undefined,
-        fallbackReply: entry.fallbackFrozenResultText ?? undefined,
+        roundOneReply: pendingPayload.frozenResultText ?? undefined,
+        fallbackReply: pendingPayload.fallbackFrozenResultText ?? undefined,
         waitForCompletion: false,
-        startedAt: entry.startedAt,
-        endedAt: entry.endedAt,
-        label: entry.label,
-        outcome: entry.outcome,
-        spawnMode: entry.spawnMode,
-        expectsCompletionMessage: entry.expectsCompletionMessage,
-        wakeOnDescendantSettle: entry.wakeOnDescendantSettle === true,
+        startedAt: pendingPayload.startedAt,
+        endedAt: pendingPayload.endedAt,
+        label: pendingPayload.label,
+        outcome: pendingPayload.outcome,
+        spawnMode: pendingPayload.spawnMode,
+        expectsCompletionMessage: pendingPayload.expectsCompletionMessage,
+        wakeOnDescendantSettle: pendingPayload.wakeOnDescendantSettle === true,
         onDeliveryResult: (delivery) => {
           if (delivery.delivered) {
             if (entry.lastAnnounceDeliveryError !== undefined) {

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -3,6 +3,24 @@ import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
+export type PendingFinalDeliveryPayload = {
+  requesterSessionKey: string;
+  requesterOrigin?: DeliveryContext;
+  requesterDisplayKey: string;
+  childSessionKey: string;
+  childRunId: string;
+  task: string;
+  label?: string;
+  startedAt?: number;
+  endedAt?: number;
+  outcome?: SubagentRunOutcome;
+  expectsCompletionMessage?: boolean;
+  spawnMode?: SpawnSubagentMode;
+  frozenResultText?: string | null;
+  fallbackFrozenResultText?: string | null;
+  wakeOnDescendantSettle?: boolean;
+};
+
 export type SubagentRunRecord = {
   runId: string;
   childSessionKey: string;
@@ -39,7 +57,15 @@ export type SubagentRunRecord = {
   frozenResultCapturedAt?: number;
   fallbackFrozenResultText?: string | null;
   fallbackFrozenResultCapturedAt?: number;
+  /** Set after the subagent_ended hook has been emitted successfully once. */
   endedHookEmittedAt?: number;
+  /** Durable marker that final user delivery still needs a retry/resume pass. */
+  pendingFinalDelivery?: boolean;
+  pendingFinalDeliveryCreatedAt?: number;
+  pendingFinalDeliveryLastAttemptAt?: number;
+  pendingFinalDeliveryAttemptCount?: number;
+  pendingFinalDeliveryLastError?: string | null;
+  pendingFinalDeliveryPayload?: PendingFinalDeliveryPayload;
   completionAnnouncedAt?: number;
   attachmentsDir?: string;
   attachmentsRootDir?: string;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
@@ -112,6 +115,7 @@ function createMinimalRun(params?: {
   isRunActive?: () => boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  sessionCtx?: Partial<TemplateContext>;
   runOverrides?: Partial<FollowupRun["run"]>;
 }) {
   const typing = createMockTypingController();
@@ -119,6 +123,7 @@ function createMinimalRun(params?: {
   const sessionCtx = {
     Provider: "whatsapp",
     MessageSid: "msg",
+    ...params?.sessionCtx,
   } as unknown as TemplateContext;
   const resolvedQueue = {
     mode: params?.resolvedQueueMode ?? "interrupt",
@@ -274,6 +279,100 @@ describe("runReplyAgent heartbeat followup guard", () => {
     } finally {
       persistSpy.mockRestore();
     }
+  });
+});
+
+describe("runReplyAgent pending final delivery capture", () => {
+  async function createSessionStoreFile(entry: SessionEntry) {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-agent-runner-pending-"));
+    const storePath = join(dir, "sessions.json");
+    await writeFile(storePath, JSON.stringify({ main: entry }), "utf8");
+    return storePath;
+  }
+
+  async function readStoredMainSession(storePath: string): Promise<SessionEntry> {
+    const raw = await readFile(storePath, "utf8");
+    return JSON.parse(raw).main as SessionEntry;
+  }
+
+  it("does not persist message-tool-only final replies for heartbeat replay", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "private final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { sourceReplyDeliveryMode: "message_tool_only" },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    await run();
+
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.pendingFinalDelivery).toBeUndefined();
+    expect(stored.pendingFinalDeliveryText).toBeUndefined();
+  });
+
+  it("does not persist sendPolicy-denied final replies for heartbeat replay", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      sendPolicy: "deny",
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "denied final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    await run();
+
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.pendingFinalDelivery).toBeUndefined();
+    expect(stored.pendingFinalDeliveryText).toBeUndefined();
+  });
+
+  it("persists only visible non-reasoning final reply text", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = await createSessionStoreFile(sessionEntry);
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hidden reasoning", isReasoning: true }, { text: "visible final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+
+    await run();
+
+    const stored = await readStoredMainSession(storePath);
+    expect(stored.pendingFinalDelivery).toBe(true);
+    expect(stored.pendingFinalDeliveryText).toBe("visible final");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -26,6 +26,7 @@ import {
 } from "../../infra/diagnostic-trace-context.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
+import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   estimateUsageCost,
@@ -82,6 +83,7 @@ import {
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
+import { resolveSourceReplyVisibilityPolicy } from "./source-reply-delivery-mode.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
@@ -802,6 +804,14 @@ function joinCommitmentAssistantText(payloads: ReplyPayload[]): string {
     .filter((text): text is string => Boolean(text))
     .join("\n")
     .trim();
+}
+
+function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string {
+  return payloads
+    .filter((payload) => payload.isReasoning !== true)
+    .map((payload) => payload.text)
+    .filter((text): text is string => Boolean(text))
+    .join("\n\n");
 }
 
 function enqueueCommitmentExtractionForTurn(params: {
@@ -1814,14 +1824,30 @@ export async function runReplyAgent(params: {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
 
-    // Capture final payloads in session store to support durable delivery retries.
-    // If the process dies or is interrupted after this point but before the channel
-    // acknowledges receipt, the next heartbeat/turn will recover it.
+    // Capture only policy-visible final payloads in session store to support
+    // durable delivery retries. Hidden reasoning, message-tool-only replies,
+    // and sendPolicy-denied replies must not become heartbeat-replayable text.
     if (sessionKey && storePath && finalPayloads.length > 0) {
-      const pendingText = finalPayloads
-        .map((payload) => payload.text)
-        .filter(Boolean)
-        .join("\n\n");
+      const sendPolicy = resolveSendPolicy({
+        cfg,
+        entry: activeSessionEntry,
+        sessionKey: params.runtimePolicySessionKey ?? sessionKey,
+        channel:
+          sessionCtx.OriginatingChannel ??
+          sessionCtx.Surface ??
+          sessionCtx.Provider ??
+          activeSessionEntry?.channel,
+        chatType: activeSessionEntry?.chatType,
+      });
+      const sourceReplyPolicy = resolveSourceReplyVisibilityPolicy({
+        cfg,
+        ctx: sessionCtx,
+        requested: opts?.sourceReplyDeliveryMode,
+        sendPolicy,
+      });
+      const pendingText = sourceReplyPolicy.suppressDelivery
+        ? ""
+        : buildPendingFinalDeliveryText(finalPayloads);
       if (pendingText) {
         await updateSessionStoreEntry({
           storePath,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1842,21 +1842,6 @@ export async function runReplyAgent(params: {
       runFollowupTurn,
     );
 
-    // After a successful (or at least non-throwing) finalize call, we can
-    // clear the pending flag.  In a real implementation, we'd wait for
-    // channel-level ACK, but this provides a baseline of durability.
-    if (sessionKey && storePath) {
-      void updateSessionStoreEntry({
-        storePath,
-        sessionKey,
-        update: async () => ({
-          pendingFinalDelivery: undefined,
-          pendingFinalDeliveryText: undefined,
-          updatedAt: Date.now(),
-        }),
-      }).catch(() => {});
-    }
-
     return result;
   } catch (error) {
     if (

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1818,14 +1818,10 @@ export async function runReplyAgent(params: {
     // If the process dies or is interrupted after this point but before the channel
     // acknowledges receipt, the next heartbeat/turn will recover it.
     if (sessionKey && storePath && finalPayloads.length > 0) {
-      const pendingText = Array.isArray(finalPayloads)
-        ? finalPayloads
-            .map((p) => (typeof p === "string" ? p : p.text))
-            .filter(Boolean)
-            .join("\n\n")
-        : typeof finalPayloads === "string"
-          ? finalPayloads
-          : finalPayloads.text;
+      const pendingText = finalPayloads
+        .map((payload) => payload.text)
+        .filter(Boolean)
+        .join("\n\n");
       if (pendingText) {
         await updateSessionStoreEntry({
           storePath,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1814,11 +1814,54 @@ export async function runReplyAgent(params: {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }
 
-    return finalizeWithFollowup(
+    // Capture final payloads in session store to support durable delivery retries.
+    // If the process dies or is interrupted after this point but before the channel
+    // acknowledges receipt, the next heartbeat/turn will recover it.
+    if (sessionKey && storePath && finalPayloads.length > 0) {
+      const pendingText = Array.isArray(finalPayloads)
+        ? finalPayloads
+            .map((p) => (typeof p === "string" ? p : p.text))
+            .filter(Boolean)
+            .join("\n\n")
+        : typeof finalPayloads === "string"
+          ? finalPayloads
+          : finalPayloads.text;
+      if (pendingText) {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            pendingFinalDelivery: true,
+            pendingFinalDeliveryText: pendingText,
+            pendingFinalDeliveryCreatedAt: Date.now(),
+            updatedAt: Date.now(),
+          }),
+        });
+      }
+    }
+
+    const result = finalizeWithFollowup(
       finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
       queueKey,
       runFollowupTurn,
     );
+
+    // After a successful (or at least non-throwing) finalize call, we can
+    // clear the pending flag.  In a real implementation, we'd wait for
+    // channel-level ACK, but this provides a baseline of durability.
+    if (sessionKey && storePath) {
+      void updateSessionStoreEntry({
+        storePath,
+        sessionKey,
+        update: async () => ({
+          pendingFinalDelivery: undefined,
+          pendingFinalDeliveryText: undefined,
+          updatedAt: Date.now(),
+        }),
+      }).catch(() => {});
+    }
+
+    return result;
   } catch (error) {
     if (
       replyOperation.result?.kind === "aborted" &&

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -62,6 +62,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     sessionStoreMocks.loadSessionStore.mockReset().mockReturnValue({});
     sessionStoreMocks.resolveStorePath.mockReset().mockReturnValue("/tmp/mock-sessions.json");
     sessionStoreMocks.resolveSessionStoreEntry.mockReset().mockReturnValue({ existing: undefined });
+    sessionStoreMocks.updateSessionStoreEntry.mockClear();
     acpManagerRuntimeMocks.getAcpSessionManager.mockReset();
     acpManagerRuntimeMocks.getAcpSessionManager.mockImplementation(() => ({
       resolveSession: () => ({ kind: "none" as const }),
@@ -148,5 +149,68 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     });
+  });
+
+  it("clears pending final delivery after final dispatch succeeds", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryLastAttemptAt: 2,
+      pendingFinalDeliveryAttemptCount: 3,
+      pendingFinalDeliveryLastError: "previous failure",
+      pendingFinalDeliveryContext: { source: "heartbeat" },
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher: createDispatcher(),
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+  });
+
+  it("preserves pending final delivery when final dispatch fails", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const dispatcher = createDispatcher();
+    vi.mocked(dispatcher.sendFinalReply).mockReturnValue(false);
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    expect(result.queuedFinal).toBe(false);
+    expect(sessionStoreMocks.updateSessionStoreEntry).not.toHaveBeenCalled();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.runtime.ts
+++ b/src/auto-reply/reply/dispatch-from-config.runtime.ts
@@ -1,3 +1,7 @@
 export { resolveStorePath } from "../../config/sessions/paths.js";
-export { loadSessionStore, resolveSessionStoreEntry } from "../../config/sessions/store.js";
+export {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  updateSessionStoreEntry,
+} from "../../config/sessions/store.js";
 export { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -92,6 +92,21 @@ const sessionStoreMocks = vi.hoisted(() => ({
   loadSessionStore: vi.fn(() => ({})),
   resolveStorePath: vi.fn(() => "/tmp/mock-sessions.json"),
   resolveSessionStoreEntry: vi.fn(() => ({ existing: sessionStoreMocks.currentEntry })),
+  updateSessionStoreEntry: vi.fn(
+    async (params: {
+      update: (entry: Record<string, unknown>) => Promise<Record<string, unknown> | null>;
+    }) => {
+      if (!sessionStoreMocks.currentEntry) {
+        return null;
+      }
+      const patch = await params.update(sessionStoreMocks.currentEntry);
+      if (!patch) {
+        return sessionStoreMocks.currentEntry;
+      }
+      sessionStoreMocks.currentEntry = { ...sessionStoreMocks.currentEntry, ...patch };
+      return sessionStoreMocks.currentEntry;
+    },
+  ),
 }));
 const acpManagerRuntimeMocks = vi.hoisted(() => ({
   getAcpSessionManager: vi.fn(),
@@ -192,6 +207,7 @@ vi.mock("./dispatch-from-config.runtime.js", () => ({
   resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
   resolveStorePath: sessionStoreMocks.resolveStorePath,
   triggerInternalHook: internalHookMocks.triggerInternalHook,
+  updateSessionStoreEntry: sessionStoreMocks.updateSessionStoreEntry,
 }));
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   initializeGlobalHookRunner: vi.fn(),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -109,6 +109,21 @@ const sessionStoreMocks = vi.hoisted(() => ({
   loadSessionStore: vi.fn(() => ({})),
   resolveStorePath: vi.fn(() => "/tmp/mock-sessions.json"),
   resolveSessionStoreEntry: vi.fn(() => ({ existing: sessionStoreMocks.currentEntry })),
+  updateSessionStoreEntry: vi.fn(
+    async (params: {
+      update: (entry: Record<string, unknown>) => Promise<Record<string, unknown> | null>;
+    }) => {
+      if (!sessionStoreMocks.currentEntry) {
+        return null;
+      }
+      const patch = await params.update(sessionStoreMocks.currentEntry);
+      if (!patch) {
+        return sessionStoreMocks.currentEntry;
+      }
+      sessionStoreMocks.currentEntry = { ...sessionStoreMocks.currentEntry, ...patch };
+      return sessionStoreMocks.currentEntry;
+    },
+  ),
 }));
 const acpManagerRuntimeMocks = vi.hoisted(() => ({
   getAcpSessionManager: vi.fn(),
@@ -358,6 +373,7 @@ vi.mock("./dispatch-from-config.runtime.js", () => ({
   resolveSessionStoreEntry: sessionStoreMocks.resolveSessionStoreEntry,
   resolveStorePath: sessionStoreMocks.resolveStorePath,
   triggerInternalHook: internalHookMocks.triggerInternalHook,
+  updateSessionStoreEntry: sessionStoreMocks.updateSessionStoreEntry,
 }));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -84,6 +84,7 @@ import {
   resolveSessionStoreEntry,
   resolveStorePath,
   triggerInternalHook,
+  updateSessionStoreEntry,
 } from "./dispatch-from-config.runtime.js";
 import type {
   DispatchFromConfigParams,
@@ -325,6 +326,34 @@ const resolveHarnessSourceVisibleRepliesDefault = (params: {
     return undefined;
   }
 };
+
+async function clearPendingFinalDeliveryAfterSuccess(params: {
+  storePath?: string;
+  sessionKey?: string;
+}): Promise<void> {
+  if (!params.storePath || !params.sessionKey) {
+    return;
+  }
+  await updateSessionStoreEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+    update: async (entry) => {
+      if (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText) {
+        return null;
+      }
+      return {
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        pendingFinalDeliveryLastAttemptAt: undefined,
+        pendingFinalDeliveryAttemptCount: undefined,
+        pendingFinalDeliveryLastError: undefined,
+        pendingFinalDeliveryContext: undefined,
+        updatedAt: Date.now(),
+      };
+    },
+  });
+}
 
 export type {
   DispatchFromConfigParams,
@@ -1453,6 +1482,8 @@ export async function dispatchReplyFromConfig(
 
     let queuedFinal = false;
     let routedFinalCount = 0;
+    let attemptedFinalDelivery = false;
+    let finalDeliveryFailed = false;
     if (!suppressDelivery) {
       for (const reply of replies) {
         // Suppress reasoning payloads from channel delivery — channels using this
@@ -1460,9 +1491,20 @@ export async function dispatchReplyFromConfig(
         if (reply.isReasoning === true) {
           continue;
         }
+        attemptedFinalDelivery = true;
         const finalReply = await sendFinalPayload(reply);
         queuedFinal = finalReply.queuedFinal || queuedFinal;
         routedFinalCount += finalReply.routedFinalCount;
+        if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {
+          finalDeliveryFailed = true;
+        }
+      }
+
+      if (attemptedFinalDelivery && !finalDeliveryFailed) {
+        await clearPendingFinalDeliveryAfterSuccess({
+          storePath: sessionStoreEntry.storePath,
+          sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+        });
       }
 
       const ttsMode = resolveConfiguredTtsMode(cfg, {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -310,6 +310,39 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+
+  if (sessionEntry?.pendingFinalDelivery && sessionEntry.pendingFinalDeliveryText) {
+    const text = sessionEntry.pendingFinalDeliveryText;
+
+    // If it's a heartbeat, we definitely want to try delivering the lost reply now.
+    // If it's a user message, we deliver the lost reply first, then continue.
+    // For now, let's just return the lost reply if it's a heartbeat.
+    if (opts?.isHeartbeat) {
+      const updatedAt = Date.now();
+      sessionEntry.pendingFinalDelivery = undefined;
+      sessionEntry.pendingFinalDeliveryText = undefined;
+      sessionEntry.pendingFinalDeliveryContext = undefined;
+      sessionEntry.updatedAt = updatedAt;
+      if (sessionKey && sessionStore) {
+        sessionStore[sessionKey] = sessionEntry;
+      }
+      if (sessionKey && storePath) {
+        const { updateSessionStoreEntry } = await import("../../config/sessions.js");
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            pendingFinalDelivery: undefined,
+            pendingFinalDeliveryText: undefined,
+            pendingFinalDeliveryContext: undefined,
+            updatedAt,
+          }),
+        });
+      }
+      return { text };
+    }
+  }
+
   if (resetTriggered && normalizeOptionalString(bodyStripped)) {
     const { applyResetModelOverride } = await loadSessionResetModelRuntime();
     await applyResetModelOverride({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -319,9 +319,10 @@ export async function getReplyFromConfig(
     // For now, let's just return the lost reply if it's a heartbeat.
     if (opts?.isHeartbeat) {
       const updatedAt = Date.now();
-      sessionEntry.pendingFinalDelivery = undefined;
-      sessionEntry.pendingFinalDeliveryText = undefined;
-      sessionEntry.pendingFinalDeliveryContext = undefined;
+      const attemptCount = (sessionEntry.pendingFinalDeliveryAttemptCount ?? 0) + 1;
+      sessionEntry.pendingFinalDeliveryLastAttemptAt = updatedAt;
+      sessionEntry.pendingFinalDeliveryAttemptCount = attemptCount;
+      sessionEntry.pendingFinalDeliveryLastError = null;
       sessionEntry.updatedAt = updatedAt;
       if (sessionKey && sessionStore) {
         sessionStore[sessionKey] = sessionEntry;
@@ -332,9 +333,9 @@ export async function getReplyFromConfig(
           storePath,
           sessionKey,
           update: async () => ({
-            pendingFinalDelivery: undefined,
-            pendingFinalDeliveryText: undefined,
-            pendingFinalDeliveryContext: undefined,
+            pendingFinalDeliveryLastAttemptAt: updatedAt,
+            pendingFinalDeliveryAttemptCount: attemptCount,
+            pendingFinalDeliveryLastError: null,
             updatedAt,
           }),
         });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -265,6 +265,16 @@ export type SessionEntry = {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  /** Durable marker that final user reply delivery still needs a retry/resume pass. */
+  pendingFinalDelivery?: boolean;
+  pendingFinalDeliveryCreatedAt?: number;
+  pendingFinalDeliveryLastAttemptAt?: number;
+  pendingFinalDeliveryAttemptCount?: number;
+  pendingFinalDeliveryLastError?: string | null;
+  /** Frozen reply text that needs delivery. */
+  pendingFinalDeliveryText?: string | null;
+  /** Original delivery context (channel, recipient, etc). */
+  pendingFinalDeliveryContext?: DeliveryContext;
   /**
    * Whether totalTokens reflects a fresh context snapshot for the latest run.
    * Undefined means legacy/unknown freshness; false forces consumers to treat

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1092,9 +1092,9 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY };
   }
 
-  // Phase 2: Stronger heartbeat deferral.
-  // If the session was updated very recently (e.g., within the last 30 seconds),
-  // defer the heartbeat to avoid interrupting potential follow-up user turns or final delivery.
+  // Phase 2: Stronger heartbeat deferral while a final delivery replay is pending.
+  // Plain `updatedAt` changes are normal for heartbeat sessions and should not
+  // suppress heartbeat runs; only defer when final delivery recovery is active.
   const { entry: recentSessionEntry } = resolveHeartbeatSession(
     cfg,
     agentId,
@@ -1103,6 +1103,7 @@ export async function runHeartbeatOnce(opts: {
   );
   const HEARTBEAT_DEFER_WINDOW_MS = 30_000;
   if (
+    recentSessionEntry?.pendingFinalDelivery === true &&
     recentSessionEntry?.updatedAt &&
     startedAt - recentSessionEntry.updatedAt < HEARTBEAT_DEFER_WINDOW_MS
   ) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1092,6 +1092,23 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: HEARTBEAT_SKIP_LANES_BUSY };
   }
 
+  // Phase 2: Stronger heartbeat deferral.
+  // If the session was updated very recently (e.g., within the last 30 seconds),
+  // defer the heartbeat to avoid interrupting potential follow-up user turns or final delivery.
+  const { entry: recentSessionEntry } = resolveHeartbeatSession(
+    cfg,
+    agentId,
+    heartbeat,
+    opts.sessionKey,
+  );
+  const HEARTBEAT_DEFER_WINDOW_MS = 30_000;
+  if (
+    recentSessionEntry?.updatedAt &&
+    startedAt - recentSessionEntry.updatedAt < HEARTBEAT_DEFER_WINDOW_MS
+  ) {
+    return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
+  }
+
   // Preflight centralizes trigger classification, event inspection, and HEARTBEAT.md gating.
   const preflight = await resolveHeartbeatPreflight({
     cfg,


### PR DESCRIPTION
  ## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: main-session final delivery recovery was not durable enough across restart/recovery
  paths, while the existing pending-final-delivery handling was primarily shaped around subagent runs.
  - Why it matters: a main session can finish work but lose or fail to replay the final response after
  interruption/restart, leaving the user without the completed result.
  - What changed: generalized pending final delivery tracking for subagents and main sessions, then
  added Phase 2 main-session restart recovery that resumes marked sessions with a durable pending
  final delivery payload.
  - What did NOT change (scope boundary): this PR does not change channel integrations, provider
  behavior, UI, or unrelated session orchestration flows.

  ## Change Type (select all)

  - [x] Bug fix
  - [x] Feature
  - [x] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [ ] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #65037
  - [x] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  - Root cause: pending final delivery state was not represented in a shared durable shape for main-
  session restart recovery, so recovery could not reliably replay a completed main-session final
  payload after interruption.
  - Missing detection / guardrail: restart recovery coverage did not lock in the main-session pending-
  final-delivery replay path.
  - Contributing context (if known): earlier durable-delivery work existed on stale-base branches and
  needed to be rebuilt cleanly on current `upstream/main`.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/agents/main-session-restart-recovery.test.ts`
  - Scenario the test should lock in: a marked main session with a durable pending final delivery
  payload is resumed and the pending delivery fields are cleared after recovery.
  - Why this is the smallest reliable guardrail: the bug is in restart recovery state handling, so a
  focused unit test can assert the persisted pending-delivery contract without requiring live
  providers or channels.
  - Existing test that already covers this (if any): related lifecycle/persistence coverage exists in
  `src/agents/subagent-registry-lifecycle.test.ts` and `src/agents/subagent-
  registry.persistence.test.ts`.
  - If no new test is added, why not: N/A, this PR adds/updates targeted test coverage.

  ## User-visible / Behavior Changes

  Users should be less likely to lose a completed main-session final response after interruption or
  restart. No config/default changes.

  ## Diagram (if applicable)

  ```text
  Before:
  [main session completes] -> [interruption/restart] -> [final delivery may not be durably replayed]

  After:
  [main session completes] -> [pending final delivery persisted] -> [restart recovery] -> [final
  payload replayed and cleared]

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): No
  - Secrets/tokens handling changed? (Yes/No): No
  - New/changed network calls? (Yes/No): No
  - Command/tool execution surface changed? (Yes/No): No
  - Data access scope changed? (Yes/No): No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: Ubuntu 24.04
  - Runtime/container: local Node.js workspace, Node v22.22.2
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): N/A

  ### Steps

  1. Rebuild the branch from current upstream/main.
  2. Cherry-pick the scoped durable-final-delivery commits.
  3. Run targeted restart recovery and lifecycle/persistence tests.
  4. Run core test type checking and diff whitespace checks.

  ### Expected

  - The branch contains only the intended durable-final-delivery commits on top of current upstream/
    main.
  - Main-session restart recovery can replay durable pending final delivery payloads.
  - Targeted tests and type checks pass.

  ### Actual

  - Branch is 2 commits ahead of upstream/main.
  - Final diff is scoped to 9 files: 321 insertions, 26 deletions.
  - Targeted tests and type checks passed locally.

  ## Evidence

  Attach at least one:

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  Local verification run:

  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/main-session-
  restart-recovery.test.ts
  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/subagent-
  registry-lifecycle.test.ts src/agents/subagent-registry.persistence.test.ts
  pnpm tsgo:core:test
  git diff --check upstream/main..HEAD
  node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts
  OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=core-runtime-infra
  OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.infra.config.ts
  test/vitest/vitest.hooks.config.ts test/vitest/vitest.secrets.config.ts test/vitest/
  vitest.logging.config.ts test/vitest/vitest.process.config.ts test/vitest/vitest.runtime-
  config.config.ts

  Diff scope:

  9 files changed, 321 insertions(+), 26 deletions(-)

  ## Human Verification (required)

  - Verified scenarios:
      - Rebuilt the PR branch from current upstream/main.
      - Confirmed only two intended commits are ahead of upstream/main.
      - Confirmed diff is limited to durable final delivery/restart recovery files.
      - Ran targeted unit tests for main-session recovery and subagent lifecycle/persistence.
      - Ran core test type checking.
  - Edge cases checked:
      - Restart recovery path with a durable pending final delivery payload.
      - Pending final delivery state clearing after recovery.
      - Subagent registry lifecycle/persistence coverage still passes.
  - What you did not verify:
      - Full test suite.
      - End-to-end live provider/channel delivery.
      - Manual UI flow.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  No review conversations exist yet for this new PR.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: restart recovery state changes could affect final delivery replay semantics.
      - Mitigation: keep the diff scoped, add targeted restart recovery coverage, and preserve
        existing lifecycle/persistence tests.