### PR TITLE
Strip OpenRouter Anthropic assistant prefill

### DIFF
--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -2,6 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { isProxyReasoningUnsupportedModelHint } from "../../plugin-sdk/provider-model-shared.js";
+import { stripTrailingAnthropicAssistantPrefillWhenThinking } from "../../plugin-sdk/provider-stream-shared.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../../shared/string-coerce.js";
 import { resolveProviderRequestPolicy } from "../provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
@@ -102,6 +103,9 @@ export function createOpenRouterWrapper(
       },
       (payload) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
+        if (isAnthropicModelRef(readStringValue(model.id))) {
+          stripTrailingAnthropicAssistantPrefillWhenThinking(payload);
+        }
       },
     );
   };

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -103,7 +103,8 @@ export function createOpenRouterWrapper(
       },
       (payload) => {
         normalizeProxyReasoningPayload(payload, thinkingLevel);
-        if (isAnthropicModelRef(readStringValue(model.id))) {
+        const modelId = readStringValue(model.id);
+        if (modelId && isAnthropicModelRef(modelId)) {
           stripTrailingAnthropicAssistantPrefillWhenThinking(payload);
         }
       },

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -340,6 +340,19 @@ describe("stripTrailingAnthropicAssistantPrefillWhenThinking", () => {
     expect(stripTrailingAnthropicAssistantPrefillWhenThinking(toolCallsPayload)).toBe(0);
   });
 
+  it("removes trailing assistant text turns for OpenAI-compatible reasoning payloads", () => {
+    const payload = {
+      reasoning: { effort: "high" },
+      messages: [
+        { role: "user", content: "Return JSON." },
+        { role: "assistant", content: "{" },
+      ],
+    };
+
+    expect(stripTrailingAnthropicAssistantPrefillWhenThinking(payload)).toBe(1);
+    expect(payload.messages).toEqual([{ role: "user", content: "Return JSON." }]);
+  });
+
   it("keeps assistant prefill when Anthropic thinking is disabled", () => {
     const payload = {
       thinking: { type: "disabled" },

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -156,10 +156,14 @@ export function createPayloadPatchStreamWrapper(
 
 function isAnthropicThinkingEnabled(payload: Record<string, unknown>): boolean {
   const thinking = payload.thinking;
-  if (!thinking || typeof thinking !== "object") {
-    return false;
+  if (thinking && typeof thinking === "object") {
+    return (thinking as { type?: unknown }).type !== "disabled";
   }
-  return (thinking as { type?: unknown }).type !== "disabled";
+  // OpenAI-compatible Anthropic proxy routes (for example OpenRouter) express
+  // extended thinking as `reasoning`/`reasoning_effort` instead of Anthropic's
+  // native `thinking` field, but the upstream Anthropic validation still
+  // rejects trailing assistant-prefill messages.
+  return Boolean(payload.reasoning || payload.reasoning_effort);
 }
 
 function assistantMessageHasAnthropicToolUse(message: Record<string, unknown>): boolean {

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -275,7 +275,7 @@ describe("buildProviderStreamFamilyHooks", () => {
       config: { thinkingConfig: { thinkingBudget: -1 } },
       reasoning: { effort: "high" },
     });
-    expect(capturedPayload?.messages).toEqual([{ role: "user", content: "hello" }]);
+    expect((capturedPayload as { messages?: unknown } | undefined)?.messages).toEqual([{ role: "user", content: "hello" }]);
 
     void requireStreamFn(
       requireWrapStreamFn(openRouterHooks.wrapStreamFn)({

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -253,6 +253,30 @@ describe("buildProviderStreamFamilyHooks", () => {
       reasoning: { effort: "high" },
     });
 
+    payloadSeed = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "prefill" },
+      ],
+    };
+    capturedPayload = undefined;
+    void requireStreamFn(
+      requireWrapStreamFn(openRouterHooks.wrapStreamFn)({
+        streamFn: baseStreamFn,
+        thinkingLevel: "high",
+        modelId: "anthropic/claude-opus-4.6",
+      } as never),
+    )(
+      { provider: "openrouter", id: "anthropic/claude-opus-4.6" } as never,
+      {} as never,
+      {},
+    );
+    expect(capturedPayload).toMatchObject({
+      config: { thinkingConfig: { thinkingBudget: -1 } },
+      reasoning: { effort: "high" },
+    });
+    expect(capturedPayload?.messages).toEqual([{ role: "user", content: "hello" }]);
+
     void requireStreamFn(
       requireWrapStreamFn(openRouterHooks.wrapStreamFn)({
         streamFn: baseStreamFn,


### PR DESCRIPTION
## Summary
- strip trailing assistant prefill turns for Anthropic model IDs in the OpenRouter stream wrapper
- treat OpenAI-compatible reasoning/reasoning_effort payloads as Anthropic thinking-enabled for prefill stripping
- add focused coverage for OpenRouter Anthropic prefill stripping and shared prefill behavior

Fixes #75395

## Tests
- pnpm exec vitest run src/plugin-sdk/provider-stream.test.ts src/plugin-sdk/provider-stream-shared.test.ts