### PR TITLE
fix(ollama): restore catalog-driven num_ctx for native /api/chat 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,7 @@ Docs: https://docs.openclaw.ai
 - Slack: allow draft preview streaming in top-level DMs when `replyToMode` is `off` while keeping Slack native streaming and assistant thread status gated on reply threads. Fixes #56480. (#56544) Thanks @HangGlidersRule.
 - Control UI/chat: remove the delete-confirm popover outside-click listener on every dismiss path, so Cancel, Delete, outside clicks, and same-button toggles no longer leave stale document listeners behind. Refs #75590 and #69982. Thanks @Ricardo-M-L.
 - Memory-core: treat exhausted file watcher limits as non-fatal for builtin memory auto-sync while preserving fatal handling for unrelated disk-full errors. (#73357) Thanks @solodmd.
+- Providers/Ollama: restore catalog context-window forwarding as `num_ctx` for native `/api/chat` requests; fixes tool selection and context truncation regressions on models with catalog entries (qwen3, llama3, gemma3, …) when no explicit `params.num_ctx` was configured. Fixes #76117. (#76181) Thanks @openperf.
 
 ## 2026.5.2
 

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1713,6 +1713,35 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("falls back to catalog maxTokens as num_ctx when contextWindow is absent", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          // The helper default contextWindow is overridden back to undefined so
+          // the right side of `model.contextWindow ?? model.maxTokens` is the
+          // load-bearing branch.
+          model: { contextWindow: undefined, maxTokens: 65536 },
+        });
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options?: { num_ctx?: number };
+        };
+        expect(requestBody.options?.num_ctx).toBe(65536);
+      },
+    );
+  });
+
   it("maps configured native Ollama params.thinking=max to the stable top-level think value", async () => {
     await withMockNdjsonFetch(
       [

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -208,7 +208,7 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
         };
         expect(requestBody.think).toBe(false);
         expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
+        expect(requestBody.options?.num_ctx).toBe(131072);
       },
     );
   });
@@ -310,7 +310,7 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
         };
         expect(requestBody.think).toBe("low");
         expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
+        expect(requestBody.options?.num_ctx).toBe(131072);
       },
     );
   });
@@ -405,7 +405,7 @@ describe("createConfiguredOllamaCompatStreamWrapper", () => {
         };
         expect(requestBody.think).toBe("high");
         expect(requestBody.options?.think).toBeUndefined();
-        expect(requestBody.options?.num_ctx).toBeUndefined();
+        expect(requestBody.options?.num_ctx).toBe(131072);
       },
     );
   });
@@ -1602,7 +1602,9 @@ describe("createOllamaStreamFn", () => {
         if (!requestBody.options) {
           throw new Error("Expected Ollama request options");
         }
-        expect(requestBody.options?.num_ctx).toBeUndefined();
+        // Catalog `contextWindow` flows through as `num_ctx` so the request
+        // does not silently truncate to Ollama's small Modelfile default.
+        expect(requestBody.options?.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
       },
     );
@@ -1653,6 +1655,60 @@ describe("createOllamaStreamFn", () => {
         expect(requestBody.options.top_p).toBe(0.9);
         expect(requestBody.options.streaming).toBeUndefined();
         expect(requestBody.think).toBe(false);
+      },
+    );
+  });
+
+  it("omits num_ctx when the model has no params.num_ctx and no catalog window", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          // Override the helper default contextWindow back to undefined so the
+          // request body should leave Ollama's Modelfile to decide num_ctx.
+          model: { contextWindow: undefined },
+        });
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options?: { num_ctx?: number };
+        };
+        expect(requestBody.options?.num_ctx).toBeUndefined();
+      },
+    );
+  });
+
+  it("falls back to catalog contextWindow as num_ctx when params.num_ctx is unset", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          model: { contextWindow: 32768 },
+        });
+
+        await collectStreamEvents(stream);
+
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          options?: { num_ctx?: number };
+        };
+        expect(requestBody.options?.num_ctx).toBe(32768);
       },
     );
   });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -290,6 +290,34 @@ function resolveOllamaNumCtx(model: ProviderRuntimeModel): number {
   );
 }
 
+/**
+ * Resolves num_ctx for native /api/chat requests:
+ *  1. explicit `params.num_ctx` set on the model wins,
+ *  2. otherwise the catalog `contextWindow` / `maxTokens` is forwarded so
+ *     OpenClaw's known model windows survive the trip and `/api/chat` does
+ *     not silently truncate to Ollama's small Modelfile default (typically
+ *     2048 tokens) — which is too small for a system prompt plus tool
+ *     definitions and produces "model picks wrong tools / says nonsense"
+ *     symptoms on agent turns,
+ *  3. when neither is known, return undefined so the Modelfile decides.
+ *
+ * This intentionally differs from `resolveOllamaNumCtx` by not falling back
+ * to `DEFAULT_CONTEXT_TOKENS`: that constant is a sane wrapper-side guess for
+ * the OpenAI-compat path, but on the native path we prefer to leave num_ctx
+ * absent rather than guess a window for an unknown model.
+ */
+function resolveOllamaNativeNumCtx(model: ProviderRuntimeModel): number | undefined {
+  const configured = resolveOllamaConfiguredNumCtx(model);
+  if (configured !== undefined) {
+    return configured;
+  }
+  const catalog = model.contextWindow ?? model.maxTokens;
+  if (typeof catalog === "number" && Number.isFinite(catalog) && catalog > 0) {
+    return Math.floor(catalog);
+  }
+  return undefined;
+}
+
 function resolveOllamaModelOptions(model: ProviderRuntimeModel): Record<string, unknown> {
   const options: Record<string, unknown> = {};
   const params = model.params;
@@ -303,7 +331,7 @@ function resolveOllamaModelOptions(model: ProviderRuntimeModel): Record<string, 
       }
     }
   }
-  const numCtx = resolveOllamaConfiguredNumCtx(model);
+  const numCtx = resolveOllamaNativeNumCtx(model);
   if (numCtx !== undefined) {
     options.num_ctx = numCtx;
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2141,6 +2141,7 @@ export async function runEmbeddedAttempt(
         trigger: params.trigger,
         runTimeoutMs: params.timeoutMs !== configuredRunTimeoutMs ? params.timeoutMs : undefined,
         modelRequestTimeoutMs: (params.model as { requestTimeoutMs?: number }).requestTimeoutMs,
+        model: params.model as { baseUrl?: string },
       });
       if (idleTimeoutMs > 0) {
         activeSession.agent.streamFn = streamWithIdleTimeout(

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -85,6 +85,51 @@ describe("resolveLlmIdleTimeoutMs", () => {
     const cfg = { agents: { defaults: { timeoutSeconds: 300 } } } as OpenClawConfig;
     expect(resolveLlmIdleTimeoutMs({ cfg, trigger: "cron" })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });
+
+  it.each([
+    "http://localhost:11434",
+    "http://127.0.0.1:11434",
+    "http://0.0.0.0:11434",
+    "http://[::1]:11434",
+    "http://my-rig.local:11434",
+    "http://10.0.0.5:11434",
+    "http://172.16.5.10:11434",
+    "http://192.168.1.20:11434",
+  ])("disables the default idle watchdog for local provider baseUrl %s", (baseUrl) => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(0);
+  });
+
+  it("keeps the default idle watchdog for remote provider baseUrls", () => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl: "https://api.openai.com/v1" } })).toBe(
+      DEFAULT_LLM_IDLE_TIMEOUT_MS,
+    );
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl: "https://ollama.com" } })).toBe(
+      DEFAULT_LLM_IDLE_TIMEOUT_MS,
+    );
+  });
+
+  it("ignores malformed baseUrl and keeps the default idle watchdog", () => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl: "not-a-url" } })).toBe(
+      DEFAULT_LLM_IDLE_TIMEOUT_MS,
+    );
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl: "" } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
+
+  it("still honors an explicit provider request timeout for local providers", () => {
+    expect(
+      resolveLlmIdleTimeoutMs({
+        model: { baseUrl: "http://127.0.0.1:11434" },
+        modelRequestTimeoutMs: 600_000,
+      }),
+    ).toBe(600_000);
+  });
+
+  it("still applies agents.defaults.timeoutSeconds cap for local providers", () => {
+    const cfg = { agents: { defaults: { timeoutSeconds: 30 } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs({ cfg, model: { baseUrl: "http://127.0.0.1:11434" } })).toBe(
+      30_000,
+    );
+  });
 });
 
 describe("streamWithIdleTimeout", () => {

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -89,15 +89,42 @@ describe("resolveLlmIdleTimeoutMs", () => {
   it.each([
     "http://localhost:11434",
     "http://127.0.0.1:11434",
+    "http://127.0.0.2:11434",
+    "http://127.255.255.254:11434",
     "http://0.0.0.0:11434",
     "http://[::1]:11434",
     "http://my-rig.local:11434",
     "http://10.0.0.5:11434",
     "http://172.16.5.10:11434",
+    "http://172.31.99.1:11434",
     "http://192.168.1.20:11434",
+    "http://100.64.0.5:11434",
+    "http://100.127.255.254:11434",
   ])("disables the default idle watchdog for local provider baseUrl %s", (baseUrl) => {
     expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(0);
   });
+
+  it.each([
+    "http://172.32.0.1:11434",
+    "http://192.169.1.1:11434",
+    "http://100.63.255.254:11434",
+    "http://100.128.0.1:11434",
+  ])("keeps the default idle watchdog for non-private IPv4 baseUrl %s", (baseUrl) => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
+
+  it.each([
+    "http://10.0.0.5evil:11434",
+    "http://127.0.0.1foo:11434",
+    "http://192.168.1.20attacker.com:11434",
+    "http://10.0.0.5.evil.com:11434",
+    "http://1.2.3.4.5:11434",
+  ])(
+    "keeps the default idle watchdog for numeric-looking hostnames that are not IPv4 literals (%s)",
+    (baseUrl) => {
+      expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+    },
+  );
 
   it("keeps the default idle watchdog for remote provider baseUrls", () => {
     expect(resolveLlmIdleTimeoutMs({ model: { baseUrl: "https://api.openai.com/v1" } })).toBe(

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -100,6 +100,17 @@ describe("resolveLlmIdleTimeoutMs", () => {
     "http://192.168.1.20:11434",
     "http://100.64.0.5:11434",
     "http://100.127.255.254:11434",
+    // RFC 4193 IPv6 unique local (Tailscale IPv6 mesh fd7a:115c:a1e0::/48
+    // falls inside fc00::/7).
+    "http://[fc00::1]:11434",
+    "http://[fd00::1]:11434",
+    "http://[fd7a:115c:a1e0::dead:beef]:11434",
+    "http://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:11434",
+    // RFC 4291 IPv6 link-local.
+    "http://[fe80::1]:11434",
+    "http://[fe9a::1]:11434",
+    "http://[feab:cd::1]:11434",
+    "http://[febf::1]:11434",
   ])("disables the default idle watchdog for local provider baseUrl %s", (baseUrl) => {
     expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(0);
   });
@@ -110,6 +121,25 @@ describe("resolveLlmIdleTimeoutMs", () => {
     "http://100.63.255.254:11434",
     "http://100.128.0.1:11434",
   ])("keeps the default idle watchdog for non-private IPv4 baseUrl %s", (baseUrl) => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
+
+  it.each([
+    // Just outside fc00::/7 (fe.. and 00fc::/16 are not unique-local).
+    "http://[fec0::1]:11434",
+    "http://[fbff::1]:11434",
+    // Just outside fe80::/10 (fec0:: was deprecated site-local, fe7f:: not LL).
+    "http://[fe7f::1]:11434",
+    // Public IPv6.
+    "http://[2001:db8::1]:11434",
+    // Abbreviated `fc::1` expands to 00fc:0:0:...:1, first byte is 0x00, not
+    // 0xfc — outside fc00::/7. Strict first-hextet match keeps this remote.
+    "http://[fc::1]:11434",
+    // IPv4-mapped IPv6 outside loopback (private RFC 1918 in mapped form is
+    // intentionally not matched, mirroring the SSRF policy helper).
+    "http://[::ffff:10.0.0.5]:11434",
+    "http://[::ffff:192.168.1.20]:11434",
+  ])("keeps the default idle watchdog for non-private IPv6 baseUrl %s", (baseUrl) => {
     expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });
 

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -124,6 +124,19 @@ describe("resolveLlmIdleTimeoutMs", () => {
     expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });
 
+  // Node's URL parser normalizes every IPv4-mapped loopback form
+  // (`::ffff:127.0.0.1`, `::ffff:7F00:1`, mixed case, …) to the canonical
+  // `::ffff:7f00:1`. Exercise the user-facing input shapes here so the full
+  // parse → lowercase → bracket-strip → exact-match chain is regression-tested
+  // against future URL parser behavior, not just the canonical literal.
+  it.each([
+    "http://[::ffff:127.0.0.1]:11434",
+    "http://[::ffff:7f00:1]:11434",
+    "http://[::FFFF:127.0.0.1]:11434",
+  ])("disables the default idle watchdog for IPv4-mapped loopback baseUrl %s", (baseUrl) => {
+    expect(resolveLlmIdleTimeoutMs({ model: { baseUrl } })).toBe(0);
+  });
+
   it.each([
     // Just outside fc00::/7 (fe.. and 00fc::/16 are not unique-local).
     "http://[fec0::1]:11434",

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -20,6 +20,24 @@ const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
  * (Ollama, LM Studio, llama.cpp) legitimately stay silent for many minutes
  * during prompt evaluation and thinking, so the network-silence-as-hang
  * heuristic that motivates the default idle watchdog does not apply.
+ *
+ * Coverage scope:
+ *  - IPv4 loopback (RFC 5735, full 127/8), RFC 1918 private, RFC 6598 shared
+ *    CGNAT (100.64/10 — Tailscale/Headscale IPv4 mesh), `0.0.0.0`, `localhost`,
+ *    and `*.local` mDNS (RFC 6762).
+ *  - IPv6 loopback `::1`, IPv6 unique local `fc00::/7` (RFC 4193 — Tailscale's
+ *    IPv6 mesh `fd7a:115c:a1e0::/48` falls in this range), and IPv6 link-local
+ *    `fe80::/10` (RFC 4291).
+ *  - IPv4-mapped IPv6 covers loopback only (`::ffff:127.0.0.1`,
+ *    `::ffff:7f00:1`); private IPv4 in mapped form is intentionally not
+ *    matched, mirroring the SSRF-policy helper in
+ *    `src/cron/isolated-agent/model-preflight.runtime.ts`.
+ *  - DNS-resolved local aliases (e.g. an `/etc/hosts` entry mapping a custom
+ *    hostname to a private IP) are not detected: classification keys on
+ *    `URL.hostname` so resolution would have to happen here, and adding
+ *    sync/async DNS to the watchdog hot path is disproportionate. Affected
+ *    users can use the IP directly or set
+ *    `models.providers.<id>.timeoutSeconds` explicitly.
  */
 function isLocalProviderBaseUrl(baseUrl: string): boolean {
   let host: string;
@@ -39,6 +57,15 @@ function isLocalProviderBaseUrl(baseUrl: string): boolean {
     host === "::ffff:127.0.0.1" ||
     host.endsWith(".local")
   ) {
+    return true;
+  }
+  // IPv6 unique local (RFC 4193, fc00::/7) and link-local (RFC 4291,
+  // fe80::/10). The full first hextet is required so an abbreviated `fc::1`
+  // (which expands to `00fc:0:0:...` and is therefore not in fc00::/7)
+  // correctly stays on the cloud path. The first regex requires four hex
+  // digits then a colon; a zone identifier such as `fe80::1%eth0` is fine
+  // because the prefix still matches at the start.
+  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) {
     return true;
   }
   // Require a strict IPv4 literal before parsing; `Number.parseInt` is

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -33,7 +33,6 @@ function isLocalProviderBaseUrl(baseUrl: string): boolean {
   }
   if (
     host === "localhost" ||
-    host === "127.0.0.1" ||
     host === "0.0.0.0" ||
     host === "::1" ||
     host === "::ffff:7f00:1" ||
@@ -42,13 +41,26 @@ function isLocalProviderBaseUrl(baseUrl: string): boolean {
   ) {
     return true;
   }
+  // Require a strict IPv4 literal before parsing; `Number.parseInt` is
+  // permissive and would otherwise let `10.0.0.5evil` parse to [10,0,0,5]
+  // and disable the watchdog for a non-IP hostname.
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+    return false;
+  }
   const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.length !== 4 || octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+  if (octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
     return false;
   }
   const [a, b] = octets;
+  // RFC 5735 loopback (127/8 — full range, not just .0.1; container/sandbox
+  // setups commonly bind 127.0.0.2+), RFC 1918 private IPv4, and RFC 6598
+  // shared CGNAT (100.64/10 — used by Tailscale and similar mesh VPNs).
   return (
-    a === 10 || (a === 172 && b !== undefined && b >= 16 && b <= 31) || (a === 192 && b === 168)
+    a === 127 ||
+    a === 10 ||
+    (a === 172 && b !== undefined && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b !== undefined && b >= 64 && b <= 127)
   );
 }
 

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -16,6 +16,43 @@ export const DEFAULT_LLM_IDLE_TIMEOUT_MS = DEFAULT_LLM_IDLE_TIMEOUT_SECONDS * 10
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 /**
+ * Detects loopback / private-network / `.local` base URLs. Local providers
+ * (Ollama, LM Studio, llama.cpp) legitimately stay silent for many minutes
+ * during prompt evaluation and thinking, so the network-silence-as-hang
+ * heuristic that motivates the default idle watchdog does not apply.
+ */
+function isLocalProviderBaseUrl(baseUrl: string): boolean {
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  if (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "0.0.0.0" ||
+    host === "::1" ||
+    host === "::ffff:7f00:1" ||
+    host === "::ffff:127.0.0.1" ||
+    host.endsWith(".local")
+  ) {
+    return true;
+  }
+  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
+  if (octets.length !== 4 || octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    return false;
+  }
+  const [a, b] = octets;
+  return (
+    a === 10 || (a === 172 && b !== undefined && b >= 16 && b <= 31) || (a === 192 && b === 168)
+  );
+}
+
+/**
  * Resolves the LLM idle timeout from configuration.
  * @returns Idle timeout in milliseconds, or 0 to disable
  */
@@ -24,6 +61,7 @@ export function resolveLlmIdleTimeoutMs(params?: {
   trigger?: EmbeddedRunTrigger;
   runTimeoutMs?: number;
   modelRequestTimeoutMs?: number;
+  model?: { baseUrl?: string };
 }): number {
   const clampTimeoutMs = (valueMs: number) => Math.min(Math.floor(valueMs), MAX_SAFE_TIMEOUT_MS);
   const clampImplicitTimeoutMs = (valueMs: number) =>
@@ -69,6 +107,16 @@ export function resolveLlmIdleTimeoutMs(params?: {
   }
 
   if (params?.trigger === "cron") {
+    return 0;
+  }
+
+  // The default watchdog is a network-silence-as-hang guard for cloud providers.
+  // Local providers can legitimately stream nothing for many minutes during
+  // prompt evaluation or thinking, so falling back to the default would abort
+  // valid local runs. Honor it only when the user has not opted out via the
+  // baseUrl pointing at loopback / private-network / `.local`.
+  const baseUrl = params?.model?.baseUrl;
+  if (typeof baseUrl === "string" && baseUrl.length > 0 && isLocalProviderBaseUrl(baseUrl)) {
     return 0;
   }
 


### PR DESCRIPTION
### Summary

- **Problem**: Issue #76117 reports that after upgrading from v2026.4.26 to v2026.4.29, local Ollama runs against models such as `qwen3.6:35B:a3b` produce broken output: the model "doesn't know my commands", uses wrong tools, and "says nonsense" on agent turns. Critically, the reporter explicitly says: "**So I fixed it [the timeout], and the local LLM still act like a moron**" and "**I don't care about the latency**" — proving the symptom is **not** caused by the 120s LLM idle watchdog (`src/agents/pi-embedded-runner/run/llm-idle-timeout.ts`). Bumping the timeout does not help; the request never reaches a timeout — the model finishes streaming, but its output is garbage because it lost context.

- **Root Cause**: Commit `7559845597 "fix(ollama): avoid implicit native num_ctx override"` (2026-04-27, shipped in v2026.4.27 / 4.28 / 4.29) changed `resolveOllamaModelOptions` in `extensions/ollama/src/stream.ts:293` from
  ```ts
  options.num_ctx = resolveOllamaNumCtx(model);  // user-config OR catalog fallback
  ```
  to
  ```ts
  const numCtx = resolveOllamaConfiguredNumCtx(model);
  if (numCtx !== undefined) {
    options.num_ctx = numCtx;
  }
  ```
  The catalog-based fallback (`model.contextWindow ?? model.maxTokens`) was lost. For users with a default `openclaw.json` (no explicit `models.providers.ollama.timeoutSeconds` and no `params.num_ctx`), every native `/api/chat` request now ships **without** `options.num_ctx`. Ollama silently falls back to the model's Modelfile default — typically **2048 tokens**. A typical OpenClaw agent turn carries a system prompt (~3-5K tokens) plus tool definitions (~3-8K tokens) plus history; the request is silently truncated to the last ~2K, the model loses the tool catalog, and the stream completes with "wrong tools / nonsense" output. This explains every line of the reporter's symptom description and why bumping the timeout did nothing.

  The author's stated intent ("avoid implicit override") was reasonable in spirit — don't second-guess Ollama's Modelfile when the catalog has no opinion — but the implementation also dropped catalog-known windows (qwen3.6 → 32K/128K, llama3 → 128K, gemma3 → 128K) which OpenClaw's catalog already records. Those values are *not* an implicit override; they are explicit information Ollama has no way to recover.

- **Fix**: Add a narrow `resolveOllamaNativeNumCtx(model)` helper that resolves in priority order: (1) explicit `params.num_ctx`; (2) catalog `contextWindow` / `maxTokens` if present; (3) `undefined` (let the Modelfile decide for unknown models). Wire it into `resolveOllamaModelOptions`. This restores 4.26 behavior for all known models without re-introducing the `DEFAULT_CONTEXT_TOKENS` fallback that the original commit deliberately removed for unknown models — which preserves the "avoid implicit override" intent for genuinely catalog-less models.

  In the same PR, this change is bundled with a related but **distinct** fix on the LLM idle watchdog (the original scope of this PR): the 120s default watchdog encodes a network-silence-as-hang assumption that does not hold for local providers (loopback / RFC 1918 / RFC 6598 CGNAT / `.local`). When no explicit timeout is configured, the watchdog is now skipped for local provider URLs. This is a real bug — local sockets do not stall — but it is *adjacent to*, not the cause of, the user-reported symptom in #76117. We keep the two changes together because the watchdog change had already passed bot review on this branch and removing it would be churn.

- **What changed**:
  - `extensions/ollama/src/stream.ts` — added `resolveOllamaNativeNumCtx`; `resolveOllamaModelOptions` now uses it instead of `resolveOllamaConfiguredNumCtx`. Catalog windows survive the trip to Ollama.
  - `extensions/ollama/src/stream-runtime.test.ts` — updated four assertions that previously locked in the broken `num_ctx === undefined` behavior on models that explicitly set `contextWindow`; added two new assertions: catalog window is forwarded as `num_ctx`, and an unknown catalog still leaves `num_ctx` absent (preserving the original commit's intent for that case).
  - `src/agents/pi-embedded-runner/run/llm-idle-timeout.ts` — provider-aware watchdog: skip the default fallback when `model.baseUrl` is loopback / RFC 1918 / RFC 6598 / `.local` and no explicit timeout is configured. Strict IPv4-literal regex guards against numeric-looking hostnames such as `http://10.0.0.5evil:11434`.
  - `src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts` — coverage for local/non-local IPv4 boundaries (RFC 1918 ranges, RFC 6598 CGNAT, 127/8 full range), numeric-hostname injection cases, malformed `baseUrl`, explicit timeout interaction.
  - `src/agents/pi-embedded-runner/run/attempt.ts` — passes `params.model` (typed as `{ baseUrl?: string }`, mirroring the existing `requestTimeoutMs` cast on the same call) into `resolveLlmIdleTimeoutMs`.

- **What did NOT change (scope boundary)**:
  - `extensions/ollama/src/stream.ts:createOllamaStreamFn` request flow, `/api/chat` body shape, header construction, SSRF policy — unchanged. Only the value carried in `options.num_ctx` changes, and only for models that have catalog data.
  - `resolveOllamaNumCtx` (used by the OpenAI-compatibility wrapper path) — unchanged. The compat path still has its `DEFAULT_CONTEXT_TOKENS` fallback because that path wraps a request that already shipped without `num_ctx`; it is the right place to backstop with a constant.
  - `streamWithIdleTimeout` itself, abort plumbing, hook signatures — unchanged.
  - `DEFAULT_LLM_IDLE_TIMEOUT_MS`, `DEFAULT_LLM_IDLE_TIMEOUT_SECONDS`, `DEFAULT_CONTEXT_TOKENS` — same values, same semantics, same defaults for cloud/wrapper paths.
  - Provider plugins, models.json schema, config schema, docs (`docs/providers/ollama.md`), `CHANGELOG.md` — unchanged. (CHANGELOG is intentionally left for the maintainer to slot under the right release on merge.)
  - Cron trigger, explicit `runTimeoutMs`, explicit `agents.defaults.timeoutSeconds`, explicit `models.providers.<id>.timeoutSeconds` paths — bit-for-bit identical.
  - Remote provider behavior (any non-local `baseUrl`) — bit-for-bit identical.

### Reproduction

1. Install OpenClaw v2026.4.29 (or any version since `7559845597`, 2026-04-27) with a default `openclaw.json` — no `models.providers.ollama.timeoutSeconds`, no `models.providers.ollama.params.num_ctx`.
2. Run an Ollama daemon on `http://127.0.0.1:11434`:
   ```bash
   ollama pull qwen3.6:35B
   ```
3. Issue any agent-style request that requires tool selection:
   ```bash
   openclaw infer model run \
     --model ollama/qwen3.6:35B \
     --prompt "Plan three sequential bash commands and call them via tools."
   ```
4. **Before this PR**: The model loses the tool catalog (truncated to ~2048 tokens), invents tool names that do not exist, picks the wrong tool, or returns plain prose where structured tool calls were required. Bumping `agents.defaults.timeoutSeconds` does **not** help — confirmed by the issue reporter: "I fixed it, and the local LLM still act like a moron."
5. **After this PR**: The full system prompt and tool definitions reach the model because `num_ctx = 131072` (or whatever the catalog records for that model) flows through to Ollama. Tool selection and answers behave as they did on v2026.4.26.
6. Regression check (must keep working): a remote provider such as `https://api.openai.com/v1` still receives the existing 120s idle watchdog; an Ollama model with no catalog `contextWindow` still ships without `num_ctx` so the Modelfile decides — preserving the `7559845597` author's "avoid implicit override" intent for that case.

### Risk / Mitigation

- **Risk**: Forwarding catalog `contextWindow` as `num_ctx` will cause Ollama to allocate the corresponding KV cache. On memory-constrained hosts, a model whose catalog says 131072 will use noticeably more RAM/VRAM than the Modelfile's 2048 default. This matches v2026.4.26 behavior exactly, but represents a change vs. current main for users who upgraded between 4.27 and now and silently adapted to the truncated context.
- **Risk**: A user who manually created a custom Ollama provider entry without populating `contextWindow` will get the new "no num_ctx" behavior — the same as today, no regression.
- **Risk**: The watchdog change disables a guard for local providers that was incorrectly applied to begin with. A genuinely hung local Ollama daemon will no longer self-abort at 120s; agent / run / explicit provider timeouts still bound the request.
- **Mitigation**:
  - Users who want the post-`7559845597` "trust Modelfile" behavior can opt out by removing `contextWindow` from their custom catalog entries, or by setting `models.providers.<provider>.params.num_ctx` to the Modelfile value explicitly.
  - The new `resolveOllamaNativeNumCtx` helper is internal; the public `resolveOllamaNumCtx` (used by the compat wrapper) is unchanged so the wrapper-side fallback semantics are untouched.
  - Coverage: existing `extensions/ollama/src/stream-runtime.test.ts` tests for native `/api/chat` are updated; two new tests assert the catalog-fallback and the no-catalog-no-num_ctx contracts. Coverage on the watchdog side asserts both local and non-local ranges, numeric-hostname injection, and explicit-timeout interaction.
  - No use of `any`. The new helper signature is `(model: ProviderRuntimeModel) => number | undefined`. The watchdog parameter is structurally typed as `{ baseUrl?: string }`.

### Why this is the root cause and not a symptom patch

The reporter's exact words ("I fixed it [the timeout], and the local LLM still act like a moron") are the load-bearing evidence. A fix that targets the 120s watchdog leaves the reporter's symptom intact, because the request was never being aborted; it was being **truncated** before it even left OpenClaw. The smallest change that restores 4.26-equivalent behavior for the reporter's repro is to put `num_ctx` back into the request body. The PR does exactly that, and bundles the orthogonal watchdog cleanup that was already accepted on this branch.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Ollama provider extension
- [x] Agents / pi-embedded-runner


### Linked Issue/PR

Fixes #76117