### PR TITLE
fix(gateway/server-channels): guard against undefined channel logger (#75168)

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -244,6 +244,43 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
+  it("does not crash when channelLogs entry is missing for a registered channel (regression for #75168)", async () => {
+    const unhandledRejection = vi.fn();
+    process.on("unhandledRejection", unhandledRejection);
+    try {
+      // Channel exits with an error, which forces the auto-restart .catch handler
+      // to run `log.error?.(...)` — and the channelLogs map is intentionally empty,
+      // so `log` is undefined. Without `log?.error?.(...)`, this throws TypeError
+      // and crashes the gateway with an unhandled rejection.
+      const startAccount = vi.fn(async () => {
+        throw new Error("simulated channel boot failure");
+      });
+      installTestRegistry(createTestPlugin({ startAccount }));
+
+      const log = createSubsystemLogger("gateway/server-channels-test-missing-logs");
+      const runtime = runtimeForLogger(log);
+      const manager = createChannelManager({
+        getRuntimeConfig: () => ({}),
+        // Intentionally empty — exercises the missing-logger race path.
+        channelLogs: {} as Record<ChannelId, SubsystemLogger>,
+        channelRuntimeEnvs: { discord: runtime } as unknown as Record<ChannelId, RuntimeEnv>,
+      });
+
+      await manager.startChannels();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(startAccount).toHaveBeenCalled();
+      expect(unhandledRejection).not.toHaveBeenCalled();
+      const snapshot = manager.getRuntimeSnapshot();
+      const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+      expect(account?.lastError).toBe("simulated channel boot failure");
+    } finally {
+      process.off("unhandledRejection", unhandledRejection);
+    }
+  });
+
   it("consumes rejected stop tasks during manual abort", async () => {
     const unhandledRejection = vi.fn();
     process.on("unhandledRejection", unhandledRejection);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -404,7 +404,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           try {
             await stopTaskScopedApprovalRuntime();
           } catch (error) {
-            log.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
+            log?.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
           }
         };
 
@@ -481,7 +481,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 }),
             );
           } catch (error) {
-            log.error?.(`[${id}] native approval bootstrap failed: ${formatErrorMessage(error)}`);
+            log?.error?.(`[${id}] native approval bootstrap failed: ${formatErrorMessage(error)}`);
           }
           setRuntime(channelId, id, {
             accountId: id,
@@ -515,12 +515,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               }
               const message = "channel exited without an error";
               setRuntime(channelId, id, { accountId: id, lastError: message });
-              log.error?.(`[${id}] ${message}`);
+              log?.error?.(`[${id}] ${message}`);
             })
             .catch((err) => {
               const message = formatErrorMessage(err);
               setRuntime(channelId, id, { accountId: id, lastError: message });
-              log.error?.(`[${id}] channel exited: ${message}`);
+              log?.error?.(`[${id}] channel exited: ${message}`);
             })
             .finally(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
@@ -542,11 +542,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   restartPending: false,
                   reconnectAttempts: attempt,
                 });
-                log.error?.(`[${id}] giving up after ${MAX_RESTART_ATTEMPTS} restart attempts`);
+                log?.error?.(`[${id}] giving up after ${MAX_RESTART_ATTEMPTS} restart attempts`);
                 return;
               }
               const delayMs = computeBackoff(CHANNEL_RESTART_POLICY, attempt);
-              log.info?.(
+              log?.info?.(
                 `[${id}] auto-restart attempt ${attempt}/${MAX_RESTART_ATTEMPTS} in ${Math.round(delayMs / 1000)}s`,
               );
               setRuntime(channelId, id, {
@@ -660,7 +660,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           CHANNEL_STOP_ABORT_TIMEOUT_MS,
         );
         if (!stoppedCleanly) {
-          log.warn?.(
+          log?.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
           setRuntime(channelId, id, {


### PR DESCRIPTION
## Summary

Fixes #75168.

The channel auto-restart promise chain in `createChannelManager` reads the per-channel logger via `const log = channelLogs[channelId]`. The type is `Record<ChannelId, SubsystemLogger>`, so TypeScript treats `log` as non-nullable, but at runtime the lookup can return `undefined` if a channel plugin's id was registered without a corresponding `channelLogs` entry (race between plugin registration and logger attachment). When the channel's startup task then exits or errors, the `.catch` / `.then` handlers call `log.error?.(...)` — and the optional chain only guards the function call, not the property access.

Result: `TypeError: Cannot read properties of undefined (reading 'error')` surfacing as an unhandled rejection that crashes the gateway every ~5 minutes under `launchd KeepAlive: true` (reported against feishu/whatsapp on v2026.4.27).

## Changes

**`src/gateway/server-channels.ts`** — switch every `log.<level>?.(...)` access in the affected closures to `log?.<level>?.(...)`. Six call sites (lines 407, 484, 518, 523, 545, 549, 663). The same safe-access pattern is already used at line 699 (`channelLogs[plugin.id]?.error?.(...)`).

```diff
-            log.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
+            log?.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
```

**`src/gateway/server-channels.test.ts`** — regression test that spins up the channel manager with an intentionally-empty `channelLogs` map and asserts that a `startAccount` failure is captured into the runtime snapshot's `lastError` rather than escaping as an unhandled rejection.

## Verified

- Without the fix, the new test fails on the assertion `expect(unhandledRejection).not.toHaveBeenCalled()` (the `TypeError` escapes).
- With the fix, all 26 tests in `src/gateway/server-channels.test.ts` pass.
- Repo `tsgo --noEmit` reports unrelated pre-existing errors in `src/agents/pi-embedded-runner/run/attempt.test.ts` and `src/agents/pi-embedded-runner.sanitize-session-history.test.ts` — confirmed they exist on a clean upstream main without my change.

## Notes

- I left the typed `params.log.X?.(...)` calls in `src/gateway/exec-approval-ios-push.ts` alone — that one's `log` is typed as required `GatewayLikeLogger` and isn't pulled out of the racing `channelLogs` map. Not the same bug shape.
- Module-scoped `const log = createSubsystemLogger(...)` in `channel-health-monitor.ts` likewise can't be undefined and was left untouched.