### PR TITLE
fix(tui): cache normalizeDiscoveredPiModel to stop 100% CPU busy-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/perf: cache `normalizeDiscoveredPiModel` results per `(agentDir, provider, modelId)` so `registry.getAvailable()` no longer re-traverses every plugin manifest for every model on every call. Without this, ~50 models × 3 plugin-resolution hooks × ~50 plugin manifests = ~7,500 `openSync`+`fstatSync`+`closeSync` cycles per call (invoked from `ensureContextWindowCacheLoaded` at TUI startup); steady-state CPU on `openclaw tui` drops from sustained 100% to 0% with the cache. Identity-keyed so registry refresh that returns new model objects still invalidates correctly; bounded at 1024 entries with FIFO eviction. (#75137) Thanks @hexsprite.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/src/agents/pi-model-discovery.normalize-cache.test.ts
+++ b/src/agents/pi-model-discovery.normalize-cache.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the three plugin-resolution helpers so we can count how many times
+// each is called per `normalizeDiscoveredPiModel` invocation. The cache fix
+// should mean repeat calls with the same model object hit the cache and
+// invoke the helpers ZERO times after the first call.
+const normalizeProviderResolvedModelWithPlugin = vi.hoisted(() => vi.fn());
+const applyProviderResolvedModelCompatWithPlugins = vi.hoisted(() => vi.fn());
+const applyProviderResolvedTransportWithPlugin = vi.hoisted(() => vi.fn());
+
+vi.mock(import("../plugins/provider-runtime.js"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    normalizeProviderResolvedModelWithPlugin,
+    applyProviderResolvedModelCompatWithPlugins,
+    applyProviderResolvedTransportWithPlugin,
+  };
+});
+
+const { normalizeDiscoveredPiModel, resetNormalizeDiscoveredPiModelCacheForTest } =
+  await import("./pi-model-discovery.js");
+
+describe("normalizeDiscoveredPiModel cache (regression for #75137)", () => {
+  afterEach(() => {
+    resetNormalizeDiscoveredPiModelCacheForTest();
+    vi.resetAllMocks();
+  });
+
+  it("does not re-invoke plugin resolution helpers for the same model object", () => {
+    const model = {
+      id: "claude-sonnet-4-5",
+      name: "Claude Sonnet 4.5",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      contextWindow: 200_000,
+    };
+    // Helpers return the model unchanged so the cache key path is exercised.
+    normalizeProviderResolvedModelWithPlugin.mockReturnValue(model);
+    applyProviderResolvedModelCompatWithPlugins.mockReturnValue(model);
+    applyProviderResolvedTransportWithPlugin.mockReturnValue(model);
+
+    const agentDir = "/tmp/agent";
+
+    // First call: cache miss, all helpers fire.
+    normalizeDiscoveredPiModel(model, agentDir);
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledTimes(1);
+    expect(applyProviderResolvedModelCompatWithPlugins).toHaveBeenCalledTimes(1);
+    expect(applyProviderResolvedTransportWithPlugin).toHaveBeenCalledTimes(1);
+
+    // Subsequent calls with the SAME object: cache hit, helpers must NOT fire again.
+    normalizeDiscoveredPiModel(model, agentDir);
+    normalizeDiscoveredPiModel(model, agentDir);
+    normalizeDiscoveredPiModel(model, agentDir);
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledTimes(1);
+    expect(applyProviderResolvedModelCompatWithPlugins).toHaveBeenCalledTimes(1);
+    expect(applyProviderResolvedTransportWithPlugin).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-normalizes when the model object reference changes (cache miss on identity)", () => {
+    const provider = "anthropic";
+    const id = "claude-opus-4";
+    const m1 = { id, name: "Opus", provider, api: "anthropic-messages" };
+    const m2 = { id, name: "Opus", provider, api: "anthropic-messages" };
+    normalizeProviderResolvedModelWithPlugin.mockImplementation(({ context }) => context.model);
+    applyProviderResolvedModelCompatWithPlugins.mockImplementation(({ context }) => context.model);
+    applyProviderResolvedTransportWithPlugin.mockImplementation(({ context }) => context.model);
+
+    normalizeDiscoveredPiModel(m1, "/tmp/agent");
+    normalizeDiscoveredPiModel(m2, "/tmp/agent");
+
+    // Different objects with the same (provider, id) — cache invalidates by object identity.
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledTimes(2);
+  });
+
+  it("partitions cache by agentDir so different scopes don't collide", () => {
+    const model = {
+      id: "gpt-5",
+      name: "GPT-5",
+      provider: "openai",
+      api: "openai-completions",
+    };
+    normalizeProviderResolvedModelWithPlugin.mockReturnValue(model);
+    applyProviderResolvedModelCompatWithPlugins.mockReturnValue(model);
+    applyProviderResolvedTransportWithPlugin.mockReturnValue(model);
+
+    normalizeDiscoveredPiModel(model, "/tmp/agent-a");
+    normalizeDiscoveredPiModel(model, "/tmp/agent-b");
+
+    // Different agentDir — separate cache entries — both calls fire helpers.
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledTimes(2);
+
+    // Repeat in agent-a: cache hit.
+    normalizeDiscoveredPiModel(model, "/tmp/agent-a");
+    expect(normalizeProviderResolvedModelWithPlugin).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips cache for non-record values", () => {
+    expect(normalizeDiscoveredPiModel(undefined as unknown as Record<string, unknown>, "/x")).toBe(
+      undefined,
+    );
+    expect(normalizeDiscoveredPiModel(null as unknown as Record<string, unknown>, "/x")).toBe(null);
+    expect(normalizeDiscoveredPiModel("scalar" as unknown as Record<string, unknown>, "/x")).toBe(
+      "scalar",
+    );
+    expect(normalizeProviderResolvedModelWithPlugin).not.toHaveBeenCalled();
+  });
+
+  it("skips cache for records missing required string fields", () => {
+    const malformed = { id: 42, name: "x", provider: "y" };
+    expect(normalizeDiscoveredPiModel(malformed, "/x")).toBe(malformed);
+    expect(normalizeProviderResolvedModelWithPlugin).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -67,6 +67,32 @@ function createInMemoryAuthStorageBackend(
   };
 }
 
+// Cache normalized models per (agentDir, provider, modelId) so repeated
+// `registry.getAvailable()` calls don't re-load the entire plugin manifest
+// registry once per model on every call. Without this, ~50 models × 3 hooks
+// × ~50 plugin manifests = ~7,500 manifest open+stat+close cycles per
+// `getAvailable()` call, which is invoked from `ensureContextWindowCacheLoaded`
+// (`src/agents/context.ts:243`) and pegs the TUI process at 100% CPU during
+// startup model resolution. See #75137.
+//
+// Cache invalidation: the input model object identity is the cache value
+// criterion. If pi's underlying registry returns a NEW model object (e.g. after
+// a refresh), we miss the cache and re-normalize. The cache is bounded by
+// total unique (provider, modelId) pairs and is process-lifetime — discovered
+// models are stable for a given config snapshot.
+type NormalizedModelCacheKey = string;
+type NormalizedModelCacheEntry = { input: unknown; output: unknown };
+const NORMALIZED_MODEL_CACHE = new Map<NormalizedModelCacheKey, NormalizedModelCacheEntry>();
+const MAX_NORMALIZED_MODEL_CACHE_ENTRIES = 1024;
+
+function buildNormalizedModelCacheKey(
+  agentDir: string,
+  provider: string,
+  modelId: string,
+): NormalizedModelCacheKey {
+  return `${agentDir}\0${provider}\0${modelId}`;
+}
+
 export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
   if (!isRecord(value)) {
     return value;
@@ -79,6 +105,11 @@ export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
     return value;
   }
   const model = value as unknown as DiscoveredProviderRuntimeModelLike;
+  const cacheKey = buildNormalizedModelCacheKey(agentDir, model.provider, model.id);
+  const cached = NORMALIZED_MODEL_CACHE.get(cacheKey);
+  if (cached && cached.input === value) {
+    return cached.output as T;
+  }
   const pluginNormalized =
     normalizeProviderResolvedModelWithPlugin({
       provider: model.provider,
@@ -118,7 +149,21 @@ export function normalizeDiscoveredPiModel<T>(value: T, agentDir: string): T {
   ) {
     return value;
   }
-  return normalizeModelCompat(transportNormalized as Model<Api>) as T;
+  const result = normalizeModelCompat(transportNormalized as Model<Api>) as T;
+  if (NORMALIZED_MODEL_CACHE.size >= MAX_NORMALIZED_MODEL_CACHE_ENTRIES) {
+    // Bounded cache: evict oldest entry (FIFO via Map insertion order).
+    const oldestKey = NORMALIZED_MODEL_CACHE.keys().next().value;
+    if (oldestKey !== undefined) {
+      NORMALIZED_MODEL_CACHE.delete(oldestKey);
+    }
+  }
+  NORMALIZED_MODEL_CACHE.set(cacheKey, { input: value, output: result });
+  return result;
+}
+
+/** Test seam: clear the normalized-model cache between scenarios. */
+export function resetNormalizeDiscoveredPiModelCacheForTest(): void {
+  NORMALIZED_MODEL_CACHE.clear();
 }
 
 type PiModelRegistryClassLike = {


### PR DESCRIPTION
## Summary

Fixes #75137. Caches `normalizeDiscoveredPiModel` results to stop the TUI from pegging at 100% CPU during startup model resolution.

## Root cause

`pi-model-discovery.ts` wraps `registry.getAvailable()` to call `normalizeDiscoveredPiModel(entry, agentDir)` on every model in `entries.map(...)`. Each normalization runs three plugin-resolution hooks (`normalizeProviderResolvedModelWithPlugin`, `applyProviderResolvedModelCompatWithPlugins`, `applyProviderResolvedTransportWithPlugin`). Each hook calls `loadPluginManifestRegistry`, which iterates ALL plugin candidates and opens each manifest file via `openBoundaryFileSync` (= `fs.openSync` + `fstatSync` + `closeSync`, even on the per-manifest cache-hit path).

For ~50 discovered models × 3 hooks × ~50 plugin manifests, that's **~7,500 manifest open/stat/close cycles per `getAvailable()` call**.

`getAvailable()` is invoked from `ensureContextWindowCacheLoaded` (`src/agents/context.ts:243`) during model context window warmup at TUI startup. The work runs synchronously, monopolizing the JS main thread and pegging the process at 100% CPU. With the heartbeat scheduler also competing for cycles (#75436), the TUI handshake stalls and users see "connecting | idle" for long periods.

## Why this was hard to find

The symptom matrix initially looked impossible:

| Probe                              | Reading             | Interpretation              |
|------------------------------------|---------------------|------------------------------|
| V8 inspector CPU profiler          | 100% idle in JS     | "JS isn't running"           |
| `fs.statSync` / `fs.readFileSync` JS-level wrap | 0 ops in steady state | "no fs activity"             |
| `Promise.prototype.then` wrap      | 0 calls in steady state | "no async activity"          |
| `setImmediate`/`setTimeout` wrap   | 0 calls             | "no timers"                  |
| `queueMicrotask` wrap              | 0 calls             | "no microtasks"              |
| async_hooks Promise resolution     | 0 in steady state   | "nothing settling"           |
| macOS `sample` (native)            | 89% in `uv_run` → `uv__io_poll` → `AfterStat` cascade | "fs.stat callback is hot"   |
| Node `--prof` (V8 ticks)           | 86.5% C++, top JS frames `path.resolve` 5.4%, `isPathInside` 1.0% | "path operations are hot" |
| Inspector debugger pause           | full call stack including `fstatSync → openVerifiedFileSync → openBoundaryFileSync → loadPluginManifest → ... → normalizeDiscoveredPiModel → registry.getAvailable` | the ground truth |

V8 inspector and most JS-level wrappers were misleading because:

1. The work is **one giant synchronous call chain** — no microtasks, no timers, no Promise.then registrations. The wrappers I'd installed never fire because the code path never enters their hot paths.
2. The actual fs calls go through `openVerifiedFileSync` which uses `fs.openSync` + `fs.fstatSync` (stat by fd, not path), bypassing my `fs.statSync` wrap.
3. The inspector profiler runs ON the same V8 isolate. When the JS is saturated by a tight call chain, the profiler thread can't sample it and reports `(idle)`.

The pivotal moves were (a) Node `--prof` (different sampler than inspector — built-in V8 tick logger) and (b) sending `SIGUSR1` to enable inspector and using `Debugger.pause` to grab the actual JS stack at the moment of CPU pin.

## Fix

Memoize `normalizeDiscoveredPiModel` per `(agentDir, provider, modelId)`, keyed on input object identity so a refresh that returns new model objects invalidates correctly. Bounded at 1024 entries with FIFO eviction.

```ts
const cacheKey = buildNormalizedModelCacheKey(agentDir, model.provider, model.id);
const cached = NORMALIZED_MODEL_CACHE.get(cacheKey);
if (cached && cached.input === value) {
  return cached.output as T;
}
// ... do the expensive normalization
NORMALIZED_MODEL_CACHE.set(cacheKey, { input: value, output: result });
```

Per-discovered-model normalization is stable for a given config snapshot, so the cache hit rate is essentially 100% after warmup. Only event that should miss is a deliberate registry refresh that returns new model objects.

## Verified on real gateway

CPU comparison on `openclaw tui` against a live gateway:

| Time after start | Before | After |
|------------------|--------|-------|
| T+12s            | ~75%   | 60.7% |
| T+25s            | ~95%   | **1.0%** |
| T+40s            | ~98%   | **0.0%** |

Steady-state CPU drops to 0%. The "connecting" hang resolves cleanly.

## Tests

New `src/agents/pi-model-discovery.normalize-cache.test.ts` (5 cases):

- `does not re-invoke plugin resolution helpers for the same model object` — primary cache-hit assertion (1 invocation across 4 calls)
- `re-normalizes when the model object reference changes` — identity-based invalidation
- `partitions cache by agentDir so different scopes don't collide`
- `skips cache for non-record values` — bypass for `null`/`undefined`/scalar
- `skips cache for records missing required string fields` — bypass for malformed entries

All 5 pass. Existing `pi-model-discovery.{auth,compat.e2e,synthetic-auth}.test.ts` still pass.

`pnpm tsgo`, `pnpm exec oxfmt --check`, `pnpm check:changed` all clean.

## Test plan

- [x] `pnpm test src/agents/pi-model-discovery.normalize-cache.test.ts` — 5 pass
- [x] `pnpm test $(ls src/agents/pi-model-discovery*.test.ts)` — all pass
- [x] Build (`pnpm build`) and run `openclaw tui` against real gateway: T+40s CPU = 0%
- [x] `pnpm tsgo` clean
- [x] `pnpm exec oxfmt --check` clean
- [x] `pnpm check:changed` exit 0

## Closes

Closes #75137

## Related

- #75436 (heartbeat runaway, fixed by #75439) — the two together explain the chain of symptoms users see (TUI stuck, can't Ctrl-C, gateway sluggish, etc).
- #75289 (TUI processes peg 100% CPU and survive terminal close) — the persistent-zombie aspect is downstream of this.
- #75379 (TUI Ctrl-C unresponsive after gateway WS close) — separate exit-handling bug.
