### PR TITLE
fix(plugins): redact git install failure urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.
 - Plugins/CLI: keep git plugin install paths credential-free, preserve existing git checkouts until replacement succeeds, honor duplicate npm install mode, and remove managed git repos on uninstall. Thanks @vincentkoc.
+- Plugins/CLI: redact authenticated git URLs from git install command failure details, so failed clone or checkout output cannot leak credentials during plugin installs. Thanks @vincentkoc.
 - Channels/status reactions: remove stale non-terminal lifecycle reactions when a run reaches done or error, so Discord does not leave a permanent thinking emoji after completion. Fixes #75458. Thanks @davelutztx.
 - Discord/doctor: migrate unsupported per-channel `agentId` entries under guild channel config into top-level `bindings[]` routes, so `openclaw doctor --fix` preserves the intended agent route instead of stripping it as an unknown key. Fixes #62455. Thanks @lobster-biscuit.
 - Gateway/config: log config health-state write failures instead of silently hiding config observe-recovery write errors. Thanks @sallyom.

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -204,7 +204,8 @@ describe("installPluginFromGitSpec", () => {
     runCommandWithTimeoutMock.mockResolvedValueOnce({
       code: 1,
       stdout: "",
-      stderr: "fatal: could not read Username for 'https://token:secret@github.com/acme/demo.git'",
+      stderr:
+        "fatal: could not read Username for 'https://token:secret@github.com/acme/demo.git' while retrying https://other:credential@github.com/acme/fallback.git",
     });
 
     const result = await installPluginFromGitSpec({
@@ -215,8 +216,11 @@ describe("installPluginFromGitSpec", () => {
     if (!result.ok) {
       expect(result.error).toContain("failed to clone github.com/acme/demo");
       expect(result.error).toContain("https://***:***@github.com/acme/demo.git");
+      expect(result.error).toContain("https://***:***@github.com/acme/fallback.git");
       expect(result.error).not.toContain("token");
       expect(result.error).not.toContain("secret");
+      expect(result.error).not.toContain("other");
+      expect(result.error).not.toContain("credential");
     }
     expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();
   });

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -200,6 +200,27 @@ describe("installPluginFromGitSpec", () => {
     }
   });
 
+  it("redacts authenticated git URLs from command failure details", async () => {
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "fatal: could not read Username for 'https://token:secret@github.com/acme/demo.git'",
+    });
+
+    const result = await installPluginFromGitSpec({
+      spec: "git:https://token:secret@github.com/acme/demo.git",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("failed to clone github.com/acme/demo");
+      expect(result.error).toContain("https://***:***@github.com/acme/demo.git");
+      expect(result.error).not.toContain("token");
+      expect(result.error).not.toContain("secret");
+    }
+    expect(installPluginFromInstalledPackageDirMock).not.toHaveBeenCalled();
+  });
+
   it("keeps the existing managed repo when replacement install fails", async () => {
     const gitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-git-install-preserve-"));
     const normalizedSpec = "git:https://github.com/acme/demo.git";

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -235,7 +235,9 @@ function formatGitCommandFailure(params: {
   stdout: string;
   stderr: string;
 }): string {
-  const detail = sanitizeForLog(params.stderr.trim() || params.stdout.trim() || "git failed");
+  const detail = sanitizeForLog(
+    redactSensitiveUrlLikeString(params.stderr.trim() || params.stdout.trim() || "git failed"),
+  );
   return `failed to ${params.action} ${sanitizeForLog(redactSensitiveUrlLikeString(params.source.label))}: ${detail}`;
 }
 

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -299,6 +299,40 @@ describe("installPluginFromNpmSpec", () => {
     ).toBe(false);
   });
 
+  it("allows duplicate npm installs in update mode", async () => {
+    const stateDir = suiteTempRootTracker.makeTempDir();
+    const npmRoot = path.join(stateDir, "npm");
+    const installRoot = path.join(npmRoot, "node_modules", "@openclaw", "voice-call");
+    fs.mkdirSync(installRoot, { recursive: true });
+    fs.writeFileSync(path.join(installRoot, "old.txt"), "old", "utf-8");
+    mockNpmViewAndInstall({
+      spec: "@openclaw/voice-call@0.0.2",
+      packageName: "@openclaw/voice-call",
+      version: "0.0.2",
+      pluginId: "voice-call",
+      npmRoot,
+    });
+
+    const result = await installPluginFromNpmSpec({
+      spec: "@openclaw/voice-call@0.0.2",
+      npmDir: npmRoot,
+      mode: "update",
+      logger: { info: () => {}, warn: () => {} },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    expect(result.targetDir).toBe(installRoot);
+    expect(result.npmResolution?.version).toBe("0.0.2");
+    expectNpmInstallIntoRoot({
+      calls: runCommandWithTimeoutMock.mock.calls,
+      npmRoot,
+      spec: "@openclaw/voice-call@0.0.2",
+    });
+  });
+
   it("aborts when integrity drift callback rejects the fetched artifact", async () => {
     mockNpmViewMetadataResult(runCommandWithTimeoutMock, {
       name: "@openclaw/voice-call",

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1061,6 +1061,37 @@ describe("uninstallPlugin", () => {
     });
     await expect(fs.access(installPath)).rejects.toThrow();
   });
+
+  it("does not delete symlinked git install targets that resolve outside the managed git root", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const extensionsDir = path.join(stateDir, "extensions");
+    const linkParentDir = path.join(stateDir, "git", "git-abc123");
+    const installPath = path.join(linkParentDir, "repo");
+    const outsideDir = path.join(tempDir, "outside");
+    await fs.mkdir(linkParentDir, { recursive: true });
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "index.js"), "// keep me");
+    await fs.symlink(outsideDir, installPath, "dir");
+
+    const result = await uninstallPlugin({
+      config: createPluginConfig({
+        entries: createSinglePluginEntries(),
+        installs: {
+          "my-plugin": createGitInstallRecord("my-plugin", installPath),
+        },
+      }),
+      pluginId: "my-plugin",
+      deleteFiles: true,
+      extensionsDir,
+    });
+
+    expectSuccessfulUninstallActions(result, {
+      directory: false,
+    });
+    await expect(fs.access(outsideDir)).resolves.toBeUndefined();
+    const linkStat = await fs.lstat(installPath);
+    expect(linkStat.isSymbolicLink()).toBe(true);
+  });
 });
 
 describe("resolveUninstallDirectoryTarget", () => {

--- a/src/shared/net/redact-sensitive-url.test.ts
+++ b/src/shared/net/redact-sensitive-url.test.ts
@@ -35,6 +35,14 @@ describe("redactSensitiveUrlLikeString", () => {
     );
   });
 
+  it("redacts every URL-like userinfo occurrence in arbitrary text", () => {
+    expect(
+      redactSensitiveUrlLikeString(
+        "fatal https://a:b@github.com/one.git and https://c:d@github.com/two.git",
+      ),
+    ).toBe("fatal https://***:***@github.com/one.git and https://***:***@github.com/two.git");
+  });
+
   it("redacts protocol URLs that are too malformed to parse", () => {
     expect(
       redactSensitiveUrlLikeString(

--- a/src/shared/net/redact-sensitive-url.ts
+++ b/src/shared/net/redact-sensitive-url.ts
@@ -70,7 +70,7 @@ export function redactSensitiveUrlLikeString(value: string): string {
     return redactedUrl;
   }
   return value
-    .replace(/\/\/([^@/?#]+)@/, "//***:***@")
+    .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
     .replace(/([?&])([^=&]+)=([^&]*)/g, (match, prefix: string, key: string) =>
       isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
     );


### PR DESCRIPTION
## Summary
- redact credential-bearing URLs in git install clone/checkout failure output
- cover npm duplicate install update mode explicitly
- cover managed git uninstall symlink escape behavior
- add changelog credit for the extra git install redaction fix

## Tests
- pnpm test:serial src/plugins/git-install.test.ts src/plugins/install.npm-spec.test.ts src/plugins/uninstall.test.ts
- Testbox tbx_01kqjv4ymtntfjab8jm576j0zd: OPENCLAW_TESTBOX=1 pnpm check:changed

## Notes
- Rebasing onto latest origin/main was clean; post-rebase diff/stat sanity and git diff --check passed, so the existing Testbox proof remains valid.