### PR TITLE
Show workspace bootstrap context in Codex prompt snapshots

### DIFF
--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/README.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/README.md
@@ -8,7 +8,9 @@ These fixtures capture the default OpenAI/Codex happy path for prompt review:
 - `messages.visibleReplies: "message_tool"`, which is the Codex-harness default for visible source replies.
 - Telegram direct chat, Discord group chat, and a heartbeat turn with `heartbeat_respond` available.
 
-The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, user turn input, and references to the complete dynamic tool catalog.
+The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, user turn input, and references to the complete dynamic tool catalog.
+
+The workspace bootstrap simulation includes dummy `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md` contents so prompt reviewers can see how those OpenClaw project/user context files are forwarded to Codex. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.
 
 The tool catalog is pinned to the canonical happy-path OpenClaw tools so optional locally installed plugin tools do not create fixture churn.
 
@@ -18,7 +20,7 @@ The Codex model prompt fixture is generated from the same Codex model catalog/ca
 pnpm prompt:snapshots:sync-codex-model
 ```
 
-These snapshots are still not a byte-for-byte raw OpenAI request capture. Codex-owned workspace context such as `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions can be added inside the Codex runtime after OpenClaw sends thread and turn params.
+These snapshots are still not a byte-for-byte raw OpenAI request capture. Codex-owned native `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions can be added inside the Codex runtime after OpenClaw sends thread and turn params.
 
 Regenerate with:
 

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -7,6 +7,7 @@
 - Default happy path: the same Codex agent is mentioned in a Discord group/channel while Telegram can remain the user's primary direct interface.
 - Group-visible output must be explicit through the message tool; the model is also told to mostly lurk unless directly addressed or clearly useful.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
+- This also simulates workspace bootstrap files forwarded through Codex `config.instructions`: `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md`.
 
 ## Scenario Metadata
 
@@ -19,6 +20,11 @@
   "model": "gpt-5.5",
   "modelProvider": "openai",
   "runtime": "codex_app_server",
+  "simulatedWorkspaceBootstrapFiles": [
+    "/tmp/openclaw-happy-path/workspace/SOUL.md",
+    "/tmp/openclaw-happy-path/workspace/TOOLS.md",
+    "/tmp/openclaw-happy-path/workspace/HEARTBEAT.md"
+  ],
   "sourceReplyDeliveryMode": "message_tool_only",
   "toolSnapshot": "codex-dynamic-tools.discord-group.json",
   "trigger": "user"
@@ -69,6 +75,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
@@ -103,6 +112,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "model": "gpt-5.5",
   "persistExtendedHistory": true,
@@ -136,7 +148,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -161,9 +173,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "limitations": [
     "This is a reconstructed prompt-layer snapshot, not a byte-for-byte raw OpenAI request captured from Codex core.",
-    "Codex-owned workspace and app context is listed as a runtime-owned gap until Codex exposes a rendered-prompt inspection API."
+    "Codex-owned workspace AGENTS.md, environment context, memories, app/plugin instructions, and provider tool serialization are still runtime-owned gaps until Codex exposes a rendered-prompt inspection API."
   ],
   "openClawRuntime": {
+    "configInstructionsFrom": "extensions/codex app-server thread/start config.instructions",
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
     "userInputFrom": "extensions/codex app-server turn/start input"
@@ -183,6 +196,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "chars": 307,
     "roughTokens": 77
   },
+  "codexWorkspaceBootstrapConfigInstructions": {
+    "chars": 632,
+    "roughTokens": 158
+  },
   "dynamicToolsJson": {
     "chars": 50058,
     "roughTokens": 12515
@@ -192,12 +209,12 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 2151
   },
   "totalTextOnly": {
-    "chars": 31122,
-    "roughTokens": 7781
+    "chars": 31756,
+    "roughTokens": 7939
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81182,
-    "roughTokens": 20296
+    "chars": 81816,
+    "roughTokens": 20454
   },
   "userInputText": {
     "chars": 870,
@@ -371,6 +388,29 @@ In your final answer, you keep the light on the things that matter most. Avoid l
 ```text
 Filesystem sandboxing defines which files can be read or written. `sandbox_mode` is `danger-full-access`: No filesystem sandboxing - all commands are permitted. Network access is enabled.
 Approval policy is currently never. Do not provide the `sandbox_permissions` for any reason, commands will be rejected.
+```
+
+### User: Codex Config Instructions (OpenClaw Workspace Bootstrap Context)
+
+```text
+OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.
+
+# Project Context
+
+The following project context files have been loaded:
+If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.
+
+## /tmp/openclaw-happy-path/workspace/SOUL.md
+
+<SOUL.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/TOOLS.md
+
+<TOOLS.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md
+
+<HEARTBEAT.md contents will be here>
 ```
 
 ### Developer: OpenClaw Runtime Instructions

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -7,6 +7,7 @@
 - Default happy path: OpenAI model through the Codex harness/runtime, Telegram direct conversation, and message-tool-only visible replies.
 - A quiet turn is represented by not calling `message(action=send)`; the normal final assistant text is private to OpenClaw/Codex.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
+- This also simulates workspace bootstrap files forwarded through Codex `config.instructions`: `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md`.
 
 ## Scenario Metadata
 
@@ -19,6 +20,11 @@
   "model": "gpt-5.5",
   "modelProvider": "openai",
   "runtime": "codex_app_server",
+  "simulatedWorkspaceBootstrapFiles": [
+    "/tmp/openclaw-happy-path/workspace/SOUL.md",
+    "/tmp/openclaw-happy-path/workspace/TOOLS.md",
+    "/tmp/openclaw-happy-path/workspace/HEARTBEAT.md"
+  ],
   "sourceReplyDeliveryMode": "message_tool_only",
   "toolSnapshot": "codex-dynamic-tools.telegram-direct.json",
   "trigger": "user"
@@ -69,6 +75,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
@@ -103,6 +112,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "model": "gpt-5.5",
   "persistExtendedHistory": true,
@@ -136,7 +148,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -161,9 +173,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "limitations": [
     "This is a reconstructed prompt-layer snapshot, not a byte-for-byte raw OpenAI request captured from Codex core.",
-    "Codex-owned workspace and app context is listed as a runtime-owned gap until Codex exposes a rendered-prompt inspection API."
+    "Codex-owned workspace AGENTS.md, environment context, memories, app/plugin instructions, and provider tool serialization are still runtime-owned gaps until Codex exposes a rendered-prompt inspection API."
   ],
   "openClawRuntime": {
+    "configInstructionsFrom": "extensions/codex app-server thread/start config.instructions",
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
     "userInputFrom": "extensions/codex app-server turn/start input"
@@ -183,6 +196,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "chars": 307,
     "roughTokens": 77
   },
+  "codexWorkspaceBootstrapConfigInstructions": {
+    "chars": 632,
+    "roughTokens": 158
+  },
   "dynamicToolsJson": {
     "chars": 49749,
     "roughTokens": 12438
@@ -192,12 +209,12 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 1934
   },
   "totalTextOnly": {
-    "chars": 29751,
-    "roughTokens": 7438
+    "chars": 30385,
+    "roughTokens": 7597
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79502,
-    "roughTokens": 19876
+    "chars": 80136,
+    "roughTokens": 20034
   },
   "userInputText": {
     "chars": 370,
@@ -371,6 +388,29 @@ In your final answer, you keep the light on the things that matter most. Avoid l
 ```text
 Filesystem sandboxing defines which files can be read or written. `sandbox_mode` is `danger-full-access`: No filesystem sandboxing - all commands are permitted. Network access is enabled.
 Approval policy is currently never. Do not provide the `sandbox_permissions` for any reason, commands will be rejected.
+```
+
+### User: Codex Config Instructions (OpenClaw Workspace Bootstrap Context)
+
+```text
+OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.
+
+# Project Context
+
+The following project context files have been loaded:
+If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.
+
+## /tmp/openclaw-happy-path/workspace/SOUL.md
+
+<SOUL.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/TOOLS.md
+
+<TOOLS.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md
+
+<HEARTBEAT.md contents will be here>
 ```
 
 ### Developer: OpenClaw Runtime Instructions

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -7,6 +7,7 @@
 - Heartbeat happy path: Codex receives the structured `heartbeat_respond` dynamic tool because `messages.visibleReplies` is `message_tool`.
 - The heartbeat tool carries the notify/no-notify decision, outcome, summary, and optional notification text instead of relying only on final-text parsing.
 - This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.
+- This also simulates workspace bootstrap files forwarded through Codex `config.instructions`: `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md`.
 
 ## Scenario Metadata
 
@@ -19,6 +20,11 @@
   "model": "gpt-5.5",
   "modelProvider": "openai",
   "runtime": "codex_app_server",
+  "simulatedWorkspaceBootstrapFiles": [
+    "/tmp/openclaw-happy-path/workspace/SOUL.md",
+    "/tmp/openclaw-happy-path/workspace/TOOLS.md",
+    "/tmp/openclaw-happy-path/workspace/HEARTBEAT.md"
+  ],
   "sourceReplyDeliveryMode": "message_tool_only",
   "toolSnapshot": "codex-dynamic-tools.heartbeat-turn.json",
   "trigger": "heartbeat"
@@ -69,6 +75,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
@@ -104,6 +113,9 @@
 {
   "approvalPolicy": "never",
   "approvalsReviewer": "user",
+  "config": {
+    "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nIf SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
+  },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "model": "gpt-5.5",
   "persistExtendedHistory": true,
@@ -137,7 +149,7 @@
 
 ## Reconstructed Model-Bound Prompt Layers
 
-This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
+This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.
 
 ### Layer Metadata
 
@@ -162,9 +174,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
   },
   "limitations": [
     "This is a reconstructed prompt-layer snapshot, not a byte-for-byte raw OpenAI request captured from Codex core.",
-    "Codex-owned workspace and app context is listed as a runtime-owned gap until Codex exposes a rendered-prompt inspection API."
+    "Codex-owned workspace AGENTS.md, environment context, memories, app/plugin instructions, and provider tool serialization are still runtime-owned gaps until Codex exposes a rendered-prompt inspection API."
   ],
   "openClawRuntime": {
+    "configInstructionsFrom": "extensions/codex app-server thread/start config.instructions",
     "developerInstructionsFrom": "extensions/codex app-server thread/start developerInstructions",
     "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
     "userInputFrom": "extensions/codex app-server turn/start input"
@@ -184,6 +197,10 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "chars": 307,
     "roughTokens": 77
   },
+  "codexWorkspaceBootstrapConfigInstructions": {
+    "chars": 632,
+    "roughTokens": 158
+  },
   "dynamicToolsJson": {
     "chars": 50872,
     "roughTokens": 12718
@@ -193,12 +210,12 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 1934
   },
   "totalTextOnly": {
-    "chars": 29849,
-    "roughTokens": 7463
+    "chars": 30483,
+    "roughTokens": 7621
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80723,
-    "roughTokens": 20181
+    "chars": 81357,
+    "roughTokens": 20340
   },
   "userInputText": {
     "chars": 468,
@@ -372,6 +389,29 @@ In your final answer, you keep the light on the things that matter most. Avoid l
 ```text
 Filesystem sandboxing defines which files can be read or written. `sandbox_mode` is `danger-full-access`: No filesystem sandboxing - all commands are permitted. Network access is enabled.
 Approval policy is currently never. Do not provide the `sandbox_permissions` for any reason, commands will be rejected.
+```
+
+### User: Codex Config Instructions (OpenClaw Workspace Bootstrap Context)
+
+```text
+OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.
+
+# Project Context
+
+The following project context files have been loaded:
+If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.
+
+## /tmp/openclaw-happy-path/workspace/SOUL.md
+
+<SOUL.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/TOOLS.md
+
+<TOOLS.md contents will be here>
+
+## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md
+
+<HEARTBEAT.md contents will be here>
 ```
 
 ### Developer: OpenClaw Runtime Instructions

--- a/test/helpers/agents/happy-path-prompt-snapshots.ts
+++ b/test/helpers/agents/happy-path-prompt-snapshots.ts
@@ -73,6 +73,7 @@ type CodexPromptSnapshotApi = {
     threadId: string;
     dynamicTools: CodexDynamicToolSpec[];
     appServer: unknown;
+    config?: Record<string, unknown>;
     promptText?: string;
   }) => {
     developerInstructions: string;
@@ -110,6 +111,43 @@ type PromptScenario = {
 };
 
 const codexApi = loadBundledPluginTestApiSync("codex") as CodexPromptSnapshotApi;
+
+const CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES = [
+  {
+    path: path.join(WORKSPACE_DIR, "SOUL.md"),
+    content: "<SOUL.md contents will be here>",
+  },
+  {
+    path: path.join(WORKSPACE_DIR, "TOOLS.md"),
+    content: "<TOOLS.md contents will be here>",
+  },
+  {
+    path: path.join(WORKSPACE_DIR, "HEARTBEAT.md"),
+    content: "<HEARTBEAT.md contents will be here>",
+  },
+] as const;
+
+const CODEX_WORKSPACE_BOOTSTRAP_INSTRUCTIONS = [
+  "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.",
+  "",
+  "# Project Context",
+  "",
+  "The following project context files have been loaded:",
+  "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+  "",
+  ...CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES.flatMap((file) => [
+    `## ${file.path}`,
+    "",
+    file.content,
+    "",
+  ]),
+]
+  .join("\n")
+  .trim();
+
+const CODEX_WORKSPACE_BOOTSTRAP_CONFIG = {
+  instructions: CODEX_WORKSPACE_BOOTSTRAP_INSTRUCTIONS,
+};
 
 const baseConfig: OpenClawConfig = {
   messages: {
@@ -506,19 +544,29 @@ function renderModelBoundPromptLayers(params: {
 }): string[] {
   const codexModelInstructions = readFixture(CODEX_MODEL_PROMPT_FIXTURE_PATH);
   const codexModelSource = JSON.parse(readFixture(CODEX_MODEL_PROMPT_SOURCE_PATH)) as unknown;
+  const codexConfigInstructions =
+    typeof params.codexSnapshot.threadStartParams.config === "object" &&
+    params.codexSnapshot.threadStartParams.config &&
+    "instructions" in params.codexSnapshot.threadStartParams.config &&
+    typeof params.codexSnapshot.threadStartParams.config.instructions === "string"
+      ? params.codexSnapshot.threadStartParams.config.instructions
+      : "";
   const openClawDeveloperInstructions = params.codexSnapshot.developerInstructions;
   const textOnlyTotal = [
     codexModelInstructions,
     CODEX_YOLO_PERMISSION_INSTRUCTIONS,
+    codexConfigInstructions,
     openClawDeveloperInstructions,
     params.scenario.prompt,
-  ].join("\n\n");
+  ]
+    .filter(Boolean)
+    .join("\n\n");
   const totalWithDynamicToolJson = [textOnlyTotal, params.dynamicToolsJson].join("\n\n");
 
   return [
     "## Reconstructed Model-Bound Prompt Layers",
     "",
-    "This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.",
+    "This is the deterministic model-bound layer stack OpenClaw can snapshot for the Codex happy path. It uses a pinned Codex `gpt-5.5` prompt fixture generated from Codex's model catalog/cache shape, then adds the Codex permission developer text, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, turn input, and the OpenClaw dynamic tool catalog. Codex can still add runtime-owned context such as native workspace `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions inside the Codex runtime.",
     "",
     "### Layer Metadata",
     "",
@@ -535,6 +583,7 @@ function renderModelBoundPromptLayers(params: {
           networkAccess: "enabled",
         },
         openClawRuntime: {
+          configInstructionsFrom: "extensions/codex app-server thread/start config.instructions",
           developerInstructionsFrom:
             "extensions/codex app-server thread/start developerInstructions",
           userInputFrom: "extensions/codex app-server turn/start input",
@@ -542,7 +591,7 @@ function renderModelBoundPromptLayers(params: {
         },
         limitations: [
           "This is a reconstructed prompt-layer snapshot, not a byte-for-byte raw OpenAI request captured from Codex core.",
-          "Codex-owned workspace and app context is listed as a runtime-owned gap until Codex exposes a rendered-prompt inspection API.",
+          "Codex-owned workspace AGENTS.md, environment context, memories, app/plugin instructions, and provider tool serialization are still runtime-owned gaps until Codex exposes a rendered-prompt inspection API.",
         ],
       }),
     ),
@@ -554,6 +603,7 @@ function renderModelBoundPromptLayers(params: {
       stableJson({
         codexModelInstructions: textStats(codexModelInstructions),
         codexPermissionDeveloperInstructions: textStats(CODEX_YOLO_PERMISSION_INSTRUCTIONS),
+        codexWorkspaceBootstrapConfigInstructions: textStats(codexConfigInstructions),
         openClawDeveloperInstructions: textStats(openClawDeveloperInstructions),
         userInputText: textStats(params.scenario.prompt),
         dynamicToolsJson: textStats(params.dynamicToolsJson),
@@ -569,6 +619,10 @@ function renderModelBoundPromptLayers(params: {
     "### Developer: Codex Permission Instructions",
     "",
     markdownFence("text", CODEX_YOLO_PERMISSION_INSTRUCTIONS),
+    "",
+    "### User: Codex Config Instructions (OpenClaw Workspace Bootstrap Context)",
+    "",
+    markdownFence("text", codexConfigInstructions),
     "",
     "### Developer: OpenClaw Runtime Instructions",
     "",
@@ -599,6 +653,7 @@ function renderScenarioSnapshot(scenario: PromptScenario): string {
     threadId: `thread-${scenario.id}`,
     dynamicTools: scenario.dynamicTools,
     appServer,
+    config: CODEX_WORKSPACE_BOOTSTRAP_CONFIG,
     promptText: scenario.prompt,
   });
   const criticalToolSpecs = scenario.dynamicTools.filter((tool) =>
@@ -614,6 +669,7 @@ function renderScenarioSnapshot(scenario: PromptScenario): string {
     "",
     ...scenario.notes.map((note) => `- ${note}`),
     "- This captures the OpenClaw-owned Codex app-server inputs and reconstructs the stable Codex model/permission layers from committed Codex prompt fixtures.",
+    "- This also simulates workspace bootstrap files forwarded through Codex `config.instructions`: `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md`.",
     "",
     "## Scenario Metadata",
     "",
@@ -630,6 +686,9 @@ function renderScenarioSnapshot(scenario: PromptScenario): string {
         chatType: scenario.ctx.ChatType,
         toolSnapshot: scenario.toolSnapshotFile,
         codexModelInstructionsFixture: CODEX_MODEL_PROMPT_FIXTURE_PATH,
+        simulatedWorkspaceBootstrapFiles: CODEX_WORKSPACE_BOOTSTRAP_CONTEXT_FILES.map(
+          (file) => file.path,
+        ),
       }),
     ),
     "",
@@ -673,7 +732,9 @@ function renderReadme(scenarios: PromptScenario[]): string {
     '- `messages.visibleReplies: "message_tool"`, which is the Codex-harness default for visible source replies.',
     "- Telegram direct chat, Discord group chat, and a heartbeat turn with `heartbeat_respond` available.",
     "",
-    "The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, OpenClaw developer instructions, user turn input, and references to the complete dynamic tool catalog.",
+    "The Markdown files show selected app-server thread/turn params plus a reconstructed model-bound prompt layer stack: Codex `gpt-5.5` model instructions from a pinned Codex model catalog fixture, Codex permission developer instructions for the happy-path yolo profile, simulated OpenClaw workspace bootstrap config instructions, OpenClaw developer instructions, user turn input, and references to the complete dynamic tool catalog.",
+    "",
+    "The workspace bootstrap simulation includes dummy `SOUL.md`, `TOOLS.md`, and `HEARTBEAT.md` contents so prompt reviewers can see how those OpenClaw project/user context files are forwarded to Codex. `AGENTS.md` is intentionally not repeated here because Codex loads it natively.",
     "",
     "The tool catalog is pinned to the canonical happy-path OpenClaw tools so optional locally installed plugin tools do not create fixture churn.",
     "",
@@ -681,7 +742,7 @@ function renderReadme(scenarios: PromptScenario[]): string {
     "",
     markdownFence("sh", "pnpm prompt:snapshots:sync-codex-model"),
     "",
-    "These snapshots are still not a byte-for-byte raw OpenAI request capture. Codex-owned workspace context such as `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions can be added inside the Codex runtime after OpenClaw sends thread and turn params.",
+    "These snapshots are still not a byte-for-byte raw OpenAI request capture. Codex-owned native `AGENTS.md`, environment context, memories, app/plugin instructions, and future collaboration-mode instructions can be added inside the Codex runtime after OpenClaw sends thread and turn params.",
     "",
     "Regenerate with:",
     "",

--- a/test/scripts/prompt-snapshots.test.ts
+++ b/test/scripts/prompt-snapshots.test.ts
@@ -68,6 +68,13 @@ describe("happy path prompt snapshots", () => {
     expect(telegram?.content).toContain(
       "Approval policy is currently never. Do not provide the `sandbox_permissions`",
     );
+    expect(telegram?.content).toContain(
+      "### User: Codex Config Instructions (OpenClaw Workspace Bootstrap Context)",
+    );
+    expect(telegram?.content).toContain("<SOUL.md contents will be here>");
+    expect(telegram?.content).toContain("<TOOLS.md contents will be here>");
+    expect(telegram?.content).toContain("<HEARTBEAT.md contents will be here>");
+    expect(telegram?.content).toContain("Codex loads AGENTS.md natively");
     expect(telegram?.content).toContain("### Tools: Dynamic Tool Catalog");
   });
 


### PR DESCRIPTION
The Codex runtime prompt snapshots now show the model prompt, OpenClaw instructions, user input, and dynamic tools. One missing piece was OpenClaw's workspace bootstrap context: after the recent Codex bootstrap forwarding work, files like SOUL.md, TOOLS.md, and HEARTBEAT.md travel through Codex config.instructions, but the happy-path fixtures did not make that layer visible.

This PR adds dummy workspace bootstrap files to the snapshot generator and renders the resulting config.instructions layer in the reconstructed model-bound prompt. It also records the simulated file paths in snapshot metadata and asserts that the generated Telegram snapshot includes the bootstrap placeholders. AGENTS.md stays documented as native Codex-owned context rather than being duplicated in these fixtures.
