### PR TITLE
Add DeepSeek reasoning content compat flag

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -656,6 +656,47 @@ describe("applyExtraParamsToAgent", () => {
     return calls[0]?.headers;
   }
 
+  it("applies per-model DeepSeek V4 reasoning_content compat", () => {
+    const payload = {
+      messages: [
+        { role: "user", content: "run" },
+        { role: "assistant", content: "done" },
+      ],
+    } as Record<string, unknown>;
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const model = {
+      api: "openai-completions",
+      provider: "custom-deepseek-proxy",
+      id: "deepseek-v4-pro",
+      compat: { requiresDeepSeekV4ReasoningContent: true },
+      reasoning: true,
+    } as Model<"openai-completions">;
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "custom-deepseek-proxy",
+      "deepseek-v4-pro",
+      undefined,
+      "high",
+      undefined,
+      undefined,
+      model,
+    );
+    void agent.streamFn?.(model, { messages: [] }, {});
+
+    expect((payload.messages as Array<Record<string, unknown>>)[1]).toHaveProperty(
+      "reasoning_content",
+      "",
+    );
+    expect(payload.thinking).toEqual({ type: "enabled" });
+    expect(payload.reasoning_effort).toBe("high");
+  });
+
   it("disables thinking for MiniMax anthropic-messages payloads", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -4,6 +4,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import type { SettingsManager } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDeepSeekV4OpenAICompatibleThinkingWrapper } from "../../plugin-sdk/provider-stream-shared.js";
 import {
   prepareProviderExtraParams as prepareProviderExtraParamsRuntime,
   resolveProviderExtraParamsForTransport as resolveProviderExtraParamsForTransportRuntime,
@@ -697,6 +698,12 @@ export function applyExtraParamsToAgent(
     },
   });
   agent.streamFn = pluginWrappedStreamFn ?? providerStreamBase;
+  if (model?.compat?.requiresDeepSeekV4ReasoningContent === true) {
+    agent.streamFn = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn: agent.streamFn,
+      thinkingLevel,
+    });
+  }
   // Apply caller/config extra params outside provider defaults so explicit values
   // like `openaiWsWarmup=false` can override provider-added defaults.
   applyPrePluginStreamWrappers(wrapperContext);

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -691,6 +691,7 @@ describe("model compat config schema", () => {
                   requiresThinkingAsText: false,
                   requiresMistralToolIds: false,
                   requiresOpenAiAnthropicToolPayload: true,
+                  requiresDeepSeekV4ReasoningContent: true,
                 },
               },
             ],

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3195,6 +3195,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           requiresOpenAiAnthropicToolPayload: {
                             type: "boolean",
                           },
+                          requiresDeepSeekV4ReasoningContent: {
+                            type: "boolean",
+                          },
                         },
                         additionalProperties: false,
                       },

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -70,6 +70,7 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     toolCallArgumentsEncoding?: string;
     requiresMistralToolIds?: boolean;
     requiresOpenAiAnthropicToolPayload?: boolean;
+    requiresDeepSeekV4ReasoningContent?: boolean;
   };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -217,6 +217,7 @@ export const ModelCompatSchema = z
     toolCallArgumentsEncoding: z.string().optional(),
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    requiresDeepSeekV4ReasoningContent: z.boolean().optional(),
   })
   .strict()
   .optional();

--- a/src/model-catalog/normalize.ts
+++ b/src/model-catalog/normalize.ts
@@ -175,6 +175,7 @@ function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefi
     "nativeWebSearchTool",
     "requiresMistralToolIds",
     "requiresOpenAiAnthropicToolPayload",
+    "requiresDeepSeekV4ReasoningContent",
   ] as const;
   for (const field of booleanFields) {
     if (typeof value[field] === "boolean") {

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -134,6 +134,31 @@ describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
     expect(payload.messages[3]).toHaveProperty("reasoning_content", "");
     expect(payload.messages[4]).toHaveProperty("reasoning_content", "native reasoning");
   });
+
+  it("can be enabled without a provider/model predicate for per-model compat", () => {
+    const payload = {
+      messages: [
+        { role: "user", content: "read file" },
+        { role: "assistant", content: "done" },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+    });
+    void wrapped?.({ provider: "custom", id: "deepseek-v4-proxy" } as never, {} as never, {});
+
+    expect(payload.messages[1]).toHaveProperty("reasoning_content", "");
+    expect(payload).toMatchObject({
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+  });
 });
 
 describe("buildCopilotDynamicHeaders", () => {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -280,14 +280,14 @@ function ensureDeepSeekV4AssistantReasoningContent(payload: Record<string, unkno
 export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
   baseStreamFn: StreamFn | undefined;
   thinkingLevel: DeepSeekV4ThinkingLevel;
-  shouldPatchModel: (model: Parameters<StreamFn>[0]) => boolean;
+  shouldPatchModel?: (model: Parameters<StreamFn>[0]) => boolean;
 }): StreamFn | undefined {
   if (!params.baseStreamFn) {
     return undefined;
   }
   const underlying = params.baseStreamFn;
   return (model, context, options) => {
-    if (!params.shouldPatchModel(model)) {
+    if (params.shouldPatchModel && !params.shouldPatchModel(model)) {
       return underlying(model, context, options);
     }
 


### PR DESCRIPTION
## Summary
- add a per-model `compat.requiresDeepSeekV4ReasoningContent` flag
- wire the flag through config/schema/model-catalog normalization
- apply the existing DeepSeek V4 reasoning_content payload wrapper when the compat flag is set
- add coverage for config parsing and payload mutation

Fixes #75105

## Tests
- pnpm exec vitest run src/plugin-sdk/provider-stream-shared.test.ts src/agents/pi-embedded-runner-extraparams.test.ts src/config/config-misc.test.ts