### PR TITLE
fix(ui): prevent orphaned click listener after delete confirm popover dismissal

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -653,22 +653,26 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
           const yes = popover.querySelector(".chat-delete-confirm__yes")!;
           const check = popover.querySelector(".chat-delete-confirm__check") as HTMLInputElement;
 
-          cancel.addEventListener("click", () => popover.remove());
+          const dismissPopover = () => {
+            popover.remove();
+            document.removeEventListener("click", closeOnOutside, true);
+          };
+
+          cancel.addEventListener("click", dismissPopover);
           yes.addEventListener("click", () => {
             if (check.checked) {
               try {
                 getSafeLocalStorage()?.setItem(SKIP_DELETE_CONFIRM_KEY, "1");
               } catch {}
             }
-            popover.remove();
+            dismissPopover();
             onDelete();
           });
 
           // Close on click outside
           const closeOnOutside = (evt: MouseEvent) => {
             if (!popover.contains(evt.target as Node) && evt.target !== btn) {
-              popover.remove();
-              document.removeEventListener("click", closeOnOutside, true);
+              dismissPopover();
             }
           };
           requestAnimationFrame(() => document.addEventListener("click", closeOnOutside, true));


### PR DESCRIPTION
## Summary

Extracted a `dismissPopover` helper that removes the `closeOnOutside` click listener when the popover is dismissed (via Cancel, Yes, or click-outside). Previously, clicking Cancel or click-outside left the listener attached — future popover interactions would fire stale handlers.

## Fix

```typescript
const dismissPopover = () => {
  popover.remove();
  document.removeEventListener("click", closeOnOutside, true);
};
```

Both `cancel.addEventListener("click", ...)` and `yes.addEventListener("click", ...)` now call `dismissPopover()` instead of just `popover.remove()`. The `closeOnOutside` handler also calls `dismissPopover()` instead of manually removing the listener.

Matches the fix pattern from upstream PR #69982.

## Test plan
- [ ] Click Cancel on delete confirm — no orphaned listener
- [ ] Click outside delete confirm — no orphaned listener
- [ ] Click Yes to confirm delete — no orphaned listener
- [ ] Subsequent popover interactions behave normally