### PR TITLE
fix(feishu): route message(action=send) through inbound thread in gro…

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -578,6 +578,94 @@ describe("feishuPlugin actions", () => {
     });
   });
 
+  it("auto-threads `send` against the inbound trigger in group_topic sessions", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:topic_xyz",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: "om_inbound",
+      replyInThread: true,
+    });
+  });
+
+  it("auto-threads `send` in group_topic_sender sessions too", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:topic_xyz:sender:ou_user",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: "om_inbound",
+      replyInThread: true,
+    });
+  });
+
+  it("does not auto-thread `send` in plain group sessions (no topic)", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "plain group reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "plain group reply",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
+  it("does not auto-thread `send` in group_topic when no inbound currentMessageId is available", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "oc_group_1:topic:topic_xyz",
+      toolContext: {},
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
   it("creates pins", async () => {
     createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -351,6 +351,14 @@ function areAnyFeishuReactionActionsEnabled(cfg: ClawdbotConfig): boolean {
   return false;
 }
 
+function isFeishuGroupTopicSessionKey(sessionKey: string | null | undefined): boolean {
+  if (typeof sessionKey !== "string" || !sessionKey) {
+    return false;
+  }
+  const parsed = parseFeishuConversationId({ conversationId: sessionKey });
+  return parsed?.scope === "group_topic" || parsed?.scope === "group_topic_sender";
+}
+
 function isSupportedFeishuDirectConversationId(conversationId: string): boolean {
   const trimmed = conversationId.trim();
   if (!trimmed || trimmed.includes(":")) {
@@ -754,11 +762,25 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (!to) {
               throw new Error(`Feishu ${ctx.action} requires a target (to).`);
             }
+            // group_topic sessions: auto-thread `send` against the inbound trigger so
+            // visible replies stay in the topic instead of falling out to the chat root.
+            const inboundMessageId = ctx.toolContext?.currentMessageId;
+            const groupTopicAutoThreadId =
+              ctx.action === "send" &&
+              isFeishuGroupTopicSessionKey(ctx.sessionKey) &&
+              typeof inboundMessageId === "string" &&
+              inboundMessageId.length > 0
+                ? inboundMessageId
+                : undefined;
             const replyToMessageId =
-              ctx.action === "thread-reply" ? resolveFeishuMessageId(ctx.params) : undefined;
+              ctx.action === "thread-reply"
+                ? resolveFeishuMessageId(ctx.params)
+                : groupTopicAutoThreadId;
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
+            const replyInThread =
+              ctx.action === "thread-reply" || groupTopicAutoThreadId !== undefined;
             const presentation = normalizeMessagePresentation(ctx.params.presentation);
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);
@@ -791,7 +813,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 card,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             } else if (mediaUrl) {
               result = await sendMedia!({
@@ -811,7 +833,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 text: text!,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             }
             return jsonActionResult({


### PR DESCRIPTION
Fixes #74903

## Summary

- **Problem:** In a Feishu `group_topic` (话题) session, when the assistant calls `message(action="send")`, the action handler sends to the chat root with `replyInThread: false`, so visible replies fall out of the topic thread.
- **Why it matters:** Operators using Feishu topic threads see the bot reply as a normal group message. The conversation is split: ordinary mention replies thread correctly, but the message-tool path doesn't.
- **What changed:** In `extensions/feishu/src/channel.ts`, when the action handler routes `action === "send"` and the active session is a `group_topic` or `group_topic_sender` scope (detected via `parseFeishuConversationId(ctx.sessionKey)`) and `ctx.toolContext.currentMessageId` is available, set `replyToMessageId = currentMessageId` and `replyInThread = true`. Existing explicit `action === "thread-reply"` behavior is unchanged.
- **What did NOT change (scope boundary):**
  - Plain `group` and `group_sender` sessions: `send` still goes to chat root (`replyInThread: false`).
  - `thread-reply` action: unchanged path; still requires explicit `messageId` param.
  - Non-Feishu channels (Telegram, Slack, Discord, etc.): untouched.
  - Auto-reply prompt-builder in `src/auto-reply/reply/groups.ts`: not modified — the fix lives entirely in the Feishu plugin per the owner-boundary rule in `extensions/CLAUDE.md` ("fix owner-specific behavior in the owner module").
  - System prompt wording for `messageToolOnly` group chat: unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74903
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `extensions/feishu/src/channel.ts:743,763` hardcoded `replyInThread: ctx.action === "thread-reply"`. The `send` action ignores the session's topic-mode context entirely.
- **Missing detection / guardrail:** No regression test asserted topic-mode `send` behavior. The only `send` tests covered the plain group case (default `replyInThread: false`); the only thread-reply tests covered the explicit `thread-reply` action.
- **Contributing context:** `parseFeishuConversationId` already exists in the same plugin and exposes `scope: "group_topic" | "group_topic_sender"`. The plumbing was available; the action handler just wasn't consulting it.

## Regression Test Plan

Coverage level that should have caught this: **plugin-action unit test** in `extensions/feishu/src/channel.test.ts`. The new tests cover the four cases that bound the fix:

1. `send` from a `group_topic` session (with `currentMessageId`) → auto-promotes to thread reply against the inbound trigger.
2. `send` from a `group_topic_sender` session (with `currentMessageId`) → also auto-promotes.
3. `send` from a plain `group` session → no change in behavior; `replyInThread: false`.
4. `send` from a `group_topic` session **without** `currentMessageId` → defensive guard: no auto-promote (we don't have a parent to thread against).

## Human Verification

**What I locally verified:**

- `pnpm test extensions/feishu/src/channel.test` → 74 Vitest shards pass (66s).
- Manual code reading of `parseFeishuConversationId` confirms it's already used in `channel.ts:315,342,1163` for the same kind of session-key parsing — no new dependency or contract added.
- New helper `isFeishuGroupTopicSessionKey` is colocated with existing `is*` helpers near the top of `channel.ts`; defensive against `null`/`undefined`/non-Feishu session keys.

**What I did NOT verify:**

- Live Feishu group-topic delivery (no Feishu test app available locally; test suite uses mocks only).
- Whether the assistant model in real sessions actually routes through `message(action=send)` instead of natural reply when `messageToolOnly` is in effect — I trust the reporter's behavior trace on this. If the model uses a different action, the fix is a no-op (safe fallback).
- Behavior under edge session keys (e.g. core wraps `sessionKey` with extra prefix segments) — `parseFeishuConversationId` only matches when the string ends in `:topic:<topicId>` etc., so non-matching wrappers fall through to no-promote, matching the existing path.

## Greptile / Reviewer Notes

- Considered fixing this in core (`src/auto-reply/reply/groups.ts:235`) by changing the prompt instruction. Rejected because:
  - `group_topic` is a Feishu-specific session-key scope; no other channel uses that exact discriminator.
  - Per `extensions/CLAUDE.md`, owner-specific behavior stays owner-specific.
  - The prompt fix would still need the channel layer to honor the topic context for the resulting `thread-reply` action — Approach B fixes the root behavior without depending on the model emitting the right action name.
- The reporter's note also flagged the prompt instruction as part of the bug. The prompt text is still accurate for plain `group` sessions; only the `group_topic` channel routing is wrong, which is what this PR fixes.
