### PR TITLE
Add tool descriptor planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.
 - Docs/Codex: clarify that ChatGPT/Codex subscription setups should use `openai/gpt-*` with `agentRuntime.id: "codex"` for native Codex runtime, while `openai-codex/*` remains the PI OAuth route. Thanks @pashpashpash.
 - Plugins/source checkout: load bundled plugins from the `extensions/*` pnpm workspace tree in source checkouts, so plugin-local dependencies and edits are used directly while packaged installs keep using the built runtime tree. Thanks @vincentkoc.
 - Plugins/beta: prepare BlueBubbles, diagnostics Prometheus, Google Meet, Nextcloud Talk, Nostr, Zalo, and Zalo Personal for `2026.5.1-beta.2` npm and ClawHub publishing. Thanks @vincentkoc.

--- a/src/tools/availability.test.ts
+++ b/src/tools/availability.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import { evaluateToolAvailability } from "./availability.js";
+import type { ToolDescriptor } from "./types.js";
+
+const baseDescriptor: ToolDescriptor = {
+  name: "example",
+  description: "Example tool",
+  inputSchema: { type: "object" },
+  owner: { kind: "core" },
+  executor: { kind: "core", executorId: "example" },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+describe("evaluateToolAvailability", () => {
+  it("treats descriptors without signals as available", () => {
+    expect(evaluateToolAvailability({ descriptor: baseDescriptor })).toEqual([]);
+  });
+
+  it("evaluates auth, env, config, plugin, and context signals from data only", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        allOf: [
+          { kind: "auth", providerId: "openai" },
+          { kind: "env", name: "OPENAI_API_KEY" },
+          { kind: "config", path: ["plugins", "entries", "demo", "config"], check: "non-empty" },
+          { kind: "plugin-enabled", pluginId: "demo" },
+          { kind: "context", key: "channel", equals: "telegram" },
+        ],
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          authProviderIds: new Set(["openai"]),
+          env: { OPENAI_API_KEY: "set" },
+          config: { plugins: { entries: { demo: { config: { mode: "local" } } } } },
+          enabledPluginIds: new Set(["demo"]),
+          values: { channel: "telegram" },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns deterministic diagnostics for missing signals", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        allOf: [
+          { kind: "auth", providerId: "openai" },
+          { kind: "env", name: "OPENAI_API_KEY" },
+          { kind: "config", path: ["plugins", "entries", "demo", "config"], check: "non-empty" },
+          { kind: "plugin-enabled", pluginId: "demo" },
+          { kind: "context", key: "channel", equals: "telegram" },
+        ],
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          authProviderIds: new Set(),
+          env: {},
+          config: { plugins: { entries: { demo: { config: {} } } } },
+          enabledPluginIds: new Set(),
+          values: { channel: "discord" },
+        },
+      }).map((entry) => entry.reason),
+    ).toEqual([
+      "auth-missing",
+      "env-missing",
+      "config-missing",
+      "plugin-disabled",
+      "context-mismatch",
+    ]);
+  });
+
+  it("does not treat credential config values as available without an injected resolver", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        kind: "config",
+        path: ["models", "providers", "openai", "apiKey"],
+        check: "available",
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          config: {
+            models: {
+              providers: {
+                openai: {
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                },
+              },
+            },
+          },
+          env: {},
+        },
+      }).map((entry) => entry.reason),
+    ).toEqual(["config-missing"]);
+  });
+
+  it("accepts credential config values only through an injected availability resolver", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        kind: "config",
+        path: ["models", "providers", "openai", "apiKey"],
+        check: "available",
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          config: {
+            models: {
+              providers: {
+                openai: {
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                },
+              },
+            },
+          },
+          env: { OPENAI_API_KEY: "set" },
+          isConfigValueAvailable: ({ value }) =>
+            isRecord(value) &&
+            value.source === "env" &&
+            value.provider === "default" &&
+            value.id === "OPENAI_API_KEY",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not infer env-template strings as configured credentials", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        kind: "config",
+        path: ["models", "providers", "openai", "apiKey"],
+        check: "available",
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          config: {
+            models: {
+              providers: {
+                openai: { apiKey: "${OPENAI_API_KEY}" },
+              },
+            },
+          },
+          env: { OPENAI_API_KEY: "set" },
+        },
+      }).map((entry) => entry.reason),
+    ).toEqual(["config-missing"]);
+  });
+
+  it("does not infer ordinary objects with source/provider/id fields as credentials", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        kind: "config",
+        path: ["tools", "example"],
+        check: "non-empty",
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          config: {
+            tools: {
+              example: { source: "manual", provider: "docs", id: "readme" },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("supports anyOf availability expressions", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: {
+        anyOf: [
+          { kind: "auth", providerId: "openai" },
+          { kind: "env", name: "OPENAI_API_KEY" },
+          {
+            allOf: [
+              { kind: "config", path: ["plugins", "entries", "local"], check: "non-empty" },
+              { kind: "plugin-enabled", pluginId: "local" },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          authProviderIds: new Set(),
+          env: { OPENAI_API_KEY: "set" },
+          enabledPluginIds: new Set(),
+        },
+      }),
+    ).toEqual([]);
+
+    expect(
+      evaluateToolAvailability({
+        descriptor,
+        context: {
+          authProviderIds: new Set(),
+          env: {},
+          enabledPluginIds: new Set(),
+        },
+      }).map((entry) => entry.reason),
+    ).toEqual(["auth-missing", "env-missing", "config-missing", "plugin-disabled"]);
+  });
+});

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -1,0 +1,170 @@
+import type {
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  ToolAvailabilityContext,
+  ToolAvailabilityDiagnostic,
+  ToolAvailabilityExpression,
+  ToolAvailabilitySignal,
+  ToolDescriptor,
+} from "./types.js";
+
+function isRecord(value: JsonValue | undefined): value is JsonObject {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveConfigPath(
+  config: JsonObject | undefined,
+  path: readonly string[],
+): JsonValue | undefined {
+  let current: JsonValue | undefined = config;
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function hasConfiguredValue(params: {
+  value: JsonValue | undefined;
+  signal: Extract<ToolAvailabilitySignal, { readonly kind: "config" }>;
+  context: ToolAvailabilityContext;
+}): boolean {
+  const { value, signal } = params;
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if ((signal.check ?? "exists") === "available") {
+    return (
+      params.context.isConfigValueAvailable?.({
+        value,
+        path: signal.path,
+        signal,
+      }) === true
+    );
+  }
+  if ((signal.check ?? "exists") === "exists") {
+    return true;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value).length > 0;
+  }
+  return true;
+}
+
+function hasAvailabilityExpressionShape(value: ToolAvailabilityExpression): boolean {
+  return "kind" in value || "allOf" in value || "anyOf" in value;
+}
+
+function diagnostic(
+  reason: ToolAvailabilityDiagnostic["reason"],
+  signal: ToolAvailabilitySignal,
+  message: string,
+): ToolAvailabilityDiagnostic {
+  return { reason, signal, message };
+}
+
+function evaluateSignal(
+  signal: ToolAvailabilitySignal,
+  context: ToolAvailabilityContext,
+): ToolAvailabilityDiagnostic | null {
+  switch (signal.kind) {
+    case "always":
+      return null;
+    case "auth":
+      return context.authProviderIds?.has(signal.providerId)
+        ? null
+        : diagnostic("auth-missing", signal, `Missing auth provider: ${signal.providerId}`);
+    case "config": {
+      const value = resolveConfigPath(context.config, signal.path);
+      return hasConfiguredValue({ value, signal, context })
+        ? null
+        : diagnostic("config-missing", signal, `Missing config path: ${signal.path.join(".")}`);
+    }
+    case "env":
+      return context.env?.[signal.name]?.trim()
+        ? null
+        : diagnostic("env-missing", signal, `Missing environment value: ${signal.name}`);
+    case "plugin-enabled":
+      return context.enabledPluginIds?.has(signal.pluginId)
+        ? null
+        : diagnostic("plugin-disabled", signal, `Plugin is not enabled: ${signal.pluginId}`);
+    case "context": {
+      const value: JsonPrimitive | undefined = context.values?.[signal.key];
+      if (!("equals" in signal)) {
+        return value === undefined
+          ? diagnostic("context-mismatch", signal, `Missing context value: ${signal.key}`)
+          : null;
+      }
+      return value === signal.equals
+        ? null
+        : diagnostic("context-mismatch", signal, `Context value did not match: ${signal.key}`);
+    }
+    default:
+      return diagnostic("unsupported-signal", signal, "Unsupported availability signal");
+  }
+}
+
+function evaluateExpression(
+  expression: ToolAvailabilityExpression,
+  context: ToolAvailabilityContext,
+): readonly ToolAvailabilityDiagnostic[] {
+  if ("kind" in expression) {
+    const diagnostic = evaluateSignal(expression, context);
+    return diagnostic ? [diagnostic] : [];
+  }
+  if ("allOf" in expression) {
+    if (expression.allOf.length === 0) {
+      return [
+        {
+          reason: "unsupported-signal",
+          message: "Empty availability allOf group",
+        },
+      ];
+    }
+    return expression.allOf.flatMap((entry) => evaluateExpression(entry, context));
+  }
+  if ("anyOf" in expression) {
+    if (expression.anyOf.length === 0) {
+      return [
+        {
+          reason: "unsupported-signal",
+          message: "Empty availability anyOf group",
+        },
+      ];
+    }
+    const diagnostics = expression.anyOf.map((entry) => evaluateExpression(entry, context));
+    return diagnostics.some((entries) => entries.length === 0) ? [] : diagnostics.flat();
+  }
+  return [
+    {
+      reason: "unsupported-signal",
+      message: "Unsupported availability expression",
+    },
+  ];
+}
+
+export function evaluateToolAvailability(params: {
+  descriptor: ToolDescriptor;
+  context?: ToolAvailabilityContext;
+}): readonly ToolAvailabilityDiagnostic[] {
+  const context = params.context ?? {};
+  const availability = params.descriptor.availability ?? { kind: "always" };
+  if (!hasAvailabilityExpressionShape(availability)) {
+    return [
+      {
+        reason: "unsupported-signal",
+        message: "Unsupported availability expression",
+      },
+    ];
+  }
+  return evaluateExpression(availability, context);
+}

--- a/src/tools/boundary.test.ts
+++ b/src/tools/boundary.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const toolsDir = new URL("./", import.meta.url);
+const moduleReferencePattern =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[^"'`]*?\s+from\s+)?["']([^"']+)["']/gu;
+
+function collectStaticModuleReferences(
+  source: string,
+): readonly { line: number; specifier: string }[] {
+  const references: { line: number; specifier: string }[] = [];
+  const lines = source.split("\n");
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("//")) {
+      continue;
+    }
+    for (const match of line.matchAll(moduleReferencePattern)) {
+      const specifier = match[1];
+      if (specifier) {
+        references.push({ line: index + 1, specifier });
+      }
+    }
+  }
+  return references;
+}
+
+describe("tool system boundary", () => {
+  it("keeps production tool modules independent from OpenClaw subsystems", () => {
+    const violations = readdirSync(toolsDir, { withFileTypes: true }).flatMap((entry) => {
+      if (!entry.isFile() || !entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) {
+        return [];
+      }
+      const source = readFileSync(new URL(entry.name, toolsDir), "utf8");
+      return collectStaticModuleReferences(source)
+        .filter(
+          (reference) =>
+            !reference.specifier.startsWith("./") && !reference.specifier.startsWith("node:"),
+        )
+        .map((reference) => `${entry.name}:${reference.line} ${reference.specifier}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/tools/descriptors.ts
+++ b/src/tools/descriptors.ts
@@ -1,0 +1,11 @@
+import type { ToolDescriptor } from "./types.js";
+
+export function defineToolDescriptor(descriptor: ToolDescriptor): ToolDescriptor {
+  return descriptor;
+}
+
+export function defineToolDescriptors(
+  descriptors: readonly ToolDescriptor[],
+): readonly ToolDescriptor[] {
+  return descriptors;
+}

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,0 +1,13 @@
+export type ToolPlanContractErrorCode = "duplicate-tool-name" | "missing-executor";
+
+export class ToolPlanContractError extends Error {
+  readonly code: ToolPlanContractErrorCode;
+  readonly toolName: string;
+
+  constructor(params: { code: ToolPlanContractErrorCode; toolName: string; message: string }) {
+    super(params.message);
+    this.name = "ToolPlanContractError";
+    this.code = params.code;
+    this.toolName = params.toolName;
+  }
+}

--- a/src/tools/execution.ts
+++ b/src/tools/execution.ts
@@ -1,0 +1,18 @@
+import type { ToolExecutorRef } from "./types.js";
+
+export function formatToolExecutorRef(ref: ToolExecutorRef): string {
+  switch (ref.kind) {
+    case "core":
+      return `core:${ref.executorId}`;
+    case "plugin":
+      return `plugin:${ref.pluginId}:${ref.toolName}`;
+    case "channel":
+      return `channel:${ref.channelId}:${ref.actionId}`;
+    case "mcp":
+      return `mcp:${ref.serverId}:${ref.toolName}`;
+    default: {
+      const exhaustive: never = ref;
+      return exhaustive;
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,23 @@
+export { evaluateToolAvailability } from "./availability.js";
+export { defineToolDescriptor, defineToolDescriptors } from "./descriptors.js";
+export { ToolPlanContractError } from "./diagnostics.js";
+export { formatToolExecutorRef } from "./execution.js";
+export { buildToolPlan } from "./planner.js";
+export { toToolProtocolDescriptor, toToolProtocolDescriptors } from "./protocol.js";
+export type {
+  BuildToolPlanOptions,
+  HiddenToolPlanEntry,
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  ToolAvailabilityContext,
+  ToolAvailabilityDiagnostic,
+  ToolAvailabilityExpression,
+  ToolAvailabilitySignal,
+  ToolDescriptor,
+  ToolExecutorRef,
+  ToolOwnerRef,
+  ToolPlan,
+  ToolPlanEntry,
+  ToolUnavailableReason,
+} from "./types.js";

--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { ToolPlanContractError } from "./diagnostics.js";
+import { formatToolExecutorRef } from "./execution.js";
+import { buildToolPlan } from "./planner.js";
+import { toToolProtocolDescriptors } from "./protocol.js";
+import type { ToolDescriptor } from "./types.js";
+
+function descriptor(name: string, overrides: Partial<ToolDescriptor> = {}): ToolDescriptor {
+  return {
+    name,
+    description: `${name} description`,
+    inputSchema: { type: "object" },
+    owner: { kind: "core" },
+    executor: { kind: "core", executorId: name },
+    ...overrides,
+  };
+}
+
+describe("buildToolPlan", () => {
+  it("sorts visible and hidden tools deterministically", () => {
+    const plan = buildToolPlan({
+      descriptors: [
+        descriptor("zeta"),
+        descriptor("alpha"),
+        descriptor("hidden", {
+          sortKey: "middle",
+          availability: { kind: "env", name: "MISSING_ENV" },
+        }),
+      ],
+      availability: { env: {} },
+    });
+
+    expect(plan.visible.map((entry) => entry.descriptor.name)).toEqual(["alpha", "zeta"]);
+    expect(plan.hidden.map((entry) => entry.descriptor.name)).toEqual(["hidden"]);
+    expect(plan.hidden[0]?.diagnostics.map((entry) => entry.reason)).toEqual(["env-missing"]);
+  });
+
+  it("fails deterministically on duplicate tool names", () => {
+    let error: unknown;
+    try {
+      buildToolPlan({
+        descriptors: [descriptor("read"), descriptor("read")],
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(ToolPlanContractError);
+    expect(error).toMatchObject({
+      code: "duplicate-tool-name",
+      toolName: "read",
+    });
+  });
+
+  it("fails closed when a visible descriptor has no executor", () => {
+    let error: unknown;
+    try {
+      buildToolPlan({
+        descriptors: [descriptor("read", { executor: undefined })],
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(ToolPlanContractError);
+    expect(error).toMatchObject({
+      code: "missing-executor",
+      toolName: "read",
+    });
+  });
+
+  it("does not require an executor for unavailable descriptors", () => {
+    const plan = buildToolPlan({
+      descriptors: [
+        descriptor("plugin_tool", {
+          executor: undefined,
+          availability: { kind: "plugin-enabled", pluginId: "demo" },
+        }),
+      ],
+      availability: { enabledPluginIds: new Set() },
+    });
+
+    expect(plan.visible).toEqual([]);
+    expect(plan.hidden[0]?.descriptor.name).toBe("plugin_tool");
+    expect(plan.hidden[0]?.diagnostics[0]?.reason).toBe("plugin-disabled");
+  });
+
+  it("hides descriptors with malformed empty allOf availability", () => {
+    const plan = buildToolPlan({
+      descriptors: [descriptor("malformed", { availability: { allOf: [] } })],
+    });
+
+    expect(plan.visible).toEqual([]);
+    expect(plan.hidden[0]?.descriptor.name).toBe("malformed");
+    expect(plan.hidden[0]?.diagnostics).toEqual([
+      {
+        reason: "unsupported-signal",
+        message: "Empty availability allOf group",
+      },
+    ]);
+  });
+
+  it("keeps protocol conversion separate from executor refs and model normalization", () => {
+    const plan = buildToolPlan({
+      descriptors: [
+        descriptor("plugin_tool", {
+          owner: { kind: "plugin", pluginId: "demo" },
+          executor: { kind: "plugin", pluginId: "demo", toolName: "plugin_tool" },
+        }),
+      ],
+    });
+
+    expect(formatToolExecutorRef(plan.visible[0].executor)).toBe("plugin:demo:plugin_tool");
+    expect(toToolProtocolDescriptors(plan.visible)).toEqual([
+      {
+        name: "plugin_tool",
+        description: "plugin_tool description",
+        inputSchema: { type: "object" },
+      },
+    ]);
+  });
+});

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -1,0 +1,58 @@
+import { evaluateToolAvailability } from "./availability.js";
+import { ToolPlanContractError } from "./diagnostics.js";
+import type {
+  BuildToolPlanOptions,
+  HiddenToolPlanEntry,
+  ToolDescriptor,
+  ToolPlan,
+  ToolPlanEntry,
+} from "./types.js";
+
+function compareDescriptors(left: ToolDescriptor, right: ToolDescriptor): number {
+  return (
+    (left.sortKey ?? left.name).localeCompare(right.sortKey ?? right.name) ||
+    left.name.localeCompare(right.name)
+  );
+}
+
+function assertUniqueNames(descriptors: readonly ToolDescriptor[]): void {
+  const seen = new Set<string>();
+  for (const descriptor of descriptors) {
+    if (seen.has(descriptor.name)) {
+      throw new ToolPlanContractError({
+        code: "duplicate-tool-name",
+        toolName: descriptor.name,
+        message: `Duplicate tool descriptor name: ${descriptor.name}`,
+      });
+    }
+    seen.add(descriptor.name);
+  }
+}
+
+export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
+  const descriptors = options.descriptors.toSorted(compareDescriptors);
+  assertUniqueNames(descriptors);
+
+  const visible: ToolPlanEntry[] = [];
+  const hidden: HiddenToolPlanEntry[] = [];
+
+  for (const descriptor of descriptors) {
+    const diagnostics = [
+      ...evaluateToolAvailability({ descriptor, context: options.availability }),
+    ];
+    if (diagnostics.length > 0) {
+      hidden.push({ descriptor, diagnostics });
+      continue;
+    }
+    if (!descriptor.executor) {
+      throw new ToolPlanContractError({
+        code: "missing-executor",
+        toolName: descriptor.name,
+        message: `Visible tool descriptor has no executor ref: ${descriptor.name}`,
+      });
+    }
+    visible.push({ descriptor, executor: descriptor.executor });
+  }
+
+  return { visible, hidden };
+}

--- a/src/tools/protocol.ts
+++ b/src/tools/protocol.ts
@@ -1,0 +1,22 @@
+import type { JsonObject, ToolPlanEntry } from "./types.js";
+
+export type ToolProtocolDescriptor = {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: JsonObject;
+};
+
+// Shared descriptor shape only. Model/provider adapters still own schema normalization.
+export function toToolProtocolDescriptor(entry: ToolPlanEntry): ToolProtocolDescriptor {
+  return {
+    name: entry.descriptor.name,
+    description: entry.descriptor.description,
+    inputSchema: entry.descriptor.inputSchema,
+  };
+}
+
+export function toToolProtocolDescriptors(
+  entries: readonly ToolPlanEntry[],
+): readonly ToolProtocolDescriptor[] {
+  return entries.map(toToolProtocolDescriptor);
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,0 +1,97 @@
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type JsonObject = { readonly [key: string]: JsonValue };
+
+export type ToolOwnerRef =
+  | { readonly kind: "core" }
+  | { readonly kind: "plugin"; readonly pluginId: string }
+  | { readonly kind: "channel"; readonly channelId: string; readonly pluginId?: string }
+  | { readonly kind: "mcp"; readonly serverId: string };
+
+export type ToolExecutorRef =
+  | { readonly kind: "core"; readonly executorId: string }
+  | { readonly kind: "plugin"; readonly pluginId: string; readonly toolName: string }
+  | { readonly kind: "channel"; readonly channelId: string; readonly actionId: string }
+  | { readonly kind: "mcp"; readonly serverId: string; readonly toolName: string };
+
+export type ToolAvailabilitySignal =
+  | { readonly kind: "always" }
+  | { readonly kind: "auth"; readonly providerId: string }
+  | {
+      readonly kind: "config";
+      readonly path: readonly string[];
+      readonly check?: "exists" | "non-empty" | "available";
+    }
+  | { readonly kind: "env"; readonly name: string }
+  | { readonly kind: "plugin-enabled"; readonly pluginId: string }
+  | { readonly kind: "context"; readonly key: string; readonly equals?: JsonPrimitive };
+
+export type ToolAvailabilityExpression =
+  | ToolAvailabilitySignal
+  | { readonly allOf: readonly ToolAvailabilityExpression[] }
+  | { readonly anyOf: readonly ToolAvailabilityExpression[] };
+
+export type ToolDescriptor = {
+  readonly name: string;
+  readonly title?: string;
+  readonly description: string;
+  readonly inputSchema: JsonObject;
+  readonly outputSchema?: JsonObject;
+  readonly owner: ToolOwnerRef;
+  readonly executor?: ToolExecutorRef;
+  readonly availability?: ToolAvailabilityExpression;
+  readonly annotations?: JsonObject;
+  readonly sortKey?: string;
+};
+
+export type ToolAvailabilityContext = {
+  readonly authProviderIds?: ReadonlySet<string>;
+  readonly config?: JsonObject;
+  readonly isConfigValueAvailable?: (params: {
+    readonly value: JsonValue;
+    readonly path: readonly string[];
+    readonly signal: Extract<ToolAvailabilitySignal, { readonly kind: "config" }>;
+  }) => boolean;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly enabledPluginIds?: ReadonlySet<string>;
+  readonly values?: Readonly<Record<string, JsonPrimitive | undefined>>;
+};
+
+export type ToolUnavailableReason =
+  | "auth-missing"
+  | "config-missing"
+  | "context-mismatch"
+  | "env-missing"
+  | "plugin-disabled"
+  | "unsupported-signal";
+
+export type ToolAvailabilityDiagnostic = {
+  readonly reason: ToolUnavailableReason;
+  readonly signal?: ToolAvailabilitySignal;
+  readonly message: string;
+};
+
+export type ToolPlanEntry = {
+  readonly descriptor: ToolDescriptor;
+  readonly executor: ToolExecutorRef;
+};
+
+export type HiddenToolPlanEntry = {
+  readonly descriptor: ToolDescriptor;
+  readonly diagnostics: readonly ToolAvailabilityDiagnostic[];
+};
+
+export type ToolPlan = {
+  readonly visible: readonly ToolPlanEntry[];
+  readonly hidden: readonly HiddenToolPlanEntry[];
+};
+
+export type BuildToolPlanOptions = {
+  readonly descriptors: readonly ToolDescriptor[];
+  readonly availability?: ToolAvailabilityContext;
+};


### PR DESCRIPTION
## Summary

- Add a generic `src/tools` descriptor planner for tool ownership, executor refs, availability expressions, diagnostics, and protocol-shaped descriptors.
- Support explicit availability composition with `allOf` / `anyOf` and config checks for `exists`, `non-empty`, and delegated `available`.
- Add boundary coverage so production `src/tools` modules stay independent from OpenClaw subsystems.

## Verification

- `pnpm test src/tools/availability.test.ts src/tools/planner.test.ts src/tools/boundary.test.ts -- --typecheck --reporter=dot`
- `pnpm tsgo:core:test`
- `pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/tools`
- `pnpm build`
- Testbox: `OPENCLAW_TESTBOX=1 pnpm check:changed`
