### PR TITLE
Fix BlueBubbles DM routing when chat identifier is present

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
+++ b/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
@@ -94,14 +94,30 @@ describe("buildBlueBubblesInboundChatResolveTarget", () => {
     expect(target).toEqual({ kind: "handle", address: "+15551234567" });
   });
 
-  it("uses sender handle for DM inbound even when chatId is present (preserves prior behavior)", () => {
+  it("prefers chat_identifier for DM inbound when BlueBubbles provides it", () => {
     const target = buildBlueBubblesInboundChatResolveTarget({
       isGroup: false,
       chatId: 99,
       chatIdentifier: "iMessage;-;+15551234567",
       senderId: "+15551234567",
     });
-    expect(target).toEqual({ kind: "handle", address: "+15551234567" });
+    expect(target).toEqual({
+      kind: "chat_identifier",
+      chatIdentifier: "iMessage;-;+15551234567",
+    });
+  });
+
+  it("trims chat_identifier for DM inbound before sender fallback", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: false,
+      chatId: undefined,
+      chatIdentifier: "  iMessage;-;founder@example.com  ",
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({
+      kind: "chat_identifier",
+      chatIdentifier: "iMessage;-;founder@example.com",
+    });
   });
 
   it("returns null for DM inbound with empty senderId", () => {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -375,8 +375,10 @@ export type BlueBubblesInboundChatResolveTarget =
  *
  * Returns null in that unresolvable group case so the caller can skip
  * actions that need a chatGuid rather than acting on a wrong one. DMs
- * always resolve via the sender handle (the chat is, by definition, the
- * conversation with that handle).
+ * prefer the inbound chat identifier when BlueBubbles provides it. On
+ * self / Apple-ID setups the visible iMessage thread can be keyed by the
+ * destination chat while senderId is only the sender handle. Falling back
+ * directly to senderId can create or target a different thread.
  */
 export function buildBlueBubblesInboundChatResolveTarget(params: {
   isGroup: boolean;
@@ -393,6 +395,10 @@ export function buildBlueBubblesInboundChatResolveTarget(params: {
       return { kind: "chat_identifier", chatIdentifier: trimmedIdentifier };
     }
     return null;
+  }
+  const trimmedIdentifier = params.chatIdentifier?.trim();
+  if (trimmedIdentifier) {
+    return { kind: "chat_identifier", chatIdentifier: trimmedIdentifier };
   }
   const trimmedSender = params.senderId.trim();
   if (!trimmedSender) {


### PR DESCRIPTION
BlueBubbles direct-message webhooks can include a chat identifier that is more precise than the sender handle. In self / Apple ID setups, the visible iMessage thread may be keyed by the chat identifier while senderId is only the sender handle. Falling back directly to senderId can create or target a different conversation for replies.\n\nThis change makes DM inbound chat resolution prefer the inbound chatIdentifier when BlueBubbles provides it, then fall back to senderId only when no identifier is available. Group behavior is unchanged: unresolvable group inbounds still refuse sender-handle fallback to avoid poisoning group actions.\n\nVerification:\n- pnpm exec vitest run extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts