### PR TITLE
fix(config): coerce visibleReplies boolean to enum equivalent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/messages: coerce `visibleReplies: true` and `visibleReplies: false` to their enum equivalents (`"automatic"` and `"message_tool"`) instead of failing Zod schema validation. Setting a boolean was intuitive but caused a silent all-channels-down failure — the strict schema rejected the value, the gateway skipped its config reload, and the Channels table went empty with no clear indication why. Fixes #75XXX.
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
 - Telegram/agents: keep typing indicators and optional generation tools off the reply critical path, so fresh Telegram replies no longer stall while provider catalogs and media models load. (#75360) Thanks @obviyus.
 - Agents/commitments: run hidden follow-up extraction on the configured agent/default model instead of falling back to direct OpenAI, so OpenAI Codex OAuth-only gateways no longer spam background API-key failures. Fixes #75334. Thanks @sene1337.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Config/messages: coerce `visibleReplies: true` and `visibleReplies: false` to their enum equivalents (`"automatic"` and `"message_tool"`) instead of failing Zod schema validation. Setting a boolean was intuitive but caused a silent all-channels-down failure — the strict schema rejected the value, the gateway skipped its config reload, and the Channels table went empty with no clear indication why. Fixes #75390.
+- Config/messages: coerce `visibleReplies: true` and `visibleReplies: false` to their enum equivalents (`"automatic"` and `"message_tool"`) instead of failing Zod schema validation. Setting a boolean was intuitive but caused a silent all-channels-down failure — the strict schema rejected the value, the gateway skipped its config reload, and the Channels table went empty with no clear indication why. Fixes #75390. Thanks @scottgl9.
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
 - Telegram/agents: keep typing indicators and optional generation tools off the reply critical path, so fresh Telegram replies no longer stall while provider catalogs and media models load. (#75360) Thanks @obviyus.
 - Agents/commitments: run hidden follow-up extraction on the configured agent/default model instead of falling back to direct OpenAI, so OpenAI Codex OAuth-only gateways no longer spam background API-key failures. Fixes #75334. Thanks @sene1337.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Config/messages: coerce `visibleReplies: true` and `visibleReplies: false` to their enum equivalents (`"automatic"` and `"message_tool"`) instead of failing Zod schema validation. Setting a boolean was intuitive but caused a silent all-channels-down failure — the strict schema rejected the value, the gateway skipped its config reload, and the Channels table went empty with no clear indication why. Fixes #75XXX.
+- Config/messages: coerce `visibleReplies: true` and `visibleReplies: false` to their enum equivalents (`"automatic"` and `"message_tool"`) instead of failing Zod schema validation. Setting a boolean was intuitive but caused a silent all-channels-down failure — the strict schema rejected the value, the gateway skipped its config reload, and the Channels table went empty with no clear indication why. Fixes #75390.
 - Agents/commitments: keep inferred follow-ups internal when heartbeat target is none, strip raw source text from stored commitments, disable tools during due-commitment heartbeat turns, bound hidden extraction queue growth, expire stale commitments, and add QA/Docker safety coverage. Thanks @vignesh07.
 - Telegram/agents: keep typing indicators and optional generation tools off the reply critical path, so fresh Telegram replies no longer stall while provider catalogs and media models load. (#75360) Thanks @obviyus.
 - Agents/commitments: run hidden follow-up extraction on the configured agent/default model instead of falling back to direct OpenAI, so OpenAI Codex OAuth-only gateways no longer spam background API-key failures. Fixes #75334. Thanks @sene1337.

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -397,11 +397,23 @@ export const ModelsConfigSchema = z
   .strict()
   .optional();
 
+// Accepts the canonical enum values and coerces legacy boolean literals:
+// true → "automatic" (keep room posting on), false → "message_tool" (private replies).
+// Boolean values were never documented but were intuitive enough that users set them;
+// coercing instead of rejecting prevents the silent all-channels-down failure.
+export const VisibleRepliesSchema = z
+  .union([
+    z.enum(["automatic", "message_tool"]),
+    z.literal(true).transform((): "automatic" => "automatic"),
+    z.literal(false).transform((): "message_tool" => "message_tool"),
+  ])
+  .optional();
+
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
     historyLimit: z.number().int().positive().optional(),
-    visibleReplies: z.enum(["automatic", "message_tool"]).optional(),
+    visibleReplies: VisibleRepliesSchema,
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -11,6 +11,7 @@ import {
   QueueSchema,
   TypingModeSchema,
   TtsConfigSchema,
+  VisibleRepliesSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
@@ -145,7 +146,7 @@ export const SessionSchema = z
 export const MessagesSchema = z
   .object({
     messagePrefix: z.string().optional(),
-    visibleReplies: z.enum(["automatic", "message_tool"]).optional(),
+    visibleReplies: VisibleRepliesSchema,
     responsePrefix: z.string().optional(),
     groupChat: GroupChatSchema,
     queue: QueueSchema,

--- a/src/config/zod-schema.visible-replies.test.ts
+++ b/src/config/zod-schema.visible-replies.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { GroupChatSchema, VisibleRepliesSchema } from "./zod-schema.core.js";
+import { MessagesSchema } from "./zod-schema.session.js";
+
+describe("VisibleRepliesSchema", () => {
+  it('accepts "automatic"', () => {
+    expect(VisibleRepliesSchema.parse("automatic")).toBe("automatic");
+  });
+
+  it('accepts "message_tool"', () => {
+    expect(VisibleRepliesSchema.parse("message_tool")).toBe("message_tool");
+  });
+
+  it("coerces boolean true to automatic", () => {
+    expect(VisibleRepliesSchema.parse(true)).toBe("automatic");
+  });
+
+  it("coerces boolean false to message_tool", () => {
+    expect(VisibleRepliesSchema.parse(false)).toBe("message_tool");
+  });
+
+  it("accepts undefined (optional)", () => {
+    expect(VisibleRepliesSchema.parse(undefined)).toBeUndefined();
+  });
+
+  it("rejects an invalid string", () => {
+    expect(() => VisibleRepliesSchema.parse("always")).toThrow();
+  });
+});
+
+describe("GroupChatSchema — visibleReplies coercion", () => {
+  it("coerces boolean true to automatic inside groupChat config", () => {
+    const result = GroupChatSchema.parse({ visibleReplies: true });
+    expect(result?.visibleReplies).toBe("automatic");
+  });
+
+  it("coerces boolean false to message_tool inside groupChat config", () => {
+    const result = GroupChatSchema.parse({ visibleReplies: false });
+    expect(result?.visibleReplies).toBe("message_tool");
+  });
+});
+
+describe("MessagesSchema — visibleReplies coercion", () => {
+  it("coerces boolean true at messages.visibleReplies", () => {
+    const result = MessagesSchema.parse({ visibleReplies: true });
+    expect(result?.visibleReplies).toBe("automatic");
+  });
+
+  it("coerces boolean true at messages.groupChat.visibleReplies", () => {
+    const result = MessagesSchema.parse({ groupChat: { visibleReplies: true } });
+    expect(result?.groupChat?.visibleReplies).toBe("automatic");
+  });
+});


### PR DESCRIPTION
## What bug this fixes

Closes #75390

Setting `messages.groupChat.visibleReplies` or `messages.visibleReplies` to boolean `true`/`false` causes an all-channels-down failure. The strict Zod schema rejects the non-enum value, the gateway silently skips its config reload, and the Channels table goes empty — with no actionable feedback pointing to the config field.

## Why boolean values happen

The field is an on/off toggle by intent. `true` is the natural value to reach for to "turn on visible replies". The previous runtime log warning (removed in #75367, moved to `openclaw doctor`) used the phrasing "restore automatic room posting" which read as a boolean enable/disable, and JSON5 configs allow unquoted values, making the mistake easy.

## Fix

Add `VisibleRepliesSchema` in `zod-schema.core.ts` using a `z.union` with transforms:
- `true → "automatic"` (visible replies on, legacy intent)
- `false → "message_tool"` (private replies, legacy intent)
- Existing enum values and `undefined` are unchanged

Used at both schema sites:
- `messages.groupChat.visibleReplies` (GroupChatSchema in `zod-schema.core.ts`)
- `messages.visibleReplies` (MessagesSchema in `zod-schema.session.ts`)

## Is this the right fix?

Yes. Coercing at the schema layer means all config load paths (startup, hot-reload, doctor, set/unset commands) get the fix automatically, and the output type remains `"automatic" | "message_tool" | undefined` — no downstream type changes needed.

## Tests

10 new tests in `src/config/zod-schema.visible-replies.test.ts` covering:
- Canonical string values pass through unchanged
- `true` → `"automatic"` at VisibleRepliesSchema, GroupChatSchema, and MessagesSchema levels
- `false` → `"message_tool"` at VisibleRepliesSchema and GroupChatSchema levels
- `undefined` accepted (optional)
- Invalid string rejected

## Evidence

Confirmed on `scottgl-aipc` (v2026.4.29). Setting `visibleReplies: true` while debugging the dotenv staging issue silently dropped all 4 channels (Matrix, Discord, Telegram, WhatsApp) for an extended period.