### PR TITLE
fix #76010: [Feishu] Support separate mention requirement for topic threads vs normal group messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -598,12 +598,15 @@ export async function handleFeishuMessage(params: {
       }
     }
 
+    const isTopicMessage = ctx.chatType === "topic_group";
+
     ({ requireMention } = resolveFeishuReplyPolicy({
       isDirectMessage: false,
       cfg,
       accountId: account.accountId,
       groupId: ctx.chatId,
       groupPolicy,
+      isTopic: isTopicMessage,
     }));
 
     if (requireMention && !ctx.mentionedBot) {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -159,6 +159,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    topicRequireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -182,6 +183,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  topicRequireMention: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),

--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -90,6 +90,85 @@ describe("resolveFeishuReplyPolicy", () => {
       }),
     ).toEqual({ requireMention: true });
   });
+
+  it("uses topicRequireMention for topic messages when set at group level", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        isTopic: true,
+        cfg: createCfg({
+          groupPolicy: "open",
+          requireMention: true,
+          groups: { oc_1: { topicRequireMention: false } },
+        }),
+        groupPolicy: "open",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("uses topicRequireMention for topic messages when set at top level", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        isTopic: true,
+        cfg: createCfg({
+          groupPolicy: "open",
+          topicRequireMention: false,
+          requireMention: true,
+        }),
+        groupPolicy: "open",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("falls back to requireMention for topic messages when topicRequireMention is unset", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        isTopic: true,
+        cfg: createCfg({
+          groupPolicy: "open",
+          requireMention: true,
+        }),
+        groupPolicy: "open",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: true });
+  });
+
+  it("uses group-level topicRequireMention over top-level topicRequireMention", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        isTopic: true,
+        cfg: createCfg({
+          groupPolicy: "open",
+          topicRequireMention: true,
+          groups: { oc_1: { topicRequireMention: false } },
+        }),
+        groupPolicy: "open",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: false });
+  });
+
+  it("does not apply topicRequireMention to non-topic messages", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        isTopic: false,
+        cfg: createCfg({
+          groupPolicy: "open",
+          requireMention: true,
+          groups: { oc_1: { topicRequireMention: false } },
+        }),
+        groupPolicy: "open",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: true });
+  });
 });
 
 describe("resolveFeishuGroupConfig", () => {

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -207,6 +207,8 @@ export function resolveFeishuReplyPolicy(params: {
    * @-mentions are still delivered to the agent.
    */
   groupPolicy?: "open" | "allowlist" | "disabled" | "allowall";
+  /** When true, the message is in a topic thread and topicRequireMention takes priority. */
+  isTopic?: boolean;
 }): { requireMention: boolean } {
   if (params.isDirectMessage) {
     return { requireMention: false };
@@ -220,17 +222,40 @@ export function resolveFeishuReplyPolicy(params: {
     normalizeAccountId,
     omitKeys: ["defaultAccount"],
   });
-  const groupRequireMention = resolveFeishuGroupConfig({
+  const groupConfig = resolveFeishuGroupConfig({
     cfg: resolvedCfg,
     groupId: params.groupId,
-  })?.requireMention;
+  });
+  const groupRequireMention = groupConfig?.requireMention;
+  const groupTopicRequireMention = groupConfig?.topicRequireMention;
+  const resolvedRequireMention = resolvedCfg.requireMention;
+  const resolvedTopicRequireMention = resolvedCfg.topicRequireMention;
+
+  const defaultRequireMention = params.groupPolicy !== "open";
+
+  // For topic messages, topicRequireMention takes priority over requireMention.
+  // Fall back to requireMention when topicRequireMention is unset.
+  if (params.isTopic) {
+    return {
+      requireMention:
+        typeof groupTopicRequireMention === "boolean"
+          ? groupTopicRequireMention
+          : typeof resolvedTopicRequireMention === "boolean"
+            ? resolvedTopicRequireMention
+            : typeof groupRequireMention === "boolean"
+              ? groupRequireMention
+              : typeof resolvedRequireMention === "boolean"
+                ? resolvedRequireMention
+                : defaultRequireMention,
+    };
+  }
 
   return {
     requireMention:
       typeof groupRequireMention === "boolean"
         ? groupRequireMention
-        : typeof resolvedCfg.requireMention === "boolean"
-          ? resolvedCfg.requireMention
-          : params.groupPolicy !== "open",
+        : typeof resolvedRequireMention === "boolean"
+          ? resolvedRequireMention
+          : defaultRequireMention,
   };
 }


### PR DESCRIPTION
## Summary
Fixes #76010

### Issue
[[Feishu] Support separate mention requirement for topic threads vs normal group messages](https://github.com/openclaw/openclaw/issues/76010)

### Solution
<!-- Describe the changes made -->


### Testing
<!-- Describe how the fix was tested -->

