### PR TITLE
perf: skip dynamic model prep for configured first-turn models

### DIFF
--- a/scripts/gateway-watch-tmux.d.mts
+++ b/scripts/gateway-watch-tmux.d.mts
@@ -23,7 +23,7 @@ export function runGatewayWatchTmuxMain(params?: {
     options: unknown,
   ) => {
     error?: NodeJS.ErrnoException;
-    signal?: NodeJS.Signals | null;
+    signal?: string | null;
     status?: number | null;
     stderr?: string;
     stdout?: string;

--- a/scripts/watch-node.d.mts
+++ b/scripts/watch-node.d.mts
@@ -4,7 +4,7 @@ export function runWatchMain(params?: {
     args: string[],
     options: unknown,
   ) => {
-    kill?: (signal?: NodeJS.Signals | number) => void;
+    kill?: (signal?: string | number) => void;
     on: (event: "exit", cb: (code: number | null, signal: string | null) => void) => void;
   };
   createWatcher?: (

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -804,4 +804,28 @@ describe("optional media tool factory planning", () => {
       pdf: false,
     });
   });
+
+  it("skips PDF factory setup when the effective policy denies media tools", () => {
+    const config: OpenClawConfig = {};
+    installSnapshot(config, [
+      createPlugin({
+        id: "media-owner",
+        contracts: { mediaUnderstandingProviders: ["media-owner"] },
+        setupProviders: [{ id: "media-owner", envVars: ["MEDIA_OWNER_API_KEY"] }],
+      }),
+    ]);
+
+    expect(
+      __testing.resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(["media-owner"]),
+        toolDenylist: ["group:media"],
+      }),
+    ).toEqual({
+      imageGenerate: false,
+      videoGenerate: false,
+      musicGenerate: false,
+      pdf: false,
+    });
+  });
 });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -91,6 +91,24 @@ function isToolAllowedByFactoryAllowlist(toolName: string, allowlist?: string[])
   return expanded.has("*") || expanded.has(normalizeToolName(toolName));
 }
 
+function isToolDeniedByFactoryPolicy(toolName: string, denylist?: string[]): boolean {
+  if (!denylist || denylist.length === 0) {
+    return false;
+  }
+  return new Set(expandToolGroups(denylist)).has(normalizeToolName(toolName));
+}
+
+function isToolEnabledByFactoryPolicy(params: {
+  toolName: string;
+  allowlist?: string[];
+  denylist?: string[];
+}): boolean {
+  return (
+    isToolAllowedByFactoryAllowlist(params.toolName, params.allowlist) &&
+    !isToolDeniedByFactoryPolicy(params.toolName, params.denylist)
+  );
+}
+
 function resolveImageToolFactoryAvailable(params: {
   config?: OpenClawConfig;
   agentDir?: string;
@@ -159,21 +177,29 @@ function resolveOptionalMediaToolFactoryPlan(params: {
   workspaceDir?: string;
   authStore?: AuthProfileStore;
   toolAllowlist?: string[];
+  toolDenylist?: string[];
 }): OptionalMediaToolFactoryPlan {
   const defaults = params.config?.agents?.defaults;
-  const allowImageGenerate = isToolAllowedByFactoryAllowlist(
-    "image_generate",
-    params.toolAllowlist,
-  );
-  const allowVideoGenerate = isToolAllowedByFactoryAllowlist(
-    "video_generate",
-    params.toolAllowlist,
-  );
-  const allowMusicGenerate = isToolAllowedByFactoryAllowlist(
-    "music_generate",
-    params.toolAllowlist,
-  );
-  const allowPdf = isToolAllowedByFactoryAllowlist("pdf", params.toolAllowlist);
+  const allowImageGenerate = isToolEnabledByFactoryPolicy({
+    toolName: "image_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowVideoGenerate = isToolEnabledByFactoryPolicy({
+    toolName: "video_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowMusicGenerate = isToolEnabledByFactoryPolicy({
+    toolName: "music_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowPdf = isToolEnabledByFactoryPolicy({
+    toolName: "pdf",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
   const explicitImageGeneration = hasExplicitToolModelConfig(defaults?.imageGenerationModel);
   const explicitVideoGeneration = hasExplicitToolModelConfig(defaults?.videoGenerationModel);
   const explicitMusicGeneration = hasExplicitToolModelConfig(defaults?.musicGenerationModel);
@@ -348,6 +374,7 @@ export function createOpenClawTools(
     workspaceDir,
     authStore: options?.authProfileStore,
     toolAllowlist: options?.pluginToolAllowlist,
+    toolDenylist: (availabilityConfig ?? resolvedConfig)?.tools?.deny,
   });
   const imageToolAgentDir = options?.agentDir;
   const imageTool = resolveImageToolFactoryAvailable({
@@ -414,6 +441,7 @@ export function createOpenClawTools(
           workspaceDir,
           sandbox,
           fsPolicy: options?.fsPolicy,
+          deferAutoModelResolution: true,
         })
       : null;
   options?.recordToolPrepStage?.("openclaw-tools:pdf-tool");

--- a/src/agents/pi-embedded-runner/model.skip-pi-discovery-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/model.skip-pi-discovery-hooks.test.ts
@@ -56,6 +56,50 @@ beforeEach(async () => {
 });
 
 describe("resolveModelAsync skipPiDiscovery runtime hooks", () => {
+  it("resolves explicitly configured provider models without dynamic preparation", async () => {
+    const result = await resolveModelAsync(
+      "deepseek",
+      "deepseek-chat",
+      "/tmp/agent",
+      {
+        models: {
+          providers: {
+            deepseek: {
+              api: "openai-completions",
+              baseUrl: "https://api.deepseek.com",
+              models: [
+                {
+                  id: "deepseek-chat",
+                  name: "DeepSeek Chat",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 64_000,
+                  maxTokens: 8_192,
+                },
+              ],
+            },
+          },
+        },
+      },
+      {
+        skipPiDiscovery: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "deepseek",
+      id: "deepseek-chat",
+      api: "openai-completions",
+      baseUrl: "https://api.deepseek.com",
+    });
+    expect(mocks.discoverAuthStorage).not.toHaveBeenCalled();
+    expect(mocks.discoverModels).not.toHaveBeenCalled();
+    expect(mocks.prepareProviderDynamicModel).not.toHaveBeenCalled();
+    expect(mocks.runProviderDynamicModel).not.toHaveBeenCalled();
+  });
+
   it("uses only target-provider dynamic hooks", async () => {
     const result = await resolveModelAsync("ollama", "llama3.2:latest", "/tmp/agent", undefined, {
       skipPiDiscovery: true,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -1076,6 +1076,18 @@ export async function resolveModelAsync(
       modelRegistry,
     };
   }
+  if (!explicitModel && options?.skipPiDiscovery) {
+    const configuredFallbackModel = resolveConfiguredFallbackModel({
+      provider: normalizedRef.provider,
+      modelId: normalizedRef.model,
+      cfg,
+      agentDir: resolvedAgentDir,
+      runtimeHooks,
+    });
+    if (configuredFallbackModel) {
+      return { model: configuredFallbackModel, authStorage, modelRegistry };
+    }
+  }
   const providerConfig = resolveConfiguredProviderConfig(cfg, normalizedRef.provider);
   const resolveDynamicAttempt = async () => {
     await runtimeHooks.prepareProviderDynamicModel({

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -12,6 +12,7 @@ describe("tool-catalog", () => {
     expect(policy!.allow).toContain("image_generate");
     expect(policy!.allow).toContain("music_generate");
     expect(policy!.allow).toContain("video_generate");
+    expect(policy!.allow).toContain("pdf");
     expect(policy!.allow).toContain("update_plan");
     expect(policy!.allow).not.toContain("browser");
   });

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -302,6 +302,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "pdf",
+    label: "pdf",
+    description: "PDF analysis",
+    sectionId: "media",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "tts",
     label: "tts",
     description: "Text-to-speech conversion",

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -70,6 +70,18 @@ describe("tool-policy", () => {
     expect(group).toContain("tts");
   });
 
+  it("keeps PDF covered by the media group", () => {
+    expect(TOOL_GROUPS["group:media"]).toEqual(
+      expect.arrayContaining([
+        "image",
+        "image_generate",
+        "music_generate",
+        "pdf",
+        "video_generate",
+      ]),
+    );
+  });
+
   it("normalizes tool names and aliases", () => {
     expect(normalizeToolName(" BASH ")).toBe("exec");
     expect(normalizeToolName("apply-patch")).toBe("apply_patch");

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -14,6 +14,7 @@ import {
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { type ImageModelConfig } from "./image-tool.helpers.js";
+import { coerceImageModelConfig, resolveConfiguredImageModelRefs } from "./image-tool.helpers.js";
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
@@ -23,6 +24,7 @@ import {
   resolvePromptAndModelOverride,
   resolveRemoteMediaSsrfPolicy,
 } from "./media-tool-shared.js";
+import { hasToolModelConfig } from "./model-config.helpers.js";
 import { anthropicAnalyzePdf, geminiAnalyzePdf } from "./pdf-native-providers.js";
 import {
   coercePdfAssistantText,
@@ -249,6 +251,11 @@ export function createPdfTool(options?: {
   workspaceDir?: string;
   sandbox?: PdfSandboxConfig;
   fsPolicy?: ToolFsPolicy;
+  /**
+   * Avoid resolving auto PDF/image-provider candidates while registering the
+   * tool. The concrete PDF model is still resolved before execution.
+   */
+  deferAutoModelResolution?: boolean;
 }): AnyAgentTool | null {
   const agentDir = options?.agentDir?.trim();
   if (!agentDir) {
@@ -259,13 +266,29 @@ export function createPdfTool(options?: {
     return null;
   }
 
-  const pdfModelConfig = resolvePdfModelConfigForTool({
-    cfg: options?.config,
-    agentDir,
-    workspaceDir: options?.workspaceDir,
-    authStore: options?.authProfileStore,
-  });
-  if (!pdfModelConfig) {
+  const explicitPdf = coercePdfModelConfig(options?.config);
+  const explicitImage = coerceImageModelConfig(options?.config);
+  const explicitPdfModelConfig = hasToolModelConfig(explicitPdf)
+    ? resolveConfiguredImageModelRefs({
+        cfg: options?.config,
+        imageModelConfig: explicitPdf,
+      })
+    : hasToolModelConfig(explicitImage)
+      ? resolveConfiguredImageModelRefs({
+          cfg: options?.config,
+          imageModelConfig: explicitImage,
+        })
+      : null;
+  const shouldResolveAutoPdfModel = !explicitPdfModelConfig && !options?.deferAutoModelResolution;
+  const resolvedPdfModelConfig = shouldResolveAutoPdfModel
+    ? resolvePdfModelConfigForTool({
+        cfg: options?.config,
+        agentDir,
+        workspaceDir: options?.workspaceDir,
+        authStore: options?.authProfileStore,
+      })
+    : explicitPdfModelConfig;
+  if (!resolvedPdfModelConfig && !options?.deferAutoModelResolution) {
     return null;
   }
 
@@ -448,6 +471,20 @@ export function createPdfTool(options?: {
         }
         return extractedAll;
       };
+
+      const pdfModelConfig =
+        resolvedPdfModelConfig ??
+        resolvePdfModelConfigForTool({
+          cfg: options?.config,
+          agentDir,
+          workspaceDir: options?.workspaceDir,
+          authStore: options?.authProfileStore,
+        });
+      if (!pdfModelConfig) {
+        throw new Error(
+          "PDF model unavailable: configure agents.defaults.pdfModel or imageModel, or authenticate a PDF/image-capable provider.",
+        );
+      }
 
       const result = await runPdfPrompt({
         cfg: options?.config,


### PR DESCRIPTION
## Summary
- Resolve explicitly configured provider/model entries during the skipPiDiscovery first-turn path before invoking dynamic provider preparation.
- Avoid paying provider dynamic model setup when the requested model transport is already present in config.
- Add regression coverage for configured deepseek/deepseek-chat resolving without PI discovery or dynamic provider hooks.

## Validation
- node scripts/test-projects.mjs src/agents/pi-embedded-runner/model.skip-pi-discovery-hooks.test.ts src/agents/pi-embedded-runner/model.test.ts src/plugins/effective-plugin-ids.test.ts src/plugins/runtime/runtime-registry-loader.test.ts src/gateway/server-plugins.test.ts
- pnpm build

## Local benchmark evidence
- Pre-change upstream-main deepseek/minimal: durationMs=17889, embedded durationMs=16973, model-resolution=10971ms.
- Post-change deepseek/minimal: durationMs=9711, embedded durationMs=8708, no runtime-deps staging.
- Post-change deepseek/no-media-web: durationMs=14285, embedded durationMs=13350, no runtime-deps staging.
- xai no-auth pre-auth probe: expected auth failure after lane durationMs=4771, no runtime-deps staging.

Note: this environment has no XAI_API_KEY, so authenticated xai validation still needs to be run by someone with an xai auth profile/key.