### PR TITLE
fix(agents): keep elevated availability across approval follow-up runs

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1003,6 +1003,7 @@ async function agentCommandInternal(
               sessionStore,
               storePath,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              bashElevated: opts.bashElevated,
               sessionHasHistory:
                 !isNewSession || (await attemptExecutionRuntime.sessionFileHasContent(sessionFile)),
               onAgentEvent: (evt) => {

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -274,6 +274,58 @@ describe("exec approval followup", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("forwards a captured bashElevated snapshot to the spawned agent followup run", async () => {
+    // Regression: #75832 — second elevated exec in the same approved turn fails
+    // the enabled gate because the followup agent run did not inherit the
+    // original turn's elevated availability. Snapshot is availability-only:
+    // defaultLevel "ask" keeps the next command behind a fresh approval.
+    await sendExecApprovalFollowup({
+      approvalId: "req-elevated-75832",
+      sessionKey: "agent:main:telegram:direct:42",
+      turnSourceChannel: "telegram",
+      turnSourceTo: "42",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "thread-1",
+      bashElevated: {
+        enabled: true,
+        allowed: true,
+        defaultLevel: "ask",
+        fullAccessAvailable: false,
+        fullAccessBlockedReason: "sandbox",
+      },
+      resultText: 'Exec completed: echo "first"',
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      expect.any(Object),
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:direct:42",
+        bashElevated: {
+          enabled: true,
+          allowed: true,
+          defaultLevel: "ask",
+          fullAccessAvailable: false,
+          fullAccessBlockedReason: "sandbox",
+        },
+      }),
+      { expectFinal: true },
+    );
+  });
+
+  it("omits bashElevated from followup args when the original turn had no snapshot", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-no-elevated",
+      sessionKey: "agent:main:telegram:direct:42",
+      turnSourceChannel: "telegram",
+      resultText: "Exec completed: ls",
+    });
+
+    const callArgs = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(callArgs).toBeDefined();
+    expect(Object.hasOwn(callArgs, "bashElevated")).toBe(false);
+  });
+
   it("throws when neither a session nor a deliverable route is available", async () => {
     await expect(
       sendExecApprovalFollowup({

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -6,6 +6,7 @@ import { sendMessage } from "../infra/outbound/message.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import type { ExecElevatedDefaults } from "./bash-tools.exec-types.js";
 import {
   formatExecDeniedUserMessage,
   isExecDeniedResultText,
@@ -21,6 +22,14 @@ type ExecApprovalFollowupParams = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  /**
+   * Snapshot of the elevated-tool defaults active on the originating approved
+   * turn. Re-attached to the spawned approval-followup agent run so a second
+   * elevated exec in the same conversation still reaches the approval-request
+   * path instead of failing the `enabled` gate. Carries availability only:
+   * defaultLevel="ask" still requires a fresh per-command approval.
+   */
+  bashElevated?: ExecElevatedDefaults;
   resultText: string;
   direct?: boolean;
 };
@@ -149,6 +158,7 @@ function buildAgentFollowupArgs(params: {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  bashElevated?: ExecElevatedDefaults;
 }) {
   const { deliveryTarget, sessionOnlyOriginChannel } = params;
   // When the followup run has no deliverable route and no gateway-internal channel,
@@ -176,6 +186,7 @@ function buildAgentFollowupArgs(params: {
       : sessionOnlyOriginChannel
         ? params.turnSourceThreadId
         : undefined,
+    ...(params.bashElevated ? { bashElevated: params.bashElevated } : {}),
     idempotencyKey: `exec-approval-followup:${params.approvalId}`,
   };
 }
@@ -250,6 +261,7 @@ export async function sendExecApprovalFollowup(
           turnSourceTo: params.turnSourceTo,
           turnSourceAccountId: params.turnSourceAccountId,
           turnSourceThreadId: params.turnSourceThreadId,
+          bashElevated: params.bashElevated,
         }),
         { expectFinal: true },
       );

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -45,6 +45,7 @@ import {
 import type {
   ExecApprovalFollowupFactory,
   ExecApprovalFollowupOutcome,
+  ExecElevatedDefaults,
   ExecToolDetails,
 } from "./bash-tools.exec-types.js";
 
@@ -78,6 +79,13 @@ export type ProcessGatewayAllowlistParams = {
   maxOutput: number;
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /**
+   * Elevated-tool defaults captured from the originating turn. Snapshotted
+   * here so the followup target can re-attach them to the spawned agent run
+   * after `/approve`, keeping the next elevated exec in the same conversation
+   * available without re-deriving sender identity.
+   */
+  bashElevated?: ExecElevatedDefaults;
 };
 
 export type ProcessGatewayAllowlistResult = {
@@ -457,6 +465,7 @@ export async function processGatewayAllowlist(
       turnSourceTo: params.turnSourceTo,
       turnSourceAccountId: params.turnSourceAccountId,
       turnSourceThreadId: params.turnSourceThreadId,
+      bashElevated: params.bashElevated,
       direct: params.approvalFollowupMode === "direct",
     });
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -148,6 +148,7 @@ export async function executeNodeHostCommand(
         turnSourceTo: params.turnSourceTo,
         turnSourceAccountId: params.turnSourceAccountId,
         turnSourceThreadId: params.turnSourceThreadId,
+        bashElevated: params.bashElevated,
       });
 
       void (async () => {

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -1,4 +1,5 @@
 import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import type { ExecElevatedDefaults } from "./bash-tools.exec-types.js";
 
 export type ExecuteNodeHostCommandParams = {
   command: string;
@@ -24,4 +25,11 @@ export type ExecuteNodeHostCommandParams = {
   notifySessionKey?: string;
   notifyOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /**
+   * Elevated-tool defaults captured from the originating turn. Forwarded to
+   * the followup target so the spawned agent run after `/approve` keeps the
+   * same `tools.elevated` availability (default level "ask" still requires a
+   * fresh approval per command).
+   */
+  bashElevated?: ExecElevatedDefaults;
 };

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -23,7 +23,7 @@ import {
 } from "./bash-tools.exec-approval-request.js";
 import { buildApprovalPendingMessage } from "./bash-tools.exec-runtime.js";
 import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { ExecElevatedDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
 export const MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS = 256;
@@ -88,6 +88,13 @@ export type ExecApprovalFollowupTarget = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
+  /**
+   * Elevated-tool availability captured from the originating turn. Threaded
+   * through the followup so the spawned agent run inherits the same
+   * `tools.elevated` defaults; without it, a second elevated exec in the
+   * same conversation fails the enabled gate before reaching approval.
+   */
+  bashElevated?: ExecElevatedDefaults;
   direct?: boolean;
 };
 
@@ -323,6 +330,7 @@ export function buildExecApprovalFollowupTarget(
     turnSourceTo: params.turnSourceTo,
     turnSourceAccountId: params.turnSourceAccountId,
     turnSourceThreadId: params.turnSourceThreadId,
+    bashElevated: params.bashElevated,
     direct: params.direct,
   };
 }
@@ -415,6 +423,7 @@ export async function sendExecApprovalFollowupResult(
     turnSourceTo: target.turnSourceTo,
     turnSourceAccountId: target.turnSourceAccountId,
     turnSourceThreadId: target.turnSourceThreadId,
+    bashElevated: target.bashElevated,
     resultText,
     direct: target.direct,
   }).catch((error) => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1705,6 +1705,7 @@ export function createExecTool(
           notifySessionKey,
           notifyOnExit,
           trustedSafeBinDirs,
+          bashElevated: elevatedDefaults,
         });
       }
 
@@ -1743,6 +1744,7 @@ export function createExecTool(
           maxOutput,
           pendingMaxOutput,
           trustedSafeBinDirs,
+          bashElevated: elevatedDefaults,
         });
         if (gatewayResult.pendingResult) {
           return gatewayResult.pendingResult;

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -12,6 +12,7 @@ import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
+import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
 import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
@@ -350,6 +351,15 @@ export function runAgentAttempt(params: {
   allowTransientCooldownProbe?: boolean;
   modelFallbacksOverride?: string[];
   sessionHasHistory?: boolean;
+  /**
+   * Snapshot of `tools.elevated` defaults for the embedded run. Set by the
+   * exec-approval followup path (via `agentCommandFromIngress`) so a second
+   * elevated exec in the same conversation keeps the original turn's
+   * elevated availability without re-deriving sender identity. Carries
+   * availability only — `defaultLevel: "ask"` keeps each command behind a
+   * fresh per-command approval, preserving the one-shot allow-once contract.
+   */
+  bashElevated?: ExecElevatedDefaults;
 }) {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
   const claudeCliFallbackPrelude =
@@ -558,6 +568,7 @@ export function runAgentAttempt(params: {
     trigger: "user",
     messageChannel: params.messageChannel,
     messageProvider: params.opts.messageProvider ?? params.messageChannel,
+    bashElevated: params.bashElevated,
     agentAccountId: params.runContext.accountId,
     messageTo: params.opts.replyTo ?? params.opts.to,
     messageThreadId: params.opts.threadId,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -4,6 +4,7 @@ import type { PromptMode } from "../../agents/system-prompt.types.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
+import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 import type { AgentStreamParams, ClientToolDefinition } from "./shared-types.js";
 
 /** Image content block for Claude API multimodal messages. */
@@ -116,6 +117,14 @@ export type AgentCommandOpts = {
   promptMode?: PromptMode;
   /** Internal ACP-ready session turn source. Manual spawn turns bypass only the dispatch gate. */
   acpTurnSource?: AcpTurnSource;
+  /**
+   * Snapshot of `tools.elevated` defaults for the spawned run. Set by the
+   * exec-approval followup path so a second elevated exec in the same
+   * conversation keeps the original turn's elevated availability. Carries
+   * availability only — `defaultLevel: "ask"` still requires a fresh
+   * per-command approval, preserving the one-shot allow-once contract.
+   */
+  bashElevated?: ExecElevatedDefaults;
 };
 
 export type AgentCommandIngressOpts = Omit<

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -130,6 +130,36 @@ export const PollParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+/**
+ * Snapshot of `tools.elevated` defaults captured from an originating turn so
+ * an approval-followup agent run can keep elevated availability in the same
+ * conversation. Carries availability only (`enabled` / `allowed` / default
+ * level); the spawned run still issues a fresh per-command approval request
+ * for `on`/`ask` modes.
+ */
+export const AgentBashElevatedDefaultsSchema = Type.Object(
+  {
+    enabled: Type.Boolean(),
+    allowed: Type.Boolean(),
+    defaultLevel: Type.Union([
+      Type.Literal("on"),
+      Type.Literal("off"),
+      Type.Literal("ask"),
+      Type.Literal("full"),
+    ]),
+    fullAccessAvailable: Type.Optional(Type.Boolean()),
+    fullAccessBlockedReason: Type.Optional(
+      Type.Union([
+        Type.Literal("sandbox"),
+        Type.Literal("host-policy"),
+        Type.Literal("channel"),
+        Type.Literal("runtime"),
+      ]),
+    ),
+  },
+  { additionalProperties: false },
+);
+
 export const AgentParamsSchema = Type.Object(
   {
     message: NonEmptyString,
@@ -172,6 +202,7 @@ export const AgentParamsSchema = Type.Object(
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
     inputProvenance: Type.Optional(InputProvenanceSchema),
     voiceWakeTrigger: Type.Optional(Type.String()),
+    bashElevated: Type.Optional(AgentBashElevatedDefaultsSchema),
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
   },

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -543,6 +543,13 @@ export const agentHandlers: GatewayRequestHandlers = {
       inputProvenance?: InputProvenance;
       workspaceDir?: string;
       voiceWakeTrigger?: string;
+      bashElevated?: {
+        enabled: boolean;
+        allowed: boolean;
+        defaultLevel: "on" | "off" | "ask" | "full";
+        fullAccessAvailable?: boolean;
+        fullAccessBlockedReason?: "sandbox" | "host-policy" | "channel" | "runtime";
+      };
     };
     const senderIsOwner = resolveSenderIsOwnerFromClient(client);
     const allowModelOverride = resolveAllowModelOverrideFromClient(client);
@@ -1374,6 +1381,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             internalEvents: request.internalEvents,
             inputProvenance,
             cleanupBundleMcpOnRunEnd: request.cleanupBundleMcpOnRunEnd,
+            ...(request.bashElevated ? { bashElevated: request.bashElevated } : {}),
             abortSignal: activeRunAbort.controller.signal,
             // Internal-only: allow workspace override for spawned subagent runs.
             workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({


### PR DESCRIPTION
### Summary

- **Problem**: After a user `/approve`s an elevated exec, a second elevated exec issued in the same conversation by the spawned approval-followup agent run fails before reaching the approval-request path. The exec tool throws `elevated is not available right now (runtime=...)` with `Failing gates: enabled (tools.elevated.enabled / agents.list[].tools.elevated.enabled)`, even though `tools.elevated.enabled` is configured `true`.
- **Root Cause**: The exec tool decides elevated availability from `defaults.elevated` (the `ExecElevatedDefaults` snapshot it received when `createOpenClawCodingTools` was constructed). The normal inbound auto-reply path computes `bashElevated` and passes it through to `runEmbeddedPiAgent`, which wires it into the tool defaults. The approval follow-up path is different: `sendExecApprovalFollowup` invokes the Gateway `agent` RPC, which dispatches through `agentCommandFromIngress` → `agentCommandInternal` → `runAgentAttempt` → `runEmbeddedPiAgent`. None of those callsites carry `bashElevated`, so the spawned follow-up run starts with `defaults.elevated === undefined` and the next elevated exec fails the `enabled` gate inside the exec tool before any approval prompt can be registered. The bug is purely transport — the user's authority is already proven by the originating turn, but the followup transport silently drops the runtime snapshot.
- **Fix**: At exec time, when the originating turn already proved elevated availability against the live `tools.elevated` policy, snapshot the `ExecElevatedDefaults` value onto the followup target and thread it through the entire approval-followup chain back into the spawned run: from the exec tool callsites in `bash-tools.exec.ts` → `processGatewayAllowlist` / `executeNodeHostCommand` params → `ExecApprovalFollowupTarget` → `sendExecApprovalFollowupResult` → `sendExecApprovalFollowup` → `buildAgentFollowupArgs` → Gateway `agent` RPC (a new optional `AgentBashElevatedDefaultsSchema` on `AgentParamsSchema`) → `agentCommandFromIngress` → `AgentCommandOpts.bashElevated` → `runAgentAttempt` → `runEmbeddedPiAgent.bashElevated` (the existing consumer that wires it into the tool's `exec.elevated` defaults). The snapshot carries availability only — `enabled`, `allowed`, `defaultLevel`, plus the `fullAccessAvailable` / `fullAccessBlockedReason` companions. Approval **decisions** are not transported, so `defaultLevel: "ask"` is preserved verbatim and the next elevated exec in the spawned run still creates a fresh per-command approval, preserving the one-shot `allow-once` contract documented in `docs/tools/elevated.md`. Chosen over re-deriving elevated state inside `agentCommandFromIngress` because `resolveElevatedPermissions` requires sender identity (`SenderId` / `SenderE164` / `From`) that the followup transport does not have on hand; transporting that PII across the agent RPC boundary would be a larger and more sensitive surface change than transporting an availability snapshot.
- **What changed**:
  - `src/agents/bash-tools.exec.ts`: pass the in-scope `elevatedDefaults` as `bashElevated` into both `processGatewayAllowlist` and `executeNodeHostCommand` callsites.
  - `src/agents/bash-tools.exec-host-gateway.ts`: extend `ProcessGatewayAllowlistParams` with optional `bashElevated`; forward into `buildExecApprovalFollowupTarget`.
  - `src/agents/bash-tools.exec-host-node.ts` + `src/agents/bash-tools.exec-host-node.types.ts`: extend `ExecuteNodeHostCommandParams` with optional `bashElevated`; forward into `buildExecApprovalFollowupTarget`.
  - `src/agents/bash-tools.exec-host-shared.ts`: extend `ExecApprovalFollowupTarget`, `buildExecApprovalFollowupTarget`, and `sendExecApprovalFollowupResult` to carry `bashElevated`.
  - `src/agents/bash-tools.exec-approval-followup.ts`: extend `ExecApprovalFollowupParams` and `buildAgentFollowupArgs` to accept and emit `bashElevated`; the field is conditionally spread so existing callers and snapshot-less cases emit no extra key on the wire.
  - `src/agents/bash-tools.exec-approval-followup.test.ts`: two new regression tests — one asserts the snapshot reaches the Gateway `agent` args; one asserts no `bashElevated` key is emitted when the original turn had no snapshot (preserving wire-format minimality).
  - `src/gateway/protocol/schema/agent.ts`: add `AgentBashElevatedDefaultsSchema` (TypeBox, additive, optional); reference it from `AgentParamsSchema`.
  - `src/gateway/server-methods/agent.ts`: typed read of `request.bashElevated`; conditionally forward into `dispatchAgentRunFromGateway`'s `ingressOpts`.
  - `src/agents/command/types.ts`: extend `AgentCommandOpts` with optional `bashElevated`. `AgentCommandIngressOpts` inherits via the existing `Omit<...>` derivation, so no new ingress contract.
  - `src/agents/agent-command.ts`: forward `opts.bashElevated` into `runAgentAttempt`.
  - `src/agents/command/attempt-execution.ts`: extend `runAgentAttempt` params with optional `bashElevated`; pass into `runEmbeddedPiAgent` (which already declares `bashElevated: ExecElevatedDefaults` on its params).
- **What did NOT change (scope boundary)**:
  - No change to `tools.elevated` policy resolution in `resolveElevatedPermissions`, gate logic in the exec tool, or the `enabled` / `allowFrom` / `allowedDecisions` contracts.
  - No change to approval **decision** transport — `allow-once` / `allow-always` are not re-applied to the spawned run.
  - No change to the auto-reply pipeline under `src/auto-reply/reply/*`. The normal inbound path already passes `bashElevated`; this PR only adds the missing path through the approval follow-up.
  - No change to subagent / cron denied-followup suppression in `shouldSuppressExecDeniedFollowup`.
  - No change to owner authorization in `agentCommandFromIngress` (`senderIsOwner` is still required to be set explicitly by ingress callers).
  - No use of `any`; new fields use the existing `ExecElevatedDefaults` type, mirrored at the gateway boundary by an inline literal that matches the TypeBox schema.
  - No new files outside the existing colocated test; no new public modules.

### Reproduction

1. Configure an agent with `tools.elevated.enabled: true`, `tools.elevated.allowFrom.telegram: ["<your-id>"]`, default level `on` or `ask`.
2. From a Telegram direct chat, ask the agent to run two elevated commands in one turn (e.g. `uname -a` and then `uptime`, both with sudo).
3. Approve the first prompt with `/approve <id> allow-once`.
4. **Before**: the second elevated exec returns
   ```
   elevated is not available right now (runtime=sandboxed).
   Failing gates: enabled (tools.elevated.enabled / agents.list[].tools.elevated.enabled)
   Context: provider=telegram session=agent:main:telegram:direct:<chat_id>
   ```
   even though `tools.elevated.enabled` is `true`.
5. **After**: the second elevated exec emits a fresh approval prompt; once approved it runs normally. The third elevated exec also prompts again — `defaultLevel: "ask"` is preserved.

### Risk / Mitigation

- **Risk**: A bug in the snapshot wiring could re-grant elevated availability to a session that no longer deserves it (for example if config changes mid-conversation between approval and follow-up). Could also leak a snapshot through an unrelated agent RPC path.
- **Mitigation**:
  - The snapshot is only built at exec time when `defaults?.elevated` already proved availability against the live policy; we do not synthesize availability where none existed.
  - `defaultLevel` is preserved verbatim, so every subsequent elevated command in the spawned follow-up run still requires a fresh `/approve`. `allow-once` is not reused — the one-shot contract from `docs/tools/elevated.md` holds.
  - The new gateway protocol field is `Type.Optional(...)` under `additionalProperties: false`. Older clients that omit it see no behavior change.
  - The exec tool's `enabled` / `allowFrom` gate logic is unchanged. Even a synthetic snapshot supplied via the agent RPC by a maximally-trusted ingress caller cannot grant elevated to a sender the live policy rejects — the spawned run still goes through fresh per-command approval against live config, so there is no command-execution bypass surface.
  - Two new regression tests in `bash-tools.exec-approval-followup.test.ts` lock in: (a) the snapshot is forwarded when present; (b) no key is emitted when absent (preserving wire-format minimality and backward compatibility).
  - Test plan:
    - `pnpm test src/agents/bash-tools.exec-approval-followup.test.ts` (new + existing)
    - Touched-surface optional: `pnpm test src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-approval-request.test.ts src/agents/command/attempt-execution.cli.test.ts`
    - `pnpm check:changed` (Testbox per `AGENTS.md` policy when fanning out)

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway (protocol schema + agent server-method)
- [x] Agents (`bash-tools.exec*`, `command/*`, `agent-command`)
- [x] Tests (`bash-tools.exec-approval-followup.test.ts`)