### PR TITLE
fix: gate media provider inventory diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: classify image/video provider inventory as internal diagnostic tool output so hidden shared-chat turns no longer expose provider, model, auth-hint, or capability fingerprints while generated media delivery remains unchanged. Fixes #75166. Thanks @volcano303.
 - Thinking/providers: resolve bundled provider thinking profiles through lightweight provider policy artifacts when startup-lazy providers are not active, so OpenAI Codex GPT-5.x keeps xhigh available in Gateway session validation. Fixes #74796. Thanks @maxschachere.
 - Plugins/TTS: keep bundled speech-provider discovery available on cold package Gateway paths and add bundled plugin matrix runtime probes for health, readiness, RPC, TTS discovery, and post-ready runtime-deps watchdog coverage. Refs #75283. Thanks @vincentkoc.
 - Google Meet/Twilio: show delegated voice call ID, DTMF, and intro-greeting state in `googlemeet doctor`, and avoid claiming DTMF was sent when no Meet PIN sequence was configured. Refs #72478. Thanks @DougButdorf.

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -8,6 +8,7 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 // Minimal mock context factory. Only the fields needed for the media emission path.
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
+  shouldEmitInternalDiagnosticToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
   toolResultFormat?: "markdown" | "plain";
   builtinToolNames?: ReadonlySet<string>;
@@ -44,6 +45,9 @@ function createMockContext(overrides?: {
     builtinToolNames: overrides?.builtinToolNames,
     shouldEmitToolResult: vi.fn(() => false),
     shouldEmitToolOutput: vi.fn(() => overrides?.shouldEmitToolOutput ?? false),
+    shouldEmitInternalDiagnosticToolOutput: vi.fn(
+      () => overrides?.shouldEmitInternalDiagnosticToolOutput ?? false,
+    ),
     emitToolSummary: vi.fn(),
     emitToolOutput: vi.fn(),
     trimMessagingToolSent: vi.fn(),
@@ -424,7 +428,83 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/generated.png"]);
   });
 
-  it("emits provider inventory output for compact video_generate list results", async () => {
+  it("queues generated media from structured details when tool output is hidden", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      toolResultFormat: "markdown",
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated image: /tmp/generated.png" }],
+        details: {
+          media: {
+            mediaUrls: ["/tmp/generated.png"],
+          },
+        },
+      },
+    });
+
+    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/generated.png"]);
+  });
+
+  function providerInventoryResult() {
+    return {
+      content: [
+        {
+          type: "text",
+          text: [
+            "openai: default=sora-2 | models=sora-2 | auth=OPENAI_API_KEY",
+            "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview | auth=GOOGLE_API_KEY",
+          ].join("\n"),
+        },
+      ],
+      details: {
+        providers: [
+          {
+            id: "openai",
+            defaultModel: "sora-2",
+            models: ["sora-2"],
+            authEnvVars: ["OPENAI_API_KEY"],
+            capabilities: { textToVideo: true },
+          },
+          {
+            id: "google",
+            defaultModel: "veo-3.1-fast-generate-preview",
+            models: ["veo-3.1-fast-generate-preview"],
+            authEnvVars: ["GOOGLE_API_KEY"],
+            capabilities: { textToVideo: true },
+          },
+        ],
+      },
+    };
+  }
+
+  it("does not emit image provider inventory when tool output is hidden", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult: vi.fn(),
+      toolResultFormat: "plain",
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result: providerInventoryResult(),
+    });
+
+    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
+  it("does not emit video provider inventory when tool output is hidden", async () => {
     const ctx = createMockContext({
       shouldEmitToolOutput: false,
       onToolResult: vi.fn(),
@@ -436,37 +516,60 @@ describe("handleToolExecutionEnd media emission", () => {
       toolName: "video_generate",
       toolCallId: "tc-1",
       isError: false,
-      result: {
-        content: [
-          {
-            type: "text",
-            text: [
-              "openai: default=sora-2 | models=sora-2",
-              "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview",
-            ].join("\n"),
-          },
-        ],
-        details: {
-          providers: [
-            { id: "openai", defaultModel: "sora-2", models: ["sora-2"] },
-            {
-              id: "google",
-              defaultModel: "veo-3.1-fast-generate-preview",
-              models: ["veo-3.1-fast-generate-preview"],
-            },
-          ],
-        },
-      },
+      result: providerInventoryResult(),
+    });
+
+    expect(ctx.emitToolOutput).not.toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
+  it("emits provider inventory only when diagnostic output is explicitly allowed", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      shouldEmitInternalDiagnosticToolOutput: true,
+      onToolResult: vi.fn(),
+      toolResultFormat: "plain",
+    });
+    const result = providerInventoryResult();
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "video_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result,
     });
 
     expect(ctx.emitToolOutput).toHaveBeenCalledWith(
       "video_generate",
       undefined,
-      [
-        "openai: default=sora-2 | models=sora-2",
-        "google: default=veo-3.1-fast-generate-preview | models=veo-3.1-fast-generate-preview",
-      ].join("\n"),
-      expect.any(Object),
+      result.content[0].text,
+      result,
+    );
+  });
+
+  it("emits provider inventory in full verbose output through diagnostic policy", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: true,
+      shouldEmitInternalDiagnosticToolOutput: true,
+      onToolResult: vi.fn(),
+      toolResultFormat: "plain",
+    });
+    const result = providerInventoryResult();
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result,
+    });
+
+    expect(ctx.emitToolOutput).toHaveBeenCalledWith(
+      "image_generate",
+      undefined,
+      result.content[0].text,
+      result,
     );
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
   });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -341,7 +341,9 @@ async function collectEmittedToolOutputMediaUrls(
   return filterToolResultMediaUrls(toolName, mediaUrls, result);
 }
 
-const COMPACT_PROVIDER_INVENTORY_TOOLS = new Set(["image_generate", "video_generate"]);
+type ToolOutputVisibility = "public" | "internal" | "diagnostic" | "media-delivery";
+
+const PROVIDER_INVENTORY_TOOLS = new Set(["image_generate", "video_generate"]);
 
 function hasProviderInventoryDetails(result: unknown): boolean {
   if (!result || typeof result !== "object") {
@@ -351,18 +353,37 @@ function hasProviderInventoryDetails(result: unknown): boolean {
   return Array.isArray(details?.providers);
 }
 
-function shouldEmitCompactToolOutput(params: {
+function classifyToolOutputVisibility(params: {
   toolName: string;
   result: unknown;
   outputText?: string;
+  hasDeliverableStructuredMedia: boolean;
+}): ToolOutputVisibility {
+  if (params.hasDeliverableStructuredMedia) {
+    return "media-delivery";
+  }
+  if (
+    PROVIDER_INVENTORY_TOOLS.has(params.toolName) &&
+    hasProviderInventoryDetails(params.result) &&
+    params.outputText?.trim()
+  ) {
+    return "diagnostic";
+  }
+  return "public";
+}
+
+function shouldEmitUserVisibleToolOutput(params: {
+  ctx: ToolHandlerContext;
+  visibility: ToolOutputVisibility;
 }): boolean {
-  if (!COMPACT_PROVIDER_INVENTORY_TOOLS.has(params.toolName)) {
-    return false;
+  switch (params.visibility) {
+    case "diagnostic":
+    case "internal":
+      return params.ctx.shouldEmitInternalDiagnosticToolOutput?.() ?? false;
+    case "media-delivery":
+    case "public":
+      return params.ctx.shouldEmitToolOutput();
   }
-  if (!hasProviderInventoryDetails(params.result)) {
-    return false;
-  }
-  return Boolean(params.outputText?.trim());
 }
 
 function readExecApprovalPendingDetails(result: unknown): {
@@ -533,15 +554,21 @@ async function emitToolResultOutput(params: {
   const mediaUrls = mediaReply
     ? filterToolResultMediaUrls(rawToolName, mediaReply.mediaUrls, result, ctx.builtinToolNames)
     : [];
+  const hasDeliverableStructuredMedia = hasStructuredMedia && mediaUrls.length > 0;
+  const outputVisibility = classifyToolOutputVisibility({
+    toolName,
+    result,
+    outputText,
+    hasDeliverableStructuredMedia,
+  });
   const shouldEmitOutput =
     !shouldSuppressStructuredMediaToolOutput({
       toolName,
       rawToolName,
       isToolError,
-      hasDeliverableStructuredMedia: hasStructuredMedia && mediaUrls.length > 0,
+      hasDeliverableStructuredMedia,
       builtinToolNames: ctx.builtinToolNames,
-    }) &&
-    (ctx.shouldEmitToolOutput() || shouldEmitCompactToolOutput({ toolName, result, outputText }));
+    }) && shouldEmitUserVisibleToolOutput({ ctx, visibility: outputVisibility });
   if (shouldEmitOutput) {
     if (outputText) {
       ctx.emitToolOutput(rawToolName, meta, outputText, result);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -118,6 +118,7 @@ export type EmbeddedPiSubscribeContext = {
 
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
+  shouldEmitInternalDiagnosticToolOutput?: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
   emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
   stripBlockTags: (
@@ -220,6 +221,7 @@ export type ToolHandlerContext = {
   flushBlockReplyBuffer: () => void | Promise<void>;
   shouldEmitToolResult: () => boolean;
   shouldEmitToolOutput: () => boolean;
+  shouldEmitInternalDiagnosticToolOutput?: () => boolean;
   emitToolSummary: (toolName?: string, meta?: string) => void;
   emitToolOutput: (toolName?: string, meta?: string, output?: string, result?: unknown) => void;
   trimMessagingToolSent: () => void;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -506,6 +506,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     typeof params.shouldEmitToolOutput === "function"
       ? params.shouldEmitToolOutput()
       : params.verboseLevel === "full";
+  const shouldEmitInternalDiagnosticToolOutput = () =>
+    typeof params.shouldEmitInternalDiagnosticToolOutput === "function"
+      ? params.shouldEmitInternalDiagnosticToolOutput()
+      : params.verboseLevel === "full";
   const formatToolOutputBlock = (text: string) => {
     const trimmed = text.trim();
     if (!trimmed) {
@@ -900,6 +904,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     noteLastAssistant,
     shouldEmitToolResult,
     shouldEmitToolOutput,
+    shouldEmitInternalDiagnosticToolOutput,
     emitToolSummary,
     emitToolOutput,
     stripBlockTags,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -20,6 +20,7 @@ export type SubscribeEmbeddedPiSessionParams = {
   toolResultFormat?: ToolResultFormat;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
+  shouldEmitInternalDiagnosticToolOutput?: () => boolean;
   onToolResult?: (payload: ReplyPayload) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4402,6 +4402,37 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("does not deliver automatic diagnostic tool text in default Discord channel turns", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    let capturedOnToolResult: ((payload: ReplyPayload) => Promise<void>) | undefined;
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      capturedOnToolResult = opts?.onToolResult as
+        | ((payload: ReplyPayload) => Promise<void>)
+        | undefined;
+      return { text: "final reply" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "channel",
+        From: "discord:channel:C1",
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:main:discord:channel:C1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(capturedOnToolResult).toBeDefined();
+    await capturedOnToolResult!({ text: "openai: default=sora-2 | auth=OPENAI_API_KEY" });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("falls back to automatic group/channel delivery when the message tool is unavailable", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();


### PR DESCRIPTION
## Summary

- Problem: `image_generate` / `video_generate` provider-list output contains provider, model, auth-env-var hint, and capability inventory, but compact list output could emit even when normal tool output was hidden.
- Why it matters: this is not raw credential disclosure, but it can fingerprint operator/provider configuration on shared or externally visible surfaces.
- What changed: provider inventory list output is classified as internal diagnostic tool output and routed through `shouldEmitUserVisibleToolOutput(...)`; generated media delivery from `details.media` remains separately queued.
- What did NOT change (scope boundary): no Discord/group-specific rules were added to the media tool handler, and no provider list content was redacted or reshaped.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75166
- Related #75550
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: commit `932194b` added compact media provider-inventory emission by OR-ing `shouldEmitCompactToolOutput(...)` with `ctx.shouldEmitToolOutput()`, so `details.providers` list results could bypass normal hidden-tool-output policy.
- Missing detection / guardrail: existing coverage explicitly expected compact `video_generate action=list` output to emit while `shouldEmitToolOutput()` was false.
- Contributing context (if known): provider list actions expose diagnostic inventory for operator troubleshooting, but that data was not marked as internal/diagnostic before the handler made user-visible delivery decisions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts`; `src/auto-reply/reply/dispatch-from-config.test.ts`
- Scenario the test should lock in: hidden image/video provider inventory does not emit, diagnostic output emits only when explicitly allowed, structured generated media still queues, and default Discord channel delivery suppresses automatic diagnostic text.
- Why this is the smallest reliable guardrail: the bug is in handler-level visibility classification, with one dispatcher test documenting channel reachability limits.
- Existing test that already covers this (if any): existing structured media tests covered some media queueing; this PR adds a hidden-output structured-media regression.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Provider inventory from `image_generate action=list` and `video_generate action=list` is no longer shown when tool output is hidden. Full verbose/debug diagnostic output still works when the explicit diagnostic policy allows it.

## Diagram (if applicable)

```text
Before:
provider list -> details.providers -> compact bypass -> visible text even when tool output hidden

After:
provider list -> diagnostic visibility -> explicit diagnostic/full-verbose policy -> visible only when allowed
generated media -> details.media -> pending media queue -> delivery preserved
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): agent tool output; Discord channel dispatcher regression
- Relevant config (redacted): hidden tool output / default Discord channel delivery

### Steps

1. Trigger `image_generate` or `video_generate` with `action=list` while `shouldEmitToolOutput()` is false.
2. Observe that the returned text includes provider/model/auth-env-var hint/capability inventory and `details.providers`.
3. Verify the handler treats that result as diagnostic and does not call `emitToolOutput` unless diagnostic output is explicitly allowed.

### Expected

- Hidden tool-output mode does not emit provider inventory text.
- Generated media in `details.media` is still queued/delivered.

### Actual

- Fixed by this PR.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Code evidence: provider list results include `details.providers`; the old handler bypassed `ctx.shouldEmitToolOutput()` via `shouldEmitCompactToolOutput(...)`; commit `932194b` added that behavior and a test expecting emission while `shouldEmitToolOutput()` was false.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: formatted changed files and linted changed TypeScript files with oxlint.
- Edge cases checked: hidden image/video inventory, explicit diagnostic/verbose emission, generated media queueing, default Discord channel automatic tool-result suppression.
- What you did **not** verify: per request, I did not run local unit/e2e tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators relying on hidden-mode compact provider lists will no longer see them.
  - Mitigation: full verbose/debug diagnostic policy can still explicitly allow diagnostic tool output.