### PR TITLE
test(ci): refresh baseline gate expectations

### DIFF
--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -31,7 +31,7 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("github-copilot", "login.ts", 101),
   bundledPluginCallsite("googlechat", "src/auth.ts", 83),
   bundledPluginCallsite("huggingface", "models.ts", 142),
-  bundledPluginCallsite("kilocode", "provider-models.ts", 130),
+  bundledPluginCallsite("kilocode", "provider-models.ts", 138),
   bundledPluginCallsite("matrix", "src/matrix/sdk/transport.ts", 112),
   bundledPluginCallsite("microsoft-foundry", "onboard.ts", 479),
   bundledPluginCallsite("microsoft", "speech-provider.ts", 140),
@@ -63,7 +63,7 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("slack", "src/monitor/media.ts", 130),
   bundledPluginCallsite("venice", "models.ts", 552),
   bundledPluginCallsite("vercel-ai-gateway", "models.ts", 181),
-  bundledPluginCallsite("voice-call", "src/providers/twilio/api.ts", 23),
+  bundledPluginCallsite("voice-call", "src/providers/twilio/api.ts", 60),
 ]);
 
 function isRawFetchCall(expression) {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -105,6 +105,10 @@ vi.mock("../../infra/gateway-lock.js", () => ({
   GatewayLockError: class GatewayLockError extends Error {},
 }));
 
+vi.mock("../../infra/supervisor-markers.js", () => ({
+  detectRespawnSupervisor: () => null,
+}));
+
 vi.mock("../../infra/ports.js", () => ({
   formatPortDiagnostics: () => [],
   inspectPortUsage: async () => ({ status: "free" }),

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -122,7 +122,7 @@ describe("production lint suppressions", () => {
       "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
       "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",
       "src/plugins/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|1",
-      "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|2",
+      "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
       "src/plugins/types.ts|typescript/no-unnecessary-type-parameters|1",
       "src/tasks/task-flow-registry.store.sqlite.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## Summary

- Problem: current PR CI is tripping on stale baseline expectations that are outside the silent-reply PR scope.
- Why it matters: these red gates mask whether focused PRs like #73400 are actually healthy.
- What changed: refreshed two legacy raw-fetch allowlist line numbers, isolated the gateway option-collision test from host supervisor env hints, and updated the lint-suppression baseline count after a production suppression was removed.
- What did NOT change (scope boundary): no runtime behavior, network behavior, or user-facing output changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #73400
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: baseline-only checks drifted after unrelated line movement / lint-suppression cleanup, and the CLI test inherited real supervisor environment hints from the host.
- Missing detection / guardrail: the affected checks already detected the drift; this PR refreshes the expected baseline and test isolation.
- Contributing context (if known): #73400 surfaced these failures while its own touched test shards were green locally.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/cli/gateway-cli/run.option-collisions.test.ts`, `test/scripts/lint-suppressions.test.ts`, `scripts/check-no-raw-channel-fetch.mjs`
- Scenario the test should lock in: raw-fetch baseline, supervisor-env-independent gateway CLI test, and production lint-suppression baseline stay current.
- Why this is the smallest reliable guardrail: it reruns exactly the failing CI gates.
- Existing test that already covers this (if any): the three commands listed below.
- If no new test is added, why not: this is a baseline/test isolation refresh for existing gates.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm via corepack
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the raw-fetch boundary check.
2. Run the gateway option-collision CLI test.
3. Run the lint-suppression test under the core-support-boundary config.

### Expected

- All three focused gates pass.

### Actual

- Before this PR, each gate had a focused failure.
- After this PR, all three focused gates pass locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Passing local commands:

```text
corepack pnpm run lint:tmp:no-raw-channel-fetch
corepack pnpm test -- src/cli/gateway-cli/run.option-collisions.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts test/scripts/lint-suppressions.test.ts
```

## Human Verification (required)

- Verified scenarios: the three focused gates that failed in #73400's CI.
- Edge cases checked: host supervisor env no longer changes the option-collision test's expected non-supervised path.
- What you did **not** verify: full CI locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
