### PR TITLE
fix(lmstudio): skip manual model load when skipModelLoad is enabled [AI-assisted]

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -119,21 +119,25 @@ export async function createLmstudioEmbeddingProvider(
     ssrfPolicy,
   };
 
-  try {
-    await ensureLmstudioModelLoaded({
-      baseUrl,
-      apiKey,
-      headers: headerOverrides,
-      ssrfPolicy,
-      modelKey: model,
-      timeoutMs: 120_000,
-    });
-  } catch (error) {
-    log.warn("lmstudio embeddings warmup failed; continuing without preload", {
-      baseUrl,
-      model,
-      error: formatErrorMessage(error),
-    });
+  // When skipModelLoad is enabled, skip preload to let LM Studio JIT handle
+  // model loading automatically.  See openclaw/openclaw#75921.
+  if (providerConfig?.skipModelLoad !== true) {
+    try {
+      await ensureLmstudioModelLoaded({
+        baseUrl,
+        apiKey,
+        headers: headerOverrides,
+        ssrfPolicy,
+        modelKey: model,
+        timeoutMs: 120_000,
+      });
+    } catch (error) {
+      log.warn("lmstudio embeddings warmup failed; continuing without preload", {
+        baseUrl,
+        model,
+        error: formatErrorMessage(error),
+      });
+    }
   }
 
   return {

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -509,4 +509,28 @@ describe("lmstudio stream wrapper", () => {
       delta: rawToolText,
     });
   });
+
+  it("skips preload when skipModelLoad is enabled", async () => {
+    const baseStream = buildDoneStreamFn();
+    const wrapped = wrapLmstudioInferencePreload({
+      provider: "lmstudio",
+      modelId: "qwen3-8b-instruct",
+      config: {
+        models: {
+          providers: {
+            lmstudio: {
+              baseUrl: "http://localhost:1234",
+              skipModelLoad: true,
+              models: [],
+            },
+          },
+        },
+      },
+      streamFn: baseStream,
+    } as never);
+
+    const events = await collectEvents(runWrappedLmstudioStream(wrapped, {}));
+    expect(events.some((e) => e.type === "done")).toBe(true);
+    expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -343,6 +343,12 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
   modelHeaders?: Record<string, string>;
 }): Promise<void> {
   const providerConfig = params.ctx.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
+  // When skipModelLoad is enabled, skip the preload step entirely so that
+  // LM Studio's Just-In-Time (JIT) model loading can manage load/unload
+  // lifecycle automatically.  See openclaw/openclaw#75921.
+  if (providerConfig?.skipModelLoad === true) {
+    return;
+  }
   const providerHeaders = { ...providerConfig?.headers, ...params.modelHeaders };
   const runtimeApiKey =
     typeof params.options?.apiKey === "string" && params.options.apiKey.trim().length > 0

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2990,6 +2990,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   description:
                     "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
                 },
+                skipModelLoad: {
+                  type: "boolean",
+                  title: "Model Provider Skip Model Load",
+                  description:
+                    "When true, skip the manual /api/v1/models/load preload call for this provider. Use this with LM Studio JIT mode so that LM Studio manages model loading and unloading automatically. Default is false (existing preload behavior preserved).",
+                },
                 models: {
                   type: "array",
                   items: {
@@ -27007,6 +27013,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "models.providers.*.request": {
       label: "Model Provider Request Overrides",
       help: "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
+      tags: ["models"],
+    },
+    "models.providers.*.skipModelLoad": {
+      label: "Model Provider Skip Model Load",
+      help: "When true, skip the manual /api/v1/models/load preload call for this provider. Use this with LM Studio JIT mode so that LM Studio manages model loading and unloading automatically. Default is false (existing preload behavior preserved).",
       tags: ["models"],
     },
     "models.providers.*.request.headers": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -872,6 +872,8 @@ export const FIELD_HELP: Record<string, string> = {
     "When true, credentials are sent via the HTTP Authorization header even if alternate auth is possible. Use this only when your provider or proxy explicitly requires Authorization forwarding.",
   "models.providers.*.request":
     "Optional request overrides for model-provider requests, including extra headers, auth overrides, proxy routing, TLS client settings, and optional allowPrivateNetwork for trusted self-hosted endpoints. Use these only when your upstream or enterprise network path requires transport customization.",
+  "models.providers.*.skipModelLoad":
+    "When true, skip the manual /api/v1/models/load preload call for this provider. Use this with LM Studio JIT mode so that LM Studio manages model loading and unloading automatically. Default is false (existing preload behavior preserved).",
   "models.providers.*.request.headers":
     "Extra headers merged into provider requests after default attribution and auth resolution.",
   "models.providers.*.request.auth":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -538,6 +538,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.providers.*.headers": "Model Provider Headers",
   "models.providers.*.authHeader": "Model Provider Authorization Header",
   "models.providers.*.request": "Model Provider Request Overrides",
+  "models.providers.*.skipModelLoad": "Model Provider Skip Model Load",
   "models.providers.*.request.headers": "Model Provider Request Headers",
   "models.providers.*.request.auth": "Model Provider Request Auth Override",
   "models.providers.*.request.auth.mode": "Model Provider Request Auth Mode",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -127,6 +127,8 @@ export type ModelProviderConfig = {
   headers?: Record<string, SecretInput>;
   authHeader?: boolean;
   request?: ConfiguredModelProviderRequest;
+  /** When true, skip the manual /api/v1/models/load call so that LM Studio JIT manages model lifecycle automatically. Default false. */
+  skipModelLoad?: boolean;
   models: ModelDefinitionConfig[];
 };
 

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -365,6 +365,7 @@ const ModelProviderSchema = z
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     request: ConfiguredModelProviderRequestSchema,
+    skipModelLoad: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
   })
   .strict();


### PR DESCRIPTION
> 🤖 AI-assisted (built with Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: When LM Studio JIT model loading is enabled, OpenClaw's call to `/api/v1/models/load` marks models as **manually loaded**, preventing LM Studio's JIT auto-unload from functioning.
- Why it matters: Users who rely on JIT to swap between large models on memory-constrained hardware cannot benefit from automatic model lifecycle management.
- What changed: Added a `skipModelLoad` boolean option to the LM Studio provider config (`models.providers.lmstudio.skipModelLoad`). When set to `true`, both inference preload and embedding warmup paths return early without calling the load API. Registered the new field in `ModelProviderConfig`, Zod schema, generated JSON schema, labels, and help text.
- What did NOT change (scope boundary): Default behavior (`false`) is fully preserved. No changes to LM Studio model discovery, inference, or embedding logic outside the preload guard.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions / Plugins

## Linked Issue/PR
- Closes #75921
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `ensureLmstudioModelLoaded` unconditionally calls `/api/v1/models/load`, which marks models as manually loaded in LM Studio, overriding JIT TTL-based lifecycle management.
- Missing detection / guardrail: No config opt-out existed for the preload call.
- Contributing context: The preload was added for reliability but conflicts with LM Studio's newer JIT auto-load/unload feature.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/lmstudio/src/stream.test.ts`
- Scenario the test should lock in: When `skipModelLoad: true` is set in provider config, `ensureLmstudioModelLoaded` must not be called.
- Why this is the smallest reliable guardrail: The preload mock assertion directly verifies the skip path without requiring a live LM Studio instance.
- Existing test that already covers this (if any): N/A (new behavior)
- If no new test is added, why not: N/A (test added)

## User-visible / Behavior Changes
New optional config key `models.providers.lmstudio.skipModelLoad` (boolean, default `false`). When `true`, OpenClaw does not call `/api/v1/models/load` before inference or embedding requests.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This change only adds an opt-in config flag that skips an outbound HTTP call to the user's own local LM Studio instance. No new secrets, dependencies, or broader permissions.
