### PR TITLE
fix: route memory embedding fetches through env proxy

### DIFF
--- a/src/memory-host-sdk/host/remote-http.ts
+++ b/src/memory-host-sdk/host/remote-http.ts
@@ -1,4 +1,5 @@
-import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
+import { fetchWithSsrFGuard, type GuardedFetchMode } from "../../infra/net/fetch-guard.js";
+import { hasProxyEnvConfigured } from "../../infra/net/proxy-env.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 export function buildRemoteBaseUrlPolicy(baseUrl: string): SsrFPolicy | undefined {
@@ -25,14 +26,21 @@ export async function withRemoteHttpResponse<T>(params: {
   ssrfPolicy?: SsrFPolicy;
   fetchImpl?: typeof fetch;
   auditContext?: string;
+  mode?: GuardedFetchMode;
   onResponse: (response: Response) => Promise<T>;
 }): Promise<T> {
+  // When env proxy vars are set (e.g. CrabTrap) and the caller hasn't
+  // explicitly chosen a mode, use trusted_env_proxy so the request routes
+  // through the operator-configured proxy instead of connecting directly.
+  const mode: GuardedFetchMode | undefined =
+    params.mode ?? (hasProxyEnvConfigured() ? "trusted_env_proxy" : undefined);
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
     fetchImpl: params.fetchImpl,
     init: params.init,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
+    ...(mode ? { mode } : {}),
   });
   try {
     return await params.onResponse(response);


### PR DESCRIPTION
## Summary

- `withRemoteHttpResponse` (used by all remote embedding providers — OpenAI, Voyage, Mistral, Gemini) calls `fetchWithSsrFGuard` without specifying a `mode`, defaulting to `STRICT`. In strict mode the guard resolves DNS, pins IPs, and connects directly — bypassing `HTTP_PROXY`/`HTTPS_PROXY` entirely.
- When the embedding endpoint resolves to private IPs (e.g. an internal gateway like CrabTrap at `10.x.x.x`), the direct connection fails with `TypeError: fetch failed` because the host is only reachable through the HTTP proxy.
- This fix auto-detects env proxy vars via `hasProxyEnvConfigured()` and switches to `trusted_env_proxy` mode so the request routes through the operator-configured proxy. This matches how `web-guarded-fetch.ts` already handles proxy environments. Callers can still override via the new `mode` param.

## Context

Discovered while debugging memory search returning `disabled: true` with `fetch failed` on an OpenClaw deployment behind CrabTrap (egress proxy). The LLM gateway key and endpoint were valid — `curl` (which respects `HTTPS_PROXY`) worked fine, but Node's fetch via the SSRF guard connected directly and failed.

## Test plan

- [x] `post-json.test.ts` — 2 tests pass
- [x] `embeddings-remote-fetch.test.ts` — 2 tests pass
- [x] `batch-http.test.ts` — 2 tests pass
- [x] `batch-openai.test.ts` — 1 test passes
- [x] `batch-gemini.test.ts` — 2 tests passes
- [x] `batch-voyage.test.ts` — 1 test passes
- [x] All pre-commit hooks pass (lint, import cycles, tsgo)
- [ ] Manual verification on a proxy-gated deployment (CrabTrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)