### PR TITLE
feat(manifest): add Manifest open-source LLM router provider

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -290,6 +290,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 | Hugging Face Inference  | `huggingface`                    | `HUGGINGFACE_HUB_TOKEN` or `HF_TOKEN`                        | `huggingface/deepseek-ai/DeepSeek-R1`         |
 | Kilo Gateway            | `kilocode`                       | `KILOCODE_API_KEY`                                           | `kilocode/kilo/auto`                          |
 | Kimi Coding             | `kimi`                           | `KIMI_API_KEY` or `KIMICODE_API_KEY`                         | `kimi/kimi-code`                              |
+| Manifest                | `manifest`                       | `MANIFEST_API_KEY`                                           | `manifest/auto`                               |
 | MiniMax                 | `minimax` / `minimax-portal`     | `MINIMAX_API_KEY` / `MINIMAX_OAUTH_TOKEN`                    | `minimax/MiniMax-M2.7`                        |
 | Mistral                 | `mistral`                        | `MISTRAL_API_KEY`                                            | `mistral/mistral-large-latest`                |
 | Moonshot                | `moonshot`                       | `MOONSHOT_API_KEY`                                           | `moonshot/kimi-k2.6`                          |

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -51,6 +51,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Kilocode](/providers/kilocode)
 - [LiteLLM (unified gateway)](/providers/litellm)
 - [LM Studio (local models)](/providers/lmstudio)
+- [Manifest (open-source LLM router)](/providers/manifest)
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)
 - [Moonshot AI (Kimi + Kimi Coding)](/providers/moonshot)

--- a/docs/providers/manifest.md
+++ b/docs/providers/manifest.md
@@ -1,0 +1,109 @@
+---
+summary: "Use Manifest, an open-source LLM router, in OpenClaw"
+read_when:
+  - You want to cut inference costs with smart model routing
+  - You need MANIFEST_API_KEY setup
+title: "Manifest"
+---
+
+[Manifest](https://manifest.build) is an open-source LLM router that cuts inference
+costs through smart routing across 16+ providers. You get full control over which
+model handles each request. Route by complexity tier, task-specificity (coding, web
+browsing, etc.) and custom tiers. API keys start with `mnfst_`.
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key at [manifest.build](https://manifest.build), or
+    self-host Manifest with Docker for fully private inference.
+  </Step>
+  <Step title="Export the key and run onboarding">
+    ```bash
+    export MANIFEST_API_KEY="mnfst_..."
+    openclaw onboard --auth-choice manifest-api-key
+    ```
+  </Step>
+  <Step title="Set the Manifest model">
+    ```bash
+    openclaw models set manifest/auto
+    ```
+  </Step>
+</Steps>
+
+<Warning>
+If you pass `--manifest-api-key` instead of the env var, the value lands in shell
+history and `ps` output. Prefer the `MANIFEST_API_KEY` environment variable when
+possible.
+</Warning>
+
+For non-interactive setup, you can also pass the key directly:
+
+```bash
+openclaw onboard --auth-choice manifest-api-key --manifest-api-key "mnfst_..."
+```
+
+## Config example
+
+```json5
+{
+  env: { MANIFEST_API_KEY: "mnfst_..." },
+  agents: {
+    defaults: {
+      model: { primary: "manifest/auto" },
+    },
+  },
+}
+```
+
+## Built-in catalog
+
+| Model ref        | Name           | Context | Max output |
+| ---------------- | -------------- | ------- | ---------- |
+| `manifest/auto`  | Manifest Auto  | 200,000 | 16,384     |
+
+## Advanced configuration
+
+<AccordionGroup>
+  <Accordion title="Auto-enable behavior">
+    The provider auto-enables when the `MANIFEST_API_KEY` environment variable is set.
+    No explicit provider config is required beyond the key.
+  </Accordion>
+
+  <Accordion title="Self-hosted Manifest">
+    Manifest is open-source and can be self-hosted with Docker. Override the base URL
+    in your config to point to your local instance:
+
+    ```json5
+    {
+      models: {
+        providers: {
+          manifest: {
+            baseUrl: "http://localhost:2099/v1",
+          },
+        },
+      },
+    }
+    ```
+
+    Self-hosted Manifest can route to local models (Ollama, vLLM, llama.cpp) for
+    fully private inference. See [manifest.build](https://manifest.build) for
+    deployment instructions.
+  </Accordion>
+
+  <Accordion title="OpenAI-compatible endpoint">
+    Manifest uses the standard `/v1/chat/completions` endpoint. Any
+    OpenAI-compatible tooling works out of the box with the Manifest base URL.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/extensions/manifest/openclaw.plugin.json
+++ b/extensions/manifest/openclaw.plugin.json
@@ -1,0 +1,58 @@
+{
+  "id": "manifest",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["manifest"],
+  "modelCatalog": {
+    "providers": {
+      "manifest": {
+        "baseUrl": "https://app.manifest.build/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "auto",
+            "name": "Manifest Auto",
+            "input": ["text", "image"],
+            "reasoning": false,
+            "contextWindow": 200000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "manifest": "static"
+    }
+  },
+  "providerAuthEnvVars": {
+    "manifest": ["MANIFEST_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "manifest",
+      "method": "api-key",
+      "choiceId": "manifest-api-key",
+      "choiceLabel": "Manifest API key",
+      "groupId": "manifest",
+      "groupLabel": "Manifest",
+      "groupHint": "Open-source LLM router",
+      "optionKey": "manifestApiKey",
+      "cliFlag": "--manifest-api-key",
+      "cliOption": "--manifest-api-key <key>",
+      "cliDescription": "Manifest API key (starts with mnfst_)"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Add [Manifest](https://manifest.build) as a provider. Manifest is an open-source LLM router that cuts inference costs through smart routing across 16+ providers. Users get full control over which model handles each request. Route by complexity tier, task-specificity (coding, web browsing, etc.) and custom tiers.

Users can now authenticate with `MANIFEST_API_KEY`.

## Changes

- `extensions/manifest/openclaw.plugin.json`: provider declaration with auth env var (`MANIFEST_API_KEY`), auth choice, base URL (`https://app.manifest.build/v1`), and static model catalog (`auto`)
- `docs/providers/manifest.md`: provider documentation with getting started, config example, self-hosted setup
- `docs/providers/index.md`: add Manifest to provider directory (alphabetical)
- `docs/concepts/model-providers.md`: add Manifest to bundled providers table

## How to test

1. `export MANIFEST_API_KEY="mnfst_..."`
2. `openclaw onboard --auth-choice manifest-api-key`
3. `openclaw models set manifest/auto`
4. Chat works through Manifest router

Self-hosted: override base URL via `models.providers.manifest.baseUrl` in config.

## AI-assisted

- [x] AI-assisted (Claude Opus 4.6)
- [x] Lightly tested (JSON validation, pattern match against NVIDIA/qianfan providers)
- [x] I understand what the code does

## Checklist

- [x] Tested locally
- [x] CI checks should pass (no code changes, only JSON + docs)
- [x] PR is focused (one thing: add Manifest provider)
- [x] Describes what and why