### PR TITLE
feat(gateway): accept opaque paperclip envelope on agent params

### DIFF
--- a/src/gateway/protocol/index.test.ts
+++ b/src/gateway/protocol/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { TALK_TEST_PROVIDER_ID } from "../../test-utils/talk-test-provider.js";
 import {
   formatValidationErrors,
+  validateAgentParams,
   validateModelsListParams,
   validateNodeEventResult,
   validateNodePresenceAlivePayload,
@@ -176,6 +177,43 @@ describe("validateWakeParams", () => {
         anotherExtra: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("validateAgentParams", () => {
+  const baseParams = {
+    message: "hello there",
+    idempotencyKey: "idem-1",
+  };
+
+  it("accepts a minimal agent request", () => {
+    expect(validateAgentParams(baseParams)).toBe(true);
+  });
+
+  it("accepts an opaque paperclip envelope at the root", () => {
+    expect(
+      validateAgentParams({
+        ...baseParams,
+        paperclip: {
+          runId: "run-123",
+          taskId: "task-456",
+          wakeReason: "issue_assigned",
+          workspace: { cwd: "/tmp" },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("still rejects unknown root properties other than paperclip", () => {
+    expect(
+      validateAgentParams({
+        ...baseParams,
+        someOtherUnknownField: "nope",
+      }),
+    ).toBe(false);
+    expect(formatValidationErrors(validateAgentParams.errors)).toContain(
+      "unexpected property 'someOtherUnknownField'",
+    );
   });
 });
 

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -174,6 +174,10 @@ export const AgentParamsSchema = Type.Object(
     voiceWakeTrigger: Type.Optional(Type.String()),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
+    // Opaque wake envelope attached by Paperclip's openclaw_gateway adapter.
+    // The gateway does not read it; declared so `additionalProperties: false`
+    // can stay strict for everything else.
+    paperclip: Type.Optional(Type.Unknown()),
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Problem

External orchestrators (today: Paperclip's [`@paperclipai/adapter-openclaw-gateway`](https://www.npmjs.com/package/@paperclipai/adapter-openclaw-gateway)) attach an opaque `paperclip` envelope at the root of every `agent` request — `runId`, `taskId`, `wakeReason`, `workspace`, etc., used for upstream observability and future correlation.

`AgentParamsSchema` is declared with `additionalProperties: false`, so the gateway rejects the entire wake with:

```
INVALID_REQUEST: invalid agent params: at root: unexpected property 'paperclip'
```

This blocks every Paperclip → OpenClaw heartbeat. Today users work around it by hot-patching the installed `protocol-Hjar_s3V.js` after every `brew upgrade openclaw`.

## Fix

Declare `paperclip: Type.Optional(Type.Unknown())` on `AgentParamsSchema` so the field is accepted and silently ignored. The gateway code never reads it (no `paperclip` references anywhere under `src/gateway/server-methods/`), so this is a pure pass-through.

`additionalProperties: false` stays in place — this only opens a single named, well-understood field, not a wildcard.

This mirrors the forward-compat stance already taken by `WakeParamsSchema` (`additionalProperties: true`) and the existing test that validates `paperclip` on wake params (`src/gateway/protocol/index.test.ts` line 167).

## Tests

Added three `validateAgentParams` cases:

- minimal valid agent request
- agent request with the new `paperclip` envelope
- still rejects other unknown root fields (regression guard)

```
pnpm exec vitest run src/gateway/protocol/index.test.ts
  → Tests  42 passed (42)

pnpm exec vitest run src/gateway/server-methods/agent.test.ts
  → Tests  164 passed (164)
```

## AI-assisted disclosure

- [x] AI-assisted (Claude Code, Opus 4.7)
- [x] Fully tested (targeted vitest specs above)
- [x] I understand what the code does — schema-only addition; no behavior change in the gateway
- [ ] Codex review not run locally; relying on PR CI