### PR TITLE
fix(cron): use non-throwing schedule identity in store reload (#75886)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/scheduler: keep one malformed persisted job (e.g. a string-shaped `schedule` field) from killing the scheduler tick by switching the store-reload schedule comparison to a non-throwing identity, isolating malformed entries with a structured warning, and adding regression coverage so other due jobs keep firing. Fixes #75886. Thanks @ottodeng.
 - Control UI/chat: keep live replies visible when a raw session alias such as `main` sends the chat turn but Gateway emits events under the canonical session key for the same run. Fixes #73716. Thanks @teebes.
 - CLI: stop treating the legacy singular `openclaw tool ...` token as a plugin id under restrictive `plugins.allow`, so it falls through as a normal unknown/reserved command instead of suggesting a stale allowlist entry. Fixes #64732. Thanks @efe-arv, @SweetSophia, and @hashtag1974.
 - Media: write inbound media buffers through same-directory temp files before rename, so failed disk writes do not leave zero-byte artifacts for later voice transcription. Fixes #55966. Thanks @OpenCodeEngineer.

--- a/src/cron/schedule-identity.ts
+++ b/src/cron/schedule-identity.ts
@@ -1,5 +1,3 @@
-import type { CronJob } from "./types.js";
-
 function readString(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -61,14 +59,51 @@ function resolveSchedulePayload(
   return schedulePayloadFromRecord(job);
 }
 
-function cronScheduleIdentity(job: Pick<CronJob, "schedule"> & { enabled?: boolean }): string {
-  const schedule = resolveSchedulePayload(job as unknown as Record<string, unknown>);
-  if (!schedule) {
-    throw new Error("Unsupported cron schedule kind");
+/**
+ * Sentinel string used when a job has a malformed/unrecognized schedule
+ * (e.g., persisted as a bare string instead of `{ kind, ... }`). We hash the
+ * raw schedule value into a stable identity so:
+ *   - two reloads of the same malformed entry compare equal (no spurious
+ *     `nextRunAtMs` invalidation that would mask a real schedule change), and
+ *   - a transition between two different malformed shapes still invalidates
+ *     stale `nextRunAtMs`.
+ *
+ * This keeps `cronSchedulingInputsEqual` total (never throws), so one corrupt
+ * persisted entry cannot kill the scheduler tick (#75886).
+ */
+function malformedScheduleIdentity(
+  job: { schedule?: unknown; enabled?: unknown } & Record<string, unknown>,
+): string {
+  let scheduleRepr: string;
+  try {
+    scheduleRepr = JSON.stringify(job.schedule ?? null) ?? "null";
+  } catch {
+    scheduleRepr = `<unserializable:${typeof job.schedule}>`;
   }
   return JSON.stringify({
     version: 1,
-    enabled: job.enabled ?? true,
+    malformed: true,
+    enabled: typeof job.enabled === "boolean" ? job.enabled : true,
+    scheduleRepr,
+  });
+}
+
+/**
+ * Non-throwing schedule identity. Returns a stable JSON string for any input,
+ * including malformed/legacy persisted jobs. Use this anywhere a throw would
+ * propagate to the scheduler tick (notably store reload comparison). Callers
+ * that need to detect malformed entries should use {@link tryCronScheduleIdentity}.
+ */
+export function cronScheduleIdentityOrNull(
+  job: { schedule?: unknown; enabled?: unknown } & Record<string, unknown>,
+): string {
+  const schedule = resolveSchedulePayload(job);
+  if (!schedule) {
+    return malformedScheduleIdentity(job);
+  }
+  return JSON.stringify({
+    version: 1,
+    enabled: typeof job.enabled === "boolean" ? job.enabled : true,
     schedule,
   });
 }
@@ -87,9 +122,15 @@ export function tryCronScheduleIdentity(
   });
 }
 
+/**
+ * Total comparison of scheduling inputs. Never throws — see #75886, where a
+ * single malformed persisted job (string-shaped `schedule` field) used to
+ * propagate "Unsupported cron schedule kind" up through the scheduler tick
+ * and freeze `nextWakeAtMs` for every other job.
+ */
 export function cronSchedulingInputsEqual(
-  previous: Pick<CronJob, "schedule"> & { enabled?: boolean },
-  next: Pick<CronJob, "schedule"> & { enabled?: boolean },
+  previous: { schedule?: unknown; enabled?: unknown } & Record<string, unknown>,
+  next: { schedule?: unknown; enabled?: unknown } & Record<string, unknown>,
 ): boolean {
-  return cronScheduleIdentity(previous) === cronScheduleIdentity(next);
+  return cronScheduleIdentityOrNull(previous) === cronScheduleIdentityOrNull(next);
 }

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -246,6 +246,7 @@ export function createMockCronStateForJobs(params: {
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedMissingSessionTargetJobIds: new Set<string>(),
+    warnedMalformedScheduleJobIds: new Set<string>(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -148,6 +148,12 @@ export type CronServiceState = {
    * single broken job does not spam the log on every scheduler cycle.
    */
   warnedMissingSessionTargetJobIds: Set<string>;
+  /**
+   * Job ids whose persisted schedule shape is malformed (#75886). Tracked so
+   * the structured warning fires once per process per job instead of on every
+   * forceReload tick.
+   */
+  warnedMalformedScheduleJobIds: Set<string>;
   storeLoadedAtMs: number | null;
   storeFileMtimeMs: number | null;
 };
@@ -161,6 +167,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     op: Promise.resolve(),
     warnedDisabled: false,
     warnedMissingSessionTargetJobIds: new Set<string>(),
+    warnedMalformedScheduleJobIds: new Set<string>(),
     storeLoadedAtMs: null,
     storeFileMtimeMs: null,
   };

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -386,4 +386,157 @@ describe("cron service store seam coverage", () => {
 
     expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBeUndefined();
   });
+
+  it("does not throw on reload when a persisted job has a string-shaped schedule (#75886)", async () => {
+    const { storePath } = await makeStorePath();
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "malformed-string-schedule",
+              name: "malformed string schedule",
+              enabled: true,
+              createdAtMs: STORE_TEST_NOW - 60_000,
+              updatedAtMs: STORE_TEST_NOW - 60_000,
+              // Malformed: a bare string instead of `{ kind: "cron", expr }`.
+              schedule: "0 6 * * *",
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "tick" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createStoreTestState(storePath);
+
+    await expect(ensureLoaded(state, { skipRecompute: true })).resolves.toBeUndefined();
+    // Second reload must also be non-throwing: the prior failure mode was
+    // cronSchedulingInputsEqual throwing during the comparison against the
+    // previous in-memory copy of the same malformed job.
+    await expect(
+      ensureLoaded(state, { forceReload: true, skipRecompute: true }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storePath,
+        jobId: "malformed-string-schedule",
+      }),
+      expect.stringContaining("unsupported schedule shape"),
+    );
+  });
+
+  it("keeps other valid jobs scheduled when one persisted job has a malformed schedule (#75886)", async () => {
+    const { storePath } = await makeStorePath();
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "malformed-string-schedule",
+              name: "malformed",
+              enabled: true,
+              createdAtMs: STORE_TEST_NOW - 60_000,
+              updatedAtMs: STORE_TEST_NOW - 60_000,
+              schedule: "0 6 * * *",
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "tick" },
+              state: {},
+            },
+            {
+              id: "valid-every-job",
+              name: "valid every job",
+              enabled: true,
+              createdAtMs: STORE_TEST_NOW - 60_000,
+              updatedAtMs: STORE_TEST_NOW - 60_000,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "tick" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state);
+
+    const validJob = findJobOrThrow(state, "valid-every-job");
+    expect(typeof validJob.state.nextRunAtMs).toBe("number");
+  });
+
+  it("preserves schedule-change invalidation when transitioning between malformed shapes (#75886)", async () => {
+    const { storePath } = await makeStorePath();
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    const baseJob = {
+      id: "malformed-transition-job",
+      name: "malformed transition",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      updatedAtMs: STORE_TEST_NOW - 60_000,
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: { nextRunAtMs: staleNextRunAtMs },
+    } as const;
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({ version: 1, jobs: [{ ...baseJob, schedule: "0 6 * * *" }] }, null, 2),
+      "utf8",
+    );
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+    expect(findJobOrThrow(state, "malformed-transition-job").state.nextRunAtMs).toBe(
+      staleNextRunAtMs,
+    );
+
+    // Different malformed shape -> identity changes -> stale nextRunAtMs cleared.
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              ...baseJob,
+              updatedAtMs: STORE_TEST_NOW,
+              schedule: "0 7 * * *",
+              state: { nextRunAtMs: staleNextRunAtMs },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    await ensureLoaded(state, { forceReload: true, skipRecompute: true });
+    expect(findJobOrThrow(state, "malformed-transition-job").state.nextRunAtMs).toBeUndefined();
+  });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
-import { cronSchedulingInputsEqual } from "../schedule-identity.js";
+import { cronSchedulingInputsEqual, tryCronScheduleIdentity } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
@@ -85,6 +85,29 @@ export async function ensureLoaded(
       hydrated.enabled = true;
     }
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
+    // #75886: persisted jobs can carry malformed schedule shapes (e.g.
+    // `schedule: "0 6 * * *"` instead of `{ kind: "cron", expr: "0 6 * * *" }`).
+    // Surface a structured warning once per jobId so the rest of the tick
+    // (and other valid jobs) keep running. The reload-comparison path is
+    // already non-throwing via `cronScheduleIdentityOrNull`.
+    if (tryCronScheduleIdentity(hydrated as unknown as Record<string, unknown>) === undefined) {
+      const jobId = typeof hydrated.id === "string" ? hydrated.id : undefined;
+      const dedupeKey = jobId ?? "<unknown>";
+      if (!state.warnedMalformedScheduleJobIds.has(dedupeKey)) {
+        state.warnedMalformedScheduleJobIds.add(dedupeKey);
+        state.deps.log.warn(
+          {
+            storePath: state.deps.storePath,
+            jobId,
+            scheduleKind:
+              hydrated.schedule && typeof hydrated.schedule === "object"
+                ? (hydrated.schedule as { kind?: unknown }).kind
+                : typeof hydrated.schedule,
+          },
+          "cron: job has unsupported schedule shape; skipping job (run openclaw doctor --fix to repair)",
+        );
+      }
+    }
     // Same shape: persisted jobs missing `sessionTarget` crash downstream
     // on any code path that dereferences `.startsWith` (e.g.
     // `runIsolatedAgentJob` in `src/gateway/server-cron.ts`). Mirror the


### PR DESCRIPTION
Closes #75886.

## What changed

- `cronScheduleIdentity` no longer throws on malformed/legacy persisted jobs. The internal helper is replaced with `cronScheduleIdentityOrNull`, which returns a stable identity string for any input. Malformed schedules (e.g. a bare-string `schedule` field) hash to a marked sentinel keyed off the raw value.
- `cronSchedulingInputsEqual` is now total (never throws) and accepts unknown-shaped inputs, so the store-reload comparison in `ensureLoaded` can no longer kill the scheduler tick.
- `ensureLoaded` isolates malformed jobs with a structured one-shot warning per `jobId` (deduped via the new `state.warnedMalformedScheduleJobIds`), keeping other valid jobs scheduled and runnable.
- `tryCronScheduleIdentity` is unchanged in behavior and is still used as the malformed-detection probe.

## Why

Per the issue: a single malformed persisted job (e.g. `schedule: "0 6 * * *"` instead of `{ kind: "cron", expr: "0 6 * * *" }`) caused `cronScheduleIdentity` to throw `Unsupported cron schedule kind`. The throw propagated through `cronSchedulingInputsEqual` → `invalidateStaleNextRunOnScheduleChange` → `ensureLoaded`, which is invoked on every tick. Result: `nextWakeAtMs` froze and no due jobs ran until restart. This matches the clawsweeper recommendation: make reload comparison non-throwing, isolate the bad entry, preserve existing schedule-change invalidation semantics.

## Validation

```
pnpm test src/cron/service/store.test.ts src/cron/store.test.ts src/cron/service/timer.regression.test.ts
```
→ 67 tests, all passing (3 new regression tests added).

```
pnpm exec oxfmt --check --threads=1 src/cron/schedule-identity.ts src/cron/service/store.ts src/cron/normalize.ts src/cron/service/store.test.ts src/cron/store.test.ts CHANGELOG.md
```
→ All matched files use the correct format.

## Regression tests added (`src/cron/service/store.test.ts`)

1. **Reload does not throw on string-shaped `schedule`** — both initial load and forceReload return cleanly; structured warning is emitted with `jobId` and `storePath`.
2. **One malformed entry does not stop other jobs** — the valid `every` job still gets `nextRunAtMs` computed when a malformed entry is present in the same store.
3. **Schedule-change invalidation preserved across malformed shapes** — transitioning between two different malformed schedule values still clears stale `nextRunAtMs`, so a future repair to the persisted entry won't carry over a stale next-run target.

Existing schedule-change invalidation semantics (cron expr change, enabled flag flip, every-anchor change, at-target change, key-order-only no-op) all still pass.
