### PR TITLE
fix(plugins): gate runtime provider discovery by plugins.allow

### DIFF
--- a/src/agents/models-config.providers.plugin-allowlist-compat.test.ts
+++ b/src/agents/models-config.providers.plugin-allowlist-compat.test.ts
@@ -84,6 +84,30 @@ describe("implicit provider plugin allowlist compatibility", () => {
     ).toEqual(["kilocode", "moonshot", "openrouter"]);
   });
 
+  it("respects allowlist for bundled plugins when bundledMode is respect-allow", () => {
+    const config = withBundledPluginEnablementCompat({
+      config: withBundledPluginAllowlistCompat({
+        config: {
+          plugins: {
+            allow: ["openrouter"],
+            bundledMode: "respect-allow",
+          },
+        },
+        pluginIds: ["kilocode", "moonshot"],
+      }),
+      pluginIds: ["kilocode", "moonshot"],
+    });
+
+    expect(
+      resolveEnabledProviderPluginIds({
+        config,
+        registry: providerRegistry,
+        manifestRegistry: providerManifestRegistry,
+        onlyPluginIds: PROVIDER_PLUGIN_IDS,
+      }),
+    ).toEqual(["openrouter"]);
+  });
+
   it("still honors explicit plugin denies over compat allowlist injection", () => {
     const config = withBundledPluginEnablementCompat({
       config: withBundledPluginAllowlistCompat({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1208,6 +1208,8 @@ export const FIELD_HELP: Record<string, string> = {
     'Select the active memory plugin by id, or "none" to disable memory plugins.',
   "plugins.slots.contextEngine":
     "Selects the active context engine plugin by id so one plugin provides context orchestration behavior.",
+  "plugins.bundledMode":
+    'Controls whether bundled plugins bypass plugins.allow on runtime discovery paths. "compat" (default) preserves legacy behavior where bundled provider plugins are force-loaded on every chat turn. "respect-allow" gates bundled plugins by the allowlist the same way third-party plugins are gated.',
   "plugins.entries":
     "Per-plugin settings keyed by plugin ID including enablement and plugin-specific runtime configuration payloads. Use this for scoped plugin tuning without changing global loader policy.",
   "plugins.entries.*.enabled":

--- a/src/config/types.plugins.ts
+++ b/src/config/types.plugins.ts
@@ -47,6 +47,16 @@ export type PluginsConfig = {
   allow?: string[];
   /** Optional plugin denylist (plugin ids). */
   deny?: string[];
+  /**
+   * Controls whether bundled plugins bypass `allow` / `entries` on runtime
+   * provider discovery paths.
+   *
+   * - `"compat"` (default): bundled provider plugins are force-loaded on
+   *   every chat turn regardless of the allowlist (legacy behavior).
+   * - `"respect-allow"`: bundled provider plugins are gated by `allow` and
+   *   `entries.<id>.enabled` the same way third-party plugins are.
+   */
+  bundledMode?: "compat" | "respect-allow";
   load?: PluginsLoadConfig;
   slots?: PluginSlotsConfig;
   entries?: Record<string, PluginEntryConfig>;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1059,6 +1059,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         entries: z.record(z.string(), PluginEntrySchema).optional(),
+        bundledMode: z.enum(["compat", "respect-allow"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -78,13 +78,20 @@ export function withActivatedPluginIds(params: {
   if (params.pluginIds.length === 0) {
     return params.config;
   }
-  const allow = new Set(params.config?.plugins?.allow ?? []);
+  const originalAllow = params.config?.plugins?.allow ?? [];
+  const respectAllow =
+    params.config?.plugins?.bundledMode === "respect-allow" && originalAllow.length > 0;
+  const originalAllowSet = respectAllow ? new Set(originalAllow) : undefined;
+  const allow = new Set(originalAllow);
   const entries = {
     ...params.config?.plugins?.entries,
   };
   for (const pluginId of params.pluginIds) {
     const normalized = pluginId.trim();
     if (!normalized) {
+      continue;
+    }
+    if (originalAllowSet && !originalAllowSet.has(normalized)) {
       continue;
     }
     allow.add(normalized);

--- a/src/plugins/bundled-compat.ts
+++ b/src/plugins/bundled-compat.ts
@@ -6,6 +6,9 @@ export function withBundledPluginAllowlistCompat(params: {
   config: OpenClawConfig | undefined;
   pluginIds: readonly string[];
 }): OpenClawConfig | undefined {
+  if (params.config?.plugins?.bundledMode === "respect-allow") {
+    return params.config;
+  }
   const allow = params.config?.plugins?.allow;
   if (!Array.isArray(allow) || allow.length === 0) {
     return params.config;
@@ -39,11 +42,16 @@ export function withBundledPluginEnablementCompat(params: {
 }): OpenClawConfig | undefined {
   const existingEntries = params.config?.plugins?.entries ?? {};
   const forcePluginsEnabled = params.config?.plugins?.enabled === false;
+  const respectAllow = params.config?.plugins?.bundledMode === "respect-allow";
+  const allowSet = respectAllow ? new Set(params.config?.plugins?.allow ?? []) : undefined;
   let changed = false;
   const nextEntries: Record<string, PluginEntryConfig> = { ...existingEntries };
 
   for (const pluginId of params.pluginIds) {
     if (existingEntries[pluginId] !== undefined) {
+      continue;
+    }
+    if (allowSet && !allowSet.has(pluginId)) {
       continue;
     }
     nextEntries[pluginId] = { enabled: true };

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -590,6 +590,75 @@ describe("resolvePluginProviders", () => {
     ).toEqual(["legacy-auth-owner"]);
   });
 
+  it("filters bundled provider plugins by allowlist when bundledMode is respect-allow", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "kilocode",
+        providerIds: ["kilocode"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+      createManifestProviderPlugin({
+        id: "moonshot",
+        providerIds: ["moonshot"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+      createManifestProviderPlugin({
+        id: "openrouter",
+        providerIds: ["openrouter"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+    ]);
+
+    const discovered = resolveDiscoveredProviderPluginIds({
+      config: {
+        plugins: {
+          allow: ["openrouter"],
+          bundledMode: "respect-allow",
+        },
+      },
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(discovered).toEqual(["openrouter"]);
+  });
+
+  it("returns all bundled provider plugins in compat mode (default)", () => {
+    setManifestPlugins([
+      createManifestProviderPlugin({
+        id: "kilocode",
+        providerIds: ["kilocode"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+      createManifestProviderPlugin({
+        id: "moonshot",
+        providerIds: ["moonshot"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+      createManifestProviderPlugin({
+        id: "openrouter",
+        providerIds: ["openrouter"],
+        origin: "bundled",
+        enabledByDefault: true,
+      }),
+    ]);
+
+    const discovered = resolveDiscoveredProviderPluginIds({
+      config: {
+        plugins: {
+          allow: ["openrouter"],
+        },
+      },
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(discovered).toEqual(["kilocode", "moonshot", "openrouter"]);
+  });
+
   it("treats explicit empty provider scopes as scoped-empty in provider helpers", () => {
     expect(
       resolveEnabledProviderPluginIds({

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -262,6 +262,7 @@ export function resolveDiscoveredProviderPluginIds(params: {
   const { registry, onlyPluginIdSet } = loadScopedProviderRegistry(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
   const shouldFilterUntrustedWorkspacePlugins = params.includeUntrustedWorkspacePlugins === false;
+  const shouldFilterBundledByAllowlist = params.config?.plugins?.bundledMode === "respect-allow";
   const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
   return listRegistryPluginIds(registry, (plugin) => {
     if (
@@ -275,6 +276,7 @@ export function resolveDiscoveredProviderPluginIds(params: {
     return isProviderPluginEligibleForSetupDiscovery({
       plugin,
       shouldFilterUntrustedWorkspacePlugins,
+      shouldFilterBundledByAllowlist,
       normalizedConfig,
       rootConfig: params.config,
     });
@@ -284,10 +286,15 @@ export function resolveDiscoveredProviderPluginIds(params: {
 function isProviderPluginEligibleForSetupDiscovery(params: {
   plugin: PluginRegistryRecord;
   shouldFilterUntrustedWorkspacePlugins: boolean;
+  shouldFilterBundledByAllowlist: boolean;
   normalizedConfig: NormalizedPluginsConfig;
   rootConfig?: PluginLoadOptions["config"];
 }): boolean {
-  if (!params.shouldFilterUntrustedWorkspacePlugins || params.plugin.origin !== "workspace") {
+  if (params.plugin.origin === "workspace") {
+    if (!params.shouldFilterUntrustedWorkspacePlugins) {
+      return true;
+    }
+  } else if (!params.shouldFilterBundledByAllowlist) {
     return true;
   }
   if (
@@ -313,12 +320,14 @@ export function resolveDiscoverableProviderOwnerPluginIds(params: {
   includeUntrustedWorkspacePlugins?: boolean;
 }): string[] {
   const shouldFilterUntrustedWorkspacePlugins = params.includeUntrustedWorkspacePlugins === false;
+  const shouldFilterBundledByAllowlist = params.config?.plugins?.bundledMode === "respect-allow";
   return resolveProviderOwnerPluginIds({
     ...params,
     isEligible: (plugin, normalizedConfig) =>
       isProviderPluginEligibleForSetupDiscovery({
         plugin,
         shouldFilterUntrustedWorkspacePlugins,
+        shouldFilterBundledByAllowlist,
         normalizedConfig,
         rootConfig: params.config,
       }),


### PR DESCRIPTION
## Summary

- Adds `plugins.bundledMode: "respect-allow"` config option that makes runtime provider plugin discovery honor `plugins.allow` for bundled plugins
- When set, bundled provider plugins are filtered by the allowlist on chat-turn discovery, matching startup behavior
- Default `"compat"` preserves existing force-load-all behavior for backwards compatibility

**Root cause**: `isProviderPluginEligibleForSetupDiscovery()` short-circuits to `true` for all `origin: "bundled"` plugins without checking the allowlist. Then `withActivatedPluginIds()` unconditionally adds every discovered plugin ID to `config.plugins.allow`, blowing open any user-set allowlist. Together these cause all ~12 bundled provider plugins to load on every first message regardless of the user's `plugins.allow` setting.

**Fix layers**:
1. `providers.ts` — thread `shouldFilterBundledByAllowlist` into discovery eligibility, derived from `bundledMode === "respect-allow"`
2. `activation-context.ts` — don't add plugin IDs to allow set that aren't already in the user's allowlist when `respect-allow`
3. `bundled-compat.ts` — skip compat allowlist/enablement injection when `respect-allow`
4. `types.plugins.ts` — add `bundledMode` field to `PluginsConfig`

## Test plan

- [x] Existing `models-config.providers.plugin-allowlist-compat.test.ts` passes (3/3) — compat behavior preserved
- [x] New test: `respect-allow` mode returns only allowed plugins from `resolveEnabledProviderPluginIds`
- [x] New test: `respect-allow` filters bundled plugins in `resolveDiscoveredProviderPluginIds`
- [x] New test: default/compat mode returns all bundled provider plugins (backwards compat)
- [x] `pnpm build` — no new errors in changed files
- [x] Formatting clean via `oxfmt`

Closes #75575

🤖 Generated with [Claude Code](https://claude.com/claude-code)