### PR TITLE
whatsapp: suppress reasoning at pipeline level via onReasoningStream no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 
 ### Fixes
+- WhatsApp: suppress reasoning at pipeline level via onReasoningStream no-op. Refs #74886. (#75258) Thanks @ThiagoCAltoe.
 
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - CLI/plugins: reject missing plugin ids before config writes in `plugins enable` and `plugins disable` so a typo no longer persists a stale config entry. (#73554) Thanks @ai-hpc.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1111,11 +1111,14 @@ export async function runAgentTurnWithFallback(params: {
   while (true) {
     try {
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
-        let text = payload.text;
-        const reply = resolveSendableOutboundReplyParts(payload);
+        if (payload.isReasoning === true) {
+          return { skip: true };
+        }
         if (params.followupRun.run.silentExpected) {
           return { skip: true };
         }
+        let text = payload.text;
+        const reply = resolveSendableOutboundReplyParts(payload);
         if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
           const stripped = stripHeartbeatToken(text, {
             mode: "message",

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -46,6 +46,22 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.text).toBe("Before\n\n\nAfter");
   });
 
+  it("drops reasoning payloads before final channel delivery", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [
+        { text: "Reasoning:\n_internal chain of thought_", isReasoning: true },
+        { text: "Visible answer" },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({ text: "Visible answer" });
+    expect(replyPayloads[0]?.text).not.toContain("internal chain of thought");
+  });
+
+
+
   it("strips media URL from payload when in messagingToolSentMediaUrls", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -16,7 +16,11 @@ import {
   resolveOriginMessageTo,
 } from "./origin-routing.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
-import { applyReplyThreading, isRenderablePayload } from "./reply-payloads-base.js";
+import {
+  applyReplyThreading,
+  isRenderablePayload,
+  shouldSuppressReasoningPayload,
+} from "./reply-payloads-base.js";
 
 const replyPayloadsDedupeRuntimeLoader = createLazyImportLoader(
   () => import("./reply-payloads-dedupe.runtime.js"),
@@ -183,9 +187,12 @@ export async function buildReplyPayloads(params: {
       }),
     )
   ).filter(isRenderablePayload);
+  const userDeliverablePayloads = replyTaggedPayloads.filter(
+    (payload) => !shouldSuppressReasoningPayload(payload),
+  );
   const silentFilteredPayloads = params.silentExpected
-    ? replyTaggedPayloads.filter(shouldKeepPayloadDuringSilentTurn)
-    : replyTaggedPayloads;
+    ? userDeliverablePayloads.filter(shouldKeepPayloadDuringSilentTurn)
+    : userDeliverablePayloads;
 
   // Drop final payloads only when block streaming succeeded end-to-end.
   // If streaming aborted (e.g., timeout), fall back to final payloads.

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunEmbeddedPiAgentParams } from "../../agents/pi-embedded-runner/run/params.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
 import type { TemplateContext } from "../templating.js";
@@ -12,15 +13,7 @@ import {
 } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
-type AgentRunParams = {
-  onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
-  onAssistantMessageStart?: () => Promise<void> | void;
-  onReasoningStream?: (payload: { text?: string }) => Promise<void> | void;
-  onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
-  onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
-  onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
-  silentExpected?: boolean;
-};
+type AgentRunParams = RunEmbeddedPiAgentParams;
 
 const state = vi.hoisted(() => ({
   compactEmbeddedPiSessionMock: vi.fn(),
@@ -399,6 +392,27 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
     expect(onBlockReply).not.toHaveBeenCalled();
     expect(res).toBeUndefined();
+  });
+
+  it("does not forward reasoning-marked streamed payloads as visible text", async () => {
+    const onBlockReply = vi.fn();
+    const onToolResult = vi.fn();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onToolResult?.({ text: "Reasoning:\n_tool_", isReasoning: true });
+      await params.onBlockReply?.({ text: "Reasoning:\n_block_", isReasoning: true });
+      return { payloads: [{ text: "Visible final" }], meta: {} };
+    });
+
+    const { run, typing } = createMinimalRun({
+      opts: { isHeartbeat: false, onBlockReply, onToolResult },
+      blockStreamingEnabled: true,
+    });
+    const res = await run();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onToolResult).not.toHaveBeenCalled();
+    expect(typing.startTypingOnText).not.toHaveBeenCalled();
+    expect(res).toMatchObject({ text: "Visible final" });
   });
 
   it("suppresses bare NO_REPLY silent-turn payloads", async () => {
@@ -1138,5 +1152,3 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(payloads[0]?.text).toContain("```");
   });
 });
-
-import type { ReplyPayload } from "../types.js";


### PR DESCRIPTION
## Summary

Fix WhatsApp reasoning leak by routing reasoning chunks through the pipeline's built-in suppression rather than letting them fall through to the deliver callback.

## Problem

When reasoning chunks are emitted by the model, they are routed to onReasoningStream by the agent runner. If WhatsApp's replyOptions doesn't provide this callback, the pipeline may fall through to the deliver layer, where reasoning payloads can leak to the WhatsApp channel.

## Fix

Provide onReasoningStream: () => {} in WhatsApp's replyOptions. This no-op callback activates the pipeline's routing path for reasoning chunks. The onBlockReply callback already contains an explicit guard that drops isReasoning=true payloads. With onReasoningStream connected, the pipeline routes reasoning through this guard.

## Changes
- extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts: added onReasoningStream: () => {} to replyOptions
- src/auto-reply/reply/agent-runner-payloads.ts: drop reasoning payloads before final channel delivery
- src/auto-reply/reply/agent-runner-payloads.test.ts: add integration test for reasoning payload filtering
- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts: preserve reasoning lanes for channel-specific final lanes
- CHANGELOG.md: add Refs #74886

Fixes #74886