### PR TITLE
fix: add sendLoadApi option for LM Studio provider

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -119,21 +119,27 @@ export async function createLmstudioEmbeddingProvider(
     ssrfPolicy,
   };
 
-  try {
-    await ensureLmstudioModelLoaded({
-      baseUrl,
-      apiKey,
-      headers: headerOverrides,
-      ssrfPolicy,
-      modelKey: model,
-      timeoutMs: 120_000,
-    });
-  } catch (error) {
-    log.warn("lmstudio embeddings warmup failed; continuing without preload", {
-      baseUrl,
-      model,
-      error: formatErrorMessage(error),
-    });
+  // Skip the load API call if sendLoadApi is explicitly set to false.
+  // This allows LM Studio's Just-In-Time (JIT) model loading to work without
+  // OpenClaw interference, letting LM Studio handle automatic loading/unloading
+  // based on its own TTL and unload settings.
+  if (providerConfig?.sendLoadApi !== false) {
+    try {
+      await ensureLmstudioModelLoaded({
+        baseUrl,
+        apiKey,
+        headers: headerOverrides,
+        ssrfPolicy,
+        modelKey: model,
+        timeoutMs: 120_000,
+      });
+    } catch (error) {
+      log.warn("lmstudio embeddings warmup failed; continuing without preload", {
+        baseUrl,
+        model,
+        error: formatErrorMessage(error),
+      });
+    }
   }
 
   return {

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -343,6 +343,13 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
   modelHeaders?: Record<string, string>;
 }): Promise<void> {
   const providerConfig = params.ctx.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
+  // Skip the load API call if sendLoadApi is explicitly set to false.
+  // This allows LM Studio's Just-In-Time (JIT) model loading to work without
+  // OpenClaw interference, letting LM Studio handle automatic loading/unloading
+  // based on its own TTL and unload settings.
+  if (providerConfig?.sendLoadApi === false) {
+    return;
+  }
   const providerHeaders = { ...providerConfig?.headers, ...params.modelHeaders };
   const runtimeApiKey =
     typeof params.options?.apiKey === "string" && params.options.apiKey.trim().length > 0

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -866,6 +866,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Optional per-provider model request timeout in seconds. Applies to provider HTTP fetches, including connect, headers, body, and total request abort handling. Use this for slow local or self-hosted model servers instead of changing global agent timeouts.",
   "models.providers.*.injectNumCtxForOpenAICompat":
     "Controls whether OpenClaw injects `options.num_ctx` for Ollama providers configured with the OpenAI-compatible adapter (`openai-completions`). Default is true. Set false only if your proxy/upstream rejects unknown `options` payload fields.",
+  "models.providers.*.sendLoadApi":
+    "Controls whether OpenClaw sends the `/api/v1/models/load` request to LM Studio before inference. When true (default), OpenClaw explicitly loads the model. Set to false to let LM Studio's Just-In-Time (JIT) model loading handle model loading/unloading automatically based on its own TTL and unload settings.",
   "models.providers.*.headers":
     "Static HTTP headers merged into provider requests for tenant routing, proxy auth, or custom gateway requirements. Use this sparingly and keep sensitive header values in secrets.",
   "models.providers.*.authHeader":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -534,6 +534,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.providers.*.maxTokens": "Model Provider Max Tokens",
   "models.providers.*.timeoutSeconds": "Model Provider Request Timeout",
   "models.providers.*.injectNumCtxForOpenAICompat": "Model Provider Inject num_ctx (OpenAI Compat)",
+  "models.providers.*.sendLoadApi": "LM Studio Send Load API",
   "models.providers.*.headers": "Model Provider Headers",
   "models.providers.*.authHeader": "Model Provider Authorization Header",
   "models.providers.*.request": "Model Provider Request Overrides",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -124,6 +124,7 @@ export type ModelProviderConfig = {
   maxTokens?: number;
   timeoutSeconds?: number;
   injectNumCtxForOpenAICompat?: boolean;
+  sendLoadApi?: boolean;
   headers?: Record<string, SecretInput>;
   authHeader?: boolean;
   request?: ConfiguredModelProviderRequest;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -362,6 +362,7 @@ export const ModelProviderSchema = z
     maxTokens: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     injectNumCtxForOpenAICompat: z.boolean().optional(),
+    sendLoadApi: z.boolean().optional(),
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     request: ConfiguredModelProviderRequestSchema,


### PR DESCRIPTION
## Summary

Adds a new provider config option `sendLoadApi` (default: true) that controls whether OpenClaw sends the `/api/v1/models/load` request to LM Studio before inference.

When set to false, OpenClaw skips the explicit model loading call, allowing LM Studio's Just-In-Time (JIT) model loading feature to work as intended. This lets LM Studio handle automatic model loading and unloading based on its own TTL and unload settings.

## Changes

- Added `sendLoadApi?: boolean` to `ModelProviderConfig` type
- Added `sendLoadApi: z.boolean().optional()` to Zod schema
- Added help text and label for `models.providers.*.sendLoadApi`
- Modified `ensureLmstudioModelLoadedBestEffort` in stream.ts to skip load call when `sendLoadApi === false`
- Modified `createLmstudioEmbeddingProvider` in embedding-provider.ts to also respect `sendLoadApi === false`

## Testing

- All 68 existing LM Studio extension tests pass
- The fix was verified by checking that `ensureLmstudioModelLoaded` is not called when `sendLoadApi` is false

Fixes openclaw/openclaw#75921