### PR TITLE
fix(control-ui): contain viewport in iOS PWA standalone mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: contain the standalone iOS PWA viewport with safe-area-aware document locking, so Add-to-Home-Screen launches cannot scroll past the device bounds. Refs #76072. Thanks @kvncrw.
 - Agents/restart recovery: match cleaned transcript locks by exact transcript lock paths plus the canonical session fallback, so interrupted main sessions using topic-suffixed transcripts resume after gateway restart. Refs #76052. Thanks @anyech.
 - Telegram/native commands: pass persisted session files into plugin commands for topic-bound sessions, so `/codex bind` works from Telegram forum topics. Refs #75845 and #76049. Thanks @MatthewSchleder.
 - Security audit/plugins: ignore plugin install backup, disabled, and dependency debris directories when enumerating installed plugin roots, avoiding false-positive findings for `.openclaw-install-backups` after plugin updates. Fixes #75456.

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>OpenClaw Control</title>
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -106,6 +106,10 @@
   --duration-fast: 100ms;
   --duration-normal: 180ms;
   --duration-slow: 300ms;
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
 
   color-scheme: dark;
 }
@@ -530,6 +534,40 @@ openclaw-app {
   position: relative;
   z-index: 1;
   min-height: 100vh;
+}
+
+@media (display-mode: standalone) {
+  html,
+  body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
+  @supports (height: 100dvh) {
+    html,
+    body {
+      height: 100dvh;
+    }
+  }
+
+  body {
+    position: fixed;
+    inset: 0;
+    padding-top: var(--safe-area-top);
+    padding-right: var(--safe-area-right);
+    padding-bottom: var(--safe-area-bottom);
+    padding-left: var(--safe-area-left);
+  }
+
+  openclaw-app {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
 }
 
 a {


### PR DESCRIPTION
## Problem

When OpenClaw Control UI is added to home screen on iOS Safari and launched in standalone PWA mode, the page scrolls both horizontally and vertically past the device bounds, ignores safe-area insets around the notch and home indicator, and does not compact to the device viewport. In a regular Safari tab the system address bar reflow constrains the visual viewport, so the bug is not visible there.

Repro:
1. Open the Control UI on iPhone Safari.
2. Add to Home Screen, launch the resulting icon (`display-mode: standalone`).
3. Scroll the document; observe both axes scroll past the screen bounds.

## Cause

- The viewport meta lacks `viewport-fit=cover`, so iOS does not expose the `safe-area-inset-*` env() values to CSS.
- `html`/`body` are not locked to the dynamic viewport with `overflow: hidden`, so iOS standalone mode lets the document become the scroll container.
- The top-level `openclaw-app` element does not enforce `min-width: 0` / `min-height: 0`, so flex/grid descendants with intrinsic content width can expand the page horizontally.

## Fix

Minimal CSS-only patch, gated on `@media (display-mode: standalone)` so desktop and regular Safari tabs are unaffected:

- Add `viewport-fit=cover` to the existing viewport meta.
- Add `safe-area-inset-*` CSS custom properties on `:root`.
- In standalone mode only:
  - Lock `html`/`body` to `100dvh` with `overflow: hidden`.
  - `position: fixed; inset: 0` the body.
  - Apply `safe-area` padding to body.
  - Constrain `openclaw-app` to the body's content box with `min-width: 0; min-height: 0`.

## Files

- `ui/index.html` — viewport meta
- `ui/src/styles/base.css` — `:root` vars + standalone @media block

## Verification

After the patch, on iPhone PWA standalone:

- `document.documentElement.scrollWidth <= window.innerWidth`
- `document.documentElement.scrollHeight <= window.innerHeight`
- Inner panes (chat list, sidebar) scroll normally; only the document is locked.

Desktop and regular Safari tabs render identically because all new rules are inside `@media (display-mode: standalone)`.