### PR TITLE
perf: skip runtime-deps manifest scans when materialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
-- Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging. Fixes #75283. Thanks @brokemac79.
+- Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging, reducing event-loop pressure from repeated runtime-deps repair on packaged installs. Fixes #75283; refs #75297 and #72338. Thanks @brokemac79, @lisandromachado, and @midhunmonachan.
 - TTS/providers: keep bundled speech-provider compat fallback available when plugins are globally disabled, so cold gateway and CLI startup can still resolve fallback speech providers instead of leaving explicit TTS provider selection with no registered providers. Refs #75265. Thanks @sliekens.
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.
 - Providers/OpenAI Codex: preserve existing wrapped Codex streams during OpenAI attribution so PI OAuth bearer injection reaches ChatGPT/Codex Responses, and strip native Codex-only unsupported payload fields without touching custom compatible endpoints. (#75111) Thanks @keshavbotagent.

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -2305,6 +2305,50 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     expect(result).toEqual({ installedSpecs: [] });
   });
 
+  it("does not scan every bundled manifest when the requested package-level deps are already materialized", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.29" }),
+    );
+    const alphaRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "alpha",
+      deps: { "alpha-runtime": "1.0.0" },
+      enabledByDefault: true,
+    });
+    const betaRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "beta",
+      deps: { "beta-runtime": "2.0.0" },
+      enabledByDefault: true,
+    });
+    const betaManifestPath = path.join(betaRoot, "openclaw.plugin.json");
+    const env = { OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(alphaRoot, { env });
+    writeInstalledPackage(installRoot, "alpha-runtime", "1.0.0");
+    writeInstalledPackage(installRoot, "beta-runtime", "2.0.0");
+    writeGeneratedRuntimeDepsManifest(installRoot, ["alpha-runtime@1.0.0", "beta-runtime@2.0.0"]);
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
+
+    const result = ensureBundledPluginRuntimeDeps({
+      env,
+      pluginId: "alpha",
+      pluginRoot: alphaRoot,
+      installDeps: () => {
+        throw new Error("already materialized package-level deps should not reinstall");
+      },
+    });
+
+    expect(result).toEqual({ installedSpecs: [] });
+    expect(
+      readFileSyncSpy.mock.calls.filter(
+        (call) => path.resolve(String(call[0])) === betaManifestPath,
+      ),
+    ).toHaveLength(0);
+  });
+
   it("accepts generated package-level runtime-deps supersets without reinstalling", () => {
     const packageRoot = makeTempDir();
     const stageDir = makeTempDir();

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -2349,6 +2349,56 @@ describe("ensureBundledPluginRuntimeDeps", () => {
     ).toHaveLength(0);
   });
 
+  it("does not skip missing manifest runtime deps when package deps are materialized", () => {
+    const packageRoot = makeTempDir();
+    const stageDir = makeTempDir();
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.29" }),
+    );
+    const pluginRoot = writeBundledPluginPackage({
+      packageRoot,
+      pluginId: "memory-core",
+      deps: { chokidar: "5.0.0", typebox: "1.1.34" },
+      runtimeDependencies: {
+        localMemoryEmbedding: ["node-llama-cpp@3.18.1"],
+      },
+    });
+    const env = { OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env });
+    writeInstalledPackage(installRoot, "chokidar", "5.0.0");
+    writeInstalledPackage(installRoot, "typebox", "1.1.34");
+    writeGeneratedRuntimeDepsManifest(installRoot, ["chokidar@5.0.0", "typebox@1.1.34"]);
+    const calls: BundledRuntimeDepsInstallParams[] = [];
+
+    const result = ensureBundledPluginRuntimeDeps({
+      env,
+      config: {
+        agents: {
+          defaults: {
+            memorySearch: { provider: "local" },
+          },
+        },
+      },
+      installDeps: (params) => {
+        calls.push(params);
+      },
+      pluginId: "memory-core",
+      pluginRoot,
+    });
+
+    expect(result).toEqual({
+      installedSpecs: ["chokidar@5.0.0", "node-llama-cpp@3.18.1", "typebox@1.1.34"],
+    });
+    expect(calls).toEqual([
+      {
+        installRoot,
+        missingSpecs: ["chokidar@5.0.0", "node-llama-cpp@3.18.1", "typebox@1.1.34"],
+        installSpecs: ["chokidar@5.0.0", "node-llama-cpp@3.18.1", "typebox@1.1.34"],
+      },
+    ]);
+  });
+
   it("accepts generated package-level runtime-deps supersets without reinstalling", () => {
     const packageRoot = makeTempDir();
     const stageDir = makeTempDir();

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -205,6 +205,17 @@ function createBundledRuntimeDepsPlan(params: {
   };
 }
 
+function arePackageLevelRuntimeDepsAlreadyMaterialized(params: {
+  installRoot: string;
+  packageRoot: string;
+  pluginDeps: readonly RuntimeDepEntry[];
+}): boolean {
+  const installSpecs = createBundledRuntimeDepsInstallSpecs({
+    deps: [...params.pluginDeps, ...collectMirroredPackageRuntimeDeps(params.packageRoot)],
+  });
+  return installSpecs.length > 0 && isRuntimeDepsPlanMaterialized(params.installRoot, installSpecs);
+}
+
 export function scanBundledPluginRuntimeDeps(params: {
   packageRoot: string;
   config?: OpenClawConfig;
@@ -342,6 +353,16 @@ export function ensureBundledPluginRuntimeDeps(params: {
     packageRoot && path.resolve(installRoot) !== path.resolve(params.pluginRoot);
   let deps = pluginDepEntries;
   if (usePackageLevelPlan && packageRoot) {
+    if (
+      arePackageLevelRuntimeDepsAlreadyMaterialized({
+        installRoot,
+        packageRoot,
+        pluginDeps: pluginDepEntries,
+      })
+    ) {
+      removeLegacyRuntimeDepsManifest(installRoot);
+      return createBundledRuntimeDepsEnsureResult([]);
+    }
     const packagePlan = collectBundledPluginRuntimeDeps({
       extensionsDir,
       ...(params.config ? { config: params.config } : {}),

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -59,7 +59,10 @@ import {
   parseInstallableRuntimeDep,
   type RuntimeDepEntry,
 } from "./bundled-runtime-deps-specs.js";
-import { normalizePluginsConfigWithResolver } from "./config-normalization-shared.js";
+import {
+  normalizePluginsConfigWithResolver,
+  type NormalizePluginId,
+} from "./config-normalization-shared.js";
 
 export {
   createBundledRuntimeDepsInstallArgs,
@@ -222,7 +225,7 @@ function collectPackageLevelRuntimeDepsForPlugin(params: {
   pluginDepEntries: readonly RuntimeDepEntry[];
   config?: OpenClawConfig;
   manifestCache: BundledPluginRuntimeDepsManifestCache;
-  normalizePluginId?: (id: string) => string | undefined;
+  normalizePluginId?: NormalizePluginId;
 }): { deps: readonly RuntimeDepEntry[]; conflicts: readonly RuntimeDepConflict[] } {
   if (!params.config) {
     return { deps: params.pluginDepEntries, conflicts: [] };

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -216,6 +216,26 @@ function arePackageLevelRuntimeDepsAlreadyMaterialized(params: {
   return installSpecs.length > 0 && isRuntimeDepsPlanMaterialized(params.installRoot, installSpecs);
 }
 
+function collectPackageLevelRuntimeDepsForPlugin(params: {
+  extensionsDir: string;
+  pluginId: string;
+  pluginDepEntries: readonly RuntimeDepEntry[];
+  config?: OpenClawConfig;
+  manifestCache: BundledPluginRuntimeDepsManifestCache;
+  normalizePluginId?: (id: string) => string | undefined;
+}): { deps: readonly RuntimeDepEntry[]; conflicts: readonly RuntimeDepConflict[] } {
+  if (!params.config) {
+    return { deps: params.pluginDepEntries, conflicts: [] };
+  }
+  return collectBundledPluginRuntimeDeps({
+    extensionsDir: params.extensionsDir,
+    config: params.config,
+    pluginIds: new Set([params.pluginId]),
+    manifestCache: params.manifestCache,
+    ...(params.normalizePluginId ? { normalizePluginId: params.normalizePluginId } : {}),
+  });
+}
+
 export function scanBundledPluginRuntimeDeps(params: {
   packageRoot: string;
   config?: OpenClawConfig;
@@ -353,11 +373,20 @@ export function ensureBundledPluginRuntimeDeps(params: {
     packageRoot && path.resolve(installRoot) !== path.resolve(params.pluginRoot);
   let deps = pluginDepEntries;
   if (usePackageLevelPlan && packageRoot) {
+    const requestedPluginPlan = collectPackageLevelRuntimeDepsForPlugin({
+      extensionsDir,
+      pluginId: params.pluginId,
+      pluginDepEntries,
+      ...(params.config ? { config: params.config } : {}),
+      manifestCache,
+      ...(normalizePluginId ? { normalizePluginId } : {}),
+    });
     if (
+      requestedPluginPlan.conflicts.length === 0 &&
       arePackageLevelRuntimeDepsAlreadyMaterialized({
         installRoot,
         packageRoot,
-        pluginDeps: pluginDepEntries,
+        pluginDeps: requestedPluginPlan.deps,
       })
     ) {
       removeLegacyRuntimeDepsManifest(installRoot);


### PR DESCRIPTION
## Summary

- Problem: packaged plugin lazy loading can still enter the package-level runtime-deps planning path even when the requested plugin deps are already materialized.
- Why it matters: that path scans bundled plugin manifests and contributes avoidable filesystem work in the gateway CPU/event-loop starvation cluster.
- What changed: add a fast path that proves the requested plugin deps plus mirrored root deps are already materialized before scanning all bundled plugin manifests.
- What did NOT change (scope boundary): no install-root selection changes, no package-manager behavior changes, no Telegram/channel behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #72338
- Related #73532
- Related #75069
- Related #75283
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the lazy plugin runtime-deps path only checked the full package-level plan after collecting all bundled plugin deps, so an already-materialized generated manifest still paid the all-plugin manifest scan cost.
- Missing detection / guardrail: no regression test asserted that a materialized generated package-level manifest avoids reading unrelated plugin manifests.
- Contributing context (if known): packaged installs with runtime-deps mirrors and channel/provider plugin loading make this path visible during gateway startup and control-plane operations.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/bundled-runtime-deps.test.ts`
- Scenario the test should lock in: generated package-level deps are already materialized, the requested plugin loads, and unrelated plugin manifests are not read.
- Why this is the smallest reliable guardrail: it exercises the exact materialization helper path with filesystem fixtures and a read spy.
- Existing test that already covers this (if any): adjacent runtime-deps materialization tests covered reinstall avoidance, but not scan avoidance.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

None directly. This is a performance/responsiveness optimization for packaged plugin runtime-deps loading.

## Diagram (if applicable)

```text
Before:
load plugin -> scan all bundled plugin manifests -> discover generated manifest is enough -> skip install

After:
load plugin -> prove requested deps already materialized -> skip all-plugin scan and install
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local plus Blacksmith Linux Testbox
- Runtime/container: Node/pnpm via repo wrappers
- Model/provider: N/A
- Integration/channel (if any): bundled plugin runtime-deps
- Relevant config (redacted): `OPENCLAW_PLUGIN_STAGE_DIR` fixture

### Steps

1. Create a packaged OpenClaw fixture with two bundled plugins and an external runtime-deps install root.
2. Materialize a generated package-level manifest containing both plugin deps.
3. Load one plugin and assert the other plugin manifest is not read.

### Expected

- The lazy runtime-deps path returns without reinstalling and without scanning unrelated plugin manifests.

### Actual

- Before this patch, the path had to collect the package-level plan first. After this patch, the fast path returns before the all-plugin scan.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused runtime-deps test passed locally; combined changed gate passed on Blacksmith Testbox before PR split.
- Edge cases checked: stale generated manifest and stale installed package paths remain covered by existing adjacent tests.
- What you did **not** verify: live Linux npm-global Telegram repro/profile.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an incomplete package-level generated manifest could hide missing deps.
  - Mitigation: the fast path checks only the requested plugin deps plus mirrored root deps with `isRuntimeDepsPlanMaterialized`; stale/incomplete manifests fall through to the existing full package-level plan.
