### PR TITLE
fix(telegram): preserve URL inline buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -996,6 +996,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: preserve URL inline keyboard buttons in shared presentation rendering. Fixes #76255. Thanks @clawSean.
 - Update: repair doctor-migratable legacy config before persisting `openclaw update --channel ...`, so old Slack/Telegram streaming keys do not block switching to beta after a package update. Thanks @vincentkoc.
 - Web fetch: late-bind `web_fetch` config and provider fallback metadata from the active runtime snapshot, matching `web_search` so long-lived tools do not use stale fetch provider settings. Thanks @vincentkoc.
 - Plugins/discovery: demote the source-only TypeScript runtime check on already-installed `origin: "global"` plugin packages from a config-blocking error to a warning and let the runtime fall through to the TypeScript source via jiti, so a single broken installed package no longer blocks `plugins install` for unrelated plugins; install-time rejection of newly-installed source-only packages is unchanged. Thanks @romneyda.

--- a/extensions/telegram/src/button-types.test-helpers.ts
+++ b/extensions/telegram/src/button-types.test-helpers.ts
@@ -11,6 +11,7 @@ export function describeTelegramInteractiveButtonBehavior(): void {
               type: "buttons",
               buttons: [
                 { label: "Approve", value: "approve", style: "success" },
+                { label: "Docs", url: "https://example.com/docs", style: "primary" },
                 { label: "Reject", value: "reject", style: "danger" },
                 { label: "Later", value: "later" },
                 { label: "Archive", value: "archive" },
@@ -25,10 +26,13 @@ export function describeTelegramInteractiveButtonBehavior(): void {
       ).toEqual([
         [
           { text: "Approve", callback_data: "approve", style: "success" },
+          { text: "Docs", url: "https://example.com/docs", style: "primary" },
           { text: "Reject", callback_data: "reject", style: "danger" },
-          { text: "Later", callback_data: "later", style: undefined },
         ],
-        [{ text: "Archive", callback_data: "archive", style: undefined }],
+        [
+          { text: "Later", callback_data: "later", style: undefined },
+          { text: "Archive", callback_data: "archive", style: undefined },
+        ],
         [{ text: "Alpha", callback_data: "alpha", style: undefined }],
       ]);
     });
@@ -60,12 +64,20 @@ export function describeTelegramInteractiveButtonBehavior(): void {
             blocks: [
               {
                 type: "buttons",
-                buttons: [{ label: "Retry", value: "retry", style: "primary" }],
+                buttons: [
+                  { label: "Retry", value: "retry", style: "primary" },
+                  { label: "Docs", value: "docs", url: "https://example.com/docs" },
+                ],
               },
             ],
           },
         }),
-      ).toEqual([[{ text: "Retry", callback_data: "retry", style: "primary" }]]);
+      ).toEqual([
+        [
+          { text: "Retry", callback_data: "retry", style: "primary" },
+          { text: "Docs", url: "https://example.com/docs", style: undefined },
+        ],
+      ]);
     });
   });
 }

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -10,7 +10,8 @@ export type TelegramButtonStyle = "danger" | "success" | "primary";
 
 type TelegramInlineButton = {
   text: string;
-  callback_data: string;
+  callback_data?: string;
+  url?: string;
   style?: TelegramButtonStyle;
 };
 
@@ -24,27 +25,34 @@ function toTelegramButtonStyle(
   return style === "danger" || style === "success" || style === "primary" ? style : undefined;
 }
 
+function toTelegramInlineButton(button: InteractiveReplyButton): TelegramInlineButton | undefined {
+  const style = toTelegramButtonStyle(button.style);
+  if (button.url) {
+    return {
+      text: button.label,
+      url: button.url,
+      style,
+    };
+  }
+  const callbackData = button.value ? sanitizeTelegramCallbackData(button.value) : undefined;
+  return callbackData
+    ? {
+        text: button.label,
+        callback_data: callbackData,
+        style,
+      }
+    : undefined;
+}
+
 function chunkInteractiveButtons(
   buttons: readonly InteractiveReplyButton[],
   rows: TelegramInlineButton[][],
 ) {
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
-    const row = buttons.slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE).flatMap((button) => {
-      if (!button.value) {
-        return [];
-      }
-      const callbackData = sanitizeTelegramCallbackData(button.value);
-      if (!callbackData) {
-        return [];
-      }
-      return [
-        {
-          text: button.label,
-          callback_data: callbackData,
-          style: toTelegramButtonStyle(button.style),
-        },
-      ];
-    });
+    const row = buttons
+      .slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE)
+      .map(toTelegramInlineButton)
+      .filter((button): button is TelegramInlineButton => Boolean(button));
     if (row.length > 0) {
       rows.push(row);
     }

--- a/extensions/telegram/src/inline-keyboard.ts
+++ b/extensions/telegram/src/inline-keyboard.ts
@@ -1,6 +1,25 @@
 import type { InlineKeyboardButton, InlineKeyboardMarkup } from "@grammyjs/types";
 import type { TelegramInlineButtons } from "./button-types.js";
 
+function toInlineKeyboardButton(
+  button: TelegramInlineButtons[number][number] | undefined,
+): InlineKeyboardButton | undefined {
+  if (!button?.text) {
+    return undefined;
+  }
+  if (button.url) {
+    return button.style
+      ? { text: button.text, url: button.url, style: button.style }
+      : { text: button.text, url: button.url };
+  }
+  if (button.callback_data) {
+    return button.style
+      ? { text: button.text, callback_data: button.callback_data, style: button.style }
+      : { text: button.text, callback_data: button.callback_data };
+  }
+  return undefined;
+}
+
 export function buildInlineKeyboard(
   buttons?: TelegramInlineButtons,
 ): InlineKeyboardMarkup | undefined {
@@ -10,14 +29,8 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton =>
-            Object.assign(
-              { text: button.text, callback_data: button.callback_data },
-              button.style ? { style: button.style } : {},
-            ),
-        ),
+        .map(toInlineKeyboardButton)
+        .filter((button): button is InlineKeyboardButton => Boolean(button)),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -318,6 +318,20 @@ describe("buildInlineKeyboard", () => {
         },
       },
       {
+        name: "keeps url buttons",
+        input: [[{ text: "Open", url: "https://example.com" }]],
+        expected: {
+          inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+        },
+      },
+      {
+        name: "prefers url over callback data when both are present",
+        input: [[{ text: "Open", callback_data: "cmd:open", url: "https://example.com" }]],
+        expected: {
+          inline_keyboard: [[{ text: "Open", url: "https://example.com" }]],
+        },
+      },
+      {
         name: "filters invalid buttons and empty rows",
         input: [
           [
@@ -325,6 +339,7 @@ describe("buildInlineKeyboard", () => {
             { text: "Ok", callback_data: "cmd:ok" },
           ],
           [{ text: "Missing data", callback_data: "" }],
+          [{ text: "Missing action" }],
           [],
         ],
         expected: {


### PR DESCRIPTION
## Summary
- preserve Telegram inline keyboard URL buttons instead of filtering them out
- map shared presentation buttons with `url` into Telegram `url` buttons, preferring URL when both URL and callback data are present
- keep raw message-tool button schema unchanged; URL buttons remain on the shared presentation path

Fixes #76255.

## Real behavior proof
- Behavior or issue addressed: Telegram shared presentation URL-only inline buttons were dropped before reaching `reply_markup.inline_keyboard`.
- Real environment tested: Crabbox real Telegram Desktop lane with an OpenClaw Telegram gateway and leased bot credentials on 2026-05-10.
- Exact steps or command run after this patch: Sent the same OpenClaw Telegram presentation-button scenario on current main and on this PR, then recorded full desktop captures scrolled to the latest visible Telegram messages.
- Evidence after fix: PR capture showing the URL inline button rendered under the message: https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-76264/pr-76264-comment-replacement-full/20260510-113356-457629000/pr-after-full.gif
- Before evidence: Current-main capture showing the URL-only inline button absent: https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-76264/pr-76264-comment-replacement-full/20260510-113356-457629000/main-before-full.gif
- Observed result after fix: The real Telegram message on this PR displays the URL inline button; current main does not.
- What was not tested: No additional Telegram callback-click behavior; this change only preserves URL link-button rendering.

## Tests
- `pnpm test extensions/telegram/src/button-types.test.ts extensions/telegram/src/send.test.ts --maxWorkers=1`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/button-types.ts extensions/telegram/src/inline-keyboard.ts extensions/telegram/src/button-types.test-helpers.ts extensions/telegram/src/send.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/button-types.ts extensions/telegram/src/inline-keyboard.ts extensions/telegram/src/button-types.test-helpers.ts extensions/telegram/src/send.test.ts`
- `git diff --check`
