### PR TITLE
fix(imessage): attach stdin error listener to prevent EPIPE gateway crash (#75438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage/RPC: attach an error listener to the child stdin stream so async write errors (e.g. EPIPE when the imsg RPC process closes its stdin) reject pending requests instead of escaping to uncaughtException and crashing the gateway. Fixes #75438. Thanks @hclsys.
 - Google Meet/Voice Call: defer Twilio dial-in intro speech until after Meet DTMF entry and route delayed speech through the active realtime Voice Call bridge. Thanks @donkeykong91 and @PfanP.
 - Google Meet/Voice Call: make Twilio setup preflight honor explicit `--transport twilio` and fail local/private Voice Call webhook URLs before joins. Thanks @donkeykong91 and @PfanP.
 - Voice Call/Twilio: retry transient 21220 live-call TwiML updates and catch answered-path initial-greeting failures, so a fast answered callback no longer crashes the Gateway or drops the Twilio greeting/listen transition. (#74606) Thanks @Sivan22.

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -1,0 +1,65 @@
+import EventEmitter from "node:events";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
+});
+
+function createFakeChildProcess() {
+  const stdin = new EventEmitter() as EventEmitter & {
+    write: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+  stdin.write = vi.fn().mockReturnValue(true);
+  stdin.end = vi.fn();
+
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const child = new EventEmitter() as ReturnType<typeof spawnMock> & {
+    stdin: typeof stdin;
+    stdout: typeof stdout;
+    stderr: typeof stderr;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = stdin;
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.killed = false;
+  child.kill = vi.fn();
+  return child;
+}
+
+describe("IMessageRpcClient — stdin error handling", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects pending requests and does not emit uncaughtException when stdin emits EPIPE", async () => {
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "");
+
+    const child = createFakeChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const { createIMessageRpcClient } = await import("./client.js");
+    const client = await createIMessageRpcClient({ cliPath: "/fake/imsg" });
+
+    const requestPromise = client.request("ping").catch((err: Error) => err);
+
+    // Simulate EPIPE on stdin (child closed its read end)
+    const epipeError = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    child.stdin.emit("error", epipeError);
+
+    const result = await requestPromise;
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/EPIPE/i);
+  });
+});

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -108,6 +108,13 @@ export class IMessageRpcClient {
       this.closedResolve?.();
     });
 
+    // stdin write errors (e.g. EPIPE when the child closes its end) are emitted
+    // on the stdin stream, not the child process. Without this listener they
+    // escape to uncaughtException and crash the gateway.
+    child.stdin.on("error", (err) => {
+      this.failAll(err instanceof Error ? err : new Error(String(err)));
+    });
+
     child.on("close", (code, signal) => {
       if (code !== 0 && code !== null) {
         const reason = signal ? `signal ${signal}` : `code ${code}`;


### PR DESCRIPTION
## Summary

`IMessageRpcClient.request()` calls `this.child.stdin.write(line)` with no error callback. When the iMessage RPC child closes its stdin (crash, rate limit, network hiccup), Node emits an async `error` on the **stdin stream** with code `EPIPE`. The existing `child.on("error", ...)` at line 106 does NOT catch stdin stream errors — those fire on the stream, not the child process — so the error escapes to `uncaughtException` and crashes the gateway.

**Fix:** add `child.stdin.on("error", ...)` listener immediately after the existing `child.on("error", ...)` block, routing errors through the existing `failAll()` helper which rejects all pending requests cleanly.

Fixes #75438.

## Pre-audit

1. **Existing-helper check:** `failAll` already exists at line 239. Reused exactly — no new helper introduced.
2. **Shared-helper caller check:** `failAll` is `private`, only called within `client.ts`. Contract unchanged.
3. **Rival scan:** no rival PRs for this specific stdin EPIPE fix.

## Test plan

- `pnpm test extensions/imessage/src/client.test.ts` — 1/1 pass (new test simulates EPIPE via mocked `spawn`, verifies pending request rejects instead of uncaughtException)
- `git diff --check` — clean