### PR TITLE
fix: trace plugin tool factory timings

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2343,6 +2343,7 @@ public struct WizardStep: Codable, Sendable {
     public let type: AnyCodable
     public let title: String?
     public let message: String?
+    public let format: AnyCodable?
     public let options: [[String: AnyCodable]]?
     public let initialvalue: AnyCodable?
     public let placeholder: String?
@@ -2354,6 +2355,7 @@ public struct WizardStep: Codable, Sendable {
         type: AnyCodable,
         title: String?,
         message: String?,
+        format: AnyCodable?,
         options: [[String: AnyCodable]]?,
         initialvalue: AnyCodable?,
         placeholder: String?,
@@ -2364,6 +2366,7 @@ public struct WizardStep: Codable, Sendable {
         self.type = type
         self.title = title
         self.message = message
+        self.format = format
         self.options = options
         self.initialvalue = initialvalue
         self.placeholder = placeholder
@@ -2376,6 +2379,7 @@ public struct WizardStep: Codable, Sendable {
         case type
         case title
         case message
+        case format
         case options
         case initialvalue = "initialValue"
         case placeholder
@@ -2785,6 +2789,24 @@ public struct ChannelsStatusResult: Codable, Sendable {
 }
 
 public struct ChannelsStartParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
+
+    public init(
+        channel: String,
+        accountid: String?)
+    {
+        self.channel = channel
+        self.accountid = accountid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case accountid = "accountId"
+    }
+}
+
+public struct ChannelsStopParams: Codable, Sendable {
     public let channel: String
     public let accountid: String?
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2343,6 +2343,7 @@ public struct WizardStep: Codable, Sendable {
     public let type: AnyCodable
     public let title: String?
     public let message: String?
+    public let format: AnyCodable?
     public let options: [[String: AnyCodable]]?
     public let initialvalue: AnyCodable?
     public let placeholder: String?
@@ -2354,6 +2355,7 @@ public struct WizardStep: Codable, Sendable {
         type: AnyCodable,
         title: String?,
         message: String?,
+        format: AnyCodable?,
         options: [[String: AnyCodable]]?,
         initialvalue: AnyCodable?,
         placeholder: String?,
@@ -2364,6 +2366,7 @@ public struct WizardStep: Codable, Sendable {
         self.type = type
         self.title = title
         self.message = message
+        self.format = format
         self.options = options
         self.initialvalue = initialvalue
         self.placeholder = placeholder
@@ -2376,6 +2379,7 @@ public struct WizardStep: Codable, Sendable {
         case type
         case title
         case message
+        case format
         case options
         case initialvalue = "initialValue"
         case placeholder
@@ -2785,6 +2789,24 @@ public struct ChannelsStatusResult: Codable, Sendable {
 }
 
 public struct ChannelsStartParams: Codable, Sendable {
+    public let channel: String
+    public let accountid: String?
+
+    public init(
+        channel: String,
+        accountid: String?)
+    {
+        self.channel = channel
+        self.accountid = accountid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case channel
+        case accountid = "accountId"
+    }
+}
+
+public struct ChannelsStopParams: Codable, Sendable {
     public let channel: String
     public let accountid: String?
 

--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -41,6 +41,9 @@ openclaw logs --follow
   raise the file log level.
 - To capture verbose-only details in file logs, set `logging.level` to `debug` or
   `trace`.
+- Trace logging also includes diagnostic timing summaries for selected hot paths,
+  such as plugin tool factory preparation. See
+  [/tools/plugin#slow-plugin-tool-setup](/tools/plugin#slow-plugin-tool-setup).
 
 ## Console capture
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -334,6 +334,37 @@ do not run in live chat traffic, check these first:
   Gateway session/status surfaces and, when debugging provider payloads, start
   the Gateway with `--raw-stream --raw-stream-path <path>`.
 
+### Slow plugin tool setup
+
+If agent turns appear to stall while preparing tools, enable trace logging and
+check for plugin tool factory timing lines:
+
+```bash
+openclaw config set logging.level trace
+openclaw logs --follow
+```
+
+Look for:
+
+```text
+[trace:plugin-tools] factory timings ...
+```
+
+The summary lists total factory time and the slowest plugin tool factories,
+including plugin id, declared tool names, result shape, and whether the tool is
+optional. Slow lines are promoted to warnings when a single factory takes at
+least 1s or total plugin tool factory prep takes at least 5s.
+
+If one plugin dominates the timing, inspect its runtime registrations:
+
+```bash
+openclaw plugins inspect <plugin-id> --runtime --json
+```
+
+Then update, reinstall, or disable that plugin. Plugin authors should move
+expensive dependency loading behind the tool execution path instead of doing it
+inside the tool factory.
+
 ### Duplicate channel or tool ownership
 
 Symptoms:

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -57,6 +57,7 @@ describe("plugin tools MCP server", () => {
     resolvePluginToolsMock.mockReturnValue([
       {
         name: "memory_recall",
+        label: "Recall memory",
         description: "Recall stored memory",
         parameters: { type: "object", properties: {} },
         execute: vi.fn(),

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -22,9 +22,13 @@ vi.mock("../config/config.js", () => ({
   getRuntimeConfig: getRuntimeConfigMock,
 }));
 
-vi.mock("../logging/console.js", () => ({
-  routeLogsToStderr: routeLogsToStderrMock,
-}));
+vi.mock("../logging/console.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/console.js")>();
+  return {
+    ...actual,
+    routeLogsToStderr: routeLogsToStderrMock,
+  };
+});
 
 vi.mock("../plugins/tools.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/tools.js")>();

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -11,7 +11,7 @@ const callGatewayTool = vi.hoisted(() => vi.fn());
 const connectToolsMcpServerToStdioMock = vi.hoisted(() => vi.fn());
 const createToolsMcpServerMock = vi.hoisted(() => vi.fn(() => ({ close: vi.fn() })));
 const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({ plugins: { enabled: true } })));
-const resolvePluginToolsMock = vi.hoisted(() => vi.fn(() => []));
+const resolvePluginToolsMock = vi.hoisted(() => vi.fn<() => AnyAgentTool[]>(() => []));
 const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../agents/tools/gateway.js", () => ({

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -8,18 +8,71 @@ import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
 
 const callGatewayTool = vi.hoisted(() => vi.fn());
+const connectToolsMcpServerToStdioMock = vi.hoisted(() => vi.fn());
+const createToolsMcpServerMock = vi.hoisted(() => vi.fn(() => ({ close: vi.fn() })));
+const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({ plugins: { enabled: true } })));
+const resolvePluginToolsMock = vi.hoisted(() => vi.fn(() => []));
+const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../agents/tools/gateway.js", () => ({
   callGatewayTool,
 }));
 
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: getRuntimeConfigMock,
+}));
+
+vi.mock("../logging/console.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
+}));
+
+vi.mock("../plugins/tools.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/tools.js")>();
+  return {
+    ...actual,
+    resolvePluginTools: resolvePluginToolsMock,
+  };
+});
+
+vi.mock("./tools-stdio-server.js", () => ({
+  connectToolsMcpServerToStdio: connectToolsMcpServerToStdioMock,
+  createToolsMcpServer: createToolsMcpServerMock,
+}));
+
 afterEach(() => {
   vi.restoreAllMocks();
   callGatewayTool.mockReset();
+  connectToolsMcpServerToStdioMock.mockReset();
+  createToolsMcpServerMock.mockClear();
+  getRuntimeConfigMock.mockClear();
+  resolvePluginToolsMock.mockReset();
+  resolvePluginToolsMock.mockReturnValue([]);
+  routeLogsToStderrMock.mockReset();
   resetGlobalHookRunner();
 });
 
 describe("plugin tools MCP server", () => {
+  it("routes logs to stderr before resolving tools for stdio", async () => {
+    const { servePluginToolsMcp } = await import("./plugin-tools-serve.js");
+    resolvePluginToolsMock.mockReturnValue([
+      {
+        name: "memory_recall",
+        description: "Recall stored memory",
+        parameters: { type: "object", properties: {} },
+        execute: vi.fn(),
+      },
+    ]);
+
+    await servePluginToolsMcp();
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
+    expect(resolvePluginToolsMock).toHaveBeenCalledTimes(1);
+    expect(routeLogsToStderrMock.mock.invocationCallOrder[0]).toBeLessThan(
+      resolvePluginToolsMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(connectToolsMcpServerToStdioMock).toHaveBeenCalledOnce();
+  });
+
   it("lists registered plugin tools and serializes non-array tool content", async () => {
     const execute = vi.fn().mockResolvedValue({
       content: "Stored.",

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -12,6 +12,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { routeLogsToStderr } from "../logging/console.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { connectToolsMcpServerToStdio, createToolsMcpServer } from "./tools-stdio-server.js";
 
@@ -34,6 +35,10 @@ export function createPluginToolsMcpServer(
 }
 
 export async function servePluginToolsMcp(): Promise<void> {
+  // MCP stdio requires stdout to stay protocol-only, including during plugin
+  // tool discovery before the transport is connected.
+  routeLogsToStderr();
+
   const config = getRuntimeConfig();
   const tools = resolveTools(config);
   const server = createPluginToolsMcpServer({ config, tools });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
 
 type MockRegistryToolEntry = {
   pluginId: string;
+  names?: string[];
   optional: boolean;
   source: string;
   factory: (ctx: unknown) => unknown;
@@ -93,6 +96,7 @@ function setMultiToolRegistry() {
 function createOptionalDemoEntry(): MockRegistryToolEntry {
   return {
     pluginId: "optional-demo",
+    names: ["optional_tool"],
     optional: true,
     source: "/tmp/optional-demo.js",
     factory: () => makeTool("optional_tool"),
@@ -108,6 +112,17 @@ function createMalformedTool(name: string) {
       return { content: [{ type: "text", text: "bad" }] };
     },
   };
+}
+
+function installConsoleMethodSpy(method: "log" | "warn") {
+  const spy = vi.fn();
+  loggingState.rawConsole = {
+    log: method === "log" ? spy : vi.fn(),
+    info: vi.fn(),
+    warn: method === "warn" ? spy : vi.fn(),
+    error: vi.fn(),
+  };
+  return spy;
 }
 
 function resolveWithConflictingCoreName(options?: { suppressNameConflicts?: boolean }) {
@@ -227,6 +242,10 @@ describe("resolvePluginTools optional tools", () => {
 
   afterEach(() => {
     resetPluginRuntimeStateForTest?.();
+    setLoggerOverride(null);
+    loggingState.rawConsole = null;
+    resetLogger();
+    vi.useRealTimers();
   });
 
   it("skips optional tools without explicit allowlist", () => {
@@ -340,6 +359,86 @@ describe("resolvePluginTools optional tools", () => {
       registry.diagnostics,
       "plugin tool is malformed (schema-bug): broken_tool missing parameters object",
     );
+  });
+
+  it("warns with plugin factory timing details when a factory is slow", () => {
+    vi.useFakeTimers({ now: 0 });
+    const warnSpy = installConsoleMethodSpy("warn");
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        names: ["optional_tool"],
+        optional: true,
+        source: "/tmp/optional-demo.js",
+        factory: () => {
+          vi.advanceTimersByTime(1200);
+          return makeTool("optional_tool");
+        },
+      },
+    ]);
+
+    const tools = resolveOptionalDemoTools(["optional_tool"]);
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("[trace:plugin-tools] factory timings");
+    expect(message).toContain("totalMs=1200");
+    expect(message).toContain("optional-demo:1200ms@1200ms");
+    expect(message).toContain("names=[optional_tool]");
+    expect(message).toContain("result=single");
+    expect(message).toContain("count=1");
+  });
+
+  it("emits trace factory timings below the warn threshold when trace logging is enabled", () => {
+    vi.useFakeTimers({ now: 0 });
+    const logSpy = installConsoleMethodSpy("log");
+    setLoggerOverride({ level: "silent", consoleLevel: "trace" });
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        names: ["optional_tool"],
+        optional: true,
+        source: "/tmp/optional-demo.js",
+        factory: () => {
+          vi.advanceTimersByTime(5);
+          return makeTool("optional_tool");
+        },
+      },
+    ]);
+
+    const tools = resolveOptionalDemoTools(["optional_tool"]);
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const message = String(logSpy.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("[trace:plugin-tools] factory timings");
+    expect(message).toContain("totalMs=5");
+    expect(message).toContain("optional-demo:5ms@5ms");
+  });
+
+  it("does not log plugin factory timings for fast factories without trace logging", () => {
+    vi.useFakeTimers({ now: 0 });
+    const warnSpy = installConsoleMethodSpy("warn");
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    setRegistry([
+      {
+        pluginId: "optional-demo",
+        names: ["optional_tool"],
+        optional: true,
+        source: "/tmp/optional-demo.js",
+        factory: () => {
+          vi.advanceTimersByTime(5);
+          return makeTool("optional_tool");
+        },
+      },
+    ]);
+
+    const tools = resolveOptionalDemoTools(["optional_tool"]);
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("skips allowlisted optional malformed plugin tools", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1,5 +1,6 @@
 import { normalizeToolName } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import { listEnabledInstalledPluginRecords } from "./installed-plugin-index.js";
 import { resolveRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
@@ -15,6 +16,23 @@ export type PluginToolMeta = {
   pluginId: string;
   optional: boolean;
 };
+
+type PluginToolFactoryTimingResult = "array" | "error" | "null" | "single";
+
+type PluginToolFactoryTiming = {
+  pluginId: string;
+  names: string[];
+  durationMs: number;
+  elapsedMs: number;
+  result: PluginToolFactoryTimingResult;
+  resultCount: number;
+  optional: boolean;
+};
+
+const log = createSubsystemLogger("plugins/tools");
+const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
+const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
+const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 
@@ -73,6 +91,72 @@ function readPluginToolName(tool: unknown): string {
   }
   // Optional-tool allowlists need a best-effort name before full shape validation.
   return typeof tool.name === "string" ? tool.name.trim() : "";
+}
+
+function toElapsedMs(value: number): number {
+  return Math.max(0, Math.round(value));
+}
+
+function describePluginToolFactoryResult(
+  resolved: AnyAgentTool | AnyAgentTool[] | null | undefined,
+  failed: boolean,
+): { result: PluginToolFactoryTimingResult; resultCount: number } {
+  if (failed) {
+    return { result: "error", resultCount: 0 };
+  }
+  if (!resolved) {
+    return { result: "null", resultCount: 0 };
+  }
+  if (Array.isArray(resolved)) {
+    return { result: "array", resultCount: resolved.length };
+  }
+  return { result: "single", resultCount: 1 };
+}
+
+function formatPluginToolFactoryTiming(timing: PluginToolFactoryTiming): string {
+  const names = timing.names.length > 0 ? timing.names.join("|") : "-";
+  return [
+    `${timing.pluginId}:${timing.durationMs}ms@${timing.elapsedMs}ms`,
+    `names=[${names}]`,
+    `result=${timing.result}`,
+    `count=${timing.resultCount}`,
+    `optional=${String(timing.optional)}`,
+  ].join(" ");
+}
+
+function formatPluginToolFactoryTimingSummary(params: {
+  totalMs: number;
+  timings: PluginToolFactoryTiming[];
+}): string {
+  const ranked = params.timings
+    .toSorted(
+      (left, right) =>
+        right.durationMs - left.durationMs || left.pluginId.localeCompare(right.pluginId),
+    )
+    .slice(0, PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT);
+  const omitted = Math.max(0, params.timings.length - ranked.length);
+  const factories =
+    ranked.length > 0
+      ? ranked.map((timing) => formatPluginToolFactoryTiming(timing)).join(", ")
+      : "none";
+  return [
+    "[trace:plugin-tools] factory timings",
+    `totalMs=${params.totalMs}`,
+    `factoryCount=${params.timings.length}`,
+    `shown=${ranked.length}`,
+    `omitted=${omitted}`,
+    `factories=${factories}`,
+  ].join(" ");
+}
+
+function shouldWarnPluginToolFactoryTimings(params: {
+  totalMs: number;
+  timings: PluginToolFactoryTiming[];
+}): boolean {
+  return (
+    params.totalMs >= PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS ||
+    params.timings.some((timing) => timing.durationMs >= PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS)
+  );
 }
 
 function describeMalformedPluginTool(tool: unknown): string | undefined {
@@ -163,6 +247,8 @@ export function resolvePluginTools(params: {
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolName(tool)));
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const blockedPlugins = new Set<string>();
+  const factoryTimingStartedAt = Date.now();
+  const factoryTimings: PluginToolFactoryTiming[] = [];
 
   for (const entry of registry.tools) {
     if (blockedPlugins.has(entry.pluginId)) {
@@ -183,17 +269,35 @@ export function resolvePluginTools(params: {
       blockedPlugins.add(entry.pluginId);
       continue;
     }
+    const declaredNames = entry.names ?? [];
     let resolved: AnyAgentTool | AnyAgentTool[] | null | undefined = null;
+    let factoryFailed = false;
+    const factoryStartedAt = Date.now();
     try {
       resolved = entry.factory(params.context);
     } catch (err) {
+      factoryFailed = true;
       context.logger.error(`plugin tool failed (${entry.pluginId}): ${String(err)}`);
+    } finally {
+      const factoryEndedAt = Date.now();
+      const result = describePluginToolFactoryResult(resolved, factoryFailed);
+      factoryTimings.push({
+        pluginId: entry.pluginId,
+        names: declaredNames,
+        durationMs: toElapsedMs(factoryEndedAt - factoryStartedAt),
+        elapsedMs: toElapsedMs(factoryEndedAt - factoryTimingStartedAt),
+        result: result.result,
+        resultCount: result.resultCount,
+        optional: entry.optional,
+      });
+    }
+    if (factoryFailed) {
       continue;
     }
     if (!resolved) {
-      if (entry.names.length > 0) {
+      if (declaredNames.length > 0) {
         context.logger.debug?.(
-          `plugin tool factory returned null (${entry.pluginId}): [${entry.names.join(", ")}]`,
+          `plugin tool factory returned null (${entry.pluginId}): [${declaredNames.join(", ")}]`,
         );
       }
       continue;
@@ -248,6 +352,17 @@ export function resolvePluginTools(params: {
         optional: entry.optional,
       });
       tools.push(tool);
+    }
+  }
+
+  if (factoryTimings.length > 0) {
+    const totalMs =
+      factoryTimings.at(-1)?.elapsedMs ?? toElapsedMs(Date.now() - factoryTimingStartedAt);
+    const timingSummary = { totalMs, timings: factoryTimings };
+    if (shouldWarnPluginToolFactoryTimings(timingSummary)) {
+      log.warn(formatPluginToolFactoryTimingSummary(timingSummary));
+    } else if (log.isEnabled("trace")) {
+      log.trace(formatPluginToolFactoryTimingSummary(timingSummary));
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds trace/warn timing summaries around plugin tool factories in resolvePluginTools.
- Promotes slow plugin factory work to warn when an individual factory is at least 1s or total factory prep is at least 5s; otherwise emits only when trace logging is enabled.
- Covers warn, trace, and quiet fast paths in plugin tool tests.
- Routes plugin-tools MCP logs to stderr before tool discovery so trace logging cannot write non-protocol bytes to stdout.
- Documents the operator troubleshooting path in plugin docs and links it from gateway logging docs.

## Verification
- pnpm test src/plugins/tools.optional.test.ts -- --reporter=verbose
- pnpm test src/mcp/plugin-tools-serve.test.ts src/plugins/tools.optional.test.ts -- --reporter=verbose
- pnpm build
- live smoke via pnpm exec tsx against resolvePluginTools emitted [trace:plugin-tools] factory timings and LIVE_TOOLS=memory_search,memory_get
- Testbox tbx_01kqjr44rpywxy8p7yfz5a4yqd: OPENCLAW_TESTBOX=1 pnpm check:changed passed after MCP follow-up
- pnpm format:docs:check
- pnpm docs:check-mdx docs/tools/plugin.md docs/gateway/logging.md
- git diff --check

Note: pnpm docs:check-links:anchors -- docs/tools/plugin.md docs/gateway/logging.md currently fails on unrelated pre-existing broken anchors in other docs files; no failures were reported for the touched docs.