### PR TITLE
fix(cron): honor agentRuntime.id when stamping cron session modelProvider

### DIFF
--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -442,6 +442,83 @@ describe("cron model formatting and precedence edge cases", () => {
     });
   });
 
+  describe("agentRuntime CLI provider stamping", () => {
+    // Regression: prior to this fix, resolveCronModelSelection derived the
+    // session-stamped provider from the model string's slash-prefix
+    // (e.g. "anthropic/claude-opus-4-6" -> "anthropic"), ignoring the agent's
+    // configured agentRuntime.id. For agents whose runtime is a CLI backend
+    // (e.g. "claude-cli"), this routed cron-fired turns through the paid
+    // Anthropic API instead of the OAuth-backed CLI. The interactive path
+    // already consults isCliProvider() via run-executor; the cron path now
+    // does the same.
+    function cfgWithClaudeCli(extra: Record<string, unknown> = {}) {
+      return {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "claude-cli" },
+            cliBackends: { "claude-cli": {} },
+            ...extra,
+          },
+        },
+      };
+    }
+
+    it("stamps agentRuntime.id when it is a configured CLI backend", async () => {
+      await expectSelectedModel(
+        {
+          cfg: cfgWithClaudeCli({ model: "anthropic/claude-opus-4-6" }),
+        },
+        { provider: "claude-cli", model: "claude-opus-4-6" },
+      );
+    });
+
+    it("stamps CLI runtime even when payload.model carries a non-CLI provider prefix", async () => {
+      await expectSelectedModel(
+        {
+          cfg: cfgWithClaudeCli({ model: "anthropic/claude-opus-4-6" }),
+          payload: {
+            kind: "agentTurn",
+            message: DEFAULT_MESSAGE,
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        },
+        { provider: "claude-cli", model: "claude-sonnet-4-6" },
+      );
+    });
+
+    it("does not rewrite provider when agentRuntime.id is not a CLI backend", async () => {
+      await expectSelectedModel(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                agentRuntime: { id: "anthropic" },
+                model: "anthropic/claude-opus-4-6",
+              },
+            },
+          },
+        },
+        { provider: "anthropic", model: "claude-opus-4-6" },
+      );
+    });
+
+    it("leaves provider untouched when no agentRuntime is configured", async () => {
+      await expectSelectedModel(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                cliBackends: { "claude-cli": {} },
+                model: "anthropic/claude-opus-4-6",
+              },
+            },
+          },
+        },
+        { provider: "anthropic", model: "claude-opus-4-6" },
+      );
+    });
+  });
+
   describe("config model format variations", () => {
     it("default model as string 'provider/model'", async () => {
       await expectSelectedModel(

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,3 +1,4 @@
+import { isCliProvider } from "../../agents/model-selection-cli.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -145,6 +146,22 @@ export async function resolveCronModelSelection(
         model = resolvedSessionOverride.ref.model;
       }
     }
+  }
+
+  // Honor the agent's configured CLI runtime: the model-string slash-prefix
+  // (e.g. "anthropic/claude-opus-4-7") names the *underlying* model provider,
+  // but when an agent has agentRuntime.id pointing at a CLI backend (e.g.
+  // "claude-cli"), the cron-fired turn must dispatch through that backend, not
+  // the paid API. The interactive path consults isCliProvider() via
+  // run-executor; this aligns the cron path with the same source of truth.
+  const runtimeId = params.cfgWithAgentDefaults.agents?.defaults?.agentRuntime?.id;
+  if (
+    typeof runtimeId === "string" &&
+    runtimeId.length > 0 &&
+    runtimeId !== provider &&
+    isCliProvider(runtimeId, params.cfgWithAgentDefaults)
+  ) {
+    provider = runtimeId;
   }
 
   return { ok: true, provider, model };


### PR DESCRIPTION
## Bug

`resolveCronModelSelection` derives `provider` purely from the model-string slash-prefix (e.g. `anthropic/claude-opus-4-7` -> `anthropic`), ignoring `agents.defaults.agentRuntime.id`. For agents whose runtime is a CLI backend (e.g. `claude-cli`), this stamps `modelProvider="anthropic"` on the cron session and routes cron-fired turns through the paid Anthropic API instead of the OAuth-backed Claude CLI.

The interactive path already consults `isCliProvider()` (`src/cron/isolated-agent/run-executor.ts:134`); the cron model-selection path never did.

## Fix

After all model-source overrides resolve, if `cfgWithAgentDefaults.agents.defaults.agentRuntime.id` is a configured CLI backend, prefer it over the model-string-derived provider. The model name itself is left untouched (the underlying model is still e.g. `claude-opus-4-7`); only the provider stamp changes.

Diff is +17 lines in `src/cron/isolated-agent/model-selection.ts` (one new import, one post-resolution check).

## Repro / Impact

Local OpenClaw setup with two agents whose `agentRuntime.id="claude-cli"` and a cron driving each: cron session entries stamped `modelProvider="anthropic"` with the underlying model name, and the cron-fired turns routed through paid API at a small but persistent daily API spend that should have flowed through the user's Claude OAuth subscription. Interactive turns from the same agents routed correctly through the CLI/OAuth path.

A workspace-side detector that walks `~/.openclaw/agents/*/sessions/sessions.json`, parses session keys matching `agent:<id>:cron:*`, and flags any whose parent agent has `agentRuntime.id="claude-cli"` but `modelProvider != "claude-cli"` confirmed three leaking sessions before the fix and zero after.

## Tests

Adds 4 cases to `src/cron/isolated-agent.model-formatting.test.ts` under a new `agentRuntime CLI provider stamping` describe block:

- positive: stamps `agentRuntime.id` when it is a configured CLI backend
- positive: stamps CLI runtime even when payload.model carries a non-CLI provider prefix
- negative: does not rewrite provider when `agentRuntime.id` is not a CLI backend
- negative: leaves provider untouched when no agentRuntime is configured

Verified the new tests fail without the patch (positive cases) and pass with the patch.

Targeted lane run locally: `pnpm exec node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts` -> 88 files / 769 tests pass. I did not run the full `pnpm build && pnpm check && pnpm test` lane in my dev environment; happy to add anything maintainers want.

## AI assistance disclosure

- AI-assisted (Claude Opus 4.7), fully tested at the targeted-suite level (769 cron-lane tests + 4 new regression cases).
- I did not run `codex review --base origin/main` locally; will respond to any GitHub Codex / bot review conversations.