### PR TITLE
fix(onboarding): scope post-config runtime deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - fix(infra): block ambient Homebrew env vars from brew resolution. (#74463) Thanks @pgondhi987.
+- Onboarding/configure: avoid staging every default plugin runtime dependency after config writes, so skipped setup flows only prepare config-selected plugin deps instead of pulling broad feature-plugin packages. Thanks @vincentkoc.
 - Thinking/providers: resolve bundled provider thinking profiles through lightweight provider policy artifacts when startup-lazy providers are not active, so OpenAI Codex GPT-5.x keeps xhigh available in Gateway session validation. Fixes #74796. Thanks @maxschachere.
 - Security/Windows: ignore workspace `.env` system-path variables and resolve stale-process `taskkill.exe` from the validated Windows install root, preventing repository-local env files from redirecting cleanup helpers. Thanks @pgondhi987.
 - Plugins/TTS: keep bundled speech-provider discovery available on cold package Gateway paths and add bundled plugin matrix runtime probes for health, readiness, RPC, TTS discovery, and post-ready runtime-deps watchdog coverage. Refs #75283. Thanks @vincentkoc.

--- a/src/commands/post-config-runtime-deps.test.ts
+++ b/src/commands/post-config-runtime-deps.test.ts
@@ -95,6 +95,7 @@ describe("preparePostConfigBundledRuntimeDeps", () => {
       packageRoot: "/pkg",
       config,
       includeConfiguredChannels: true,
+      includeEnabledByDefaultPlugins: false,
       env,
     });
     expect(mocks.repairBundledRuntimeDepsPackagePlanAsync).toHaveBeenCalledWith(
@@ -102,6 +103,7 @@ describe("preparePostConfigBundledRuntimeDeps", () => {
         packageRoot: "/pkg",
         config,
         includeConfiguredChannels: true,
+        includeEnabledByDefaultPlugins: false,
         env,
       }),
     );

--- a/src/commands/post-config-runtime-deps.ts
+++ b/src/commands/post-config-runtime-deps.ts
@@ -66,6 +66,7 @@ export async function preparePostConfigBundledRuntimeDeps(params: {
     packageRoot,
     config: params.config,
     includeConfiguredChannels: true,
+    includeEnabledByDefaultPlugins: false,
     env,
   });
   if (plan.conflicts.length > 0) {
@@ -102,6 +103,7 @@ export async function preparePostConfigBundledRuntimeDeps(params: {
       packageRoot,
       config: params.config,
       includeConfiguredChannels: true,
+      includeEnabledByDefaultPlugins: false,
       env,
       ...(params.installDeps
         ? {

--- a/src/plugins/bundled-runtime-deps-selection.ts
+++ b/src/plugins/bundled-runtime-deps-selection.ts
@@ -482,6 +482,7 @@ export function isBundledPluginConfiguredForRuntimeDeps(params: {
   pluginDir: string;
   configuredModelOwnerPluginIds?: ReadonlySet<string>;
   includeConfiguredChannels?: boolean;
+  includeEnabledByDefaultPlugins?: boolean;
   manifestCache?: BundledPluginRuntimeDepsManifestCache;
 }): boolean {
   if (
@@ -560,7 +561,11 @@ export function isBundledPluginConfiguredForRuntimeDeps(params: {
   ) {
     return true;
   }
-  return manifest.enabledByDefault && manifest.providers.length === 0;
+  return (
+    (params.includeEnabledByDefaultPlugins ?? true) &&
+    manifest.enabledByDefault &&
+    manifest.providers.length === 0
+  );
 }
 
 function isBundledPluginExplicitlyDisabledForRuntimeDeps(params: {
@@ -600,6 +605,7 @@ function shouldIncludeBundledPluginRuntimeDeps(params: {
   pluginDir: string;
   configuredModelOwnerPluginIds?: ReadonlySet<string>;
   includeConfiguredChannels?: boolean;
+  includeEnabledByDefaultPlugins?: boolean;
   manifestCache?: BundledPluginRuntimeDepsManifestCache;
 }): boolean {
   if (params.exactPluginIds) {
@@ -650,6 +656,7 @@ function shouldIncludeBundledPluginRuntimeDeps(params: {
     pluginDir: params.pluginDir,
     configuredModelOwnerPluginIds: params.configuredModelOwnerPluginIds,
     includeConfiguredChannels: params.includeConfiguredChannels,
+    includeEnabledByDefaultPlugins: params.includeEnabledByDefaultPlugins,
     manifestCache: params.manifestCache,
   });
 }
@@ -660,6 +667,7 @@ export function collectBundledPluginRuntimeDeps(params: {
   pluginIds?: ReadonlySet<string>;
   exactPluginIds?: ReadonlySet<string>;
   includeConfiguredChannels?: boolean;
+  includeEnabledByDefaultPlugins?: boolean;
   manifestCache?: BundledPluginRuntimeDepsManifestCache;
   normalizePluginId?: NormalizePluginId;
 }): {
@@ -707,6 +715,7 @@ export function collectBundledPluginRuntimeDeps(params: {
         pluginDir,
         configuredModelOwnerPluginIds,
         includeConfiguredChannels: params.includeConfiguredChannels,
+        includeEnabledByDefaultPlugins: params.includeEnabledByDefaultPlugins,
         manifestCache,
       })
     ) {

--- a/src/plugins/bundled-runtime-deps.test.ts
+++ b/src/plugins/bundled-runtime-deps.test.ts
@@ -1145,6 +1145,7 @@ describe("createBundledRuntimeDepsPackagePlan config policy", () => {
     name: string;
     config: Parameters<typeof createBundledRuntimeDepsPackagePlan>[0]["config"];
     includeConfiguredChannels: boolean;
+    includeEnabledByDefaultPlugins?: boolean;
     expectedDeps: string[];
   };
 
@@ -1329,18 +1330,43 @@ describe("createBundledRuntimeDepsPackagePlan config policy", () => {
       includeConfiguredChannels: false,
       expectedDeps: ["alpha-runtime@1.0.0"],
     },
+    {
+      name: "can omit default-enabled bundled plugins for post-config repair",
+      config: {},
+      includeConfiguredChannels: true,
+      includeEnabledByDefaultPlugins: false,
+      expectedDeps: [],
+    },
+    {
+      name: "includes configured channels when default-enabled plugins are omitted",
+      config: { channels: { telegram: { botToken: "123:abc" } } },
+      includeConfiguredChannels: true,
+      includeEnabledByDefaultPlugins: false,
+      expectedDeps: ["telegram-runtime@2.0.0"],
+    },
+    {
+      name: "includes configured provider deps when default-enabled plugins are omitted",
+      config: { agents: { defaults: { model: "amazon-bedrock/claude-opus-4-7" } } },
+      includeConfiguredChannels: false,
+      includeEnabledByDefaultPlugins: false,
+      expectedDeps: ["bedrock-runtime@3.0.0"],
+    },
   ];
 
-  it.each(cases)("$name", ({ config, includeConfiguredChannels, expectedDeps }) => {
-    const result = createBundledRuntimeDepsPackagePlan({
-      packageRoot: setupPolicyPackageRoot(),
-      config,
-      includeConfiguredChannels,
-    });
+  it.each(cases)(
+    "$name",
+    ({ config, includeConfiguredChannels, includeEnabledByDefaultPlugins, expectedDeps }) => {
+      const result = createBundledRuntimeDepsPackagePlan({
+        packageRoot: setupPolicyPackageRoot(),
+        config,
+        includeConfiguredChannels,
+        ...(includeEnabledByDefaultPlugins !== undefined ? { includeEnabledByDefaultPlugins } : {}),
+      });
 
-    expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual(expectedDeps);
-    expect(result.conflicts).toEqual([]);
-  });
+      expect(result.deps.map((dep) => `${dep.name}@${dep.version}`)).toEqual(expectedDeps);
+      expect(result.conflicts).toEqual([]);
+    },
+  );
 
   it("honors deny and disabled entries when scanning an explicit effective plugin set", () => {
     const packageRoot = setupPolicyPackageRoot();

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -92,6 +92,7 @@ export type BundledRuntimeDepsPackagePlanParams = {
   pluginIds?: readonly string[];
   exactPluginIds?: readonly string[];
   includeConfiguredChannels?: boolean;
+  includeEnabledByDefaultPlugins?: boolean;
   env?: NodeJS.ProcessEnv;
 };
 
@@ -367,6 +368,9 @@ export function createBundledRuntimeDepsPackagePlan(
     ...(!exactPluginIds && params.includeConfiguredChannels !== undefined
       ? { includeConfiguredChannels: params.includeConfiguredChannels }
       : {}),
+    ...(!exactPluginIds && params.includeEnabledByDefaultPlugins !== undefined
+      ? { includeEnabledByDefaultPlugins: params.includeEnabledByDefaultPlugins }
+      : {}),
     manifestCache,
     ...(normalizePluginId ? { normalizePluginId } : {}),
   });
@@ -394,6 +398,7 @@ export async function repairBundledRuntimeDepsPackagePlanAsync(params: {
   pluginIds?: readonly string[];
   exactPluginIds?: readonly string[];
   includeConfiguredChannels?: boolean;
+  includeEnabledByDefaultPlugins?: boolean;
   env: NodeJS.ProcessEnv;
   installDeps?: (params: BundledRuntimeDepsInstallParams) => Promise<void> | void;
   onProgress?: (message: string) => void;


### PR DESCRIPTION
## Summary
- keep the broad runtime-deps planner default unchanged for gateway/doctor repair paths
- add `includeEnabledByDefaultPlugins` so post-config flows can omit default feature-plugin packages
- make onboarding/configure post-config repair stage only config-selected deps instead of every enabled-by-default bundled plugin
- update changelog with Thanks @vincentkoc

## Bug / behavior
Packaged onboarding/configure post-config repair treated enabled-by-default feature plugins as required even when the user skipped setup. A quickstart local config with channels/providers/search/skills skipped still planned broad feature-plugin runtime deps.

## Live evidence
Package-plan probe against packaged `dist/extensions` before this change:
- skip-style local config: 18 install specs, including browser/playwright, Deepgram, Microsoft, QQ, readability, and other broad feature-plugin deps
- configured WhatsApp config: 20 install specs

Package-plan probe after this change:
- skip-style local config: 2 install specs, only the config-selected/default memory slot deps (`chokidar`, `typebox`)
- configured WhatsApp config: 5 install specs, WhatsApp deps plus the same memory deps

## Validation
- Crabbox `cbx_01d6e6afe35b` / `jade-barnacle`, hydrated from branch ref `qa-onboarding-stress`
- `run_e2a7fc1be27a`: remote changed lanes verified only changelog plus `post-config-runtime-deps` and bundled runtime-deps files; lanes core/coreTests/docs
- `run_58832c0ea98e`: `pnpm test:serial src/commands/post-config-runtime-deps.test.ts src/plugins/bundled-runtime-deps.test.ts` passed, 162 tests
- `run_077c602fb654`: `pnpm check:changed` passed
