### PR TITLE
fix: avoid redundant loadOpenClawPlugins calls in web provider and auto-enable resolution (ARM64 perf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/web-provider: avoid a redundant `loadOpenClawPlugins` call on every request in gateway mode by reusing the active registry when available, while still deriving candidate plugin ids to respect `origin` and scope filters; reduces tool-creation overhead from ~8–47 s to <1 s on ARM64. Fixes #75513. Thanks @jochen.
 - Plugins/runtime-deps: accept already materialized package-level runtime-deps supersets as converged, so later lazy plugin activation no longer prunes and relaunches `pnpm install` after gateway startup pre-staging. Fixes #75283. Thanks @brokemac79.
 - TTS/providers: keep bundled speech-provider compat fallback available when plugins are globally disabled, so cold gateway and CLI startup can still resolve fallback speech providers instead of leaving explicit TTS provider selection with no registered providers. Refs #75265. Thanks @sliekens.
 - Discord: collapse repeated native slash-command deploy rate-limit startup logs into one non-fatal warning while keeping per-request REST timing in verbose output. Thanks @discord.

--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -18,6 +18,12 @@ export function materializePluginAutoEnableCandidates(params: {
 }): PluginAutoEnableResult {
   const env = params.env ?? process.env;
   const config = params.config ?? {};
+  // Skip manifest registry loading when there are no candidates — it is
+  // expensive on ARM64 (involves disk I/O + large JSON serialization) and
+  // entirely unnecessary when the candidate list is empty.
+  if (params.candidates.length === 0 && !params.manifestRegistry) {
+    return { config, changes: [], autoEnabledReasons: {} };
+  }
   const manifestRegistry = resolvePluginAutoEnableManifestRegistry({
     config,
     env,

--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -18,12 +18,6 @@ export function materializePluginAutoEnableCandidates(params: {
 }): PluginAutoEnableResult {
   const env = params.env ?? process.env;
   const config = params.config ?? {};
-  // Skip manifest registry loading when there are no candidates — it is
-  // expensive on ARM64 (involves disk I/O + large JSON serialization) and
-  // entirely unnecessary when the candidate list is empty.
-  if (params.candidates.length === 0 && !params.manifestRegistry) {
-    return { config, changes: [], autoEnabledReasons: {} };
-  }
   const manifestRegistry = resolvePluginAutoEnableManifestRegistry({
     config,
     env,

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -9,7 +9,7 @@ import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasExplicitPluginIdScope, normalizePluginIdScope } from "./plugin-scope.js";
 import type { PluginRegistry } from "./registry.js";
-import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
   createPluginRuntimeLoaderLogger,
@@ -149,6 +149,16 @@ export function resolvePluginWebProviders<TEntry>(
     return deps.mapRegistryProviders({ registry, onlyPluginIds: pluginIds });
   }
 
+  // Fast path: use the active gateway registry if available. The gateway registry
+  // was loaded at startup with all plugins; filtering by onlyPluginIds afterward
+  // gives the same result without a redundant loadOpenClawPlugins call per request.
+  const gatewayRegistry = getActivePluginRegistry();
+  if (gatewayRegistry) {
+    return deps.mapRegistryProviders({
+      registry: gatewayRegistry,
+      onlyPluginIds: params.onlyPluginIds,
+    });
+  }
   const loadOptions = resolveWebProviderLoadOptions(params, deps);
   const compatible = resolveCompatibleRuntimePluginRegistry(loadOptions);
   if (compatible) {

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -149,14 +149,24 @@ export function resolvePluginWebProviders<TEntry>(
     return deps.mapRegistryProviders({ registry, onlyPluginIds: pluginIds });
   }
 
-  // Fast path: use the active gateway registry if available. The gateway registry
-  // was loaded at startup with all plugins; filtering by onlyPluginIds afterward
-  // gives the same result without a redundant loadOpenClawPlugins call per request.
+  // Fast path: if the active gateway registry is available, derive the candidate
+  // plugin ids from config/origin/scope first (cheap), then map providers from the
+  // active registry instead of triggering a full loadOpenClawPlugins call.
+  // Deriving candidates ensures origin and onlyPluginIds filters are respected.
   const gatewayRegistry = getActivePluginRegistry();
   if (gatewayRegistry) {
+    const candidateIds = normalizePluginIdScope(
+      deps.resolveCandidatePluginIds({
+        config: params.config,
+        workspaceDir,
+        env,
+        onlyPluginIds: params.onlyPluginIds,
+        origin: params.origin,
+      }) ?? undefined,
+    );
     return deps.mapRegistryProviders({
       registry: gatewayRegistry,
-      onlyPluginIds: params.onlyPluginIds,
+      onlyPluginIds: candidateIds,
     });
   }
   const loadOptions = resolveWebProviderLoadOptions(params, deps);


### PR DESCRIPTION
Fixes #75513

## What

Two targeted fixes that eliminate redundant `loadOpenClawPlugins` calls on every request, reducing tool creation time from ~47s → ~500ms on ARM64.

## Fix 1: `resolvePluginWebProviders` — use active gateway registry directly

**File:** `src/plugins/web-provider-runtime-shared.ts`

`resolvePluginWebProviders` built load options with capability-specific `onlyPluginIds`. The resulting cacheKey never matched the active gateway registry (loaded at startup without `onlyPluginIds`), so `resolveCompatibleRuntimePluginRegistry` always returned `null` and `loadOpenClawPlugins` was called on every request.

The fix: when the active gateway registry is available, use it directly and let `mapRegistryProviders` filter by `onlyPluginIds`. The gateway registry was loaded at startup with the full plugin config.

**Before** (per-request on warm gateway, ARM64):
- `createWebSearchTool`: ~8.3s
- `createImageGenerateTool`: ~3.5s  
- `createVideoGenerateTool`: ~4.9s
- `createMusicGenerateTool`: ~1.1s

**After:** <20ms each.

## Fix 2: `materializePluginAutoEnableCandidates` — skip manifest load with empty candidates

**File:** `src/config/plugin-auto-enable.apply.ts`

`applyPluginAutoEnable` calls `detectPluginAutoEnableCandidates` (which loads the manifest registry) and then passes the result to `materializePluginAutoEnableCandidates`. When the candidate list is empty — common in production deployments with fully explicit plugin config — `materializePluginAutoEnableCandidates` loaded the manifest registry a second time unnecessarily.

The fix: early return when `candidates` is empty and no pre-loaded `manifestRegistry` was provided.

## Measurements (Raspberry Pi 4, ARM64, Node 22, gateway mode)

```
# Warm request timing (2nd request), before fix:
before-imageGenerate  t=2ms
before-videoGenerate  t=3547ms   ← 3.5s
before-musicGenerate  t=8463ms   ← 4.9s
before-webSearch      t=9544ms   ← 1.1s
before-webFetch       t=17856ms  ← 8.3s  (no JIT benefit — pure per-request overhead)
after-createTools     t=18334ms

# Warm request timing, after fix:
before-imageGenerate  t=1ms
before-videoGenerate  t=5ms
before-musicGenerate  t=11ms
before-webSearch      t=14ms
before-webFetch       t=14ms
after-createTools     t=671ms
```

Total 2nd request: ~47s → ~14s. The `createOpenClawCodingTools` overhead is the dominant factor on ARM64; the LLM call and active-memory plugin account for the remaining ~13s.

## Relation to prior work

Follows up on #73075 / PR #73076. The fixes in that PR addressed `ensureOpenClawModelsJson` caching. These two fixes address a separate hot path (`createOpenClawCodingTools` → tool provider resolution) that was not visible in the earlier investigation.

Note: `resolvePluginCapabilityProviders` had a related issue (fast path gated on `!hasExplicitPluginConfig`) that appears to already be resolved in the current `main` and ships in 2026.4.29.

## Testing

Manually verified on ARM64 (Raspberry Pi 4). No behavioral change — the active gateway registry contains the same providers as a freshly loaded subset registry. The `mapRegistryProviders` filter by `onlyPluginIds` ensures only the relevant capability providers are returned.