### PR TITLE
fix(agent-tools): skip device identity for agent loopback gateway calls

### DIFF
--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -166,5 +166,12 @@ export async function callGatewayTool<T = Record<string, unknown>>(
     clientDisplayName: "agent",
     mode: GATEWAY_CLIENT_MODES.BACKEND,
     scopes,
+    // Agent loopback gateway calls authenticate via the shared gateway token,
+    // not device pairing. Presenting a device identity would gate admin-scope
+    // RPCs (cron.add, agents.create, etc.) behind the device pairing approval
+    // flow — which has no operator to approve in headless agent contexts like
+    // Blink Claw. The shared OPENCLAW_GATEWAY_TOKEN already proves authority
+    // for the loopback caller, so skip device identity entirely.
+    deviceIdentity: null,
   });
 }


### PR DESCRIPTION
## Summary

Agent in-process loopback gateway calls (`callGatewayTool` in `src/agents/tools/gateway.ts`) currently default to presenting a device identity (`resolveDeviceIdentityForGatewayCall()`). On any device that was paired through the bootstrap handoff, this causes **every admin-scope RPC from the agent — `cron.add`, `cron.update`, `cron.remove`, `cron.run`, `agents.create`, `agents.update`, `agents.delete`, `chat.inject`, `sessions.compact`, etc. — to fail forever** with:

```
gateway closed (1008): pairing required:
device is asking for more scopes than currently approved (reason: scope-upgrade)
```

There is no in-band recovery path. The agent has no way to escalate its own loopback device's approved scopes — that requires an external operator approval, which doesn't exist in headless deployments.

## Repro

1. Pair the gateway client device through the standard bootstrap handoff (which uses `BOOTSTRAP_HANDOFF_OPERATOR_SCOPES` from `src/shared/device-bootstrap-profile.ts` — intentionally `read / write / approvals / talk.secrets`, no `admin`).
2. From a chat session whose sender is an owner candidate, ask the agent to set a reminder via the `cron` tool.
3. Tool result: `gateway closed (1008): pairing required: device is asking for more scopes than currently approved`.

The same error reproduces deterministically for every other admin-scope method in `src/gateway/method-scopes.ts:149-175`.

## Root cause

After `a40c10d3e2` ("fix: harden agent gateway authorization scopes", Feb 19, 2026), `cron.add / update / remove / run` moved into `ADMIN_SCOPE`. The bootstrap pairing profile in `src/shared/device-bootstrap-profile.ts` deliberately excludes `operator.admin`. Result: every device paired via bootstrap permanently loses cron-write capability from the agent's loopback path.

The scope-upgrade rejection is enforced at `src/gateway/server/ws-connection/message-handler.ts:1117-1138` — but **only when the connection presents a device identity**. A connection authenticated purely by the shared gateway token (no device) is granted exactly the scopes it requests at connect time, with no upgrade approval needed.

## Fix

Pass `deviceIdentity: null` from `callGatewayTool`. Agent loopback calls authenticate via the shared `OPENCLAW_GATEWAY_TOKEN` — that already proves authority for the in-process caller. Skipping the device layer bypasses the scope-upgrade rejection. Existing `paired.json` / `device-auth.json` files become inert for these calls; no per-machine cleanup needed.

The change is one field in one file:

```ts
return await callGateway<T>({
  // ...existing fields...
  deviceIdentity: null,  // ← new
});
```

## Why this is the right layer

- The shared gateway token is a stronger authn signal than the device identity for an in-process loopback caller (the token is held by the same process).
- The device-pairing scope model is designed for *external* operators (CLI, mobile, web) where human approval makes sense. There is no human in the loop for agent self-loopback.
- Removing the device identity from this one call site doesn't weaken any other auth path — external operator clients (CLI, mobile, web) still present device identities and still go through scope approval.
- The only behavioral diff is: agents can now use admin-scope tools they were always supposed to be able to use. This matches the intent of `src/agents/tool-policy.ts` — owner-only tools (`cron`, `gateway`, `nodes`) are gated by `senderIsOwner`, not by device-pairing scope.

## Verification

- `pnpm test src/agents/tools/gateway.test.ts` → 13/13 pass
- `pnpm test src/agents/tools/cron-tool*.test.ts` → 364/364 pass across 36 files
- Live-verified the failure mode and the fix on a production headless agent (Blink Claw, OpenClaw 2026.4.21). The exact session-recorded error string is in the description above.

## Test plan

- [ ] Reviewer can repro the bootstrap-paired admin-scope deadlock by following the repro section
- [ ] Existing test suites pass (`gateway.test.ts`, `cron-tool*.test.ts`)
- [ ] No regression in CLI device-pairing behavior — CLI clients construct their own `GatewayClient` and continue to present device identity

Happy to add a regression test if you want one — e.g. a unit test asserting `callGatewayTool` calls `callGateway` with `deviceIdentity: null`. Let me know the preferred shape.
