### PR TITLE
fix(imessage): handle rpc stdin write errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: reject pending RPC requests when the `imsg rpc` stdin pipe fails or closes, preventing broken-pipe write errors from escaping as gateway-level uncaught exceptions. Fixes #75438. Thanks @SL4N.
 - Voice Call/Twilio: honor stored pre-connect TwiML before realtime webhook shortcuts and reject DTMF sequences outside conversation mode, so Meet PIN entry cannot be skipped or silently dropped. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: play Twilio Meet DTMF before opening the realtime media stream and carry the intro as the initial Voice Call message, so the greeting is generated after Meet admits the phone participant instead of racing a live-call TwiML update. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: make Twilio setup preflight honor explicit `--transport twilio` and fail local/private Voice Call webhook URLs before joins. Thanks @donkeykong91 and @PfanP.

--- a/extensions/imessage/src/client.stdin-write-error.test.ts
+++ b/extensions/imessage/src/client.stdin-write-error.test.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
+});
+
+function createMockChild() {
+  return Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    killed: false,
+    kill: vi.fn(() => true),
+  });
+}
+
+describe("IMessageRpcClient stdin write errors", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "development");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects pending requests when stdin emits a write error", async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const { createIMessageRpcClient } = await import("./client.js");
+    const client = await createIMessageRpcClient({ cliPath: "imsg-test" });
+    const clientInternals = client as unknown as { reader: unknown };
+    const pending = client.request("send.message", {}, { timeoutMs: 1000 });
+
+    child.stdin.destroy(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+
+    await expect(pending).rejects.toThrow("write EPIPE");
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(clientInternals.reader).toBeNull();
+    await expect(client.request("send.message", {}, { timeoutMs: 1000 })).rejects.toThrow(
+      "imsg rpc not running",
+    );
+    await expect(client.stop()).resolves.toBeUndefined();
+  });
+
+  it("rejects the request when the stdin write callback reports an error", async () => {
+    const child = createMockChild();
+    vi.spyOn(child.stdin, "write").mockImplementation(((
+      _chunk: unknown,
+      encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void),
+      callback?: (err?: Error | null) => void,
+    ) => {
+      const writeCallback =
+        typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+      writeCallback?.(new Error("EPIPE"));
+      return false;
+    }) as typeof child.stdin.write);
+    spawnMock.mockReturnValue(child);
+
+    const { createIMessageRpcClient } = await import("./client.js");
+    const client = await createIMessageRpcClient({ cliPath: "imsg-test" });
+
+    await expect(client.request("send.message", {}, { timeoutMs: 1000 })).rejects.toThrow(
+      /imsg rpc write failed \(send\.message\): EPIPE/i,
+    );
+  });
+});

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -103,6 +103,20 @@ export class IMessageRpcClient {
       }
     });
 
+    child.stdin?.on("error", (err) => {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.failAll(error);
+      if (this.child === child) {
+        this.reader?.close();
+        this.reader = null;
+        if (!child.killed) {
+          child.kill("SIGTERM");
+        }
+        this.child = null;
+        this.closedResolve?.();
+      }
+    });
+
     child.on("error", (err) => {
       this.failAll(err instanceof Error ? err : new Error(String(err)));
       this.closedResolve?.();
@@ -164,8 +178,8 @@ export class IMessageRpcClient {
     const line = `${JSON.stringify(payload)}\n`;
     const timeoutMs = opts?.timeoutMs ?? DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS;
 
+    const key = String(id);
     const response = new Promise<T>((resolve, reject) => {
-      const key = String(id);
       const timer =
         timeoutMs > 0
           ? setTimeout(() => {
@@ -180,7 +194,19 @@ export class IMessageRpcClient {
       });
     });
 
-    this.child.stdin.write(line);
+    try {
+      this.child.stdin.write(line, (err?: Error | null) => {
+        if (!err) {
+          return;
+        }
+        this.rejectPending(key, new Error(`imsg rpc write failed (${method}): ${err.message}`));
+      });
+    } catch (err) {
+      this.rejectPending(
+        key,
+        new Error(`imsg rpc write failed (${method}): ${formatErrorMessage(err)}`),
+      );
+    }
     return await response;
   }
 
@@ -244,6 +270,18 @@ export class IMessageRpcClient {
       pending.reject(err);
       this.pending.delete(key);
     }
+  }
+
+  private rejectPending(key: string, err: Error) {
+    const pending = this.pending.get(key);
+    if (!pending) {
+      return;
+    }
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+    }
+    this.pending.delete(key);
+    pending.reject(err);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #75438.

This adds local stdin failure handling for the iMessage RPC client so broken pipe errors reject the affected request instead of escaping through the process-level uncaught exception path.

Changes:
- attach an `error` listener to the `imsg rpc` stdin stream and fail pending requests when the pipe breaks
- reject the pending request when `stdin.write()` reports an error through its callback
- add focused regression coverage for both the async stdin error path and the write callback error path
- add a changelog entry

## Verification

- `pnpm exec vitest run extensions/imessage/src/client.stdin-write-error.test.ts extensions/imessage/src/status.test.ts extensions/imessage/src/monitor.watch-subscribe-retry.test.ts`
- `pnpm exec vitest run extensions/codex/src/app-server/client.test.ts src/infra/unhandled-rejections.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/imessage/src/client.ts extensions/imessage/src/client.stdin-write-error.test.ts CHANGELOG.md`
- `pnpm exec oxlint extensions/imessage/src/client.ts extensions/imessage/src/client.stdin-write-error.test.ts extensions/imessage/src/status.test.ts`