### PR TITLE
Fix Telegram CLI message sends hanging before gateway dispatch

### DIFF
--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -1,6 +1,6 @@
 import { installChannelActionsContractSuite } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import { telegramPlugin } from "../api.js";
 
 describe("telegram actions contract", () => {
@@ -20,5 +20,11 @@ describe("telegram actions contract", () => {
         expectedCapabilities: ["delivery-pin", "presentation"],
       },
     ],
+  });
+
+  it("keeps bundled Telegram message actions gateway-owned", () => {
+    for (const action of ["send", "poll", "react", "delete", "edit"] as const) {
+      expect(telegramPlugin.actions?.resolveExecutionMode?.({ action })).toBe("gateway");
+    }
   });
 });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -219,6 +219,10 @@ async function sendTelegramOutbound(params: {
 }
 
 const telegramMessageActions: ChannelMessageActionAdapter = {
+  resolveExecutionMode: (ctx) =>
+    getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.resolveExecutionMode?.(ctx) ??
+    telegramMessageActionsImpl.resolveExecutionMode?.(ctx) ??
+    "local",
   describeMessageTool: (ctx) =>
     getOptionalTelegramRuntime()?.channel?.telegram?.messageActions?.describeMessageTool?.(ctx) ??
     telegramMessageActionsImpl.describeMessageTool?.(ctx) ??

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -5,6 +5,12 @@ vi.mock("../../../commands/message.js", () => ({
   messageCommand: messageCommandMock,
 }));
 
+const callGatewayMock = vi.fn(async () => ({ ok: true, messageId: "m-1" }));
+vi.mock("../../../gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+  randomIdempotencyKey: () => "idem-test",
+}));
+
 vi.mock("../../../globals.js", () => ({
   danger: (s: string) => s,
   setVerbose: vi.fn(),
@@ -85,6 +91,7 @@ describe("runMessageAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     messageCommandMock.mockClear().mockResolvedValue(undefined);
+    callGatewayMock.mockClear().mockResolvedValue({ ok: true, messageId: "m-1" });
     hasHooksMock.mockClear().mockReturnValue(false);
     runGatewayStopMock.mockClear().mockResolvedValue(undefined);
     runGlobalGatewayStopSafelyMock.mockClear();
@@ -254,5 +261,57 @@ describe("runMessageAction", () => {
       expect.anything(),
     );
     expectNoAccountFieldInPassedOptions();
+  });
+
+  it("routes telegram send through gateway fast path without local plugin registry loading", async () => {
+    const runMessageAction = createRunMessageAction();
+
+    await expect(
+      runMessageAction("send", {
+        channel: "telegram",
+        account: "default",
+        target: "-100123",
+        message: "hi",
+        json: true,
+      }),
+    ).rejects.toThrow("exit");
+
+    expect(ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(messageCommandMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "message.action",
+        clientName: "cli",
+        mode: "cli",
+        params: expect.objectContaining({
+          channel: "telegram",
+          action: "send",
+          accountId: "default",
+          idempotencyKey: "idem-test",
+          params: expect.objectContaining({
+            to: "-100123",
+            message: "hi",
+          }),
+        }),
+      }),
+    );
+    expect(runtimeMock.log).toHaveBeenCalledWith(expect.stringContaining('"messageId": "m-1"'));
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("exits with failure when telegram gateway fast path fails", async () => {
+    callGatewayMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+    const runMessageAction = createRunMessageAction();
+
+    await expect(
+      runMessageAction("send", {
+        channel: "telegram",
+        target: "-100123",
+        message: "hi",
+      }),
+    ).rejects.toThrow("exit");
+
+    expect(errorMock).toHaveBeenCalledWith("Error: gateway unavailable");
+    expect(exitMock).toHaveBeenCalledWith(1);
   });
 });

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { resolveMessageSecretScope } from "../../../cli/message-secret-scope.js";
 import { messageCommand } from "../../../commands/message.js";
+import { callGateway, randomIdempotencyKey } from "../../../gateway/call.js";
 import { danger, setVerbose } from "../../../globals.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
 import { runGlobalGatewayStopSafely } from "../../../plugins/hook-runner-global.js";
@@ -46,6 +47,97 @@ function resolveMessagePluginLoadOptions(
   return { scope: "configured-channels" };
 }
 
+function readStringOption(opts: Record<string, unknown>, key: string): string | undefined {
+  const value = opts[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readBooleanOption(opts: Record<string, unknown>, key: string): boolean | undefined {
+  return typeof opts[key] === "boolean" ? opts[key] : undefined;
+}
+
+function shouldUseTelegramGatewayFastPath(action: string, opts: Record<string, unknown>): boolean {
+  return (
+    action === "send" &&
+    opts.dryRun !== true &&
+    readStringOption(opts, "channel") === "telegram" &&
+    Boolean(readStringOption(opts, "target"))
+  );
+}
+
+async function runTelegramGatewayFastPath(action: string, opts: Record<string, unknown>) {
+  const normalized = normalizeMessageOptions(opts);
+  const target = readStringOption(normalized, "target");
+  if (!target) {
+    throw new Error("Telegram message send requires --target.");
+  }
+  const message = readStringOption(normalized, "message") ?? "";
+  const mediaUrl = readStringOption(normalized, "media");
+  if (!message && !mediaUrl) {
+    throw new Error("Telegram message send requires --message or --media.");
+  }
+  const params: Record<string, unknown> = {
+    to: target,
+    message,
+  };
+  const accountId = readStringOption(normalized, "accountId");
+  const threadId = readStringOption(normalized, "threadId");
+  const replyToId = readStringOption(normalized, "replyTo");
+  const presentation = readStringOption(normalized, "presentation");
+  const delivery = readStringOption(normalized, "delivery");
+  if (mediaUrl) {
+    params.mediaUrl = mediaUrl;
+  }
+  if (threadId) {
+    params.threadId = threadId;
+  }
+  if (replyToId) {
+    params.replyTo = replyToId;
+  }
+  if (presentation) {
+    params.presentation = presentation;
+  }
+  if (delivery) {
+    params.delivery = delivery;
+  }
+  for (const key of ["pin", "gifPlayback", "forceDocument", "silent"] as const) {
+    const value = readBooleanOption(normalized, key);
+    if (value !== undefined) {
+      params[key] = value;
+    }
+  }
+  const payload = await callGateway<Record<string, unknown>>({
+    method: "message.action",
+    params: {
+      channel: "telegram",
+      action,
+      params,
+      accountId,
+      idempotencyKey: randomIdempotencyKey(),
+    },
+    timeoutMs: 30_000,
+    clientName: "cli",
+    mode: "cli",
+  });
+  if (normalized.json === true) {
+    defaultRuntime.log(
+      JSON.stringify(
+        {
+          action,
+          channel: "telegram",
+          dryRun: false,
+          handledBy: "gateway",
+          payload,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  defaultRuntime.log(`Telegram message sent${payload.messageId ? ` (${payload.messageId})` : ""}`);
+}
+
 export function createMessageCliHelpers(
   message: Command,
   messageChannelOptions: string,
@@ -65,6 +157,21 @@ export function createMessageCliHelpers(
 
   const runMessageAction = async (action: string, opts: Record<string, unknown>) => {
     setVerbose(Boolean(opts.verbose));
+    if (shouldUseTelegramGatewayFastPath(action, opts)) {
+      let failed = false;
+      await runCommandWithRuntime(
+        defaultRuntime,
+        async () => {
+          await runTelegramGatewayFastPath(action, opts);
+        },
+        (err) => {
+          failed = true;
+          defaultRuntime.error(danger(String(err)));
+        },
+      );
+      defaultRuntime.exit(failed ? 1 : 0);
+      return;
+    }
     ensurePluginRegistryLoaded(resolveMessagePluginLoadOptions(opts));
     const deps = createDefaultDeps();
     let failed = false;

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -19,7 +19,7 @@ const mocks = vi.hoisted(() => ({
   resolveOutboundChannelPlugin: vi.fn(),
   executeSendAction: vi.fn(),
   executePollAction: vi.fn(),
-  callGatewayLeastPrivilege: vi.fn(),
+  callGateway: vi.fn(),
   randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
 }));
 
@@ -34,7 +34,7 @@ vi.mock("./outbound-send-service.js", () => ({
 }));
 
 vi.mock("./message.gateway.runtime.js", () => ({
-  callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
+  callGateway: mocks.callGateway,
   randomIdempotencyKey: mocks.randomIdempotencyKey,
 }));
 
@@ -189,7 +189,7 @@ describe("runMessageAction plugin dispatch", () => {
       async ({ ctx }: { ctx: Parameters<typeof executePluginAction>[0]["ctx"] }) =>
         await executePluginAction({ action: "poll", ctx }),
     );
-    mocks.callGatewayLeastPrivilege.mockReset();
+    mocks.callGateway.mockReset();
     mocks.randomIdempotencyKey.mockClear();
   });
 
@@ -372,7 +372,7 @@ describe("runMessageAction plugin dispatch", () => {
           },
         ]),
       );
-      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+      mocks.callGateway.mockResolvedValue({
         ok: true,
         added: "✅",
       });
@@ -408,7 +408,7 @@ describe("runMessageAction plugin dispatch", () => {
         dryRun: false,
       });
 
-      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledWith(
+      expect(mocks.callGateway).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "message.action",
           params: expect.objectContaining({
@@ -462,7 +462,7 @@ describe("runMessageAction plugin dispatch", () => {
           },
         ]),
       );
-      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+      mocks.callGateway.mockResolvedValue({
         ok: true,
         messageId: "gw-send-1",
       });
@@ -488,7 +488,7 @@ describe("runMessageAction plugin dispatch", () => {
         dryRun: false,
       });
 
-      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledWith(
+      expect(mocks.callGateway).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "message.action",
           params: expect.objectContaining({
@@ -1040,7 +1040,7 @@ describe("runMessageAction plugin dispatch", () => {
           },
         ]),
       );
-      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+      mocks.callGateway.mockResolvedValue({
         ok: true,
         pollId: "gw-poll-1",
       });
@@ -1067,7 +1067,7 @@ describe("runMessageAction plugin dispatch", () => {
         dryRun: false,
       });
 
-      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledWith(
+      expect(mocks.callGateway).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "message.action",
           params: expect.objectContaining({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -188,9 +188,9 @@ async function callGatewayMessageAction<T>(params: {
   gateway?: MessageActionRunnerGateway;
   actionParams: Record<string, unknown>;
 }): Promise<T> {
-  const { callGatewayLeastPrivilege } = await loadMessageActionGatewayRuntime();
+  const { callGateway } = await loadMessageActionGatewayRuntime();
   const gateway = resolveGatewayActionOptions(params.gateway);
-  return await callGatewayLeastPrivilege<T>({
+  return await callGateway<T>({
     url: gateway.url,
     token: gateway.token,
     method: "message.action",

--- a/src/infra/outbound/message.gateway.runtime.ts
+++ b/src/infra/outbound/message.gateway.runtime.ts
@@ -1,1 +1,1 @@
-export { callGatewayLeastPrivilege, randomIdempotencyKey } from "../../gateway/call.js";
+export { callGateway, randomIdempotencyKey } from "../../gateway/call.js";

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -203,9 +203,9 @@ async function callMessageGateway<T>(params: {
   method: string;
   params: Record<string, unknown>;
 }): Promise<T> {
-  const { callGatewayLeastPrivilege } = await loadMessageGatewayRuntime();
+  const { callGateway } = await loadMessageGatewayRuntime();
   const gateway = resolveGatewayOptions(params.gateway);
-  return await callGatewayLeastPrivilege<T>({
+  return await callGateway<T>({
     url: gateway.url,
     token: gateway.token,
     method: params.method,


### PR DESCRIPTION
## Summary

Fixes `openclaw message send --channel telegram ...` hanging in the local CLI process by ensuring Telegram sends are delegated to the live gateway message-action path.

Fixes #75477

## Changes

- Preserve Telegram `actions.resolveExecutionMode` through the bundled plugin wrapper so gateway-owned message actions stay gateway-owned.
- Use the normal CLI gateway helper for message-action gateway calls instead of forcing least-privilege helper semantics on the CLI path.
- Add a Telegram-specific CLI send fast path that calls `message.action` directly and avoids loading the local channel plugin registry/runtime in the CLI process.
- Add regression coverage for the wrapper execution mode and CLI fast path.

## Validation

```bash
pnpm exec vitest run extensions/telegram/src/channel-actions.contract.test.ts src/cli/program/message/helpers.test.ts
pnpm exec vitest run src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message.channels.test.ts src/infra/outbound/message.test.ts
```

Local production validation on a downstream fork confirmed:

```bash
openclaw message send --channel telegram --account default --target <chat> --message "..." --json
```

returns a gateway-handled JSON payload with Telegram `messageId` instead of leaving a stuck `openclaw-message` process.
