### PR TITLE
[codex] Guard Codex ACP gpt-5.5 adapter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
+- ACP/Codex: guard `openai-codex/gpt-5.5` model overrides behind explicit Codex ACP adapter `0.12.0+` pins, so stale `@zed-industries/codex-acp@0.11.x` commands fail before `session/new` with an actionable upgrade hint instead of an opaque adapter startup error. Thanks @91wan.
 - Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging, reducing event-loop pressure from repeated runtime-deps repair on packaged installs. Fixes #75283; refs #75297 and #72338. Thanks @brokemac79, @lisandromachado, and @midhunmonachan.
 - TTS/providers: keep bundled speech-provider compat fallback available when plugins are globally disabled, so cold gateway and CLI startup can still resolve fallback speech providers instead of leaving explicit TTS provider selection with no registered providers. Refs #75265. Thanks @sliekens.
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -553,6 +553,9 @@ Two ways to start an ACP session:
   normalize OpenClaw Codex refs such as `openai-codex/gpt-5.4` to Codex
   ACP startup config before `session/new`; slash forms such as
   `openai-codex/gpt-5.4/high` also set Codex ACP reasoning effort.
+  `openai-codex/gpt-5.5` requires Codex ACP adapter `0.12.0` or newer
+  when the adapter command pins an explicit `@zed-industries/codex-acp`
+  version; older pinned adapters fail early with a clear upgrade hint.
   Other harnesses must advertise ACP `models` and support
   `session/set_model`; otherwise OpenClaw/acpx fails clearly instead of
   silently falling back to the target agent default.
@@ -783,15 +786,15 @@ roots.
 `/acp` has convenience commands and a generic setter. Equivalent
 operations:
 
-| Command                      | Maps to                              | Notes                                                                                                                                                                          |
-| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `/acp model <id>`            | runtime config key `model`           | For Codex ACP, OpenClaw normalizes `openai-codex/<model>` to the adapter model id and maps slash reasoning suffixes such as `openai-codex/gpt-5.4/high` to `reasoning_effort`. |
-| `/acp set thinking <level>`  | runtime config key `thinking`        | For Codex ACP, OpenClaw sends the corresponding `reasoning_effort` where the adapter supports one.                                                                             |
-| `/acp permissions <profile>` | runtime config key `approval_policy` | —                                                                                                                                                                              |
-| `/acp timeout <seconds>`     | runtime config key `timeout`         | —                                                                                                                                                                              |
-| `/acp cwd <path>`            | runtime cwd override                 | Direct update.                                                                                                                                                                 |
-| `/acp set <key> <value>`     | generic                              | `key=cwd` uses the cwd override path.                                                                                                                                          |
-| `/acp reset-options`         | clears all runtime overrides         | —                                                                                                                                                                              |
+| Command                      | Maps to                              | Notes                                                                                                                                                                                                                                                               |
+| ---------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/acp model <id>`            | runtime config key `model`           | For Codex ACP, OpenClaw normalizes `openai-codex/<model>` to the adapter model id and maps slash reasoning suffixes such as `openai-codex/gpt-5.4/high` to `reasoning_effort`; `gpt-5.5` is guarded to explicit `@zed-industries/codex-acp` `0.12.0+` adapter pins. |
+| `/acp set thinking <level>`  | runtime config key `thinking`        | For Codex ACP, OpenClaw sends the corresponding `reasoning_effort` where the adapter supports one.                                                                                                                                                                  |
+| `/acp permissions <profile>` | runtime config key `approval_policy` | —                                                                                                                                                                                                                                                                   |
+| `/acp timeout <seconds>`     | runtime config key `timeout`         | —                                                                                                                                                                                                                                                                   |
+| `/acp cwd <path>`            | runtime cwd override                 | Direct update.                                                                                                                                                                                                                                                      |
+| `/acp set <key> <value>`     | generic                              | `key=cwd` uses the cwd override path.                                                                                                                                                                                                                               |
+| `/acp reset-options`         | clears all runtime overrides         | —                                                                                                                                                                                                                                                                   |
 
 ## acpx harness, plugin setup, and permissions
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -10,6 +10,7 @@ type TestSessionStore = {
 const DOCUMENTED_OPENCLAW_BRIDGE_COMMAND =
   "env OPENCLAW_HIDE_BANNER=1 OPENCLAW_SUPPRESS_NOTES=1 openclaw acp --url ws://127.0.0.1:18789 --token-file ~/.openclaw/gateway.token --session agent:main:main";
 const CODEX_ACP_COMMAND = "npx @zed-industries/codex-acp@^0.12.0";
+const OLD_CODEX_ACP_COMMAND = "npx @zed-industries/codex-acp@0.11.1";
 const CODEX_ACP_WRAPPER_COMMAND = `node "/tmp/openclaw/acpx/codex-acp-wrapper.mjs"`;
 
 function makeRuntime(
@@ -220,6 +221,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
   it("injects Codex ACP startup config into the scoped registry", () => {
     expect(__testing.isCodexAcpCommand(CODEX_ACP_COMMAND)).toBe(true);
     expect(__testing.isCodexAcpCommand(CODEX_ACP_WRAPPER_COMMAND)).toBe(true);
+    expect(__testing.readCodexAcpPackageVersionFromCommand(CODEX_ACP_COMMAND)).toBe("^0.12.0");
+    expect(__testing.supportsCodexAcpGpt55(CODEX_ACP_COMMAND)).toBe(true);
+    expect(__testing.supportsCodexAcpGpt55(OLD_CODEX_ACP_COMMAND)).toBe(false);
     expect(
       __testing.appendCodexAcpConfigOverrides(CODEX_ACP_COMMAND, {
         model: "gpt-5.4",
@@ -260,6 +264,38 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         model: "gpt-5.5",
       }),
     );
+  });
+
+  it("rejects gpt-5.5 startup for explicit pre-0.12 Codex ACP adapters", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      agentRegistry: {
+        resolve: (agentName: string) => (agentName === "codex" ? OLD_CODEX_ACP_COMMAND : agentName),
+        list: () => ["codex", "openclaw"],
+      },
+    });
+    const ensure = vi.spyOn(delegate, "ensureSession").mockResolvedValue({
+      sessionKey: "agent:codex:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "codex",
+    });
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:codex:acp:test",
+        agent: "codex",
+        mode: "persistent",
+        model: "openai-codex/gpt-5.5",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_INVALID_RUNTIME_OPTION",
+      message: expect.stringContaining("@zed-industries/codex-acp >= 0.12.0"),
+    });
+
+    expect(ensure).not.toHaveBeenCalled();
   });
 
   it("maps explicit Codex ACP thinking to startup reasoning effort", async () => {
@@ -323,6 +359,37 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       value: "gpt-5.4",
     });
     expect(setConfigOption).toHaveBeenCalledOnce();
+  });
+
+  it("rejects gpt-5.5 model config controls for explicit pre-0.12 Codex ACP adapters", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => ({
+        acpxRecordId: "agent:codex:acp:test",
+        agentCommand: OLD_CODEX_ACP_COMMAND,
+      })),
+      save: vi.fn(async () => {}),
+    };
+    const { runtime, delegate } = makeRuntime(baseStore);
+    const setConfigOption = vi.spyOn(delegate, "setConfigOption").mockResolvedValue(undefined);
+    const handle: Parameters<NonNullable<AcpRuntime["setConfigOption"]>>[0]["handle"] = {
+      sessionKey: "agent:codex:acp:test",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:test",
+      acpxRecordId: "agent:codex:acp:test",
+    };
+
+    await expect(
+      runtime.setConfigOption({
+        handle,
+        key: "model",
+        value: "openai-codex/gpt-5.5",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_INVALID_RUNTIME_OPTION",
+      message: expect.stringContaining("@zed-industries/codex-acp >= 0.12.0"),
+    });
+
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it("normalizes Codex ACP slash reasoning suffixes to config controls", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -201,6 +201,67 @@ function isCodexAcpPackageSpec(value: string): boolean {
   return /^@zed-industries\/codex-acp(?:@.+)?$/i.test(value.trim());
 }
 
+function readCodexAcpPackageVersionSpec(value: string): string | undefined {
+  const match = /^@zed-industries\/codex-acp(?:@(?<version>.+))?$/i.exec(value.trim());
+  const version = match?.groups?.version?.trim();
+  return version ? version : undefined;
+}
+
+function readCodexAcpPackageVersionFromCommand(command: string | undefined): string | undefined {
+  if (!command) {
+    return undefined;
+  }
+  for (const part of unwrapEnvCommand(splitCommandParts(command.trim()))) {
+    const version = readCodexAcpPackageVersionSpec(part);
+    if (version) {
+      return version;
+    }
+  }
+  return undefined;
+}
+
+function parseSemver(value: string): { major: number; minor: number; patch: number } | undefined {
+  const match = /(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)/.exec(value);
+  if (!match?.groups) {
+    return undefined;
+  }
+  return {
+    major: Number.parseInt(match.groups.major, 10),
+    minor: Number.parseInt(match.groups.minor, 10),
+    patch: Number.parseInt(match.groups.patch, 10),
+  };
+}
+
+function isCodexAcpGpt55Model(model: string | undefined): boolean {
+  return model === "gpt-5.5" || model?.startsWith("gpt-5.5-") === true;
+}
+
+function supportsCodexAcpGpt55(command: string | undefined): boolean {
+  const versionSpec = readCodexAcpPackageVersionFromCommand(command);
+  if (!versionSpec) {
+    return true;
+  }
+  const semver = parseSemver(versionSpec);
+  if (!semver) {
+    return true;
+  }
+  return semver.major > 0 || semver.minor >= 12;
+}
+
+function assertCodexAcpCommandSupportsModel(
+  command: string | undefined,
+  override: CodexAcpModelOverride | undefined,
+): void {
+  if (!isCodexAcpGpt55Model(override?.model) || supportsCodexAcpGpt55(command)) {
+    return;
+  }
+  const versionSpec = readCodexAcpPackageVersionFromCommand(command);
+  throw new AcpRuntimeError(
+    "ACP_INVALID_RUNTIME_OPTION",
+    `Codex ACP model "${override?.model}" requires @zed-industries/codex-acp >= 0.12.0; current command uses ${versionSpec}. Upgrade the Codex ACP adapter or use gpt-5.4.`,
+  );
+}
+
 function isCodexAcpCommand(command: string | undefined): boolean {
   if (!command) {
     return false;
@@ -489,6 +550,7 @@ export class AcpxRuntime implements AcpRuntime {
       normalizeAgentName(input.agent) === CODEX_ACP_AGENT_ID && isCodexAcpCommand(command)
         ? normalizeCodexAcpModelOverride(input.model, input.thinking)
         : undefined;
+    assertCodexAcpCommandSupportsModel(command, codexModelOverride);
 
     if (!codexModelOverride) {
       return delegate.ensureSession(input);
@@ -549,6 +611,7 @@ export class AcpxRuntime implements AcpRuntime {
           return;
         }
         if (override) {
+          assertCodexAcpCommandSupportsModel(command, override);
           if (override.model) {
             await delegate.setConfigOption({
               ...input,
@@ -607,7 +670,9 @@ export const __testing = {
   assertSupportedRuntimeSessionMode,
   codexAcpSessionModelId,
   isCodexAcpCommand,
+  readCodexAcpPackageVersionFromCommand,
   normalizeCodexAcpModelOverride,
+  supportsCodexAcpGpt55,
 };
 
 export type { AcpAgentRegistry, AcpRuntimeOptions, AcpSessionRecord, AcpSessionStore };


### PR DESCRIPTION
## Summary

- Guard Codex ACP `gpt-5.5` model overrides when the adapter command explicitly pins an old `@zed-industries/codex-acp` version.
- Keep current `@zed-industries/codex-acp@^0.12.0`, wrapper, and local binary paths working.
- Document the `gpt-5.5` / Codex ACP 0.12.0+ compatibility boundary.

## Why

`gpt-5.5` works with Codex ACP 0.12.x, but stale explicit 0.11.x adapter commands can still reach `session/new` and fail with opaque adapter startup errors. This PR fails earlier with an actionable upgrade hint while preserving existing supported paths.

## Validation

- `pnpm test extensions/acpx/src/runtime.test.ts`
- `pnpm check:changed`
- `git diff --check HEAD~1..HEAD`

## Notes

This does not change the default model and does not make `gpt-5.5` the global ACP default. It only guards explicit Codex ACP model mapping for stale pinned adapters.