### PR TITLE
fix(gateway): improve transcript session-key cache hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/update: recover an installed-but-unloaded macOS LaunchAgent after package updates, rerun Gateway health/version/channel readiness checks, and print restart, reinstall, and rollback guidance before reporting update failure. (#76790) Thanks @jonathanlindsay.
+- Gateway/transcripts: validate transcript session-key cache hits with a cheap session-store fingerprint before falling back to full combined-store loads, avoiding repeated store scans on transcript updates while preserving stale mapping recovery. Fixes #76123. Thanks @kaka4413.
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.
 - Memory/status: split builtin sqlite-vec store readiness from embedding-provider readiness in `memory status --deep` and `openclaw status`, so local vector-store failures no longer look like provider failures and provider failures no longer hide a healthy local vector store.
 - CLI/doctor: trust a ready gateway memory probe when CLI-side active memory backend resolution is unavailable, preventing false "No active memory plugin is registered" warnings for healthy runtime setups. Fixes #76792. Thanks @som-686.

--- a/src/gateway/session-transcript-key.test.ts
+++ b/src/gateway/session-transcript-key.test.ts
@@ -4,11 +4,13 @@ import type { SessionEntry } from "../config/sessions/types.js";
 const {
   loadConfigMock,
   loadCombinedSessionStoreForGatewayMock,
+  resolveGatewaySessionStoreFingerprintMock,
   resolveGatewaySessionStoreTargetMock,
   resolveSessionTranscriptCandidatesMock,
 } = vi.hoisted(() => ({
   loadConfigMock: vi.fn(() => ({ session: {} })),
   loadCombinedSessionStoreForGatewayMock: vi.fn(),
+  resolveGatewaySessionStoreFingerprintMock: vi.fn(() => "store:v1"),
   resolveGatewaySessionStoreTargetMock: vi.fn(),
   resolveSessionTranscriptCandidatesMock: vi.fn(),
 }));
@@ -19,6 +21,7 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("./session-utils.js", () => ({
   loadCombinedSessionStoreForGateway: loadCombinedSessionStoreForGatewayMock,
+  resolveGatewaySessionStoreFingerprint: resolveGatewaySessionStoreFingerprintMock,
   resolveGatewaySessionStoreTarget: resolveGatewaySessionStoreTargetMock,
   resolveSessionTranscriptCandidates: resolveSessionTranscriptCandidatesMock,
 }));
@@ -35,6 +38,8 @@ describe("resolveSessionKeyForTranscriptFile", () => {
     clearSessionTranscriptKeyCacheForTests();
     loadConfigMock.mockClear();
     loadCombinedSessionStoreForGatewayMock.mockReset();
+    resolveGatewaySessionStoreFingerprintMock.mockReset();
+    resolveGatewaySessionStoreFingerprintMock.mockReturnValue("store:v1");
     resolveGatewaySessionStoreTargetMock.mockReset();
     resolveSessionTranscriptCandidatesMock.mockReset();
     resolveGatewaySessionStoreTargetMock.mockImplementation(({ key }: { key: string }) => ({
@@ -68,7 +73,8 @@ describe("resolveSessionKeyForTranscriptFile", () => {
     expect(resolveSessionTranscriptCandidatesMock).toHaveBeenCalledTimes(2);
 
     expect(resolveSessionKeyForTranscriptFile("/tmp/two.jsonl")).toBe("agent:main:two");
-    expect(resolveSessionTranscriptCandidatesMock).toHaveBeenCalledTimes(3);
+    expect(loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledTimes(1);
+    expect(resolveSessionTranscriptCandidatesMock).toHaveBeenCalledTimes(2);
   });
 
   it("drops stale cached mappings and falls back to the current store contents", () => {
@@ -97,6 +103,7 @@ describe("resolveSessionKeyForTranscriptFile", () => {
 
     expect(resolveSessionKeyForTranscriptFile("/tmp/shared.jsonl")).toBe("agent:main:beta");
 
+    resolveGatewaySessionStoreFingerprintMock.mockReturnValue("store:v2");
     store = {
       "agent:main:alpha": { sessionId: "sess-alpha-2", updatedAt: now + 1 },
       "agent:main:beta": {
@@ -107,6 +114,7 @@ describe("resolveSessionKeyForTranscriptFile", () => {
     };
 
     expect(resolveSessionKeyForTranscriptFile("/tmp/shared.jsonl")).toBe("agent:main:alpha");
+    expect(loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledTimes(2);
   });
 
   it("returns undefined for blank transcript paths", () => {

--- a/src/gateway/session-transcript-key.ts
+++ b/src/gateway/session-transcript-key.ts
@@ -8,11 +8,17 @@ import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/sessi
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   loadCombinedSessionStoreForGateway,
+  resolveGatewaySessionStoreFingerprint,
   resolveGatewaySessionStoreTarget,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.js";
 
-const TRANSCRIPT_SESSION_KEY_CACHE = new Map<string, string>();
+type TranscriptSessionKeyCacheEntry = {
+  key: string;
+  storeFingerprint: string;
+};
+
+const TRANSCRIPT_SESSION_KEY_CACHE = new Map<string, TranscriptSessionKeyCacheEntry>();
 const TRANSCRIPT_SESSION_KEY_CACHE_MAX = 256;
 
 function resolveTranscriptPathForComparison(value: string | undefined): string | undefined {
@@ -63,9 +69,20 @@ export function resolveSessionKeyForTranscriptFile(sessionFile: string): string 
     return undefined;
   }
   const cfg = getRuntimeConfig();
-  const { store } = loadCombinedSessionStoreForGateway(cfg);
+  const cachedEntry = TRANSCRIPT_SESSION_KEY_CACHE.get(targetPath);
+  const currentStoreFingerprint = cachedEntry
+    ? resolveGatewaySessionStoreFingerprint(cfg)
+    : undefined;
+  if (
+    cachedEntry &&
+    currentStoreFingerprint !== undefined &&
+    cachedEntry.storeFingerprint === currentStoreFingerprint
+  ) {
+    return cachedEntry.key;
+  }
 
-  const cachedKey = TRANSCRIPT_SESSION_KEY_CACHE.get(targetPath);
+  const { store } = loadCombinedSessionStoreForGateway(cfg);
+  const cachedKey = cachedEntry?.key;
   if (
     cachedKey &&
     sessionKeyMatchesTranscriptPath({
@@ -75,6 +92,15 @@ export function resolveSessionKeyForTranscriptFile(sessionFile: string): string 
       targetPath,
     })
   ) {
+    const storeFingerprint = currentStoreFingerprint ?? resolveGatewaySessionStoreFingerprint(cfg);
+    if (storeFingerprint) {
+      TRANSCRIPT_SESSION_KEY_CACHE.set(targetPath, {
+        key: cachedKey,
+        storeFingerprint,
+      });
+    } else {
+      TRANSCRIPT_SESSION_KEY_CACHE.delete(targetPath);
+    }
     return cachedKey;
   }
 
@@ -147,7 +173,13 @@ export function resolveSessionKeyForTranscriptFile(sessionFile: string): string 
           TRANSCRIPT_SESSION_KEY_CACHE.delete(oldest);
         }
       }
-      TRANSCRIPT_SESSION_KEY_CACHE.set(targetPath, resolvedKey);
+      const storeFingerprint =
+        currentStoreFingerprint ?? resolveGatewaySessionStoreFingerprint(cfg);
+      if (storeFingerprint) {
+        TRANSCRIPT_SESSION_KEY_CACHE.set(targetPath, { key: resolvedKey, storeFingerprint });
+      } else {
+        TRANSCRIPT_SESSION_KEY_CACHE.delete(targetPath);
+      }
       return resolvedKey;
     }
   }

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -23,6 +23,7 @@ import {
   pruneLegacyStoreKeys,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewayModelSupportsImages,
+  resolveGatewaySessionStoreFingerprint,
   resolveGatewaySessionStoreTarget,
   resolveSessionDisplayModelIdentityRef,
   resolveSessionModelIdentityRef,
@@ -427,6 +428,40 @@ describe("gateway session utils", () => {
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "main" });
     expect(target.canonicalKey).toBe("global");
     expect(target.agentId).toBe("ops");
+  });
+
+  test("resolveGatewaySessionStoreFingerprint changes when a session store appears", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-fingerprint-"));
+    const storePath = path.join(dir, "sessions.json");
+    const cfg = {
+      session: { mainKey: "main", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+
+    const missingFingerprint = resolveGatewaySessionStoreFingerprint(cfg);
+    fs.writeFileSync(storePath, JSON.stringify({ "agent:ops:main": { sessionId: "s1" } }));
+    const createdFingerprint = resolveGatewaySessionStoreFingerprint(cfg);
+
+    expect(missingFingerprint).toContain(`${storePath}:missing`);
+    expect(createdFingerprint).not.toBe(missingFingerprint);
+  });
+
+  test("resolveGatewaySessionStoreFingerprint changes when session key config changes", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-config-fingerprint-"));
+    const storePath = path.join(dir, "sessions.json");
+    fs.writeFileSync(storePath, JSON.stringify({ "agent:ops:main": { sessionId: "s1" } }));
+    const cfg = {
+      session: { mainKey: "main", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const changedCfg = {
+      session: { mainKey: "work", store: storePath },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+
+    expect(resolveGatewaySessionStoreFingerprint(changedCfg)).not.toBe(
+      resolveGatewaySessionStoreFingerprint(cfg),
+    );
   });
 
   test("resolveGatewaySessionStoreTarget uses canonical key for main alias", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -797,6 +797,51 @@ function isStorePathTemplate(store?: string): boolean {
   return typeof store === "string" && store.includes("{agentId}");
 }
 
+function readGatewaySessionStoreFingerprintPart(storePath: string): string | undefined {
+  try {
+    const stat = fs.statSync(storePath, { bigint: true });
+    return `${storePath}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}:${stat.ino}`;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return `${storePath}:missing`;
+    }
+    return undefined;
+  }
+}
+
+function resolveGatewaySessionStoreConfigFingerprint(cfg: OpenClawConfig): string {
+  return JSON.stringify({
+    agentIds: listAgentIds(cfg)
+      .map((agentId) => normalizeAgentId(agentId))
+      .toSorted(),
+    defaultAgentId: normalizeAgentId(resolveDefaultAgentId(cfg)),
+    sessionMainKey: normalizeMainKey(cfg.session?.mainKey),
+    sessionScope: normalizeOptionalString(cfg.session?.scope) ?? "",
+    sessionStore: normalizeOptionalString(cfg.session?.store) ?? "",
+  });
+}
+
+export function resolveGatewaySessionStoreFingerprint(cfg: OpenClawConfig): string | undefined {
+  const storeConfig = cfg.session?.store;
+  const targets =
+    storeConfig && !isStorePathTemplate(storeConfig)
+      ? [{ storePath: resolveStorePath(storeConfig) }]
+      : resolveAllAgentSessionStoreTargetsSync(cfg).map((target) => ({
+          storePath: target.storePath,
+        }));
+  const storePaths = [...new Set(targets.map((target) => target.storePath))].toSorted();
+  const parts: string[] = [];
+  for (const storePath of storePaths) {
+    const part = readGatewaySessionStoreFingerprintPart(storePath);
+    if (!part) {
+      return undefined;
+    }
+    parts.push(part);
+  }
+  return [resolveGatewaySessionStoreConfigFingerprint(cfg), ...parts].join("|");
+}
+
 function listExistingAgentIdsFromDisk(): string[] {
   const root = resolveStateDir();
   const agentsDir = path.join(root, "agents");


### PR DESCRIPTION
## Problem

Transcript update broadcasts call `resolveSessionKeyForTranscriptFile`, which loaded combined session stores before checking `TRANSCRIPT_SESSION_KEY_CACHE`. Tool-heavy runs can broadcast transcript updates many times, so the same transcript repeatedly paid for full combined session-store loads and scans.

## Fix

This stores transcript session-key cache entries with a cheap session-store fingerprint. When the fingerprint matches, `resolveSessionKeyForTranscriptFile` returns from the hot cache hit before loading the full combined store. When the fingerprint changes or cannot be resolved, the resolver falls back to the existing full validation path.

The fingerprint includes the relevant session-store config shape plus sorted store file stats, so config-only changes such as `session.mainKey`, `session.store`, session scope, default agent id, or configured agent ids invalidate cached mappings without parsing the stores.

## Quality

This does not disable tools, plugins, or memory. It preserves stale mapping recovery and keeps the duplicate/freshest selection logic on the existing full-resolution fallback path.

## Tests run

- `corepack pnpm test src/gateway/session-transcript-key.test.ts`
- `corepack pnpm test src/gateway/session-utils.test.ts -t resolveGatewaySessionStoreFingerprint`
- `corepack pnpm exec oxfmt --check --threads=1 src/gateway/session-transcript-key.ts src/gateway/session-transcript-key.test.ts src/gateway/session-utils.ts src/gateway/session-utils.test.ts`
- `git diff --check`

Fixes #76123.

Thanks @kaka4413.
