### PR TITLE
fix: use veto instead of failure for loop circuit breaker blocking

### DIFF
--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -437,7 +437,7 @@ export async function runBeforeToolCallHook(args: {
         });
         return {
           blocked: true,
-          kind: "failure",
+          kind: "veto",
           deniedReason: "tool-loop",
           reason: loopResult.message,
           params,


### PR DESCRIPTION
## Problem

When the global circuit breaker fires (e.g., 15+ identical no-progress `exec` calls), the blocked tool call is returned with `kind: "failure"` from `runBeforeToolCallHook`. The wrapper in `wrapToolWithBeforeToolCallHook` then throws an `Error`:

```
if (outcome.kind !== "veto") throw new Error(outcome.reason);
```

The model interprets this `Error` as a tool execution error (not a circuit breaker warning) and retries the same command — entering an **infinite retry loop**. The circuit breaker successfully blocks every `exec` call, but the model keeps generating new ones, burning tokens continuously.

## Root Cause

The `kind` field for critical loop detection results is `"failure"`, which maps to the throw-an-Error path. The model never sees a proper result — just a tool error — so it has no signal to stop.

## Fix

Change `kind` from `"failure"` to `"veto"` for critical loop detection blocks. The `"veto"` path returns a proper `buildBlockedToolResult` as a normal tool response, so the model reads the circuit breaker message as text content instead of as an error.

### Before (broken)

```
Tool exec -> Error thrown -> Model: "command failed, retry" -> infinite loop
Token burn: ~300 tokens x N retries, with no end
```

### After (fixed)

```
Tool exec -> Blocked result returned -> Model: "I see the circuit breaker message, I'll stop"
```

## Changes

- `src/agents/pi-tools.before-tool-call.ts`: line 440, changed `kind: "failure"` -> `kind: "veto"` in the critical loop detection return block

## Verification

Tested by triggering a loop with 15+ identical exec calls. Before the fix, the agent continued retrying indefinitely. After the fix, the agent reads the blocked result and stops retrying.
