### PR TITLE
fix(memory-host-markdown): use global regex to replace all managed blocks (#75491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/dreaming: globally replace and collapse adjacent duplicate managed blocks in inline daily files using a CR/LF-tolerant separator, so repeated memory/dreaming runs no longer accumulate duplicate managed sections under the same heading. Fixes #75491. Thanks @ottodeng.
 - Voice Call/Twilio: honor stored pre-connect TwiML before realtime webhook shortcuts and reject DTMF sequences outside conversation mode, so Meet PIN entry cannot be skipped or silently dropped. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: play Twilio Meet DTMF before opening the realtime media stream and carry the intro as the initial Voice Call message, so the greeting is generated after Meet admits the phone participant instead of racing a live-call TwiML update. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: make Twilio setup preflight honor explicit `--transport twilio` and fail local/private Voice Call webhook URLs, including IPv6 loopback and unique-local forms, before joins. Thanks @donkeykong91 and @PfanP.

--- a/src/plugin-sdk/memory-host-markdown.test.ts
+++ b/src/plugin-sdk/memory-host-markdown.test.ts
@@ -47,4 +47,52 @@ describe("replaceManagedMarkdownBlock", () => {
       }),
     ).toBe("alpha\n\n<!-- start -->\nbeta\n<!-- end -->\n");
   });
+
+  it("matches blocks with CRLF line endings", () => {
+    const original =
+      "# Title\r\n\r\n## Generated\r\n<!-- start -->\r\n- old\r\n<!-- end -->\r\n";
+    expect(
+      replaceManagedMarkdownBlock({
+        original,
+        heading: "## Generated",
+        startMarker: "<!-- start -->",
+        endMarker: "<!-- end -->",
+        body: "- new",
+      }),
+    ).toBe(
+      "# Title\r\n\r\n## Generated\n<!-- start -->\n- new\n<!-- end -->\r\n",
+    );
+  });
+
+  it("collapses pre-existing duplicate blocks back to one", () => {
+    const dup = "## Generated\n<!-- start -->\n- old\n<!-- end -->";
+    const original = `# Title\n\n${dup}\n\n${dup}\n\n${dup}\n`;
+    const result = replaceManagedMarkdownBlock({
+      original,
+      heading: "## Generated",
+      startMarker: "<!-- start -->",
+      endMarker: "<!-- end -->",
+      body: "- new",
+    });
+    const newBlock = "## Generated\n<!-- start -->\n- new\n<!-- end -->";
+    // Should contain exactly one copy of the new block.
+    const matches = result.split(newBlock).length - 1;
+    expect(matches).toBe(1);
+    // And no remnants of the old body.
+    expect(result).not.toContain("- old");
+  });
+
+  it("is idempotent across repeated calls with the same body", () => {
+    const params = {
+      heading: "## Generated",
+      startMarker: "<!-- start -->",
+      endMarker: "<!-- end -->",
+      body: "- only",
+    } as const;
+    const first = replaceManagedMarkdownBlock({ original: "# Title\n", ...params });
+    const second = replaceManagedMarkdownBlock({ original: first, ...params });
+    const third = replaceManagedMarkdownBlock({ original: second, ...params });
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
 });

--- a/src/plugin-sdk/memory-host-markdown.ts
+++ b/src/plugin-sdk/memory-host-markdown.ts
@@ -17,13 +17,35 @@ export function withTrailingNewline(content: string): string {
 export function replaceManagedMarkdownBlock(params: ManagedMarkdownBlockParams): string {
   const headingPrefix = params.heading ? `${params.heading}\n` : "";
   const managedBlock = `${headingPrefix}${params.startMarker}\n${params.body}\n${params.endMarker}`;
+
+  // Match against any line-ending style: \n, \r\n, or \r. A whitespace mismatch
+  // between the on-disk file and the template should not cause the matcher to
+  // miss the existing block (which previously caused the block to be appended
+  // again, accumulating duplicates over time).
+  const headingMatcher = params.heading
+    ? `${escapeRegex(params.heading)}[\\r\\n]+`
+    : "";
   const existingPattern = new RegExp(
-    `${params.heading ? `${escapeRegex(params.heading)}\\n` : ""}${escapeRegex(params.startMarker)}[\\s\\S]*?${escapeRegex(params.endMarker)}`,
-    "m",
+    `${headingMatcher}${escapeRegex(params.startMarker)}[\\s\\S]*?${escapeRegex(params.endMarker)}`,
+    "gm",
   );
 
   if (existingPattern.test(params.original)) {
-    return params.original.replace(existingPattern, managedBlock);
+    // Reset lastIndex after .test() before reusing the regex with .replace().
+    existingPattern.lastIndex = 0;
+    // The `g` flag replaces all occurrences. If the file already contains
+    // duplicate managed blocks (from prior runs with the non-global regex),
+    // every duplicate is rewritten to the same fresh block. The resulting
+    // identical adjacent blocks are then collapsed to a single block so the
+    // file self-heals back to one canonical block per marker.
+    let next = params.original.replace(existingPattern, managedBlock);
+    const escapedBlock = escapeRegex(managedBlock);
+    const adjacentDuplicates = new RegExp(
+      `(${escapedBlock})(?:[\\r\\n]*${escapedBlock})+`,
+      "g",
+    );
+    next = next.replace(adjacentDuplicates, "$1");
+    return next;
   }
 
   const trimmed = params.original.trimEnd();


### PR DESCRIPTION
Fixes #75491.

## Problem

`replaceManagedMarkdownBlock` used `new RegExp(..., "m")` (no `g` flag) to find and replace existing managed blocks. Two failure modes followed:

1. **Whitespace / line-ending mismatch (e.g. CRLF) ⇒ append duplicate**.
   The heading separator was `\n`, so a file with `\r\n` between heading and start marker did not match the existing block. The function then took the "no existing block" branch and appended a second copy.

2. **Once duplicates exist, `.replace()` without `g` only rewrites one copy**.
   Each subsequent dreaming run re-rewrote one duplicate while the others stayed, so files accumulated several copies of the block (the issue reports 5+ copies in a real file).

## Fix

- Add `g` to the regex so `.replace()` rewrites every existing block in a single pass.
- Loosen the heading separator from `\n` to `[\r\n]+` so CRLF and lone-CR files match the same managed block instead of silently appending.
- After the global replace, collapse adjacent identical managed blocks back to a single block. This lets affected files that already contain duplicates **self-heal** the next time the dreaming run executes — Otto reported 5 stale copies in `2026-04-30.md`; with this fix the next run will leave exactly one.
- Reset `lastIndex` between `.test()` and `.replace()` to avoid the global-regex sticky-position hazard.

## Tests

Existing tests still pass. Added three new cases:

- CRLF heading separator → matches and replaces in place.
- Pre-existing duplicate blocks → collapsed back to one canonical block (`- old` body fully removed).
- Repeated invocations with the same body are idempotent.

All 8 cases pass locally (verified via a standalone harness because vitest deps are not installed in this checkout; the test file itself uses the existing project test layout).