### PR TITLE
test(release): check built bundled extension deps

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S node --import tsx
 
 import { execSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -128,6 +128,7 @@ function normalizePluginSyncVersion(version: string): string {
 export function collectBundledExtensionRootDependencyGapErrors(params: {
   rootPackage: PackageJson;
   extensions: BundledExtension[];
+  sourceLabel?: string;
 }): string[] {
   const rootDeps = {
     ...params.rootPackage.dependencies,
@@ -148,7 +149,7 @@ export function collectBundledExtensionRootDependencyGapErrors(params: {
       const unexpected = missing.filter((dep) => !allowlisted.includes(dep));
       const resolved = allowlisted.filter((dep) => !missing.includes(dep));
       const parts = [
-        `bundled extension '${extension.id}' root dependency mirror drift`,
+        `bundled extension '${extension.id}' ${params.sourceLabel ?? "root"} dependency mirror drift`,
         `missing in root package: ${missing.length > 0 ? missing.join(", ") : "(none)"}`,
       ];
       if (unexpected.length > 0) {
@@ -164,8 +165,10 @@ export function collectBundledExtensionRootDependencyGapErrors(params: {
   return errors;
 }
 
-function collectBundledExtensions(): BundledExtension[] {
-  const extensionsDir = resolve("extensions");
+function collectBundledExtensionsFromDir(extensionsDir: string): BundledExtension[] {
+  if (!existsSync(extensionsDir)) {
+    return [];
+  }
   const entries = readdirSync(extensionsDir, { withFileTypes: true }).filter((entry) =>
     entry.isDirectory(),
   );
@@ -185,6 +188,14 @@ function collectBundledExtensions(): BundledExtension[] {
   });
 }
 
+function collectBundledExtensions(): BundledExtension[] {
+  return collectBundledExtensionsFromDir(resolve("extensions"));
+}
+
+function collectBuiltBundledExtensions(): BundledExtension[] {
+  return collectBundledExtensionsFromDir(resolve("dist", "extensions"));
+}
+
 function checkBundledExtensionRootDependencyMirrors() {
   const rootPackage = JSON.parse(readFileSync(resolve("package.json"), "utf8")) as PackageJson;
   const extensions = collectBundledExtensions();
@@ -200,6 +211,13 @@ function checkBundledExtensionRootDependencyMirrors() {
     rootPackage,
     extensions,
   });
+  errors.push(
+    ...collectBundledExtensionRootDependencyGapErrors({
+      rootPackage,
+      extensions: collectBuiltBundledExtensions(),
+      sourceLabel: "built root",
+    }),
+  );
   if (errors.length > 0) {
     console.error("release-check: bundled extension root dependency mirror validation failed:");
     for (const error of errors) {

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -33,6 +33,26 @@ describe("collectAppcastSparkleVersionErrors", () => {
 });
 
 describe("collectBundledExtensionRootDependencyGapErrors", () => {
+  it("flags packaged built extension dependency gaps that source manifests cannot see", () => {
+    expect(
+      collectBundledExtensionRootDependencyGapErrors({
+        rootPackage: { dependencies: {} },
+        sourceLabel: "built root",
+        extensions: [
+          {
+            id: "telegram",
+            packageJson: {
+              dependencies: { grammy: "^1.42.0" },
+              openclaw: { install: { npmSpec: "@openclaw/telegram" } },
+            },
+          },
+        ],
+      }),
+    ).toEqual([
+      "bundled extension 'telegram' built root dependency mirror drift | missing in root package: grammy | new gaps: grammy",
+    ]);
+  });
+
   it("allows known gaps but still flags unallowlisted ones", () => {
     expect(
       collectBundledExtensionRootDependencyGapErrors({


### PR DESCRIPTION
## Summary

- make release-check inspect built `dist/extensions/*/package.json` manifests in addition to source `extensions/*/package.json`
- label built-manifest dependency mirror errors separately so packaged-output gaps are obvious
- add a regression test for a packaged Telegram runtime dependency gap that source manifests alone cannot see

## Why

Issue #75685 reproduced a packaged `2026.4.29` install where Discord and Telegram bundled channel files required `discord-api-types/v10` and `grammy`, but those deps were absent from the installed root package until `OPENCLAW_EAGER_BUNDLED_PLUGIN_DEPS=1 node scripts/postinstall-bundled-plugins.mjs` repaired them.

The existing release check covers source extension manifests, but the reported gap was visible in the generated/published `dist/extensions/*/package.json` manifests. Checking the built manifests during release validation should catch that class before publishing.

## Test plan

- `pnpm exec vitest run test/release-check.test.ts --config vitest.unit.config.ts`
- `pnpm exec oxfmt --check --threads=1 scripts/release-check.ts test/release-check.test.ts`
