### PR TITLE
fix(exec-approvals): honor OPENCLAW_STATE_DIR for the on-disk file and socket

### DIFF
--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -29,6 +29,7 @@ let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
 
 const tempDirs: string[] = [];
 const originalOpenClawHome = process.env.OPENCLAW_HOME;
+const originalOpenClawStateDir = process.env.OPENCLAW_STATE_DIR;
 
 beforeAll(async () => {
   ({
@@ -58,6 +59,11 @@ afterEach(() => {
     delete process.env.OPENCLAW_HOME;
   } else {
     process.env.OPENCLAW_HOME = originalOpenClawHome;
+  }
+  if (originalOpenClawStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalOpenClawStateDir;
   }
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -89,6 +95,24 @@ describe("exec approvals store helpers", () => {
     expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
       path.normalize(path.join(dir, ".openclaw", "exec-approvals.sock")),
     );
+  });
+
+  it("honors OPENCLAW_STATE_DIR for the file and socket paths (regression for #75204)", () => {
+    const homeDir = createHomeDir();
+    const stateDir = path.join(homeDir, "openclaw-state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    expect(path.normalize(resolveExecApprovalsPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.json")),
+    );
+    expect(path.normalize(resolveExecApprovalsSocketPath())).toBe(
+      path.normalize(path.join(stateDir, "exec-approvals.sock")),
+    );
+
+    expect(
+      path.normalize(resolveExecApprovalsPath({ ...process.env, OPENCLAW_STATE_DIR: stateDir })),
+    ).toBe(path.normalize(path.join(stateDir, "exec-approvals.json")));
   });
 
   it("merges socket defaults from normalized, current, and built-in fallback", () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -197,8 +198,8 @@ const DEFAULT_SECURITY: ExecSecurity = "full";
 const DEFAULT_ASK: ExecAsk = "off";
 export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const EXEC_APPROVALS_FILENAME = "exec-approvals.json";
+const EXEC_APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";
 
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
@@ -207,12 +208,18 @@ function hashExecApprovalsRaw(raw: string | null): string {
     .digest("hex");
 }
 
-export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+// Resolve the on-disk exec-approvals file path under the active state
+// directory. Honors `OPENCLAW_STATE_DIR` (and the legacy fallbacks) the same
+// way every other persisted artifact does, instead of hardcoding `~/.openclaw`.
+// Fixes #75204.
+export function resolveExecApprovalsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), EXEC_APPROVALS_FILENAME);
 }
 
-export function resolveExecApprovalsSocketPath(): string {
-  return expandHomePrefix(DEFAULT_SOCKET);
+export function resolveExecApprovalsSocketPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(resolveStateDir(env), EXEC_APPROVALS_SOCKET_FILENAME);
 }
 
 function normalizeAllowlistPattern(value: string | undefined): string | null {


### PR DESCRIPTION
Closes #75204.

## Problem

`resolveExecApprovalsPath()` and `resolveExecApprovalsSocketPath()` in `src/infra/exec-approvals.ts` hardcoded `~/.openclaw/exec-approvals.json` and `~/.openclaw/exec-approvals.sock` and expanded them through `expandHomePrefix()`. That call only resolves the `~` prefix; it does **not** consult `OPENCLAW_STATE_DIR`.

Operators who set `OPENCLAW_STATE_DIR=~/openclaw` (or any non-default state dir) end up with two state directories on disk:

- The configured `~/openclaw/` holding everything else (sessions, credentials, plugin state, …)
- A stray `~/.openclaw/` containing only `exec-approvals.json`

`openclaw doctor` then warns:

```
Multiple state directories detected. This can split session history.
  - ~/.openclaw
  - ~/openclaw
```

…while the responsible writer keeps recreating the split on every approval write. The full reproduction is in the linked issue.

## Fix

Route both resolver helpers through `resolveStateDir(env)` from `src/config/paths.ts`, the same utility every other persisted artifact already uses (sessions, pairing store, push-web subscriptions, state migrations, plugin runtime caches, etc.).

```diff
-const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
-const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const EXEC_APPROVALS_FILENAME = "exec-approvals.json";
+const EXEC_APPROVALS_SOCKET_FILENAME = "exec-approvals.sock";

-export function resolveExecApprovalsPath(): string {
-  return expandHomePrefix(DEFAULT_FILE);
+export function resolveExecApprovalsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), EXEC_APPROVALS_FILENAME);
 }
```

(same shape for the socket helper)

When `OPENCLAW_STATE_DIR` is **unset**, `resolveStateDir` preserves the legacy fallback chain (existing `~/.openclaw`, then `~/.clawdbot`, then the default new `~/.openclaw`), so existing installs see no behavior change.

The two resolver functions now accept an optional `env` parameter (defaulting to `process.env`), which keeps **every existing call site working unchanged** — there are 13 internal callers across `exec-approvals.ts`, plus the test surfaces in `invoke-system-run.test.ts` and `exec-approvals-store.test.ts`. None of them needed to change.

## Backward compatibility

| Scenario | Before | After |
|---|---|---|
| No env override | `<home>/.openclaw/exec-approvals.json` | same |
| `OPENCLAW_STATE_DIR=/foo` | `<home>/.openclaw/exec-approvals.json` (split state) | `/foo/exec-approvals.json` (unified) |
| `OPENCLAW_HOME=/h`, no state-dir | `/h/.openclaw/exec-approvals.json` | same |
| Legacy `~/.clawdbot` exists, no env override | `<home>/.openclaw/exec-approvals.json` | `<home>/.clawdbot/exec-approvals.json` (now follows the same legacy detection as every other artifact — note: this only flips when `~/.openclaw` doesn't exist yet) |

The legacy-detection delta is intentional alignment with the rest of the codebase. In practice, every install path creates `~/.openclaw` before exec-approvals are ever written, so this doesn't change the on-disk location in normal operation.

## Test plan

- **New regression test** `exec-approvals-store.test.ts` — "honors OPENCLAW_STATE_DIR for the file and socket paths (regression for #75204)". Sets `OPENCLAW_STATE_DIR` to a separate dir from `OPENCLAW_HOME` and asserts both file and socket paths resolve under the configured state dir.
- **Existing test still passes** — "expands home-prefixed default file and socket paths" sets only `OPENCLAW_HOME`. With the override absent, `resolveStateDir` returns `<home>/.openclaw`, matching the existing assertion.
- Existing afterEach now also cleans up `OPENCLAW_STATE_DIR` between tests so the new case can't leak into siblings.

## Why this is the smallest fix that resolves the issue

The bug is two hardcoded constants. The state-dir resolver already exists, is well-tested, and handles every edge case (env override, home-relative expansion, legacy directory detection, Nix mode, the OPENCLAW_HOME interaction). The fix is to call it. Every alternative — adding a per-helper env-var lookup, exposing a new wrapper, extending `expandHomePrefix` — would be more code for the same outcome and would diverge from the codebase's standard pattern.