### PR TITLE
fix(telegram): remove strict SecretRef resolve in read-only token inspection

### DIFF
--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -83,13 +83,7 @@ function resolveRuntimeTokenValue(params: {
     }
     return { status: "configured_unavailable" };
   }
-  // Runtime resolution stays strict for non-env SecretRefs.
-  resolveSecretInputString({
-    value: params.value,
-    path: params.path,
-    defaults: params.cfg?.secrets?.defaults,
-    mode: "strict",
-  });
+  // Non-env SecretRefs cannot be resolved in read-only paths; return configured_unavailable.
   return { status: "configured_unavailable" };
 }
 


### PR DESCRIPTION
Resubmit of #74895 (rebased on current main). Closes #74832

🤖 Generated with [Claude Code](https://claude.ai/claude-code)