### PR TITLE
feat(browser): expose runtime headed browser start via --headed flag

### DIFF
--- a/extensions/browser/src/cli/browser-cli-examples.ts
+++ b/extensions/browser/src/cli/browser-cli-examples.ts
@@ -2,6 +2,7 @@ export const browserCoreExamples = [
   "openclaw browser status",
   "openclaw browser start",
   "openclaw browser start --headless",
+  "openclaw browser start --headed",
   "openclaw browser stop",
   "openclaw browser tabs",
   "openclaw browser open https://example.com",

--- a/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts
@@ -30,6 +30,37 @@ describe("browser manage start timeout option", () => {
     expect(startCall?.[1]?.query).toEqual({ headless: true });
   });
 
+  it("passes headless=false for browser start --headed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "start", "--headed"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall?.[1]?.query).toEqual({ headless: false });
+  });
+
+  it("sends no headless query when neither --headless nor --headed is passed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "start"], { from: "user" });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall?.[1]?.query).toBeUndefined();
+  });
+
+  it("rejects browser start --headless --headed with an error", async () => {
+    const capture = getBrowserCliRuntimeCapture();
+    capture.resetRuntimeCapture();
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program
+      .parseAsync(["browser", "start", "--headless", "--headed"], { from: "user" })
+      .catch(() => {
+        // exit() throws in the test runtime; swallow.
+      });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall).toBeUndefined();
+    expect(capture.runtimeErrors.join("\n")).toMatch(/mutually exclusive/);
+  });
+
   it("combines browser profile with browser start --headless", async () => {
     const program = createBrowserManageProgram({ withParentTimeout: true });
     await program.parseAsync(["browser", "--browser-profile", "work", "start", "--headless"], {
@@ -38,6 +69,16 @@ describe("browser manage start timeout option", () => {
 
     const startCall = findBrowserManageCall("/start");
     expect(startCall?.[1]?.query).toEqual({ profile: "work", headless: true });
+  });
+
+  it("combines browser profile with browser start --headed", async () => {
+    const program = createBrowserManageProgram({ withParentTimeout: true });
+    await program.parseAsync(["browser", "--browser-profile", "work", "start", "--headed"], {
+      from: "user",
+    });
+
+    const startCall = findBrowserManageCall("/start");
+    expect(startCall?.[1]?.query).toEqual({ profile: "work", headless: false });
   });
 
   it("uses a longer built-in timeout for browser status", async () => {

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -352,14 +352,28 @@ export function registerBrowserManageCommands(
     .command("start")
     .description("Start the browser (no-op if already running)")
     .option("--headless", "Launch a local managed browser headless for this start")
-    .action(async (opts: { headless?: boolean }, cmd) => {
+    .option("--headed", "Launch a local managed browser headed (visible window) for this start")
+    .action(async (opts: { headless?: boolean; headed?: boolean }, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
+      if (opts.headless && opts.headed) {
+        defaultRuntime.error(
+          danger("--headless and --headed are mutually exclusive; pass at most one."),
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
+      let headlessQuery: { headless: boolean } | undefined;
+      if (opts.headless) {
+        headlessQuery = { headless: true };
+      } else if (opts.headed) {
+        headlessQuery = { headless: false };
+      }
       await runBrowserCommand(async () => {
         await runBrowserToggle(parent, {
           profile,
           path: "/start",
-          query: opts.headless ? { headless: true } : undefined,
+          query: headlessQuery,
         });
       });
     });


### PR DESCRIPTION
Closes #75879.

## What

Adds `--headed` to `openclaw browser start` so users can flip a managed browser profile to a headed (visible) window at runtime without editing `openclaw.json` or restarting the gateway. Exactly mirrors the existing `--headless` flag and uses the already-supported `/start?headless=false` request-level override.

## Why

Per #75879, the internals already support a per-request headed override (`POST /start?headless=false` → `resolveManagedBrowserHeadlessMode()` honors `headlessOverride`), but the public CLI only exposed `--headless`. That means users can force headless from the CLI but cannot cleanly force headed for the standard "agent gets stuck → human takes over the visible browser → reattach" handoff pattern.

## Changes

- `extensions/browser/src/cli/browser-cli-manage.ts`
  - Add `--headed` option to `browser start`.
  - Send `{ headless: false }` query when `--headed` is set.
  - Reject `--headless --headed` together with a clear CLI error and exit 1.
  - No flag → no override (server uses configured default), preserving existing behavior.
- `extensions/browser/src/cli/browser-cli-examples.ts`
  - Document `openclaw browser start --headed` next to the existing `--headless` example.
- `extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts`
  - Tests for: `--headed` sends `headless=false`; no flag sends no override; conflicting flags error; `--headed` combines with `--browser-profile`.

## Out of scope (per the issue's non-goals)

- No browser-tool schema change in this PR. The issue mentions adding a similar boolean to the tool action schema; that's a separate touch with extra surface to think through (capabilities check, schema migrations) and the CLI surface alone covers the primary handoff workflow.
- No live mode-switching on a running Chrome process — `stop -> start --headed` is the documented sequence, matching how `--headless` works today.

## Tests

```
pnpm exec vitest run --config test/vitest/vitest.extension-browser.config.ts -- extensions/browser/src/cli/
# 7 files, 46 tests passed
```

`pnpm check:changed` is also clean (lint + tsgo + import-cycles).

## Notes

First-time contributor — happy to adjust scope, naming (`--no-headless` vs `--headed`), or help text. The flag name `--headed` is what the issue suggested as the primary form.
