### PR TITLE
fix(agents): skip model normalization during TUI context window warmup

### DIFF
--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -237,7 +237,14 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
         await import("./pi-model-discovery-runtime.js");
       const agentDir = resolveOpenClawAgentDir();
       const authStorage = discoverAuthStorage(agentDir);
-      const modelRegistry = discoverModels(authStorage, agentDir) as unknown as ModelRegistryLike;
+      // Skip provider-plugin normalization here: applyDiscoveredContextWindows
+      // only reads model.id / contextTokens / contextWindow, none of which are
+      // mutated by the normalize/compat/transport hooks. Running those hooks
+      // for every catalog entry on TUI/chat startup blocks the main thread for
+      // tens of seconds when users have large registries (e.g. 100+ HF models).
+      const modelRegistry = discoverModels(authStorage, agentDir, {
+        normalizeModels: false,
+      }) as unknown as ModelRegistryLike;
       const models =
         typeof modelRegistry.getAvailable === "function"
           ? modelRegistry.getAvailable()


### PR DESCRIPTION
## Summary

`ensureContextWindowCacheLoaded()` calls `discoverModels()` without `normalizeModels: false`, which triggers `normalizeDiscoveredPiModel` for every catalog entry on TUI/chat cold start. For users with large registries (e.g. 100+ HuggingFace models), this results in hundreds of provider-plugin hook calls that block the main thread for 30–60 seconds, causing 100% CPU and unresponsive input.

Upstream commit `9682f3937e` added the `normalizeModels` option to `discoverModels` for the `models list` command, but the call in `context.ts` was missed.

## Fix

Pass `{ normalizeModels: false }` in `ensureContextWindowCacheLoaded()` because `applyDiscoveredContextWindows()` only reads `model.id`, `contextTokens`, and `contextWindow` — none of which are mutated by the normalize/compat/transport hooks.

## Test plan

- [ ] `pnpm openclaw tui` cold start with a large model registry (100+ models) should not hang for tens of seconds
- [ ] CPU during idle TUI should drop from ~98% to <10% after startup
- [ ] TUI/chat input should remain responsive during and after startup
- [ ] `pnpm test src/agents/` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)