### PR TITLE
feat(feishu): add feishu_bitable_delete_record tool

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -476,6 +476,25 @@ async function updateRecord(
   };
 }
 
+
+
+async function deleteRecord(
+  client: Lark.Client,
+  appToken: string,
+  tableId: string,
+  recordId: string,
+) {
+  const res = await client.bitable.appTableRecord.delete({
+    path: { app_token: appToken, table_id: tableId, record_id: recordId },
+  });
+  ensureLarkSuccess(res, "bitable.appTableRecord.delete", { appToken, tableId, recordId });
+
+  return {
+    deleted: true,
+    record_id: recordId,
+  };
+}
+
 // ============ Schemas ============
 
 const GetMetaSchema = Type.Object({
@@ -566,6 +585,16 @@ const UpdateRecordSchema = Type.Object({
   fields: Type.Record(Type.String(), Type.Any(), {
     description: "Field values to update (same format as create_record)",
   }),
+});
+
+
+
+const DeleteRecordSchema = Type.Object({
+  app_token: Type.String({
+    description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
+  }),
+  table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  record_id: Type.String({ description: "Record ID to delete" }),
 });
 
 // ============ Tool Registration ============
@@ -719,6 +748,28 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         params.table_id,
         params.record_id,
         params.fields,
+      );
+    },
+  });
+
+
+  registerBitableTool<{
+    app_token: string;
+    table_id: string;
+    record_id: string;
+    accountId?: string;
+  }>({
+    name: "feishu_bitable_delete_record",
+    label: "Feishu Bitable Delete Record",
+    description:
+      "Delete a record (row) from a Bitable table. This action is irreversible.",
+    parameters: DeleteRecordSchema,
+    async execute({ params, defaultAccountId }) {
+      return deleteRecord(
+        getClient(params, defaultAccountId),
+        params.app_token,
+        params.table_id,
+        params.record_id,
       );
     },
   });


### PR DESCRIPTION
## Summary

- **Problem**: The Feishu Bitable tool set supports list/get/create/update records but missing delete, forcing users to manually delete records in the Feishu UI
- **Why it matters**: CRM and content workflow automation requires record deletion (removing duplicates, cleaning up abandoned records)
- **What changed**: Added `deleteRecord()` function, `DeleteRecordSchema`, and `feishu_bitable_delete_record` tool registration
- **What did NOT change**: No changes to existing tools — purely additive

## Change Type
- [x] Feature

## Scope
- [x] Integrations (Feishu Bitable tools)

## Linked Issue
- Closes #55654

## User-visible / Behavior Changes
- New tool `feishu_bitable_delete_record` available with parameters: `app_token`, `table_id`, `record_id`
- Description includes `"This action is irreversible."` warning

## Security Impact
- New permissions/capabilities? **No** — uses existing `base:record:delete` scope already required for other bitable tools
- Secrets/tokens handling changed? **No**
- New/changed network calls? **Yes** — calls `DELETE /open-apis/bitable/v1/apps/{app_token}/tables/{table_id}/records/{record_id}` (existing Feishu API)
- Command/tool execution surface changed? **No** — follows existing `registerBitableTool` pattern
- Data access scope changed? **No**

## Verification

The implementation mirrors the existing `updateRecord` pattern exactly:
1. Uses the same Lark SDK method (`client.bitable.appTableRecord.delete`)
2. Same error handling (`ensureLarkSuccess`)
3. Same tool registration pattern (`registerBitableTool`)
4. Consistent parameter descriptions matching other bitable schemas

### API Reference
- Feishu API docs: https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-record/delete
- Requires `base:record:delete` scope (already in the bitable tool set)

## Human Verification
- Verified consistent code style with existing record tools (get/create/update)
- Verified DeleteRecordSchema follows same pattern as GetRecordSchema
- Verified the Feishu API endpoint and parameters match official docs
- Edge case: returns `{ deleted: true, record_id }` for success, throws on failure (same as other tools)

## Compatibility / Migration
- Backward compatible? **Yes** — purely additive, no existing behavior changed
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery
- How to disable: Remove or do not call `feishu_bitable_delete_record` tool
- Known risks: Deletion is irreversible by design — tool description warns users

## Risks and Mitigations
- Risk: Accidental data deletion
  - Mitigation: Tool description includes "This action is irreversible." warning; follows same pattern as other mutating bitable tools
