### PR TITLE
fix #76071: handle thoughtSignature-only parts to prevent Gemini stream hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Google: fix Gemini 2.5 Flash-Lite `reasoning: "minimal"` rejections by raising its thinking-budget floor to 512 while preserving the existing Gemini 2.5 Pro and Flash minimal presets. (#70629) Thanks @ericberic.
 - Agents/status: resolve `session_status(sessionKey="current")` for sparse channel-plugin sessions after literal current lookups miss, so Scope, Slack, Discord, and other plugin-driven agents avoid retrying through `Unknown sessionKey: current`. Fixes #74141. (#72306) Thanks @bittoby.
 - Cron: retry recurring wake-now main-session jobs through temporary heartbeat busy skips before recording success, so queued cron events no longer appear as ok ghost runs while the main lane is still busy. Fixes #75964. (#76083) Thanks @kshetrajna12 and @xuruiray.
+- Providers/Google: keep Gemini thinking-signature-only stream chunks active during reasoning, so Gemini 3.1 Pro Preview replies no longer hit idle timeouts before visible text. Fixes #76071. (#76080) Thanks @marcoschierhorn and @zhangguiping-xydt.
 
 ## 2026.4.30
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -768,7 +768,7 @@ describe("google transport stream", () => {
     });
   });
 
-  it("emits a thinking_signature event for thoughtSignature-only parts to keep the stream active", async () => {
+  it("emits thinking activity for thoughtSignature-only parts to keep the stream active", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       buildSseResponse([
         {
@@ -810,12 +810,28 @@ describe("google transport stream", () => {
         { reasoning: "high" },
       ),
     );
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
     const result = await stream.result();
 
     expect(result.content).toEqual([
       { type: "thinking", thinking: "draft", thinkingSignature: "sig_2" },
       { type: "text", text: "answer" },
     ]);
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "thinking_start",
+      "thinking_delta",
+      "thinking_delta",
+      "thinking_end",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+    expect(events[3]).toMatchObject({ type: "thinking_delta", delta: "" });
   });
 
   it("starts a thinking block for thoughtSignature-only parts that arrive before any text", async () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -767,4 +767,104 @@ describe("google transport stream", () => {
       thinkingConfig: { includeThoughts: true, thinkingBudget: expectedBudget },
     });
   });
+
+  it("emits a thinking_signature event for thoughtSignature-only parts to keep the stream active", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thought: true, text: "draft", thoughtSignature: "sig_1" },
+                  { thoughtSignature: "sig_2" },
+                  { text: "answer" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 5,
+            thoughtsTokenCount: 3,
+            totalTokenCount: 18,
+          },
+        },
+      ]),
+    );
+
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          systemPrompt: "You are a helpful assistant.",
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+        { reasoning: "high" },
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      { type: "thinking", thinking: "draft", thinkingSignature: "sig_2" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("starts a thinking block for thoughtSignature-only parts that arrive before any text", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thoughtSignature: "sig_1" },
+                  { thought: true, text: "draft" },
+                  { text: "answer" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 10,
+            candidatesTokenCount: 5,
+            thoughtsTokenCount: 3,
+            totalTokenCount: 18,
+          },
+        },
+      ]),
+    );
+
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          systemPrompt: "You are a helpful assistant.",
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+        { reasoning: "high" },
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      { type: "thinking", thinking: "draft", thinkingSignature: "sig_1" },
+      { type: "text", text: "answer" },
+    ]);
+  });
 });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -797,8 +797,11 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
           const candidate = chunk.candidates?.[0];
           if (candidate?.content?.parts) {
             for (const part of candidate.content.parts) {
-              if (typeof part.text === "string") {
-                const isThinking = part.thought === true;
+              const hasThoughtSignature =
+                typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
+              const hasText = typeof part.text === "string";
+              if (hasText || (hasThoughtSignature && !part.functionCall)) {
+                const isThinking = part.thought === true || !hasText;
                 const currentBlock = output.content[currentBlockIndex];
                 if (
                   currentBlockIndex < 0 ||
@@ -829,7 +832,8 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 }
                 const activeBlock = output.content[currentBlockIndex];
                 if (activeBlock?.type === "thinking") {
-                  activeBlock.thinking += part.text;
+                  const delta = hasText ? part.text : "";
+                  activeBlock.thinking += delta;
                   activeBlock.thinkingSignature = retainThoughtSignature(
                     activeBlock.thinkingSignature,
                     part.thoughtSignature,
@@ -837,7 +841,7 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   stream.push({
                     type: "thinking_delta",
                     contentIndex: currentBlockIndex,
-                    delta: part.text,
+                    delta,
                     partial: output as never,
                   });
                 } else if (activeBlock?.type === "text") {
@@ -891,45 +895,6 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   type: "toolcall_end",
                   contentIndex: blockIndex,
                   toolCall,
-                  partial: output as never,
-                });
-              }
-              // Gemini 3+ models can emit thoughtSignature-only parts during the
-              // thinking phase before user-visible text arrives. Emit a stream event
-              // so that idle-timeout wrappers detect model activity and don't kill
-              // the stream prematurely.
-              if (
-                typeof part.thoughtSignature === "string" &&
-                part.thoughtSignature.length > 0 &&
-                typeof part.text !== "string" &&
-                !part.functionCall
-              ) {
-                if (
-                  currentBlockIndex < 0 ||
-                  output.content[currentBlockIndex]?.type !== "thinking"
-                ) {
-                  if (currentBlockIndex >= 0) {
-                    pushTextBlockEnd(stream, output, currentBlockIndex);
-                  }
-                  output.content.push({ type: "thinking", thinking: "" });
-                  currentBlockIndex = output.content.length - 1;
-                  stream.push({
-                    type: "thinking_start",
-                    contentIndex: currentBlockIndex,
-                    partial: output as never,
-                  });
-                }
-                const activeBlock = output.content[currentBlockIndex];
-                if (activeBlock?.type === "thinking") {
-                  activeBlock.thinkingSignature = retainThoughtSignature(
-                    activeBlock.thinkingSignature,
-                    part.thoughtSignature,
-                  );
-                }
-                stream.push({
-                  type: "thinking_signature",
-                  contentIndex: currentBlockIndex,
-                  signature: part.thoughtSignature,
                   partial: output as never,
                 });
               }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -894,6 +894,45 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   partial: output as never,
                 });
               }
+              // Gemini 3+ models can emit thoughtSignature-only parts during the
+              // thinking phase before user-visible text arrives. Emit a stream event
+              // so that idle-timeout wrappers detect model activity and don't kill
+              // the stream prematurely.
+              if (
+                typeof part.thoughtSignature === "string" &&
+                part.thoughtSignature.length > 0 &&
+                typeof part.text !== "string" &&
+                !part.functionCall
+              ) {
+                if (
+                  currentBlockIndex < 0 ||
+                  output.content[currentBlockIndex]?.type !== "thinking"
+                ) {
+                  if (currentBlockIndex >= 0) {
+                    pushTextBlockEnd(stream, output, currentBlockIndex);
+                  }
+                  output.content.push({ type: "thinking", thinking: "" });
+                  currentBlockIndex = output.content.length - 1;
+                  stream.push({
+                    type: "thinking_start",
+                    contentIndex: currentBlockIndex,
+                    partial: output as never,
+                  });
+                }
+                const activeBlock = output.content[currentBlockIndex];
+                if (activeBlock?.type === "thinking") {
+                  activeBlock.thinkingSignature = retainThoughtSignature(
+                    activeBlock.thinkingSignature,
+                    part.thoughtSignature,
+                  );
+                }
+                stream.push({
+                  type: "thinking_signature",
+                  contentIndex: currentBlockIndex,
+                  signature: part.thoughtSignature,
+                  partial: output as never,
+                });
+              }
             }
           }
           if (typeof candidate?.finishReason === "string") {


### PR DESCRIPTION
## Summary
Fixes #76071 — Gemini 3.1 Pro Preview hangs in agent runtime

### Issue
[Bug]: Gemini 3.1 Pro Preview hangs in agent runtime; direct API works in seconds, openclaw idle-times-out at full timeoutSeconds

### Changes
- `fix(google): handle thoughtSignature-only parts to prevent Gemini stream hang`

### Changed Files
```
extensions/google/transport-stream.test.ts | 100 +++++++++++++++++++++++++++++
extensions/google/transport-stream.ts      |  39 +++++++++++
```

### Root Cause
Gemini 3.1 Pro Preview may emit parts with only `thoughtSignature` and no text content, causing the transport stream to stall at `idle-timeout`.

### Fix
Emit a `thinking_signature` event for `thoughtSignature`-only parts to keep the stream active, and start a thinking block when these parts arrive before any text.