### PR TITLE
fix(channels): clear all stale reactions on terminal status (#75458)

### DIFF
--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -232,6 +232,60 @@ describe("createStatusReactionController", () => {
     expect(calls.length).toBe(callsAfterTerminal);
   });
 
+  it(
+    "should remove every other known emoji on terminal state to avoid leftover " +
+      "intermediate reactions when an earlier remove was dropped (#75458)",
+    async () => {
+      const { calls, controller } = createEnabledController();
+
+      // Walk through several intermediate states so multiple emojis end up
+      // observed by the controller. Only one is current at any time, but a
+      // dropped removeReaction (e.g. Discord rate-limit) could leave any of
+      // the previous reactions on the message in real life.
+      void controller.setQueued();
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+      void controller.setThinking();
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+      void controller.setTool("exec");
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+
+      // Reach terminal state.
+      await controller.setDone();
+      await vi.runAllTimersAsync();
+
+      const removeEmojis = calls
+        .filter((c) => c.method === "remove")
+        .map((c) => c.emoji);
+
+      // Every non-terminal emoji that the controller might have set should be
+      // explicitly removed at the terminal state, so the message ends up with
+      // exactly the terminal reaction.
+      expect(removeEmojis).toContain(DEFAULT_EMOJIS.thinking);
+      expect(removeEmojis).toContain(DEFAULT_EMOJIS.coding);
+      expect(removeEmojis).toContain(DEFAULT_EMOJIS.queued);
+      // The terminal emoji itself must not be removed.
+      expect(removeEmojis).not.toContain(DEFAULT_EMOJIS.done);
+    },
+  );
+
+  it(
+    "should not call removeReaction on terminal cleanup when adapter lacks it (#75458)",
+    async () => {
+      const { calls, controller } = createSetOnlyController();
+
+      void controller.setThinking();
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+
+      await controller.setDone();
+      await vi.runAllTimersAsync();
+
+      const removeCalls = calls.filter((c) => c.method === "remove");
+      expect(removeCalls).toHaveLength(0);
+      // Terminal emoji should still be set.
+      expectSetEmojiCall(calls, DEFAULT_EMOJIS.done);
+    },
+  );
+
   it("should only fire last state when rapidly changing (debounce)", async () => {
     const { calls, controller } = createEnabledController();
 

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -335,6 +335,26 @@ export function createStatusReactionController(params: {
     // Directly enqueue to ensure we return the updated promise
     return enqueue(async () => {
       await applyEmoji(emoji);
+      // Terminal cleanup: best-effort remove every other known reaction.
+      // applyEmoji() only removes the immediately previous emoji, so a failed
+      // transition (e.g. a Discord rate-limit or out-of-order phase update)
+      // can leave a stale intermediate reaction (e.g. thinking) on the message
+      // alongside the terminal reaction. After a terminal state we want
+      // exactly one reaction on the message: the terminal one. See #75458.
+      if (adapter.removeReaction) {
+        for (const previous of knownEmojis) {
+          if (!previous || previous === emoji) {
+            continue;
+          }
+          try {
+            await adapter.removeReaction(previous);
+          } catch (err) {
+            if (onError) {
+              onError(err);
+            }
+          }
+        }
+      }
       pendingEmoji = "";
     });
   }


### PR DESCRIPTION
Fixes #75458.

## Problem

`finishWithEmoji` (status reaction terminal path) only relies on `applyEmoji` to remove the immediately previous reaction. If any earlier `removeReaction` call was dropped — Discord rate-limit, transient API error, or any out-of-order phase update — the message ends up with **the terminal reaction AND a stale intermediate reaction at the same time**. The reporter saw `🤔` (thinking) persist alongside the completed turn.

## Fix

After applying the terminal emoji, best-effort `removeReaction` for every *other* known emoji. The terminal reaction itself is preserved; cleanup errors are routed to `onError` so a single failed remove does not block the other ones.

Adapters that do not implement `removeReaction` (set-only backends, e.g. Telegram which atomically replaces the reaction) are unaffected — the cleanup loop is guarded by the optional capability check.

## Tests

Two new cases in `status-reactions.test.ts`:

- Walks `queued → thinking → coding → done` and asserts that on `setDone`, **every non-terminal known emoji is removed** while the terminal emoji itself is not.
- Set-only adapter walks `thinking → done` and asserts the cleanup loop is a no-op (no `removeReaction` calls), so non-Discord channels keep their existing behaviour.

Logic was first validated with a standalone simulator that reproduces the dropped-`removeReaction` scenario from the issue, then mirrored into the real test file. All cases pass.

## Risk

Low. The change is purely additive — terminal reactions still arrive identically; the new behaviour only fires extra `removeReaction` calls (which were already used elsewhere in the controller) on the terminal transition. Worst-case, a transient remove fails again and we end up no worse than today.