### PR TITLE
fix(agents): keep blank user entries during session repair instead of dropping them (#75313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/session repair: rewrite blank-only persisted user messages to a `(continue)` placeholder instead of dropping them entirely, so repaired session JSONL files always retain at least one user-role entry and strict OpenAI-compatible providers (Qwen3.6, mlx-vlm) no longer reject sessions with "No user query found in messages." Fixes #75313. Thanks @w-sss.
 - Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging. Fixes #75283. Thanks @brokemac79.
 - TTS/providers: keep bundled speech-provider compat fallback available when plugins are globally disabled, so cold gateway and CLI startup can still resolve fallback speech providers instead of leaving explicit TTS provider selection with no registered providers. Refs #75265. Thanks @sliekens.
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -180,6 +180,41 @@ describe("repairSessionFileIfNeeded", () => {
     expect(JSON.parse(repairedLines[2])?.id).toBe("msg-1");
   });
 
+  it("rewrites blank user messages with string-format content", async () => {
+    // Content as a plain string (not array) that is blank should also be rewritten.
+    const { file } = await createTempSessionPath();
+    const { header } = buildSessionHeaderAndMessage();
+    const blankUserEntry = {
+      type: "message",
+      id: "msg-blank-str",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: "   ",
+      },
+    };
+    const userMessage = {
+      type: "message",
+      id: "msg-1",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hello" },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(blankUserEntry)}\n${JSON.stringify(userMessage)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(true);
+    expect(result.rewrittenBlankUserMessages).toBe(1);
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedLines = repaired.trim().split("\n");
+    expect(repairedLines).toHaveLength(3);
+    const blankEntry = JSON.parse(repairedLines[1] ?? "{}");
+    expect(blankEntry.message.content).toEqual([{ type: "text", text: BLANK_USER_FALLBACK_TEXT }]);
+  });
+
   it("rewrites blank user text blocks while preserving media blocks", async () => {
     const { file } = await createTempSessionPath();
     const { header } = buildSessionHeaderAndMessage();

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { repairSessionFileIfNeeded } from "./session-file-repair.js";
+import { BLANK_USER_FALLBACK_TEXT, repairSessionFileIfNeeded } from "./session-file-repair.js";
 
 function buildSessionHeaderAndMessage() {
   const header = {
@@ -145,7 +145,10 @@ describe("repairSessionFileIfNeeded", () => {
     ]);
   });
 
-  it("drops persisted blank user text messages", async () => {
+  it("rewrites persisted blank user text messages with (continue) placeholder (#75313)", async () => {
+    // Regression for openclaw/openclaw#75313: dropping blank user entries can leave
+    // a session with no user role at all (e.g. [system, assistant, …]), which strict
+    // OpenAI-compatible chat templates reject with "No user query found in messages."
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
     const blankUserEntry = {
@@ -165,16 +168,19 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file, warn });
 
     expect(result.repaired).toBe(true);
-    expect(result.droppedBlankUserMessages).toBe(1);
-    expect(warn.mock.calls[0]?.[0]).toContain("dropped 1 blank user message(s)");
+    expect(result.rewrittenBlankUserMessages).toBe(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("rewrote 1 blank user message(s) with (continue)");
 
     const repaired = await fs.readFile(file, "utf-8");
     const repairedLines = repaired.trim().split("\n");
-    expect(repairedLines).toHaveLength(2);
-    expect(JSON.parse(repairedLines[1])?.id).toBe("msg-1");
+    expect(repairedLines).toHaveLength(3);
+    const blankEntry = JSON.parse(repairedLines[1] ?? "{}");
+    expect(blankEntry.id).toBe("msg-blank");
+    expect(blankEntry.message.content).toEqual([{ type: "text", text: BLANK_USER_FALLBACK_TEXT }]);
+    expect(JSON.parse(repairedLines[2])?.id).toBe("msg-1");
   });
 
-  it("removes blank user text blocks while preserving media blocks", async () => {
+  it("rewrites blank user text blocks while preserving media blocks", async () => {
     const { file } = await createTempSessionPath();
     const { header } = buildSessionHeaderAndMessage();
     const mediaUserEntry = {
@@ -204,7 +210,7 @@ describe("repairSessionFileIfNeeded", () => {
     ]);
   });
 
-  it("reports both drops and rewrites in the warn message when both occur", async () => {
+  it("reports assistant rewrites and blank-user rewrites in the warn message when both occur", async () => {
     const { file } = await createTempSessionPath();
     const { header } = buildSessionHeaderAndMessage();
     const poisonedAssistantEntry = {
@@ -222,7 +228,24 @@ describe("repairSessionFileIfNeeded", () => {
         stopReason: "error",
       },
     };
-    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n{"type":"message"`;
+    const blankUserEntry = {
+      type: "message",
+      id: "msg-blank",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "   " }],
+      },
+    };
+    const userMessage = {
+      type: "message",
+      id: "msg-3",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: { role: "user", content: "hello" },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(poisonedAssistantEntry)}\n${JSON.stringify(blankUserEntry)}\n${JSON.stringify(userMessage)}\n{"type":"message"`;
     await fs.writeFile(file, original, "utf-8");
 
     const warn = vi.fn();
@@ -231,9 +254,11 @@ describe("repairSessionFileIfNeeded", () => {
     expect(result.repaired).toBe(true);
     expect(result.droppedLines).toBe(1);
     expect(result.rewrittenAssistantMessages).toBe(1);
+    expect(result.rewrittenBlankUserMessages).toBe(1);
     const warnMessage = warn.mock.calls[0]?.[0] as string;
     expect(warnMessage).toContain("dropped 1 malformed line(s)");
     expect(warnMessage).toContain("rewrote 1 assistant message(s)");
+    expect(warnMessage).toContain("rewrote 1 blank user message(s) with (continue)");
   });
 
   it("does not rewrite silent-reply turns (stopReason=stop, content=[]) on disk", async () => {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -6,7 +6,7 @@ type RepairReport = {
   repaired: boolean;
   droppedLines: number;
   rewrittenAssistantMessages?: number;
-  droppedBlankUserMessages?: number;
+  rewrittenBlankUserMessages?: number;
   rewrittenUserMessages?: number;
   backupPath?: string;
   reason?: string;
@@ -71,15 +71,31 @@ function rewriteAssistantEntryWithEmptyContent(entry: SessionMessageEntry): Sess
   };
 }
 
-type UserEntryRepair =
-  | { kind: "drop" }
-  | { kind: "rewrite"; entry: SessionMessageEntry }
-  | { kind: "keep" };
+type UserEntryRepair = { kind: "rewrite"; entry: SessionMessageEntry } | { kind: "keep" };
+
+// Synthetic user text used when all content blocks are blank.  Dropping a
+// blank user entry entirely can leave a session with no user role at all
+// (e.g. [system, assistant, assistant, …]), which strict OpenAI-compatible
+// chat templates reject with "No user query found in messages."
+// See openclaw/openclaw#75313.
+export const BLANK_USER_FALLBACK_TEXT = "(continue)";
 
 function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEntryRepair {
   const content = entry.message.content;
   if (typeof content === "string") {
-    return content.trim() ? { kind: "keep" } : { kind: "drop" };
+    if (!content.trim()) {
+      return {
+        kind: "rewrite",
+        entry: {
+          ...entry,
+          message: {
+            ...entry.message,
+            content: [{ type: "text", text: BLANK_USER_FALLBACK_TEXT }],
+          },
+        },
+      };
+    }
+    return { kind: "keep" };
   }
   if (!Array.isArray(content)) {
     return { kind: "keep" };
@@ -100,8 +116,19 @@ function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEn
     touched = true;
     return false;
   });
+  // All text blocks were blank — rewrite with synthetic placeholder instead
+  // of dropping, so the session always retains at least one user role entry.
   if (nextContent.length === 0) {
-    return { kind: "drop" };
+    return {
+      kind: "rewrite",
+      entry: {
+        ...entry,
+        message: {
+          ...entry.message,
+          content: [{ type: "text", text: BLANK_USER_FALLBACK_TEXT }],
+        },
+      },
+    };
   }
   if (!touched) {
     return { kind: "keep" };
@@ -121,7 +148,7 @@ function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEn
 function buildRepairSummaryParts(params: {
   droppedLines: number;
   rewrittenAssistantMessages: number;
-  droppedBlankUserMessages: number;
+  rewrittenBlankUserMessages: number;
   rewrittenUserMessages: number;
 }): string {
   const parts: string[] = [];
@@ -131,8 +158,10 @@ function buildRepairSummaryParts(params: {
   if (params.rewrittenAssistantMessages > 0) {
     parts.push(`rewrote ${params.rewrittenAssistantMessages} assistant message(s)`);
   }
-  if (params.droppedBlankUserMessages > 0) {
-    parts.push(`dropped ${params.droppedBlankUserMessages} blank user message(s)`);
+  if (params.rewrittenBlankUserMessages > 0) {
+    parts.push(
+      `rewrote ${params.rewrittenBlankUserMessages} blank user message(s) with (continue)`,
+    );
   }
   if (params.rewrittenUserMessages > 0) {
     parts.push(`rewrote ${params.rewrittenUserMessages} user message(s)`);
@@ -168,7 +197,7 @@ export async function repairSessionFileIfNeeded(params: {
   const entries: unknown[] = [];
   let droppedLines = 0;
   let rewrittenAssistantMessages = 0;
-  let droppedBlankUserMessages = 0;
+  let rewrittenBlankUserMessages = 0;
   let rewrittenUserMessages = 0;
 
   for (const line of lines) {
@@ -190,13 +219,19 @@ export async function repairSessionFileIfNeeded(params: {
         ((entry as { message: { role?: unknown } }).message?.role ?? undefined) === "user"
       ) {
         const repairedUser = repairUserEntryWithBlankTextContent(entry as SessionMessageEntry);
-        if (repairedUser.kind === "drop") {
-          droppedBlankUserMessages += 1;
-          continue;
-        }
         if (repairedUser.kind === "rewrite") {
+          const msg = (repairedUser.entry as { message?: { content?: unknown } }).message;
+          const content = msg?.content;
+          if (
+            Array.isArray(content) &&
+            content.length === 1 &&
+            (content[0] as { text?: string })?.text === BLANK_USER_FALLBACK_TEXT
+          ) {
+            rewrittenBlankUserMessages += 1;
+          } else {
+            rewrittenUserMessages += 1;
+          }
           entries.push(repairedUser.entry);
-          rewrittenUserMessages += 1;
           continue;
         }
       }
@@ -220,7 +255,7 @@ export async function repairSessionFileIfNeeded(params: {
   if (
     droppedLines === 0 &&
     rewrittenAssistantMessages === 0 &&
-    droppedBlankUserMessages === 0 &&
+    rewrittenBlankUserMessages === 0 &&
     rewrittenUserMessages === 0
   ) {
     return { repaired: false, droppedLines: 0 };
@@ -254,7 +289,7 @@ export async function repairSessionFileIfNeeded(params: {
       repaired: false,
       droppedLines,
       rewrittenAssistantMessages,
-      droppedBlankUserMessages,
+      rewrittenBlankUserMessages,
       rewrittenUserMessages,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
@@ -264,7 +299,7 @@ export async function repairSessionFileIfNeeded(params: {
     `session file repaired: ${buildRepairSummaryParts({
       droppedLines,
       rewrittenAssistantMessages,
-      droppedBlankUserMessages,
+      rewrittenBlankUserMessages,
       rewrittenUserMessages,
     })} (${path.basename(sessionFile)})`,
   );
@@ -272,7 +307,7 @@ export async function repairSessionFileIfNeeded(params: {
     repaired: true,
     droppedLines,
     rewrittenAssistantMessages,
-    droppedBlankUserMessages,
+    rewrittenBlankUserMessages,
     rewrittenUserMessages,
     backupPath,
   };


### PR DESCRIPTION
## Summary

Fixes #75313. Session repair previously dropped blank user-role entries entirely, which could leave a session with no user role at all (e.g. `[system, assistant, assistant, …]`). Strict OpenAI-compatible chat templates (Qwen3.6, mlx-vlm, etc.) reject such message arrays with `No user query found in messages.` → HTTP 500.

## Fix

Instead of `{ kind: "drop" }`, blank user entries are now rewritten with a synthetic `"(continue)"` text placeholder, preserving the user role in the session transcript.

## Changes

- `src/agents/session-file-repair.ts`: `repairUserEntryWithBlankTextContent` returns `{ kind: "rewrite" }` with `BLANK_USER_FALLBACK_TEXT = "(continue)"` instead of `{ kind: "drop" }`
- Report field renamed: `droppedBlankUserMessages` → `rewrittenBlankUserMessages`
- Test updates: 10/10 tests pass

## Impact

- Affects all users of `repairSessionFileIfNeeded` (compaction, session resume)
- Prevents HTTP 500 from strict providers when session repair encounters blank user messages
- Related to #75305 (pre-compaction flush sending empty user messages to Anthropic)