### PR TITLE
fix(ci): restore baseline checks

### DIFF
--- a/scripts/deadcode-unused-files.allowlist.mjs
+++ b/scripts/deadcode-unused-files.allowlist.mjs
@@ -70,4 +70,8 @@ export const KNIP_UNUSED_FILE_ALLOWLIST = [
 // Knip can disagree across supported local/CI platforms for files that are
 // only reachable through test-only import graphs. Ignore these when reported,
 // but do not require them to be reported.
-export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = ["src/gateway/test/server-sessions-helpers.ts"];
+export const KNIP_OPTIONAL_UNUSED_FILE_ALLOWLIST = [
+  "src/commands/doctor/shared/legacy-config-runtime-migrate.ts",
+  "src/commands/doctor/shared/runtime-compat-api.ts",
+  "src/gateway/test/server-sessions-helpers.ts",
+];

--- a/src/cli/channel-options.test.ts
+++ b/src/cli/channel-options.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testing, resolveCliChannelOptions } from "./channel-options.js";
+import { __testing as startupMetadataTesting } from "./startup-metadata.js";
 
 const readFileSyncMock = vi.hoisted(() => vi.fn());
 
@@ -23,6 +24,7 @@ vi.mock("../channels/ids.js", () => ({
 describe("resolveCliChannelOptions", () => {
   afterEach(() => {
     __testing.resetPrecomputedChannelOptionsForTests();
+    startupMetadataTesting.clearStartupMetadataCache();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- clear startup metadata cache between CLI channel option tests
- treat runtime doctor compatibility helper files as optional Knip unused-file allowlist entries across platforms

## Verification
- pnpm test src/cli/channel-options.test.ts
- pnpm deadcode:unused-files
- pnpm deadcode:ci
- pnpm tsgo:prod
- pnpm exec oxfmt --check --threads=1 src/cli/channel-options.test.ts scripts/deadcode-unused-files.allowlist.mjs
- git diff --check