### PR TITLE
fix: dedupe config future-version warning per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config: log the "newer OpenClaw" version warning once per process instead of once per config snapshot read. (#75927) Thanks @romneyda.
 - Gateway/chat history: merge Claude CLI transcript imports for Anthropic-routed sessions that still have a Claude CLI binding, so local chat history does not hide CLI JSONL turns. Fixes #75850. Thanks @alfredjbclaw.
 - Media: trim serialized JSON suffixes after local `MEDIA:` directive file extensions, so generated-image metadata cannot pollute the parsed media path and cause false `ENOENT` delivery failures. Fixes #75182. Thanks @TnzGit and @hclsys.
 - Cron: make scheduler reload schedule comparison tolerate malformed persisted jobs, so one bad cron entry no longer aborts the whole tick. Fixes #75886. Thanks @samfox-ai.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -156,6 +156,7 @@ type ShippedPluginInstallConfigReadMigration = {
 
 const CONFIG_HEALTH_STATE_FILENAME = "config-health.json";
 const loggedInvalidConfigs = new Set<string>();
+const warnedFutureTouchedVersions = new Set<string>();
 
 type ConfigHealthFingerprint = {
   hash: string;
@@ -952,6 +953,10 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
     return;
   }
   if (shouldWarnOnTouchedVersion(VERSION, touched)) {
+    if (warnedFutureTouchedVersions.has(touched)) {
+      return;
+    }
+    warnedFutureTouchedVersions.add(touched);
     logger.warn(
       `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
     );


### PR DESCRIPTION
## Summary

Fixes this

<img width="765" height="101" alt="image" src="https://github.com/user-attachments/assets/8fd0820c-a160-4f8e-933d-7d74119f79b5" />

- `warnIfConfigFromFuture` had no dedup, so the "Config was last written by a newer OpenClaw" warning fired multiple times per process.
- It is called from both `loadConfig` (`src/config/io.ts:1602`) and `readConfigFileSnapshot` (`src/config/io.ts:1810`). The latter is invoked from ~87 sites across plugins CLI, secrets/security audits, mcp-config, runtime-schema, wizard, exec-policy-cli, etc., so a typical boot exercises several of them.
- Only the runtime-load lane was deduped via `loadPinnedRuntimeConfig`. The snapshot lane re-parses the file fresh each time and re-warned.

## Fix

Module-level `Set<string>` keyed on the `touched` version inside `warnIfConfigFromFuture`. At most one warning per touched version per process, across both call sites. Mirrors the existing `loggedInvalidConfigs` pattern at `src/config/io.ts:158`.

Sibling processes (CLI dispatcher, gateway, doctor, watcher) still warn once each — fixing cross-process duplication would require shared IPC state and is out of scope.

## Test plan

- [ ] Boot with a config whose `meta.lastTouchedVersion` is newer than `VERSION`; confirm the warning prints exactly once.
- [ ] Run a CLI path that triggers both `loadConfig` and `readConfigFileSnapshot` in the same process; confirm still single warning.
- [ ] Confirm `pnpm test:changed` passes.