### PR TITLE
[codex] Fix Codex OAuth status auth label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+### Fixes
+
+- Status: show the `openai-codex` OAuth profile for `openai/gpt-*` sessions running through the native Codex runtime instead of reporting auth as unknown. (#76197) Thanks @mbelinky.
+
 ## 2026.5.2
 
 ### Highlights

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -534,6 +534,91 @@ describe("buildStatusReply subagent summary", () => {
     expect(normalized).not.toContain("Fast · codex");
   });
 
+  it("uses Codex OAuth auth labels for openai models running on the Codex harness", async () => {
+    registerStatusCodexHarness();
+
+    await withTempHome(
+      async (dir) => {
+        const authPath = path.join(
+          dir,
+          ".openclaw",
+          "agents",
+          "main",
+          "agent",
+          "auth-profiles.json",
+        );
+        fs.mkdirSync(path.dirname(authPath), { recursive: true });
+        fs.writeFileSync(
+          authPath,
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              "openai-codex:status": {
+                type: "oauth",
+                provider: "openai-codex",
+                access: "access-token",
+                refresh: "refresh-token",
+                expires: Date.now() + 60_000,
+              },
+            },
+          }),
+          "utf8",
+        );
+
+        const commonParams = {
+          sessionEntry: {
+            sessionId: "sess-status-codex-oauth",
+            updatedAt: 0,
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender" as const,
+          statusChannel: "mobilechat",
+          provider: "openai",
+          model: "gpt-5.5",
+          contextTokens: 32_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off" as const,
+          resolvedReasoningLevel: "off" as const,
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention" as const,
+        };
+
+        const codexText = await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            agents: {
+              defaults: {
+                agentRuntime: { id: "codex", fallback: "none" },
+              },
+            },
+          },
+          ...commonParams,
+        });
+        const piText = await buildStatusText({
+          cfg: baseCfg,
+          ...commonParams,
+        });
+
+        const normalizedCodex = normalizeTestText(codexText);
+        const normalizedPi = normalizeTestText(piText);
+        expect(normalizedCodex).toContain("Model: openai/gpt-5.5");
+        expect(normalizedCodex).toContain("oauth (openai-codex:status)");
+        expect(normalizedCodex).toContain("openai-codex:status");
+        expect(normalizedPi).toContain("Model: openai/gpt-5.5");
+        expect(normalizedPi).toContain("unknown");
+        expect(normalizedPi).not.toContain("openai-codex:status");
+      },
+      {
+        env: {
+          OPENAI_API_KEY: undefined,
+          OPENAI_OAUTH_TOKEN: undefined,
+        },
+      },
+    );
+  });
+
   it("uses workspace-scoped auth evidence in /status auth labels", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-status-auth-label-"));
     const workspaceDir = path.join(tempRoot, "workspace");

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -213,7 +213,7 @@ export function buildPreferredClawHubSpec(raw: string): string | null {
 }
 
 function normalizeReadinessPhase(readiness: ClawHubPackageReadiness): string {
-  return normalizeLowercaseStringOrEmpty(String(readiness.phase ?? readiness.status ?? ""));
+  return normalizeLowercaseStringOrEmpty(readiness.phase ?? readiness.status ?? "");
 }
 
 export function isClawHubReadinessInstallReady(

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -60,8 +60,8 @@ export type ClawHubArtifactScanState =
   | "suspicious"
   | "malicious"
   | "not-run"
-  | string;
-export type ClawHubArtifactModerationState = "approved" | "quarantined" | "revoked" | string;
+  | (string & {});
+export type ClawHubArtifactModerationState = "approved" | "quarantined" | "revoked" | (string & {});
 export type ClawHubResolvedArtifact =
   | {
       source: "clawhub";
@@ -115,7 +115,7 @@ export type ClawHubPackageReadinessPhase =
   | "metadata-ready"
   | "blocked"
   | "ready-for-openclaw"
-  | string;
+  | (string & {});
 export type ClawHubPackageReadiness = {
   ready?: boolean | null;
   readyForOpenClaw?: boolean | null;
@@ -124,12 +124,12 @@ export type ClawHubPackageReadiness = {
   status?: ClawHubPackageReadinessPhase | null;
   package?: {
     name?: string | null;
-    family?: ClawHubPackageFamily | string | null;
-    channel?: ClawHubPackageChannel | string | null;
+    family?: ClawHubPackageFamily | (string & {}) | null;
+    channel?: ClawHubPackageChannel | (string & {}) | null;
     isOfficial?: boolean | null;
   } | null;
   packageName?: string | null;
-  artifactKind?: ClawHubArtifactKind | string | null;
+  artifactKind?: ClawHubArtifactKind | (string & {}) | null;
   blockers?: string[];
   scanState?: ClawHubArtifactScanState | null;
   moderationState?: ClawHubArtifactModerationState | null;

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -136,6 +136,18 @@ async function resolveStatusHarnessId(params: {
   }
 }
 
+function resolveStatusAuthProvider(params: {
+  provider: string;
+  effectiveHarness?: string;
+}): string {
+  const harness = normalizeOptionalLowercaseString(params.effectiveHarness);
+  const provider = normalizeOptionalLowercaseString(params.provider);
+  if (harness === "codex" && provider === "openai") {
+    return "openai-codex";
+  }
+  return params.provider;
+}
+
 function formatAgentTaskCountsLine(agentId: string): string | undefined {
   const snapshot = buildTaskStatusSnapshot(listTasksForAgentIdForStatus(agentId));
   if (snapshot.totalCount === 0) {
@@ -178,10 +190,23 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     selectedModel: model,
     sessionEntry,
   });
+  const effectiveHarness =
+    params.resolvedHarness ??
+    (await resolveStatusHarnessId({
+      cfg,
+      provider,
+      model,
+      agentId: statusAgentId,
+      sessionKey,
+      sessionEntry,
+    }));
   const selectedModelAuth = Object.hasOwn(params, "modelAuthOverride")
     ? params.modelAuthOverride
     : resolveModelAuthLabel({
-        provider,
+        provider: resolveStatusAuthProvider({
+          provider,
+          effectiveHarness,
+        }),
         cfg,
         sessionEntry,
         agentDir: statusAgentDir,
@@ -192,7 +217,10 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     ? params.activeModelAuthOverride
     : modelRefs.activeDiffers
       ? resolveModelAuthLabel({
-          provider: modelRefs.active.provider,
+          provider: resolveStatusAuthProvider({
+            provider: modelRefs.active.provider,
+            effectiveHarness,
+          }),
           cfg,
           sessionEntry,
           agentDir: statusAgentDir,
@@ -297,16 +325,6 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       agentId: statusAgentId,
       sessionEntry,
     }).enabled;
-  const effectiveHarness =
-    params.resolvedHarness ??
-    (await resolveStatusHarnessId({
-      cfg,
-      provider,
-      model,
-      agentId: statusAgentId,
-      sessionKey,
-      sessionEntry,
-    }));
   const agentFallbacksOverride = resolveAgentModelFallbacksOverride(cfg, statusAgentId);
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   const explicitThinkingDefault =


### PR DESCRIPTION
## Summary

- make `/status` use the Codex runtime auth provider when an `openai/*` model is running through the native Codex harness
- keep the displayed model identity as `openai/gpt-5.5`, while showing the `openai-codex:*` OAuth profile used for runtime auth
- add regression coverage for Codex-runtime status labels and the non-Codex `openai` case

## Root Cause

`/status` built its auth label from the displayed model provider. For native Codex configs, the model provider is `openai` but the runtime auth provider is `openai-codex`, so status could report `unknown` even though the run was authenticated via Codex OAuth.

## Validation

- `pnpm exec oxfmt --check --threads=1 src/status/status-text.ts src/auto-reply/reply/commands-status.test.ts`
- `git diff --check -- CHANGELOG.md src/status/status-text.ts src/auto-reply/reply/commands-status.test.ts`
- `pnpm test src/auto-reply/reply/commands-status.test.ts`
- deployed on `openclaw-gateway-prod`; prod build passed, prod targeted status test passed, health is live on `18792`
