### PR TITLE
fix(plugins): exclude runtimeSubagentMode from plugin loader cache key

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -671,7 +671,12 @@ function buildCacheKey(params: {
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
   const discoveryMode = params.toolDiscovery === true ? "tool-discovery" : "default-discovery";
-  const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
+  // Note: runtimeSubagentMode is intentionally excluded from the cache key.
+  // It does not affect which plugins are loaded or how they are configured —
+  // it is metadata stored alongside the active registry state. Including it
+  // produces redundant register() calls when call sites pass inconsistent
+  // allowGatewaySubagentBinding values across the message processing pipeline.
+  // Restores the fix originally landed in #61854 (issue #61756).
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   const activationMode = params.activate === false ? "snapshot" : "active";
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
@@ -681,7 +686,7 @@ function buildCacheKey(params: {
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${moduleLoadMode}::${discoveryMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
+  })}::${scopeKey}::${setupOnlyKey}::${setupOnlyModeKey}::${setupOnlyRequirementKey}::${startupChannelMode}::${moduleLoadMode}::${discoveryMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}::${activationMode}`;
 }
 
 function matchesScopedPluginRequest(params: {


### PR DESCRIPTION
## Summary

Restore the fix originally landed in #61854 (issue #61756): exclude `runtimeSubagentMode` from the plugin loader cache key.

## Background

`runtimeSubagentMode` (`"default" | "explicit" | "gateway-bindable"`) is derived from `runtimeOptions.allowGatewaySubagentBinding`. It does **not** affect which plugins are loaded or how they are configured — it is metadata stored alongside the active registry state and used by `activatePluginRegistry()` to decide whether to preserve the existing global hook runner.

When this value is part of `buildCacheKey()`, the same scoped plugin load (e.g. `onlyPluginIds: ["openai"]`) called from different sites with different `allowGatewaySubagentBinding` flags produces different cache keys, leading to redundant `register()` calls and full module re-imports on every message dispatch.

## Repro

1. Configure an agent with `agentRuntime.id: "codex"` and `model.primary: "openai/gpt-5.5"`.
2. Send any message via Telegram.
3. Observe in gateway debug logs:

```
[plugins] loading openai from .../extensions/openai/index.js   (~120ms)
... 8-10 more times ...
```

The same provider plugin module is imported 9-10 times per single message dispatch on a fully warm gateway with stable config.

## Fix

Drop `runtimeSubagentMode` from the cache-key string. The `getCompatibleActivePluginRegistry` compatibility re-check on `loadContext.runtimeSubagentMode === "default" && getActivePluginRuntimeSubagentMode() === "gateway-bindable"` (loader.ts:1100+) becomes redundant after this change but is left in place for safety.

## Refs

- Issue #61756 — original report
- PR #61854 — original fix (regressed in 2026.4.27 plugin-loading refactor)

## Test plan

- [ ] Send a series of messages on a multi-channel deployment; verify that the per-dispatch plugin re-import count drops from ~10 to 0.
- [ ] Run existing plugin loader tests.
- [ ] Verify no regression in subagent gateway binding (sanity check spawning a subagent that needs gateway-bindable runtime).

🤖 Patch authored after debugging a slow message dispatch on a personal VPS.