### PR TITLE
fix(gateway): keep requested plugin tools invokable

### DIFF
--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -39,6 +39,7 @@ export function resolveGatewayScopedTools(params: {
   excludeToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   senderIsOwner?: boolean;
+  gatewayRequestedTools?: string[];
 }) {
   const {
     agentId,
@@ -53,11 +54,15 @@ export function resolveGatewayScopedTools(params: {
   } = resolveEffectiveToolPolicy({ config: params.cfg, sessionKey: params.sessionKey });
   const profilePolicy = resolveToolProfilePolicy(profile);
   const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
-  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow);
-  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
-    providerProfilePolicy,
-    providerProfileAlsoAllow,
-  );
+  const gatewayRequestedTools = params.gatewayRequestedTools ?? [];
+  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, [
+    ...(profileAlsoAllow ?? []),
+    ...gatewayRequestedTools,
+  ]);
+  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(providerProfilePolicy, [
+    ...(providerProfileAlsoAllow ?? []),
+    ...gatewayRequestedTools,
+  ]);
   const groupPolicy = resolveGroupToolPolicy({
     config: params.cfg,
     sessionKey: params.sessionKey,
@@ -101,6 +106,7 @@ export function resolveGatewayScopedTools(params: {
       agentProviderPolicy,
       groupPolicy,
       subagentPolicy,
+      gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
     ]),
   });
 

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -7,6 +7,10 @@ type RunBeforeToolCallHook = typeof runBeforeToolCallHookType;
 type RunBeforeToolCallHookArgs = Parameters<RunBeforeToolCallHook>[0];
 type RunBeforeToolCallHookResult = Awaited<ReturnType<RunBeforeToolCallHook>>;
 
+const pluginToolMetaState = vi.hoisted(
+  () => new Map<string, { pluginId: string; optional: boolean }>(),
+);
+
 const hookMocks = vi.hoisted(() => ({
   resolveToolLoopDetectionConfig: vi.fn(() => ({ warnAt: 3 })),
   runBeforeToolCallHook: vi.fn(
@@ -63,7 +67,8 @@ vi.mock("../plugins/config-state.js", async (importOriginal) => {
 });
 
 vi.mock("../plugins/tools.js", () => ({
-  getPluginToolMeta: () => undefined,
+  getPluginToolMeta: (tool: { name?: string }) =>
+    typeof tool?.name === "string" ? pluginToolMetaState.get(tool.name) : undefined,
 }));
 
 // Perf: the real tool factory instantiates many tools per request; for these HTTP
@@ -135,6 +140,11 @@ vi.mock("../agents/openclaw-tools.js", () => {
       name: "browser",
       parameters: { type: "object", properties: {} },
       execute: async () => ({ ok: true, result: "browser" }),
+    },
+    {
+      name: "plugin_doctor",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ ok: true, permissionFlow: true }),
     },
     {
       name: "owner_only_test",
@@ -259,6 +269,8 @@ beforeEach(() => {
   pluginHttpHandlers = [];
   cfg = {};
   lastCreateOpenClawToolsContext = undefined;
+  pluginToolMetaState.clear();
+  pluginToolMetaState.set("plugin_doctor", { pluginId: "test-plugin", optional: true });
   hookMocks.resolveToolLoopDetectionConfig.mockClear();
   hookMocks.resolveToolLoopDetectionConfig.mockImplementation(() => ({ warnAt: 3 }));
   hookMocks.runBeforeToolCallHook.mockClear();
@@ -461,6 +473,25 @@ describe("POST /tools/invoke", () => {
 
     expect(res.status).toBe(200);
     expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
+  });
+
+  it("allows the requested plugin tool through Gateway profile filtering", async () => {
+    cfg = {
+      ...cfg,
+      agents: { list: [{ id: "main", default: true }] },
+      tools: { profile: "minimal" },
+    };
+
+    const res = await invokeToolAuthed({
+      tool: "plugin_doctor",
+      sessionKey: "main",
+    });
+
+    const body = await expectOkInvokeResponse(res);
+    expect(body.result).toMatchObject({ ok: true, permissionFlow: true });
+    expect(lastCreateOpenClawToolsContext?.pluginToolAllowlist).toEqual(
+      expect.arrayContaining(["plugin_doctor"]),
+    );
   });
 
   it("blocks tool execution when before_tool_call rejects the invoke", async () => {

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -183,6 +183,9 @@ export async function invokeGatewayTool(params: {
     }
   }
 
+  const knownCoreTool = isKnownCoreToolId(toolName);
+  const gatewayRequestedTools = knownCoreTool ? [] : [toolName];
+
   const action = normalizeOptionalString(params.input.action);
   const argsRaw = params.input.args;
   const args =
@@ -203,9 +206,9 @@ export async function invokeGatewayTool(params: {
       surface: "http",
       disablePluginTools,
       senderIsOwner: params.senderIsOwner,
+      gatewayRequestedTools,
     });
 
-  const knownCoreTool = isKnownCoreToolId(toolName);
   let { agentId, tools } = resolveTools(knownCoreTool);
   if (knownCoreTool && !tools.some((candidate) => candidate.name === toolName)) {
     ({ agentId, tools } = resolveTools(false));


### PR DESCRIPTION
## Summary
- Fix Gateway tool invocation so directly requested plugin-provided tools remain resolvable under restrictive tool profiles.
- Keep explicit deny lists and the HTTP safety deny list in force; this only widens resolution for the single requested tool.
- Add regression coverage for the catalog/invoke mismatch where a plugin tool could appear available but return "Tool not available" at invoke time.

## Why
Operators should not get inconsistent behavior where a tool is visible to the Gateway catalog but filtered out during direct invocation. This makes tool invocation more stable and predictable, and helps unblock users relying on Gateway tool calls in constrained profiles.

## Test plan
- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/tools-invoke-http.test.ts
- node scripts/run-tsgo.mjs -p tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src-desktop-tool-gateway-invoke-pr.tsbuildinfo
- pnpm exec oxfmt --check src/gateway/tool-resolution.ts src/gateway/tools-invoke-shared.ts src/gateway/tools-invoke-http.test.ts