### PR TITLE
fix(agents): allow configured subagents in sessions_spawn when allowAgents is "*"

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -796,6 +796,9 @@ function resolveAcpSubagentEnvelopeState(params: {
     allowAgents:
       resolveAgentConfig(params.cfg, requesterAgentId)?.subagents?.allowAgents ??
       params.cfg.agents?.defaults?.subagents?.allowAgents,
+    configuredAgentIds: Array.isArray(params.cfg.agents?.list)
+      ? params.cfg.agents.list.map((entry) => normalizeAgentId(entry.id))
+      : undefined,
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -811,6 +811,9 @@ export async function spawnSubagentDirect(
     allowAgents:
       resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ??
       cfg?.agents?.defaults?.subagents?.allowAgents,
+    configuredAgentIds: Array.isArray(cfg.agents?.list)
+      ? cfg.agents.list.map((entry) => normalizeAgentId(entry.id))
+      : undefined,
   });
   if (!targetPolicy.ok) {
     return {

--- a/src/agents/subagent-target-policy.ts
+++ b/src/agents/subagent-target-policy.ts
@@ -59,6 +59,7 @@ export function resolveSubagentTargetPolicy(params: {
   targetAgentId: string;
   requestedAgentId?: string;
   allowAgents?: readonly string[];
+  configuredAgentIds?: readonly string[];
 }): SubagentTargetPolicyResult {
   const requesterAgentId = normalizeAgentId(params.requesterAgentId);
   const targetAgentId = normalizeAgentId(params.targetAgentId);
@@ -69,6 +70,7 @@ export function resolveSubagentTargetPolicy(params: {
   const allowed = resolveSubagentAllowedTargetIds({
     requesterAgentId,
     allowAgents: params.allowAgents,
+    configuredAgentIds: params.configuredAgentIds,
   });
   if (allowed.allowAny || allowed.allowedIds.includes(targetAgentId)) {
     return { ok: true };


### PR DESCRIPTION
## Summary

- Problem: Custom subagents configured in `agents.list` are rejected by `sessions_spawn` with "agentId is not allowed" even when `allowAgents: ["*"]` is set
- Why it matters: Users cannot spawn subagents that appear in `agents_list`, breaking multi-agent workflows
- What changed: `resolveSubagentTargetPolicy` now accepts and forwards `configuredAgentIds` to `resolveSubagentAllowedTargetIds` so allowAny mode works correctly
- What did NOT change: `agents_list` behavior was already correct; no changes to policy evaluation logic

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Skills / tool execution
- [ ] Gateway / orchestration
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76228
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `resolveSubagentTargetPolicy` was not passing `configuredAgentIds` to `resolveSubagentAllowedTargetIds`, so when `allowAgents: ["*"]` the allowedIds defaulted to empty array
- Missing detection / guardrail: No unit test covers allowAny + configuredAgentIds interaction
- Contributing context: `agents-list-tool.ts` correctly passed this parameter; `subagent-spawn.ts` and `acp-spawn.ts` did not

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-target-policy.test.ts`
- Scenario the test should lock in: `resolveSubagentTargetPolicy` with `allowAgents: ["*"]` and configured agent IDs should return ok=true for those agents
- Why this is the smallest reliable guardrail: Tests the exact function that was missing the parameter
- Existing test that already covers this (if any): No existing test for this combination
- If no new test is added, why not: Test addition can be done in follow-up; fix is minimal and correct

## User-visible / Behavior Changes

- `sessions_spawn` now correctly allows custom subagents when `allowAgents: ["*"]` is configured
