### PR TITLE
[codex] Avoid media completion double posts

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -829,6 +829,45 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("does not fallback when announce-agent delivered media through the message tool", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        didSendViaMessagingTool: true,
+        messagingToolSentMediaUrls: ["/tmp/generated-night-drive.mp3"],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.\nMEDIA:/tmp/generated-night-drive.mp3",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction: "Deliver the generated music through the message tool.",
+        },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        delivered: true,
+        path: "direct",
+      }),
+    );
+    expect(callGateway).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("uses a direct channel fallback when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -558,10 +558,31 @@ function hasVisibleGatewayAgentPayload(response: unknown): boolean {
     response && typeof response === "object" && "result" in response
       ? (response as { result?: unknown }).result
       : undefined;
-  const payloads =
-    result && typeof result === "object" && "payloads" in result
-      ? (result as { payloads?: unknown }).payloads
-      : undefined;
+  if (!result || typeof result !== "object") {
+    return false;
+  }
+  const resultRecord = result as {
+    didSendViaMessagingTool?: unknown;
+    messagingToolSentTexts?: unknown;
+    messagingToolSentMediaUrls?: unknown;
+    payloads?: unknown;
+  };
+  if (resultRecord.didSendViaMessagingTool === true) {
+    return true;
+  }
+  if (
+    Array.isArray(resultRecord.messagingToolSentTexts) &&
+    resultRecord.messagingToolSentTexts.some((item) => typeof item === "string" && item.trim())
+  ) {
+    return true;
+  }
+  if (
+    Array.isArray(resultRecord.messagingToolSentMediaUrls) &&
+    resultRecord.messagingToolSentMediaUrls.some((item) => typeof item === "string" && item.trim())
+  ) {
+    return true;
+  }
+  const payloads = "payloads" in resultRecord ? resultRecord.payloads : undefined;
   if (!Array.isArray(payloads)) {
     return false;
   }


### PR DESCRIPTION
## Summary
- Treat successful `message` tool sends as visible completion delivery when async media completion announce-agent returns no normalized payloads.
- Keep the raw completion fallback for true empty/no-side-effect announce runs.
- Add a regression test for music-generation media delivered through the message tool.

## Root Cause
Async media completion announces ask the agent to deliver generated files with the `message` tool and then return `NO_REPLY`. That final reply normalizes to an empty payload list, so the completion fallback path treated the announce as undelivered and sent the raw completion text/media again.

## Validation
- `pnpm test src/agents/subagent-announce-delivery.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/subagent-announce-delivery.ts src/agents/subagent-announce-delivery.test.ts`
- `pnpm check:changed --staged` (local fallback; Blacksmith Testbox was unavailable because CLI auth is missing)
