### PR TITLE
fix(agents): keep state.messages intact across z.ai-style provider turns in embedded runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
 - Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis. Long `process(poll)`, browser, or `exec` tool calls that exceed `agents.defaults.timeoutSeconds` previously rotated auth profiles, switched to a fallback model, and surfaced a misleading "LLM request timed out" error even though the primary model had already responded. Mirrors the existing `timedOutDuringCompaction` precedent (#46889). Fixes #52147. (#75873) Thanks @simonusa.
 - Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
+- Agents/compaction: keep prior context on consecutive turns against z.ai-style providers (z.ai direct, openrouter z-ai/*, in-house GLM gateways); Pi's internal auto-compaction was misfiring after successful turns and clearing state.messages before the next provider request. (#76056) Thanks @openperf.
 
 ## 2026.5.2
 

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -301,8 +301,10 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../pi-settings.js", () => ({
+    applyPiAutoCompactionGuard: vi.fn(() => ({ supported: true, disabled: false })),
     applyPiCompactionSettingsFromConfig: vi.fn(),
     ensurePiCompactionReserveTokens: vi.fn(),
+    isSilentOverflowProneModel: vi.fn(() => false),
     resolveCompactionReserveTokensFloor: vi.fn(() => 0),
   }));
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -973,6 +973,9 @@ async function compactEmbeddedPiSessionDirectOnce(
         cfg: params.config,
         contextTokenBudget: ctxInfo.tokens,
       });
+      // contextEngineInfo is intentionally omitted: this guard runs inside the
+      // compaction LLM session, which is not the user-facing agent session and
+      // has no associated context engine.
       applyPiAutoCompactionGuard({
         settingsManager,
         silentOverflowProneProvider: isSilentOverflowProneModel({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -75,7 +75,11 @@ import {
   setCompactionSafeguardCancelReason,
 } from "../pi-hooks/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
-import { applyPiCompactionSettingsFromConfig } from "../pi-settings.js";
+import {
+  applyPiAutoCompactionGuard,
+  applyPiCompactionSettingsFromConfig,
+  isSilentOverflowProneModel,
+} from "../pi-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
@@ -960,11 +964,22 @@ async function compactEmbeddedPiSessionDirectOnce(
       });
       await resourceLoader.reload();
       // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
+      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
+      // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
+      // both guards. effectiveModel.baseUrl matches the surrounding scope so
+      // auth-profile-injected baseUrls reach the endpoint-class detector.
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
         contextTokenBudget: ctxInfo.tokens,
+      });
+      applyPiAutoCompactionGuard({
+        settingsManager,
+        silentOverflowProneProvider: isSilentOverflowProneModel({
+          provider,
+          modelId,
+          baseUrl: effectiveModel.baseUrl ?? undefined,
+        }),
       });
 
       const { customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -321,6 +321,7 @@ vi.mock("../../pi-settings.js", () => ({
       keepRecentTokens: 40_000,
     },
   }),
+  isSilentOverflowProneModel: () => false,
 }));
 
 vi.mock("../extensions.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -107,6 +107,7 @@ import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settin
 import {
   applyPiAutoCompactionGuard,
   applyPiCompactionSettingsFromConfig,
+  isSilentOverflowProneModel,
 } from "../../pi-settings.js";
 import {
   createClientToolNameConflictError,
@@ -1474,10 +1475,16 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         contextTokenBudget: params.contextTokenBudget,
       });
-      applyPiAutoCompactionGuard({
+      const piAutoCompactionGuardArgs = {
         settingsManager,
         contextEngineInfo: activeContextEngine?.info,
-      });
+        silentOverflowProneProvider: isSilentOverflowProneModel({
+          provider: params.provider,
+          modelId: params.modelId,
+          baseUrl: params.model.baseUrl ?? undefined,
+        }),
+      };
+      applyPiAutoCompactionGuard(piAutoCompactionGuardArgs);
 
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
@@ -1496,12 +1503,15 @@ export async function runEmbeddedAttempt(
       });
       await resourceLoader.reload();
       // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
+      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
+      // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
+      // both guards.
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
         contextTokenBudget: params.contextTokenBudget,
       });
+      applyPiAutoCompactionGuard(piAutoCompactionGuardArgs);
       prepStages.mark("session-resource-loader");
 
       // Get hook runner early so it's available when creating tools

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -378,10 +378,16 @@ describe("isSilentOverflowProneModel", () => {
   // openclaw#75799 reporter's setup: an OpenAI-compatible in-house gateway
   // exposing Zhipu's GLM family directly (model id `glm-5.1`, no `z-ai/`
   // qualifier, custom baseUrl that is not api.z.ai). Catch the bare GLM
-  // family name so direct gateway deployments hit the guard.
-  it("flags bare glm- model ids without a namespace prefix", () => {
+  // family name so direct gateway deployments hit the guard regardless of
+  // what `provider` field the user picked — gateways relabel the upstream
+  // identity, so `provider` here can be anything from `openai` to a custom
+  // string. False positives only disable Pi's secondary compaction path;
+  // OpenClaw's preemptive compaction continues to handle real overflow.
+  it("flags bare glm- model ids without a namespace prefix, regardless of provider", () => {
     expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-5.1" })).toBe(true);
     expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-4.7" })).toBe(true);
+    expect(isSilentOverflowProneModel({ provider: "openai", modelId: "glm-5.1" })).toBe(true);
+    expect(isSilentOverflowProneModel({ provider: "openrouter", modelId: "glm-5.1" })).toBe(true);
   });
 
   // Detection is intentionally narrow to z.ai-style accounting. Namespaced GLM

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./pi-compaction-constants.js";
 import {
+  applyPiAutoCompactionGuard,
   applyPiCompactionSettingsFromConfig,
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+  isSilentOverflowProneModel,
   resolveCompactionReserveTokensFloor,
 } from "./pi-settings.js";
 
@@ -343,5 +345,165 @@ describe("resolveCompactionReserveTokensFloor", () => {
         agents: { defaults: { compaction: { reserveTokensFloor: 0 } } },
       }),
     ).toBe(0);
+  });
+});
+
+describe("isSilentOverflowProneModel", () => {
+  // Reporter's repro shape: openrouter routing to z-ai/glm. Both the bare
+  // `z-ai/...` form and the `openrouter/z-ai/...` qualified form must hit.
+  it("flags z-ai-prefixed model ids regardless of qualifier", () => {
+    expect(isSilentOverflowProneModel({ provider: "openrouter", modelId: "z-ai/glm-5.1" })).toBe(
+      true,
+    );
+    expect(
+      isSilentOverflowProneModel({ provider: "openrouter", modelId: "openrouter/z-ai/glm-5" }),
+    ).toBe(true);
+  });
+
+  it("flags a config-set z.ai provider regardless of model id", () => {
+    expect(isSilentOverflowProneModel({ provider: "z.ai", modelId: "glm-5.1" })).toBe(true);
+    expect(isSilentOverflowProneModel({ provider: "z-ai", modelId: "glm-5.1" })).toBe(true);
+  });
+
+  it("flags a direct api.z.ai baseUrl via endpointClass", () => {
+    expect(
+      isSilentOverflowProneModel({
+        provider: "openai",
+        modelId: "glm-5.1",
+        baseUrl: "https://api.z.ai/api/coding/paas/v4",
+      }),
+    ).toBe(true);
+  });
+
+  // openclaw#75799 reporter's setup: an OpenAI-compatible in-house gateway
+  // exposing Zhipu's GLM family directly (model id `glm-5.1`, no `z-ai/`
+  // qualifier, custom baseUrl that is not api.z.ai). Catch the GLM family
+  // name with or without a path namespace so deploys that proxy it under
+  // their own provider name still hit the guard.
+  it("flags glm- model ids regardless of path namespace", () => {
+    expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-5.1" })).toBe(true);
+    expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-4.7" })).toBe(true);
+    expect(
+      isSilentOverflowProneModel({ provider: "ollama", modelId: "ollama/glm-5.1:cloud" }),
+    ).toBe(true);
+  });
+
+  // pi-ai's overflow.ts only documents z.ai as the silent-overflow style. We
+  // intentionally do NOT extend the guard to anthropic/openai/google/openrouter-
+  // anthropic routes — adding them without a reproducible repro would broaden
+  // the kill surface and regress baseline behavior for those providers.
+  it("does not flag anthropic, openai, google or other routes", () => {
+    expect(
+      isSilentOverflowProneModel({ provider: "anthropic", modelId: "claude-sonnet-4.6" }),
+    ).toBe(false);
+    expect(isSilentOverflowProneModel({ provider: "openai", modelId: "gpt-5.5" })).toBe(false);
+    expect(
+      isSilentOverflowProneModel({
+        provider: "openrouter",
+        modelId: "anthropic/claude-sonnet-4.6",
+      }),
+    ).toBe(false);
+    expect(isSilentOverflowProneModel({ provider: "google", modelId: "gemini-2.5-pro" })).toBe(
+      false,
+    );
+  });
+
+  it("treats missing fields as not silent-overflow-prone", () => {
+    expect(isSilentOverflowProneModel({})).toBe(false);
+    expect(
+      isSilentOverflowProneModel({ provider: undefined, modelId: undefined, baseUrl: null }),
+    ).toBe(false);
+  });
+});
+
+describe("applyPiAutoCompactionGuard", () => {
+  // Direct repro of openclaw#75799: pi-ai's silent-overflow detection misfires
+  // on a successful turn against z.ai-style providers, triggering Pi's
+  // _runAutoCompaction from inside Session.prompt() and reassigning
+  // agent.state.messages between the runner's prompt.submitted trajectory
+  // event and the provider request. Disabling Pi auto-compaction here keeps
+  // state.messages intact; OpenClaw's preemptive compaction continues to
+  // handle real overflow on its own path.
+  it("disables Pi auto-compaction for silent-overflow-prone providers", () => {
+    const setCompactionEnabled = vi.fn();
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 4_000,
+      applyOverrides: () => {},
+      setCompactionEnabled,
+    };
+
+    const result = applyPiAutoCompactionGuard({
+      settingsManager,
+      silentOverflowProneProvider: true,
+    });
+
+    expect(result).toEqual({ supported: true, disabled: true });
+    expect(setCompactionEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("disables Pi auto-compaction when a context engine plugin owns compaction", () => {
+    const setCompactionEnabled = vi.fn();
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 4_000,
+      applyOverrides: () => {},
+      setCompactionEnabled,
+    };
+
+    const result = applyPiAutoCompactionGuard({
+      settingsManager,
+      contextEngineInfo: {
+        id: "third-party",
+        name: "Third-party Context Engine",
+        version: "0.1.0",
+        ownsCompaction: true,
+      },
+    });
+
+    expect(result).toEqual({ supported: true, disabled: true });
+    expect(setCompactionEnabled).toHaveBeenCalledWith(false);
+  });
+
+  // Default-mode runs against ordinary providers must keep Pi's auto-compaction
+  // enabled. Disabling it across the board would silently remove Pi's
+  // overflow-recovery path inside Session.prompt() for users who are not
+  // affected by z.ai's silent-overflow accounting.
+  it("leaves Pi auto-compaction alone for non-z.ai providers without engine ownership", () => {
+    const setCompactionEnabled = vi.fn();
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 4_000,
+      applyOverrides: () => {},
+      setCompactionEnabled,
+    };
+
+    const result = applyPiAutoCompactionGuard({
+      settingsManager,
+      contextEngineInfo: {
+        id: "legacy",
+        name: "Legacy Context Engine",
+        version: "1.0.0",
+      },
+      silentOverflowProneProvider: false,
+    });
+
+    expect(result).toEqual({ supported: true, disabled: false });
+    expect(setCompactionEnabled).not.toHaveBeenCalled();
+  });
+
+  it("reports unsupported when the settings manager has no setCompactionEnabled hook", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 4_000,
+      applyOverrides: () => {},
+    };
+
+    const result = applyPiAutoCompactionGuard({
+      settingsManager,
+      silentOverflowProneProvider: true,
+    });
+
+    expect(result).toEqual({ supported: false, disabled: false });
   });
 });

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -377,15 +377,25 @@ describe("isSilentOverflowProneModel", () => {
 
   // openclaw#75799 reporter's setup: an OpenAI-compatible in-house gateway
   // exposing Zhipu's GLM family directly (model id `glm-5.1`, no `z-ai/`
-  // qualifier, custom baseUrl that is not api.z.ai). Catch the GLM family
-  // name with or without a path namespace so deploys that proxy it under
-  // their own provider name still hit the guard.
-  it("flags glm- model ids regardless of path namespace", () => {
+  // qualifier, custom baseUrl that is not api.z.ai). Catch the bare GLM
+  // family name so direct gateway deployments hit the guard.
+  it("flags bare glm- model ids without a namespace prefix", () => {
     expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-5.1" })).toBe(true);
     expect(isSilentOverflowProneModel({ provider: "custom", modelId: "glm-4.7" })).toBe(true);
+  });
+
+  // Detection is intentionally narrow to z.ai-style accounting. Namespaced GLM
+  // ids that route through providers with their own overflow accounting must
+  // NOT be flagged — those hosts may not exhibit the z.ai silent-overflow
+  // shape, and disabling Pi auto-compaction for them would over-broaden the
+  // kill surface beyond the reproducible repro.
+  it("does not flag namespaced GLM ids routed through non-z.ai hosts", () => {
     expect(
       isSilentOverflowProneModel({ provider: "ollama", modelId: "ollama/glm-5.1:cloud" }),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      isSilentOverflowProneModel({ provider: "opencode-go", modelId: "opencode-go/glm-5.1" }),
+    ).toBe(false);
   });
 
   // pi-ai's overflow.ts only documents z.ai as the silent-overflow style. We

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -131,12 +131,14 @@ export function applyPiCompactionSettingsFromConfig(params: {
  * provider call (openclaw#75799).
  *
  * True on any of: `zai-native` endpoint class, normalized provider id `zai`,
- * a `z-ai/` / `openrouter/z-ai/` model-id namespace prefix, or a `glm-` model
- * name (with or without a path namespace) — covering in-house gateways and
- * ollama-style deploys that expose Zhipu's GLM family directly without a
- * `z-ai/` qualifier. Intentionally narrow to z.ai-style accounting; other
- * providers documented as silently truncating are not added without a
- * reproducible repro.
+ * a `z-ai/` / `openrouter/z-ai/` model-id namespace prefix, or a bare `glm-`
+ * model id (no namespace prefix) — the latter covers in-house gateways that
+ * expose Zhipu's GLM family directly without a `z-ai/` qualifier. Intentionally
+ * narrow: namespaced GLM ids that route through other providers (e.g.
+ * `ollama/glm-*`, `opencode-go/glm-*`) are NOT included because their hosts
+ * have their own overflow accounting and may not exhibit the z.ai silent-
+ * overflow shape. Other providers documented as silently truncating are not
+ * added without a reproducible repro.
  */
 export function isSilentOverflowProneModel(model: {
   provider?: string | null;
@@ -157,8 +159,7 @@ export function isSilentOverflowProneModel(model: {
     if (
       normalized.startsWith("z-ai/") ||
       normalized.startsWith("openrouter/z-ai/") ||
-      normalized.startsWith("glm-") ||
-      normalized.includes("/glm-")
+      normalized.startsWith("glm-")
     ) {
       return true;
     }

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineInfo } from "../context-engine/types.js";
 import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./pi-compaction-constants.js";
+import { resolveProviderEndpoint } from "./provider-attribution.js";
+import { normalizeProviderId } from "./provider-id.js";
 
 export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 
@@ -122,18 +124,80 @@ export function applyPiCompactionSettingsFromConfig(params: {
   };
 }
 
-/** Decide whether Pi's internal auto-compaction should be disabled for this run. */
-function shouldDisablePiAutoCompaction(params: { contextEngineInfo?: ContextEngineInfo }): boolean {
-  return params.contextEngineInfo?.ownsCompaction === true;
+/**
+ * Detect providers whose pi-ai `isContextOverflow` Case 2 (silent overflow)
+ * fires on a successful turn and triggers Pi's `_runAutoCompaction` from
+ * inside `Session.prompt()`, collapsing `agent.state.messages` before the
+ * provider call (openclaw#75799).
+ *
+ * True on any of: `zai-native` endpoint class, normalized provider id `zai`,
+ * a `z-ai/` / `openrouter/z-ai/` model-id namespace prefix, or a `glm-` model
+ * name (with or without a path namespace) — covering in-house gateways and
+ * ollama-style deploys that expose Zhipu's GLM family directly without a
+ * `z-ai/` qualifier. Intentionally narrow to z.ai-style accounting; other
+ * providers documented as silently truncating are not added without a
+ * reproducible repro.
+ */
+export function isSilentOverflowProneModel(model: {
+  provider?: string | null;
+  modelId?: string | null;
+  baseUrl?: string | null;
+}): boolean {
+  const provider = normalizeProviderId(typeof model.provider === "string" ? model.provider : "");
+  if (provider === "zai") {
+    return true;
+  }
+  if (typeof model.baseUrl === "string" && model.baseUrl.length > 0) {
+    if (resolveProviderEndpoint(model.baseUrl).endpointClass === "zai-native") {
+      return true;
+    }
+  }
+  if (typeof model.modelId === "string" && model.modelId.length > 0) {
+    const normalized = model.modelId.toLowerCase();
+    if (
+      normalized.startsWith("z-ai/") ||
+      normalized.startsWith("openrouter/z-ai/") ||
+      normalized.startsWith("glm-") ||
+      normalized.includes("/glm-")
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
-/** Disable Pi auto-compaction via settings when a context engine owns compaction. */
+/**
+ * Disable Pi's `_checkCompaction → _runAutoCompaction` (which would otherwise
+ * fire from inside `Session.prompt()` and reassign `agent.state.messages`
+ * before the provider call) when OpenClaw or a plugin owns compaction:
+ * `contextEngineInfo.ownsCompaction === true`, or the active model is
+ * silent-overflow-prone (openclaw#75799). Default-mode runs against ordinary
+ * providers keep Pi's auto-compaction as the existing baseline.
+ */
+function shouldDisablePiAutoCompaction(params: {
+  contextEngineInfo?: ContextEngineInfo;
+  silentOverflowProneProvider?: boolean;
+}): boolean {
+  return (
+    params.contextEngineInfo?.ownsCompaction === true || params.silentOverflowProneProvider === true
+  );
+}
+
+/**
+ * Apply the auto-compaction guard. Callers that reload a `DefaultResourceLoader`
+ * MUST call this AGAIN after each `reload()` — `settingsManager.reload()`
+ * rehydrates `compaction.enabled` from disk and silently restores Pi's
+ * default-on behavior, undoing the guard. Mirrors the existing
+ * `applyPiCompactionSettingsFromConfig` re-call pattern at the same sites.
+ */
 export function applyPiAutoCompactionGuard(params: {
   settingsManager: PiSettingsManagerLike;
   contextEngineInfo?: ContextEngineInfo;
+  silentOverflowProneProvider?: boolean;
 }): { supported: boolean; disabled: boolean } {
   const disable = shouldDisablePiAutoCompaction({
     contextEngineInfo: params.contextEngineInfo,
+    silentOverflowProneProvider: params.silentOverflowProneProvider,
   });
   const hasMethod = typeof params.settingsManager.setCompactionEnabled === "function";
   if (!disable || !hasMethod) {


### PR DESCRIPTION
### Summary

- **Problem**: For Telegram (and other channel) sessions running against z.ai-style OpenAI-compatible providers (z.ai direct, openrouter `z-ai/glm-*`), conversational context is lost on consecutive turns. The HTTP request body that reaches the provider contains only the system prompt and the just-submitted user message, even though the runner's `prompt.submitted` trajectory event captured the full prior transcript with `messagesLen` matching the number of stored messages. Pronouns lose their referent, and continuation requests can ship a bare tool result without its preceding assistant tool call.
- **Root Cause**: pi-coding-agent's `Session.prompt()` runs `_checkCompaction(lastAssistant, false)` *before* it appends the new user message. For z.ai-style providers, pi-ai's `isContextOverflow` (Case 2 — "Silent overflow z.ai style") returns `true` whenever the last successful assistant turn has `usage.input + usage.cacheRead > contextWindow`, even with `stopReason: "stop"`. That triggers Pi's `_runAutoCompaction("overflow", true)` which reassigns `agent.state.messages` to the post-compaction view — typically a single compaction summary, sometimes empty. When `agent.prompt(messages)` then runs the agent loop, the snapshot of `state.messages` is the now-tiny array, so `streamFn` ships a near-empty transcript to the provider. The runner's `prompt.submitted` event already deep-cloned `state.messages` via `safeJsonStringify` *before* `_checkCompaction` mutated it, so the trajectory still shows the pre-compaction count — making the trajectory look correct while the actual provider call is starved of context. OpenClaw's runner already drives compaction itself (`shouldPreemptivelyCompactBeforePrompt` and the tool-result-context-guard mid-turn precheck), so Pi's parallel auto-compaction inside `Session.prompt()` is redundant for the failure cases this fix targets.
- **Fix**: Extend `applyPiAutoCompactionGuard` so `setCompactionEnabled(false)` also fires when the active model matches z.ai-style silent-overflow accounting. Detection routes through structured channels already present in the codebase — the `ProviderEndpointClass` typed enum (matching `endpointClass === "zai-native"` for direct `api.z.ai`), the existing `normalizeProviderId` normalizer (matching the `zai` family for a config-set z.ai provider), and a `z-ai/` or `openrouter/z-ai/` model-id prefix as a documented string fallback for openrouter routing — any one signal is sufficient. The compaction-LLM call site reads `effectiveModel.baseUrl` (the post-`applyAuthHeaderOverride` view that matches every other reference in that scope), so an `api.z.ai` baseUrl injected via auth profile is still visible to the detector. The existing `contextEngineInfo.ownsCompaction === true` short-circuit is preserved unchanged. Default-mode runs against non-z.ai providers are *not* touched — Pi's auto-compaction stays on for them, preserving the existing baseline. To survive `DefaultResourceLoader.reload()` rehydrating settings from disk and silently re-enabling auto-compaction (the same rehydration the existing `applyPiCompactionSettingsFromConfig` re-call sites already document), the guard is invoked **a second time after the reload** in both the embedded runner and the runner-driven compaction LLM session, mirroring the pattern already used for compaction config rehydration.
- **What changed**:
  - `src/agents/pi-settings.ts`: new exported `isSilentOverflowProneModel({provider, modelId, baseUrl})` helper using `resolveProviderEndpoint`'s `endpointClass`, `normalizeProviderId`, and the `z-ai/` / `openrouter/z-ai/` model-id prefix. `shouldDisablePiAutoCompaction` and `applyPiAutoCompactionGuard` accept a new `silentOverflowProneProvider?: boolean` in addition to the existing `contextEngineInfo`.
  - `src/agents/pi-embedded-runner/run/attempt.ts`: the existing `applyPiAutoCompactionGuard` call now computes `silentOverflowProneProvider` from `params.model`. A second `applyPiAutoCompactionGuard` call is added immediately after `resourceLoader.reload()`, alongside the existing post-reload `applyPiCompactionSettingsFromConfig` re-call.
  - `src/agents/pi-embedded-runner/compact.ts`: imports `applyPiAutoCompactionGuard` and `isSilentOverflowProneModel`; adds a guard call after the local `resourceLoader.reload()`. This site previously had no guard call at all, leaving the nested compaction LLM session vulnerable to the same `_checkCompaction` re-entry on z.ai-style runs.
  - `src/agents/pi-settings.test.ts`: nine new cases appended to the existing colocated test file. Five cases for `isSilentOverflowProneModel` (z-ai-prefixed model ids in both bare and qualified forms, config-set `z.ai`/`z-ai` provider, direct `api.z.ai` baseUrl, anthropic/openai/google routes negative, missing fields negative) and four cases for `applyPiAutoCompactionGuard` (silent-overflow-prone disables, `ownsCompaction === true` still disables, default-mode + non-z.ai is left enabled, missing `setCompactionEnabled` reports unsupported).
- **What did NOT change (scope boundary)**:
  - No vendored dependency edits — `pi-coding-agent` and `pi-ai` are untouched. Their compaction and overflow-detection logic is correct in isolation; this fix only stops them from firing in parallel with OpenClaw's runner-owned compaction in the cases listed above.
  - No change to default-mode runs against non-z.ai providers. They retain Pi's auto-compaction inside `Session.prompt()` as before.
  - No change to other documented-unreliable providers (e.g. ollama silent truncation). Reporter's repro is z.ai-specific; extending the guard without an actual repro would be speculation.
  - No change to `shouldPreemptivelyCompactBeforePrompt`, the tool-result-context-guard mid-turn precheck, context-engine assemble, the trajectory event's snapshot timing, or any provider transport.
  - No change to the CLI `/compact` entrypoint surface — its nested runner-driven compaction LLM session is protected through the `compact.ts` site this PR modifies.
  - No `any` types introduced.
  - No edits to baseline / inventory / snapshot fixtures.

### Reproduction

1. Run OpenClaw with the bundled legacy `LegacyContextEngine` (default).
2. Configure an OpenAI-compatible provider that points at a z.ai-style model — for example, `provider: openrouter` with `model: z-ai/glm-5.1` via a custom `baseUrl` for an in-house model gateway. Anything where the previous successful assistant turn has `usage.input + usage.cacheRead > model.contextWindow` works (z.ai-family accounting is documented as silent-overflow style in pi-ai's overflow.ts).
3. Open a Telegram session and send: `"first off - there's a folder full of my projects at /root/code - these all live in github. They're my main focus"`. The agent calls a tool, observes `/root/code`, and replies.
4. Send a follow-up: `"just note where they are - remember that. They'll be needed in future"`.
5. Capture the outbound openai-completions request body at the gateway (correlate with the run id from the OpenClaw trajectory). Without the fix, the body contains only the system message and the just-sent user message, while the trajectory's `prompt.submitted` event records the full pre-existing transcript. The agent's reply ignores the earlier `/root/code` context and asks what *"they"* refers to.
6. With this fix, `applyPiAutoCompactionGuard` sets `setCompactionEnabled(false)` for z.ai-style runs both before *and* after `resourceLoader.reload()`, Pi's `_checkCompaction` short-circuits inside `Session.prompt()`, `state.messages` keeps its prior contents, and the model receives the full transcript. Coreference resolves correctly.

Targeted test: `pnpm test src/agents/pi-settings.test.ts` — 25/25 pass (16 existing + 9 new), including the explicit silent-overflow-prone disable regression case for #75799 and the explicit baseline-preservation case for default-mode + non-z.ai providers.

### Risk / Mitigation

- **Risk 1 — Real overflow recovery on z.ai**: With Pi's auto-compaction off for z.ai-style runs, a genuine context overflow on the previous turn previously had two recovery paths (Pi's `_runAutoCompaction` and OpenClaw's `shouldPreemptivelyCompactBeforePrompt`). After this PR only OpenClaw's path runs for z.ai.
  - **Mitigation**: OpenClaw's preemptive check already runs unconditionally on every turn and skips submission with a preemptive-overflow signal when compaction is needed; the tool-result-context-guard mid-turn precheck handles overflows mid-tool-loop. The runner's compaction recovery path then drives compaction. Default-mode runs against non-z.ai providers are not changed — they keep Pi's auto-compaction as the secondary recovery.
- **Risk 2 — z.ai detection scope**: `isSilentOverflowProneModel` uses three signals (typed `endpointClass` enum, normalized provider id, model-id prefix). A future provider rename or an unusual proxy that re-exposes z.ai under a different model-id namespace could miss detection.
  - **Mitigation**: All three signals are documented in JSDoc with their intended channel; the new tests pin each branch; and the helper is exported so follow-up changes can extend it once a reproducible repro for additional providers exists. Detection is intentionally conservative — false negatives leave the existing buggy behavior, but never invent a regression for unrelated providers. The auth-profile-injected baseUrl case is exercised at the compaction-LLM site by reading the post-override `effectiveModel.baseUrl`.
- **Risk 3 — Rehydration regression**: The post-reload re-call adds two new call sites. If `applyPiAutoCompactionGuard` ever gains expensive side effects, those sites will execute twice per run.
  - **Mitigation**: `applyPiAutoCompactionGuard` is a small decision plus at most one `setCompactionEnabled(false)` call; that write is idempotent (sets the same field to the same value when already disabled). The two `applyPiCompactionSettingsFromConfig` calls already follow the same "before + after reload" pattern at the same files.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents (pi-embedded-runner, pi-settings)
- [x] Tests

### Linked Issue/PR

Fixes #75799