### PR TITLE
docs: align memory search cache defaults

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -404,12 +404,12 @@ Supported formats: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif` (i
 
 ## Embedding cache
 
-| Key                | Type      | Default | Description                      |
-| ------------------ | --------- | ------- | -------------------------------- |
-| `cache.enabled`    | `boolean` | `false` | Cache chunk embeddings in SQLite |
-| `cache.maxEntries` | `number`  | `50000` | Max cached embeddings            |
+| Key                | Type      | Default | Description                                   |
+| ------------------ | --------- | ------- | --------------------------------------------- |
+| `cache.enabled`    | `boolean` | `true`  | Cache chunk embeddings in SQLite              |
+| `cache.maxEntries` | `number`  | unset   | Optional best-effort cap on cached embeddings |
 
-Prevents re-embedding unchanged text during reindex or transcript updates.
+Prevents re-embedding unchanged text during reindex or transcript updates. Set `cache.maxEntries` when you need to bound disk growth; when unset, OpenClaw keeps cached embeddings until normal cache invalidation or manual cleanup removes them.
 
 ---
 


### PR DESCRIPTION
## What\nUpdates docs/reference/memory-config.md so the embedding cache defaults match the current runtime and config schema: cache.enabled defaults to true and cache.maxEntries has no built-in default cap.\n\n## Why\nThe docs still said cache.enabled defaulted to false and cache.maxEntries defaulted to 50000, which contradicted src/agents/memory-search.ts and schema help.\n\n## Testing\n- corepack pnpm dlx markdownlint-cli2 docs/reference/memory-config.md\n- node static alignment check for docs/runtime/schema help\n\nNote: attempted targeted vitest for memory-search/schema help, but it stalled and was killed after repeated Rolldown plugin timing warnings; this is a docs-only correction.