### PR TITLE
fix(config): unset array[index] removes single element (#76290)

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2212,6 +2212,35 @@ describe("config cli", () => {
     });
   });
 
+  describe("config unset - array index only removes one element (#76290)", () => {
+    it("removes only the element at the specified index", async () => {
+      const resolved: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "agent-a" },
+            { id: "agent-b" },
+            { id: "agent-c" },
+          ],
+        },
+      };
+      const runtimeMerged: OpenClawConfig = {
+        ...withRuntimeDefaults(resolved),
+      };
+      setSnapshot(resolved, runtimeMerged);
+
+      await runConfigCommand(["config", "unset", "agents.list[1]"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.agents?.list).toEqual([
+        { id: "agent-a" },
+        { id: "agent-c" },
+      ]);
+      // Array-index unset should NOT pass unsetPaths to avoid double-splice
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toBeUndefined();
+    });
+  });
+
   describe("config file", () => {
     it("prints the active config file path", async () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1697,10 +1697,16 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
       runtime.exit(1);
       return;
     }
+    // For array-index unset, the in-memory splice already produced the correct
+    // nextConfig and the merge-patch will carry the whole replacement array.
+    // Passing the path in unsetPaths would cause a redundant second splice
+    // during the write phase, removing an additional element (issue #76290).
+    const lastSegment = parsedPath[parsedPath.length - 1];
+    const targetsArrayIndex = /^[0-9]+$/.test(lastSegment);
     await replaceConfigFile({
       nextConfig: next,
       ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-      writeOptions: { unsetPaths: [parsedPath] },
+      ...(targetsArrayIndex ? {} : { writeOptions: { unsetPaths: [parsedPath] } }),
     });
     runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));
   } catch (err) {


### PR DESCRIPTION
## Root Cause

`openclaw config unset 'agents.list[1]'` performed a **double splice**:

1. `unsetAtPath()` correctly spliced the in-memory clone (index 1 removed → `[a, c]`)
2. The write phase received `writeOptions: { unsetPaths: [["agents","list","1"]] }` and `applyUnsetPathsForWrite()` spliced index 1 **again** on the persist candidate (which already reflected the 2-element array via merge-patch), leaving only `[a]`.

## Fix

For array-index paths (final segment is numeric), skip passing `unsetPaths` to the write options. The merge-patch already carries the correct spliced array; `unsetPaths` is only needed for object-key removal where merge-patch can't express deletion.

## Test

Added unit test: 3-element `agents.list`, unset index 1 → verify written config has exactly 2 elements (`[agent-a, agent-c]`) and no `unsetPaths` write option is passed.

Closes #76290