### PR TITLE
fix(discord): read snake_case thread owner fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/voice: run voice-channel turns under a voice-output policy that hides the agent `tts` tool and asks for spoken reply text, so `/vc join` sessions synthesize and play agent replies instead of ending with `NO_REPLY`. Fixes #61536. Thanks @aounakram.
+- Discord: resolve thread `ownerId` and `parentId` from Discord API-style snake_case payload fields, so bot-owned autoThreads do not require unnecessary mentions. Thanks @mgh3326.
 - Plugins/runtime-deps: prune legacy version-scoped plugin runtime-deps roots during bundled dependency repair and cover the path in Package Acceptance's upgrade-survivor matrix, so upgrades from 2026.4.x no longer leave stale per-plugin runtime trees after doctor runs. Thanks @vincentkoc.
 - Plugins/runtime-deps: keep Gateway startup plugin imports and runtime plugin fallback loads verify-only after startup/config repair planning, so packaged installs no longer spawn package-manager repair from hot paths after readiness. Refs #75283 and #75069. Thanks @brokemac79 and @xiaohuaxi.
 - Voice Call/realtime: add default-off fast memory/session context for `openclaw_agent_consult`, giving live calls a bounded answer-or-miss path before the full agent consult. Fixes #71849. Thanks @amzzzzzzz.

--- a/extensions/discord/src/monitor/channel-access.test.ts
+++ b/extensions/discord/src/monitor/channel-access.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDiscordChannelInfoSafe,
+  resolveDiscordChannelOwnerIdSafe,
+  resolveDiscordChannelParentIdSafe,
+} from "./channel-access.js";
+
+describe("resolveDiscordChannelOwnerIdSafe", () => {
+  it("reads camelCase ownerId directly", () => {
+    expect(resolveDiscordChannelOwnerIdSafe({ ownerId: "owner-1" })).toBe("owner-1");
+  });
+
+  it("falls back to direct snake_case owner_id", () => {
+    expect(resolveDiscordChannelOwnerIdSafe({ owner_id: "owner-2" })).toBe("owner-2");
+  });
+
+  it("falls back to rawData.owner_id when direct properties are missing", () => {
+    expect(resolveDiscordChannelOwnerIdSafe({ rawData: { owner_id: "owner-3" } })).toBe("owner-3");
+  });
+
+  it("prefers camelCase over snake_case and rawData", () => {
+    expect(
+      resolveDiscordChannelOwnerIdSafe({
+        ownerId: "camel",
+        owner_id: "snake",
+        rawData: { owner_id: "raw" },
+      }),
+    ).toBe("camel");
+  });
+
+  it("prefers direct snake_case over rawData", () => {
+    expect(
+      resolveDiscordChannelOwnerIdSafe({
+        owner_id: "snake",
+        rawData: { owner_id: "raw" },
+      }),
+    ).toBe("snake");
+  });
+
+  it("ignores non-string values from any source", () => {
+    expect(resolveDiscordChannelOwnerIdSafe({ ownerId: 123 })).toBeUndefined();
+    expect(resolveDiscordChannelOwnerIdSafe({ owner_id: 123 })).toBeUndefined();
+    expect(resolveDiscordChannelOwnerIdSafe({ rawData: { owner_id: 123 } })).toBeUndefined();
+  });
+
+  it("returns undefined for unknown / non-object inputs", () => {
+    expect(resolveDiscordChannelOwnerIdSafe(undefined)).toBeUndefined();
+    expect(resolveDiscordChannelOwnerIdSafe(null)).toBeUndefined();
+    expect(resolveDiscordChannelOwnerIdSafe(42)).toBeUndefined();
+  });
+
+  it("does not throw when accessors throw", () => {
+    const channel = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+        has() {
+          throw new Error("boom");
+        },
+      },
+    );
+
+    expect(() => resolveDiscordChannelOwnerIdSafe(channel)).not.toThrow();
+    expect(resolveDiscordChannelOwnerIdSafe(channel)).toBeUndefined();
+  });
+});
+
+describe("resolveDiscordChannelParentIdSafe", () => {
+  it("reads camelCase parentId directly", () => {
+    expect(resolveDiscordChannelParentIdSafe({ parentId: "parent-1" })).toBe("parent-1");
+  });
+
+  it("falls back to direct snake_case parent_id", () => {
+    expect(resolveDiscordChannelParentIdSafe({ parent_id: "parent-2" })).toBe("parent-2");
+  });
+
+  it("falls back to rawData.parent_id when direct properties are missing", () => {
+    expect(resolveDiscordChannelParentIdSafe({ rawData: { parent_id: "parent-3" } })).toBe(
+      "parent-3",
+    );
+  });
+
+  it("prefers camelCase over snake_case and rawData", () => {
+    expect(
+      resolveDiscordChannelParentIdSafe({
+        parentId: "camel",
+        parent_id: "snake",
+        rawData: { parent_id: "raw" },
+      }),
+    ).toBe("camel");
+  });
+
+  it("ignores non-string fallback values", () => {
+    expect(resolveDiscordChannelParentIdSafe({ parent_id: 7 })).toBeUndefined();
+    expect(resolveDiscordChannelParentIdSafe({ rawData: { parent_id: 7 } })).toBeUndefined();
+  });
+});
+
+describe("resolveDiscordChannelInfoSafe", () => {
+  it("populates ownerId and parentId from camelCase fields", () => {
+    expect(
+      resolveDiscordChannelInfoSafe({
+        ownerId: "owner-camel",
+        parentId: "parent-camel",
+      }),
+    ).toMatchObject({ ownerId: "owner-camel", parentId: "parent-camel" });
+  });
+
+  it("populates ownerId and parentId from direct snake_case fields", () => {
+    expect(
+      resolveDiscordChannelInfoSafe({
+        owner_id: "owner-snake",
+        parent_id: "parent-snake",
+      }),
+    ).toMatchObject({ ownerId: "owner-snake", parentId: "parent-snake" });
+  });
+
+  it("populates ownerId and parentId from rawData snake_case fields", () => {
+    expect(
+      resolveDiscordChannelInfoSafe({
+        rawData: { owner_id: "owner-raw", parent_id: "parent-raw" },
+      }),
+    ).toMatchObject({ ownerId: "owner-raw", parentId: "parent-raw" });
+  });
+});

--- a/extensions/discord/src/monitor/channel-access.ts
+++ b/extensions/discord/src/monitor/channel-access.ts
@@ -28,6 +28,35 @@ function resolveDiscordChannelNumberPropertySafe(
   return typeof value === "number" ? value : undefined;
 }
 
+// Discord's gateway/REST payloads expose some fields in snake_case while the
+// discord.js channel objects expose them in camelCase. Threads in particular
+// can surface `owner_id` / `parent_id` directly or nested in a `rawData`
+// payload. Resolution priority is camelCase → direct snake_case → rawData.
+const DISCORD_CHANNEL_SNAKE_CASE_ALIASES: Record<string, string> = {
+  ownerId: "owner_id",
+  parentId: "parent_id",
+};
+
+function resolveDiscordChannelStringWithAliasSafe(
+  channel: unknown,
+  camelKey: string,
+): string | undefined {
+  const camelValue = resolveDiscordChannelStringPropertySafe(channel, camelKey);
+  if (camelValue !== undefined) {
+    return camelValue;
+  }
+  const snakeKey = DISCORD_CHANNEL_SNAKE_CASE_ALIASES[camelKey];
+  if (!snakeKey) {
+    return undefined;
+  }
+  const directSnake = resolveDiscordChannelStringPropertySafe(channel, snakeKey);
+  if (directSnake !== undefined) {
+    return directSnake;
+  }
+  const rawData = readDiscordChannelPropertySafe(channel, "rawData");
+  return resolveDiscordChannelStringPropertySafe(rawData, snakeKey);
+}
+
 export type DiscordChannelInfoSafe = {
   name?: string;
   topic?: string;
@@ -50,7 +79,11 @@ export function resolveDiscordChannelTopicSafe(channel: unknown): string | undef
 }
 
 export function resolveDiscordChannelParentIdSafe(channel: unknown): string | undefined {
-  return resolveDiscordChannelStringPropertySafe(channel, "parentId");
+  return resolveDiscordChannelStringWithAliasSafe(channel, "parentId");
+}
+
+export function resolveDiscordChannelOwnerIdSafe(channel: unknown): string | undefined {
+  return resolveDiscordChannelStringWithAliasSafe(channel, "ownerId");
 }
 
 export function resolveDiscordChannelParentSafe(channel: unknown): unknown {
@@ -63,8 +96,8 @@ export function resolveDiscordChannelInfoSafe(channel: unknown): DiscordChannelI
     name: resolveDiscordChannelNameSafe(channel),
     topic: resolveDiscordChannelTopicSafe(channel),
     type: resolveDiscordChannelNumberPropertySafe(channel, "type"),
-    parentId: resolveDiscordChannelStringPropertySafe(channel, "parentId"),
-    ownerId: resolveDiscordChannelStringPropertySafe(channel, "ownerId"),
+    parentId: resolveDiscordChannelParentIdSafe(channel),
+    ownerId: resolveDiscordChannelOwnerIdSafe(channel),
     parentName: resolveDiscordChannelNameSafe(parent),
   };
 }


### PR DESCRIPTION
## Summary

- Teach Discord channel access helpers to read snake_case Discord payload fields.
- `ownerId` now falls back to `owner_id` and `rawData.owner_id`.
- `parentId` now falls back to `parent_id` and `rawData.parent_id`.
- Add focused regression coverage for the Discord thread/channel payload shapes.

## Why

Some Discord thread/channel objects can surface API-style snake_case fields instead of discord.js-style camelCase fields. In those cases, OpenClaw could fail to resolve the thread owner, which breaks bot-owned autoThread detection and can cause unnecessary bot mentions in auto-created threads.

## Test Plan

- [x] `pnpm test extensions/discord/src/monitor/channel-access.test.ts`
- [x] `pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/channel-access.ts extensions/discord/src/monitor/channel-access.test.ts`
- [x] `node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.extensions.json extensions/discord/src/monitor/channel-access.ts extensions/discord/src/monitor/channel-access.test.ts`
