### PR TITLE
fix(dispatch): tag provider-inventory tool results and suppress on non-direct surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/dispatch: tag image and video provider inventory tool results with an internal-shape marker and suppress the inventory text on non-direct chat surfaces at the reply dispatcher, so verbose-mode operators in shared Discord guild and group rooms no longer leak provider/model/auth-hint details even when the emission-side gate is bypassed. Refs #75166 and #75550. Thanks @zenx1111.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -39,6 +39,7 @@ import {
   stripDowngradedToolCallText,
   THINKING_TAG_SCAN_RE,
 } from "./pi-embedded-utils.js";
+import { classifyInternalToolOutputShape } from "./tool-output-shapes.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
@@ -534,10 +535,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && filteredMediaUrls.length === 0) {
       return;
     }
+    const internalShape = classifyInternalToolOutputShape(result);
     try {
       void params.onToolResult({
         text: cleanedText,
         mediaUrls: filteredMediaUrls.length ? filteredMediaUrls : undefined,
+        ...(internalShape ? { internalShape } : {}),
       });
     } catch {
       // ignore tool result delivery failures

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -151,6 +151,7 @@ export type AgentRuntimeReplyPayload = {
   isReasoning?: boolean;
   isCompactionNotice?: boolean;
   channelData?: Record<string, unknown>;
+  internalShape?: "provider-inventory";
 };
 
 export type AgentRuntimeSystemPromptSectionId =

--- a/src/agents/tool-output-shapes.test.ts
+++ b/src/agents/tool-output-shapes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyInternalToolOutputShape,
+  hasProviderInventoryDetails,
+} from "./tool-output-shapes.js";
+
+describe("hasProviderInventoryDetails", () => {
+  it("matches results with details.providers array", () => {
+    expect(
+      hasProviderInventoryDetails({
+        details: {
+          providers: [{ id: "openai", defaultModel: "sora-2", models: ["sora-2"] }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("matches an empty providers array (still inventory shape)", () => {
+    expect(hasProviderInventoryDetails({ details: { providers: [] } })).toBe(true);
+  });
+
+  it("rejects results without details", () => {
+    expect(hasProviderInventoryDetails({})).toBe(false);
+    expect(hasProviderInventoryDetails(null)).toBe(false);
+    expect(hasProviderInventoryDetails(undefined)).toBe(false);
+  });
+
+  it("rejects details with non-array providers", () => {
+    expect(hasProviderInventoryDetails({ details: { providers: "openai" } })).toBe(false);
+    expect(hasProviderInventoryDetails({ details: { providers: { id: "openai" } } })).toBe(false);
+  });
+
+  it("rejects details when providers key is missing", () => {
+    expect(hasProviderInventoryDetails({ details: { models: ["sora-2"] } })).toBe(false);
+  });
+
+  it("rejects when details itself is an array", () => {
+    expect(hasProviderInventoryDetails({ details: [{ providers: [] }] })).toBe(false);
+  });
+});
+
+describe("classifyInternalToolOutputShape", () => {
+  it("returns 'provider-inventory' for provider-inventory shape", () => {
+    expect(
+      classifyInternalToolOutputShape({
+        details: { providers: [{ id: "openai" }] },
+      }),
+    ).toBe("provider-inventory");
+  });
+
+  it("returns undefined for ordinary tool results", () => {
+    expect(
+      classifyInternalToolOutputShape({ content: [{ type: "text", text: "ok" }] }),
+    ).toBeUndefined();
+    expect(classifyInternalToolOutputShape(undefined)).toBeUndefined();
+    expect(classifyInternalToolOutputShape(null)).toBeUndefined();
+  });
+});

--- a/src/agents/tool-output-shapes.ts
+++ b/src/agents/tool-output-shapes.ts
@@ -1,0 +1,46 @@
+/**
+ * Shape detectors for tool-result payloads whose visibility on shared chat
+ * surfaces (Discord guild channels, group rooms) needs stricter handling than
+ * arbitrary tool output. Kept as a tiny pure module so both the agent
+ * emission path and the reply dispatcher can reach the same detection without
+ * duplicating logic. Refs #75166.
+ */
+
+export type InternalToolOutputShape = "provider-inventory";
+
+function readDetailsRecord(result: unknown): Record<string, unknown> | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const details = (result as { details?: unknown }).details;
+  return details && typeof details === "object" && !Array.isArray(details)
+    ? (details as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Returns true when a tool result carries the canonical
+ * `details.providers: [...]` shape used by `image_generate` /
+ * `video_generate` `action=list` and the shared media-generate list helper.
+ * This shape contains operator environment data (provider ids, models,
+ * configured state, auth env-var hints) that must not leak to non-direct
+ * chat surfaces by default.
+ */
+export function hasProviderInventoryDetails(result: unknown): boolean {
+  const details = readDetailsRecord(result);
+  return Array.isArray(details?.providers);
+}
+
+/**
+ * Maps a tool result to an internal shape tag that downstream delivery code
+ * uses to gate visibility. Returns undefined when no internal shape applies
+ * and the payload should follow normal tool-output routing.
+ */
+export function classifyInternalToolOutputShape(
+  result: unknown,
+): InternalToolOutputShape | undefined {
+  if (hasProviderInventoryDetails(result)) {
+    return "provider-inventory";
+  }
+  return undefined;
+}

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -1,3 +1,4 @@
+import type { InternalToolOutputShape } from "../agents/tool-output-shapes.js";
 import type {
   InteractiveReply,
   MessagePresentation,
@@ -46,6 +47,13 @@ export type ReplyPayload = {
   isCompactionNotice?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
+  /**
+   * Tags a tool-result payload as carrying an internal shape (e.g. provider
+   * inventory) whose visibility on non-direct chat surfaces is restricted.
+   * The reply dispatcher reads this to suppress text on shared surfaces
+   * while still allowing direct/DM delivery. Refs #75166.
+   */
+  internalShape?: InternalToolOutputShape;
 };
 
 export type ReplyPayloadMetadata = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1466,6 +1466,127 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "NO_REPLY" });
   });
 
+  it("suppresses provider-inventory tool text on Discord guild channel surfaces", async () => {
+    setNoAbort();
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "openai: default=sora-2 | models=sora-2",
+        internalShape: "provider-inventory",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("suppresses provider-inventory tool text on group surfaces", async () => {
+    setNoAbort();
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "group",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "google: default=veo-3.1-fast-generate-preview",
+        internalShape: "provider-inventory",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("delivers provider-inventory tool text in DM sessions", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "openai: default=sora-2 | models=sora-2",
+        internalShape: "provider-inventory",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(firstToolResultPayload(dispatcher)).toEqual(
+      expect.objectContaining({
+        text: "openai: default=sora-2 | models=sora-2",
+        internalShape: "provider-inventory",
+      }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("preserves provider-inventory media on shared surfaces while dropping the inventory text", async () => {
+    setNoAbort();
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "openai: default=sora-2 | models=sora-2",
+        mediaUrls: ["https://example.com/preview.png"],
+        internalShape: "provider-inventory",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    const sent = firstToolResultPayload(dispatcher);
+    expect(sent?.text).toBeUndefined();
+    expect(sent?.mediaUrls).toEqual(["https://example.com/preview.png"]);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
   it("sends tool results via dispatcher in DM sessions", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -118,6 +118,7 @@ const agentEventMocks = vi.hoisted(() => ({
 const ttsMocks = vi.hoisted(() => {
   const state = {
     synthesizeFinalAudio: false,
+    synthesizeToolAudio: false,
   };
   return {
     state,
@@ -136,6 +137,19 @@ const ttsMocks = vi.hoisted(() => {
           ...params.payload,
           mediaUrl: "https://example.com/tts-synth.opus",
           audioAsVoice: true,
+        };
+      }
+      if (
+        state.synthesizeToolAudio &&
+        params.kind === "tool" &&
+        typeof params.payload?.text === "string" &&
+        params.payload.text.trim()
+      ) {
+        return {
+          ...params.payload,
+          mediaUrl: "https://example.com/tts-tool.opus",
+          audioAsVoice: true,
+          spokenText: params.payload.text,
         };
       }
       return params.payload;
@@ -788,6 +802,7 @@ describe("dispatchReplyFromConfig", () => {
     threadInfoMocks.parseSessionThreadInfo.mockReset();
     threadInfoMocks.parseSessionThreadInfo.mockImplementation(parseGenericThreadSessionInfo);
     ttsMocks.state.synthesizeFinalAudio = false;
+    ttsMocks.state.synthesizeToolAudio = false;
     ttsMocks.maybeApplyTtsToPayload.mockClear();
     ttsMocks.normalizeTtsAutoMode.mockClear();
     ttsMocks.resolveTtsConfig.mockClear();
@@ -1585,6 +1600,52 @@ describe("dispatchReplyFromConfig", () => {
     expect(sent?.text).toBeUndefined();
     expect(sent?.mediaUrls).toEqual(["https://example.com/preview.png"]);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("suppresses provider-inventory before tool TTS can synthesize shared audio", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeToolAudio = true;
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "all" });
+    const cfg = {
+      ...automaticGroupReplyConfig,
+      messages: {
+        tts: {
+          auto: "all",
+          mode: "all",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "channel",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({
+        text: "openai: default=sora-2 | models=sora-2",
+        internalShape: "provider-inventory",
+      });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "tool",
+        payload: expect.objectContaining({
+          internalShape: "provider-inventory",
+          text: expect.any(String),
+        }),
+      }),
+    );
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });
 
   it("sends tool results via dispatcher in DM sessions", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1109,6 +1109,19 @@ export async function dispatchReplyFromConfig(
       ) {
         return null;
       }
+      // Defense-in-depth for #75166: tool-result payloads tagged as
+      // operator-environment inventory (e.g. image/video provider lists)
+      // must not surface as visible text on non-direct chat surfaces, even
+      // when verbose progress is otherwise enabled. Direct/DM operators
+      // still receive full visibility so the inventory remains a useful
+      // operator affordance where it does not leak into shared rooms.
+      if (payload.internalShape === "provider-inventory" && ctx.ChatType !== "direct") {
+        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+        if (!hasMedia) {
+          return null;
+        }
+        return { ...payload, text: undefined };
+      }
       if (shouldSendToolSummaries) {
         return payload;
       }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1202,8 +1202,15 @@ export async function dispatchReplyFromConfig(
             if (suppressDelivery) {
               return;
             }
+            const preTtsPayload =
+              payload.internalShape === "provider-inventory" && ctx.ChatType !== "direct"
+                ? resolveToolDeliveryPayload(payload)
+                : payload;
+            if (!preTtsPayload) {
+              return;
+            }
             const ttsPayload = await maybeApplyTtsToReplyPayload({
-              payload,
+              payload: preTtsPayload,
               cfg,
               channel: deliveryChannel,
               kind: "tool",


### PR DESCRIPTION
## Summary

- Problem: provider/model/auth-hint inventory from `image_generate` and `video_generate` `action=list` can reach Discord guild channels and other shared surfaces as visible tool output, leaking operator environment details (#75166).
- Why it matters: shared chat rooms expose configured providers, models, capabilities, and auth env-var names to every participant, even though the agent only needs that data internally.
- What changed: tag tool-result payloads carrying `details.providers` shape with a new `internalShape: "provider-inventory"` marker on `ReplyPayload`, and have the reply dispatcher drop the inventory text on any non-direct surface (`ctx.ChatType !== "direct"`), preserving media artifacts and DM visibility.
- What did NOT change: provider list generation, generated media delivery, exec approval routing, DM/direct visibility, or any plugin contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #75166
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `dispatch-from-config.ts` derives tool-summary visibility from `ChatType !== "group"` and Slack-non-direct, but Discord guild messages set `ChatType: "channel"`, so tool summaries pass through. Tool-result payloads have no shape provenance once `details` is flattened to text, so the dispatcher cannot distinguish operator-environment inventory from ordinary tool output.
- Missing detection / guardrail: no payload-shape signal reaches the delivery layer.
- Contributing context: the compact provider-inventory emission was introduced alongside `image_generate` / `video_generate` `action=list` for operator convenience.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/agents/tool-output-shapes.test.ts`.
- Scenario the test should lock in: provider-inventory payloads do not deliver text on `ChatType: "channel"` or `"group"`, do deliver in `"direct"`, and preserve media when text is dropped.
- Why this is the smallest reliable guardrail: the dispatcher is the last point where structured shape is available to make a per-surface decision.

## User-visible / Behavior Changes

- Discord guild channels and other non-direct shared surfaces no longer receive `image_generate` / `video_generate` `action=list` provider-inventory text as visible tool output, even with verbose progress enabled.
- Direct/DM chats are unchanged: operators still see full provider inventory.
- Generated images, videos, and other tool media are unchanged.
- No config knob, no migration.

## Diagram (if applicable)

```text
Before:
[image_generate action=list] -> agent emits inventory text
   -> dispatcher: ChatType="channel" passes through
   -> Discord guild: provider/model/auth-hint text DELIVERED

After:
[image_generate action=list] -> agent emits inventory text
   -> ReplyPayload tagged internalShape="provider-inventory"
   -> dispatcher: ChatType!="direct" drops text, keeps media
   -> Discord guild: text DROPPED, agent context intact
   -> DM: text DELIVERED
```

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (the leak was metadata, never secret values)
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **Yes (narrowed)** — provider-inventory tool text no longer reaches non-direct surfaces. Risk low; DM/direct path preserved; agent reasoning context unchanged.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime: Node 22+ / pnpm
- Channel: Discord guild
- Config: stock (no special config)

### Steps

1. In a Discord guild channel, ask the agent to perform an image-generation task that prompts it to call `image_generate` with `action: "list"`.
2. Observe whether provider/model inventory text appears in the channel.

### Expected

With this PR: inventory text is suppressed on the guild surface; the agent retains full inventory in context.

### Actual

Without this PR: inventory text is delivered to the guild as visible tool output.

## Evidence

- [x] Failing test/log before + passing after

```
pnpm test src/agents/tool-output-shapes.test.ts                          -> 8/8 passed
pnpm test src/auto-reply/reply/dispatch-from-config.test.ts              -> 98/98 passed (4 new)
pnpm test src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts  -> 23/23 passed
pnpm test src/agents/pi-embedded-subscribe.handlers.tools.test.ts        -> 28/28 passed
pnpm check:changed                                                       -> exit 0, 21 phases
pnpm exec oxfmt --check (touched files)                                  -> clean
```

The new dispatcher tests cover: Discord guild suppression, group suppression, DM passthrough, and media-preservation when text is dropped.

## Human Verification (required)

- Verified scenarios: targeted unit and dispatcher integration tests pass; `pnpm check:changed` green including core and core-test typecheck.
- Edge cases checked: empty `details.providers: []`, non-array providers, missing `details`, primitive results; default test ctx uses `ChatType: "direct"` so existing tests do not accidentally trip the new filter.
- What I did **not** verify: live Discord guild end-to-end against a running Gateway; macOS/Windows; Bun workflow.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — `internalShape` is optional; consumers that ignore it see identical behavior.
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- Risk: a future tool returns `details.providers` for a non-inventory reason and gets suppressed on shared surfaces.
  - Mitigation: the classifier lives in a single small module (`src/agents/tool-output-shapes.ts`); a future contributor can narrow it (e.g., also gate on `toolName`) in one place.

## AI-assisted disclosure

- [x] AI-assisted (Claude). Reviewed and understood every line of the diff before submission.
