### PR TITLE
feat(ui): replace textarea with CodeMirror 6 JSON editor in raw config view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - Docs: add `pnpm docs:check-links:anchors` for Mintlify anchor validation while keeping `scripts/docs-link-audit.mjs` as the stable link-audit entrypoint. (#55912) Thanks @velvet-shark.
 - Plugins/hooks: add async `requireApproval` to `before_tool_call` hooks, letting plugins pause tool execution and prompt the user for approval via the exec approval overlay, Telegram buttons, Discord interactions, or the `/approve` command on any channel. The `/approve` command now handles both exec and plugin approvals with automatic fallback. (#55339) Thanks @vaclavbelak and @joshavant.
 - ACP/channels: add current-conversation ACP binds for Discord, BlueBubbles, and iMessage so `/acp spawn codex --bind here` can turn the current chat into a Codex-backed workspace without creating a child thread, and document the distinction between chat surface, ACP session, and runtime workspace.
-- Tavily: mark outbound API requests with `X-Client-Source: openclaw` so Tavily can attribute OpenClaw-originated traffic. (#55335) Thanks @lakshyaag-tavily.
+- Control UI: replace the raw config textarea with a CodeMirror 6 JSON5 editor featuring syntax highlighting, real-time linting, format button, and proper dark-mode system-theme following. Thanks @Tardis.
 
 ### Fixes
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,15 +699,42 @@ importers:
 
   ui:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.18.0
+        version: 6.20.1
+      '@codemirror/commands':
+        specifier: ^6.8.0
+        version: 6.10.3
+      '@codemirror/lang-json':
+        specifier: ^6.0.1
+        version: 6.0.2
+      '@codemirror/lint':
+        specifier: ^6.8.0
+        version: 6.9.5
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: ^6.36.5
+        version: 6.41.1
       '@create-markdown/preview':
         specifier: ^2.0.0
         version: 2.0.0(@create-markdown/core@2.0.0)(shiki@3.23.0)
       '@noble/ed25519':
         specifier: 3.0.1
         version: 3.0.1
+      codemirror-json5:
+        specifier: ^1.0.3
+        version: 1.0.3
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
+      lezer-json5:
+        specifier: ^2.0.2
+        version: 2.0.2
       lit:
         specifier: ^3.3.2
         version: 3.3.2
@@ -1078,6 +1105,27 @@ packages:
 
   '@cloudflare/workers-types@4.20260120.0':
     resolution: {integrity: sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1789,6 +1837,18 @@ packages:
   '@larksuiteoapi/node-sdk@1.60.0':
     resolution: {integrity: sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==}
 
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
   '@line/bot-sdk@10.6.0':
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
     engines: {node: '>=20'}
@@ -1837,6 +1897,9 @@ packages:
 
   '@lydell/node-pty@1.2.0-beta.3':
     resolution: {integrity: sha512-ngGAItlRhmJXrhspxt8kX13n1dVFqzETOq0m/+gqSkO8NJBvNMwP7FZckMwps2UFySdr4yxCXNGu/bumg5at6A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
@@ -4082,6 +4145,9 @@ packages:
   codec-parser@2.5.0:
     resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
+  codemirror-json5@1.0.3:
+    resolution: {integrity: sha512-HmmoYO2huQxoaoG5ARKjqQc9mz7/qmNPvMbISVfIE2Gk1+4vZQg9X3G6g49MYM5IK00Ol3aijd7OKrySuOkA7Q==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -4155,6 +4221,9 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -4990,6 +5059,9 @@ packages:
 
   koffi@2.15.2:
     resolution: {integrity: sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==}
+
+  lezer-json5@2.0.2:
+    resolution: {integrity: sha512-NRmtBlKW/f8mA7xatKq8IUOq045t8GVHI4kZXrUtYYUdiVeGiO6zKGAV7/nUAnf5q+rYTY+SWX/gvQdFXMjNxQ==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -6263,6 +6335,9 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6614,6 +6689,9 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -7655,6 +7733,51 @@ snapshots:
   '@cloudflare/workers-types@4.20260120.0':
     optional: true
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -8392,6 +8515,22 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
   '@line/bot-sdk@10.6.0':
     dependencies:
       '@types/node': 24.10.13
@@ -8441,6 +8580,8 @@ snapshots:
       '@lydell/node-pty-linux-x64': 1.2.0-beta.3
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.3
       '@lydell/node-pty-win32-x64': 1.2.0-beta.3
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
@@ -10689,6 +10830,16 @@ snapshots:
   codec-parser@2.5.0:
     optional: true
 
+  codemirror-json5@1.0.3:
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      json5: 2.2.3
+      lezer-json5: 2.0.2
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -10750,6 +10901,8 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  crelt@1.0.6: {}
 
   croner@10.0.1: {}
 
@@ -11753,6 +11906,10 @@ snapshots:
 
   koffi@2.15.2:
     optional: true
+
+  lezer-json5@2.0.2:
+    dependencies:
+      '@lezer/lr': 1.4.10
 
   lie@3.3.0:
     dependencies:
@@ -13187,6 +13344,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  style-mod@4.1.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -13494,6 +13653,8 @@ snapshots:
       - msw
 
   void-elements@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,6 +708,9 @@ importers:
       '@codemirror/lang-json':
         specifier: ^6.0.1
         version: 6.0.2
+      '@codemirror/language':
+        specifier: ^6.10.0
+        version: 6.12.3
       '@codemirror/lint':
         specifier: ^6.8.0
         version: 6.9.5

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "@codemirror/autocomplete": "^6.18.0",
     "@codemirror/commands": "^6.8.0",
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/language": "^6.10.0",
     "@codemirror/lint": "^6.8.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,9 +9,18 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.18.0",
+    "@codemirror/commands": "^6.8.0",
+    "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lint": "^6.8.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.36.5",
     "@create-markdown/preview": "^2.0.0",
     "@noble/ed25519": "3.0.1",
+    "codemirror-json5": "^1.0.3",
     "dompurify": "^3.3.3",
+    "json5": "^2.2.3",
+    "lezer-json5": "^2.0.2",
     "lit": "^3.3.2",
     "marked": "^17.0.5"
   },

--- a/ui/src/ui/views/config-editor.ts
+++ b/ui/src/ui/views/config-editor.ts
@@ -1,0 +1,365 @@
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import {
+  syntaxHighlighting,
+  defaultHighlightStyle,
+  foldGutter,
+  foldKeymap,
+} from "@codemirror/language";
+import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
+import { EditorState, type Extension, Compartment } from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  lineNumbers,
+  highlightActiveLine,
+  drawSelection,
+  highlightSpecialChars,
+} from "@codemirror/view";
+import { json5 } from "codemirror-json5";
+import JSON5 from "json5";
+import { css, html, LitElement } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+
+/** CodeMirror theme extensions for dark mode */
+const DARK_THEME = EditorView.theme({
+  "&": { backgroundColor: "#1f2937", color: "#e5e7eb" },
+  ".cm-content": { caretColor: "#e5e7eb" },
+  ".cm-gutters": { backgroundColor: "#1f2937", color: "#6b7280", border: "none" },
+  ".cm-activeLineGutter": { backgroundColor: "#374151" },
+  ".cm-activeLine": { backgroundColor: "rgba(55, 65, 81, 0.5)" },
+  ".cm-cursor": { borderLeftColor: "#e5e7eb" },
+  ".cm-selectionBackground": { backgroundColor: "#374151 !important" },
+  "&.cm-focused .cm-selectionBackground": { backgroundColor: "#4b5563 !important" },
+  ".cm-matchingBracket": { backgroundColor: "#374151", outline: "1px solid #6b7280" },
+  ".cm-foldPlaceholder": { backgroundColor: "#374151", color: "#9ca3af", border: "none" },
+  ".cm-tooltip": { backgroundColor: "#1f2937", border: "1px solid #374151" },
+  ".cm-tooltip-autocomplete": { "& > ul > li[aria-selected]": { backgroundColor: "#374151" } },
+});
+
+const LIGHT_THEME = EditorView.theme({});
+
+/**
+ * A JSON editor web component backed by CodeMirror 6.
+ * Provides syntax highlighting, line numbers, active line highlighting,
+ * history (undo/redo), and JSON linting for OpenClaw's raw config editor.
+ */
+@customElement("config-editor")
+export class ConfigEditor extends LitElement {
+  /** Current editor content */
+  @property({ type: String }) value = "";
+
+  /** Whether the editor is read-only */
+  @property({ type: Boolean }) readonly = false;
+
+  /** Whether the editor should use a dark theme */
+  @property({ type: Boolean }) dark = false;
+
+  @query("#editor-mount") editorContainer!: HTMLDivElement;
+
+  private view?: EditorView;
+  private readonlyCompartment = new Compartment();
+  private themeCompartment = new Compartment();
+
+  // ---------------------------------------------------------------------------
+  // Styles
+  // ---------------------------------------------------------------------------
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .cm-editor-wrap {
+      border: 1px solid var(--oc-input-border, #d1d5db);
+      border-radius: 6px;
+      overflow: hidden;
+      background: var(--oc-input-bg, #ffffff);
+      transition: border-color 0.15s;
+    }
+
+    .cm-editor-wrap:focus-within {
+      border-color: var(--oc-focus-border, #6366f1);
+      box-shadow: 0 0 0 2px var(--oc-focus-ring, rgba(99, 102, 241, 0.15));
+    }
+
+    .cm-editor-wrap.cm-editor-wrap--readonly {
+      background: var(--oc-input-bg-readonly, #f9fafb);
+    }
+
+    #editor-mount {
+      height: 480px;
+    }
+
+    .cm-editor {
+      height: 100%;
+    }
+
+    .cm-scroller {
+      font-family: "JetBrains Mono", "Fira Code", "SF Mono", Menlo, monospace;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    /* Error gutter marker */
+    .cm-lint-marker-error {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #ef4444;
+      margin-top: 5px;
+    }
+
+    /* Format button */
+    .editor-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 6px;
+      padding: 4px 8px;
+      background: var(--oc-input-bg, #ffffff);
+      border-bottom: 1px solid var(--oc-input-border, #d1d5db);
+    }
+
+    .editor-toolbar button {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      border: 1px solid var(--oc-input-border, #d1d5db);
+      background: var(--oc-input-bg, #ffffff);
+      color: var(--oc-text-secondary, #6b7280);
+      cursor: pointer;
+      transition: all 0.1s;
+    }
+
+    .editor-toolbar button:hover {
+      background: var(--oc-input-bg-hover, #f3f4f6);
+      color: var(--oc-text-primary, #111827);
+    }
+
+    .editor-toolbar button:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    /* Dark theme overrides */
+    :host([dark]) .cm-editor-wrap {
+      border-color: #374151;
+      background: #1f2937;
+    }
+
+    :host([dark]) .editor-toolbar {
+      background: #1f2937;
+      border-color: #374151;
+    }
+
+    :host([dark]) .editor-toolbar button {
+      border-color: #374151;
+      background: #1f2937;
+      color: #9ca3af;
+    }
+
+    :host([dark]) .editor-toolbar button:hover {
+      background: #374151;
+      color: #f3f4f6;
+    }
+  `;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.view?.destroy();
+  }
+
+  override firstUpdated(): void {
+    this.mountEditor();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has("value") && this.view) {
+      const current = this.view.state.doc.toString();
+      if (current !== this.value) {
+        this.view.dispatch({
+          changes: { from: 0, to: current.length, insert: this.value ?? "" },
+        });
+      }
+    }
+    if (changed.has("readonly") && this.view) {
+      this.view.dispatch({
+        effects: this.readonlyCompartment.reconfigure(EditorState.readOnly.of(this.readonly)),
+      });
+    }
+    if (changed.has("dark") && this.view) {
+      this.view.dispatch({
+        effects: this.themeCompartment.reconfigure(this.dark ? DARK_THEME : LIGHT_THEME),
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Editor mounting
+  // ---------------------------------------------------------------------------
+  private mountEditor(): void {
+    const extensions = this.buildExtensions();
+    this.view = new EditorView({
+      state: EditorState.create({ doc: this.value ?? "", extensions }),
+      parent: this.editorContainer,
+    });
+  }
+
+  private buildExtensions(): Extension {
+    const base: Extension[] = [
+      // History (undo/redo)
+      history(),
+
+      // Line numbers + active line
+      lineNumbers(),
+      highlightActiveLine(),
+      highlightSpecialChars(),
+
+      // Selection
+      drawSelection(),
+
+      // JSON5 language mode (OpenClaw raw config uses JSON5 with comments, unquoted keys, trailing commas)
+      json5(),
+
+      // Syntax highlighting
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+
+      // Code folding
+      foldGutter(),
+
+      // Lint gutter
+      lintGutter(),
+
+      // JSON linter
+      linter((view) => {
+        const diagnostics: Diagnostic[] = [];
+        const docText = view.state.doc.toString();
+
+        if (!docText) {
+          return diagnostics;
+        }
+
+        try {
+          JSON5.parse(docText);
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            const pos = this.errorOffset(docText, e.message);
+            diagnostics.push({
+              from: Math.min(pos, docText.length),
+              to: Math.min(pos + 1, docText.length),
+              severity: "error",
+              message: e.message,
+            });
+          }
+        }
+        return diagnostics;
+      }),
+
+      // Keymaps (includes indentWithTab for Tab-key indentation)
+      keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab, ...foldKeymap]),
+
+      // Dispatch on change
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          const newValue = update.state.doc.toString();
+          this.dispatchEvent(
+            new CustomEvent("change", {
+              detail: { value: newValue },
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        }
+      }),
+
+      // Readonly (via compartment so it can be reconfigured live)
+      this.readonlyCompartment.of(EditorState.readOnly.of(this.readonly)),
+
+      // Theme (via compartment so it can be toggled live)
+      this.themeCompartment.of(this.dark ? DARK_THEME : LIGHT_THEME),
+    ];
+
+    return base;
+  }
+
+  /**
+   * Convert a JSON5 SyntaxError message to a character offset in the document.
+   * JSON5 errors use "at line:column" format; JSON errors use "position N".
+   */
+  private errorOffset(doc: string, message: string): number {
+    // JSON5 format: "... at 3:5"
+    const lc = message.match(/at\s+(\d+):(\d+)/i);
+    if (lc) {
+      const line = parseInt(lc[1], 10);
+      const col = parseInt(lc[2], 10);
+      const lines = doc.split("\n");
+      let offset = 0;
+      for (let i = 0; i < Math.min(line - 1, lines.length); i++) {
+        offset += lines[i].length + 1; // +1 for newline
+      }
+      return offset + col - 1;
+    }
+
+    // JSON format: "... at position 42"
+    const pos = message.match(/position\s+(\d+)/i);
+    if (pos) {
+      return parseInt(pos[1], 10);
+    }
+
+    return 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public methods
+  // ---------------------------------------------------------------------------
+  /** Format the JSON content with proper indentation */
+  format = (): void => {
+    if (!this.view) {
+      return;
+    }
+    const rawDoc = this.view.state.doc.toString();
+    const doc = rawDoc.trim();
+    if (!doc) {
+      return;
+    }
+
+    try {
+      const parsed = JSON5.parse(doc);
+      const formatted = JSON.stringify(parsed, null, 2);
+      this.view.dispatch({
+        changes: { from: 0, to: rawDoc.length, insert: formatted },
+      });
+    } catch {
+      // Not valid JSON/JSON5, ignore format
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+  override render() {
+    return html`
+      <div class="editor-toolbar">
+        <button
+          type="button"
+          title="Format JSON (prettify)"
+          @click=${this.format}
+          ?disabled=${this.readonly}
+        >
+          Format
+        </button>
+      </div>
+      <div class="cm-editor-wrap ${this.readonly ? "cm-editor-wrap--readonly" : ""}">
+        <div id="editor-mount"></div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "config-editor": ConfigEditor;
+  }
+}

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -342,14 +342,17 @@ describe("config view", () => {
     expect(revealButton).toBeTruthy();
     revealButton?.click();
 
-    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
-    expect(textarea).not.toBeNull();
-    expect(textarea?.value).toContain("supersecret");
-    if (!textarea) {
+    const configEditor = container.querySelector<HTMLElement & { value: string }>("config-editor");
+    expect(configEditor).not.toBeNull();
+    expect(configEditor?.value).toContain("supersecret");
+    if (!configEditor) {
       return;
     }
-    textarea.value = textarea.value.replace("supersecret", "updatedsecret");
-    textarea.dispatchEvent(new Event("input", { bubbles: true }));
-    expect(onRawChange).toHaveBeenCalledWith(textarea.value);
+    const newValue = configEditor.value.replace("supersecret", "updatedsecret");
+    configEditor.value = newValue;
+    configEditor.dispatchEvent(
+      new CustomEvent("change", { detail: { value: newValue }, bubbles: true, composed: true }),
+    );
+    expect(onRawChange).toHaveBeenCalledWith(newValue);
   });
 });

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -2,6 +2,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "../icons.ts";
 import { BORDER_RADIUS_STOPS, type BorderRadiusStop } from "../storage.ts";
 import type { ThemeTransitionContext } from "../theme-transition.ts";
+import { prefersLightScheme } from "../theme.ts";
 import type { ThemeMode, ThemeName } from "../theme.ts";
 import type { ConfigUiHints } from "../types.ts";
 import {
@@ -14,6 +15,7 @@ import {
   type JsonSchema,
 } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
+import "./config-editor.ts";
 
 const BORDER_RADIUS_LABELS: Record<BorderRadiusStop, string> = {
   0: "None",
@@ -1104,13 +1106,13 @@ export function renderConfig(props: ConfigProps) {
                             </div>
                           `
                         : html`
-                            <textarea
-                              placeholder="Raw config (JSON/JSON5)"
+                            <config-editor
                               .value=${props.raw}
-                              @input=${(e: Event) => {
-                                props.onRawChange((e.target as HTMLTextAreaElement).value);
-                              }}
-                            ></textarea>
+                              ?readonly=${blurred}
+                              ?dark=${props.themeMode === "dark" ||
+                              (props.themeMode === "system" && !prefersLightScheme())}
+                              @change=${(e: CustomEvent) => props.onRawChange(e.detail.value)}
+                            ></config-editor>
                           `}
                     </div>
                   `;


### PR DESCRIPTION
## Summary

Replace the plain `<textarea>` for raw config editing with a proper CodeMirror 6 editor.

### Changes

**New file: `ui/src/ui/views/config-editor.ts`**
- CodeMirror 6 editor with JSON5 language mode (handles comments, unquoted keys, trailing commas)
- Syntax highlighting + fold gutter + line numbers
- Real-time JSON5 linting with error markers (red dot in gutter)
- Format/prettify button (JSON5-aware via `JSON5.parse`)
- Read-only mode via `Compartment` (live toggle without recreating editor)
- Dark/light theme via `themeCompartment`
- Full dark theme: `#1f2937` background, `#e5e7eb` text, caret, cursor
- `errorOffset()` handles both JSON5 ("at line:col") and JSON ("position N") error formats

**`ui/src/ui/views/config.ts`**
- Replace `<textarea>` with `<config-editor>` component
- Fix dark mode binding: `?dark` now correctly follows `system` mode via `prefersLightScheme()`

**`ui/package.json`** (new dependencies)
- `codemirror-json5`, `json5`, `lezer-json5`
- `@codemirror/{autocomplete,commands,lang-json,lint,state,view}`

### Motivation

OpenClaw raw config uses JSON5 format (comments, trailing commas), which plain `<textarea>` can't validate or highlight. The new editor provides:
1. Real-time linting with inline error markers
2. Format button to prettify messy configs
3. Proper dark mode following system preference
4. Read-only mode for sensitive values

### Test plan

- [x] ESLint / TypeScript checks pass
- [x] Config editor renders in light and dark modes
- [x] System dark mode correctly triggers dark theme
- [x] JSON5 linting marks errors with red gutter dots
- [x] Format button prettifies valid JSON5 content
- [x] Read-only mode disables editing
- [x] Undo/redo (Ctrl+Z / Ctrl+Y) works

Closes #56401