### PR TITLE
fix(model): clarify session-scoped model switches

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -596,7 +596,7 @@ export async function handleDirectiveOnly(
     parts.push(
       modelSelection.isDefault
         ? `Model reset to default (${labelWithAlias}).`
-        : `Model set to ${labelWithAlias}.`,
+        : `Model set to ${labelWithAlias} for this session.`,
     );
     if (profileOverride) {
       parts.push(`Auth profile set to ${profileOverride}.`);

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -939,6 +939,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
 
     expect(result?.text).toContain("Model set to");
     expect(result?.text).toContain("openai/gpt-4o");
+    expect(result?.text).toContain("for this session");
     expect(result?.text).not.toContain("failed");
     expect(sessionEntry.liveModelSwitchPending).toBe(true);
   });
@@ -1046,7 +1047,9 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       }),
     );
 
-    expect(result?.text).toContain("Model set to Opus (anthropic/claude-opus-4-6).");
+    expect(result?.text).toContain(
+      "Model set to Opus (anthropic/claude-opus-4-6) for this session.",
+    );
     expect(result?.text).toContain("Auth profile set to anthropic:work.");
     expect(sessionEntry.providerOverride).toBe("anthropic");
     expect(sessionEntry.modelOverride).toBe("claude-opus-4-6");

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -304,7 +304,7 @@ export async function applyInlineDirectiveOverrides(params: {
             : undefined,
           modelSelection.isDefault
             ? `Model reset to default (${labelWithAlias}).`
-            : `Model set to ${labelWithAlias}.`,
+            : `Model set to ${labelWithAlias} for this session.`,
           modelResolution.profileOverride
             ? `Auth profile set to ${modelResolution.profileOverride}.`
             : undefined,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: `/model` acknowledged a model switch without saying the override is scoped to the current session.
- Why it matters: users can mistake the acknowledgement for a durable agent default change, then get surprised after a reset or restart.
- What changed: model switch acknowledgements now say `for this session` when setting a non-default model.
- What did NOT change (scope boundary): this does not change persistence semantics, model selection logic, or default reset wording.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75965
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the acknowledgement text did not describe the existing session-scoped behavior.
- Missing detection / guardrail: model directive tests checked that the success message existed, but not that it communicated the scope.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/directive-handling.model.test.ts`
- Scenario the test should lock in: `/model openai/gpt-4o` reports that the model is set for this session.
- Why this is the smallest reliable guardrail: the affected behavior is the directive acknowledgement string.
- Existing test that already covers this (if any): model directive persistence tests already covered successful switching.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`/model` acknowledgements for non-default selections now say the switch applies to this session.

## Diagram (if applicable)

```text
Before:
/user sends /model openai/gpt-4o -> "Model set to openai/gpt-4o."

After:
/user sends /model openai/gpt-4o -> "Model set to openai/gpt-4o for this session."
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo test runner
- Model/provider: N/A
- Integration/channel (if any): text command acknowledgement
- Relevant config (redacted): N/A

### Steps

1. Send `/model openai/gpt-4o` in a session where that model is allowed.
2. Read the acknowledgement text.

### Expected

- The acknowledgement makes clear the switch applies to this session.

### Actual

- Before this PR, the acknowledgement did not state the scope.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/auto-reply/reply/directive-handling.model.test.ts`

Result: 47 tests passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: model directive success acknowledgement includes `for this session`, alias acknowledgement includes the same scope text, and the targeted test file passes.
- Edge cases checked: default reset wording is unchanged.
- What you did **not** verify: live Telegram group behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: acknowledgement text changes can affect brittle tests or docs that assert the exact sentence.
  - Mitigation: updated the targeted unit tests for the new user-facing wording.