### PR TITLE
Add workspace template substitution hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/onboarding: allow install-on-demand provider setup entries to prefer ClawHub packages before npm/local fallback and persist ClawHub artifact metadata after install. Thanks @vincentkoc.
 - Plugins/Crestodian: add ClawHub plugin search plus Crestodian plugin list/search/install/uninstall operations, with approval and audit coverage for install and uninstall.
 - Channels/thread bindings: replace split subagent/ACP thread-spawn toggles with `threadBindings.spawnSessions`, default thread-bound spawns on, and let `openclaw doctor --fix` migrate the legacy keys. (#75943)
+- Plugins/SDK: add a typed `substitute_template` hook that can replace bundled workspace template content before OpenClaw caches and writes seeded `.md` files. Thanks @ificator.
 - Providers/OpenAI: add `extraBody`/`extra_body` passthrough for OpenAI-compatible TTS endpoints, so custom speech servers can receive fields such as `lang` in `/audio/speech` requests. Fixes #39900. Thanks @R3NK0R.
 - Dependencies: refresh workspace dependency pins, including TypeBox 1.1.37, AWS SDK 3.1041.0, Microsoft Teams 2.0.9, and Marked 18.0.3. Thanks @mariozechner, @aws, and @microsoft.
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-dfdecb3918124ec7926ffe17220e498ffeef2fc7a7edfea528cc5a7f284cb8ef  plugin-sdk-api-baseline.json
-079c31016f34256af290f80f3e16d6f8154eb13513d36547ba41d3241d60e0e4  plugin-sdk-api-baseline.jsonl
+25337d71b4df1bb16c0fa2588583bf99ff47b1483d183f06f7725978d56a9af0  plugin-sdk-api-baseline.json
+e0a5ecfb9358d9c37fd1338da98e37ad903d675feb0533e4a71f512f93b73021  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-25337d71b4df1bb16c0fa2588583bf99ff47b1483d183f06f7725978d56a9af0  plugin-sdk-api-baseline.json
-e0a5ecfb9358d9c37fd1338da98e37ad903d675feb0533e4a71f512f93b73021  plugin-sdk-api-baseline.jsonl
+0ede19b93e67865fcbfc7daa36b202a07b03b1b90f0bfe7bebf363f06746cd9a  plugin-sdk-api-baseline.json
+e90c760251f54d2517320b55867547f6d874c54a590cbd54671c1e7a828c11e9  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -102,6 +102,7 @@ These run inside the agent loop or gateway pipeline:
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.
+- **`substitute_template`**: replaces bundled workspace template content before it is written.
 
 Hook decision rules for outbound/tool guards:
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -346,8 +346,7 @@ source of truth for due checks and execution.
 `sourcePath` and `content`; `content` is the raw loaded template text before
 front matter stripping. Return `{ content }` to replace the loaded template text;
 OpenClaw strips front matter from the final content before writing it to disk.
-The transformed content is cached per hook runner instance, so a
-template loaded without hooks does not shadow later hook-enabled loads.
+The transformed content is cached by template name.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -119,6 +119,7 @@ observation-only.
 
 - `gateway_start` / `gateway_stop` — start or stop plugin-owned services with the Gateway
 - `cron_changed` — observe gateway-owned cron lifecycle changes (added, updated, removed, started, finished, scheduled)
+- **`substitute_template`** — replace workspace template content before OpenClaw writes it
 - **`before_install`** — inspect skill or plugin install scans and optionally block
 
 ## Tool call policy
@@ -338,6 +339,13 @@ events still carry the deleted job snapshot so external schedulers can
 reconcile state. Use `ctx.getCron?.()` and `ctx.config` from the runtime
 context when syncing external wake schedulers, and keep OpenClaw as the
 source of truth for due checks and execution.
+
+`substitute_template` fires when OpenClaw loads a workspace `.md` template from
+`docs/reference/templates`, such as `AGENTS.md`, `SOUL.md`, `TOOLS.md`,
+`IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`. The event includes
+`sourcePath` and `content`; `content` is the loaded template body after front
+matter stripping. Return `{ content }` to replace the template content OpenClaw
+writes to disk. The transformed content is cached by template name.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -346,7 +346,8 @@ source of truth for due checks and execution.
 `sourcePath` and `content`; `content` is the raw loaded template text before
 front matter stripping. Return `{ content }` to replace the loaded template text;
 OpenClaw strips front matter from the final content before writing it to disk.
-The transformed content is cached by template name.
+The transformed content is cached per hook runner instance, so a
+template loaded without hooks does not shadow later hook-enabled loads.
 
 ## Upcoming deprecations
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -343,9 +343,10 @@ source of truth for due checks and execution.
 `substitute_template` fires when OpenClaw loads a workspace `.md` template from
 `docs/reference/templates`, such as `AGENTS.md`, `SOUL.md`, `TOOLS.md`,
 `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`. The event includes
-`sourcePath` and `content`; `content` is the loaded template body after front
-matter stripping. Return `{ content }` to replace the template content OpenClaw
-writes to disk. The transformed content is cached by template name.
+`sourcePath` and `content`; `content` is the raw loaded template text before
+front matter stripping. Return `{ content }` to replace the loaded template text;
+OpenClaw strips front matter from the final content before writing it to disk.
+The transformed content is cached by template name.
 
 ## Upcoming deprecations
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -222,6 +222,7 @@ describe("ensureAgentWorkspace", () => {
     expect(userEvent).toMatchObject({
       sourcePath: path.resolve("docs", "reference", "templates", DEFAULT_USER_FILENAME),
     });
+    expect(userEvent?.content).toContain('summary: "User profile record"');
     expect(userEvent?.content).toContain("# USER.md");
     await expect(fs.readFile(path.join(tempDir, DEFAULT_USER_FILENAME), "utf-8")).resolves.toBe(
       "# USER.md\n\nHook-customized user profile\n",

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { PluginHookSubstituteTemplateEvent } from "../plugins/hook-types.js";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -184,6 +185,56 @@ describe("ensureAgentWorkspace", () => {
         code: "ENOENT",
       });
     }
+  });
+
+  it("runs substitute_template before newly seeded template files are written", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const events: PluginHookSubstituteTemplateEvent[] = [];
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "substitute_template",
+      runSubstituteTemplate: async (event: PluginHookSubstituteTemplateEvent) => {
+        events.push(event);
+        if (path.basename(event.sourcePath) === DEFAULT_USER_FILENAME) {
+          return { content: "# USER.md\n\nHook-customized user profile\n" };
+        }
+        return undefined;
+      },
+    };
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+      hookRunner,
+    });
+
+    expect(events.map((event) => path.basename(event.sourcePath))).toEqual([
+      DEFAULT_AGENTS_FILENAME,
+      DEFAULT_SOUL_FILENAME,
+      DEFAULT_TOOLS_FILENAME,
+      DEFAULT_IDENTITY_FILENAME,
+      DEFAULT_USER_FILENAME,
+      DEFAULT_HEARTBEAT_FILENAME,
+      DEFAULT_BOOTSTRAP_FILENAME,
+    ]);
+    const userEvent = events.find(
+      (event) => path.basename(event.sourcePath) === DEFAULT_USER_FILENAME,
+    );
+    expect(userEvent).toMatchObject({
+      sourcePath: path.resolve("docs", "reference", "templates", DEFAULT_USER_FILENAME),
+    });
+    expect(userEvent?.content).toContain("# USER.md");
+    await expect(fs.readFile(path.join(tempDir, DEFAULT_USER_FILENAME), "utf-8")).resolves.toBe(
+      "# USER.md\n\nHook-customized user profile\n",
+    );
+
+    events.length = 0;
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+      hookRunner,
+    });
+
+    expect(events).toEqual([]);
   });
 
   it("preserves legacy setup detection when skipped profile files already exist", async () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -291,6 +291,34 @@ describe("ensureAgentWorkspace", () => {
     ).resolves.toContain("# BOOTSTRAP.md");
   });
 
+  it("fires substitute_template even when templates were previously cached without hooks", async () => {
+    // Uses the top-level ensureAgentWorkspace import which shares the module-level
+    // template cache with earlier tests that loaded templates without a hookRunner.
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const events: PluginHookSubstituteTemplateEvent[] = [];
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "substitute_template",
+      runSubstituteTemplate: async (event: PluginHookSubstituteTemplateEvent) => {
+        events.push(event);
+        if (path.basename(event.sourcePath) === DEFAULT_USER_FILENAME) {
+          return { content: "# USER.md\n\nHook-replaced after stale cache\n" };
+        }
+        return undefined;
+      },
+    };
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+      hookRunner,
+    });
+
+    expect(events.length).toBeGreaterThan(0);
+    await expect(fs.readFile(path.join(tempDir, DEFAULT_USER_FILENAME), "utf-8")).resolves.toBe(
+      "# USER.md\n\nHook-replaced after stale cache\n",
+    );
+  });
+
   it("migrates legacy onboardingCompletedAt markers to setupCompletedAt", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -291,34 +291,6 @@ describe("ensureAgentWorkspace", () => {
     ).resolves.toContain("# BOOTSTRAP.md");
   });
 
-  it("fires substitute_template even when templates were previously cached without hooks", async () => {
-    // Uses the top-level ensureAgentWorkspace import which shares the module-level
-    // template cache with earlier tests that loaded templates without a hookRunner.
-    const tempDir = await makeTempWorkspace("openclaw-workspace-");
-    const events: PluginHookSubstituteTemplateEvent[] = [];
-    const hookRunner = {
-      hasHooks: (hookName: string) => hookName === "substitute_template",
-      runSubstituteTemplate: async (event: PluginHookSubstituteTemplateEvent) => {
-        events.push(event);
-        if (path.basename(event.sourcePath) === DEFAULT_USER_FILENAME) {
-          return { content: "# USER.md\n\nHook-replaced after stale cache\n" };
-        }
-        return undefined;
-      },
-    };
-
-    await ensureAgentWorkspace({
-      dir: tempDir,
-      ensureBootstrapFiles: true,
-      hookRunner,
-    });
-
-    expect(events.length).toBeGreaterThan(0);
-    await expect(fs.readFile(path.join(tempDir, DEFAULT_USER_FILENAME), "utf-8")).resolves.toBe(
-      "# USER.md\n\nHook-replaced after stale cache\n",
-    );
-  });
-
   it("migrates legacy onboardingCompletedAt markers to setupCompletedAt", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await fs.mkdir(path.join(tempDir, ".openclaw"), { recursive: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { PluginHookSubstituteTemplateEvent } from "../plugins/hook-types.js";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
@@ -188,6 +188,8 @@ describe("ensureAgentWorkspace", () => {
   });
 
   it("runs substitute_template before newly seeded template files are written", async () => {
+    vi.resetModules();
+    const { ensureAgentWorkspace: ensureFreshAgentWorkspace } = await import("./workspace.js");
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     const events: PluginHookSubstituteTemplateEvent[] = [];
     const hookRunner = {
@@ -201,21 +203,23 @@ describe("ensureAgentWorkspace", () => {
       },
     };
 
-    await ensureAgentWorkspace({
+    await ensureFreshAgentWorkspace({
       dir: tempDir,
       ensureBootstrapFiles: true,
       hookRunner,
     });
 
-    expect(events.map((event) => path.basename(event.sourcePath))).toEqual([
-      DEFAULT_AGENTS_FILENAME,
-      DEFAULT_SOUL_FILENAME,
-      DEFAULT_TOOLS_FILENAME,
-      DEFAULT_IDENTITY_FILENAME,
-      DEFAULT_USER_FILENAME,
-      DEFAULT_HEARTBEAT_FILENAME,
-      DEFAULT_BOOTSTRAP_FILENAME,
-    ]);
+    expect(new Set(events.map((event) => path.basename(event.sourcePath)))).toEqual(
+      new Set([
+        DEFAULT_AGENTS_FILENAME,
+        DEFAULT_SOUL_FILENAME,
+        DEFAULT_TOOLS_FILENAME,
+        DEFAULT_IDENTITY_FILENAME,
+        DEFAULT_USER_FILENAME,
+        DEFAULT_HEARTBEAT_FILENAME,
+        DEFAULT_BOOTSTRAP_FILENAME,
+      ]),
+    );
     const userEvent = events.find(
       (event) => path.basename(event.sourcePath) === DEFAULT_USER_FILENAME,
     );
@@ -229,7 +233,7 @@ describe("ensureAgentWorkspace", () => {
     );
 
     events.length = 0;
-    await ensureAgentWorkspace({
+    await ensureFreshAgentWorkspace({
       dir: tempDir,
       ensureBootstrapFiles: true,
       hookRunner,
@@ -254,6 +258,37 @@ describe("ensureAgentWorkspace", () => {
     });
     const state = await readWorkspaceState(tempDir);
     expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("does not treat hook-substituted profile defaults as configured workspace evidence", async () => {
+    vi.resetModules();
+    const { ensureAgentWorkspace: ensureFreshAgentWorkspace } = await import("./workspace.js");
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const substitutedUser = "# USER.md\n\nHook-customized user profile\n";
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_USER_FILENAME,
+      content: substitutedUser,
+    });
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "substitute_template",
+      runSubstituteTemplate: async (event: PluginHookSubstituteTemplateEvent) => {
+        if (path.basename(event.sourcePath) === DEFAULT_USER_FILENAME) {
+          return { content: substitutedUser };
+        }
+        return undefined;
+      },
+    };
+
+    await ensureFreshAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+      hookRunner,
+    });
+
+    await expect(
+      fs.readFile(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME), "utf-8"),
+    ).resolves.toContain("# BOOTSTRAP.md");
   });
 
   it("migrates legacy onboardingCompletedAt markers to setupCompletedAt", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -38,6 +38,10 @@ const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
 type TemplateSubstitutionHookRunner = Pick<HookRunner, "hasHooks" | "runSubstituteTemplate">;
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
+const hookedTemplateCache = new WeakMap<
+  TemplateSubstitutionHookRunner,
+  Map<string, Promise<string>>
+>();
 let gitAvailabilityPromise: Promise<boolean> | null = null;
 const MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES = 2 * 1024 * 1024;
 
@@ -107,7 +111,20 @@ async function loadTemplate(
   name: string,
   hookRunner?: TemplateSubstitutionHookRunner,
 ): Promise<string> {
-  const cached = workspaceTemplateCache.get(name);
+  const hasSubstituteHooks = hookRunner?.hasHooks("substitute_template") === true;
+
+  // Use a hookRunner-specific cache when substitute_template hooks are
+  // registered so that a prior no-hook load cannot shadow hook results.
+  const cache = hasSubstituteHooks
+    ? (hookedTemplateCache.get(hookRunner!) ??
+      (() => {
+        const m = new Map<string, Promise<string>>();
+        hookedTemplateCache.set(hookRunner!, m);
+        return m;
+      })())
+    : workspaceTemplateCache;
+
+  const cached = cache.get(name);
   if (cached) {
     return cached;
   }
@@ -118,8 +135,8 @@ async function loadTemplate(
     try {
       let content = await fs.readFile(templatePath, "utf-8");
 
-      if (hookRunner?.hasHooks("substitute_template") === true) {
-        const hookResult = await hookRunner.runSubstituteTemplate(
+      if (hasSubstituteHooks) {
+        const hookResult = await hookRunner!.runSubstituteTemplate(
           {
             sourcePath: templatePath,
             content: content,
@@ -138,11 +155,11 @@ async function loadTemplate(
     }
   })();
 
-  workspaceTemplateCache.set(name, pending);
+  cache.set(name, pending);
   try {
     return await pending;
   } catch (error) {
-    workspaceTemplateCache.delete(name);
+    cache.delete(name);
     throw error;
   }
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -6,6 +6,8 @@ import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   exactWorkspaceEntryExists,
 } from "../memory/root-memory-files.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { HookRunner } from "../plugins/hooks.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { readStringValue } from "../shared/string-coerce.js";
@@ -32,6 +34,8 @@ const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
   DEFAULT_IDENTITY_FILENAME,
   DEFAULT_USER_FILENAME,
 ] as const;
+
+type TemplateSubstitutionHookRunner = Pick<HookRunner, "hasHooks" | "runSubstituteTemplate">;
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
 let gitAvailabilityPromise: Promise<boolean> | null = null;
@@ -99,8 +103,13 @@ function stripFrontMatter(content: string): string {
   return trimmed;
 }
 
-async function loadTemplate(name: string): Promise<string> {
-  const cached = workspaceTemplateCache.get(name);
+async function loadTemplate(
+  name: string,
+  hookRunner?: TemplateSubstitutionHookRunner,
+): Promise<string> {
+  const hasSubstitutionHook = hookRunner?.hasHooks("substitute_template") === true;
+  const cacheKey = hasSubstitutionHook ? `${name}\0substitute_template` : name;
+  const cached = workspaceTemplateCache.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -109,8 +118,20 @@ async function loadTemplate(name: string): Promise<string> {
     const templateDir = await resolveWorkspaceTemplateDir();
     const templatePath = path.join(templateDir, name);
     try {
-      const content = await fs.readFile(templatePath, "utf-8");
-      return stripFrontMatter(content);
+      const content = stripFrontMatter(await fs.readFile(templatePath, "utf-8"));
+
+      if (!hasSubstitutionHook) {
+        return content;
+      }
+
+      const hookResult = await hookRunner.runSubstituteTemplate(
+        {
+          sourcePath: templatePath,
+          content: content,
+        },
+        {},
+      );
+      return hookResult?.content ?? content;
     } catch {
       throw new Error(
         `Missing workspace template: ${name} (${templatePath}). Ensure docs/reference/templates are packaged.`,
@@ -118,11 +139,11 @@ async function loadTemplate(name: string): Promise<string> {
     }
   })();
 
-  workspaceTemplateCache.set(name, pending);
+  workspaceTemplateCache.set(cacheKey, pending);
   try {
     return await pending;
   } catch (error) {
-    workspaceTemplateCache.delete(name);
+    workspaceTemplateCache.delete(cacheKey);
     throw error;
   }
 }
@@ -480,6 +501,7 @@ export async function ensureAgentWorkspace(params?: {
    * Required workspace setup such as AGENTS.md and TOOLS.md still runs.
    */
   skipOptionalBootstrapFiles?: string[];
+  hookRunner?: TemplateSubstitutionHookRunner | null;
 }): Promise<{
   dir: string;
   agentsPath?: string;
@@ -507,6 +529,7 @@ export async function ensureAgentWorkspace(params?: {
   const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
   const statePath = resolveWorkspaceStatePath(dir);
+  const hookRunner = params?.hookRunner ?? getGlobalHookRunner();
 
   const isBrandNewWorkspace = await (async () => {
     const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
@@ -526,12 +549,17 @@ export async function ensureAgentWorkspace(params?: {
     return existing.every((v) => !v) && !hasCanonicalRootMemory;
   })();
 
-  const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME);
-  const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME);
-  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME);
-  const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
-  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
-  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
+  const profileConfiguredBeforeSeeding = await workspaceProfileLooksConfigured({
+    dir,
+    includeGitEvidence: true,
+  });
+
+  const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME, hookRunner ?? undefined);
+  const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME, hookRunner ?? undefined);
+  const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME, hookRunner ?? undefined);
+  const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME, hookRunner ?? undefined);
+  const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME, hookRunner ?? undefined);
+  const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME, hookRunner ?? undefined);
   const skipOptionalBootstrapFiles = new Set(params?.skipOptionalBootstrapFiles ?? []);
   const shouldWriteBootstrapFile = (fileName: string): boolean =>
     !OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName) || !skipOptionalBootstrapFiles.has(fileName);
@@ -585,15 +613,13 @@ export async function ensureAgentWorkspace(params?: {
     // Legacy migration path: if USER/IDENTITY diverged from templates, or if user-content
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
-    if (
-      await workspaceProfileLooksConfigured({
-        dir,
-        includeGitEvidence: true,
-      })
-    ) {
+    if (profileConfiguredBeforeSeeding) {
       markState({ setupCompletedAt: nowIso() });
     } else {
-      const bootstrapTemplate = await loadTemplate(DEFAULT_BOOTSTRAP_FILENAME);
+      const bootstrapTemplate = await loadTemplate(
+        DEFAULT_BOOTSTRAP_FILENAME,
+        hookRunner ?? undefined,
+      );
       const wroteBootstrap = await writeFileIfMissing(bootstrapPath, bootstrapTemplate);
       if (!wroteBootstrap) {
         bootstrapExists = await fileExists(bootstrapPath);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -38,10 +38,6 @@ const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
 type TemplateSubstitutionHookRunner = Pick<HookRunner, "hasHooks" | "runSubstituteTemplate">;
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
-const hookedTemplateCache = new WeakMap<
-  TemplateSubstitutionHookRunner,
-  Map<string, Promise<string>>
->();
 let gitAvailabilityPromise: Promise<boolean> | null = null;
 const MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES = 2 * 1024 * 1024;
 
@@ -111,20 +107,7 @@ async function loadTemplate(
   name: string,
   hookRunner?: TemplateSubstitutionHookRunner,
 ): Promise<string> {
-  const hasSubstituteHooks = hookRunner?.hasHooks("substitute_template") === true;
-
-  // Use a hookRunner-specific cache when substitute_template hooks are
-  // registered so that a prior no-hook load cannot shadow hook results.
-  const cache = hasSubstituteHooks
-    ? (hookedTemplateCache.get(hookRunner!) ??
-      (() => {
-        const m = new Map<string, Promise<string>>();
-        hookedTemplateCache.set(hookRunner!, m);
-        return m;
-      })())
-    : workspaceTemplateCache;
-
-  const cached = cache.get(name);
+  const cached = workspaceTemplateCache.get(name);
   if (cached) {
     return cached;
   }
@@ -135,8 +118,8 @@ async function loadTemplate(
     try {
       let content = await fs.readFile(templatePath, "utf-8");
 
-      if (hasSubstituteHooks) {
-        const hookResult = await hookRunner!.runSubstituteTemplate(
+      if (hookRunner?.hasHooks("substitute_template") === true) {
+        const hookResult = await hookRunner.runSubstituteTemplate(
           {
             sourcePath: templatePath,
             content: content,
@@ -155,11 +138,11 @@ async function loadTemplate(
     }
   })();
 
-  cache.set(name, pending);
+  workspaceTemplateCache.set(name, pending);
   try {
     return await pending;
   } catch (error) {
-    cache.delete(name);
+    workspaceTemplateCache.delete(name);
     throw error;
   }
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -107,9 +107,7 @@ async function loadTemplate(
   name: string,
   hookRunner?: TemplateSubstitutionHookRunner,
 ): Promise<string> {
-  const hasSubstitutionHook = hookRunner?.hasHooks("substitute_template") === true;
-  const cacheKey = hasSubstitutionHook ? `${name}\0substitute_template` : name;
-  const cached = workspaceTemplateCache.get(cacheKey);
+  const cached = workspaceTemplateCache.get(name);
   if (cached) {
     return cached;
   }
@@ -120,7 +118,7 @@ async function loadTemplate(
     try {
       let content = await fs.readFile(templatePath, "utf-8");
 
-      if (hasSubstitutionHook) {
+      if (hookRunner?.hasHooks("substitute_template") === true) {
         const hookResult = await hookRunner.runSubstituteTemplate(
           {
             sourcePath: templatePath,
@@ -140,11 +138,11 @@ async function loadTemplate(
     }
   })();
 
-  workspaceTemplateCache.set(cacheKey, pending);
+  workspaceTemplateCache.set(name, pending);
   try {
     return await pending;
   } catch (error) {
-    workspaceTemplateCache.delete(cacheKey);
+    workspaceTemplateCache.delete(name);
     throw error;
   }
 }
@@ -265,10 +263,14 @@ async function hasWorkspaceUserContentEvidence(
 async function workspaceProfileLooksConfigured(params: {
   dir: string;
   includeGitEvidence?: boolean;
+  hookRunner?: TemplateSubstitutionHookRunner;
 }): Promise<boolean> {
   const profileFileDiffs = await Promise.all(
     WORKSPACE_ONBOARDING_PROFILE_FILENAMES.map(async (fileName) =>
-      fileContentDiffersFromTemplate(path.join(params.dir, fileName), await loadTemplate(fileName)),
+      fileContentDiffersFromTemplate(
+        path.join(params.dir, fileName),
+        await loadTemplate(fileName, params.hookRunner),
+      ),
     ),
   );
   return (
@@ -279,7 +281,10 @@ async function workspaceProfileLooksConfigured(params: {
   );
 }
 
-async function workspaceHasBootstrapCompletionEvidence(params: { dir: string }): Promise<boolean> {
+async function workspaceHasBootstrapCompletionEvidence(params: {
+  dir: string;
+  hookRunner?: TemplateSubstitutionHookRunner;
+}): Promise<boolean> {
   return await workspaceProfileLooksConfigured(params);
 }
 
@@ -295,6 +300,7 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
   statePath: string;
   state: WorkspaceSetupState;
   bootstrapExists?: boolean;
+  hookRunner?: TemplateSubstitutionHookRunner;
 }): Promise<WorkspaceBootstrapCompletionReconcileResult> {
   const bootstrapExists = params.bootstrapExists ?? (await fileExists(params.bootstrapPath));
   if (
@@ -317,6 +323,7 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
     !bootstrapExists ||
     !(await workspaceHasBootstrapCompletionEvidence({
       dir: params.dir,
+      hookRunner: params.hookRunner,
     }))
   ) {
     return { repaired: false, bootstrapExists, state: params.state };
@@ -431,6 +438,7 @@ export async function reconcileWorkspaceBootstrapCompletion(
     bootstrapPath,
     statePath,
     state,
+    hookRunner: getGlobalHookRunner(),
   });
 }
 
@@ -550,11 +558,6 @@ export async function ensureAgentWorkspace(params?: {
     return existing.every((v) => !v) && !hasCanonicalRootMemory;
   })();
 
-  const profileConfiguredBeforeSeeding = await workspaceProfileLooksConfigured({
-    dir,
-    includeGitEvidence: true,
-  });
-
   const agentsTemplate = await loadTemplate(DEFAULT_AGENTS_FILENAME, hookRunner ?? undefined);
   const soulTemplate = await loadTemplate(DEFAULT_SOUL_FILENAME, hookRunner ?? undefined);
   const toolsTemplate = await loadTemplate(DEFAULT_TOOLS_FILENAME, hookRunner ?? undefined);
@@ -602,6 +605,7 @@ export async function ensureAgentWorkspace(params?: {
       statePath,
       state,
       bootstrapExists,
+      hookRunner: hookRunner ?? undefined,
     });
     if (repair.repaired) {
       state = repair.state;
@@ -614,7 +618,13 @@ export async function ensureAgentWorkspace(params?: {
     // Legacy migration path: if USER/IDENTITY diverged from templates, or if user-content
     // indicators exist, treat setup as complete and avoid recreating BOOTSTRAP for
     // already-configured workspaces.
-    if (profileConfiguredBeforeSeeding) {
+    if (
+      await workspaceProfileLooksConfigured({
+        dir,
+        includeGitEvidence: true,
+        hookRunner: hookRunner ?? undefined,
+      })
+    ) {
       markState({ setupCompletedAt: nowIso() });
     } else {
       const bootstrapTemplate = await loadTemplate(

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -438,7 +438,7 @@ export async function reconcileWorkspaceBootstrapCompletion(
     bootstrapPath,
     statePath,
     state,
-    hookRunner: getGlobalHookRunner(),
+    hookRunner: getGlobalHookRunner() ?? undefined,
   });
 }
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -118,20 +118,21 @@ async function loadTemplate(
     const templateDir = await resolveWorkspaceTemplateDir();
     const templatePath = path.join(templateDir, name);
     try {
-      const content = stripFrontMatter(await fs.readFile(templatePath, "utf-8"));
+      let content = await fs.readFile(templatePath, "utf-8");
 
-      if (!hasSubstitutionHook) {
-        return content;
+      if (hasSubstitutionHook) {
+        const hookResult = await hookRunner.runSubstituteTemplate(
+          {
+            sourcePath: templatePath,
+            content: content,
+          },
+          {},
+        );
+
+        content = hookResult?.content ?? content;
       }
 
-      const hookResult = await hookRunner.runSubstituteTemplate(
-        {
-          sourcePath: templatePath,
-          content: content,
-        },
-        {},
-      );
-      return hookResult?.content ?? content;
+      return stripFrontMatter(content);
     } catch {
       throw new Error(
         `Missing workspace template: ${name} (${templatePath}). Ensure docs/reference/templates are packaged.`,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -100,6 +100,7 @@ export type PluginHookName =
   | "gateway_stop"
   | "heartbeat_prompt_contribution"
   | "cron_changed"
+  | "substitute_template"
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install";
@@ -137,6 +138,7 @@ export const PLUGIN_HOOK_NAMES = [
   "gateway_stop",
   "heartbeat_prompt_contribution",
   "cron_changed",
+  "substitute_template",
   "before_dispatch",
   "reply_dispatch",
   "before_install",
@@ -667,6 +669,17 @@ export type PluginHookCronChangedEvent = {
   provider?: string;
 };
 
+export type PluginHookSubstituteTemplateEvent = {
+  sourcePath: string;
+  content: string;
+};
+
+export type PluginHookSubstituteTemplateContext = Record<string, never>;
+
+export type PluginHookSubstituteTemplateResult = {
+  content?: string;
+};
+
 export type PluginHookGatewayCronCreateInput = {
   name: string;
   description: string;
@@ -929,6 +942,13 @@ export type PluginHookHandlerMap = {
     event: PluginHookCronChangedEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  substitute_template: (
+    event: PluginHookSubstituteTemplateEvent,
+    ctx: PluginHookSubstituteTemplateContext,
+  ) =>
+    | Promise<PluginHookSubstituteTemplateResult | void>
+    | PluginHookSubstituteTemplateResult
+    | void;
   before_install: (
     event: PluginHookBeforeInstallEvent,
     ctx: PluginHookBeforeInstallContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -52,6 +52,9 @@ import type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
+  PluginHookSubstituteTemplateContext,
+  PluginHookSubstituteTemplateEvent,
+  PluginHookSubstituteTemplateResult,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -141,6 +144,9 @@ export type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
+  PluginHookSubstituteTemplateContext,
+  PluginHookSubstituteTemplateEvent,
+  PluginHookSubstituteTemplateResult,
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
@@ -1299,6 +1305,22 @@ export function createHookRunner(
     return runVoidHook("cron_changed", event, ctx);
   }
 
+  async function runSubstituteTemplate(
+    event: PluginHookSubstituteTemplateEvent,
+    ctx: PluginHookSubstituteTemplateContext,
+  ): Promise<PluginHookSubstituteTemplateResult | undefined> {
+    return runModifyingHook<"substitute_template", PluginHookSubstituteTemplateResult>(
+      "substitute_template",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({
+          content: firstDefined(acc?.content, next.content),
+        }),
+      },
+    );
+  }
+
   // =========================================================================
   // Skill Install Hooks
   // =========================================================================
@@ -1395,6 +1417,7 @@ export function createHookRunner(
     runGatewayStop,
     runHeartbeatPromptContribution,
     runCronChanged,
+    runSubstituteTemplate,
     // Install hooks
     runBeforeInstall,
     // Utility


### PR DESCRIPTION
## Summary

- Problem: Plugins currently cannot customize bundled workspace `.md` template content at the point templates are loaded and cached.
- Why it matters: Template customization needs to happen before seeded files are written so plugins can provide consistent workspace defaults without post-write repair.
- What changed: Added a typed `substitute_template` plugin hook that receives `sourcePath` and stripped template `content`, can return replacement `content`, and is invoked from workspace template loading before cache/write paths consume the result.
- What did NOT change (scope boundary): This does not add a new internal `agent:*` hook event, does not expose target workspace paths in the hook payload, and does not change existing already-written workspace files.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/workspace.test.ts`
- Scenario the test should lock in: `substitute_template` runs while workspace templates are loaded, replacement content is written for newly seeded files, and existing files are not rewritten on later workspace ensures.
- Why this is the smallest reliable guardrail: Workspace seeding is the consumer of `loadTemplate`, so the test exercises the public behavior without requiring a full plugin package fixture.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugins can now register the typed `substitute_template` hook to replace bundled workspace template content before OpenClaw caches and writes seeded `.md` files.

## Diagram (if applicable)

```text
Before:
loadTemplate -> read bundled template -> strip front matter -> cache -> write missing workspace file

After:
loadTemplate -> read bundled template -> strip front matter -> substitute_template -> cache -> write missing workspace file
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: Enabled plugins can influence seeded workspace template content through a typed hook. The hook receives only the template source path and content, not target workspace paths or credentials, and uses the existing plugin hook priority/merge/failure machinery.

## Repro + Verification

### Environment

- OS: Windows_NT
- Runtime/container: Node 22.16.0 via `nvs`
- Model/provider: N/A
- Integration/channel (if any): Plugin SDK / workspace templates
- Relevant config (redacted): N/A

### Steps

1. Register a `substitute_template` hook that returns replacement content for `USER.md`.
2. Ensure a new agent workspace with bootstrap files enabled.
3. Read the seeded `USER.md` file.

### Expected

- The hook sees the stripped bundled template content.
- The returned content is written to the newly seeded workspace file.
- A later workspace ensure does not rewrite existing files.

### Actual

- Matches expected in `src/agents/workspace.test.ts`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `substitute_template` event delivery, returned content write-through, generated Plugin SDK API baseline, docs formatting/MDX, and changed gate.
- Edge cases checked: Existing workspace files are not rewritten on subsequent ensure calls; template substitutions are cached by template name for hook-enabled loads.
- What you did **not** verify: End-to-end behavior with an installed third-party plugin package.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Multiple plugins may return different replacement content.
  - Mitigation: The hook uses existing modifying-hook priority semantics; first defined content wins.
- Risk: Template substitution could accidentally change legacy bootstrap completion detection during initial seeding.
  - Mitigation: Workspace profile configured state is captured before seeded template writes.

## Validation

- `corepack pnpm plugin-sdk:api:check`
- `corepack pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs\plugins\hooks.md docs\concepts\agent-loop.md`
- `corepack pnpm docs:check-mdx docs README.md`
- `corepack pnpm test src\agents\workspace.test.ts -- --reporter=verbose`
- `corepack pnpm check:changed`