### PR TITLE
fix(deadcode): ignore pnpm progress noise

### DIFF
--- a/scripts/check-deadcode-unused-files.mjs
+++ b/scripts/check-deadcode-unused-files.mjs
@@ -28,6 +28,17 @@ function uniqueSorted(values) {
   );
 }
 
+function looksLikeRepoFilePath(value) {
+  const normalized = normalizeRepoPath(value.trim());
+  return (
+    normalized.length > 0 &&
+    !normalized.includes(" ") &&
+    !normalized.startsWith("-") &&
+    /[./]/u.test(normalized) &&
+    /^[A-Za-z0-9_@./+~-]+$/u.test(normalized)
+  );
+}
+
 export function parseKnipCompactUnusedFiles(output) {
   const files = [];
   let inUnusedFilesSection = false;
@@ -50,7 +61,12 @@ export function parseKnipCompactUnusedFiles(output) {
     if (sawUnusedFilesSection && !inUnusedFilesSection) {
       continue;
     }
-    files.push(line.slice(separatorIndex + 2).trim());
+    const source = line.slice(0, separatorIndex).trim();
+    const file = line.slice(separatorIndex + 2).trim();
+    if (!looksLikeRepoFilePath(source) || !looksLikeRepoFilePath(file)) {
+      continue;
+    }
+    files.push(file);
   }
 
   return uniqueSorted(files);

--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -29,6 +29,17 @@ left-pad: package.json
     ]);
   });
 
+  it("ignores pnpm dlx progress noise in captured output", () => {
+    expect(
+      parseKnipCompactUnusedFiles(`
+Progress: resolved 1, reused 0, downloaded 0, added 0
+Progress: resolved 65, reused 8, downloaded 13, added 21, done
+Unused files (1)
+src/a.ts: src/a.ts
+`),
+    ).toEqual(["src/a.ts"]);
+  });
+
   it("reports unexpected and stale allowlist entries", () => {
     expect(
       compareUnusedFilesToAllowlist(["src/a.ts", "src/new.ts"], ["src/a.ts", "src/old.ts"]),


### PR DESCRIPTION
## Summary
- ignore pnpm dlx progress/status lines when parsing Knip compact unused-file output
- keep file-only compact output support intact
- add a regression test for captured pnpm progress noise before an unused-files section

## Tests
- `pnpm deadcode:unused-files`
- `node scripts/test-projects.mjs test/scripts/check-deadcode-unused-files.test.ts`
- `pnpm check:changed`
