### PR TITLE
Fix Slack hook content fallback for bot alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Models CLI: restore `openclaw models list --provider <id>` catalog and registry fallback rows for unconfigured providers, so provider-specific verification commands no longer report "No models found." Fixes #75517; supersedes #75615. Thanks @lotsoftick and @koshaji.
+- Slack/hooks: preserve bot alert attachment text in message-received hook content when command text is blank. Fixes #76035; refs #76036. Thanks @amsminn.
 - Control UI/chat: show inline feedback when local slash-command dispatch is unavailable or fails unexpectedly instead of clearing the composer silently. Fixes #52105. Thanks @MooreQiao.
 - Memory/markdown: replace CRLF managed blocks in place and collapse duplicate marker blocks without rewriting unmanaged markdown, so Dreaming and Memory Wiki files self-heal from repeated generated sections. Fixes #75491; supersedes #75495, #75810, and #76008. Thanks @asaenokkostya-coder, @ottodeng, @everettjf, and @lrg913427-dot.
 - Agents/tools: return critical tool-loop circuit-breaker stops as blocked tool results instead of thrown tool failures, so models see the guardrail and stop retrying the same call. Thanks @rayraiser.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -114,7 +114,7 @@ Each event includes: `type`, `action`, `sessionKey`, `timestamp`, `messages` (pu
 
 **Command events** (`command:new`, `command:reset`): `context.sessionEntry`, `context.previousSessionEntry`, `context.commandSource`, `context.workspaceDir`, `context.cfg`.
 
-**Message events** (`message:received`): `context.from`, `context.content`, `context.channelId`, `context.metadata` (provider-specific data including `senderId`, `senderName`, `guildId`).
+**Message events** (`message:received`): `context.from`, `context.content`, `context.channelId`, `context.metadata` (provider-specific data including `senderId`, `senderName`, `guildId`). `context.content` prefers a nonblank command body for command-like messages, then falls back to the raw inbound body and generic body; it does not include agent-only enrichment such as thread history or link summaries.
 
 **Message events** (`message:sent`): `context.to`, `context.content`, `context.success`, `context.channelId`.
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -536,7 +536,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       subtype: "bot_message",
       attachments: [
         {
-          text: "Readiness probe failed: Get http://10.42.13.132:8000/status: context deadline exceeded",
+          text: "Readiness probe failed: Get https://status.example.test/readiness: context deadline exceeded",
         },
       ],
     });
@@ -545,6 +545,11 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     expect(prepared).toBeTruthy();
     expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
+    // Slack message attachments can carry the user-visible body even when the
+    // top-level message text is empty.
+    expect(prepared!.ctxPayload.CommandBody).toBe("");
+    expect(prepared!.ctxPayload.BodyForCommands).toBe("");
+    expect(prepared!.ctxPayload.BodyForAgent).toContain("Readiness probe failed");
   });
 
   it("drops bot-authored room messages when allowBots is true but no owner is present (#59284)", async () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -221,11 +221,12 @@ export function resolveTranscriptPolicy(params: {
   model?: ProviderRuntimeModel;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
-  const cacheKey = canCacheTranscriptPolicy(params)
-    ? resolveTranscriptPolicyCacheKey({ ...params, provider, config: params.config })
+  const cacheConfig = canCacheTranscriptPolicy(params) ? params.config : undefined;
+  const cacheKey = cacheConfig
+    ? resolveTranscriptPolicyCacheKey({ ...params, provider, config: cacheConfig })
     : undefined;
-  if (cacheKey) {
-    const cached = transcriptPolicyCache.get(params.config)?.get(cacheKey);
+  if (cacheConfig && cacheKey) {
+    const cached = transcriptPolicyCache.get(cacheConfig)?.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -259,11 +260,11 @@ export function resolveTranscriptPolicy(params: {
           modelId: params.modelId,
         }),
       );
-  if (cacheKey) {
-    let configCache = transcriptPolicyCache.get(params.config);
+  if (cacheConfig && cacheKey) {
+    let configCache = transcriptPolicyCache.get(cacheConfig);
     if (!configCache) {
       configCache = new Map();
-      transcriptPolicyCache.set(params.config, configCache);
+      transcriptPolicyCache.set(cacheConfig, configCache);
     }
     configCache.set(cacheKey, policy);
   }

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -97,6 +97,30 @@ describe("message hook mappers", () => {
     expect(canonical.guildId).toBe("guild-1");
   });
 
+  it("falls back to raw body when command body is blank", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        BodyForCommands: " \n\t",
+        RawBody: "Readiness probe failed",
+      }),
+    );
+
+    expect(canonical.content).toBe("Readiness probe failed");
+    expect(toPluginMessageReceivedEvent(canonical).content).toBe("Readiness probe failed");
+    expect(toInternalMessageReceivedContext(canonical).content).toBe("Readiness probe failed");
+  });
+
+  it("keeps nonblank command body ahead of raw body for hook content", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        BodyForCommands: "/status",
+        RawBody: "Readiness probe failed",
+      }),
+    );
+
+    expect(canonical.content).toBe("/status");
+  });
+
   it("supports explicit content/messageId overrides", () => {
     const canonical = deriveInboundMessageHookContext(makeInboundCtx(), {
       content: "override-content",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -80,6 +80,10 @@ export type CanonicalSentMessageHookContext = {
   groupId?: string;
 };
 
+function readNonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
 export function deriveInboundMessageHookContext(
   ctx: FinalizedMsgContext,
   overrides?: {
@@ -89,13 +93,10 @@ export function deriveInboundMessageHookContext(
 ): CanonicalInboundMessageHookContext {
   const content =
     overrides?.content ??
-    (typeof ctx.BodyForCommands === "string"
-      ? ctx.BodyForCommands
-      : typeof ctx.RawBody === "string"
-        ? ctx.RawBody
-        : typeof ctx.Body === "string"
-          ? ctx.Body
-          : "");
+    readNonBlankString(ctx.BodyForCommands) ??
+    readNonBlankString(ctx.RawBody) ??
+    readNonBlankString(ctx.Body) ??
+    "";
   const channelId = normalizeLowercaseStringOrEmpty(
     ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "",
   );


### PR DESCRIPTION

## Summary

- Problem: Slack bot alert messages can have empty top-level `text` and empty command text while their user-visible alert body lives in attachment text.
- Why it matters: OpenClaw could still reply because Slack prepare preserved the alert body in `RawBody` and `BodyForAgent`, but plugin `message_received.content` stayed empty, so plugin listeners could not match or process the current message.
- Discovery context: I found this while running a local/private plugin listener against a Slack alert channel. The Slack event reached the plugin hook, but `message_received.content` was blank even though OpenClaw itself could answer the same alert.
- What changed: Hook content now uses `BodyForCommands` only when it is nonblank, then falls back to `RawBody`, then `Body`. Slack prepare regression coverage also asserts alert attachment text stays available to the agent while command fields remain blank.
- What did NOT change (scope boundary): Slack command detection and agent prompt enrichment still use their existing fields. Nonblank command text, such as `/status`, still wins over raw message text for hook content.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76035
- Related: N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `deriveInboundMessageHookContext()` treated any string `BodyForCommands`, including `""` or whitespace-only text, as the canonical hook content and never reached the `RawBody` fallback.
- Missing detection / guardrail: Hook mapper tests did not cover blank command content with nonblank raw inbound content, and the Slack prepare regression did not assert that bot alert attachment text leaves command fields blank while preserving `RawBody`/`BodyForAgent`.
- Contributing context (if known): Slack bot alert events can use `subtype: "bot_message"` with empty top-level `text` while putting the visible alert text in attachment text.

## Slack Schema Evidence

- Slack's [`message` event reference](https://docs.slack.dev/reference/events/message/) defines channel messages and notes that messages can include an `attachments` property.
- Slack's [`bot_message` subtype reference](https://docs.slack.dev/reference/events/message/bot_message/) defines `subtype: "bot_message"` as the event shape for integration bot messages.
- Slack Node SDK's [`BotMessageEvent` type](https://docs.slack.dev/tools/node-slack-sdk/reference/types/interfaces/BotMessageEvent/) includes `type: "message"`, `subtype: "bot_message"`, top-level `text`, and optional `attachments?: MessageAttachment[]`.
- Slack Node SDK's [`MessageAttachment` type](https://docs.slack.dev/tools/node-slack-sdk/reference/types/interfaces/MessageAttachment/) defines attachment `text` as the attachment's main body text, so an alert body in `attachments[0].text` is a valid Slack payload shape even when command text is blank.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/hooks/message-hook-mappers.test.ts`
  - `extensions/slack/src/monitor/message-handler/prepare.test.ts`
- Scenario the test should lock in: A blank or whitespace-only command body falls back to raw inbound hook content, while a nonblank command body remains preferred. Slack bot alert attachment text remains in `RawBody` and `BodyForAgent` while `CommandBody` and `BodyForCommands` stay blank.
- Why this is the smallest reliable guardrail: The bug is in the shared hook mapper selection rule, with a Slack prepare fixture proving the channel-specific input shape that triggered it.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Plugin and internal `message:received` hooks can now receive raw inbound content when command text is blank. For Slack bot alerts, this means plugin listeners see the alert body instead of `content: ""`.

## Diagram (if applicable)

```text
Before:
Slack bot alert attachment text
  -> Slack prepare RawBody/BodyForAgent populated, BodyForCommands blank
  -> hook mapper selects blank BodyForCommands
  -> plugin message_received.content = ""

After:
Slack bot alert attachment text
  -> Slack prepare RawBody/BodyForAgent populated, BodyForCommands blank
  -> hook mapper skips blank command text and falls back to RawBody
  -> plugin message_received.content = alert body
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22 via repo test wrapper
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): Slack account with bot-authored messages allowed

### Steps

1. Receive a Slack `message` event shaped like a bot alert: `subtype: "bot_message"`, top-level `text: ""`, and attachment text containing the visible alert body.
2. Slack prepare extracts the attachment text into the current message body for agent processing, while command text stays blank.
3. Emit plugin/internal `message_received` hook context from the finalized inbound message.

### Expected

- `RawBody` and `BodyForAgent` contain the Slack alert text.
- `CommandBody` and `BodyForCommands` are blank.
- `message_received.content` contains the Slack alert text.
- Nonblank command content still wins over raw inbound content.

### Actual

- Before this PR, `message_received.content` was `""` because the mapper selected blank `BodyForCommands` and did not fall back to `RawBody`.
- After this PR, blank command content is skipped and `RawBody` becomes hook content.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted proof:

- `pnpm test src/hooks/message-hook-mappers.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts -- --reporter=verbose`
- `pnpm test:changed`
- `pnpm exec oxfmt --check --threads=1 src/hooks/message-hook-mappers.ts src/hooks/message-hook-mappers.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts docs/automation/hooks.md`
- `pnpm check:docs`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm check:changed`

## Human Verification (required)

- Author-side verification performed before opening this PR:
  - Hook mapper falls back from blank/whitespace command content to raw inbound content.
  - Hook mapper keeps nonblank command content ahead of raw inbound content.
  - Slack bot alert fixture preserves attachment text in `RawBody` and `BodyForAgent` while command fields are blank.
- Edge cases covered by the targeted tests:
  - Whitespace-only `BodyForCommands`.
  - Nonblank command text such as `/status`.
- Out of scope / not claimed by this PR:
  - Live Slack delivery.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The hook content fallback rule is shared across channels, so other blank-command inbound contexts can now expose raw inbound content to `message_received` hooks where they previously emitted blank content.
  - Why acceptable: The new mapper tests lock in the intended generic precedence rule, and docs now state that hook content prefers nonblank command text before raw inbound body. This PR treats the fallback as the shared hook contract because `message_received.content` is the representative current-message body, not a command-parser-only field.
