### PR TITLE
test: clear current main CI regressions

### DIFF
--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "description": "OpenClaw Brave plugin",
   "type": "module",
-  "dependencies": {
-    "typebox": "1.1.34"
-  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,10 +327,6 @@ importers:
         version: link:../../packages/plugin-sdk
 
   extensions/brave:
-    dependencies:
-      typebox:
-        specifier: 1.1.34
-        version: 1.1.34
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/scripts/e2e/npm-telegram-rtt-driver.mjs
+++ b/scripts/e2e/npm-telegram-rtt-driver.mjs
@@ -16,6 +16,7 @@ const scenarioIds = (
   .split(",")
   .map((value) => value.trim())
   .filter(Boolean);
+const scenarioIdSet = new Set(scenarioIds);
 
 if (!groupId || !driverToken || !sutToken) {
   throw new Error(
@@ -63,9 +64,6 @@ function messageText(message) {
   return message.text ?? message.caption ?? "";
 }
 
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 async function flushUpdates(bot) {
   let updates = await bot.getUpdates({ timeout: 0, allowed_updates: ["message"] });
@@ -194,7 +192,7 @@ async function main() {
     }),
   );
 
-  if (scenarioIds.includes("telegram-mentioned-message-reply")) {
+  if (scenarioIdSet.has("telegram-mentioned-message-reply")) {
     const marker = `OPENCLAW_RTT_${Date.now().toString(36)}`;
     scenarios.push(
       await runScenario({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -895,44 +895,57 @@ function getCompatibleActivePluginRegistry(
   if (!activeCacheKey) {
     return undefined;
   }
-  const loadContext = resolvePluginLoadCacheContext(options);
-  if (loadContext.cacheKey === activeCacheKey) {
-    return activeRegistry;
-  }
-  if (!loadContext.shouldActivate) {
-    const activatingCacheKey = resolvePluginLoadCacheContext({
+  const compatibilityOptions = [options];
+  if (options.installBundledRuntimeDeps === false) {
+    // A request that skips bundled runtime-dep repair can safely reuse an
+    // already-active registry that was loaded with repair enabled. The inverse
+    // is not true because a caller asking for repair may need staged deps.
+    compatibilityOptions.push({
       ...options,
-      activate: true,
-    }).cacheKey;
-    if (activatingCacheKey === activeCacheKey) {
-      return activeRegistry;
-    }
+      installBundledRuntimeDeps: true,
+    });
   }
-  if (
-    loadContext.runtimeSubagentMode === "default" &&
-    getActivePluginRuntimeSubagentMode() === "gateway-bindable"
-  ) {
-    const gatewayBindableCacheKey = resolvePluginLoadCacheContext({
-      ...options,
-      runtimeOptions: {
-        ...options.runtimeOptions,
-        allowGatewaySubagentBinding: true,
-      },
-    }).cacheKey;
-    if (gatewayBindableCacheKey === activeCacheKey) {
+
+  for (const candidateOptions of compatibilityOptions) {
+    const loadContext = resolvePluginLoadCacheContext(candidateOptions);
+    if (loadContext.cacheKey === activeCacheKey) {
       return activeRegistry;
     }
     if (!loadContext.shouldActivate) {
-      const activatingGatewayBindableCacheKey = resolvePluginLoadCacheContext({
-        ...options,
+      const activatingCacheKey = resolvePluginLoadCacheContext({
+        ...candidateOptions,
         activate: true,
+      }).cacheKey;
+      if (activatingCacheKey === activeCacheKey) {
+        return activeRegistry;
+      }
+    }
+    if (
+      loadContext.runtimeSubagentMode === "default" &&
+      getActivePluginRuntimeSubagentMode() === "gateway-bindable"
+    ) {
+      const gatewayBindableCacheKey = resolvePluginLoadCacheContext({
+        ...candidateOptions,
         runtimeOptions: {
-          ...options.runtimeOptions,
+          ...candidateOptions.runtimeOptions,
           allowGatewaySubagentBinding: true,
         },
       }).cacheKey;
-      if (activatingGatewayBindableCacheKey === activeCacheKey) {
+      if (gatewayBindableCacheKey === activeCacheKey) {
         return activeRegistry;
+      }
+      if (!loadContext.shouldActivate) {
+        const activatingGatewayBindableCacheKey = resolvePluginLoadCacheContext({
+          ...candidateOptions,
+          activate: true,
+          runtimeOptions: {
+            ...candidateOptions.runtimeOptions,
+            allowGatewaySubagentBinding: true,
+          },
+        }).cacheKey;
+        if (activatingGatewayBindableCacheKey === activeCacheKey) {
+          return activeRegistry;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- drop the unused Brave plugin `typebox` runtime dependency and lockfile importer entry
- fix lint findings in the Telegram RTT driver
- let skip-repair registry loads reuse an active registry that already performed bundled runtime dependency repair

## Testing
- `node --check scripts/e2e/npm-telegram-rtt-driver.mjs`
- `git diff --check`
- CI should cover the previously failing shards on the PR branch
