### PR TITLE
fix(plugins): cache plugin CLI registry per-program to dedupe loads

### DIFF
--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -197,6 +197,26 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
+  it("reuses the loaded plugin registry on repeat calls for the same program", async () => {
+    const program = createProgram();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig);
+    await registerPluginCliCommands(program, {} as OpenClawConfig);
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads when the requested primary command changes", async () => {
+    const program = createProgram();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      primary: "memory",
+    });
+    await registerPluginCliCommands(program, {} as OpenClawConfig);
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(2);
+  });
+
   it("loads plugin CLI commands from the auto-enabled config snapshot", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -17,6 +17,26 @@ type RegisterPluginCliOptions = {
   primary?: string | null;
 };
 
+type PluginCliRegistrationEntries = Awaited<
+  ReturnType<typeof loadPluginCliRegistrationEntriesWithDefaults>
+>;
+
+// Cache the loaded plugin CLI entries on the Commander program so that repeat
+// calls within one invocation reuse the work. `openclaw completion
+// --write-state` enters this function three times (pairing subcli "before"
+// hook, plugins subcli "after" hook, and the completion action's own eager
+// call); without this cache each call pays the full plugin sweep (~20s on
+// Pi-class hardware). Cache key is the `primary` filter; a different filter
+// resolves to a different plugin set and forces a reload.
+const PLUGIN_CLI_ENTRIES_CACHE_KEY = Symbol.for("openclaw.plugin-cli-registration-entries-cache");
+
+interface ProgramWithEntriesCache {
+  [PLUGIN_CLI_ENTRIES_CACHE_KEY]?: {
+    primary: string | undefined;
+    entries: PluginCliRegistrationEntries;
+  };
+}
+
 const logger = createPluginCliLogger();
 
 export const loadValidatedConfigForPluginRegistration =
@@ -46,21 +66,27 @@ export async function registerPluginCliCommands(
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? undefined;
 
-  await registerPluginCliCommandGroups(
-    program,
-    await loadPluginCliRegistrationEntriesWithDefaults({
+  const programWithCache = program as Command & ProgramWithEntriesCache;
+  const cached = programWithCache[PLUGIN_CLI_ENTRIES_CACHE_KEY];
+  let entries: PluginCliRegistrationEntries;
+  if (cached && cached.primary === primary) {
+    entries = cached.entries;
+  } else {
+    entries = await loadPluginCliRegistrationEntriesWithDefaults({
       cfg,
       env,
       loaderOptions,
       primaryCommand: primary,
-    }),
-    {
-      mode,
-      primary,
-      existingCommands: new Set(program.commands.map((cmd) => cmd.name())),
-      logger,
-    },
-  );
+    });
+    programWithCache[PLUGIN_CLI_ENTRIES_CACHE_KEY] = { primary, entries };
+  }
+
+  await registerPluginCliCommandGroups(program, entries, {
+    mode,
+    primary,
+    existingCommands: new Set(program.commands.map((cmd) => cmd.name())),
+    logger,
+  });
 }
 
 export async function registerPluginCliCommandsFromValidatedConfig(


### PR DESCRIPTION
## Summary

- **Problem**: `openclaw completion --write-state` triggers the full plugin sweep **three times** in one invocation (~67 s on a Raspberry Pi 5 with the bundled 2026.4.29 build).
- **Why it matters**: This causes the in-update completion-cache regen to time out (30 s budget) and eats ~40 s of the post-update gateway-restart 60 s health-check budget, contributing to flaky upgrades on slow targets.
- **What changed**: `registerPluginCliCommands` now caches `loadPluginCliRegistrationEntriesWithDefaults`'s output on the Commander program instance, keyed by `primary`. Repeat calls within one invocation reuse the entries instead of triggering another full plugin sweep.
- **What did NOT change**: registration semantics (mode/primary), `loadPluginCliCommandRegistryWithContext`'s `cache: false` (which is correct — snapshot loads must not cache a registry whose commands were never globally registered), or any public API.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

Three independent CLI bootstrap paths each call `registerPluginCliCommands` during `completion --write-state`:

- `pairing` subcli's "before" plugin-load hook (`src/cli/program/register.subclis-core.ts`)
- `plugins` subcli's "after" plugin-load hook (same file)
- `completion --write-state` action's own eager call (`src/cli/completion-cli.ts`)

All three reach `loadPluginCliCommandRegistryWithContext`, which sets `cache: false` for legitimate reasons. The result was three full plugin sweeps per invocation.

- **Root cause**: missing dedup at the `registerPluginCliCommands` layer.
- **Missing detection / guardrail**: no test asserted that `loadOpenClawPlugins` is called only once per Commander program instance during repeat `registerPluginCliCommands` calls.
- **Contributing context**: the post-load "command already registered" debug log at `register-plugin-cli-command-groups.ts:57-61` was a partial guard at the Commander level, not at the load level — so it didn't save the dlopen cost.

## Regression Test Plan

- Coverage level: [x] Unit test
- Target test file: `src/plugins/cli.test.ts`
- Scenarios locked in:
  - Calling `registerPluginCliCommands` twice on the same program calls `loadOpenClawPlugins` exactly once.
  - Calling with a different `primary` value invalidates the cache and reloads (correct behavior — the underlying `loadOpenClawPlugins` call honors `onlyPluginIds` derived from `primary`).
- Why this is the smallest reliable guardrail: a unit test on the public `registerPluginCliCommands` function asserts the dedup contract directly without needing CLI integration plumbing.
- Existing test that already covered this: none.

## Performance evidence

Pre-fix baseline on Pi 5, openclaw 2026.4.29:

```
[plugins] loaded 117 plugin(s) (70 attempted) in 24200.8ms
[plugins] loaded 117 plugin(s) (70 attempted) in 17881.8ms
[plugins] loaded 117 plugin(s) (70 attempted) in 17923.2ms
ELAPSED: 67.123s
```

Post-fix expectation: one sweep (~22–25 s on the same hardware), saving ~40 s. Same improvement applies to in-update completion-cache regen and gateway-restart health budget on slow targets.

## Local verification

- `oxlint:core` — 0 warnings/errors on 5567 files
- `pnpm tsgo` — full project typecheck passed
- `pnpm test 'src/plugins/cli*.test.ts' 'src/plugins/loader*.test.ts'` — 9 files, 56 tests passed (includes 2 new tests covering the cache contract)

Not run locally due to Pi 5 memory limits (8 GB total; tsgolint alone needs ~3 GB RSS plus the kernel/types working set):

- `tsgolint` (typed-lint over the full project) — earlyoom SIGTERM'd it at 2983 MiB RSS
- Full `pnpm test`
- `pnpm build`

Relying on CI to cover those.

---

🤖 [AI-assisted] — generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7).