### PR TITLE
fix: guard against undefined content blocks in anthropic-messages adapter

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -337,6 +337,9 @@ function convertAnthropicMessages(
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
       for (const block of msg.content) {
+        if (!block) {
+          continue;
+        }
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
             blocks.push({

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -244,3 +244,66 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(bedrockCanonical.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
   });
 });
+
+describe("transformTransportMessages handles malformed content blocks", () => {
+  const model = makeModel("anthropic-messages" as Api, "minimax", "MiniMax-M2.5");
+
+  function assistantMsg(
+    content: unknown[],
+    stopReason = "max_tokens" as const,
+  ): Extract<Context["messages"][number], { role: "assistant" }> {
+    return {
+      role: "assistant",
+      provider: "minimax",
+      api: "anthropic-messages",
+      model: "MiniMax-M2.5",
+      stopReason,
+      timestamp: Date.now(),
+      content,
+    } as Extract<Context["messages"][number], { role: "assistant" }>;
+  }
+
+  it("does not throw when content is an empty array", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    // empty-content assistant with non-error stopReason passes through
+    expect(result.some((m) => m.role === "assistant")).toBe(true);
+  });
+
+  it("does not throw when content contains only a thinking block", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([{ type: "thinking", thinking: "reasoning...", thinkingSignature: "" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    // thinking without signature is converted to text for non-same-model
+    expect((assistant as any).content[0].type).toBe("text");
+  });
+
+  it("does not throw when a content block is undefined", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([undefined, { type: "text", text: "hi" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect((assistant as any).content).toHaveLength(1);
+    expect((assistant as any).content[0].type).toBe("text");
+  });
+
+  it("does not throw when a content block is null", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([null, { type: "text", text: "ok" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect((assistant as any).content).toHaveLength(1);
+  });
+});

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -68,6 +68,9 @@ export function transformTransportMessages(
       msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
     const content: typeof msg.content = [];
     for (const block of msg.content) {
+      if (!block) {
+        continue;
+      }
       if (block.type === "thinking") {
         if (block.redacted) {
           if (isSameModel) {


### PR DESCRIPTION
Fixes #75633

## Root Cause

The anthropic-messages adapter's message reconstruction loops in `convertAnthropicMessages` and `transformTransportMessages` access `block.type` without guarding against `block` being `undefined` or `null`. When a provider like MiniMax returns a response where the content array contains sparse/malformed entries (or session repair preserves them), the loop crashes with:

```
Cannot read properties of undefined (reading 'type')
```

This affects ~26% of cron sessions when MiniMax's Anthropic-compatible endpoint returns responses with only thinking blocks or empty content that gets stored with malformed entries.

## Fix

Added defensive `if (!block) { continue; }` guards in both iteration sites:

- `src/agents/transport-message-transform.ts` — the shared message transform used by all transports
- `src/agents/anthropic-transport-stream.ts` — the Anthropic-specific wire-format reconstruction in `convertAnthropicMessages`

## Files Changed

- `src/agents/transport-message-transform.ts`
- `src/agents/anthropic-transport-stream.ts`
- `src/agents/transport-message-transform.test.ts` (new tests)

## Test Coverage

Added tests for:
- `content: []` (empty array) — no crash, message passes through
- `content: [{type:"thinking",...}]` (only thinking) — converted to text, no crash
- `content: [undefined, {type:"text",...}]` — undefined skipped, text preserved
- `content: [null, {type:"text",...}]` — null skipped, text preserved