### PR TITLE
fix: avoid quadratic task registry maintenance

### DIFF
--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -851,7 +851,7 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       }
       continue;
     }
-    await cleanupTerminalAcpSession(current, taskRegistryMaintenanceRuntime.listTaskRecords());
+    await cleanupTerminalAcpSession(current, tasks);
     if (
       shouldPruneTerminalTask(current, now) &&
       taskRegistryMaintenanceRuntime.deleteTaskRecordById(current.taskId)

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -90,6 +90,7 @@ vi.mock("../utils/message-channel.js", () => ({
 function configureTaskRegistryMaintenanceRuntimeForTest(params: {
   currentTasks: Map<string, ReturnType<typeof createTaskRecord>>;
   snapshotTasks: ReturnType<typeof createTaskRecord>[];
+  listTaskRecords?: () => ReturnType<typeof createTaskRecord>[];
   acpEntry?: AcpSessionStoreEntry;
   acpEntries?: AcpSessionStoreEntry[];
   sessionBindings?: SessionBindingRecord[];
@@ -126,7 +127,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
     deleteTaskRecordById: (taskId: string) => params.currentTasks.delete(taskId),
     ensureTaskRegistryReady: () => {},
     getTaskById: (taskId: string) => params.currentTasks.get(taskId),
-    listTaskRecords: () => params.snapshotTasks,
+    listTaskRecords: params.listTaskRecords ?? (() => params.snapshotTasks),
     markTaskLostById: (patch: {
       taskId: string;
       endedAt: number;
@@ -1625,6 +1626,47 @@ describe("task-registry", () => {
         targetSessionKey: childSessionKey,
         reason: "terminal-task-cleanup",
       });
+    });
+  });
+
+  it("reuses the maintenance task snapshot while closing terminal ACP sessions", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+      const tasks = Array.from({ length: 20 }, (_, index) => {
+        const task = createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          requesterSessionKey: "agent:main:main",
+          scopeKind: "session",
+          childSessionKey: `agent:claude:acp:terminal-${index}`,
+          runId: `run-terminal-acp-snapshot-${index}`,
+          task: `Terminal ACP task ${index}`,
+          status: "succeeded",
+          deliveryStatus: "delivered",
+        });
+        return {
+          ...task,
+          endedAt: now - 60_000,
+          lastEventAt: now - 60_000,
+        };
+      });
+      const currentTasks = new Map(tasks.map((task) => [task.taskId, task]));
+      let listCalls = 0;
+
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: tasks,
+        listTaskRecords: () => {
+          listCalls += 1;
+          return tasks;
+        },
+      });
+
+      await runTaskRegistryMaintenance();
+
+      expect(listCalls).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary

- Reuse the task snapshot already captured at the start of `runTaskRegistryMaintenance()` when checking terminal ACP session cleanup.
- Avoid calling `listTaskRecords()` once per task; that function clones/sorts/maps the entire registry.
- Add a regression test that verifies maintenance only lists task records for the initial sweep and final orphan cleanup, not per task.

Fixes #75708.

## Validation

Validated on the 2026.4.29 owned fork with the same patch:

```bash
pnpm exec vitest run src/tasks/task-registry.test.ts
```

Result: 57 tests passed.

Note: this PR branch was prepared from current `upstream/main`. The separate PR worktree does not have its own `node_modules`, so I did not reinstall dependencies there just to rerun the same focused test.
