### PR TITLE
fix(discord): allow configured ack reactions in tool-only guilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: allow explicitly configured ack reactions in tool-only guild channels while keeping automatic lifecycle/status reactions suppressed. Fixes #74922. Thanks @samvilian.
 - Doctor/WhatsApp: warn when Linux crontabs still run the legacy `ensure-whatsapp.sh` health check, which can misreport `Gateway inactive` when cron lacks the systemd user-bus environment. Fixes #60204. Thanks @mySebbe.
 - Slack/setup: print the generated app manifest as plain JSON instead of embedding it inside the framed setup note, so it can be copied into Slack without deleting border characters. Fixes #65751. Thanks @theDanielJLewis.
 - Channels/WhatsApp: route CLI logout through the live Gateway and stop runtime-backed listeners before channel removal, so removing a WhatsApp account does not leave the old socket replying until restart. Fixes #67746. Thanks @123Mismail.

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -885,7 +885,7 @@ describe("processDiscordMessage session routing", () => {
     expect(createDiscordDraftStream).not.toHaveBeenCalled();
   });
 
-  it("suppresses automatic status reactions for always-on guild replies", async () => {
+  it("sends the configured ack while suppressing automatic status reactions for always-on guild replies", async () => {
     const ctx = await createBaseContext({
       shouldRequireMention: false,
       effectiveWasMentioned: false,
@@ -906,7 +906,7 @@ describe("processDiscordMessage session routing", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
-    expect(sendMocks.reactMessageDiscord).not.toHaveBeenCalled();
+    expect(getReactionEmojis()).toEqual(["👀"]);
     expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -176,9 +176,11 @@ export async function processDiscordMessage(
         shouldBypassMention,
       }),
     );
-  const shouldSendAckReaction = !sourceRepliesAreToolOnly && shouldAckReaction();
+  const shouldSendAckReaction = shouldAckReaction();
   const statusReactionsEnabled =
-    shouldSendAckReaction && cfg.messages?.statusReactions?.enabled !== false;
+    !sourceRepliesAreToolOnly &&
+    shouldSendAckReaction &&
+    cfg.messages?.statusReactions?.enabled !== false;
   const feedbackRest = createDiscordRestClient({
     cfg,
     token,


### PR DESCRIPTION
## Summary
- Allow a configured Discord `ackReaction` to send for guild/channel turns that resolve to `message_tool_only`.
- Keep lifecycle/status reactions gated off for tool-only routes, so this does not re-enable automatic final replies or status emoji churn.
- Update the focused Discord process test for the reported `ackReactionScope: "all"` shape.

Fixes #74922

## Test Plan
- `pnpm test extensions/discord/src/monitor/message-handler.process.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- Independent breaker review: no blockers; verified initial ack is decoupled from status/lifecycle reactions.
