### PR TITLE
docs(doctor): clarify service repair prompts

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -29,10 +29,10 @@ openclaw doctor --generate-gateway-token
 
 - `--no-workspace-suggestions`: disable workspace memory/search suggestions
 - `--yes`: accept defaults without prompting
-- `--repair`: apply recommended repairs without prompting
+- `--repair`: apply recommended non-service repairs without prompting; gateway service installs and rewrites still require interactive confirmation or explicit gateway commands
 - `--fix`: alias for `--repair`
 - `--force`: apply aggressive repairs, including overwriting custom service config when needed
-- `--non-interactive`: run without prompts; safe migrations only
+- `--non-interactive`: run without prompts; safe migrations and non-service repairs only
 - `--generate-gateway-token`: generate and configure a gateway token
 - `--deep`: scan system services for extra gateway installs
 
@@ -41,6 +41,7 @@ Notes:
 - Interactive prompts (like keychain/OAuth fixes) only run when stdin is a TTY and `--non-interactive` is **not** set. Headless runs (cron, Telegram, no terminal) will skip prompts.
 - Performance: non-interactive `doctor` runs skip eager plugin loading so headless health checks stay fast. Interactive sessions still fully load plugins when a check needs their contribution.
 - `--fix` (alias for `--repair`) writes a backup to `~/.openclaw/openclaw.json.bak` and drops unknown config keys, listing each removal.
+- `doctor --fix --non-interactive` reports missing or stale gateway service definitions but does not install or rewrite them outside update repair mode. Run `openclaw gateway install` for a missing service, or `openclaw gateway install --force` when you intentionally want to replace the launcher.
 - State integrity checks now detect orphan transcript files in the sessions directory. Archiving them as `.deleted.<timestamp>` requires an interactive confirmation; `--fix`, `--yes`, and headless runs leave them in place.
 - Doctor also scans `~/.openclaw/cron/jobs.json` (or `cron.store`) for legacy cron job shapes and can rewrite them in place before the scheduler has to auto-normalize them at runtime.
 - Doctor repairs missing bundled plugin runtime dependencies without writing into packaged global installs. For root-owned npm installs or hardened systemd units, set `OPENCLAW_PLUGIN_STAGE_DIR` to a writable directory such as `/var/lib/openclaw/plugin-runtime-deps`; it can also be a path-list such as `/opt/openclaw/plugin-runtime-deps:/var/lib/openclaw/plugin-runtime-deps`, where earlier roots are read-only lookup layers and the final root is the repair target.


### PR DESCRIPTION
## Summary

- document that `doctor --fix --non-interactive` reports missing or stale Gateway service definitions without installing or rewriting them outside update repair mode
- point users at `openclaw gateway install` for missing services and `openclaw gateway install --force` for intentional launcher replacement
- follow-up to the docs gap from https://github.com/openclaw/openclaw/pull/75589

## Tests

- Local: `pnpm docs:list`
- Local: `git diff --check origin/main...HEAD`
- Local: `pnpm changed:lanes --json` selected docs-only
- Local: `pnpm exec oxfmt --check --threads=1 docs/cli/doctor.md`
- Crabbox `cbx_85f0261eb5ba` / `crimson-crab`: `run_8acb3fb00096` passed `git diff --check origin/main...HEAD && pnpm exec oxfmt --check --threads=1 docs/cli/doctor.md && pnpm check:changed`
