### PR TITLE
fix(runtime): synchronously resolve web search SecretRefs at runtime

### DIFF
--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -596,4 +596,257 @@ describe("web search runtime", () => {
       }),
     ).rejects.toThrow("web_search is enabled but no provider is currently available.");
   });
+
+  it("resolves file SecretRefs synchronously when runtime snapshot has unresolved refs", async () => {
+    const { writeFileSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = join(tmpdir(), "openclaw-test-secretref-runtime");
+    mkdirSync(dir, { recursive: true });
+    const secretFile = join(dir, "api-key.txt");
+    try {
+      writeFileSync(secretFile, "test-brave-key-12345", { mode: 0o600 });
+      const provider = createCustomSearchProvider({
+        createTool: ({ config }) => ({
+          description: "custom",
+          parameters: {},
+          execute: async (args) => ({
+            ...args,
+            apiKey: getCustomSearchApiKey(config),
+          }),
+        }),
+      });
+      resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+      resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+      const config: OpenClawConfig = {
+        secrets: {
+          providers: {
+            "test-vault": {
+              source: "file",
+              path: secretFile,
+              mode: "singleValue",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "custom-search": {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "file",
+                    provider: "test-vault",
+                    id: "value",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await expect(
+        runWebSearch({
+          config,
+          args: { query: "secretref-file" },
+        }),
+      ).resolves.toEqual({
+        provider: "custom",
+        result: {
+          query: "secretref-file",
+          apiKey: "test-brave-key-12345",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves env SecretRefs synchronously when runtime snapshot has unresolved refs", async () => {
+    const provider = createCustomSearchProvider({
+      createTool: ({ config }) => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          apiKey: getCustomSearchApiKey(config),
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+    const originalEnv = process.env["OPENCLAW_TEST_WEB_SEARCH_KEY"];
+    try {
+      process.env["OPENCLAW_TEST_WEB_SEARCH_KEY"] = "env-resolved-key-99999";
+
+      const config: OpenClawConfig = {
+        plugins: {
+          entries: {
+            "custom-search": {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "OPENCLAW_TEST_WEB_SEARCH_KEY",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await expect(
+        runWebSearch({
+          config,
+          args: { query: "secretref-env" },
+        }),
+      ).resolves.toEqual({
+        provider: "custom",
+        result: {
+          query: "secretref-env",
+          apiKey: "env-resolved-key-99999",
+        },
+      });
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env["OPENCLAW_TEST_WEB_SEARCH_KEY"];
+      } else {
+        process.env["OPENCLAW_TEST_WEB_SEARCH_KEY"] = originalEnv;
+      }
+    }
+  });
+
+  it("resolves SecretRefs even when runtime snapshot is active with unresolved refs", async () => {
+    const { writeFileSync, mkdirSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = join(tmpdir(), "openclaw-test-secretref-snapshot");
+    mkdirSync(dir, { recursive: true });
+    const secretFile = join(dir, "api-key.txt");
+    try {
+      writeFileSync(secretFile, "snapshot-resolved-key", { mode: 0o600 });
+      const provider = createCustomSearchProvider({
+        createTool: ({ config }) => ({
+          description: "custom",
+          parameters: {},
+          execute: async (args) => ({
+            ...args,
+            apiKey: getCustomSearchApiKey(config),
+          }),
+        }),
+      });
+      resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+      resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+      const sourceConfig = createCustomSearchConfig({
+        source: "file",
+        provider: "snapshot-vault",
+        id: "value",
+      });
+
+      const snapshotConfig = createCustomSearchConfig({
+        source: "file",
+        provider: "snapshot-vault",
+        id: "value",
+      });
+
+      activateSecretsRuntimeSnapshot({
+        sourceConfig,
+        config: snapshotConfig,
+        authStores: [],
+        warnings: [],
+        webTools: {
+          search: {
+            providerSource: "auto-detect",
+            selectedProvider: "custom",
+            diagnostics: [],
+          },
+          fetch: {
+            providerSource: "none",
+            diagnostics: [],
+          },
+          diagnostics: [],
+        },
+      });
+
+      const config: OpenClawConfig = {
+        secrets: {
+          providers: {
+            "snapshot-vault": {
+              source: "file",
+              path: secretFile,
+              mode: "singleValue",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "custom-search": {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "file",
+                    provider: "snapshot-vault",
+                    id: "value",
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      await expect(
+        runWebSearch({
+          config,
+          args: { query: "snapshot-secretref" },
+        }),
+      ).resolves.toEqual({
+        provider: "custom",
+        result: {
+          query: "snapshot-secretref",
+          apiKey: "snapshot-resolved-key",
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes through plain string values without transformation", async () => {
+    const provider = createCustomSearchProvider({
+      createTool: ({ config }) => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          apiKey: getCustomSearchApiKey(config),
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+    const config = createCustomSearchConfig("plain-string-key");
+
+    await expect(
+      runWebSearch({
+        config,
+        args: { query: "plain-string" },
+      }),
+    ).resolves.toEqual({
+      provider: "custom",
+      result: {
+        query: "plain-string",
+        apiKey: "plain-string-key",
+      },
+    });
+  });
 });

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -1,9 +1,12 @@
+import fs from "node:fs";
+import os from "node:os";
 import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
   selectApplicableRuntimeConfig,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isSecretRef, type SecretRef } from "../config/types.secrets.js";
 import { logVerbose } from "../globals.js";
 import type {
   PluginWebSearchProviderEntry,
@@ -48,12 +51,61 @@ function resolveSearchConfig(cfg?: OpenClawConfig): WebSearchConfig {
   return resolveWebProviderConfig(cfg, "search") as NonNullable<WebSearchConfig> | undefined;
 }
 
+function resolveFileSecretRefSync(ref: SecretRef, fullConfig: OpenClawConfig): string | undefined {
+  const providers = (fullConfig as Record<string, unknown>).secrets as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const providerEntries = providers?.providers as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!providerEntries) return undefined;
+  const providerCfg = providerEntries[ref.provider];
+  if (!providerCfg || providerCfg.source !== "file" || typeof providerCfg.path !== "string")
+    return undefined;
+  const secretPath = (providerCfg.path as string).replace(/^~(?=\/)/, os.homedir());
+  try {
+    const stat = fs.statSync(secretPath);
+    if (stat.mode & 0o077) {
+      logVerbose(
+        `resolveWebSearchRuntimeConfig: skipping secret file ${secretPath} with insecure permissions`,
+      );
+      return undefined;
+    }
+    const content = fs.readFileSync(secretPath, "utf8").replace(/^\uFEFF/, "");
+    if (providerCfg.mode === "singleValue") return content.replace(/\r?\n$/, "");
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed[ref.id] as string | undefined)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSecretRefsInConfig<T>(value: T, fullConfig: OpenClawConfig): T {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value))
+    return value.map((item) => resolveSecretRefsInConfig(item, fullConfig)) as T;
+  if (isSecretRef(value)) {
+    if (value.source === "file") return resolveFileSecretRefSync(value, fullConfig) as T;
+    if (value.source === "env") return process.env[value.id] as T;
+    return undefined as T;
+  }
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    result[key] = resolveSecretRefsInConfig((value as Record<string, unknown>)[key], fullConfig);
+  }
+  return result as T;
+}
+
 function resolveWebSearchRuntimeConfig(config?: OpenClawConfig): OpenClawConfig | undefined {
-  return selectApplicableRuntimeConfig({
+  const resolved = selectApplicableRuntimeConfig({
     inputConfig: config,
     runtimeConfig: getRuntimeConfigSnapshot(),
     runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
   });
+  if (!resolved) return resolved;
+  return resolveSecretRefsInConfig(resolved, config ?? resolved);
 }
 
 export function resolveWebSearchEnabled(params: {


### PR DESCRIPTION
## Summary

- PR #72563 assumed `selectApplicableRuntimeConfig` returns a config with resolved SecretRefs, but the runtime config snapshot stores the raw config with unresolved `{source, provider, id}` objects
- This causes `web_search` to fail with `unresolved SecretRef "file:brave-api-key:value"` at `readConfiguredSecretString`, even when the runtime snapshot is present
- After `selectApplicableRuntimeConfig`, unconditionally walk the resolved config tree and synchronously replace any remaining SecretRef objects with their actual values from disk (`source=file`) or `process.env` (`source=env`)

## Root Cause Detail

```mermaid
graph TD
    A[runWebSearch called] --> B[resolveWebSearchRuntimeConfig]
    B --> C[selectApplicableRuntimeConfig]
    C --> D{snapshot present?}
    D -->|yes| E[return snapshot config]
    D -->|no| F[return inputConfig]
    E --> G[config.plugins.entries.brave.config.webSearch.apiKey]
    G --> H[Still SecretRef object!]
    H --> I[createBraveToolDefinition captures SecretRef in closure]
    I --> J[executeBraveSearch → resolveBraveApiKey]
    J --> K[readConfiguredSecretString throws: unresolved SecretRef]
    
    style H fill:#f66,color:#fff
    style K fill:#f66,color:#fff
```

The fix adds a post-processing step after `selectApplicableRuntimeConfig` that synchronously resolves all SecretRef objects:

```mermaid
graph TD
    A[resolveWebSearchRuntimeConfig] --> B[selectApplicableRuntimeConfig]
    B --> C[resolveSecretRefsInConfig]
    C --> D{value is SecretRef?}
    D -->|source=file| E[fs.readFileSync from secrets.providers path]
    D -->|source=env| F[process.env ref.id]
    D -->|not SecretRef| G[keep as-is]
    E --> H[Return concrete string value]
    F --> H
    G --> I[recurse into children]
    
    style H fill:#6f6,color:#000
```

## Testing

- **4 new test cases** covering file SecretRef resolution, env SecretRef resolution, snapshot-present-with-unresolved-refs (the exact bug scenario), and plain string passthrough
- All 21 tests pass (17 existing + 4 new)

## Related

- Supersedes the incomplete fix in #72563 which only routes through the snapshot but doesn't resolve the SecretRefs within it
- The `source=exec` SecretRef type is not handled here (returns `undefined`) since exec-based providers require async subprocess spawning which is not suitable for synchronous resolution