### PR TITLE
docs(docker): document python3 runtime baseline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -158,11 +158,12 @@ LABEL org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
 
 WORKDIR /app
 
-# Install runtime system utilities missing from bookworm-slim.
+# Install baseline runtime system utilities missing from bookworm-slim.
 # `ca-certificates` ships in `bookworm` (full) but not in `bookworm-slim`,
 # so it must be installed explicitly here. Without it `/etc/ssl/certs/`
 # stays empty and every HTTPS outbound dies at TLS handshake with
-# `error setting certificate file`.
+# `error setting certificate file`. `python3` keeps user-authored workspace
+# scripts and Python-backed skills runnable in the published gateway image.
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
     apt-get update && \
@@ -200,7 +201,7 @@ RUN install -d -m 0755 "$COREPACK_HOME" && \
     chmod -R a+rX "$COREPACK_HOME"
 
 # Install additional system packages needed by your skills or extensions.
-# Example: docker build --build-arg OPENCLAW_DOCKER_APT_PACKAGES="python3 wget" .
+# Example: docker build --build-arg OPENCLAW_DOCKER_APT_PACKAGES="ffmpeg wget" .
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -125,7 +125,7 @@ The setup script accepts these optional environment variables:
 | Variable                                   | Purpose                                                         |
 | ------------------------------------------ | --------------------------------------------------------------- |
 | `OPENCLAW_IMAGE`                           | Use a remote image instead of building locally                  |
-| `OPENCLAW_DOCKER_APT_PACKAGES`             | Install extra apt packages during build (space-separated)       |
+| `OPENCLAW_DOCKER_APT_PACKAGES`             | Install extra apt packages during local image builds            |
 | `OPENCLAW_EXTENSIONS`                      | Pre-install plugin deps at build time (space-separated names)   |
 | `OPENCLAW_EXTRA_MOUNTS`                    | Extra host bind mounts (comma-separated `source:target[:opts]`) |
 | `OPENCLAW_HOME_VOLUME`                     | Persist `/home/node` in a named Docker volume                   |
@@ -384,7 +384,7 @@ See [ClawDock](/install/clawdock) for the full helper guide.
     full-featured container:
 
     1. **Persist `/home/node`**: `export OPENCLAW_HOME_VOLUME="openclaw_home"`
-    2. **Bake system deps**: `export OPENCLAW_DOCKER_APT_PACKAGES="git curl jq"`
+    2. **Bake extra system deps**: `export OPENCLAW_DOCKER_APT_PACKAGES="jq ffmpeg"`
     3. **Install Playwright browsers**:
        ```bash
        docker compose run --rm openclaw-cli \
@@ -409,6 +409,10 @@ See [ClawDock](/install/clawdock) for the full helper guide.
     refreshed through Dependabot Docker base-image PRs; release builds do not run
     a distro upgrade layer. See
     [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
+    The official OpenClaw Docker release image includes baseline runtime tools
+    such as `curl`, `git`, `lsof`, `openssl`, and `python3`, so workspace Python
+    scripts run without a custom image. `OPENCLAW_DOCKER_APT_PACKAGES` adds
+    packages beyond that baseline when you build locally.
   </Accordion>
 </AccordionGroup>
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const dockerInstallDocsPath = join(repoRoot, "docs", "install", "docker.md");
 const packageJsonPath = join(repoRoot, "package.json");
 
 function collapseDockerContinuations(dockerfile: string): string {
@@ -60,6 +61,17 @@ describe("Dockerfile", () => {
     expect(pythonInstallIndex).toBeGreaterThan(runtimeIndex);
     expect(pythonInstallIndex).toBeLessThan(dockerfile.indexOf("RUN chown node:node /app"));
     expect(dockerfile).toContain("ca-certificates procps hostname curl git lsof openssl python3");
+  });
+
+  it("documents python3 as a default gateway runtime package", async () => {
+    const docs = await readFile(dockerInstallDocsPath, "utf8");
+
+    expect(docs).toContain("The official OpenClaw Docker release image includes");
+    expect(docs).toContain("`python3`");
+    expect(docs).toMatch(/workspace\s+Python\s+scripts/);
+    expect(docs).toMatch(
+      /`OPENCLAW_DOCKER_APT_PACKAGES`\s+adds\s+packages\s+beyond\s+that\s+baseline/,
+    );
   });
 
   it("installs optional browser dependencies after pnpm install", async () => {


### PR DESCRIPTION
## Problem

#75417 restored `python3` in the gateway runtime image and closed #75041, but the Docker install docs and Dockerfile build-arg example still describe `OPENCLAW_DOCKER_APT_PACKAGES` like Python is an extra package to bake into local images. That leaves users reading the docs with the wrong mental model: official release images now include `python3`; the build arg is only for packages beyond that baseline.

## Root cause

The runtime package fix landed in `Dockerfile`, `src/dockerfile.test.ts`, and `CHANGELOG.md`, but the user-visible Docker install page was not updated. The Dockerfile example also still used `python3 wget`, which made `python3` look optional even after it became part of the default runtime package list.

## Complete fix boundary

- Update the Dockerfile runtime comment to call the package list a baseline and explain why `python3` is included.
- Change the optional package example from `python3 wget` to non-baseline extras.
- Update `docs/install/docker.md` so the environment-variable table and power-user example describe `OPENCLAW_DOCKER_APT_PACKAGES` as local-build extras.
- Document that official OpenClaw Docker release images include `python3` for workspace Python scripts.
- Add a `src/dockerfile.test.ts` docs assertion for the `python3` baseline wording so the user-visible docs do not drift again.

## What intentionally did not change

- Did not re-add the core `python3` runtime package change; #75417 already merged that.
- Did not add another changelog entry; #75417 already added the release note that fixes #75041.
- Did not change `scripts/docker/setup.sh`; it already passes local build extras through only when building `openclaw:local`.
- Did not touch sandbox docs or sandbox Dockerfiles; those are a separate execution boundary.

## Tests run

- `pnpm test src/dockerfile.test.ts` (15 tests passed)
- `pnpm exec oxfmt --check --threads=1 Dockerfile src/dockerfile.test.ts docs/install/docker.md`
- `git diff --check upstream/main..HEAD`
- `pnpm check:changed`

Docker smoke attempted but could not start locally because the Docker daemon is unavailable on this machine:

```text
ERROR: error during connect: Head http://%2F%2F.%2Fpipe%2FdockerDesktopLinuxEngine/_ping: open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified.
```

## Linked issue

Refs #75041. Follow-up to #75417.

## CI red analysis

After rebasing onto latest `upstream/main`, the previous file conflict in `src/dockerfile.test.ts` is resolved. New exact-head GitHub checks are running after the force-with-lease update. The local Docker smoke failure is unrelated to this diff because Docker fails before reading the Dockerfile; the Docker Desktop Linux engine pipe is missing locally.