### PR TITLE
Escape backticks in zsh completion descriptions

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -31,6 +31,25 @@ describe("completion-cli", () => {
     expect(script).toContain("--force[Force the action]");
   });
 
+  it("escapes zsh descriptions that contain backticks", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program
+      .command("models")
+      .description("Model commands")
+      .option("--status-json", "Output JSON (alias for `models status --json`)");
+    program
+      .command("hooks")
+      .description("Hook commands")
+      .command("install")
+      .description("Deprecated: install via `openclaw plugins install`");
+
+    const script = getCompletionScript("zsh", program);
+
+    expect(script).toContain("--status-json[Output JSON (alias for \\`models status --json\\`)]");
+    expect(script).toContain("install[Deprecated: install via \\`openclaw plugins install\\`]");
+  });
+
   it("defers zsh registration until compinit is available", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -195,6 +195,7 @@ function generateZshArgs(cmd: Command): string {
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
       const desc = opt.description
         .replace(/\\/g, "\\\\")
+        .replace(/`/g, "\\`")
         .replace(/"/g, '\\"')
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
@@ -213,6 +214,7 @@ function generateZshSubcmdList(cmd: Command): string {
       const desc = c
         .description()
         .replace(/\\/g, "\\\\")
+        .replace(/`/g, "\\`")
         .replace(/'/g, "'\\''")
         .replace(/\[/g, "\\[")
         .replace(/\]/g, "\\]");


### PR DESCRIPTION
## Summary
- Escape backticks in generated zsh option descriptions to avoid command substitution.
- Apply the same escaping to generated zsh subcommand descriptions.
- Add a regression test covering command examples wrapped in backticks.

## Test plan
- [x] `pnpm --dir ~/Projects/github.com/openclaw exec node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/completion-cli.test.ts`
- [x] `pnpm --dir ~/Projects/github.com/openclaw exec node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)