### PR TITLE
fix(codex): mark idle-timeout flags so embedded retry path engages

### DIFF
--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -95,6 +95,8 @@ export class CodexAppServerEventProjector {
   private promptError: unknown;
   private promptErrorSource: EmbeddedRunAttemptResult["promptErrorSource"] = null;
   private aborted = false;
+  private timedOut = false;
+  private idleTimedOut = false;
   private tokenUsage: ReturnType<typeof normalizeUsage>;
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
@@ -217,8 +219,8 @@ export class CodexAppServerEventProjector {
     return {
       aborted: this.aborted || turnInterrupted,
       externalAbort: false,
-      timedOut: false,
-      idleTimedOut: false,
+      timedOut: this.timedOut,
+      idleTimedOut: this.idleTimedOut,
       timedOutDuringCompaction: false,
       promptError,
       promptErrorSource: promptError ? this.promptErrorSource || "prompt" : null,
@@ -257,8 +259,10 @@ export class CodexAppServerEventProjector {
     };
   }
 
-  markTimedOut(): void {
+  markTimedOut(kind: "idle" | "wallclock" = "idle"): void {
     this.aborted = true;
+    this.timedOut = true;
+    this.idleTimedOut = kind === "idle";
     this.promptError = "codex app-server attempt timed out";
     this.promptErrorSource = "prompt";
   }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1055,7 +1055,7 @@ export async function runCodexAppServerAttempt(
   const timeout = setTimeout(
     () => {
       timedOut = true;
-      projector?.markTimedOut();
+      projector?.markTimedOut("wallclock");
       runAbortController.abort("timeout");
     },
     Math.max(100, params.timeoutMs),


### PR DESCRIPTION
When a Codex app-server attempt times out (no `turn/completed` arrives
within the turn-completion idle window), the event projector calls
markTimedOut() which sets `aborted = true` and a prompt error string.
But the result returned by buildResult() hardcoded
`timedOut: false, idleTimedOut: false`.

The embedded runner's failover policy gates the same-model idle-timeout
retry on those flags (see allowSameModelIdleTimeoutRetry in
pi-embedded-runner: it requires `timedOut && idleTimedOut`). Because the
flags were never set, every Codex app-server timeout fell through to
`surface_error` even when a quick retry on the same model would recover.

This is observable when the upstream WebSocket goes silent mid-stream
(e.g. Cloudflare-fronted `api.openai.com` cutting an idle WebSocket
during a long-context turn — see openai/codex#17003): the harness
correctly fires its own turn-completion idle timer, but the embedded
runner cannot retry, so the user sees an "app-server attempt timed out"
failure even when a fresh request would have succeeded immediately.

Changes:

- Add private `timedOut` / `idleTimedOut` fields on
  `CodexAppServerEventProjector`.
- Surface them through `buildResult()` so consumers (pi-embedded-runner)
  see the real values instead of hardcoded `false`.
- `markTimedOut()` accepts an optional `kind: "idle" | "wallclock"`
  (default `"idle"`) so the projector distinguishes idle-watchdog
  timeouts from the outer wallclock `timeoutMs` abort. The wallclock
  caller in `run-attempt.ts` passes `"wallclock"` to keep
  `idleTimedOut` false in that case (a hard wallclock cap reaching
  3+ hours is semantically different from an idle stall and should
  not necessarily trigger same-model retry).
- Behaviour on non-timeout aborts is unchanged: both flags remain
  `false`, preserving existing test expectations.