### PR TITLE
fix(codex): reject bind options without values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/hooks: derive hook `ctx.channelId` from the conversation target instead of the provider name, so Discord and other channel plugins can keep per-channel state isolated. Fixes #59881. Thanks @bradfreels.
 - Gateway/config: log config health-state write failures instead of silently hiding config observe-recovery write errors. Thanks @sallyom.
 - Diagnostics: reset stuck-session timers on reply, tool, status, block, and ACP progress events, and back off repeated `session.stuck` diagnostics while a session remains unchanged. Supersedes #72010. Thanks @rubencu.
+- Codex/commands: show `/codex bind` usage when option values are missing instead of starting a bind with shifted arguments. Thanks @Lucenx9.
 
 ## 2026.4.30
 

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -1418,17 +1418,32 @@ function parseBindArgs(args: string[]): ParsedBindArgs {
       continue;
     }
     if (arg === "--cwd") {
-      parsed.cwd = args[index + 1];
+      const value = readRequiredOptionValue(args, index);
+      if (!value) {
+        parsed.help = true;
+        continue;
+      }
+      parsed.cwd = value;
       index += 1;
       continue;
     }
     if (arg === "--model") {
-      parsed.model = args[index + 1];
+      const value = readRequiredOptionValue(args, index);
+      if (!value) {
+        parsed.help = true;
+        continue;
+      }
+      parsed.model = value;
       index += 1;
       continue;
     }
     if (arg === "--provider" || arg === "--model-provider") {
-      parsed.provider = args[index + 1];
+      const value = readRequiredOptionValue(args, index);
+      if (!value) {
+        parsed.help = true;
+        continue;
+      }
+      parsed.provider = value;
       index += 1;
       continue;
     }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1434,6 +1434,34 @@ describe("codex command", () => {
     });
   });
 
+  it("shows help when bind option values are missing", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const startCodexConversationThread = vi.fn(async () => ({
+      kind: "codex-app-server-session" as const,
+      version: 1 as const,
+      sessionFile,
+      workspaceDir: "/repo",
+    }));
+    const requestConversationBinding = vi.fn();
+
+    await expect(
+      handleCodexCommand(
+        createContext("bind --cwd --model gpt-5.4", sessionFile, {
+          requestConversationBinding,
+        }),
+        {
+          deps: createDeps({
+            startCodexConversationThread,
+          }),
+        },
+      ),
+    ).resolves.toEqual({
+      text: expect.stringContaining("Usage: /codex bind"),
+    });
+    expect(startCodexConversationThread).not.toHaveBeenCalled();
+    expect(requestConversationBinding).not.toHaveBeenCalled();
+  });
+
   it("returns the binding approval reply when conversation bind needs approval", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const reply = { text: "Approve this?" };


### PR DESCRIPTION
## Summary

- Problem: `/codex bind --cwd` / `--model` / `--provider` accepted missing option values and could treat the next flag as the value or fall back into a bind attempt.
- Why it matters: a malformed bind command can start or request a Codex conversation binding with unintended workspace/model/provider inputs instead of telling the user what to fix.
- What changed: `parseBindArgs` now uses the same required-option guard as the Codex Computer Use parser and returns bind usage when option values are missing.
- What did NOT change (scope boundary): no Codex app-server protocol, auth, runtime, or thread lifecycle behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the bind parser read `args[index + 1]` directly for value-taking options, unlike the nearby Computer Use parser which rejects missing or flag-shaped values.
- Missing detection / guardrail: there was no command test for `/codex bind` option values being omitted.
- Contributing context (if known): `parseBindArgs` predated the shared `readRequiredOptionValue` helper used later in the same file.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/commands.test.ts`
- Scenario the test should lock in: `/codex bind --cwd --model gpt-5.4` returns bind usage and does not start a Codex thread or request a conversation binding.
- Why this is the smallest reliable guardrail: it covers the command parser and command handler boundary without starting app-server runtime.
- Existing test that already covers this (if any): none for bind missing option values.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed `/codex bind` commands with missing option values now show usage instead of attempting a bind with shifted or omitted arguments.

## Diagram (if applicable)

```text
Before:
/codex bind --cwd --model gpt-5.4 -> parser treats --model as cwd -> bind attempt

After:
/codex bind --cwd --model gpt-5.4 -> usage text -> no bind attempt
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout, Node 24.15.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Codex plugin command handler
- Relevant config (redacted): N/A

### Steps

1. Run `/codex bind --cwd --model gpt-5.4` in a context with a session file.
2. Observe command handling.
3. Compare whether a Codex thread/binding is started.

### Expected

- The command returns `/codex bind` usage and does not start or request a binding.

### Actual

- Before this fix, the parser accepted the flag-shaped value and continued into bind handling.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `git diff --check`
  - `pnpm test extensions/codex/src/commands.test.ts`
  - `pnpm test:extension codex`
  - `pnpm check`
- Edge cases checked: missing bind option value where the next token is another flag.
- What you did **not** verify: live app-server bind against a real Codex account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
