### PR TITLE
fix: use context-aware reserveTokensFloor in overflow recovery hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/agent-runner: make context-overflow recovery guidance choose `agents.defaults.compaction.reserveTokensFloor` from the active model context window instead of always recommending `20000`, so large-context Feishu conversations no longer appear to overflow after only a few messages. Fixes #65839 and #72106. Thanks @XuXuClassMate.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.
 - Gateway/cron: stop a lazy cron startup that loses a hot-reload race, preventing the old cron service from starting after reload has already replaced cron state.

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
@@ -8,6 +9,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildContextOverflowRecoveryText,
+  computeContextAwareReserveTokensFloor,
   MAX_LIVE_SWITCH_RETRIES,
 } from "./agent-runner-execution.js";
 import type { FollowupRun } from "./queue.js";
@@ -311,8 +313,21 @@ function createMinimalRunAgentTurnParams(overrides?: {
   };
 }
 
+describe("computeContextAwareReserveTokensFloor", () => {
+  it("returns context-window-aware reserve floor tiers", () => {
+    expect(computeContextAwareReserveTokensFloor(1_000_000)).toBe(100_000);
+    expect(computeContextAwareReserveTokensFloor(999_999)).toBe(50_000);
+    expect(computeContextAwareReserveTokensFloor(200_000)).toBe(50_000);
+    expect(computeContextAwareReserveTokensFloor(199_999)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(100_000)).toBe(35_000);
+    expect(computeContextAwareReserveTokensFloor(99_999)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(undefined)).toBe(20_000);
+    expect(computeContextAwareReserveTokensFloor(0)).toBe(20_000);
+  });
+});
+
 describe("buildContextOverflowRecoveryText", () => {
-  it("keeps the generic compaction-buffer hint without heartbeat model evidence", () => {
+  it("uses the shared default context window without heartbeat model evidence", () => {
     const text = buildContextOverflowRecoveryText({
       cfg: {},
       primaryProvider: "openrouter",
@@ -320,7 +335,55 @@ describe("buildContextOverflowRecoveryText", () => {
     });
 
     expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain(
+      `to ${computeContextAwareReserveTokensFloor(DEFAULT_CONTEXT_TOKENS)} or higher`,
+    );
     expect(text).not.toContain("heartbeat model bleed");
+  });
+
+  it("uses primary model metadata before stale session context tokens", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.test",
+              models: [makeTestModel("qwen3.6-plus", 1_000_000)],
+            },
+          },
+        },
+      },
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "qwen3.6-plus",
+        contextTokens: 32_768,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("to 100000 or higher");
+  });
+
+  it("falls back to session context tokens when model metadata is unavailable", () => {
+    const text = buildContextOverflowRecoveryText({
+      cfg: {},
+      primaryProvider: "openrouter",
+      primaryModel: "qwen3.6-plus",
+      activeSessionEntry: {
+        sessionId: "session",
+        updatedAt: 1,
+        modelProvider: "openrouter",
+        model: "qwen3.6-plus",
+        contextTokens: 100_000,
+      },
+    });
+
+    expect(text).toContain("reserveTokensFloor");
+    expect(text).toContain("to 35000 or higher");
   });
 
   it("points to heartbeat model bleed when the last runtime model matches configured heartbeat.model", () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import {
@@ -459,9 +460,32 @@ function buildExternalRunFailureReply(
   };
 }
 
-const CONTEXT_OVERFLOW_RESET_HINT =
-  "\n\nTo prevent this, increase your compaction buffer by setting " +
-  "`agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.";
+const DEFAULT_RESERVE_TOKENS_FLOOR = 20_000;
+
+export function computeContextAwareReserveTokensFloor(contextWindow: number | undefined): number {
+  if (!contextWindow || contextWindow <= 0) {
+    return DEFAULT_RESERVE_TOKENS_FLOOR;
+  }
+  if (contextWindow >= 1_000_000) {
+    return 100_000;
+  }
+  if (contextWindow >= 200_000) {
+    return 50_000;
+  }
+  if (contextWindow >= 100_000) {
+    return 35_000;
+  }
+  return DEFAULT_RESERVE_TOKENS_FLOOR;
+}
+
+function buildContextOverflowResetHint(contextWindow: number | undefined): string {
+  const effectiveContextWindow = contextWindow ?? DEFAULT_CONTEXT_TOKENS;
+  const reserveFloor = computeContextAwareReserveTokensFloor(effectiveContextWindow);
+  return (
+    "\n\nTo prevent this, increase your compaction buffer by setting " +
+    `\`agents.defaults.compaction.reserveTokensFloor\` to ${reserveFloor} or higher in your config.`
+  );
+}
 
 type ModelRefLike = {
   provider: string;
@@ -617,16 +641,22 @@ export function buildContextOverflowRecoveryText(params: {
   const prefix = params.duringCompaction
     ? "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again."
     : "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.";
-  return (
-    prefix +
-    (resolveHeartbeatBleedHint({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      primaryProvider: params.primaryProvider,
-      primaryModel: params.primaryModel,
-      activeSessionEntry: params.activeSessionEntry,
-    }) ?? CONTEXT_OVERFLOW_RESET_HINT)
-  );
+  const heartbeatHint = resolveHeartbeatBleedHint({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    primaryProvider: params.primaryProvider,
+    primaryModel: params.primaryModel,
+    activeSessionEntry: params.activeSessionEntry,
+  });
+  if (heartbeatHint) {
+    return prefix + heartbeatHint;
+  }
+  const primaryContextWindow = resolveContextWindowForHint({
+    cfg: params.cfg,
+    ref: { provider: params.primaryProvider ?? "", model: params.primaryModel ?? "" },
+    activeSessionEntry: params.activeSessionEntry,
+  });
+  return prefix + buildContextOverflowResetHint(primaryContextWindow);
 }
 
 function shouldApplyOpenAIGptChatGuard(params: { provider?: string; model?: string }): boolean {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -541,21 +541,22 @@ function resolveContextWindowForHint(params: {
   ref: ModelRefLike;
   activeSessionEntry?: SessionEntry;
 }) {
+  const modelContextWindow = resolveContextTokensForModel({
+    cfg: params.cfg,
+    provider: params.ref.provider,
+    model: params.ref.model,
+    allowAsyncLoad: false,
+  });
+  if (modelContextWindow != null && modelContextWindow > 0) {
+    return modelContextWindow;
+  }
   const activeContextTokens =
     typeof params.activeSessionEntry?.contextTokens === "number" &&
     Number.isFinite(params.activeSessionEntry.contextTokens) &&
     params.activeSessionEntry.contextTokens > 0
       ? Math.floor(params.activeSessionEntry.contextTokens)
       : undefined;
-  return (
-    activeContextTokens ??
-    resolveContextTokensForModel({
-      cfg: params.cfg,
-      provider: params.ref.provider,
-      model: params.ref.model,
-      allowAsyncLoad: false,
-    })
-  );
+  return activeContextTokens ?? undefined;
 }
 
 function resolveHeartbeatBleedHint(params: {


### PR DESCRIPTION
## Summary

Replace the hardcoded 20000 `reserveTokensFloor` hint with context-window-aware tiers (100k/50k/35k/20k based on model context size).

## Changes

- Add `computeContextAwareReserveTokensFloor()` function with tier logic:
  - 100_000 for contextWindow >= 1_000_000
  - 50_000 for contextWindow >= 200_000
  - 35_000 for contextWindow >= 100_000
  - 20_000 for smaller/undefined
- Use session `contextTokens` as fallback when model metadata unavailable
- Use `DEFAULT_CONTEXT_TOKENS` as fallback when both model metadata and session context are unavailable
- Add comprehensive unit tests for tier boundaries

## Files Changed

- `src/auto-reply/reply/agent-runner-execution.ts`
- `src/auto-reply/reply/agent-runner-execution.test.ts`
- `CHANGELOG.md`

