### PR TITLE
docs(subagents): document announce timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/subagents: document `agents.defaults.subagents.announceTimeoutMs` in the sub-agent and configuration references. (#75509) Thanks @akrimm702.
 - Cron: add direct `cron.get`, `openclaw cron get <id>`, and agent-tool `get` support for inspecting one stored cron job by id. (#75117) Thanks @samzong.
 - Agents/tools: add per-sender tool policies with canonical channel-scoped sender keys, so operators can restrict dangerous tools by requester identity across global, agent, group, core, bundled, and plugin tool surfaces. (#66933) Thanks @JerranC.
 - ACP: expose Gateway session lineage metadata through ACP session listings and session info snapshots so clients can render subagent graphs without private Gateway side channels. (#73458) Thanks @samzong.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -392,6 +392,7 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
         model: "minimax/MiniMax-M2.7",
         maxConcurrent: 8,
         runTimeoutSeconds: 900,
+        announceTimeoutMs: 120000,
         archiveAfterMinutes: 60,
       },
     },
@@ -402,6 +403,7 @@ Experimental built-in tool flags. Default off unless a strict-agentic GPT-5 auto
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
+- `announceTimeoutMs`: per-call timeout (milliseconds) for gateway `agent` announce delivery attempts. Default: `120000`. Transient retries can make the total announce wait longer than one configured timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
 ---

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -343,6 +343,9 @@ See [Configuration reference](/gateway/configuration-reference) and
 <ParamField path="agents.defaults.subagents.requireAgentId" type="boolean" default="false">
   Block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection). Per-agent override: `agents.list[].subagents.requireAgentId`.
 </ParamField>
+<ParamField path="agents.defaults.subagents.announceTimeoutMs" type="number" default="120000">
+  Maximum time to wait for a child-session announce delivery before treating the announce step as timed out. Values are positive integer milliseconds and are clamped to the platform-safe timer maximum.
+</ParamField>
 
 If the requester session is sandboxed, `sessions_spawn` rejects targets
 that would run unsandboxed.
@@ -380,6 +383,7 @@ worker sub-sub-agents.
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
         runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
+        announceTimeoutMs: 120000, // max time to wait for child announce delivery
       },
     },
   },

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -344,7 +344,7 @@ See [Configuration reference](/gateway/configuration-reference) and
   Block `sessions_spawn` calls that omit `agentId` (forces explicit profile selection). Per-agent override: `agents.list[].subagents.requireAgentId`.
 </ParamField>
 <ParamField path="agents.defaults.subagents.announceTimeoutMs" type="number" default="120000">
-  Maximum time to wait for a child-session announce delivery before treating the announce step as timed out. Values are positive integer milliseconds and are clamped to the platform-safe timer maximum.
+  Per-call timeout for gateway `agent` announce delivery attempts. Values are positive integer milliseconds and are clamped to the platform-safe timer maximum. Transient retries can make the total announce wait longer than one configured timeout.
 </ParamField>
 
 If the requester session is sandboxed, `sessions_spawn` rejects targets
@@ -383,7 +383,7 @@ worker sub-sub-agents.
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
         runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
-        announceTimeoutMs: 120000, // max time to wait for child announce delivery
+        announceTimeoutMs: 120000, // per-call gateway announce timeout
       },
     },
   },

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -441,7 +441,7 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
-    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
     announceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;


### PR DESCRIPTION
## Summary
- document `agents.defaults.subagents.announceTimeoutMs` in the sub-agent config reference
- include the option in the nested sub-agent example next to related timeout/concurrency settings
- clarify that the value is the per-call gateway `agent` announce timeout; transient retries can make total announce wait longer than one configured timeout

## Why
Follow-up to #47558. Rechecked against current `main` (`b0db82be15291f5ca66f434ff46f2884c4b3e133`): `announceTimeoutMs` still exists in schema/runtime and is still not documented in `docs/tools/subagents.md`.

This remains intentionally tiny instead of rebasing the old broad docs branch.

## Real behavior proof

- **Behavior addressed:** the public sub-agent docs omitted the live `agents.defaults.subagents.announceTimeoutMs` config key, and the old wording treated the timeout like a whole announce-step bound instead of a per-call gateway `agent` timeout.
- **Real environment tested:** local OpenClaw checkout on macOS, comparing PR #75509 against live `openclaw/openclaw` `main` and the GitHub PR API after the branch update.
- **Exact steps or command run after this patch:** `git fetch origin main`; `git diff --check origin/main...akrimm/docs/subagents-announce-timeout`; `git merge-tree --write-tree origin/main akrimm/docs/subagents-announce-timeout`; `git diff --stat origin/main...akrimm/docs/subagents-announce-timeout`; `git grep -n 'announceTimeoutMs' origin/main akrimm/docs/subagents-announce-timeout -- docs/tools/subagents.md src config docs`.
- **Evidence after fix:** terminal output from maintainer fixup on PR head `6956bdfabc`: `git diff --check origin/main...HEAD` exited 0; `pnpm exec oxfmt --check --threads=1 docs/tools/subagents.md docs/gateway/config-tools.md src/config/types.agent-defaults.ts CHANGELOG.md` printed `All matched files use the correct format`; `pnpm docs:list` listed the docs index successfully, including `tools/subagents.md` and `gateway/config-tools.md`. Source proof: `src/agents/subagent-announce-delivery.ts` defaults to `120_000`, and `src/config/zod-schema.agent-defaults.ts` accepts positive integer `announceTimeoutMs`.
- **Observed result after fix:** the PR remains open, non-draft, conflict-free, and still relevant because the runtime/schema key exists on current `main` but the docs page still lacks it.
- **What was not tested:** rendered docs deployment was not tested; this is a docs-only correction with no runtime code path change.

## Validation
- `git diff --check origin/main...akrimm/docs/subagents-announce-timeout`
- `git merge-tree --write-tree origin/main akrimm/docs/subagents-announce-timeout`
- `corepack pnpm exec oxfmt --check --threads=1 docs/tools/subagents.md` (prior branch validation)
- `corepack pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config /tmp/openclaw-pr75509-markdownlint-cli2.jsonc docs/tools/subagents.md` (prior branch validation)
