### PR TITLE
fix(macos): preserve gateway auth config writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Discord/threads: ignore webhook-authored copies in already-bound Discord session threads even when the webhook id differs, preventing PluralKit proxy copies from creating duplicate turn pressure. Fixes #52005. Thanks @acgh213.
 - Discord/threads: return the created thread as partial success when the follow-up initial message fails, so agents do not retry thread creation and create empty duplicate threads. Fixes #48450. Thanks @dahifi.
 - Discord/components: consume every button or select in a non-reusable component message after the first authorized click, so single-use panels cannot fire sibling callbacks. Fixes #54227. Thanks @fujiwarakasei.
+- macOS/config: preserve existing `gateway.auth` and unrelated config keys during app fallback writes, so dashboard or Talk settings changes cannot strand Control UI clients by dropping persisted auth. Fixes #75631. Thanks @Fuma2013.
 - Discord/reactions: skip reaction listener registration when DMs and group DMs are disabled and every configured guild has `reactionNotifications: "off"`, avoiding needless reaction-event queue work. Fixes #47516. Thanks @x4v13r1120.
 - CLI sessions: preserve explicit manual-attach reuse bindings so trusted CLI sessions are not invalidated on the first turn when auth, prompt, or MCP fingerprints drift. Fixes #75849. Thanks @alfredjbclaw.
 - Telegram/streaming: keep partial preview streaming enabled for plain reply-to replies, disabling drafts only for real native quote excerpts that require Telegram quote parameters. Fixes #73505. Thanks @choury.

--- a/apps/macos/Sources/OpenClaw/ConfigStore.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigStore.swift
@@ -48,7 +48,10 @@ enum ConfigStore {
     }
 
     @MainActor
-    static func save(_ root: sending [String: Any]) async throws {
+    static func save(
+        _ root: sending [String: Any],
+        allowGatewayAuthMutation: Bool = false) async throws
+    {
         let overrides = await self.overrideStore.overrides
         if await self.isRemoteMode() {
             if let override = overrides.saveRemote {
@@ -63,7 +66,10 @@ enum ConfigStore {
                 do {
                     try await self.saveToGateway(root)
                 } catch {
-                    OpenClawConfigFile.saveDict(root)
+                    OpenClawConfigFile.saveDict(
+                        root,
+                        preserveExistingKeys: true,
+                        allowGatewayAuthMutation: allowGatewayAuthMutation)
                 }
             }
         }

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -52,7 +52,11 @@ enum OpenClawConfigFile {
         }
     }
 
-    static func saveDict(_ dict: [String: Any]) {
+    static func saveDict(
+        _ dict: [String: Any],
+        preserveExistingKeys: Bool = false,
+        allowGatewayAuthMutation: Bool = false)
+    {
         self.withFileLock {
             // Nix mode disables config writes in production, but tests rely on saving temp configs.
             if ProcessInfo.processInfo.isNixMode, !ProcessInfo.processInfo.isRunningTests { return }
@@ -64,7 +68,15 @@ enum OpenClawConfigFile {
             let hadMetaBefore = self.hasMeta(previousRoot)
             let gatewayModeBefore = self.gatewayMode(previousRoot)
 
-            var output = dict
+            var output = if preserveExistingKeys, let previousRoot {
+                self.mergeExistingConfig(previousRoot, overridingWith: dict)
+            } else {
+                dict
+            }
+            let preservedGatewayAuth = self.preserveGatewayAuthIfNeeded(
+                previousRoot: previousRoot,
+                output: &output,
+                allowGatewayAuthMutation: allowGatewayAuthMutation)
             self.stampMeta(&output)
 
             do {
@@ -76,13 +88,16 @@ enum OpenClawConfigFile {
                 let nextBytes = data.count
                 let nextAttributes = try? FileManager().attributesOfItem(atPath: url.path)
                 let gatewayModeAfter = self.gatewayMode(output)
-                let suspicious = self.configWriteSuspiciousReasons(
+                var suspicious = self.configWriteSuspiciousReasons(
                     existsBefore: previousData != nil,
                     previousBytes: previousBytes,
                     nextBytes: nextBytes,
                     hadMetaBefore: hadMetaBefore,
                     gatewayModeBefore: gatewayModeBefore,
                     gatewayModeAfter: gatewayModeAfter)
+                if preservedGatewayAuth {
+                    suspicious.append("gateway-auth-preserved")
+                }
                 if !suspicious.isEmpty {
                     self.logger.warning("config write anomaly (\(suspicious.joined(separator: ", "))) at \(url.path)")
                 }
@@ -123,7 +138,7 @@ enum OpenClawConfigFile {
                     "hasMetaAfter": self.hasMeta(output),
                     "gatewayModeBefore": gatewayModeBefore ?? NSNull(),
                     "gatewayModeAfter": self.gatewayMode(output) ?? NSNull(),
-                    "suspicious": [],
+                    "suspicious": preservedGatewayAuth ? ["gateway-auth-preserved"] : [],
                     "error": error.localizedDescription,
                 ])
             }
@@ -329,6 +344,52 @@ enum OpenClawConfigFile {
         else { return nil }
         let trimmed = mode.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func gatewayAuth(_ root: [String: Any]?) -> [String: Any]? {
+        guard let root,
+              let gateway = root["gateway"] as? [String: Any]
+        else { return nil }
+        return gateway["auth"] as? [String: Any]
+    }
+
+    private static func configDictionariesEqual(_ left: [String: Any]?, _ right: [String: Any]) -> Bool {
+        guard let left else { return false }
+        return NSDictionary(dictionary: left).isEqual(NSDictionary(dictionary: right))
+    }
+
+    private static func mergeExistingConfig(
+        _ existing: [String: Any],
+        overridingWith next: [String: Any]) -> [String: Any]
+    {
+        var merged = existing
+        for (key, value) in next {
+            if let nextDict = value as? [String: Any],
+               let existingDict = merged[key] as? [String: Any]
+            {
+                merged[key] = self.mergeExistingConfig(existingDict, overridingWith: nextDict)
+            } else {
+                merged[key] = value
+            }
+        }
+        return merged
+    }
+
+    private static func preserveGatewayAuthIfNeeded(
+        previousRoot: [String: Any]?,
+        output: inout [String: Any],
+        allowGatewayAuthMutation: Bool) -> Bool
+    {
+        guard !allowGatewayAuthMutation,
+              let previousAuth = self.gatewayAuth(previousRoot)
+        else {
+            return false
+        }
+        var gateway = output["gateway"] as? [String: Any] ?? [:]
+        let changed = !self.configDictionariesEqual(gateway["auth"] as? [String: Any], previousAuth)
+        gateway["auth"] = previousAuth
+        output["gateway"] = gateway
+        return changed
     }
 
     private static func configWriteSuspiciousReasons(

--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -348,7 +348,7 @@ struct TailscaleIntegrationSection: View {
         }
 
         do {
-            try await ConfigStore.save(root)
+            try await ConfigStore.save(root, allowGatewayAuthMutation: true)
             return (true, nil)
         } catch {
             return (false, error.localizedDescription)

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -164,6 +164,110 @@ struct OpenClawConfigFileTests {
 
     @MainActor
     @Test
+    func `save dict preserves gateway auth unless explicitly allowed`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        let configPath = stateDir.appendingPathComponent("openclaw.json")
+
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        await TestIsolation.withEnvValues([
+            "OPENCLAW_STATE_DIR": stateDir.path,
+            "OPENCLAW_CONFIG_PATH": configPath.path,
+        ]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "auth": [
+                        "mode": "token",
+                        "token": "existing-token", // pragma: allowlist secret
+                    ],
+                ],
+            ])
+
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                ],
+            ])
+
+            let root = OpenClawConfigFile.loadDict()
+            let gateway = root["gateway"] as? [String: Any]
+            let auth = gateway?["auth"] as? [String: Any]
+            #expect(gateway?["mode"] as? String == "local")
+            #expect(auth?["mode"] as? String == "token")
+            #expect(auth?["token"] as? String == "existing-token") // pragma: allowlist secret
+
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                ],
+            ], allowGatewayAuthMutation: true)
+
+            let allowedRoot = OpenClawConfigFile.loadDict()
+            let allowedGateway = allowedRoot["gateway"] as? [String: Any]
+            #expect(allowedGateway?["mode"] as? String == "local")
+            #expect((allowedGateway?["auth"] as? [String: Any]) == nil)
+        }
+    }
+
+    @MainActor
+    @Test
+    func `save dict can merge local fallback writes with fresh config`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        let configPath = stateDir.appendingPathComponent("openclaw.json")
+
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        await TestIsolation.withEnvValues([
+            "OPENCLAW_STATE_DIR": stateDir.path,
+            "OPENCLAW_CONFIG_PATH": configPath.path,
+        ]) {
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "remote",
+                    "auth": [
+                        "mode": "password",
+                        "password": "existing-password", // pragma: allowlist secret
+                    ],
+                ],
+                "browser": [
+                    "enabled": true,
+                    "profile": "work",
+                ],
+                "channels": [
+                    "discord": [
+                        "enabled": true,
+                    ],
+                ],
+            ])
+
+            OpenClawConfigFile.saveDict([
+                "gateway": [
+                    "mode": "local",
+                ],
+                "browser": [
+                    "enabled": false,
+                ],
+            ], preserveExistingKeys: true)
+
+            let root = OpenClawConfigFile.loadDict()
+            let gateway = root["gateway"] as? [String: Any]
+            let auth = gateway?["auth"] as? [String: Any]
+            let browser = root["browser"] as? [String: Any]
+            let discord = ((root["channels"] as? [String: Any])?["discord"] as? [String: Any])
+            #expect(gateway?["mode"] as? String == "local")
+            #expect(auth?["mode"] as? String == "password")
+            #expect(auth?["password"] as? String == "existing-password") // pragma: allowlist secret
+            #expect(browser?["enabled"] as? Bool == false)
+            #expect(browser?["profile"] as? String == "work")
+            #expect(discord?["enabled"] as? Bool == true)
+        }
+    }
+
+    @MainActor
+    @Test
     func `load dict audits suspicious out-of-band clobbers`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

- Problem: macOS app/dashboard config writes can fall back to direct full-config saves and drop persisted `gateway.auth` or unrelated config keys.
- Why it matters: dropping auth can force restart-time behavior changes and disconnect Control UI/dashboard clients with `1012 service restart`.
- What changed: local fallback saves now merge against a fresh on-disk snapshot, direct saves preserve existing `gateway.auth` by default, and the Tailscale auth editor opts into explicit auth mutation.
- What did NOT change (scope boundary): this does not migrate every macOS settings writer to Gateway `config.patch` or change Gateway RPC semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75631
- Related #75815
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: macOS app-side full-config fallback writes treated a stale app snapshot as authoritative for the persisted config file.
- Missing detection / guardrail: direct config saves audited suspicious changes but did not preserve `gateway.auth` before writing.
- Contributing context (if known): Gateway `config.set`/`config.patch` paths have stronger base-hash protections than the local macOS fallback path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift`
- Scenario the test should lock in: direct and fallback-style config writes preserve existing `gateway.auth` and unrelated config keys unless the caller explicitly edits auth.
- Why this is the smallest reliable guardrail: it exercises the macOS file writer and merge behavior without requiring a live Gateway restart.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

macOS/dashboard settings writes preserve persisted Gateway auth and unrelated config by default, reducing surprise disconnect/auth drift after settings changes.

## Diagram (if applicable)

```text
Before:
[dashboard/app setting save] -> [local full-config fallback] -> [gateway.auth may disappear]

After:
[dashboard/app setting save] -> [fresh snapshot merge] -> [gateway.auth and unknown keys preserved]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this hardens persisted token/auth handling by preserving existing `gateway.auth` unless a caller explicitly opts into auth mutation.

## Repro + Verification

### Environment

- OS: macOS host, SwiftPM package under `apps/macos`
- Runtime/container: local checkout on Node 24.13.0 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): macOS app/dashboard config path
- Relevant config (redacted): tests use temp `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`

### Steps

1. Start with an `openclaw.json` containing `gateway.auth` and unrelated config.
2. Save a partial macOS app/dashboard config snapshot that omits auth and unrelated keys.
3. Reload the config from disk.

### Expected

- Existing `gateway.auth` is still present.
- Unrelated config keys are still present for fallback-merge writes.
- Explicit auth edits can still remove or replace auth by opting into auth mutation.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `swift test --package-path apps/macos --filter OpenClawIPCTests.OpenClawConfigFileTests`
  - `swift test --package-path apps/macos --filter OpenClawIPCTests.ConfigStoreTests`
  - `node scripts/check-changed.mjs CHANGELOG.md apps/macos/Sources/OpenClaw/ConfigStore.swift apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift`
  - `git diff --check origin/main..HEAD`
- Edge cases checked: explicit auth mutation remains possible through the Tailscale auth editor path; fallback merge preserves unrelated nested config.
- What you did **not** verify: a live macOS dashboard settings gesture against a running Gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: some caller intentionally expected a generic direct save to remove `gateway.auth` by omission.
  - Mitigation: callers that edit auth can pass `allowGatewayAuthMutation: true`; the known auth editor path does so.
