### PR TITLE
fix: normalize CRLF line endings in replaceManagedMarkdownBlock to prevent duplicate blocks

### DIFF
--- a/src/plugin-sdk/memory-host-markdown.test.ts
+++ b/src/plugin-sdk/memory-host-markdown.test.ts
@@ -37,6 +37,19 @@ describe("replaceManagedMarkdownBlock", () => {
     ).toBe("# Title\n\n## Generated\n<!-- start -->\n- new\n<!-- end -->\n\n## Notes\nkept\n");
   });
 
+  it("replaces existing block even with CRLF line endings", () => {
+    expect(
+      replaceManagedMarkdownBlock({
+        original:
+          "# Title\r\n\r\n## Generated\r\n<!-- start -->\r\n- old\r\n<!-- end -->\r\n\r\n## Notes\r\nkept\r\n",
+        heading: "## Generated",
+        startMarker: "<!-- start -->",
+        endMarker: "<!-- end -->",
+        body: "- new",
+      }),
+    ).toBe("# Title\n\n## Generated\n<!-- start -->\n- new\n<!-- end -->\n\n## Notes\nkept\n");
+  });
+
   it("supports headingless blocks", () => {
     expect(
       replaceManagedMarkdownBlock({

--- a/src/plugin-sdk/memory-host-markdown.ts
+++ b/src/plugin-sdk/memory-host-markdown.ts
@@ -17,16 +17,20 @@ export function withTrailingNewline(content: string): string {
 export function replaceManagedMarkdownBlock(params: ManagedMarkdownBlockParams): string {
   const headingPrefix = params.heading ? `${params.heading}\n` : "";
   const managedBlock = `${headingPrefix}${params.startMarker}\n${params.body}\n${params.endMarker}`;
+  // Normalize CRLF to LF so the regex matches regardless of line endings.
+  // Without this, files with \r\n line endings cause the regex to miss
+  // existing managed blocks, leading to duplicate appends on each run.
+  const normalized = params.original.replace(/\r\n/g, "\n");
   const existingPattern = new RegExp(
     `${params.heading ? `${escapeRegex(params.heading)}\\n` : ""}${escapeRegex(params.startMarker)}[\\s\\S]*?${escapeRegex(params.endMarker)}`,
     "m",
   );
 
-  if (existingPattern.test(params.original)) {
-    return params.original.replace(existingPattern, managedBlock);
+  if (existingPattern.test(normalized)) {
+    return normalized.replace(existingPattern, managedBlock);
   }
 
-  const trimmed = params.original.trimEnd();
+  const trimmed = normalized.trimEnd();
   if (trimmed.length === 0) {
     return `${managedBlock}\n`;
   }


### PR DESCRIPTION
## Problem

When a daily memory file uses CRLF line endings (common on Windows/WSL), the regex in `replaceManagedMarkdownBlock` fails to match the existing managed block because the pattern uses a literal `\n` but the file contains `\r\n`.

This causes the function to fall through to the append path, adding a duplicate copy of the managed block on every run. Over time, files accumulate multiple copies (reporter observed 5 copies growing a 50KB file to 243KB).

Fixes #75491

## Fix

Normalize CRLF to LF in the input before regex matching:

```typescript
const normalized = params.original.replace(/\r\n/g, "\n");
```

## Testing

Added a test case that verifies existing managed blocks are replaced correctly when the input uses CRLF line endings.