### PR TITLE
perf(path-guards): add fast path for canonical absolute POSIX inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Infra/path-guards: skip `path.resolve` and `path.relative` in `isPathInside` when both inputs are already canonical absolute POSIX paths and the target literally starts with the root with no parent-reference (`..`) segments, so directory walkers, sandbox bridges, plugin discovery, and security scanners pay only a `startsWith` and char check on the common case (~10x speedup on a realistic loader workload while preserving the existing slow path for non-canonical or risky inputs). Refs #75895, #75575, and #68782. Thanks @Enderfga.
 - Tools: add a platform-level tool descriptor planner for descriptor-first visibility, generic availability checks, and executor references. Thanks @shakkernerd.
 - Docs/Codex: clarify that ChatGPT/Codex subscription setups should use `openai/gpt-*` with `agentRuntime.id: "codex"` for native Codex runtime, while `openai-codex/*` remains the PI OAuth route. Thanks @pashpashpash.
 - Plugins/source checkout: load bundled plugins from the `extensions/*` pnpm workspace tree in source checkouts, so plugin-local dependencies and edits are used directly while packaged installs keep using the built runtime tree. Thanks @vincentkoc.

--- a/src/infra/path-guards.test.ts
+++ b/src/infra/path-guards.test.ts
@@ -74,6 +74,21 @@ describe("isPathInside", () => {
     ["/workspace/root", "/workspace/root/nested/file.txt", true],
     ["/workspace/root", "/workspace/root/..file.txt", true],
     ["/workspace/root", "/workspace/root/../escape.txt", false],
+    // Sibling that shares a string prefix but is not under the root.
+    ["/workspace/root", "/workspace/rootless/file.txt", false],
+    // Deep canonical absolute path — exercises the literal-prefix fast path.
+    ["/workspace/root", "/workspace/root/a/b/c/d/e/file.txt", true],
+    // Trailing parent reference inside root — slow path catches the escape.
+    ["/workspace/root", "/workspace/root/a/..", true],
+    ["/workspace/root", "/workspace/root/a/../..", false],
+    // Nested parent-reference deeper in the path.
+    ["/workspace/root", "/workspace/root/a/b/../../../escape", false],
+    // Root is the filesystem root.
+    ["/", "/anything/at/all", true],
+    ["/", "/", true],
+    // Relative inputs still work via the slow-path resolve.
+    ["foo", "foo/bar", true],
+    ["foo", "../escape", false],
   ])("checks posix containment %s -> %s", (basePath, targetPath, expected) => {
     expect(isPathInside(basePath, targetPath)).toBe(expected);
   });

--- a/src/infra/path-guards.ts
+++ b/src/infra/path-guards.ts
@@ -4,6 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
 const SYMLINK_OPEN_CODES = new Set(["ELOOP", "EINVAL", "ENOTSUP"]);
 const PARENT_SEGMENT_PREFIX = /^\.\.(?:[\\/]|$)/u;
+const POSIX_SEPARATOR_CHAR_CODE = 0x2f;
 
 export function normalizeWindowsPathForComparison(input: string): string {
   let normalized = path.win32.normalize(input);
@@ -42,6 +43,25 @@ export function isPathInside(root: string, target: string): boolean {
     return (
       relative === "" || (!PARENT_SEGMENT_PREFIX.test(relative) && !path.win32.isAbsolute(relative))
     );
+  }
+
+  // Fast path: when both inputs are already absolute POSIX paths, target has no
+  // parent-reference (`..`) segments, and target is a literal prefix of root
+  // followed by a path separator (or equals root), the answer is unambiguously
+  // `true` — equivalent to running `path.resolve` + `path.relative` and finding
+  // the result has no leading `..`. This avoids per-call resolve/relative cost
+  // in hot loops (directory walkers, sandbox checks) where the caller has
+  // already produced canonical absolute paths.
+  if (
+    root.length > 0 &&
+    root.charCodeAt(0) === POSIX_SEPARATOR_CHAR_CODE &&
+    target.length >= root.length &&
+    target.charCodeAt(0) === POSIX_SEPARATOR_CHAR_CODE &&
+    !target.includes("/..") &&
+    (target === root ||
+      (target.startsWith(root) && target.charCodeAt(root.length) === POSIX_SEPARATOR_CHAR_CODE))
+  ) {
+    return true;
   }
 
   const resolvedRoot = path.resolve(root);


### PR DESCRIPTION
## Summary

Add a literal-prefix fast path to `isPathInside` (`src/infra/path-guards.ts`).
For the common case where both inputs are already canonical absolute POSIX
paths and `target` contains no parent-reference (`..`) segments, the answer
collapses to a `startsWith` + char check — equivalent to the existing
`path.resolve` + `path.relative` slow path, but without the per-call
allocation and normalisation cost. Inputs that don't match the precondition
fall through to the existing slow path with no behaviour change.

`isPathInside` has 50+ call sites in this repo, many in tight loops
(directory walkers, sandbox bridges, install scanners). On a realistic
loader workload it dominates CPU.

## Why

While debugging `openclaw message send` taking 5+ minutes to hang on macOS
with v2026.4.29 (related to issues #75895, #75575, #68782 — the CLI loaded
all bundled-plugin runtime deps even for a single channel send, then did a
DFS through 88k files), I traced the hot path with the V8 inspector and
landed inside `isPathInside`:

```
#0 path.relative                    node:path:1357:5
#1 isPathInside                     src/infra/path-guards.ts:48
#2 (DFS over node_modules)          collectRuntimePackageWildcardImportTargets
#3 collectRuntimePackageImportTargets
#4 registerBundledRuntimeDependencyJitiAliases
…
```

The DFS code path itself was removed on `main` (`bundled-runtime-deps-jiti-aliases.ts`
no longer exists), so the original symptom is mostly resolved upstream. But
`isPathInside` itself remained a hot-path bottleneck for any walker — and
this fast path benefits all current and future callers.

## Microbenchmark

Realistic loader workload: 8 deep `node_modules` paths, 4M total calls,
Apple Silicon, Node v25.5.0:

| variant | duration  | ops/s       |
| ------- | --------- | ----------- |
| slow    | 7,936 ms  | 504,042     |
| fast    |   784 ms  | 5,101,094   |

~10× speedup on the prefix-match case; both produce identical results on
every input. Bench script:
<https://gist.github.com/Enderfga/> _(can attach if useful — 30 lines)_

## Correctness

The fast path is intentionally conservative — it returns `true` only when
all of the following hold:

- `root` is non-empty and starts with `/`
- `target` starts with `/` and is at least as long as `root`
- `target` contains no `/..` substring (so the slow path's `..`
  rejection cannot disagree)
- `target === root`, **or** `target` literally starts with `root` and
  the next character is `/`

If any precondition fails, the existing slow path runs, so behaviour
is unchanged for:

- Windows paths (separate branch above)
- Relative inputs (resolved against CWD by the slow path)
- Sibling-prefix collisions (e.g. root `/workspace/root`, target
  `/workspace/rootless/file.txt` — fast path skipped because next
  char isn't `/`)
- Targets containing `..` segments (e.g. `/workspace/root/a/../escape`)
- Inputs needing normalisation (`//`, trailing `/.`, etc.)

## Tests

- 9 new cases added to `src/infra/path-guards.test.ts` covering the
  fast path, the parent-reference guard, sibling string-prefix
  collisions, deep canonical paths, filesystem root, and relative-input
  fall-through to the slow path.
- `pnpm exec vitest run src/infra/path-guards.test.ts` → 30 passed.
- `pnpm exec vitest run src/infra/ src/security/` → no new failures vs.
  baseline `main` (both runs hit the same set of pre-existing main-CI
  failures unrelated to this change).

## AI-assisted

Claude Opus 4.7 helped author this change. Lightly tested:

- Validated against the v2026.4.29 production hang reproduction
  (`openclaw message send` going from > 5 min hang to ~9 s end-to-end
  once this and related env-var-gated fixes were in place).
- Targeted `vitest` runs locally; did not run full `pnpm check && pnpm test`.

If you'd like a different naming for `POSIX_SEPARATOR_CHAR_CODE`, a
literal `0x2f` inline at each use, or want me to drop the bench
mention from the description, happy to revise.