### PR TITLE
build: never bundle @larksuiteoapi/node-sdk

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -124,6 +124,7 @@ const bundledPluginFile = (pluginId: string, relativePath: string) =>
   `${bundledPluginRoot(pluginId)}/${relativePath}`;
 const explicitNeverBundleDependencies = [
   "@lancedb/lancedb",
+  "@larksuiteoapi/node-sdk",
   "@matrix-org/matrix-sdk-crypto-nodejs",
   "matrix-js-sdk",
   "qrcode-terminal",


### PR DESCRIPTION
Problem: The CJS code in @larksuiteoapi/node-sdk (which uses __dirname) was being inlined by tsdown into the ESM build output. In Node.js 24's ESM context, __dirname is not available, causing the Feishu channel to crash on startup.

Fix: Add @larksuiteoapi/node-sdk to explicitNeverBundleDependencies in tsdown.config.ts so it remains an external dependency with its own CJS module scope.