### PR TITLE
fix: keep ClawHub publish dry-run preflight

### DIFF
--- a/scripts/plugin-clawhub-publish.sh
+++ b/scripts/plugin-clawhub-publish.sh
@@ -76,7 +76,7 @@ echo "Resolved source ref: ${source_ref:-<missing>}"
 echo "Resolved ClawHub workdir: ${clawhub_workdir}"
 echo "Publish auth: GitHub Actions OIDC via ClawHub short-lived token"
 
-printf 'Publish command:'
+printf 'Publish command: CLAWHUB_WORKDIR=%q' "${clawhub_workdir}"
 printf ' %q' "${publish_cmd[@]}"
 printf '\n'
 

--- a/test/plugin-clawhub-release.test.ts
+++ b/test/plugin-clawhub-release.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   collectClawHubPublishablePluginPackages,
@@ -359,6 +359,41 @@ describe("collectPluginClawHubReleasePlan", () => {
     });
 
     expect(plan.candidates.map((plugin) => plugin.packageName)).toEqual(["@openclaw/demo-plugin"]);
+  });
+});
+
+describe("plugin-clawhub-publish.sh", () => {
+  it("previews the publish command through the ClawHub CLI dry-run preflight", () => {
+    const repoDir = createTempPluginRepo();
+    const binDir = join(repoDir, "bin");
+    const markerPath = join(repoDir, "clawhub-invoked");
+    mkdirSync(binDir, { recursive: true });
+    const clawhubPath = join(binDir, "clawhub");
+    writeFileSync(
+      clawhubPath,
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > ${JSON.stringify(markerPath)}\nexit 0\n`,
+    );
+    chmodSync(clawhubPath, 0o755);
+
+    const output = execFileSync(
+      "bash",
+      [
+        join(process.cwd(), "scripts/plugin-clawhub-publish.sh"),
+        "--dry-run",
+        "extensions/demo-plugin",
+      ],
+      {
+        cwd: repoDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(output).toContain("Publish command: CLAWHUB_WORKDIR=");
+    expect(readFileSync(markerPath, "utf8")).toContain("--dry-run");
   });
 });
 


### PR DESCRIPTION
## Summary

- keep `scripts/plugin-clawhub-publish.sh --dry-run` on the real ClawHub CLI dry-run preflight
- print `CLAWHUB_WORKDIR=...` in the preview command so the displayed command matches the publish environment
- add a regression test that proves dry-run invokes the ClawHub CLI with `--dry-run`

## Why

The Plugin ClawHub Release preview path should validate the package publish plan before the protected publish job. This preserves the dependency-backed ClawHub dry-run preflight while making the printed preview command complete enough to copy and inspect.

## Verification

- `pnpm test test/plugin-clawhub-release.test.ts` -> 14 passed
- `pnpm exec oxfmt --check --threads=1 scripts/plugin-clawhub-publish.sh test/plugin-clawhub-release.test.ts` -> passed
- `git diff --check` -> passed
- `OPENCLAW_TESTBOX=1 pnpm check:changed` -> passed in Testbox `tbx_01kqp0m6v5j0vd99afn3p6a4k2`
