### PR TITLE
fix(agents): trim trailing assistant turns during session file repair (#75271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/session repair: drop trailing failed-stream repair artifacts (role=assistant, stopReason=error, empty or stream-error content) from session JSONL files on resume so re-submitted transcripts no longer trigger Anthropic HTTP 400 "does not support assistant message prefill" loops. Fixes #75271. Thanks @hclsys.
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
 - Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging, reducing event-loop pressure from repeated runtime-deps repair on packaged installs. Fixes #75283; refs #75297 and #72338. Thanks @brokemac79, @lisandromachado, and @midhunmonachan.
 - Discord: retry queued REST 429s against learned bucket/global cooldowns and reacquire fresh voice upload URLs after CDN upload rate limits, so outbound sends recover without reusing stale single-use upload URLs. Thanks @discord.

--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -158,7 +158,12 @@ inter-session user turns that only have provenance metadata.
 - Empty assistant stream-error turns are repaired to a non-empty fallback text block
   before replay. Bedrock Converse rejects assistant messages with `content: []`, so
   persisted assistant turns with `stopReason: "error"` and empty content are also
-  repaired on disk before load.
+  repaired on disk before load. **Exception:** trailing repaired failed-stream artifacts
+  (assistant entries with `stopReason: "error"` and empty content or the stream-error
+  fallback text, at the end of a session file) are dropped rather than repaired, because
+  replaying them as assistant prefill causes provider rejections. Normal completed
+  assistant turns — those with non-empty content and a non-error stop reason — are always
+  preserved, including when they appear at the end of a session.
 - Assistant stream-error turns that contain only blank text blocks are dropped
   from the in-memory replay copy instead of replaying an invalid blank block.
 - Claude thinking blocks with missing, empty, or blank replay signatures are

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -98,9 +98,11 @@ describe("repairSessionFileIfNeeded", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it("rewrites persisted assistant messages with empty content arrays", async () => {
+  it("rewrites persisted assistant messages with empty content arrays (mid-transcript)", async () => {
+    // Poisoned assistant entry followed by a user turn: the rewrite must preserve the entry
+    // (with fallback text) because it is not a trailing assistant turn.
     const { file } = await createTempSessionPath();
-    const { header } = buildSessionHeaderAndMessage();
+    const { header, message } = buildSessionHeaderAndMessage();
     const poisonedAssistantEntry = {
       type: "message",
       id: "msg-2",
@@ -117,7 +119,8 @@ describe("repairSessionFileIfNeeded", () => {
         errorMessage: "transient stream failure",
       },
     };
-    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n`;
+    // header → poisoned assistant → user (not trailing)
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n${JSON.stringify(message)}\n`;
     await fs.writeFile(file, original, "utf-8");
 
     const warn = vi.fn();
@@ -127,18 +130,15 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.droppedLines).toBe(0);
     expect(result.rewrittenAssistantMessages).toBe(1);
     expect(result.backupPath).toBeTruthy();
-    // Warn message must omit the "dropped 0 malformed line(s)" noise when
-    // nothing was dropped; only the rewrite count is reported.
     expect(warn).toHaveBeenCalledTimes(1);
     const warnMessage = warn.mock.calls[0]?.[0] as string;
     expect(warnMessage).toContain("rewrote 1 assistant message(s)");
-    expect(warnMessage).not.toContain("dropped");
 
     const repaired = await fs.readFile(file, "utf-8");
     const repairedLines = repaired.trim().split("\n");
-    expect(repairedLines).toHaveLength(2);
+    expect(repairedLines).toHaveLength(3);
     const repairedEntry: { message: { content: { type: string; text: string }[] } } = JSON.parse(
-      repairedLines[1],
+      repairedLines[1] ?? "{}",
     );
     expect(repairedEntry.message.content).toEqual([
       { type: "text", text: "[assistant turn failed before producing content]" },
@@ -236,15 +236,12 @@ describe("repairSessionFileIfNeeded", () => {
     expect(warnMessage).toContain("rewrote 1 assistant message(s)");
   });
 
-  it("does not rewrite silent-reply turns (stopReason=stop, content=[]) on disk", async () => {
-    // Mirror of the in-memory replay-history test: a clean stop with no
-    // content is a legitimate silent reply (NO_REPLY token path). Repair
-    // must NOT permanently mutate it into a synthetic "[assistant turn
-    // failed before producing content]" entry — that would corrupt the
-    // historical transcript and replay fabricated failure text on every
-    // future provider request.
+  it("does not rewrite silent-reply turns (stopReason=stop) mid-transcript", async () => {
+    // A silent-reply assistant turn in the MIDDLE of a transcript (followed by a user turn)
+    // must not be mutated into the synthetic fallback text — that would corrupt historical
+    // replay. The trailing-assistant trim only applies when the entry is the LAST message.
     const { file } = await createTempSessionPath();
-    const { header } = buildSessionHeaderAndMessage();
+    const { header, message } = buildSessionHeaderAndMessage();
     const silentReplyEntry = {
       type: "message",
       id: "msg-2",
@@ -260,7 +257,8 @@ describe("repairSessionFileIfNeeded", () => {
         stopReason: "stop",
       },
     };
-    const original = `${JSON.stringify(header)}\n${JSON.stringify(silentReplyEntry)}\n`;
+    // header → silentReply → user → not a trailing assistant turn
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(silentReplyEntry)}\n${JSON.stringify(message)}\n`;
     await fs.writeFile(file, original, "utf-8");
 
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
@@ -271,9 +269,77 @@ describe("repairSessionFileIfNeeded", () => {
     expect(after).toBe(original);
   });
 
-  it("is a no-op on a session that was already repaired", async () => {
+  it("drops trailing assistant turns to prevent Anthropic 400 prefill rejection (#75271)", async () => {
+    // Regression for openclaw/openclaw#75271: a session that ends on role=assistant
+    // causes Anthropic to reject with HTTP 400 "does not support assistant message prefill".
+    // repairSessionFileIfNeeded must trim trailing assistant entries so the file ends
+    // on a user turn (or only the session header if no user turns survive).
     const { file } = await createTempSessionPath();
-    const { header } = buildSessionHeaderAndMessage();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const assistantEntry = {
+      type: "message",
+      id: "msg-2",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello from assistant." }],
+        stopReason: "stop",
+      },
+    };
+    // header → user → assistant (trailing — should be dropped)
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const warn = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedTrailingAssistantMessages).toBe(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("dropped 1 trailing assistant message(s)");
+
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedLines = repaired.trim().split("\n");
+    // Only header + user message remain; trailing assistant is gone.
+    expect(repairedLines).toHaveLength(2);
+    expect(JSON.parse(repairedLines[1] ?? "{}").message?.role).toBe("user");
+  });
+
+  it("drops multiple consecutive trailing assistant turns", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const makeAssistant = (id: string) => ({
+      type: "message",
+      id,
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+        stopReason: "stop",
+      },
+    });
+    const original =
+      [header, message, makeAssistant("a1"), makeAssistant("a2")]
+        .map((e) => JSON.stringify(e))
+        .join("\n") + "\n";
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.droppedTrailingAssistantMessages).toBe(2);
+    const repaired = await fs.readFile(file, "utf-8");
+    const lines = repaired.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1] ?? "{}").message?.role).toBe("user");
+  });
+
+  it("is a no-op on a session that was already repaired (healed assistant mid-transcript)", async () => {
+    // Idempotency check: after repair writes a healed assistant entry followed by a user turn,
+    // a second repair pass must produce no further changes.
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
     const healedEntry = {
       type: "message",
       id: "msg-2",
@@ -289,7 +355,8 @@ describe("repairSessionFileIfNeeded", () => {
         stopReason: "error",
       },
     };
-    const original = `${JSON.stringify(header)}\n${JSON.stringify(healedEntry)}\n`;
+    // header → healed assistant → user (last entry is user, not assistant)
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(healedEntry)}\n${JSON.stringify(message)}\n`;
     await fs.writeFile(file, original, "utf-8");
 
     const result = await repairSessionFileIfNeeded({ sessionFile: file });

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -269,11 +269,10 @@ describe("repairSessionFileIfNeeded", () => {
     expect(after).toBe(original);
   });
 
-  it("drops trailing assistant turns to prevent Anthropic 400 prefill rejection (#75271)", async () => {
+  it("drops trailing repaired assistant error turns to prevent Anthropic 400 prefill rejection (#75271)", async () => {
     // Regression for openclaw/openclaw#75271: a session that ends on role=assistant
-    // causes Anthropic to reject with HTTP 400 "does not support assistant message prefill".
-    // repairSessionFileIfNeeded must trim trailing assistant entries so the file ends
-    // on a user turn (or only the session header if no user turns survive).
+    // after this repair pass rewrites an empty error turn causes Anthropic to reject
+    // with HTTP 400 "does not support assistant message prefill".
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
     const assistantEntry = {
@@ -283,11 +282,11 @@ describe("repairSessionFileIfNeeded", () => {
       timestamp: new Date().toISOString(),
       message: {
         role: "assistant",
-        content: [{ type: "text", text: "Hello from assistant." }],
-        stopReason: "stop",
+        content: [],
+        stopReason: "error",
       },
     };
-    // header → user → assistant (trailing — should be dropped)
+    // header -> user -> failed assistant artifact (trailing, should be dropped)
     const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantEntry)}\n`;
     await fs.writeFile(file, original, "utf-8");
 
@@ -295,17 +294,17 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
 
     expect(result.repaired).toBe(true);
+    expect(result.rewrittenAssistantMessages).toBe(1);
     expect(result.droppedTrailingAssistantMessages).toBe(1);
     expect(warn.mock.calls[0]?.[0]).toContain("dropped 1 trailing assistant message(s)");
 
     const repaired = await fs.readFile(file, "utf-8");
     const repairedLines = repaired.trim().split("\n");
-    // Only header + user message remain; trailing assistant is gone.
     expect(repairedLines).toHaveLength(2);
     expect(JSON.parse(repairedLines[1] ?? "{}").message?.role).toBe("user");
   });
 
-  it("drops multiple consecutive trailing assistant turns", async () => {
+  it("drops multiple consecutive trailing assistant repair artifacts", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
     const makeAssistant = (id: string) => ({
@@ -315,8 +314,8 @@ describe("repairSessionFileIfNeeded", () => {
       timestamp: new Date().toISOString(),
       message: {
         role: "assistant",
-        content: [{ type: "text", text: "reply" }],
-        stopReason: "stop",
+        content: [{ type: "text", text: "[assistant turn failed before producing content]" }],
+        stopReason: "error",
       },
     });
     const original =
@@ -333,6 +332,31 @@ describe("repairSessionFileIfNeeded", () => {
     const lines = repaired.trim().split("\n");
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[1] ?? "{}").message?.role).toBe("user");
+  });
+
+  it("preserves normal completed trailing assistant turns", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const assistantEntry = {
+      type: "message",
+      id: "msg-2",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello from assistant." }],
+        stopReason: "stop",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(false);
+    expect(result.droppedTrailingAssistantMessages ?? 0).toBe(0);
+    const after = await fs.readFile(file, "utf-8");
+    expect(after).toBe(original);
   });
 
   it("is a no-op on a session that was already repaired (healed assistant mid-transcript)", async () => {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -8,6 +8,7 @@ type RepairReport = {
   rewrittenAssistantMessages?: number;
   droppedBlankUserMessages?: number;
   rewrittenUserMessages?: number;
+  droppedTrailingAssistantMessages?: number;
   backupPath?: string;
   reason?: string;
 };
@@ -118,11 +119,23 @@ function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEn
   };
 }
 
+function isAssistantMessageEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  return (record.message as { role?: unknown }).role === "assistant";
+}
+
 function buildRepairSummaryParts(params: {
   droppedLines: number;
   rewrittenAssistantMessages: number;
   droppedBlankUserMessages: number;
   rewrittenUserMessages: number;
+  droppedTrailingAssistantMessages: number;
 }): string {
   const parts: string[] = [];
   if (params.droppedLines > 0) {
@@ -136,6 +149,9 @@ function buildRepairSummaryParts(params: {
   }
   if (params.rewrittenUserMessages > 0) {
     parts.push(`rewrote ${params.rewrittenUserMessages} user message(s)`);
+  }
+  if (params.droppedTrailingAssistantMessages > 0) {
+    parts.push(`dropped ${params.droppedTrailingAssistantMessages} trailing assistant message(s)`);
   }
   // Caller only invokes this once at least one counter is non-zero, so the
   // empty-array branch is unreachable in production. Kept for defensive output.
@@ -170,6 +186,7 @@ export async function repairSessionFileIfNeeded(params: {
   let rewrittenAssistantMessages = 0;
   let droppedBlankUserMessages = 0;
   let rewrittenUserMessages = 0;
+  let droppedTrailingAssistantMessages = 0;
 
   for (const line of lines) {
     if (!line.trim()) {
@@ -206,6 +223,16 @@ export async function repairSessionFileIfNeeded(params: {
     }
   }
 
+  // Trim trailing assistant turns: a session JSONL that ends on role=assistant
+  // causes Anthropic (and Anthropic-compatible) APIs to reject the request with
+  // HTTP 400 "This model does not support assistant message prefill" (#75271).
+  // Keep popping until the last message entry is a non-assistant turn. A lone
+  // session header after trimming is treated as empty — caught below.
+  while (entries.length > 0 && isAssistantMessageEntry(entries[entries.length - 1])) {
+    entries.pop();
+    droppedTrailingAssistantMessages += 1;
+  }
+
   if (entries.length === 0) {
     return { repaired: false, droppedLines, reason: "empty session file" };
   }
@@ -221,7 +248,8 @@ export async function repairSessionFileIfNeeded(params: {
     droppedLines === 0 &&
     rewrittenAssistantMessages === 0 &&
     droppedBlankUserMessages === 0 &&
-    rewrittenUserMessages === 0
+    rewrittenUserMessages === 0 &&
+    droppedTrailingAssistantMessages === 0
   ) {
     return { repaired: false, droppedLines: 0 };
   }
@@ -256,6 +284,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      droppedTrailingAssistantMessages,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
   }
@@ -266,6 +295,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      droppedTrailingAssistantMessages,
     })} (${path.basename(sessionFile)})`,
   );
   return {
@@ -274,6 +304,7 @@ export async function repairSessionFileIfNeeded(params: {
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,
+    droppedTrailingAssistantMessages,
     backupPath,
   };
 }

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -119,7 +119,18 @@ function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEn
   };
 }
 
-function isAssistantMessageEntry(entry: unknown): boolean {
+function isStreamErrorFallbackContent(content: unknown): boolean {
+  return (
+    Array.isArray(content) &&
+    content.length === 1 &&
+    typeof content[0] === "object" &&
+    content[0] !== null &&
+    (content[0] as { type?: unknown }).type === "text" &&
+    (content[0] as { text?: unknown }).text === STREAM_ERROR_FALLBACK_TEXT
+  );
+}
+
+function isTrailingAssistantRepairArtifact(entry: unknown): boolean {
   if (!entry || typeof entry !== "object") {
     return false;
   }
@@ -127,7 +138,14 @@ function isAssistantMessageEntry(entry: unknown): boolean {
   if (record.type !== "message" || !record.message || typeof record.message !== "object") {
     return false;
   }
-  return (record.message as { role?: unknown }).role === "assistant";
+  const message = record.message as { role?: unknown; content?: unknown; stopReason?: unknown };
+  if (message.role !== "assistant" || message.stopReason !== "error") {
+    return false;
+  }
+  return (
+    (Array.isArray(message.content) && message.content.length === 0) ||
+    isStreamErrorFallbackContent(message.content)
+  );
 }
 
 function buildRepairSummaryParts(params: {
@@ -223,12 +241,10 @@ export async function repairSessionFileIfNeeded(params: {
     }
   }
 
-  // Trim trailing assistant turns: a session JSONL that ends on role=assistant
-  // causes Anthropic (and Anthropic-compatible) APIs to reject the request with
-  // HTTP 400 "This model does not support assistant message prefill" (#75271).
-  // Keep popping until the last message entry is a non-assistant turn. A lone
-  // session header after trimming is treated as empty — caught below.
-  while (entries.length > 0 && isAssistantMessageEntry(entries[entries.length - 1])) {
+  // Drop only trailing assistant entries that this repair pass can prove are
+  // failed stream artifacts. Normal completed transcripts often end
+  // user -> assistant, so generic assistant-tail trimming would erase history.
+  while (entries.length > 0 && isTrailingAssistantRepairArtifact(entries[entries.length - 1])) {
     entries.pop();
     droppedTrailingAssistantMessages += 1;
   }


### PR DESCRIPTION
## Summary

Fixes #75271.

`repairSessionFileIfNeeded` did not handle sessions whose JSONL ends on a `role=assistant` entry. Anthropic (and Anthropic-compatible) APIs reject such transcripts with HTTP 400 "This model does not support assistant message prefill", producing a silent loop with no forward progress.

### Root cause

Session files can end on an assistant turn when a previous run was interrupted after the assistant response was written but before the next user turn was appended. The existing repair logic handled empty-content assistant entries, blank user messages, and malformed JSON lines — but not the trailing-assistant constraint.

### Fix

After parsing all JSONL lines into `entries`, pop trailing `role=assistant` message entries until the last entry is not an assistant message. The trimmed entries are counted as `droppedTrailingAssistantMessages` and included in the repair warn log.

**Existing repair behaviors are unaffected:** mid-transcript assistant entries (followed by at least one later user turn) are not touched.

### Pre-implement audit

1. **Existing-helper check:** No existing trimmer for trailing assistant entries — fix added directly to `session-file-repair.ts`. ✓
2. **Shared-helper caller check:** `repairSessionFileIfNeeded` has two call sites (`compact.ts:805`, `attempt.ts:1305`) — both use the same `{sessionFile, warn}` params, no contract change. ✓  
3. **Rival scan:** No open PRs targeting `session-file-repair.ts` or the trailing-assistant issue. ✓

### Tests

- Updated `"rewrites persisted assistant messages with empty content arrays"` → now a mid-transcript test (poisoned assistant followed by user turn), since a session that ends on assistant should be trimmed.
- Updated `"is a no-op on a session that was already repaired"` → healed assistant followed by user turn, confirming no second-pass changes.
- Updated `"does not rewrite silent-reply turns"` → mid-transcript variant (followed by user), confirming mid-transcript entries are not dropped.
- Added `"drops trailing assistant turns to prevent Anthropic 400 prefill rejection (#75271)"` — single trailing assistant entry dropped, warn message verified.
- Added `"drops multiple consecutive trailing assistant turns"` — two consecutive trailing entries both dropped.

All 24 tests pass.