### PR TITLE
fix(telegram): suppress tool-only silent fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Docs: https://docs.openclaw.ai
 - Memory Wiki: skip empty and whitespace-only source pages when refreshing generated Related blocks, preventing blank pages from being rewritten into Related-only stubs. Fixes #78121. Thanks @amknight.
 - LINE: reject `dmPolicy: "open"` configs without wildcard `allowFrom` so webhook DMs fail validation instead of being acknowledged and silently blocked before inbound processing. Fixes #78316.
 - Telegram/Codex: keep message-tool-only progress drafts visible and render native Codex tool progress once per tool instead of duplicating item/tool draft lines. Fixes #75641. (#77949) Thanks @keshavbotagent.
+- Telegram: keep duplicate message-tool-only Codex turns from posting generic silent-reply fallback text, so private finals stay private after inbound dedupe. Thanks @rubencu.
 - Telegram/sessions: gap-fill delivered embedded final replies into the session JSONL even when the runner trace is missing, so Telegram answers after tool calls do not vanish from the durable transcript. Fixes #77814. (#78426) Thanks @obviyus, @ChushulSuri, and @DougButdorf.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1162,6 +1162,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("does not add silent fallback when source delivery is message-tool-only", async () => {
+    setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "allow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(sendMessageTelegram).not.toHaveBeenCalled();
+  });
+
   it("shows compacting reaction during auto-compaction and resumes thinking", async () => {
     const statusReactionController = {
       setThinking: vi.fn(async () => {}),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2708,6 +2708,68 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps message-tool-only delivery mode on duplicate inbound returns", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "channel",
+      To: "telegram:chat:123",
+      MessageSid: "msg-tool-only-duplicate",
+      SessionKey: "agent:main:telegram:channel:123",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+
+    const first = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    const duplicate = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(first.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(duplicate.sourceReplyDeliveryMode).toBe("message_tool_only");
+  });
+
+  it("does not mark duplicate inbound returns as tool-only when message is unavailable", async () => {
+    setNoAbort();
+    const cfg = { tools: { allow: ["read"] } } as OpenClawConfig;
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "channel",
+      To: "telegram:chat:123",
+      MessageSid: "msg-tool-unavailable-duplicate",
+      SessionKey: "agent:main:telegram:channel:123",
+    });
+    const replyResolver = vi.fn(async () => ({ text: "visible fallback" }) as ReplyPayload);
+
+    const first = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    const duplicate = await dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(first.sourceReplyDeliveryMode).toBeUndefined();
+    expect(duplicate.sourceReplyDeliveryMode).toBeUndefined();
+  });
+
   it("keeps local discord exec approval tool prompts when the native runtime is inactive", async () => {
     setNoAbort();
     const cfg = {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -709,14 +709,15 @@ function firstToolResultPayload(dispatcher: ReplyDispatcher): ReplyPayload | und
 }
 
 async function dispatchTwiceWithFreshDispatchers(params: Omit<DispatchReplyArgs, "dispatcher">) {
-  await dispatchReplyFromConfig({
+  const first = await dispatchReplyFromConfig({
     ...params,
     dispatcher: createDispatcher(),
   });
-  await dispatchReplyFromConfig({
+  const second = await dispatchReplyFromConfig({
     ...params,
     dispatcher: createDispatcher(),
   });
+  return [first, second] as const;
 }
 
 describe("dispatchReplyFromConfig", () => {
@@ -2721,16 +2722,9 @@ describe("dispatchReplyFromConfig", () => {
     });
     const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
 
-    const first = await dispatchReplyFromConfig({
+    const [first, duplicate] = await dispatchTwiceWithFreshDispatchers({
       ctx,
       cfg,
-      dispatcher: createDispatcher(),
-      replyResolver,
-    });
-    const duplicate = await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher: createDispatcher(),
       replyResolver,
     });
 
@@ -2752,16 +2746,9 @@ describe("dispatchReplyFromConfig", () => {
     });
     const replyResolver = vi.fn(async () => ({ text: "visible fallback" }) as ReplyPayload);
 
-    const first = await dispatchReplyFromConfig({
+    const [first, duplicate] = await dispatchTwiceWithFreshDispatchers({
       ctx,
       cfg,
-      dispatcher: createDispatcher(),
-      replyResolver,
-    });
-    const duplicate = await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher: createDispatcher(),
       replyResolver,
     });
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -421,19 +421,9 @@ export async function dispatchReplyFromConfig(
     });
   };
 
-  const inboundDedupeClaim = claimInboundDedupe(ctx);
-  if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {
-    recordProcessed("skipped", { reason: "duplicate" });
-    return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
-  }
   let inboundDedupeReplayUnsafe = false;
   const markInboundDedupeReplayUnsafe = () => {
     inboundDedupeReplayUnsafe = true;
-  };
-  const commitInboundDedupeIfClaimed = () => {
-    if (inboundDedupeClaim.status === "claimed") {
-      commitInboundDedupe(inboundDedupeClaim.key);
-    }
   };
 
   const initialSessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
@@ -793,6 +783,20 @@ export async function dispatchReplyFromConfig(
     sourceReplyDeliveryMode === "message_tool_only"
       ? { ...result, sourceReplyDeliveryMode }
       : result;
+
+  const inboundDedupeClaim = claimInboundDedupe(ctx);
+  if (inboundDedupeClaim.status === "duplicate" || inboundDedupeClaim.status === "inflight") {
+    recordProcessed("skipped", { reason: "duplicate" });
+    return attachSourceReplyDeliveryMode({
+      queuedFinal: false,
+      counts: dispatcher.getQueuedCounts(),
+    });
+  }
+  const commitInboundDedupeIfClaimed = () => {
+    if (inboundDedupeClaim.status === "claimed") {
+      commitInboundDedupe(inboundDedupeClaim.key);
+    }
+  };
 
   let pluginFallbackReason:
     | "plugin-bound-fallback-missing-plugin"


### PR DESCRIPTION
## Summary

- Problem: Telegram could post generic silent-reply fallback text after a Codex turn whose source replies were configured for `message_tool_only`.
- Why it matters: Codex finals intended to stay private could leak as repetitive filler in Telegram, while explicit message-tool sends should remain the only visible source replies.
- What changed: shared dispatch now reports the resolved source-delivery mode, including duplicate/no-op turns, and Telegram suppresses empty/error fallback delivery when automatic source delivery is intentionally suppressed.
- What did NOT change (scope boundary): explicit message-tool delivery, configured `automatic` visible replies, and non-Telegram fallback behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: shared dispatch correctly suppressed automatic source delivery for message-tool-only turns, but Telegram's post-dispatch fallback did not know that resolved mode and treated "no visible final" as a case requiring fallback text.
- Missing detection / guardrail: Telegram tests covered normal `NO_REPLY` rewriting but not message-tool-only no-visible-response, error fallback suppression, duplicate fast paths, or first-turn topic labeling under suppressed automatic delivery.
- Contributing context (if known): Codex harness defaults can come from runtime plugin registration, so source-delivery mode must be resolved after runtime plugins load and with message-tool availability included.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot-message-dispatch.test.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`
- Scenario the test should lock in: message-tool-only Telegram turns do not synthesize silent/error fallback, duplicate dispatch returns still notify the resolved delivery mode, message-tool-unavailable falls back to `automatic`, and runtime plugin harness defaults are loaded before mode resolution.
- Why this is the smallest reliable guardrail: the bug sits at the shared dispatch to Telegram fallback seam; these tests exercise that seam without needing live Telegram or a real Codex run.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram no longer posts generic fallback text for Codex/message-tool-only turns where automatic source delivery is intentionally suppressed. Explicit message-tool replies remain visible.

## Diagram (if applicable)

```text
Before:
[Codex Telegram turn] -> [message_tool_only suppresses automatic final] -> [Telegram sees no visible final] -> [fallback filler sent]

After:
[Codex Telegram turn] -> [resolved message_tool_only reported to Telegram] -> [Telegram suppresses fallback] -> [only explicit message tool sends are visible]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw worktree, repo test wrapper
- Model/provider: mocked dispatch; Codex harness default covered by test registration
- Integration/channel (if any): Telegram
- Relevant config (redacted): source reply delivery resolved to `message_tool_only`

### Steps

1. Run a Telegram turn where the source delivery mode resolves to `message_tool_only`.
2. Have the agent produce no automatic visible final in Telegram.
3. Observe Telegram fallback handling after dispatch.

### Expected

- Telegram does not post fallback filler or generic error fallback when automatic source delivery is intentionally suppressed.

### Actual

- Before this PR, Telegram could synthesize fallback text after the no-visible-final path.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/telegram/src/bot-message-dispatch.test.ts src/auto-reply/reply/dispatch-from-config.test.ts
pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts src/auto-reply/get-reply-options.types.ts
git diff --check
codex review --base origin/main
```

Results:

- `dispatch-from-config.test.ts`: 100 passed
- `bot-message-dispatch.test.ts`: 111 passed
- formatting check: passed
- `git diff --check`: passed
- `codex review --base origin/main`: no regressions found after addressing review findings
- Testbox changed gate: not run because `blacksmith auth status` reports this machine is not authenticated to an organization.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Telegram dispatch and shared dispatch tests, including no-visible-response suppression, error fallback suppression, duplicate delivery-mode notification, message-tool-unavailable fallback, ack cleanup, and first-DM topic labeling.
- Edge cases checked: duplicate/inflight return path, plugin harness default registration order, and policies that remove the `message` tool.
- What you did **not** verify: a new after-fix live Telegram/Codex roundtrip and Testbox changed gate, due local auth/environment limits. Historical before-fix Telegram/Codex runtime logs are included below as redacted proof of the observed fallback behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: resolving source-delivery mode for duplicate/no-op dispatches now loads runtime plugins first so harness defaults are accurate.
  - Mitigation: uses the existing runtime plugin loader path and adds coverage proving plugin-provided Codex defaults are available before delivery-mode notification.


## Real behavior proof

- Behavior or issue addressed: Telegram tool-only source delivery should not fall through to the silent-reply fallback path after the message tool already owns visible delivery; duplicate inbound returns must preserve `message_tool_only` so Telegram does not synthesize visible filler such as `Nothing new to add from my side.`.
- Real environment tested: macOS local OpenClaw source worktree on PR head `e33a66bfaeeea41eb69ba62f1982aa7dc889bdbe`, Node 22, pnpm, plus historical live Telegram/Codex trajectory logs from the local OpenClaw instance with private Telegram identifiers redacted.
- Exact steps or command run after this patch: inspected the redacted Telegram trajectory JSONL lines for successful Codex direct turns with `assistantTexts=["NO_REPLY"]`; ran the local Node resolver for the same redacted direct Telegram session key to confirm the downstream silent-reply rewrite selected the visible fallback text; verified the PR-head dispatch path keeps `sourceReplyDeliveryMode: "message_tool_only"` on duplicate returns and Telegram skips fallback send/edit/deliver calls for that mode.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live output from the local Node resolver/probe and redacted trajectory scan:

```json
{"sessionKey":"agent:main:telegram:direct:<redacted>","input":"NO_REPLY","index":17,"text":"Nothing new to add from my side."}
{"afterFix":"sourceReplyDeliveryMode remained message_tool_only on duplicate inbound return; Telegram fallback delivery was not invoked for message_tool_only source delivery","visibleFallbackText":"not sent by Telegram fallback after this patch"}
```

Redacted live trajectory evidence for the real upstream condition:

| UTC timestamp | trajectory basename + line | run | logged assistant text | outcome |
| --- | --- | --- | --- | --- |
| 2026-05-05T02:31:52.968Z | `65d238ff-3780-4f27-a2dc-d9c1d6923e93.trajectory.jsonl:11` | `e7c0c53c...` | `NO_REPLY` | adjacent `session.ended` at line 12: `success` |
| 2026-05-05T22:49:05.667Z | `73b9c3a6-35cc-4f14-ac57-c8cd1a3377ef.trajectory.jsonl:167` | `7f78bba2...` | `NO_REPLY` | adjacent `session.ended` at line 168: `success` |

Additional exact `NO_REPLY` Telegram-direct completions were present at `8f1fc860-773b-409a-b4fa-05fd6e9f6092.trajectory.jsonl:342` (2026-04-25T22:31:40.214Z), `1398b4bd-9f66-42cf-ac95-09280ac447ab.trajectory.jsonl:2098` (2026-04-26T14:53:46.542Z), and `269676dd-a284-444c-ad6a-20938c5e15cb.trajectory.jsonl:30` (2026-05-04T16:03:23.281Z).
- Observed result after fix: the real Telegram/Codex condition is a successful direct turn whose assistant text is exactly `NO_REPLY`; the PR-head dispatch path carries `message_tool_only` through duplicate/no-op returns, so Telegram treats explicit message-tool sends as the visible delivery path and does not add synthesized silent-reply fallback text for that source-delivery mode.
- What was not tested: a fresh end-to-end live Telegram send from this branch after the PR-body update; owner performs final live Telegram verification outside this agent run.
