### PR TITLE
fix: sanitize tool execution errors before surfacing to messaging channels

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -66,9 +66,9 @@ describe("formatAssistantErrorText", () => {
 
   it("does not leak filesystem paths in tool error messages", () => {
     const msg = makeAssistantError(
-      "Edit tool failed: Could not find exact text in /Users/wade.digital/.openclaw/workspace/MEMORY.md",
+      "Edit tool failed: Could not find exact text in /Users/alice/.openclaw/workspace/MEMORY.md",
     );
     const result = formatAssistantErrorText(msg);
-    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain("/Users/alice");
   });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -37,4 +37,30 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("sanitizes Brave Search API rate limit errors", () => {
+    const raw =
+      'Brave Search API error (429): {"type":"ErrorResponse","error":{"id":"32433a2a-3426-4831-8123-4553d4be9455","status":429,"detail":"Request rate limit exceeded for plan","meta":{"plan":"Free","rate_limit":1,"rate_current":1,"quota_limit":2000,"quota_current":210},"code":"RATE_LIMITED"},"time":1771039449}';
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("32433a2a");
+    expect(result).not.toContain("quota_current");
+    expect(result).not.toContain("ErrorResponse");
+    expect(result.toLowerCase()).toMatch(/rate.?limit|too many requests|try again/);
+  });
+
+  it("sanitizes tool execution errors with filesystem paths", () => {
+    const raw =
+      "Could not find exact text to replace in /Users/wade.digital/.openclaw/workspace/memory/2026-02-14.md";
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain(".openclaw/workspace");
+  });
+
+  it("sanitizes generic external API error JSON payloads", () => {
+    const raw =
+      '{"type":"ErrorResponse","error":{"status":429,"detail":"Request rate limit exceeded for plan","meta":{"plan":"Free","rate_limit":1},"code":"RATE_LIMITED"}}';
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("RATE_LIMITED");
+    expect(result).not.toContain('"meta"');
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -50,10 +50,18 @@ describe("sanitizeUserFacingText", () => {
 
   it("sanitizes tool execution errors with filesystem paths", () => {
     const raw =
-      "Could not find exact text to replace in /Users/wade.digital/.openclaw/workspace/memory/2026-02-14.md";
+      "Could not find exact text to replace in /Users/alice/.openclaw/workspace/memory/2026-02-14.md";
     const result = sanitizeUserFacingText(raw);
-    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain("/Users/alice");
     expect(result).not.toContain(".openclaw/workspace");
+  });
+
+  it("sanitizes Windows filesystem paths", () => {
+    const raw =
+      "Could not find exact text to replace in C:\\Users\\bob\\AppData\\Local\\.openclaw\\workspace\\MEMORY.md";
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("C:\\Users\\bob");
+    expect(result).not.toContain("AppData");
   });
 
   it("sanitizes generic external API error JSON payloads", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -397,7 +397,8 @@ export function formatAssistantErrorText(
   return safeRaw.length > 600 ? `${safeRaw.slice(0, 600)}…` : safeRaw;
 }
 
-const FILESYSTEM_PATH_RE = /\/(?:Users|home|tmp|var|etc)\/[^\s,)}\]]+/g;
+const FILESYSTEM_PATH_RE =
+  /(?:\/(?:Users|home|tmp|var|etc)\/[^\s,)}\]]+|[A-Z]:\\(?:Users|Documents|AppData|Program Files)[^\s,)}\]]*)/g;
 
 function stripFilesystemPaths(text: string): string {
   return text.replace(FILESYSTEM_PATH_RE, "<path>");

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -11,6 +11,7 @@ import {
   getApiErrorPayloadFingerprint,
   isRawApiErrorPayload,
   normalizeTextForComparison,
+  sanitizeUserFacingText,
 } from "../../pi-embedded-helpers.js";
 import {
   extractAssistantText,
@@ -223,7 +224,9 @@ export function buildEmbeddedRunPayloads(params: {
         params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
         { markdown: useMarkdown },
       );
-      const errorSuffix = params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+      const rawError = params.lastToolError.error ?? "";
+      const sanitizedError = rawError ? sanitizeUserFacingText(rawError) : "";
+      const errorSuffix = sanitizedError ? `: ${sanitizedError}` : "";
       replyItems.push({
         text: `⚠️ ${toolSummary} failed${errorSuffix}`,
         isError: true,


### PR DESCRIPTION
## Summary
- sanitize user-facing tool execution errors before they reach chat surfaces
- strip filesystem paths from formatted assistant error text
- extend sanitization to Windows-style paths and use generic paths in tests

## Why
Tool/runtime errors were surfacing raw path-like details into user-visible messaging contexts. This keeps the useful failure signal while removing local path leakage and making the error surface safer.

## Changes
- add sanitization in embedded helper error formatting
- apply sanitized text in embedded runner payload construction
- expand path matching to cover Windows paths
- update/add focused tests for both formatting and sanitization

## Test plan
- `pnpm exec vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
