### PR TITLE
fix(mcp): normalize empty parameter-free tool schema before sending to OpenAI (#75362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/hooks: derive hook `ctx.channelId` from the conversation target instead of the provider name, so Discord and other channel plugins can keep per-channel state isolated. Fixes #59881. Thanks @bradfreels.
 - Gateway/config: log config health-state write failures instead of silently hiding config observe-recovery write errors. Thanks @sallyom.
 - Diagnostics: reset stuck-session timers on reply, tool, status, block, and ACP progress events, and back off repeated `session.stuck` diagnostics while a session remains unchanged. Supersedes #72010. Thanks @rubencu.
+- Agents/OpenAI: normalize parameter-free MCP tool schemas whose `properties` value is null or undefined, so OpenAI no longer rejects MCP tools without parameters. Fixes #75362. (#75401) Thanks @SymbolStar.
 
 ## 2026.4.30
 

--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -29,4 +29,24 @@ describe("OpenAI strict tool schema normalization", () => {
       resolveOpenAIStrictToolFlagForInventory([{ name: "write", parameters: schema }], true),
     ).toBe(false);
   });
+
+  it("normalizes parameter-free MCP tool schema with properties:undefined (#75362)", () => {
+    const schema = { type: "object", properties: undefined } as unknown;
+    const normalized = normalizeStrictOpenAIJsonSchema(schema) as Record<string, unknown>;
+    expect(normalized.type).toBe("object");
+    expect(normalized.properties).toEqual({});
+    expect(normalized.required).toEqual([]);
+    expect(normalized.additionalProperties).toBe(false);
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(true);
+  });
+
+  it("normalizes truly empty MCP tool schema {} for strict mode", () => {
+    const schema = {};
+    const normalized = normalizeStrictOpenAIJsonSchema(schema) as Record<string, unknown>;
+    expect(normalized.type).toBe("object");
+    expect(normalized.properties).toEqual({});
+    expect(normalized.required).toEqual([]);
+    expect(normalized.additionalProperties).toBe(false);
+    expect(isStrictOpenAIJsonSchemaCompatible(schema)).toBe(true);
+  });
 });

--- a/src/agents/pi-tools-parameter-schema.ts
+++ b/src/agents/pi-tools-parameter-schema.ts
@@ -134,10 +134,6 @@ function isTypedSchemaMissingProperties(
   if (!("type" in schemaRecord) || conditionalKey !== null) {
     return false;
   }
-  // Treat both missing `properties` and `properties` set to a non-object value
-  // (e.g. undefined/null) as "missing properties" — MCP servers sometimes return
-  // `{ type: "object" }` or `{ type: "object", properties: undefined }` for
-  // parameter-free tools.
   if (!("properties" in schemaRecord)) {
     return true;
   }

--- a/src/agents/pi-tools-parameter-schema.ts
+++ b/src/agents/pi-tools-parameter-schema.ts
@@ -107,7 +107,13 @@ function hasTopLevelObjectSchema(
   schemaRecord: Record<string, unknown>,
   conditionalKey: TopLevelConditionalKey | null,
 ): boolean {
-  return "type" in schemaRecord && "properties" in schemaRecord && conditionalKey === null;
+  return (
+    "type" in schemaRecord &&
+    "properties" in schemaRecord &&
+    schemaRecord.properties != null &&
+    typeof schemaRecord.properties === "object" &&
+    conditionalKey === null
+  );
 }
 
 function isObjectLikeSchemaMissingType(
@@ -125,7 +131,18 @@ function isTypedSchemaMissingProperties(
   schemaRecord: Record<string, unknown>,
   conditionalKey: TopLevelConditionalKey | null,
 ): boolean {
-  return "type" in schemaRecord && !("properties" in schemaRecord) && conditionalKey === null;
+  if (!("type" in schemaRecord) || conditionalKey !== null) {
+    return false;
+  }
+  // Treat both missing `properties` and `properties` set to a non-object value
+  // (e.g. undefined/null) as "missing properties" — MCP servers sometimes return
+  // `{ type: "object" }` or `{ type: "object", properties: undefined }` for
+  // parameter-free tools.
+  if (!("properties" in schemaRecord)) {
+    return true;
+  }
+  const props = schemaRecord.properties;
+  return props == null || typeof props !== "object" || Array.isArray(props);
 }
 
 function isTrulyEmptySchema(schemaRecord: Record<string, unknown>): boolean {

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -207,6 +207,8 @@ describe("normalizeToolParameters", () => {
     expect(parameters.type).toBe("object");
     expect(parameters.properties).toEqual({});
   });
+
+  it("preserves existing properties on type:object schemas", () => {
     const tool: AnyAgentTool = {
       name: "query",
       label: "query",

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -176,7 +176,37 @@ describe("normalizeToolParameters", () => {
     expect(parameters.properties).toEqual({});
   });
 
-  it("preserves existing properties on type:object schemas", () => {
+  it("injects properties:{} when properties key exists but is undefined (MCP SDK edge case #75362)", () => {
+    const tool: AnyAgentTool = {
+      name: "get_flux_instance",
+      label: "get_flux_instance",
+      description: "Get flux instance",
+      parameters: { type: "object", properties: undefined } as unknown as Record<string, unknown>,
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+
+    const parameters = normalized.parameters as Record<string, unknown>;
+    expect(parameters.type).toBe("object");
+    expect(parameters.properties).toEqual({});
+  });
+
+  it("injects properties:{} when properties key is null (MCP SDK edge case #75362)", () => {
+    const tool: AnyAgentTool = {
+      name: "get_flux_instance",
+      label: "get_flux_instance",
+      description: "Get flux instance",
+      parameters: { type: "object", properties: null } as unknown as Record<string, unknown>,
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+
+    const parameters = normalized.parameters as Record<string, unknown>;
+    expect(parameters.type).toBe("object");
+    expect(parameters.properties).toEqual({});
+  });
     const tool: AnyAgentTool = {
       name: "query",
       label: "query",


### PR DESCRIPTION
Fixes #75362

## Summary

MCP servers may return `inputSchema` as `{ type: "object" }` without a `properties` field, or with `properties` set to `undefined`/`null`. The `hasTopLevelObjectSchema` guard only checked `"properties" in schemaRecord` (key existence) without verifying the value is a real object. This caused such schemas to pass through unnormalized, resulting in OpenAI rejecting them with `400 Invalid schema for function: object schema missing properties`.

## Root Cause

In `pi-tools-parameter-schema.ts`:
- `hasTopLevelObjectSchema` checked `"properties" in schemaRecord` — which is `true` even when the value is `undefined`
- `isTypedSchemaMissingProperties` checked `!("properties" in schemaRecord)` — which is `false` when the key exists with value `undefined`

Result: schemas like `{ type: "object", properties: undefined }` passed through without normalization.

## Fix

- Tighten `hasTopLevelObjectSchema` to require `properties` to be a non-null object
- Broaden `isTypedSchemaMissingProperties` to catch `properties` keys with `undefined`/`null`/non-object values

## Regression History

- #60158: original issue report
- #60176: original fix (normalize `{}` → `{ type: "object", properties: {} }`)
- #75362: this regression (edge case with `properties: undefined` not caught)

## Tests

Added unit tests in:
- `openai-tool-schema.test.ts`: strict mode normalization for empty/undefined properties
- `pi-tools.schema.test.ts`: `normalizeToolParameters` with `properties: undefined` and `properties: null`