### PR TITLE
fix(agents): exempt tool-execution timeouts from model fallback (#52147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
+- Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis. Long `process(poll)`, browser, or `exec` tool calls that exceed `agents.defaults.timeoutSeconds` previously rotated auth profiles, switched to a fallback model, and surfaced a misleading "LLM request timed out" error even though the primary model had already responded. Mirrors the existing `timedOutDuringCompaction` precedent (#46889). Fixes #52147. (#75873) Thanks @simonusa.
 
 ## 2026.5.2
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -220,6 +220,7 @@ export class CodexAppServerEventProjector {
       timedOut: false,
       idleTimedOut: false,
       timedOutDuringCompaction: false,
+      timedOutDuringToolExecution: false,
       promptError,
       promptErrorSource: promptError ? this.promptErrorSource || "prompt" : null,
       sessionIdUsed: this.params.sessionId,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -68,6 +68,7 @@ function createAttemptResult(sessionIdUsed: string): EmbeddedRunAttemptResult {
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     promptError: null,
     promptErrorSource: null,
     sessionIdUsed,

--- a/src/agents/harness/v2.test.ts
+++ b/src/agents/harness/v2.test.ts
@@ -47,6 +47,7 @@ function createAttemptResult(): EmbeddedRunAttemptResult {
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     promptError: null,
     promptErrorSource: null,
     sessionIdUsed: "session-1",

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -168,6 +168,7 @@ const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunA
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     promptError: null,
     promptErrorSource: null,
     sessionIdUsed: "session:test",

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -45,6 +45,7 @@ export function makeAttemptResult(
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     promptError: null,
     promptErrorSource: null,
     sessionIdUsed: "test-session",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1133,6 +1133,7 @@ export async function runEmbeddedPiAgent(
             timedOut,
             idleTimedOut,
             timedOutDuringCompaction,
+            timedOutDuringToolExecution,
             sessionIdUsed,
             sessionFileUsed,
             lastAssistant: sessionLastAssistant,
@@ -1932,6 +1933,7 @@ export async function runEmbeddedPiAgent(
             failoverReason: assistantFailoverReason,
             timedOut,
             timedOutDuringCompaction,
+            timedOutDuringToolExecution,
             profileRotated: false,
           });
           const assistantFailoverOutcome = await handleAssistantFailover({
@@ -1944,6 +1946,7 @@ export async function runEmbeddedPiAgent(
             timedOut,
             idleTimedOut,
             timedOutDuringCompaction,
+            timedOutDuringToolExecution,
             allowSameModelIdleTimeoutRetry:
               timedOut &&
               idleTimedOut &&

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1244,7 +1244,10 @@ export async function runEmbeddedPiAgent(
           // ── Timeout-triggered compaction ──────────────────────────────────
           // When the LLM times out with high context usage, compact before
           // retrying to break the death spiral of repeated timeouts.
-          if (timedOut && !timedOutDuringCompaction) {
+          // Skip when the timeout fired during tool execution: the LLM had
+          // already responded, the prompt wasn't the problem, and compacting
+          // would lose the in-flight tool context. See #52147.
+          if (timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution) {
             // Only consider prompt-side tokens here. API totals include output
             // tokens, which can make a long generation look like high context
             // pressure even when the prompt itself was small.
@@ -2078,7 +2081,17 @@ export async function runEmbeddedPiAgent(
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
+          // Skip when the timeout fired during tool execution: the assistant
+          // did produce a response (a tool call) that ran long; the generic
+          // "no response from model" payload would mislead the caller. The
+          // partial tool output already in the session is the correct artifact
+          // to surface. See #52147.
+          if (
+            timedOut &&
+            !timedOutDuringCompaction &&
+            !timedOutDuringToolExecution &&
+            !payloadsWithToolMedia?.length
+          ) {
             const timeoutText = idleTimedOut
               ? "The model did not produce a response before the model idle timeout. " +
                 "Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers."

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1138,9 +1138,6 @@ export async function runEmbeddedPiAgent(
             lastAssistant: sessionLastAssistant,
             currentAttemptAssistant,
           } = attempt;
-          // Field is optional in the public harness SDK contract; default to
-          // false here so internal code can rely on a strict boolean. Internal
-          // embedded-runner attempt sets this explicitly. See #52147.
           const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
           if (sessionIdUsed && sessionIdUsed !== activeSessionId) {
             activeSessionId = sessionIdUsed;
@@ -1247,9 +1244,6 @@ export async function runEmbeddedPiAgent(
           // ── Timeout-triggered compaction ──────────────────────────────────
           // When the LLM times out with high context usage, compact before
           // retrying to break the death spiral of repeated timeouts.
-          // Skip when the timeout fired during tool execution: the LLM had
-          // already responded, the prompt wasn't the problem, and compacting
-          // would lose the in-flight tool context. See #52147.
           if (timedOut && !timedOutDuringCompaction && !timedOutDuringToolExecution) {
             // Only consider prompt-side tokens here. API totals include output
             // tokens, which can make a long generation look like high context
@@ -2084,11 +2078,6 @@ export async function runEmbeddedPiAgent(
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          // Skip when the timeout fired during tool execution: the assistant
-          // did produce a response (a tool call) that ran long; the generic
-          // "no response from model" payload would mislead the caller. The
-          // partial tool output already in the session is the correct artifact
-          // to surface. See #52147.
           if (
             timedOut &&
             !timedOutDuringCompaction &&

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1133,12 +1133,15 @@ export async function runEmbeddedPiAgent(
             timedOut,
             idleTimedOut,
             timedOutDuringCompaction,
-            timedOutDuringToolExecution,
             sessionIdUsed,
             sessionFileUsed,
             lastAssistant: sessionLastAssistant,
             currentAttemptAssistant,
           } = attempt;
+          // Field is optional in the public harness SDK contract; default to
+          // false here so internal code can rely on a strict boolean. Internal
+          // embedded-runner attempt sets this explicitly. See #52147.
+          const timedOutDuringToolExecution = attempt.timedOutDuringToolExecution ?? false;
           if (sessionIdUsed && sessionIdUsed !== activeSessionId) {
             activeSessionId = sessionIdUsed;
           }

--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -19,6 +19,7 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     allowSameModelIdleTimeoutRetry: false,
     assistantProfileFailureReason: null,
     lastProfileId: undefined,

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -42,6 +42,7 @@ export async function handleAssistantFailover(params: {
   timedOut: boolean;
   idleTimedOut: boolean;
   timedOutDuringCompaction: boolean;
+  timedOutDuringToolExecution: boolean;
   allowSameModelIdleTimeoutRetry: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
   lastProfileId?: string;
@@ -177,6 +178,7 @@ export async function handleAssistantFailover(params: {
       failoverReason: params.failoverReason,
       timedOut: params.timedOut,
       timedOutDuringCompaction: params.timedOutDuringCompaction,
+      timedOutDuringToolExecution: params.timedOutDuringToolExecution,
       profileRotated: true,
     });
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -101,6 +101,7 @@ import {
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
 } from "../../pi-embedded-helpers.js";
+import { countActiveToolExecutions } from "../../pi-embedded-subscribe.handlers.tools.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import {
@@ -782,6 +783,7 @@ export async function runEmbeddedAttempt(
   let timedOut = false;
   let idleTimedOut = false;
   let timedOutDuringCompaction = false;
+  let timedOutDuringToolExecution = false;
   let promptError: unknown = null;
   let emitDiagnosticRunCompleted:
     | ((outcome: "completed" | "aborted" | "error", err?: unknown) => void)
@@ -2250,6 +2252,14 @@ export async function runEmbeddedAttempt(
         aborted = true;
         if (isTimeout) {
           timedOut = true;
+          // Distinguish run-timer fires that occur while tool execution is in
+          // flight (LLM already responded; primary model is not at fault) from
+          // LLM-phase timeouts. Mirrors the `timedOutDuringCompaction` precedent
+          // (#46889) so the failover policy can skip pointless model fallback.
+          // Closes #52147.
+          if (!timedOutDuringCompaction && countActiveToolExecutions(params.runId) > 0) {
+            timedOutDuringToolExecution = true;
+          }
         }
         if (isTimeout) {
           runAbortController.abort(reason ?? makeTimeoutAbortReason());
@@ -3456,6 +3466,7 @@ export async function runEmbeddedAttempt(
         timedOut,
         idleTimedOut,
         timedOutDuringCompaction,
+        timedOutDuringToolExecution,
         promptError: promptError ? formatErrorMessage(promptError) : undefined,
         promptErrorSource,
         usage: attemptUsage,
@@ -3474,6 +3485,7 @@ export async function runEmbeddedAttempt(
           timedOut,
           idleTimedOut,
           timedOutDuringCompaction,
+          timedOutDuringToolExecution,
           promptError: promptError ? formatErrorMessage(promptError) : undefined,
           promptErrorSource,
           usage: attemptUsage,
@@ -3498,6 +3510,7 @@ export async function runEmbeddedAttempt(
         timedOut,
         idleTimedOut,
         timedOutDuringCompaction,
+        timedOutDuringToolExecution,
         promptError: promptError ? formatErrorMessage(promptError) : undefined,
       });
       trajectoryEndRecorded = true;
@@ -3511,6 +3524,7 @@ export async function runEmbeddedAttempt(
         timedOut,
         idleTimedOut,
         timedOutDuringCompaction,
+        timedOutDuringToolExecution,
         promptError,
         promptErrorSource,
         preflightRecovery,
@@ -3555,6 +3569,7 @@ export async function runEmbeddedAttempt(
           timedOut,
           idleTimedOut,
           timedOutDuringCompaction,
+          timedOutDuringToolExecution,
           promptError: promptError ? formatErrorMessage(promptError) : undefined,
         });
       }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2252,11 +2252,6 @@ export async function runEmbeddedAttempt(
         aborted = true;
         if (isTimeout) {
           timedOut = true;
-          // Distinguish run-timer fires that occur while tool execution is in
-          // flight (LLM already responded; primary model is not at fault) from
-          // LLM-phase timeouts. Mirrors the `timedOutDuringCompaction` precedent
-          // (#46889) so the failover policy can skip pointless model fallback.
-          // Closes #52147.
           if (!timedOutDuringCompaction && countActiveToolExecutions(params.runId) > 0) {
             timedOutDuringToolExecution = true;
           }

--- a/src/agents/pi-embedded-runner/run/failover-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.test.ts
@@ -72,6 +72,7 @@ describe("resolveRunFailoverDecision", () => {
         failoverReason: "rate_limit",
         timedOut: false,
         timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -91,6 +92,7 @@ describe("resolveRunFailoverDecision", () => {
         failoverReason: "rate_limit",
         timedOut: false,
         timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
         profileRotated: true,
       }),
     ).toEqual({
@@ -110,6 +112,7 @@ describe("resolveRunFailoverDecision", () => {
         failoverReason: null,
         timedOut: false,
         timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
         profileRotated: false,
       }),
     ).toEqual({
@@ -134,6 +137,64 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("does not rotate or fallback assistant timeouts that fired during tool execution (#52147)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: true,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: true,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "continue_normal",
+    });
+  });
+
+  it("does not fallback assistant tool-execution timeouts even after profile rotation exhausted (#52147)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: true,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: true,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "continue_normal",
+    });
+  });
+
+  it("still rotates assistant timeouts that fired during LLM phase (no active tool execution)", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: true,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: false,
+        failoverReason: null,
+        timedOut: true,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "rotate_profile",
+      reason: null,
+    });
+  });
+
   it("does not rotate or fallback assistant timeouts after an external abort", () => {
     expect(
       resolveRunFailoverDecision({
@@ -145,6 +206,7 @@ describe("resolveRunFailoverDecision", () => {
         failoverReason: null,
         timedOut: true,
         timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
         profileRotated: false,
       }),
     ).toEqual({

--- a/src/agents/pi-embedded-runner/run/failover-policy.ts
+++ b/src/agents/pi-embedded-runner/run/failover-policy.ts
@@ -56,6 +56,7 @@ type AssistantDecisionParams = {
   failoverReason: FailoverReason | null;
   timedOut: boolean;
   timedOutDuringCompaction: boolean;
+  timedOutDuringToolExecution: boolean;
   profileRotated: boolean;
 };
 
@@ -81,7 +82,7 @@ function shouldRotatePrompt(params: PromptDecisionParams): boolean {
 function shouldRotateAssistant(params: AssistantDecisionParams): boolean {
   return (
     (!params.aborted && (params.failoverFailure || params.failoverReason !== null)) ||
-    (params.timedOut && !params.timedOutDuringCompaction)
+    (params.timedOut && !params.timedOutDuringCompaction && !params.timedOutDuringToolExecution)
   );
 }
 

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -58,6 +58,12 @@ export type EmbeddedRunAttemptResult = {
   idleTimedOut: boolean;
   /** True if the timeout occurred while compaction was in progress or pending. */
   timedOutDuringCompaction: boolean;
+  /**
+   * True if the run-level timer fired while at least one tool execution was
+   * still in flight. The LLM had already responded; the timeout is unrelated
+   * to the primary model and must not trigger model fallback. Closes #52147.
+   */
+  timedOutDuringToolExecution: boolean;
   promptError: unknown;
   /**
    * Identifies which phase produced the promptError.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -58,16 +58,7 @@ export type EmbeddedRunAttemptResult = {
   idleTimedOut: boolean;
   /** True if the timeout occurred while compaction was in progress or pending. */
   timedOutDuringCompaction: boolean;
-  /**
-   * True if the run-level timer fired while at least one tool execution was
-   * still in flight. The LLM had already responded; the timeout is unrelated
-   * to the primary model and must not trigger model fallback. Closes #52147.
-   *
-   * Optional for plugin-SDK back-compat: this type is re-exported as
-   * `AgentHarnessAttemptResult` and third-party harnesses cannot necessarily
-   * observe in-flight tool state. Treat absent as `false` at the runner
-   * boundary; internal embedded-runner code always sets it explicitly.
-   */
+  /** Optional because this type is re-exported as `AgentHarnessAttemptResult`. */
   timedOutDuringToolExecution?: boolean;
   promptError: unknown;
   /**

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -62,8 +62,13 @@ export type EmbeddedRunAttemptResult = {
    * True if the run-level timer fired while at least one tool execution was
    * still in flight. The LLM had already responded; the timeout is unrelated
    * to the primary model and must not trigger model fallback. Closes #52147.
+   *
+   * Optional for plugin-SDK back-compat: this type is re-exported as
+   * `AgentHarnessAttemptResult` and third-party harnesses cannot necessarily
+   * observe in-flight tool state. Treat absent as `false` at the runner
+   * boundary; internal embedded-runner code always sets it explicitly.
    */
-  timedOutDuringToolExecution: boolean;
+  timedOutDuringToolExecution?: boolean;
   promptError: unknown;
   /**
    * Identifies which phase produced the promptError.

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -92,6 +92,26 @@ function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
 }
 
+/**
+ * Count tool executions currently in flight for a given run.
+ *
+ * Reads the existing `toolStartData` map: handleToolExecutionStart inserts on
+ * tool start, handleToolExecutionEnd deletes on completion. Used by the
+ * embedded run timer to detect whether a run-level timeout fired while tool
+ * execution was active (in which case the failover policy should not rotate
+ * to a fallback model — the LLM had already responded).
+ */
+export function countActiveToolExecutions(runId: string): number {
+  const prefix = `${runId}:`;
+  let count = 0;
+  for (const key of toolStartData.keys()) {
+    if (key.startsWith(prefix)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 function isCronAddAction(args: unknown): boolean {
   if (!args || typeof args !== "object") {
     return false;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -92,15 +92,6 @@ function buildToolStartKey(runId: string, toolCallId: string): string {
   return `${runId}:${toolCallId}`;
 }
 
-/**
- * Count tool executions currently in flight for a given run.
- *
- * Reads the existing `toolStartData` map: handleToolExecutionStart inserts on
- * tool start, handleToolExecutionEnd deletes on completion. Used by the
- * embedded run timer to detect whether a run-level timeout fired while tool
- * execution was active (in which case the failover policy should not rotate
- * to a fallback model — the LLM had already responded).
- */
 export function countActiveToolExecutions(runId: string): number {
   const prefix = `${runId}:`;
   let count = 0;

--- a/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
+++ b/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
@@ -109,6 +109,7 @@ export function makeEmbeddedRunnerAttempt(
     timedOut: false,
     idleTimedOut: false,
     timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
     promptError: null,
     promptErrorSource: null,
     sessionIdUsed: "session:test",

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -745,6 +745,8 @@ function buildArtifactsCapture(params: {
     idleTimedOut: runtimeArtifacts?.idleTimedOut ?? runtimeEnd?.idleTimedOut,
     timedOutDuringCompaction:
       runtimeArtifacts?.timedOutDuringCompaction ?? runtimeEnd?.timedOutDuringCompaction,
+    timedOutDuringToolExecution:
+      runtimeArtifacts?.timedOutDuringToolExecution ?? runtimeEnd?.timedOutDuringToolExecution,
     promptError:
       runtimeArtifacts?.promptError ?? runtimeEnd?.promptError ?? runtimeCompletion?.promptError,
     promptErrorSource: runtimeArtifacts?.promptErrorSource ?? runtimeCompletion?.promptErrorSource,

--- a/src/trajectory/metadata.test.ts
+++ b/src/trajectory/metadata.test.ts
@@ -185,6 +185,7 @@ describe("trajectory metadata", () => {
       timedOut: false,
       idleTimedOut: false,
       timedOutDuringCompaction: false,
+      timedOutDuringToolExecution: false,
       compactionCount: 1,
       assistantTexts: ["done"],
       finalPromptText: "run tests",

--- a/src/trajectory/metadata.ts
+++ b/src/trajectory/metadata.ts
@@ -46,6 +46,7 @@ type BuildTrajectoryArtifactsParams = {
   timedOut: boolean;
   idleTimedOut: boolean;
   timedOutDuringCompaction: boolean;
+  timedOutDuringToolExecution: boolean;
   promptError?: string;
   promptErrorSource?: string | null;
   usage?: unknown;
@@ -303,6 +304,7 @@ export function buildTrajectoryArtifacts(
     timedOut: params.timedOut,
     idleTimedOut: params.idleTimedOut,
     timedOutDuringCompaction: params.timedOutDuringCompaction,
+    timedOutDuringToolExecution: params.timedOutDuringToolExecution,
     promptError: params.promptError,
     promptErrorSource: params.promptErrorSource,
     usage: params.usage,


### PR DESCRIPTION
## Summary

Closes #52147.

When the embedded run-level timer fires while tool execution is in flight (e.g. `process(poll)` loops, browser automation, long `exec`), the LLM has already responded. Today's failover policy still treats this as `timedOut && !timedOutDuringCompaction` → rotates auth profiles, then escalates to model fallback with `FailoverError: LLM request timed out.`

That's wrong on three axes:
- the LLM was not pending — fallback model has nothing useful to do
- the original task is interrupted mid-execution
- the `LLM request timed out` error message is misleading (no LLM request was in flight)

This PR mirrors the existing `timedOutDuringCompaction` precedent (PR #46889): a new flag is set when `abortRun(isTimeout=true)` fires while at least one tool is still active, and the failover policy adds a parallel exemption. **No behavior change for LLM-phase timeouts.**

The bot's 2026-04-28 review on #52147 verified the gap on current `main` and endorsed this exact approach as the cleanest fix.

## Detection

Uses the existing `toolStartData` map in `pi-embedded-subscribe.handlers.tools.ts` — entries are inserted at tool start (`handleToolExecutionStart` line 610) and deleted at tool end (`handleToolExecutionEnd` line 828). New `countActiveToolExecutions(runId)` helper filters by `runId:` key prefix since the map is shared across runs.

The flag is only set in `abortRun` when `isTimeout && !timedOutDuringCompaction && activeCount > 0`. Compaction takes precedence (existing behavior).

## Plumbing

Mirrors the existing `timedOutDuringCompaction` flow exactly:
- `EmbeddedRunAttemptResult.timedOutDuringToolExecution: boolean`
- threaded through trajectory artifacts + export for diagnostic visibility (parallel field to the compaction flag)
- `failover-policy.ts` `shouldRotateAssistant` adds the exemption  
- `assistant-failover.ts` + `run.ts` thread the param

## Test plan

- [x] 3 new failover-policy regressions:
  - tool-exec timeout → `continue_normal` regardless of profile-rotation state
  - LLM-phase timeout (no active tool) → still rotates as before (locks in current behavior)
- [x] All 191 related embedded-runner / harness / trajectory tests pass:
  - `pnpm vitest run src/agents/pi-embedded-runner/run/failover-policy.test.ts src/agents/pi-embedded-runner/run/assistant-failover.test.ts`
  - `pnpm vitest run src/agents/pi-embedded-runner/run/compaction-timeout.test.ts src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts`
  - `pnpm vitest run src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
  - `pnpm vitest run src/agents/harness/v2.test.ts src/agents/harness/selection.test.ts src/trajectory/metadata.test.ts`

## Scope boundary

Doesn't change behavior for:
- LLM-phase timeouts (the existing rotation/fallback path)
- `timedOutDuringCompaction` (untouched)
- External aborts (untouched)
- Idle-watchdog timeouts (untouched — the LLM-idle-timeout handler still calls `abortRun(true)` and is correctly classified as LLM-phase since no tool is in flight by definition during idle wait)

## Note

AI-assisted (Claude Opus 4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)