### PR TITLE
fix(plugins): drop duplicate official flag in plugins search output

### DIFF
--- a/src/cli/plugins-search-command.ts
+++ b/src/cli/plugins-search-command.ts
@@ -41,10 +41,10 @@ function formatPackageSearchLine(entry: ClawHubPackageSearchResult): string {
   const flags = [
     pkg.family,
     pkg.channel,
-    pkg.isOfficial ? "official" : undefined,
+    pkg.isOfficial && pkg.channel !== "official" ? "official" : undefined,
     pkg.latestVersion ? `v${pkg.latestVersion}` : undefined,
   ].filter(Boolean);
-  const summary = pkg.summary ? `  ${theme.muted(pkg.summary)}` : "";
+  const summary = pkg.summary ? theme.muted(` — ${pkg.summary}`) : "";
   return `${pkg.name}  ${theme.muted(flags.join(" | "))}${summary}\n  ${theme.muted(`Install: openclaw plugins install clawhub:${pkg.name}`)}`;
 }
 


### PR DESCRIPTION
## Summary

Removes destined-to-be-duplicate word "official" from plugin search results

<img width="801" height="103" alt="image" src="https://github.com/user-attachments/assets/3a01c3e7-a25d-4bc1-bb3b-a4232e6b0ff3" />

AI Generated description:

- `openclaw plugins search` was rendering the `isOfficial` boolean as the literal string `"official"` alongside `pkg.channel`, so first-party packages on the official channel showed `code-plugin | official | official` (a duplicate flag).
- Skip the boolean badge when `pkg.channel === "official"` — the channel name already conveys it. Community packages flagged official still render `community | official`, so the trust-vs-channel distinction is preserved when it carries info.

Spotted while smoke-testing #75869:

```
@openclaw/discord  code-plugin | official | official  OpenClaw Discord channel plugin
```

After:

```
@openclaw/discord  code-plugin | official  OpenClaw Discord channel plugin
```

More changes coming on this branch — keeping draft.

## Test plan

- [x] `pnpm test src/cli/plugins-search-command.test.ts`
- [ ] `pnpm dev plugins search calendar` (live ClawHub spot-check)
- [ ] `pnpm dev plugins search slack --json` (JSON output unchanged)