### PR TITLE
fix(channels): use plugin module loader cache

### DIFF
--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -13,12 +13,12 @@ import {
   type BundledChannelPluginMetadata,
 } from "../../plugins/bundled-channel-runtime.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
-import {
-  getCachedPluginJitiLoader,
-  type PluginJitiLoaderCache,
-} from "../../plugins/jiti-loader-cache.js";
 import { passesManifestOwnerBasePolicy } from "../../plugins/manifest-owner-policy.js";
 import { unwrapDefaultModuleExport } from "../../plugins/module-export.js";
+import {
+  getCachedPluginModuleLoader,
+  type PluginModuleLoaderCache,
+} from "../../plugins/plugin-module-loader-cache.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { resolveBundledChannelRootScope, type BundledChannelRootScope } from "./bundled-root.js";
@@ -94,7 +94,7 @@ type BundledChannelLoadContext = {
 const log = createSubsystemLogger("channels");
 const MAX_BUNDLED_CHANNEL_LOAD_CONTEXTS = 32;
 const bundledChannelLoadContextsByRoot = new Map<string, BundledChannelLoadContext>();
-const sourceBundledEntryLoaderCache: PluginJitiLoaderCache = new Map();
+const sourceBundledEntryLoaderCache: PluginModuleLoaderCache = new Map();
 
 function isSourceModulePath(modulePath: string): boolean {
   return /\.(?:c|m)?tsx?$/iu.test(modulePath);
@@ -223,7 +223,7 @@ function loadGeneratedBundledChannelModule(params: {
     if (!isSourceModulePath(modulePath)) {
       throw error;
     }
-    const loader = getCachedPluginJitiLoader({
+    const loader = getCachedPluginModuleLoader({
       cache: sourceBundledEntryLoaderCache,
       modulePath,
       importerUrl: import.meta.url,

--- a/src/channels/plugins/package-state-probes.ts
+++ b/src/channels/plugins/package-state-probes.ts
@@ -6,9 +6,9 @@ import {
   type PluginChannelCatalogEntry,
 } from "../../plugins/channel-catalog-registry.js";
 import {
-  getCachedPluginJitiLoader,
-  type PluginJitiLoaderCache,
-} from "../../plugins/jiti-loader-cache.js";
+  getCachedPluginModuleLoader,
+  type PluginModuleLoaderCache,
+} from "../../plugins/plugin-module-loader-cache.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { loadChannelPluginModule, resolveExistingPluginModulePath } from "./module-loader.js";
 
@@ -29,7 +29,7 @@ type ChannelPackageStateMetadata = {
 export type ChannelPackageStateMetadataKey = "configuredState" | "persistedAuthState";
 
 const log = createSubsystemLogger("channels");
-const sourcePackageStateLoaderCache: PluginJitiLoaderCache = new Map();
+const sourcePackageStateLoaderCache: PluginModuleLoaderCache = new Map();
 
 function isSourceModulePath(modulePath: string): boolean {
   return /\.(?:c|m)?tsx?$/iu.test(modulePath);
@@ -42,7 +42,7 @@ function loadChannelPackageStateModule(params: { modulePath: string; rootDir: st
     if (!isSourceModulePath(params.modulePath)) {
       throw error;
     }
-    const loader = getCachedPluginJitiLoader({
+    const loader = getCachedPluginModuleLoader({
       cache: sourcePackageStateLoaderCache,
       modulePath: params.modulePath,
       importerUrl: import.meta.url,


### PR DESCRIPTION
## Summary
- update bundled channel source fallback loaders to use the remaining plugin module loader cache helper
- fix stale imports left after the jiti-loader-cache helper was removed from main

## Validation
- pnpm exec oxfmt --check --threads=1 src/channels/plugins/bundled.ts src/channels/plugins/package-state-probes.ts
- pnpm test src/gateway/server-startup-post-attach.test.ts src/channels/plugins/configured-state.test.ts src/config/plugin-auto-enable.core.test.ts
- pnpm check:base-config-schema