### PR TITLE
fix(ci): restore baseline checks

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -10,6 +10,8 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
   "src/auto-reply/reply/get-reply.test-loader.ts",
   "src/cli/daemon-cli-compat.ts",
   "src/commands/doctor/shared/deprecation-compat.ts",
+  "src/commands/doctor/shared/legacy-config-runtime-migrate.ts",
+  "src/commands/doctor/shared/runtime-compat-api.ts",
   "src/config/doc-baseline.runtime.ts",
   "src/config/doc-baseline.ts",
   "src/gateway/gateway-cli-backend.live-helpers.ts",

--- a/src/cli/channel-options.test.ts
+++ b/src/cli/channel-options.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testing, resolveCliChannelOptions } from "./channel-options.js";
+import { __testing as startupMetadataTesting } from "./startup-metadata.js";
 
 const readFileSyncMock = vi.hoisted(() => vi.fn());
 
@@ -23,6 +24,7 @@ vi.mock("../channels/ids.js", () => ({
 describe("resolveCliChannelOptions", () => {
   afterEach(() => {
     __testing.resetPrecomputedChannelOptionsForTests();
+    startupMetadataTesting.clearStartupMetadataCache();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- clear startup metadata cache between CLI channel option tests
- allowlist runtime doctor compatibility helper files in the deadcode unused-file gate

## Verification
- pnpm test src/cli/channel-options.test.ts
- pnpm deadcode:unused-files
- pnpm deadcode:ci
- pnpm tsgo:prod
- pnpm exec oxfmt --check --threads=1 src/cli/channel-options.test.ts scripts/deadcode-unused-files.allowlist.mjs
- git diff --check