### PR TITLE
fix(codex): normalize file url image inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config: log config health-state write failures instead of silently hiding config observe-recovery write errors. Thanks @sallyom.
 - Diagnostics: reset stuck-session timers on reply, tool, status, block, and ACP progress events, and back off repeated `session.stuck` diagnostics while a session remains unchanged. Supersedes #72010. Thanks @rubencu.
 - Agents/OpenAI: normalize parameter-free MCP tool schemas whose `properties` value is null or undefined, so OpenAI no longer rejects MCP tools without parameters. Fixes #75362. (#75401) Thanks @SymbolStar.
+- Codex/conversations: decode local `file://` image paths safely before forwarding inbound media to Codex, and fall back to remote image URLs when a local file URL is unusable. Thanks @Lucenx9.
 
 ## 2026.4.30
 

--- a/extensions/codex/src/conversation-turn-input.test.ts
+++ b/extensions/codex/src/conversation-turn-input.test.ts
@@ -41,4 +41,65 @@ describe("codex conversation turn input", () => {
       { type: "image", url: "https://example.test/photo.webp?sig=1" },
     ]);
   });
+
+  it("decodes local file urls before forwarding image attachments", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file:///tmp/photo%20one.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([
+      { type: "text", text: "look", text_elements: [] },
+      {
+        type: "localImage",
+        path: expect.stringMatching(/[\\/]tmp[\\/]photo one\.png$/),
+      },
+    ]);
+  });
+
+  it("falls back to remote image urls when local file urls are not usable", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file://example.test/share/photo.png",
+            mediaUrl: "https://example.test/photo.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([
+      { type: "text", text: "look", text_elements: [] },
+      { type: "image", url: "https://example.test/photo.png" },
+    ]);
+  });
+
+  it("ignores malformed local file urls without failing the turn input", () => {
+    expect(
+      buildCodexConversationTurnInput({
+        prompt: "look",
+        event: {
+          content: "look",
+          channel: "webchat",
+          isGroup: false,
+          metadata: {
+            mediaPath: "file:///tmp/%E0%A4%A.png",
+            mediaType: "image/png",
+          },
+        },
+      }),
+    ).toEqual([{ type: "text", text: "look", text_elements: [] }]);
+  });
 });

--- a/extensions/codex/src/conversation-turn-input.ts
+++ b/extensions/codex/src/conversation-turn-input.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { safeFileURLToPath } from "openclaw/plugin-sdk/file-access-runtime";
 import type { PluginHookInboundClaimEvent } from "openclaw/plugin-sdk/plugin-entry";
 import type { CodexUserInput } from "./app-server/protocol.js";
 
@@ -49,7 +50,10 @@ function toCodexImageInput(media: InboundMedia): CodexUserInput | undefined {
     return undefined;
   }
   if (media.path) {
-    return { type: "localImage", path: normalizeFileUrl(media.path) };
+    const localPath = normalizeFilePath(media.path);
+    if (localPath) {
+      return { type: "localImage", path: localPath };
+    }
   }
   return media.url ? { type: "image", url: media.url } : undefined;
 }
@@ -65,8 +69,15 @@ function isImageMedia(media: InboundMedia): boolean {
   return IMAGE_EXTENSIONS.has(path.extname(candidate.split(/[?#]/, 1)[0] ?? "").toLowerCase());
 }
 
-function normalizeFileUrl(value: string): string {
-  return value.startsWith("file://") ? new URL(value).pathname : value;
+function normalizeFilePath(value: string): string | undefined {
+  if (!value.startsWith("file://")) {
+    return value;
+  }
+  try {
+    return safeFileURLToPath(value);
+  } catch {
+    return undefined;
+  }
 }
 
 function readStringArray(value: unknown): string[] {


### PR DESCRIPTION
## Summary

- Problem: Codex conversation image input converted `file://` media paths with `new URL(...).pathname`, which can produce invalid local paths on Windows and throws on malformed file URLs.
- Why it matters: inbound image attachments can be dropped or forwarded with unusable paths before Codex sees them, especially for file URLs with spaces, platform-specific path forms, or a remote URL fallback.
- What changed: Codex conversation input now uses the repo's safe file-URL decoder, skips unusable local file URLs, and falls back to a remote image URL when one is available.
- What did NOT change (scope boundary): no media download, channel ingestion, Codex app-server runtime, or model behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Codex's conversation input builder treated file URLs as generic URLs and read `.pathname` directly instead of using the repo's file-URL normalization helper.
- Missing detection / guardrail: existing Codex conversation input tests covered local paths and remote image URLs, but not encoded, unusable, or malformed local file URLs.
- Contributing context (if known): other media paths already use `safeFileURLToPath`; this Codex-specific conversion path had drifted from that behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/conversation-turn-input.test.ts`
- Scenario the test should lock in: local `file://` image paths are decoded before forwarding, unusable file URLs fall back to remote image URLs, and malformed file URLs do not fail the input builder.
- Why this is the smallest reliable guardrail: the bug is in the pure Codex input conversion helper and does not require app-server or channel runtime.
- Existing test that already covers this (if any): none for file URL media paths.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex-bound conversations handle inbound image attachments with `file://` paths more reliably and can fall back to the remote image URL when the local file URL cannot be safely converted.

## Diagram (if applicable)

```text
Before:
file:///tmp/photo%20one.png -> new URL().pathname -> raw localImage path
malformed file URL -> exception during input build

After:
file:///tmp/photo%20one.png -> safeFileURLToPath -> localImage path
unusable local file URL + remote URL -> remote image URL
malformed file URL only -> image omitted, text input preserved
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout, Node 24.15.0, pnpm 10.33.2
- Model/provider: Codex plugin input builder
- Integration/channel (if any): plugin inbound conversation media metadata
- Relevant config (redacted): N/A

### Steps

1. Build Codex conversation input for an inbound event with `metadata.mediaPath = "file:///tmp/photo%20one.png"` and image MIME type.
2. Build Codex conversation input for an inbound event with an unusable local `file://host/...` path plus `metadata.mediaUrl`.
3. Build Codex conversation input for an inbound event with a malformed `file://` path.

### Expected

- Encoded local file URLs decode to local image paths.
- Unusable local file URLs fall back to the remote image URL when present.
- Malformed local file URLs do not throw or drop the text prompt.

### Actual

- Before this fix, Codex used `new URL(value).pathname` directly and could produce unusable local paths or throw while building the turn input.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `git diff --check`
  - `pnpm test extensions/codex/src/conversation-turn-input.test.ts`
  - `pnpm test:extension codex`
  - `pnpm check`
- Edge cases checked: encoded local file URL, unusable hosted file URL with remote fallback, malformed local file URL without fallback.
- What you did **not** verify: live inbound media from every channel transport.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
