### PR TITLE
fix(discord): preserve multipart upload content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: preserve multipart Content-Type headers for attachment uploads across REST fetch paths, so generated images and other media no longer fail delivery with `CONTENT_TYPE_INVALID`. Thanks @FunJim.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -1,3 +1,4 @@
+import { fetch as undiciFetch } from "undici";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { serializeRequestBody } from "./rest-body.js";
 import { RequestClient } from "./rest.js";
@@ -404,6 +405,79 @@ describe("RequestClient", () => {
       }),
     );
     expect(form.get("files[0]")).toBeInstanceOf(Blob);
+  });
+
+  it("dispatches multipart uploads with a multipart/form-data content type", async () => {
+    const fetchSpy = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      expect(init?.headers).toBeInstanceOf(Headers);
+      expect((init?.headers as Headers).get("Content-Type")).toMatch(
+        /^multipart\/form-data; boundary=/,
+      );
+      expect(init?.body).not.toBeInstanceOf(FormData);
+      const request = new Request("https://discord.test/upload", {
+        method: "POST",
+        headers: init?.headers,
+        body: init?.body,
+      });
+      expect(request.headers.get("Content-Type")).toMatch(/^multipart\/form-data; boundary=/);
+      return new Response(JSON.stringify({ id: "msg" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const client = new RequestClient("test-token", { fetch: fetchSpy, queueRequests: false });
+
+    await expect(
+      client.post("/channels/c1/messages", {
+        body: {
+          content: "file",
+          files: [{ name: "a.txt", data: new Uint8Array([1]), contentType: "text/plain" }],
+        },
+      }),
+    ).resolves.toEqual({ id: "msg" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches multipart uploads through undici fetch with a multipart/form-data content type", async () => {
+    const server = await new Promise<import("node:http").Server>((resolve) => {
+      void import("node:http").then(({ createServer }) => {
+        const srv = createServer((req, res) => {
+          expect(req.headers["content-type"]).toMatch(/^multipart\/form-data; boundary=/);
+          req.resume();
+          req.on("end", () => {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ id: "msg" }));
+          });
+        });
+        srv.listen(0, () => resolve(srv));
+      });
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not bind to a TCP port");
+      }
+      const client = new RequestClient("test-token", {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        apiVersion: 10,
+        fetch: undiciFetch as unknown as typeof fetch,
+        queueRequests: false,
+      });
+
+      await expect(
+        client.post("/channels/c1/messages", {
+          body: {
+            content: "file",
+            files: [{ name: "a.txt", data: new Uint8Array([1]), contentType: "text/plain" }],
+          },
+        }),
+      ).resolves.toEqual({ id: "msg" });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
   });
 
   it("serializes form multipart uploads for sticker-style endpoints", () => {

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { inspect } from "node:util";
 import { serializeRequestBody } from "./rest-body.js";
 import {
@@ -72,6 +73,52 @@ function coerceResponseBody(raw: string): unknown {
   } catch {
     return raw;
   }
+}
+
+function escapeMultipartQuotedValue(value: string): string {
+  return value.replace(/["\r\n]/g, (ch) => (ch === '"' ? "%22" : ch === "\r" ? "%0D" : "%0A"));
+}
+
+async function formDataToMultipartBody(body: FormData, headers: Headers): Promise<BodyInit> {
+  const boundary = `----openclaw-discord-${randomBytes(12).toString("hex")}`;
+  headers.set("Content-Type", `multipart/form-data; boundary=${boundary}`);
+  const chunks: Buffer[] = [];
+  const push = (value: string | Buffer) => {
+    chunks.push(typeof value === "string" ? Buffer.from(value) : value);
+  };
+  for (const [key, value] of body.entries()) {
+    push(`--${boundary}\r\n`);
+    const escapedKey = escapeMultipartQuotedValue(key);
+    if (typeof value === "string") {
+      push(`Content-Disposition: form-data; name="${escapedKey}"\r\n\r\n`);
+      push(value);
+      push("\r\n");
+      continue;
+    }
+    const filename = (value as Blob & { name?: unknown }).name;
+    const escapedFilename = escapeMultipartQuotedValue(
+      typeof filename === "string" && filename.length > 0 ? filename : "blob",
+    );
+    push(`Content-Disposition: form-data; name="${escapedKey}"; filename="${escapedFilename}"\r\n`);
+    if (value.type) {
+      push(`Content-Type: ${value.type}\r\n`);
+    }
+    push("\r\n");
+    push(Buffer.from(await value.arrayBuffer()));
+    push("\r\n");
+  }
+  push(`--${boundary}--\r\n`);
+  return Buffer.concat(chunks) as unknown as BodyInit;
+}
+
+async function normalizeFetchBody(
+  body: BodyInit | undefined,
+  headers: Headers,
+): Promise<BodyInit | undefined> {
+  if (body instanceof FormData) {
+    return await formDataToMultipartBody(body, headers);
+  }
+  return body;
 }
 
 export class RequestClient {
@@ -155,7 +202,7 @@ export class RequestClient {
       const response = await (this.customFetch ?? fetch)(url, {
         method,
         headers,
-        body,
+        body: await normalizeFetchBody(body, headers),
         signal: controller.signal,
       });
       const text = await response.text();

--- a/extensions/discord/src/proxy-request-client.ts
+++ b/extensions/discord/src/proxy-request-client.ts
@@ -1,41 +1,8 @@
-import { FormData as UndiciFormData } from "undici";
 import { RequestClient, type RequestClientOptions } from "./internal/discord.js";
 
 type ProxyRequestClientOptions = RequestClientOptions;
 
 export const DISCORD_REST_TIMEOUT_MS = 15_000;
-
-function toUndiciFormData(body: FormData): UndiciFormData {
-  const converted = new UndiciFormData();
-  for (const [key, value] of body.entries()) {
-    if (typeof value === "string") {
-      converted.append(key, value);
-      continue;
-    }
-    const filename = (value as Blob & { name?: unknown }).name;
-    if (typeof filename === "string" && filename.length > 0) {
-      converted.append(key, value, filename);
-      continue;
-    }
-    converted.append(key, value);
-  }
-  return converted;
-}
-
-function wrapDiscordFetch(fetchImpl: NonNullable<RequestClientOptions["fetch"]>) {
-  return (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-    if (init?.body instanceof FormData) {
-      // The proxy fetch path needs undici's FormData class to preserve multipart
-      // boundaries. Preserve the REST client's AbortController signal so timeout
-      // and abortAllRequests keep working.
-      return fetchImpl(input, {
-        ...init,
-        body: toUndiciFormData(init.body) as unknown as BodyInit,
-      });
-    }
-    return fetchImpl(input, init);
-  };
-}
 
 export function createDiscordRequestClient(
   token: string,
@@ -49,6 +16,6 @@ export function createDiscordRequestClient(
     maxQueueSize: 1000,
     timeout: DISCORD_REST_TIMEOUT_MS,
     ...options,
-    fetch: wrapDiscordFetch(options.fetch),
+    fetch: options.fetch,
   });
 }


### PR DESCRIPTION
## Summary

- Problem: Discord media/attachment sends could fail with `Invalid Form Body` / `CONTENT_TYPE_INVALID` because multipart upload requests could reach the Discord API without a valid `multipart/form-data` content type.
- Why it matters: generated images and other local media artifacts were successfully created, queued for Discord delivery, and then rejected by Discord, leaving users with text replies but no visible attachment.
- What changed: normalize Discord REST `FormData` bodies into explicit multipart payloads with a generated boundary and matching `Content-Type`, and cover both custom-fetch and undici-fetch paths with regression tests.
- What did NOT change (scope boundary): no Discord send API behavior, media loading policy, permission handling, retry behavior, or unrelated approval code was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

No existing GitHub issue/PR was found for this exact Discord multipart attachment failure after searching for Discord attachment/media upload, multipart, `Invalid Form Body`, and `CONTENT_TYPE_INVALID`.

## Root Cause (if applicable)

- Root cause: Discord message uploads are serialized as `FormData` with `payload_json` plus file parts. In the affected runtime/fetch path, that `FormData` object was not preserved as a native multipart body, so the outgoing request could be sent with an invalid/default content type such as `text/plain;charset=UTF-8` instead of `multipart/form-data; boundary=...`.
- Missing detection / guardrail: existing tests asserted that request serialization produced `FormData`, but did not verify the actual dispatched request content type seen by fetch/undici.
- Contributing context (if known): proxy-specific conversion existed in `proxy-request-client`, but direct and custom fetch paths still depended on runtime-specific `FormData` handling.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/internal/rest.test.ts`
- Scenario the test should lock in: Discord REST multipart message uploads dispatch with a `multipart/form-data; boundary=...` content type for both custom fetch and undici fetch.
- Why this is the smallest reliable guardrail: the bug was at the Discord REST request/body boundary, below the high-level send API, so checking the actual fetch-level request catches the failure without needing live Discord credentials.
- Existing test that already covers this (if any): existing serialization tests covered `payload_json` and file parts, but not the outgoing request content type.
- If no new test is added, why not: N/A — new regression coverage is included.

## User-visible / Behavior Changes

Discord media attachments generated or sent by OpenClaw should now upload successfully instead of failing with `CONTENT_TYPE_INVALID` when the affected multipart path is used.

## Diagram (if applicable)

```text
Before:
[Discord media send] -> [FormData body] -> [fetch/undici sees non-native FormData] -> [text/plain or invalid Content-Type] -> [Discord rejects]

After:
[Discord media send] -> [FormData body] -> [explicit multipart body + boundary header] -> [Discord accepts attachment]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Darwin 25.2.0 arm64
- Runtime/container: local OpenClaw gateway rebuilt and restarted from this branch
- Model/provider: image generation via configured OpenClaw image-generation provider
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord channel enabled with bot token and local proxy configured; secrets redacted

### Steps

1. Generate an image artifact with OpenClaw image generation.
2. Send the generated local media path to Discord as an attachment.
3. Observe the outbound Discord API request and final Discord message.

### Expected

- Discord receives a multipart request with `Content-Type: multipart/form-data; boundary=...`.
- The message appears in Discord with the image attachment.

### Actual

- Before: Discord rejected the request with `Invalid Form Body` / `CONTENT_TYPE_INVALID`, and the generated image did not appear in Discord.
- After: the rebuilt gateway successfully sent generated images as Discord attachments, confirmed visually in Discord.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed before the fix in gateway logs:

```text
message failed: Invalid Form Body
CONTENT_TYPE_INVALID: Expected "Content-Type" header to be one of {'application/json', 'application/x-www-form-urlencoded', 'multipart/form-data'}.
```

Automated verification after the fix:

```text
pnpm vitest run extensions/discord/src/internal/rest.test.ts extensions/discord/src/proxy-request-client.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts

Test Files  3 passed (3)
Tests       55 passed (55)
```

Manual verification after rebuild/restart:

- Generated two image attachments via OpenClaw and sent them to Discord.
- Confirmed the images were visible in Discord.

## Human Verification (required)

- Verified scenarios:
  - Discord REST multipart body emits a valid `multipart/form-data; boundary=...` header in unit/seam tests.
  - The undici fetch path receives and sends the correct multipart content type.
  - A rebuilt OpenClaw gateway successfully sends generated image attachments to Discord.
- Edge cases checked:
  - Existing proxy request client tests still pass after centralizing multipart normalization in the REST client.
  - Existing Discord basic send/media tests still pass.
- What you did **not** verify:
  - Full repo-wide `pnpm build && pnpm check && pnpm test` was not run locally for this small Discord-only fix.
  - Other non-Discord integrations were not live-tested.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Multipart serialization is now explicit in the Discord REST client rather than delegated to runtime-specific `FormData` handling.
  - Mitigation: Added tests for custom fetch and undici fetch content type behavior, and kept the change scoped to Discord REST multipart request bodies only.
