### PR TITLE
fix(codex): emit dynamic tool progress events [AI-assisted]

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -597,6 +597,101 @@ describe("runCodexAppServerAttempt", () => {
     expect(queueAgentHarnessMessage("session-1", "after timeout")).toBe(false);
   });
 
+  it("emits TUI-compatible tool events for Codex dynamic tool calls", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const onRunAgentEvent = vi.fn();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    __testing.setCodexAppServerClientFactoryForTests(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+    params.onAgentEvent = onRunAgentEvent;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), { interval: 1 });
+
+    await expect(
+      handleRequest?.({
+        id: "request-tool-1",
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: null,
+          tool: "message",
+          arguments: { action: "send", text: "already sent" },
+        },
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      contentItems: [{ type: "inputText", text: "Unknown OpenClaw tool: message" }],
+    });
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await run;
+
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: {
+        phase: "start",
+        name: "message",
+        toolCallId: "call-1",
+        args: { action: "send", text: "already sent" },
+      },
+    });
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "tool",
+      data: {
+        phase: "result",
+        name: "message",
+        toolCallId: "call-1",
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "Unknown OpenClaw tool: message" }],
+        },
+      },
+    });
+  });
+
   it("releases the session when Codex accepts a turn but never sends progress", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -72,6 +72,7 @@ import {
   type CodexServerNotification,
   type CodexDynamicToolCallParams,
   type CodexDynamicToolCallResponse,
+  type CodexDynamicToolCallOutputContentItem,
   type CodexTurnStartResponse,
   type JsonObject,
   type JsonValue,
@@ -905,6 +906,7 @@ export async function runCodexAppServerAttempt(
         name: call.tool,
         arguments: call.arguments,
       });
+      emitCodexDynamicToolStartEvent(params, call);
       const response = await handleDynamicToolCallWithTimeout({
         call,
         toolBridge,
@@ -928,6 +930,7 @@ export async function runCodexAppServerAttempt(
         success: response.success,
         contentItems: response.contentItems,
       });
+      emitCodexDynamicToolResultEvent(params, call, response);
       return response as JsonValue;
     } finally {
       activeAppServerTurnRequests = Math.max(0, activeAppServerTurnRequests - 1);
@@ -1323,6 +1326,59 @@ function failedDynamicToolResponse(message: string): CodexDynamicToolCallRespons
   return {
     success: false,
     contentItems: [{ type: "inputText", text: message }],
+  };
+}
+
+function emitCodexDynamicToolStartEvent(
+  params: EmbeddedRunAttemptParams,
+  call: CodexDynamicToolCallParams,
+): void {
+  emitCodexAppServerEvent(params, {
+    stream: "tool",
+    data: {
+      phase: "start",
+      name: call.tool,
+      toolCallId: call.callId,
+      args: call.arguments,
+    },
+  });
+}
+
+function emitCodexDynamicToolResultEvent(
+  params: EmbeddedRunAttemptParams,
+  call: CodexDynamicToolCallParams,
+  response: CodexDynamicToolCallResponse,
+): void {
+  emitCodexAppServerEvent(params, {
+    stream: "tool",
+    data: {
+      phase: "result",
+      name: call.tool,
+      toolCallId: call.callId,
+      isError: !response.success,
+      result: codexDynamicToolResponseToToolResult(response),
+    },
+  });
+}
+
+function codexDynamicToolResponseToToolResult(
+  response: CodexDynamicToolCallResponse,
+): Record<string, unknown> {
+  return {
+    content: response.contentItems.map(codexDynamicToolContentItemToToolContent),
+  };
+}
+
+function codexDynamicToolContentItemToToolContent(
+  item: CodexDynamicToolCallOutputContentItem,
+): Record<string, unknown> {
+  if (item.type === "inputText") {
+    return { type: "text", text: item.text };
+  }
+  return {
+    type: "image",
+    mimeType: "image",
+    imageUrl: item.imageUrl,
   };
 }
 


### PR DESCRIPTION
## Summary
- emit canonical `stream: "tool"` start/result events around Codex app-server dynamic tool calls
- normalize Codex dynamic tool output into the TUI-compatible tool result shape
- add a regression test covering the Codex dynamic tool request path

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/codex/src/app-server/run-attempt.test.ts`

## Note
This branch is based on my fork main because my token cannot sync upstream workflow-file history, but the change is intentionally limited to the Codex app-server dynamic tool call path.