### PR TITLE
fix(active-memory): fast-fail stalled recall paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/active-memory: fast-fail empty or unavailable Memory Search results, enforce the configured recall timeout budget, and discard embedded timeout boilerplate so stalled recalls no longer delay replies or inject timeout text. Thanks @codexGW.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1582,6 +1582,189 @@ describe("active-memory plugin", () => {
     ]);
   });
 
+  it("fast-fails empty recall when memory_search reports zero hits", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 10_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const sessionKey = "agent:main:empty-search-fast-fail";
+    hoisted.sessionStore[sessionKey] = {
+      sessionId: "s-empty-search-fast-fail",
+      updatedAt: 0,
+    };
+    let aborted = false;
+    runEmbeddedPiAgent.mockImplementationOnce(
+      (params: { abortSignal?: AbortSignal; onToolResult?: (payload: unknown) => void }) => {
+        const pending = new Promise<never>((_resolve, reject) => {
+          params.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              const error = new Error("aborted by fast-fail");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+        params.onToolResult?.({
+          text: `🧠 Memory Search\n\`\`\`txt\n${JSON.stringify(
+            {
+              results: [],
+              debug: {
+                backend: "qmd",
+                configuredMode: "search",
+                effectiveMode: "query",
+                searchMs: 12,
+                hits: 0,
+              },
+            },
+            null,
+            2,
+          )}\n\`\`\``,
+        });
+        return pending;
+      },
+    );
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what do you remember about my preferences?", messages: [] },
+      { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
+    );
+
+    expect(result).toBeUndefined();
+    expect(aborted).toBe(true);
+    const lines = getActiveMemoryLines(sessionKey);
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("🧩 Active Memory: status=empty"),
+        expect.stringContaining("hits=0"),
+      ]),
+    );
+  });
+
+  it("fast-fails unavailable recall when memory_search is denied by scope", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      allowedChatTypes: ["channel"],
+      timeoutMs: 10_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const sessionKey = "agent:main:discord:channel:1488793123260862544";
+    hoisted.sessionStore[sessionKey] = {
+      sessionId: "s-scope-denied-fast-fail",
+      updatedAt: 0,
+    };
+    let aborted = false;
+    runEmbeddedPiAgent.mockImplementationOnce(
+      (params: { abortSignal?: AbortSignal; onToolResult?: (payload: unknown) => void }) => {
+        const pending = new Promise<never>((_resolve, reject) => {
+          params.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              const error = new Error("aborted by unavailable fast-fail");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+        params.onToolResult?.({
+          text: `🧠 Memory Search\n\`\`\`txt\n${JSON.stringify(
+            {
+              results: [],
+              disabled: true,
+              unavailable: true,
+              error: "qmd search denied by scope",
+              warning: "Memory search is unavailable due to an embedding/provider error.",
+              action: "Check embedding provider configuration and retry memory_search.",
+              debug: {
+                error: "qmd search denied by scope",
+                warning: "Memory search is unavailable due to an embedding/provider error.",
+                action: "Check embedding provider configuration and retry memory_search.",
+              },
+            },
+            null,
+            2,
+          )}\n\`\`\``,
+        });
+        return pending;
+      },
+    );
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "Testing 1, 2, 3", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey,
+        messageProvider: "discord",
+        channelId: "1488793123260862544",
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(aborted).toBe(true);
+    const lines = getActiveMemoryLines(sessionKey);
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("🧩 Active Memory: status=unavailable"),
+        expect.stringContaining("Memory search is unavailable"),
+      ]),
+    );
+  });
+
+  it("does not fast-fail unavailable output from memory_get", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 10_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const sessionKey = "agent:main:memory-get-unavailable-not-terminal";
+    hoisted.sessionStore[sessionKey] = {
+      sessionId: "s-memory-get-unavailable-not-terminal",
+      updatedAt: 0,
+    };
+    let aborted = false;
+    runEmbeddedPiAgent.mockImplementationOnce(
+      async (params: { abortSignal?: AbortSignal; onToolResult?: (payload: unknown) => void }) => {
+        params.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            aborted = true;
+          },
+          { once: true },
+        );
+        params.onToolResult?.({
+          text: `📓 Memory Get\n\`\`\`txt\n${JSON.stringify(
+            {
+              disabled: true,
+              error: "wiki corpus result not found",
+            },
+            null,
+            2,
+          )}\n\`\`\``,
+        });
+        return { payloads: [{ text: "Useful search summary after memory_get miss." }] };
+      },
+    );
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what should I remember?", messages: [] },
+      { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
+    );
+
+    expect(aborted).toBe(false);
+    expect((result as { prependContext?: string } | undefined)?.prependContext).toContain(
+      "Useful search summary after memory_get miss.",
+    );
+  });
+
   it("returns nothing when the subagent says none", async () => {
     runEmbeddedPiAgent.mockResolvedValueOnce({
       payloads: [{ text: "NONE" }],
@@ -1598,6 +1781,37 @@ describe("active-memory plugin", () => {
     );
 
     expect(result).toBeUndefined();
+  });
+
+  it("treats embedded timeout boilerplate as timeout instead of memory context", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      timeoutMs: 10_000,
+      logging: true,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const sessionKey = "agent:main:timeout-boilerplate";
+    hoisted.sessionStore[sessionKey] = {
+      sessionId: "s-timeout-boilerplate",
+      updatedAt: 0,
+    };
+    runEmbeddedPiAgent.mockResolvedValueOnce({
+      payloads: [
+        {
+          text: "Request timed out before a response was generated. Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+        },
+      ],
+    });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "what wings should i order? timeout boilerplate", messages: [] },
+      { agentId: "main", trigger: "user", sessionKey, messageProvider: "webchat" },
+    );
+
+    expect(result).toBeUndefined();
+    const lines = getActiveMemoryLines(sessionKey);
+    expect(lines).toEqual([expect.stringContaining("🧩 Active Memory: status=timeout")]);
+    expect(lines.join("\n")).not.toContain("Request timed out before a response was generated");
   });
 
   it("returns partial transcript text on timeout when the subagent has already written assistant output", async () => {
@@ -2175,7 +2389,7 @@ describe("active-memory plugin", () => {
     ).toBe(true);
   });
 
-  it("does not spend the model timeout budget on active-memory subagent setup", async () => {
+  it("does not extend the user-visible recall budget with setup grace", async () => {
     const CONFIGURED_TIMEOUT_MS = 10;
     __testing.setMinimumTimeoutMsForTests(1);
     __testing.setSetupGraceTimeoutMsForTests(100);
@@ -2200,19 +2414,19 @@ describe("active-memory plugin", () => {
       },
     );
 
-    expect(result?.prependContext).toContain("remember the ramen place");
+    expect(result).toBeUndefined();
     expect(runEmbeddedPiAgent.mock.calls.at(-1)?.[0]?.timeoutMs).toBe(CONFIGURED_TIMEOUT_MS);
     const infoLines = vi
       .mocked(api.logger.info)
       .mock.calls.map((call: unknown[]) => String(call[0]));
-    expect(infoLines.some((line: string) => line.includes("status=timeout"))).toBe(false);
+    expect(infoLines.some((line: string) => line.includes("status=timeout"))).toBe(true);
   });
 
   it("returns timeout within a hard deadline even when the subagent never checks the abort signal", async () => {
     const CONFIGURED_TIMEOUT_MS = 200;
     const HARD_DEADLINE_MARGIN_MS = 4_800;
     __testing.setMinimumTimeoutMsForTests(1);
-    __testing.setSetupGraceTimeoutMsForTests(0);
+    __testing.setSetupGraceTimeoutMsForTests(5_000);
     api.pluginConfig = {
       agents: ["main"],
       timeoutMs: CONFIGURED_TIMEOUT_MS,

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -205,6 +205,7 @@ type RecallSubagentResult = {
   rawReply: string;
   transcriptPath?: string;
   searchDebug?: ActiveMemorySearchDebug;
+  terminalStatus?: "empty" | "unavailable";
 };
 
 type CachedActiveRecallResult = {
@@ -1609,6 +1610,132 @@ function readActiveMemorySearchDebugFromRunResult(
   );
 }
 
+function extractJsonObjectText(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+    return trimmed;
+  }
+  const fenced = /```(?:json|txt)?\s*([\s\S]*?)```/i.exec(trimmed);
+  const fencedBody = fenced?.[1]?.trim();
+  if (fencedBody?.startsWith("{") && fencedBody.endsWith("}")) {
+    return fencedBody;
+  }
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    return trimmed.slice(start, end + 1);
+  }
+  return undefined;
+}
+
+function parseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const jsonText = extractJsonObjectText(value);
+  if (!jsonText) {
+    return undefined;
+  }
+  try {
+    return asRecord(JSON.parse(jsonText));
+  } catch {
+    return undefined;
+  }
+}
+
+function isFormattedMemorySearchToolOutput(payload: unknown): boolean {
+  const record = asRecord(payload);
+  const text = normalizeOptionalString(record?.text)?.trimStart();
+  return text ? /^🧠\s+Memory Search(?::|\s|$)/u.test(text) : false;
+}
+
+function extractEmptyMemorySearchDebugFromToolPayload(
+  payload: unknown,
+): ActiveMemorySearchDebug | undefined {
+  if (!isFormattedMemorySearchToolOutput(payload)) {
+    return undefined;
+  }
+  const record = asRecord(payload);
+  const parsed = parseJsonObject(normalizeOptionalString(record?.text));
+  if (!parsed) {
+    return undefined;
+  }
+  const results = parsed.results;
+  if (!Array.isArray(results) || results.length > 0) {
+    return undefined;
+  }
+  const details = asRecord(parsed.details);
+  if (
+    normalizeOptionalString(parsed.error) ||
+    normalizeOptionalString(parsed.warning) ||
+    normalizeOptionalString(parsed.action) ||
+    parsed.disabled === true ||
+    normalizeOptionalString(details?.error) ||
+    normalizeOptionalString(details?.warning) ||
+    normalizeOptionalString(details?.action) ||
+    details?.disabled === true
+  ) {
+    return undefined;
+  }
+  const debug = normalizeSearchDebug(parsed.debug) ?? normalizeSearchDebug(details?.debug);
+  if (!debug || debug.hits !== 0 || debug.error) {
+    return undefined;
+  }
+  return debug;
+}
+
+function extractUnavailableMemorySearchDebugFromToolPayload(
+  payload: unknown,
+): ActiveMemorySearchDebug | undefined {
+  if (!isFormattedMemorySearchToolOutput(payload)) {
+    return undefined;
+  }
+  const record = asRecord(payload);
+  const parsed = parseJsonObject(normalizeOptionalString(record?.text));
+  if (!parsed) {
+    return undefined;
+  }
+  const results = parsed.results;
+  if (Array.isArray(results) && results.length > 0) {
+    return undefined;
+  }
+  const details = asRecord(parsed.details);
+  const parsedDebug = asRecord(parsed.debug);
+  const detailsDebug = asRecord(details?.debug);
+  const disabled = parsed.disabled === true || details?.disabled === true;
+  const unavailable = parsed.unavailable === true || details?.unavailable === true;
+  const error =
+    normalizeOptionalString(parsed.error) ??
+    normalizeOptionalString(details?.error) ??
+    normalizeOptionalString(parsedDebug?.error) ??
+    normalizeOptionalString(detailsDebug?.error);
+  const warning =
+    normalizeOptionalString(parsed.warning) ??
+    normalizeOptionalString(details?.warning) ??
+    normalizeOptionalString(parsedDebug?.warning) ??
+    normalizeOptionalString(detailsDebug?.warning);
+  const action =
+    normalizeOptionalString(parsed.action) ??
+    normalizeOptionalString(details?.action) ??
+    normalizeOptionalString(parsedDebug?.action) ??
+    normalizeOptionalString(detailsDebug?.action);
+  if (!disabled && !unavailable && !error && !warning && !action) {
+    return undefined;
+  }
+  return (
+    normalizeSearchDebug({
+      ...detailsDebug,
+      ...parsedDebug,
+      error,
+      warning,
+      action,
+    }) ?? { error, warning, action }
+  );
+}
+
 function extractAssistantTextFromSessionRecord(value: unknown): string {
   const record = asRecord(value);
   if (!record) {
@@ -1774,6 +1901,20 @@ function normalizeNoRecallValue(value: string): boolean {
   return NO_RECALL_VALUES.has(value.trim().toLowerCase());
 }
 
+function isTimeoutBoilerplateSummary(singleLine: string): boolean {
+  const normalized = singleLine.toLowerCase();
+  return (
+    normalized.includes("request timed out before a response was generated") ||
+    normalized.includes("please try again, or increase") ||
+    normalized.includes("agents.defaults.timeoutseconds")
+  );
+}
+
+function isTimeoutBoilerplateReply(rawReply: string): boolean {
+  const singleLine = rawReply.trim().replace(/\s+/g, " ").trim();
+  return singleLine ? isTimeoutBoilerplateSummary(singleLine) : false;
+}
+
 function normalizeActiveSummary(rawReply: string): string | null {
   const trimmed = rawReply.trim();
   if (normalizeNoRecallValue(trimmed)) {
@@ -1781,6 +1922,9 @@ function normalizeActiveSummary(rawReply: string): string | null {
   }
   const singleLine = trimmed.replace(/\s+/g, " ").trim();
   if (!singleLine || normalizeNoRecallValue(singleLine)) {
+    return null;
+  }
+  if (isTimeoutBoilerplateSummary(singleLine)) {
     return null;
   }
   return singleLine;
@@ -2118,36 +2262,94 @@ async function runRecallSubagent(params: {
     channelId: params.channelId,
   });
 
+  let runAbortSignal: AbortSignal | undefined;
+  let removeParentAbortListener: (() => void) | undefined;
   try {
     const embeddedConfig = applyActiveMemoryRuntimeConfigSnapshot(params.api.config, params.config);
-    const result = await params.api.runtime.agent.runEmbeddedPiAgent({
-      sessionId: subagentSessionId,
-      sessionKey: subagentSessionKey,
-      agentId: params.agentId,
-      messageChannel,
-      messageProvider,
-      sessionFile,
-      workspaceDir,
-      agentDir,
-      config: embeddedConfig,
-      prompt,
-      provider: modelRef.provider,
-      model: modelRef.model,
-      timeoutMs: params.config.timeoutMs,
-      runId: subagentSessionId,
-      trigger: "manual",
-      toolsAllow: ["memory_recall", "memory_search", "memory_get"],
-      disableMessageTool: true,
-      allowGatewaySubagentBinding: true,
-      bootstrapContextMode: "lightweight",
-      verboseLevel: "off",
-      thinkLevel: params.config.thinking,
-      reasoningLevel: "off",
-      silentExpected: true,
-      authProfileFailurePolicy: "local",
-      cleanupBundleMcpOnRunEnd: true,
-      abortSignal: params.abortSignal,
+    const runController = new AbortController();
+    runAbortSignal = runController.signal;
+    const abortRun = () => {
+      const reason = params.abortSignal?.reason;
+      if (reason instanceof Error) {
+        runController.abort(reason);
+      } else if (reason !== undefined) {
+        runController.abort(new Error("Operation aborted", { cause: reason }));
+      } else {
+        runController.abort(new Error("Operation aborted"));
+      }
+    };
+    if (params.abortSignal?.aborted) {
+      abortRun();
+    } else {
+      params.abortSignal?.addEventListener("abort", abortRun, { once: true });
+      removeParentAbortListener = () => {
+        params.abortSignal?.removeEventListener("abort", abortRun);
+      };
+    }
+    let resolveEmptySearch: ((result: RecallSubagentResult) => void) | undefined;
+    let emptySearchResult: RecallSubagentResult | undefined;
+    let emptySearchResolved = false;
+    const emptySearchPromise = new Promise<RecallSubagentResult>((resolve) => {
+      resolveEmptySearch = resolve;
     });
+    const runPromise = params.api.runtime.agent
+      .runEmbeddedPiAgent({
+        sessionId: subagentSessionId,
+        sessionKey: subagentSessionKey,
+        agentId: params.agentId,
+        messageChannel,
+        messageProvider,
+        sessionFile,
+        workspaceDir,
+        agentDir,
+        config: embeddedConfig,
+        prompt,
+        provider: modelRef.provider,
+        model: modelRef.model,
+        timeoutMs: params.config.timeoutMs,
+        runId: subagentSessionId,
+        trigger: "manual",
+        toolsAllow: ["memory_recall", "memory_search", "memory_get"],
+        disableMessageTool: true,
+        allowGatewaySubagentBinding: true,
+        bootstrapContextMode: "lightweight",
+        verboseLevel: "off",
+        thinkLevel: params.config.thinking,
+        reasoningLevel: "off",
+        silentExpected: true,
+        authProfileFailurePolicy: "local",
+        cleanupBundleMcpOnRunEnd: true,
+        abortSignal: runController.signal,
+        shouldEmitToolOutput: () => true,
+        onToolResult: (payload: unknown) => {
+          if (emptySearchResolved) {
+            return;
+          }
+          const unavailableDebug = extractUnavailableMemorySearchDebugFromToolPayload(payload);
+          const emptyDebug = unavailableDebug
+            ? undefined
+            : extractEmptyMemorySearchDebugFromToolPayload(payload);
+          const searchDebug = unavailableDebug ?? emptyDebug;
+          if (!searchDebug) {
+            return;
+          }
+          emptySearchResolved = true;
+          emptySearchResult = {
+            rawReply: "NONE",
+            searchDebug,
+            terminalStatus: unavailableDebug ? "unavailable" : "empty",
+          };
+          resolveEmptySearch?.(emptySearchResult);
+          runController.abort(new Error("active-memory terminal memory_search fast-fail"));
+        },
+      })
+      .catch((error: unknown) => {
+        if (emptySearchResolved && runController.signal.aborted && emptySearchResult) {
+          return emptySearchResult;
+        }
+        throw error;
+      });
+    const result = await Promise.race([runPromise, emptySearchPromise]);
     if (params.abortSignal?.aborted) {
       const reason = params.abortSignal.reason;
       if (reason instanceof Error) {
@@ -2159,6 +2361,9 @@ async function runRecallSubagent(params: {
           : new Error("Operation aborted");
       abortErr.name = "AbortError";
       throw abortErr;
+    }
+    if ("rawReply" in result) {
+      return result;
     }
     const rawReply = (result.payloads ?? [])
       .map((payload) => payload.text?.trim() ?? "")
@@ -2174,13 +2379,15 @@ async function runRecallSubagent(params: {
       searchDebug,
     };
   } catch (error) {
-    if (params.abortSignal?.aborted) {
+    const isAbortError = error instanceof Error && error.name === "AbortError";
+    if (params.abortSignal?.aborted || runAbortSignal?.aborted || isAbortError) {
       const partialReply = await readPartialAssistantText(sessionFile);
       const searchDebug = partialReply ? await readActiveMemorySearchDebug(sessionFile) : undefined;
       attachPartialTimeoutData(error, partialReply, searchDebug);
     }
     throw error;
   } finally {
+    removeParentAbortListener?.();
     if (tempDir) {
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
     }
@@ -2280,10 +2487,9 @@ async function maybeResolveActiveRecall(params: {
   const controller = new AbortController();
   const TIMEOUT_SENTINEL = Symbol("timeout");
   let sessionFile: string | undefined;
-  const watchdogTimeoutMs = params.config.timeoutMs + setupGraceTimeoutMs;
   const timeoutId = setTimeout(() => {
-    controller.abort(new Error(`active-memory timeout after ${watchdogTimeoutMs}ms`));
-  }, watchdogTimeoutMs);
+    controller.abort(new Error(`active-memory timeout after ${params.config.timeoutMs}ms`));
+  }, params.config.timeoutMs);
   timeoutId.unref?.();
 
   const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
@@ -2335,7 +2541,8 @@ async function maybeResolveActiveRecall(params: {
       return result;
     }
 
-    const { rawReply, transcriptPath, searchDebug } = raceResult;
+    const { rawReply, transcriptPath, searchDebug, terminalStatus } = raceResult;
+    const timeoutBoilerplate = isTimeoutBoilerplateReply(rawReply);
     const summary = truncateSummary(
       normalizeActiveSummary(rawReply) ?? "",
       params.config.maxSummaryChars,
@@ -2353,7 +2560,7 @@ async function maybeResolveActiveRecall(params: {
             searchDebug,
           }
         : {
-            status: "empty",
+            status: timeoutBoilerplate ? "timeout" : (terminalStatus ?? "empty"),
             elapsedMs: Date.now() - startedAt,
             summary: null,
             searchDebug,
@@ -2374,11 +2581,16 @@ async function maybeResolveActiveRecall(params: {
     if (shouldCacheResult(result)) {
       setCachedResult(cacheKey, result, params.config.cacheTtlMs);
     }
-    resetCircuitBreaker(cbKey);
+    if (result.status === "timeout") {
+      recordCircuitBreakerTimeout(cbKey);
+    } else {
+      resetCircuitBreaker(cbKey);
+    }
     return result;
   } catch (error) {
-    if (controller.signal.aborted) {
-      const partialTimeoutData = readPartialTimeoutData(error);
+    const partialTimeoutData = readPartialTimeoutData(error);
+    const isAbortError = error instanceof Error && error.name === "AbortError";
+    if (controller.signal.aborted || (isAbortError && partialTimeoutData.rawReply)) {
       const result = await buildTimeoutRecallResult({
         elapsedMs: Date.now() - startedAt,
         maxSummaryChars: params.config.maxSummaryChars,
@@ -2646,7 +2858,7 @@ export default definePluginEntry({
   },
 });
 
-export const __testing = {
+const activeMemoryTesting = {
   buildCacheKey,
   buildCircuitBreakerKey,
   buildMetadata,
@@ -2676,3 +2888,5 @@ export const __testing = {
     return timeoutCircuitBreaker.get(key);
   },
 };
+
+export { activeMemoryTesting as __testing };


### PR DESCRIPTION
## Summary
- Fast-fail active-memory recall when the embedded subagent reports a clean `memory_search` result with `results: []` and `debug.hits === 0`.
- Fast-fail unavailable Memory Search output without treating unrelated `memory_get` misses as terminal recall failures.
- Enforce the configured active-memory recall budget as the user-visible hard timeout, then abort and swallow late embedded subagent rejections.
- Treat embedded harness timeout boilerplate as timeout/no recall instead of injecting it as useful memory context.
- Add focused regressions for zero-hit Memory Search, unavailable Memory Search, non-terminal Memory Get misses, timeout boilerplate, and hard timeout budget behavior.

## Root Cause
Active-memory recall waited for the embedded subagent timeout even after Memory Search had already proven there were no hits or was unavailable. Separately, the plugin waited for the setup-grace watchdog before resolving timeout and could normalize the embedded harness timeout message as an `ok` memory summary.

## Validation
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/active-memory/index.ts extensions/active-memory/index.test.ts`
- `pnpm exec oxlint extensions/active-memory/index.ts extensions/active-memory/index.test.ts`
- `pnpm test extensions/active-memory/index.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed`
- Live Samantha Discord thread proof after rebuild/restart: active-memory logged `status=timeout`, `elapsedMs=5040`, `summaryChars=0` for `timeoutMs=5000`; no `<active_memory_plugin>` context or timeout boilerplate was injected into the main prompt.

## Notes
- Testbox was not run because the Blacksmith CLI was not authenticated on this machine; previous local auth checks reported no authenticated organization.
- QMD semantic search quality is intentionally left for a separate follow-up; the live proof still showed QMD returning zero hits while direct `memory_get` found useful file memory.
