### PR TITLE
Fix/feishu sdk bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Docs: https://docs.openclaw.ai
 - CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
 - Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis. Long `process(poll)`, browser, or `exec` tool calls that exceed `agents.defaults.timeoutSeconds` previously rotated auth profiles, switched to a fallback model, and surfaced a misleading "LLM request timed out" error even though the primary model had already responded. Mirrors the existing `timedOutDuringCompaction` precedent (#46889). Fixes #52147. (#75873) Thanks @simonusa.
 - Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
-- Agents/compaction: keep prior context on consecutive turns against z.ai-style providers (z.ai direct, openrouter z-ai/*, in-house GLM gateways); Pi's internal auto-compaction was misfiring after successful turns and clearing state.messages before the next provider request. (#76056) Thanks @openperf.
+- Agents/compaction: keep prior context on consecutive turns against z.ai-style providers (z.ai direct, openrouter z-ai/\*, in-house GLM gateways); Pi's internal auto-compaction was misfiring after successful turns and clearing state.messages before the next provider request. (#76056) Thanks @openperf.
+- Build/Feishu: externalize `@larksuiteoapi/node-sdk` from the tsdown bundle so the SDK's CJS `__dirname` usage is not inlined into ESM output, fixing Feishu channel startup crashes on Node 24.
 
 ## 2026.5.2
 

--- a/src/config/legacy.ts
+++ b/src/config/legacy.ts
@@ -17,7 +17,7 @@ export function findLegacyConfigIssues(
   raw: unknown,
   sourceRaw?: unknown,
   extraRules: LegacyConfigRule[] = [],
-  touchedPaths?: ReadonlyArray<ReadonlyArray<string>>,
+  _touchedPaths?: ReadonlyArray<ReadonlyArray<string>>,
 ): LegacyConfigIssue[] {
   if (!raw || typeof raw !== "object") {
     return [];

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -610,7 +610,7 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
  */
 export function validateConfigObjectRaw(
   raw: unknown,
-  opts?: {
+  _opts?: {
     sourceRaw?: unknown;
     touchedPaths?: ReadonlyArray<ReadonlyArray<string>>;
   },

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -138,11 +138,14 @@ describe("tsdown config", () => {
 
     if (typeof neverBundle === "function") {
       expect(neverBundle("@lancedb/lancedb")).toBe(true);
+      expect(neverBundle("@larksuiteoapi/node-sdk")).toBe(true);
       expect(neverBundle("@matrix-org/matrix-sdk-crypto-nodejs")).toBe(true);
       expect(neverBundle("matrix-js-sdk/lib/client.js")).toBe(true);
       expect(neverBundle("not-a-runtime-dependency")).toBe(false);
     } else {
-      expect(neverBundle).toEqual(expect.arrayContaining(["@lancedb/lancedb", "matrix-js-sdk"]));
+      expect(neverBundle).toEqual(
+        expect.arrayContaining(["@lancedb/lancedb", "@larksuiteoapi/node-sdk", "matrix-js-sdk"]),
+      );
     }
   });
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -124,6 +124,7 @@ const bundledPluginFile = (pluginId: string, relativePath: string) =>
   `${bundledPluginRoot(pluginId)}/${relativePath}`;
 const explicitNeverBundleDependencies = [
   "@lancedb/lancedb",
+  "@larksuiteoapi/node-sdk",
   "@matrix-org/matrix-sdk-crypto-nodejs",
   "matrix-js-sdk",
   "qrcode-terminal",


### PR DESCRIPTION
Problem: The CJS code in @larksuiteoapi/node-sdk (which uses __dirname) was being inlined by tsdown into the ESM build output. In Node.js 24's ESM context, __dirname is not available, causing the Feishu channel to crash on startup.

Fix: Add @larksuiteoapi/node-sdk to explicitNeverBundleDependencies in tsdown.config.ts so it remains an external dependency with its own CJS module scope.