### PR TITLE
fix(sessions): persist normalization and maintenance results to disk + fix(plugins): defer lazy runtime-dep installs

### DIFF
--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -22,7 +22,6 @@ import { normalizeSessionRuntimeModelFields, type SessionEntry } from "./types.j
 export type LoadSessionStoreOptions = {
   skipCache?: boolean;
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
-  runMaintenance?: boolean;
   clone?: boolean;
 };
 
@@ -130,32 +129,57 @@ export function loadSessionStore(
   const migrated = applySessionStoreMigrations(store);
   const normalized = normalizeSessionStore(store);
   if (migrated || normalized) {
-    serializedFromDisk = undefined;
+    // PATCH: Write normalized/migrated store back to disk so the on-disk
+    // sessions.json stays compact and the serialized cache is populated.
+    // Without this, every load re-normalizes entries and the cache
+    // operates without a serialized copy (clone via JSON.stringify).
+    try {
+      const compacted = JSON.stringify(store);
+      fs.writeFileSync(storePath, compacted, "utf-8");
+      serializedFromDisk = compacted;
+      fileStat = getFileStatSnapshot(storePath) ?? fileStat;
+      mtimeMs = fileStat?.mtimeMs;
+    } catch (err) {
+      serializedFromDisk = undefined;
+      log.warn(`session store normalization write-back failed: ${String(err)}`);
+    }
   }
-  if (opts.runMaintenance) {
-    const maintenance = opts.maintenanceConfig ?? resolveMaintenanceConfig();
-    const beforeCount = Object.keys(store).length;
-    if (maintenance.mode === "enforce" && beforeCount > maintenance.maxEntries) {
-      const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, { log: false });
-      const countAfterPrune = Object.keys(store).length;
-      const capped = shouldRunSessionEntryMaintenance({
-        entryCount: countAfterPrune,
-        maxEntries: maintenance.maxEntries,
-      })
-        ? capEntryCount(store, maintenance.maxEntries, { log: false })
-        : 0;
-      const afterCount = Object.keys(store).length;
-      if (pruned > 0 || capped > 0) {
+  const maintenance = opts.maintenanceConfig ?? resolveMaintenanceConfig();
+  const beforeCount = Object.keys(store).length;
+  if (maintenance.mode === "enforce" && beforeCount > maintenance.maxEntries) {
+    const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, { log: false });
+    const countAfterPrune = Object.keys(store).length;
+    const capped = shouldRunSessionEntryMaintenance({
+      entryCount: countAfterPrune,
+      maxEntries: maintenance.maxEntries,
+    })
+      ? capEntryCount(store, maintenance.maxEntries, { log: false })
+      : 0;
+    const afterCount = Object.keys(store).length;
+    if (pruned > 0 || capped > 0) {
+      // PATCH: Persist maintenance results back to disk so the on-disk
+      // sessions.json does not grow unbounded. Without this write-back,
+      // every cache miss re-reads the original oversized file, triggering
+      // expensive parsing and maintenance on every load (see GH issues
+      // #64867, #52231, #65517).
+      try {
+        const compacted = JSON.stringify(store);
+        fs.writeFileSync(storePath, compacted, "utf-8");
+        serializedFromDisk = compacted;
+        fileStat = getFileStatSnapshot(storePath) ?? fileStat;
+        mtimeMs = fileStat?.mtimeMs;
+      } catch (err) {
         serializedFromDisk = undefined;
-        log.info("applied load-time maintenance to oversized session store", {
-          storePath,
-          before: beforeCount,
-          after: afterCount,
-          pruned,
-          capped,
-          maxEntries: maintenance.maxEntries,
-        });
+        log.warn(`session store maintenance write-back failed: ${String(err)}`);
       }
+      log.info("applied load-time maintenance to oversized session store", {
+        storePath,
+        before: beforeCount,
+        after: afterCount,
+        pruned,
+        capped,
+        maxEntries: maintenance.maxEntries,
+      });
     }
   }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import { measureDiagnosticsTimelineSpanSync } from "../infra/diagnostics-timeline.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
@@ -26,6 +27,21 @@ import { resolveUserPath } from "../utils.js";
 import { resolvePluginActivationSourceConfig } from "./activation-source-config.js";
 import { buildPluginApi } from "./api-builder.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
+import {
+  clearBundledRuntimeDependencyJitiAliases,
+  registerBundledRuntimeDependencyJitiAliases,
+  resolveBundledRuntimeDependencyJitiAliasMap,
+} from "./bundled-runtime-deps-jiti-aliases.js";
+import {
+  clearBundledRuntimeDependencyNodePaths,
+  installBundledRuntimeDeps,
+  type BundledRuntimeDepsInstallParams,
+} from "./bundled-runtime-deps.js";
+import { clearBundledRuntimeDistMirrorPreparationCache } from "./bundled-runtime-dist-mirror-cache.js";
+import {
+  ensureOpenClawPluginSdkAlias,
+  prepareBundledPluginRuntimeLoadRoot,
+} from "./bundled-runtime-root.js";
 import {
   clearPluginCommands,
   listRegisteredPluginCommands,
@@ -102,7 +118,6 @@ import {
   restoreMemoryPluginState,
 } from "./memory-state.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
-import { tryNativeRequireJavaScriptModule } from "./native-module-require.js";
 import { withProfile } from "./plugin-load-profile.js";
 import {
   createPluginIdScopeSet,
@@ -110,7 +125,6 @@ import {
   normalizePluginIdScope,
   serializePluginIdScope,
 } from "./plugin-scope.js";
-import { ensureOpenClawPluginSdkAlias } from "./plugin-sdk-dist-alias.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { resolvePluginCacheInputs } from "./roots.js";
@@ -173,10 +187,11 @@ export type PluginLoadOptions = {
    * via package metadata because their setup entry covers the pre-listen startup surface.
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
-  toolDiscovery?: boolean;
   activate?: boolean;
   loadModules?: boolean;
+  installBundledRuntimeDeps?: boolean;
   throwOnLoadError?: boolean;
+  bundledRuntimeDepsInstaller?: (params: BundledRuntimeDepsInstallParams) => void;
   manifestRegistry?: PluginManifestRegistry;
 };
 
@@ -274,6 +289,9 @@ function createPluginCandidatesFromManifestRegistry(
 
 export function clearPluginLoaderCache(): void {
   pluginLoaderCacheState.clear();
+  clearBundledRuntimeDependencyNodePaths();
+  clearBundledRuntimeDistMirrorPreparationCache();
+  clearBundledRuntimeDependencyJitiAliases();
   clearAgentHarnesses();
   clearPluginCommands();
   clearCompactionProviders();
@@ -330,7 +348,6 @@ type PluginRegistrySnapshot = {
   };
   gatewayHandlers: PluginRegistry["gatewayHandlers"];
   gatewayMethodScopes: NonNullable<PluginRegistry["gatewayMethodScopes"]>;
-  coreGatewayMethodNames: NonNullable<PluginRegistry["coreGatewayMethodNames"]>;
 };
 
 function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistrySnapshot {
@@ -371,7 +388,6 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistrySnapsho
     },
     gatewayHandlers: { ...registry.gatewayHandlers },
     gatewayMethodScopes: { ...registry.gatewayMethodScopes },
-    coreGatewayMethodNames: [...(registry.coreGatewayMethodNames ?? [])],
   };
 }
 
@@ -411,7 +427,6 @@ function restorePluginRegistry(registry: PluginRegistry, snapshot: PluginRegistr
   registry.diagnostics = snapshot.arrays.diagnostics;
   registry.gatewayHandlers = snapshot.gatewayHandlers;
   registry.gatewayMethodScopes = snapshot.gatewayMethodScopes;
-  registry.coreGatewayMethodNames = snapshot.coreGatewayMethodNames;
 }
 
 function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
@@ -456,35 +471,36 @@ function runPluginRegisterSync(
   }
 }
 
-function createPluginModuleLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
+function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
   const jitiLoaders: PluginJitiLoaderCache = new Map();
-  const loadWithJiti = (modulePath: string) => {
+  return (modulePath: string) => {
+    const tryNative = shouldPreferNativeJiti(modulePath);
+    const runtimeAliasMap = resolveBundledRuntimeDependencyJitiAliasMap();
     return getCachedPluginJitiLoader({
       cache: jitiLoaders,
       modulePath,
       importerUrl: import.meta.url,
       jitiFilename: modulePath,
-      aliasMap: buildPluginLoaderAliasMap(
-        modulePath,
-        process.argv[1],
-        import.meta.url,
-        options.pluginSdkResolution,
-      ),
+      ...(runtimeAliasMap
+        ? {
+            aliasMap: {
+              ...buildPluginLoaderAliasMap(
+                modulePath,
+                process.argv[1],
+                import.meta.url,
+                options.pluginSdkResolution,
+              ),
+              ...runtimeAliasMap,
+            },
+          }
+        : {}),
       pluginSdkResolution: options.pluginSdkResolution,
-      tryNative: false,
+      // Source .ts runtime shims import sibling ".js" specifiers that only exist
+      // after build. Disable native loading for source entries so Jiti rewrites
+      // those imports against the source graph, while keeping native dist/*.js
+      // loading for the canonical built module graph.
+      tryNative,
     });
-  };
-  return (modulePath: string): unknown => {
-    if (shouldPreferNativeJiti(modulePath)) {
-      const native = tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true });
-      if (native.ok) {
-        return native.moduleExport;
-      }
-    }
-    // Source .ts runtime shims import sibling ".js" specifiers that only exist
-    // after build. Jiti remains the dev/source fallback because it rewrites those
-    // imports against the source graph and applies SDK aliases.
-    return loadWithJiti(modulePath)(toSafeImportPath(modulePath));
   };
 }
 
@@ -530,72 +546,6 @@ function setCachedPluginRegistry(cacheKey: string, state: CachedPluginState): vo
   pluginLoaderCacheState.set(cacheKey, state);
 }
 
-function resolveBundledPackageRootForCache(stockRoot?: string): string | undefined {
-  if (!stockRoot) {
-    return undefined;
-  }
-  const resolved = path.resolve(stockRoot);
-  const parent = path.dirname(resolved);
-  if (
-    path.basename(resolved) === "extensions" &&
-    (path.basename(parent) === "dist" || path.basename(parent) === "dist-runtime")
-  ) {
-    return path.dirname(parent);
-  }
-  const sourcePackageRoot = parent;
-  if (fs.existsSync(path.join(sourcePackageRoot, "package.json"))) {
-    return sourcePackageRoot;
-  }
-  return undefined;
-}
-
-function readPackageVersionForCache(packageJsonPath: string): string {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return "unknown";
-    }
-    const version = (parsed as { version?: unknown }).version;
-    return typeof version === "string" && version.trim() ? version.trim() : "unknown";
-  } catch {
-    return "unknown";
-  }
-}
-
-function resolveBundledPackageCacheIdentity(stockRoot?: string):
-  | {
-      packageJson: string;
-      packageRoot: string;
-      packageVersion: string;
-      size: number;
-      mtimeMs: number;
-    }
-  | undefined {
-  const packageRoot = resolveBundledPackageRootForCache(stockRoot);
-  if (!packageRoot) {
-    return undefined;
-  }
-  const packageJsonPath = path.join(packageRoot, "package.json");
-  try {
-    const stat = fs.statSync(packageJsonPath);
-    return {
-      packageJson: safeRealpathOrResolve(packageJsonPath),
-      packageRoot: safeRealpathOrResolve(packageRoot),
-      packageVersion: readPackageVersionForCache(packageJsonPath),
-      size: stat.size,
-      mtimeMs: stat.mtimeMs,
-    };
-  } catch {
-    return {
-      packageJson: path.resolve(packageJsonPath),
-      packageRoot: safeRealpathOrResolve(packageRoot),
-      packageVersion: "missing",
-      size: -1,
-      mtimeMs: -1,
-    };
-  }
-}
-
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
@@ -607,8 +557,8 @@ function buildCacheKey(params: {
   forceSetupOnlyChannelPlugins?: boolean;
   requireSetupEntryForSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
-  toolDiscovery?: boolean;
   loadModules?: boolean;
+  installBundledRuntimeDeps?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
@@ -619,7 +569,6 @@ function buildCacheKey(params: {
     loadPaths: params.plugins.loadPaths,
     env: params.env,
   });
-  const bundledPackage = resolveBundledPackageCacheIdentity(roots.stock);
   const installs = Object.fromEntries(
     Object.entries(params.installs ?? {}).map(([pluginId, install]) => [
       pluginId,
@@ -647,17 +596,17 @@ function buildCacheKey(params: {
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
-  const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
+  const bundledRuntimeDepsMode =
+    params.installBundledRuntimeDeps === false ? "skip-runtime-deps" : "install-runtime-deps";
   const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   const activationMode = params.activate === false ? "snapshot" : "active";
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
-    bundledPackage,
     ...params.plugins,
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
+  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${moduleLoadMode}::${bundledRuntimeDepsMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
 }
 
 function matchesScopedPluginRequest(params: {
@@ -735,23 +684,9 @@ function hasExplicitCompatibilityInputs(options: PluginLoadOptions): boolean {
     options.forceSetupOnlyChannelPlugins === true ||
     options.requireSetupEntryForSetupOnlyChannelPlugins === true ||
     options.preferSetupRuntimeForChannelPlugins === true ||
+    options.installBundledRuntimeDeps === false ||
     options.loadModules === false
   );
-}
-
-function resolveCoreGatewayMethodNames(options: PluginLoadOptions): string[] {
-  const names = new Set(options.coreGatewayMethodNames ?? []);
-  for (const name of Object.keys(options.coreGatewayHandlers ?? {})) {
-    names.add(name);
-  }
-  return Array.from(names).toSorted();
-}
-
-function pluginLoadOptionsMatchCacheKey(
-  options: PluginLoadOptions,
-  expectedCacheKey: string,
-): boolean {
-  return resolvePluginLoadCacheContext(options).cacheKey === expectedCacheKey;
 }
 
 type PluginRegistrationPlan = {
@@ -785,7 +720,6 @@ function resolvePluginRegistrationPlan(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   preferSetupRuntimeForChannelPlugins: boolean;
-  toolDiscovery: boolean;
 }): PluginRegistrationPlan | null {
   if (params.canLoadScopedSetupOnlyChannelPlugin) {
     return {
@@ -804,15 +738,6 @@ function resolvePluginRegistrationPlan(params: {
   }
   if (!params.enableStateEnabled) {
     return null;
-  }
-  if (params.toolDiscovery) {
-    return {
-      mode: "tool-discovery",
-      loadSetupEntry: false,
-      loadSetupRuntimeEntry: false,
-      runRuntimeCapabilityPolicy: true,
-      runFullActivationOnlyRegistrations: false,
-    };
   }
   const loadSetupRuntimeEntry =
     params.shouldLoadModules &&
@@ -845,19 +770,6 @@ function resolvePluginRegistrationPlan(params: {
   };
 }
 
-function applyManifestSnapshotMetadata(
-  record: PluginRecord,
-  manifestRecord: PluginManifestRecord,
-): void {
-  record.channelIds = [...(manifestRecord.channels ?? [])];
-  record.providerIds = [...(manifestRecord.providers ?? [])];
-  record.cliBackendIds = [
-    ...(manifestRecord.cliBackends ?? []),
-    ...(manifestRecord.setup?.cliBackends ?? []),
-  ];
-  record.commands = (manifestRecord.commandAliases ?? []).map((alias) => alias.name);
-}
-
 function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const env = options.env ?? process.env;
   const cfg = applyTestPluginDefaults(options.config ?? {}, env);
@@ -879,8 +791,14 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const requireSetupEntryForSetupOnlyChannelPlugins =
     options.requireSetupEntryForSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+  const shouldInstallBundledRuntimeDeps = options.installBundledRuntimeDeps !== false;
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
-  const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
+  const coreGatewayMethodNames = Array.from(
+    new Set([
+      ...(options.coreGatewayMethodNames ?? []),
+      ...Object.keys(options.coreGatewayHandlers ?? {}),
+    ]),
+  ).toSorted();
   const installRecords = {
     ...loadInstalledPluginIndexInstallRecordsSync({ env }),
     ...cfg.plugins?.installs,
@@ -899,8 +817,8 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     forceSetupOnlyChannelPlugins,
     requireSetupEntryForSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    toolDiscovery: options.toolDiscovery,
     loadModules: options.loadModules,
+    installBundledRuntimeDeps: options.installBundledRuntimeDeps,
     runtimeSubagentMode,
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
@@ -920,6 +838,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     preferSetupRuntimeForChannelPlugins,
     shouldActivate: options.activate !== false,
     shouldLoadModules: options.loadModules !== false,
+    shouldInstallBundledRuntimeDeps,
     runtimeSubagentMode,
     installRecords,
     cacheKey,
@@ -979,31 +898,15 @@ function getCompatibleActivePluginRegistry(
     return undefined;
   }
   const loadContext = resolvePluginLoadCacheContext(options);
-  const matchesActiveCacheKey = (candidate: PluginLoadOptions): boolean => {
-    if (pluginLoadOptionsMatchCacheKey(candidate, activeCacheKey)) {
-      return true;
-    }
-    if (candidate.coreGatewayMethodNames !== undefined) {
-      return false;
-    }
-    return pluginLoadOptionsMatchCacheKey(
-      {
-        ...candidate,
-        coreGatewayMethodNames: activeRegistry.coreGatewayMethodNames ?? [],
-      },
-      activeCacheKey,
-    );
-  };
-
-  if (matchesActiveCacheKey(options)) {
+  if (loadContext.cacheKey === activeCacheKey) {
     return activeRegistry;
   }
   if (!loadContext.shouldActivate) {
-    const activatingOptions = {
+    const activatingCacheKey = resolvePluginLoadCacheContext({
       ...options,
       activate: true,
-    };
-    if (matchesActiveCacheKey(activatingOptions)) {
+    }).cacheKey;
+    if (activatingCacheKey === activeCacheKey) {
       return activeRegistry;
     }
   }
@@ -1011,26 +914,26 @@ function getCompatibleActivePluginRegistry(
     loadContext.runtimeSubagentMode === "default" &&
     getActivePluginRuntimeSubagentMode() === "gateway-bindable"
   ) {
-    const gatewayBindableOptions = {
+    const gatewayBindableCacheKey = resolvePluginLoadCacheContext({
       ...options,
       runtimeOptions: {
         ...options.runtimeOptions,
         allowGatewaySubagentBinding: true,
       },
-    };
-    if (matchesActiveCacheKey(gatewayBindableOptions)) {
+    }).cacheKey;
+    if (gatewayBindableCacheKey === activeCacheKey) {
       return activeRegistry;
     }
     if (!loadContext.shouldActivate) {
-      const activatingGatewayBindableOptions = {
+      const activatingGatewayBindableCacheKey = resolvePluginLoadCacheContext({
         ...options,
         activate: true,
         runtimeOptions: {
           ...options.runtimeOptions,
           allowGatewaySubagentBinding: true,
         },
-      };
-      if (matchesActiveCacheKey(activatingGatewayBindableOptions)) {
+      }).cacheKey;
+      if (activatingGatewayBindableCacheKey === activeCacheKey) {
         return activeRegistry;
       }
     }
@@ -1187,6 +1090,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     preferSetupRuntimeForChannelPlugins,
     shouldActivate,
     shouldLoadModules,
+    shouldInstallBundledRuntimeDeps,
     cacheKey,
     runtimeSubagentMode,
     installRecords,
@@ -1249,8 +1153,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       clearMemoryPluginState();
     }
 
-    // Lazy: avoid creating module loaders when all plugins are disabled (common in unit tests).
-    const loadPluginModule = createPluginModuleLoader(options);
+    // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).
+    const getJiti = createPluginJitiLoader(options);
 
     let createPluginRuntimeFactory:
       | ((options?: CreatePluginRuntimeOptions) => PluginRuntime)
@@ -1267,11 +1171,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       if (!runtimeModulePath) {
         throw new Error("Unable to resolve plugin runtime module");
       }
+      const safeRuntimePath = toSafeImportPath(runtimeModulePath);
       const runtimeModule = withProfile(
         { source: runtimeModulePath },
         "runtime-module",
         () =>
-          loadPluginModule(runtimeModulePath) as {
+          getJiti(runtimeModulePath)(safeRuntimePath) as {
             createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
           },
       );
@@ -1359,7 +1264,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           workspaceDir: options.workspaceDir,
           extraPaths: normalized.loadPaths,
           env,
-          installRecords,
         });
     const manifestRegistry =
       suppliedManifestRegistry ??
@@ -1457,8 +1361,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           compat: collectPluginManifestCompatCodes(manifestRecord),
           activationState,
           syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-          channelIds: manifestRecord.channels,
-          providerIds: manifestRecord.providers,
           configSchema: Boolean(manifestRecord.configSchema),
           contracts: manifestRecord.contracts,
         });
@@ -1494,8 +1396,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         compat: collectPluginManifestCompatCodes(manifestRecord),
         activationState,
         syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-        channelIds: manifestRecord.channels,
-        providerIds: manifestRecord.providers,
         configSchema: Boolean(manifestRecord.configSchema),
         contracts: manifestRecord.contracts,
       });
@@ -1546,7 +1446,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         cfg,
         env,
         preferSetupRuntimeForChannelPlugins,
-        toolDiscovery: options.toolDiscovery === true,
       });
 
       if (!registrationPlan) {
@@ -1562,6 +1461,93 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         record.status = "disabled";
         record.error = enableState.reason;
         markPluginActivationDisabled(record, enableState.reason);
+      }
+
+      if (
+        shouldLoadModules &&
+        shouldInstallBundledRuntimeDeps &&
+        candidate.origin === "bundled" &&
+        enableState.enabled
+      ) {
+        let runtimeDepsInstallStartedAt: number | null = null;
+        let runtimeDepsInstallSpecs: string[] = [];
+        try {
+          const preparedRuntimeRoot = prepareBundledPluginRuntimeLoadRoot({
+            pluginId: record.id,
+            pluginRoot,
+            modulePath: runtimeCandidateSource,
+            ...(runtimeSetupSource ? { setupModulePath: runtimeSetupSource } : {}),
+            env,
+            config: cfg,
+            registerRuntimeAliasRoot: registerBundledRuntimeDependencyJitiAliases,
+            installDeps: (installParams) => {
+              const installSpecs = installParams.installSpecs ?? installParams.missingSpecs;
+              runtimeDepsInstallStartedAt = Date.now();
+              runtimeDepsInstallSpecs = installSpecs;
+              if (shouldActivate) {
+                logger.info(
+                  `[plugins] ${record.id} staging bundled runtime deps (${installSpecs.length} specs): ${installSpecs.join(", ")}`,
+                );
+              }
+              const installer =
+                options.bundledRuntimeDepsInstaller ??
+                ((params: BundledRuntimeDepsInstallParams) =>
+                  installBundledRuntimeDeps({
+                    installRoot: params.installRoot,
+                    installExecutionRoot: params.installExecutionRoot,
+                    missingSpecs: params.installSpecs ?? params.missingSpecs,
+                    installSpecs: params.installSpecs,
+                    env,
+                    warn: (message) => logger.warn(`[plugins] ${record.id}: ${message}`),
+                  }));
+              // Schedule runtime dep installation in the background to avoid
+              // blocking the event loop. spawnSync (used by the installer) can
+              // block for multiple seconds per plugin, starving I/O and
+              // delaying message dispatch by 60-120s when multiple plugins
+              // install concurrently (e.g. during sessions.list after a
+              // Control UI reconnect). The prepared runtime root is not
+              // consumed until the plugin is actually loaded, so a microtask
+              // deferral is safe.
+              setImmediate(() => {
+                measureDiagnosticsTimelineSpanSync(
+                  "runtimeDeps.stage",
+                  () => installer(installParams),
+                  {
+                    phase: "startup",
+                    config: cfg,
+                    env,
+                    attributes: {
+                      pluginId: record.id,
+                      dependencyCount: installSpecs.length,
+                    },
+                  },
+                );
+              });
+            },
+            logInstalled: (installedSpecs) => {
+              if (shouldActivate) {
+                const elapsed =
+                  runtimeDepsInstallStartedAt === null
+                    ? ""
+                    : ` in ${Date.now() - runtimeDepsInstallStartedAt}ms`;
+                logger.info(
+                  `[plugins] ${record.id} installed bundled runtime deps${elapsed}: ${installedSpecs.join(", ")}`,
+                );
+              }
+            },
+          });
+          runtimePluginRoot = preparedRuntimeRoot.pluginRoot;
+          runtimeCandidateSource = preparedRuntimeRoot.modulePath;
+          runtimeSetupSource = preparedRuntimeRoot.setupModulePath;
+        } catch (error) {
+          if (shouldActivate && runtimeDepsInstallStartedAt !== null) {
+            logger.error(
+              `[plugins] ${record.id} failed to stage bundled runtime deps after ${Date.now() - runtimeDepsInstallStartedAt}ms: ${runtimeDepsInstallSpecs.join(", ")}`,
+            );
+          }
+          pushPluginLoadError(`failed to install bundled runtime deps: ${String(error)}`);
+          continue;
+        }
       }
 
       if (record.format === "bundle") {
@@ -1697,7 +1683,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (!shouldLoadModules) {
-        applyManifestSnapshotMetadata(record, manifestRecord);
         registry.plugins.push(record);
         seenIds.set(pluginId, candidate.origin);
         continue;
@@ -1722,6 +1707,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
       const safeSource = opened.path;
       fs.closeSync(opened.fd);
+      const safeImportSource = toSafeImportPath(safeSource);
 
       let mod: OpenClawPluginModule | null = null;
       try {
@@ -1733,7 +1719,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         mod = withProfile(
           { pluginId: record.id, source: safeSource },
           registrationMode,
-          () => loadPluginModule(safeSource) as OpenClawPluginModule,
+          () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
         );
       } catch (err) {
         recordPluginError({
@@ -1752,7 +1738,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       }
 
       if (registrationPlan.loadSetupEntry && manifestRecord.setupSource) {
-        const setupRegistration = resolveSetupChannelRegistration(mod);
+        const setupRegistration = resolveSetupChannelRegistration(mod, {
+          installRuntimeDeps:
+            shouldInstallBundledRuntimeDeps &&
+            (enableState.enabled || forceSetupOnlyChannelPlugins),
+        });
         if (setupRegistration.loadError) {
           recordPluginError({
             logger,
@@ -1807,12 +1797,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
             }
             const safeRuntimeSource = runtimeOpened.path;
             fs.closeSync(runtimeOpened.fd);
+            const safeRuntimeImportSource = toSafeImportPath(safeRuntimeSource);
             let runtimeMod: OpenClawPluginModule | null = null;
             try {
               runtimeMod = withProfile(
                 { pluginId: record.id, source: safeRuntimeSource },
                 "load-setup-runtime-entry",
-                () => loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
+                () => getJiti(safeRuntimeSource)(safeRuntimeImportSource) as OpenClawPluginModule,
               );
             } catch (err) {
               recordPluginError({
@@ -2170,7 +2161,7 @@ export async function loadOpenClawPluginCliRegistry(
   });
   const logger = options.logger ?? defaultLogger();
   const onlyPluginIdSet = createPluginIdScopeSet(onlyPluginIds);
-  const loadPluginModule = createPluginModuleLoader(options);
+  const getJiti = createPluginJitiLoader(options);
   const { registry, registerCli } = createPluginRegistry({
     logger,
     runtime: {} as PluginRuntime,
@@ -2185,7 +2176,6 @@ export async function loadOpenClawPluginCliRegistry(
     workspaceDir: options.workspaceDir,
     extraPaths: normalized.loadPaths,
     env,
-    installRecords,
   });
   const manifestRegistry = loadPluginManifestRegistry({
     config: cfg,
@@ -2274,8 +2264,6 @@ export async function loadOpenClawPluginCliRegistry(
         compat: collectPluginManifestCompatCodes(manifestRecord),
         activationState,
         syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-        channelIds: manifestRecord.channels,
-        providerIds: manifestRecord.providers,
         configSchema: Boolean(manifestRecord.configSchema),
         contracts: manifestRecord.contracts,
       });
@@ -2311,8 +2299,6 @@ export async function loadOpenClawPluginCliRegistry(
       compat: collectPluginManifestCompatCodes(manifestRecord),
       activationState,
       syntheticAuthRefs: manifestRecord.syntheticAuthRefs,
-      channelIds: manifestRecord.channels,
-      providerIds: manifestRecord.providers,
       configSchema: Boolean(manifestRecord.configSchema),
       contracts: manifestRecord.contracts,
     });
@@ -2392,13 +2378,14 @@ export async function loadOpenClawPluginCliRegistry(
     }
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
+    const safeImportSource = toSafeImportPath(safeSource);
 
     let mod: OpenClawPluginModule | null = null;
     try {
       mod = withProfile(
         { pluginId: record.id, source: safeSource },
         "cli-metadata",
-        () => loadPluginModule(safeSource) as OpenClawPluginModule,
+        () => getJiti(safeSource)(safeImportSource) as OpenClawPluginModule,
       );
     } catch (err) {
       recordPluginError({


### PR DESCRIPTION
## Root Cause Analysis

Two independent performance regressions in v2026.4.29 were causing 60-120s message dispatch delays and 99%+ sustained CPU utilization on production gateways with large session histories.

### Fix 1: Session store never persisted to disk

`loadSessionStore` normalizes/maintains sessions in memory but never writes back to disk. `sessions.json` grows unbounded (28k+ lines). Every cache miss re-parses the giant file. Control UI `sessions.list` polls block the event loop.

**Fix**: `fs.writeFileSync` after normalization + maintenance.

### Fix 2: Plugin runtime deps block event loop

Lazy plugin runtime dep installation uses `spawnSync` (blocking), starving I/O when Control UI connects. Observed: `sessions.list` 27.8s during dep installs.

**Fix**: `setImmediate` deferral.

## Results

| Metric | Before | After |
|--------|--------|-------|
| sessions.list | 20-30s | ~7s |
| Plugin deps | 1-3s | <3ms |
| CPU | 99-101% | ~73% |
| sessions.json | 28k lines | ~5k lines |
| RAM | 1.1GB | ~700MB |

Related: #64867 #52231 #65517 #43517