### PR TITLE
fix: symlink node_modules into mirrored dist root for ESM bare-specifier resolution

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -337,6 +337,9 @@ function convertAnthropicMessages(
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
       for (const block of msg.content) {
+        if (!block) {
+          continue;
+        }
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
             blocks.push({

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -244,3 +244,66 @@ describe("transformTransportMessages synthetic tool-result policy", () => {
     expect(bedrockCanonical.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
   });
 });
+
+describe("transformTransportMessages handles malformed content blocks", () => {
+  const model = makeModel("anthropic-messages" as Api, "minimax", "MiniMax-M2.5");
+
+  function assistantMsg(
+    content: unknown[],
+    stopReason = "max_tokens" as const,
+  ): Extract<Context["messages"][number], { role: "assistant" }> {
+    return {
+      role: "assistant",
+      provider: "minimax",
+      api: "anthropic-messages",
+      model: "MiniMax-M2.5",
+      stopReason,
+      timestamp: Date.now(),
+      content,
+    } as Extract<Context["messages"][number], { role: "assistant" }>;
+  }
+
+  it("does not throw when content is an empty array", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    // empty-content assistant with non-error stopReason passes through
+    expect(result.some((m) => m.role === "assistant")).toBe(true);
+  });
+
+  it("does not throw when content contains only a thinking block", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([{ type: "thinking", thinking: "reasoning...", thinkingSignature: "" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    // thinking without signature is converted to text for non-same-model
+    expect((assistant as any).content[0].type).toBe("text");
+  });
+
+  it("does not throw when a content block is undefined", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([undefined, { type: "text", text: "hi" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect((assistant as any).content).toHaveLength(1);
+    expect((assistant as any).content[0].type).toBe("text");
+  });
+
+  it("does not throw when a content block is null", () => {
+    const messages: Context["messages"] = [
+      { role: "user", content: "hello", timestamp: Date.now() },
+      assistantMsg([null, { type: "text", text: "ok" }]),
+    ];
+    const result = transformTransportMessages(messages, model);
+    const assistant = result.find((m) => m.role === "assistant");
+    expect((assistant as any).content).toHaveLength(1);
+  });
+});

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -68,6 +68,9 @@ export function transformTransportMessages(
       msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
     const content: typeof msg.content = [];
     for (const block of msg.content) {
+      if (!block) {
+        continue;
+      }
       if (block.type === "thinking") {
         if (block.redacted) {
           if (isSameModel) {

--- a/src/plugins/bundled-runtime-root.test.ts
+++ b/src/plugins/bundled-runtime-root.test.ts
@@ -790,4 +790,59 @@ describe("prepareBundledPluginRuntimeRoot", () => {
     expect(refreshedStat.mtimeMs).toBeGreaterThan(initialStat.mtimeMs);
     expect(fs.readFileSync(mirrorEntry, "utf8")).toContain("v2");
   });
+
+  it("creates node_modules symlink in mirrored dist root for ESM resolution", () => {
+    const packageRoot = makeTempRoot();
+    const stageDir = makeTempRoot();
+    const pluginRoot = path.join(packageRoot, "dist", "extensions", "slack");
+    const env = { ...process.env, OPENCLAW_PLUGIN_STAGE_DIR: stageDir };
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "2026.4.29", type: "module" }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginRoot, "index.js"), "export default {};\n", "utf8");
+    fs.writeFileSync(
+      path.join(pluginRoot, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/slack",
+        version: "1.0.0",
+        type: "module",
+        dependencies: { json5: "^2.2.3" },
+        openclaw: { extensions: ["./index.js"] },
+      }),
+      "utf8",
+    );
+    const installRoot = resolveBundledRuntimeDependencyInstallRoot(pluginRoot, { env });
+    fs.mkdirSync(path.join(installRoot, "node_modules", "json5", "lib"), { recursive: true });
+    fs.writeFileSync(
+      path.join(installRoot, "node_modules", "json5", "package.json"),
+      JSON.stringify({ name: "json5", version: "2.2.3", main: "lib/index.js" }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(installRoot, "node_modules", "json5", "lib", "index.js"),
+      "module.exports = {};\n",
+      "utf8",
+    );
+    writeGeneratedRuntimeDepsManifest(installRoot, ["json5@^2.2.3"]);
+
+    prepareBundledPluginRuntimeRoot({
+      pluginId: "slack",
+      pluginRoot,
+      modulePath: path.join(pluginRoot, "index.js"),
+      env,
+    });
+
+    // The mirrored dist root should have a node_modules symlink pointing to installRoot/node_modules
+    const mirrorDistRoot = path.join(installRoot, "dist");
+    const distNodeModules = path.join(mirrorDistRoot, "node_modules");
+    expect(fs.existsSync(distNodeModules)).toBe(true);
+    expect(fs.lstatSync(distNodeModules).isSymbolicLink()).toBe(true);
+    // The symlink target should resolve to the installRoot's node_modules
+    expect(fs.realpathSync(distNodeModules)).toBe(
+      fs.realpathSync(path.join(installRoot, "node_modules")),
+    );
+  });
 });

--- a/src/plugins/bundled-runtime-root.ts
+++ b/src/plugins/bundled-runtime-root.ts
@@ -328,6 +328,7 @@ function prepareBundledPluginRuntimeDistMirror(params: {
     });
   }
   ensureOpenClawPluginSdkAlias(mirrorDistRoot);
+  ensureBundledRuntimeDistNodeModulesLink(mirrorDistRoot, params.installRoot);
   return mirrorExtensionsRoot;
 }
 
@@ -420,6 +421,7 @@ function mirrorCanonicalBundledRuntimeDistRoot(params: {
     });
   }
   ensureOpenClawPluginSdkAlias(targetCanonicalDistRoot);
+  ensureBundledRuntimeDistNodeModulesLink(targetCanonicalDistRoot, params.installRoot);
 
   const pluginId = path.basename(params.pluginRoot);
   const sourceCanonicalPluginRoot = path.join(sourceCanonicalDistRoot, "extensions", pluginId);
@@ -454,6 +456,44 @@ function precomputeCanonicalBundledRuntimeDistPluginMetadata(params: {
     return undefined;
   }
   return precomputeBundledRuntimeMirrorMetadata({ sourceRoot: sourceCanonicalPluginRoot });
+}
+
+function ensureBundledRuntimeDistNodeModulesLink(
+  mirrorDistRoot: string,
+  installRoot: string,
+): void {
+  const installNodeModules = path.join(installRoot, "node_modules");
+  const distNodeModules = path.join(mirrorDistRoot, "node_modules");
+  if (path.resolve(installNodeModules) === path.resolve(distNodeModules)) {
+    return;
+  }
+  try {
+    const stat = fs.lstatSync(distNodeModules);
+    if (stat.isSymbolicLink()) {
+      // Already linked — verify target matches.
+      const existingTarget = fs.realpathSync(distNodeModules);
+      if (existingTarget === fs.realpathSync(installNodeModules)) {
+        return;
+      }
+      fs.unlinkSync(distNodeModules);
+    } else {
+      // Non-symlink entry exists (unexpected); leave it alone.
+      return;
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return;
+    }
+  }
+  if (!fs.existsSync(installNodeModules)) {
+    return;
+  }
+  try {
+    fs.symlinkSync(installNodeModules, distNodeModules, "dir");
+  } catch {
+    // Best-effort: if symlink fails (e.g. permissions), ESM resolution can still
+    // walk up to <installRoot>/node_modules via parent directory traversal.
+  }
 }
 
 function ensureBundledRuntimeDistPackageJson(mirrorDistRoot: string): void {


### PR DESCRIPTION
## Summary

When bundled plugin dist files are mirrored into the plugin-runtime-deps install root (e.g. `~/.openclaw/plugin-runtime-deps/openclaw-<ver>-<hash>/dist/`), ESM bare-specifier imports like `import JSON5 from "json5"` from chunks inside that `dist/` directory must resolve dependencies via `node_modules` traversal.

## Root Cause

The mirrored `dist/` directory contains a `package.json` with `{"type": "module"}` and shared chunks (e.g. `frontmatter-Cc-V8aI2.js`) that import runtime dependencies like `json5`. The actual `node_modules/` lives at `<installRoot>/node_modules/`, one level above `dist/`.

In Node 25, when modules are loaded via `require(esm)` (the CJS-to-ESM bridge used by the plugin loader's `tryNativeRequireJavaScriptModule`), the ESM resolver does not consistently walk above the `dist/` package boundary to find `<installRoot>/node_modules/`. This causes Slack and Telegram channel providers to crash immediately after gateway startup with:

```
Cannot find package 'json5' imported from .../dist/frontmatter-Cc-V8aI2.js
```

## Fix

After mirroring the dist root, create a symlink `<installRoot>/dist/node_modules → <installRoot>/node_modules` so ESM bare-specifier resolution finds runtime dependencies immediately from the importing file's directory, regardless of the loading mechanism (native `import()`, `require(esm)`, or jiti).

The symlink is created best-effort: if it fails (e.g. filesystem permissions), the existing parent-directory traversal path remains as fallback.

## Changed Files

- `src/plugins/bundled-runtime-root.ts` — add `ensureBundledRuntimeDistNodeModulesLink()` called from both `prepareBundledPluginRuntimeDistMirror` and `mirrorCanonicalBundledRuntimeDistRoot`
- `src/plugins/bundled-runtime-root.test.ts` — test verifying the symlink is created

## Test Coverage

Added unit test: "creates node_modules symlink in mirrored dist root for ESM resolution"

Fixes #75623