### PR TITLE
fix(agents): gate media provider inventory output

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -8,6 +8,7 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 // Minimal mock context factory. Only the fields needed for the media emission path.
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
+  shouldEmitProviderInventoryToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
   toolResultFormat?: "markdown" | "plain";
   builtinToolNames?: ReadonlySet<string>;
@@ -44,6 +45,9 @@ function createMockContext(overrides?: {
     builtinToolNames: overrides?.builtinToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
+    shouldEmitProviderInventoryToolOutput: vi.fn(
+      () => overrides?.shouldEmitProviderInventoryToolOutput ?? false,
+    ),
     emitToolSummary: vi.fn(),
     emitToolOutput: vi.fn(),
     trimMessagingToolSent: vi.fn(),
@@ -136,6 +140,46 @@ async function handleCaseVariantBuiltinMedia(mediaPathOrUrl: string) {
     isError: false,
     result: {
       content: [{ type: "text", text: `MEDIA:${mediaPathOrUrl}` }],
+    },
+  });
+
+  return ctx;
+}
+
+const providerInventoryText = [
+  "openai: default=sora-2 | models=sora-2",
+  "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview",
+].join("\n");
+
+async function handleProviderInventoryListResult(params: {
+  toolName: "image_generate" | "video_generate";
+  shouldEmitToolOutput: boolean;
+  shouldEmitProviderInventoryToolOutput?: boolean;
+}) {
+  const ctx = createMockContext({
+    shouldEmitToolOutput: params.shouldEmitToolOutput,
+    shouldEmitProviderInventoryToolOutput: params.shouldEmitProviderInventoryToolOutput,
+    onToolResult: vi.fn(),
+    toolResultFormat: "plain",
+  });
+
+  await handleToolExecutionEnd(ctx, {
+    type: "tool_execution_end",
+    toolName: params.toolName,
+    toolCallId: "tc-1",
+    isError: false,
+    result: {
+      content: [{ type: "text", text: providerInventoryText }],
+      details: {
+        providers: [
+          { id: "openai", defaultModel: "sora-2", models: ["sora-2"] },
+          {
+            id: "google",
+            defaultModel: "veo-3.1-fast-generate-preview",
+            models: ["veo-3.1-fast-generate-preview"],
+          },
+        ],
+      },
     },
   });
 
@@ -424,52 +468,55 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/generated.png"]);
   });
 
-  it("emits provider inventory output for compact video_generate list results", async () => {
-    const ctx = createMockContext({
-      shouldEmitToolOutput: false,
-      onToolResult: vi.fn(),
-      toolResultFormat: "plain",
-    });
+  it.each(["image_generate", "video_generate"] as const)(
+    "keeps %s provider inventory internal when tool output is hidden",
+    async (toolName) => {
+      const ctx = await handleProviderInventoryListResult({
+        toolName,
+        shouldEmitToolOutput: false,
+      });
 
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "video_generate",
-      toolCallId: "tc-1",
-      isError: false,
-      result: {
-        content: [
-          {
-            type: "text",
-            text: [
-              "openai: default=sora-2 | models=sora-2",
-              "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview",
-            ].join("\n"),
-          },
-        ],
-        details: {
-          providers: [
-            { id: "openai", defaultModel: "sora-2", models: ["sora-2"] },
-            {
-              id: "google",
-              defaultModel: "veo-3.1-fast-generate-preview",
-              models: ["veo-3.1-fast-generate-preview"],
-            },
-          ],
-        },
-      },
-    });
+      expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+      expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    },
+  );
 
-    expect(ctx.emitToolOutput).toHaveBeenCalledWith(
-      "video_generate",
-      undefined,
-      [
-        "openai: default=sora-2 | models=sora-2",
-        "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview",
-      ].join("\n"),
-      expect.any(Object),
-    );
-    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
-  });
+  it.each(["image_generate", "video_generate"] as const)(
+    "emits %s provider inventory when explicit tool output is enabled",
+    async (toolName) => {
+      const ctx = await handleProviderInventoryListResult({
+        toolName,
+        shouldEmitToolOutput: true,
+      });
+
+      expect(ctx.emitToolOutput).toHaveBeenCalledWith(
+        toolName,
+        undefined,
+        providerInventoryText,
+        expect.any(Object),
+      );
+      expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    },
+  );
+
+  it.each(["image_generate", "video_generate"] as const)(
+    "emits %s provider inventory through explicit inventory opt-in",
+    async (toolName) => {
+      const ctx = await handleProviderInventoryListResult({
+        toolName,
+        shouldEmitToolOutput: false,
+        shouldEmitProviderInventoryToolOutput: true,
+      });
+
+      expect(ctx.emitToolOutput).toHaveBeenCalledWith(
+        toolName,
+        undefined,
+        providerInventoryText,
+        expect.any(Object),
+      );
+      expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+    },
+  );
 
   it("does NOT emit media for error results", async () => {
     const onToolResult = vi.fn();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -341,28 +341,21 @@ async function collectEmittedToolOutputMediaUrls(
   return filterToolResultMediaUrls(toolName, mediaUrls, result);
 }
 
-const COMPACT_PROVIDER_INVENTORY_TOOLS = new Set(["image_generate", "video_generate"]);
+const PROVIDER_INVENTORY_TOOLS = new Set(["image_generate", "video_generate"]);
 
-function hasProviderInventoryDetails(result: unknown): boolean {
-  if (!result || typeof result !== "object") {
-    return false;
-  }
-  const details = readToolResultDetailsRecord(result);
-  return Array.isArray(details?.providers);
-}
-
-function shouldEmitCompactToolOutput(params: {
+function isProviderInventoryToolOutput(params: {
   toolName: string;
   result: unknown;
   outputText?: string;
 }): boolean {
-  if (!COMPACT_PROVIDER_INVENTORY_TOOLS.has(params.toolName)) {
+  if (!PROVIDER_INVENTORY_TOOLS.has(params.toolName) || !params.outputText?.trim()) {
     return false;
   }
-  if (!hasProviderInventoryDetails(params.result)) {
+  if (!params.result || typeof params.result !== "object") {
     return false;
   }
-  return Boolean(params.outputText?.trim());
+  const details = readToolResultDetailsRecord(params.result);
+  return Array.isArray(details?.providers);
 }
 
 function readExecApprovalPendingDetails(result: unknown): {
@@ -533,6 +526,7 @@ async function emitToolResultOutput(params: {
   const mediaUrls = mediaReply
     ? filterToolResultMediaUrls(rawToolName, mediaReply.mediaUrls, result, ctx.builtinToolNames)
     : [];
+  const isProviderInventoryOutput = isProviderInventoryToolOutput({ toolName, result, outputText });
   const shouldEmitOutput =
     !shouldSuppressStructuredMediaToolOutput({
       toolName,
@@ -541,7 +535,8 @@ async function emitToolResultOutput(params: {
       hasDeliverableStructuredMedia: hasStructuredMedia && mediaUrls.length > 0,
       builtinToolNames: ctx.builtinToolNames,
     }) &&
-    (ctx.shouldEmitToolOutput() || shouldEmitCompactToolOutput({ toolName, result, outputText }));
+    (ctx.shouldEmitToolOutput() ||
+      (isProviderInventoryOutput && ctx.shouldEmitProviderInventoryToolOutput()));
   if (shouldEmitOutput) {
     if (outputText) {
       ctx.emitToolOutput(rawToolName, meta, outputText, result);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -118,6 +118,7 @@ export type EmbeddedPiSubscribeContext = {
 
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
+  shouldEmitProviderInventoryToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
   emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
   stripBlockTags: (
@@ -184,6 +185,7 @@ export type ToolHandlerParams = Pick<
   | "sessionId"
   | "agentId"
   | "toolResultFormat"
+  | "shouldEmitProviderInventoryToolOutput"
 >;
 
 export type ToolHandlerState = Pick<
@@ -220,6 +222,7 @@ export type ToolHandlerContext = {
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
+  shouldEmitProviderInventoryToolOutput: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
   emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
   trimMessagingToolSent: () => void;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -506,6 +506,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     typeof params.shouldEmitToolOutput === "function"
       ? params.shouldEmitToolOutput()
       : params.verboseLevel === "full";
+  const shouldEmitProviderInventoryToolOutput = () =>
+    typeof params.shouldEmitProviderInventoryToolOutput === "function"
+      ? params.shouldEmitProviderInventoryToolOutput()
+      : false;
   const formatToolOutputBlock = (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) {
@@ -900,6 +904,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,
+    shouldEmitProviderInventoryToolOutput,
     emitToolSummary,
     emitToolOutput,
     stripBlockTags,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -20,6 +20,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
+  shouldEmitProviderInventoryToolOutput?: () => boolean;
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */


### PR DESCRIPTION
## Summary

- Problem: `image_generate` and `video_generate` provider inventory list output could bypass hidden tool-output policy and appear on shared chat surfaces.
- Why it matters: provider/model/configuration inventory is operator environment detail and should stay internal unless deliberately exposed.
- What changed: provider inventory now requires normal full tool output or a new dedicated `shouldEmitProviderInventoryToolOutput` opt-in. Hidden/shared surfaces stay safe by default, while trusted/private callers can expose inventory without enabling every tool output.
- What did NOT change (scope boundary): generated media delivery, structured media extraction, provider list generation, and internal tool results are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75166
- Related #75550
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: provider inventory list results had a compact-output bypass that allowed media provider inventory to emit even when `shouldEmitToolOutput()` was false.
- Missing detection / guardrail: the focused media handler test asserted the old compact emission behavior for `video_generate`, but did not cover hidden group/channel visibility or image generation inventory.
- Contributing context (if known): compact provider inventory was useful for diagnostics but reused the visible tool-output channel without a provider-inventory-specific policy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`
- Scenario the test should lock in: provider inventory from both `image_generate` and `video_generate` remains internal when tool output is hidden, still emits with full tool output, and can emit through the dedicated provider-inventory opt-in.
- Why this is the smallest reliable guardrail: the leak comes from the tool-result output gate, so the focused handler test exercises the exact branch without Discord transport setup.
- Existing test that already covers this (if any): generated media delivery tests already cover media queuing; this PR updates provider inventory coverage to the intended visibility contract.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Provider inventory list text for image/video generation no longer appears as visible tool output when tool output is hidden. Generated media delivery is unchanged. Trusted/private callers can opt into provider inventory specifically.

## Diagram (if applicable)

```text
Before:
image/video provider list -> compact inventory bypass -> visible tool output

After:
image/video provider list -> full output OR provider-inventory opt-in -> visible tool output
                          -> otherwise internal only
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Not locally reproduced per contributor request
- Runtime/container: Not locally reproduced per contributor request
- Model/provider: image/video provider inventory list result
- Integration/channel (if any): Discord/group-channel class shared chat surface
- Relevant config (redacted): hidden/default tool output surface

### Steps

1. In a shared chat surface where tool output is hidden, trigger `image_generate` or `video_generate` with provider list/inventory output.
2. Observe whether provider/model/auth-hint inventory text is delivered as visible tool output.
3. Enable full tool output or trusted/private provider-inventory opt-in and repeat to confirm diagnostics remain available when requested.

### Expected

Provider inventory remains internal when tool output is hidden; explicit full output or provider-inventory opt-in can still show it.

### Actual

Before this change, provider inventory could bypass the hidden-output gate and appear visibly.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Lint-only local checks run on the PR files:

- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-subscribe.ts src/agents/pi-embedded-subscribe.types.ts src/agents/pi-embedded-subscribe.handlers.types.ts src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.core.json src/agents/pi-embedded-subscribe.ts src/agents/pi-embedded-subscribe.types.ts src/agents/pi-embedded-subscribe.handlers.types.ts src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`

Unit/e2e tests were intentionally not run locally.

## Human Verification (required)

- Verified scenarios: lint/format only on changed PR files, as requested.
- Edge cases checked: static coverage for hidden, full-output, and provider-inventory opt-in branches in focused media handler tests.
- What you did **not** verify: no local unit, integration, e2e, Discord, or media-provider runtime execution was run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators relying on hidden-surface provider inventory being visible will no longer see that diagnostic text by default.
  - Mitigation: full tool output still emits provider inventory, and trusted/private callers now have a dedicated provider-inventory opt-in.