### PR TITLE
Fix Codex strict JSON docs examples

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -194,9 +194,9 @@ Choose your preferred auth method and follow the setup steps.
       </Step>
       <Step title="Use the native Codex runtime">
         ```bash
-        openclaw config set plugins.entries.codex '{ enabled: true }' --strict-json --merge
+        openclaw config set plugins.entries.codex '{"enabled":true}' --strict-json --merge
         openclaw config set agents.defaults.model.primary openai/gpt-5.5
-        openclaw config set agents.defaults.agentRuntime '{ id: "codex", fallback: "none" }' --strict-json
+        openclaw config set agents.defaults.agentRuntime '{"id":"codex","fallback":"none"}' --strict-json
         ```
       </Step>
       <Step title="Verify Codex auth is available">


### PR DESCRIPTION
Follow-up to #75910.

That docs update clarified the subscription path for Codex runtime mode, but two setup commands used JSON5-style object literals while also passing `--strict-json`. The config CLI parses strict values with `JSON.parse`, so users copying those examples would fail before enabling the Codex runtime.

This keeps the guidance the same and changes those two examples to valid JSON.
