### PR TITLE
fix(cron): rewrite anthropic provider for cli runtime in cron lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/agent: rewrite the canonical execution provider to the configured CLI runtime alias before invoking the cron CLI agent path, so cron and hook lanes honor `agents.defaults.agentRuntime.id` (e.g. `claude-cli`) the same way the mention/Slack lane does. Without this rewrite, cron-triggered runs received the raw provider id (e.g. `anthropic`) and silently bypassed the configured CLI runtime.
 - Gateway: keep directly requested plugin tools invokable under restrictive tool profiles while preserving explicit deny lists and the HTTP safety deny list, preventing catalog/invoke mismatches that surface as "Tool not available". Thanks @BunsDev.
 - Gateway/update: allow beta binaries to refresh gateway services when the config was last written by the matching stable release version, avoiding false newer-config downgrade blocks during beta channel updates.
 - Channels: keep Matrix and Mattermost bundled in the core package instead of advertising external npm installs before those channels are cut over. Thanks @vincentkoc.

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,3 +1,4 @@
+import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import { normalizeToolList } from "../../agents/tool-policy.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
@@ -137,10 +138,16 @@ export function createCronPromptExecutor(params: {
         }
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
-        if (isCliProvider(providerOverride, params.cfgWithAgentDefaults)) {
+        const cliExecutionProvider =
+          resolveCliRuntimeExecutionProvider({
+            provider: providerOverride,
+            cfg: params.cfgWithAgentDefaults,
+            agentId: params.agentId,
+          }) ?? providerOverride;
+        if (isCliProvider(cliExecutionProvider, params.cfgWithAgentDefaults)) {
           const cliSessionId = params.cronSession.isNewSession
             ? undefined
-            : await getCliSessionId(params.cronSession.sessionEntry, providerOverride);
+            : await getCliSessionId(params.cronSession.sessionEntry, cliExecutionProvider);
           const result = await runCliAgent({
             sessionId: params.cronSession.sessionEntry.sessionId,
             sessionKey: params.runSessionKey,
@@ -151,7 +158,7 @@ export function createCronPromptExecutor(params: {
             workspaceDir: params.workspaceDir,
             config: params.cfgWithAgentDefaults,
             prompt: promptText,
-            provider: providerOverride,
+            provider: cliExecutionProvider,
             model: modelOverride,
             thinkLevel: params.thinkLevel,
             timeoutMs: params.timeoutMs,

--- a/src/cron/isolated-agent/run.runtime-aliases.test.ts
+++ b/src/cron/isolated-agent/run.runtime-aliases.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  isCliProviderMock,
+  loadRunCronIsolatedAgentTurn,
+  runCliAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+// Regression test for cron lane parity with the mention/Slack lane: when the
+// fallback wrapper invokes the run callback with a canonical provider id (e.g.
+// "anthropic") but `agents.defaults.agentRuntime.id` selects a CLI runtime
+// (e.g. "claude-cli"), the cron executor must rewrite the execution provider
+// before calling runCliAgent. Without the rewrite, runCliAgent receives the
+// raw provider id and the CLI runtime never executes.
+describe("runCronIsolatedAgentTurn — cli runtime alias rewrite", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  function mockFallbackInvocationWithProvider(provider: string, model: string) {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
+        const result = await params.run(provider, model);
+        return { result, provider, model, attempts: [] };
+      },
+    );
+  }
+
+  it("rewrites canonical provider to CLI runtime when agents.defaults.agentRuntime selects claude-cli", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "output" }],
+      meta: { agentMeta: { sessionId: "test-session", usage: { input: 5, output: 10 } } },
+    });
+    mockFallbackInvocationWithProvider("anthropic", "claude-opus-4-6");
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        cfg: {
+          agents: {
+            defaults: { agentRuntime: { id: "claude-cli" } },
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    expect(runCliAgentMock.mock.calls[0][0]).toHaveProperty("provider", "claude-cli");
+  });
+
+  it("rewrites per-agent runtime override over canonical provider", async () => {
+    isCliProviderMock.mockReturnValue(true);
+    runCliAgentMock.mockResolvedValue({
+      payloads: [{ text: "output" }],
+      meta: { agentMeta: { sessionId: "test-session", usage: { input: 5, output: 10 } } },
+    });
+    mockFallbackInvocationWithProvider("anthropic", "claude-opus-4-6");
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        cfg: {
+          agents: {
+            list: [{ id: "scout", agentRuntime: { id: "claude-cli" } }],
+          },
+        },
+        agentId: "scout",
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runCliAgentMock).toHaveBeenCalledOnce();
+    expect(runCliAgentMock.mock.calls[0][0]).toHaveProperty("provider", "claude-cli");
+  });
+});


### PR DESCRIPTION
## Problem

When `agents.defaults.agentRuntime.id = \"claude-cli\"` is set in `openclaw.json`, Slack/mention turns correctly use the cli runtime (subscription-quota path), but **cron and webhook-hook turns always fall through to the embedded path** (anthropic SDK direct) and bypass the configured cli runtime.

In a deployment using OpenClaw v2026.4.29 with a Supabase webhook hook → \`action: agent\` mapping, every hook-triggered turn hit anthropic API direct and rejected with \`\"out of extra usage\"\`, even though the same agent answered Slack mentions just fine through claude-cli.

## Root cause

Two lanes call \`isCliProvider(provider, cfg)\` to decide cli vs embedded execution.

**Slack/mention lane** — \`src/agents/command/attempt-execution.ts:306-313\` rewrites the raw \`\"anthropic\"\` provider to the configured cli runtime before the check:

\`\`\`ts
const cliExecutionProvider = isRawModelRun
  ? params.providerOverride
  : (resolveCliRuntimeExecutionProvider({
      provider: params.providerOverride,
      cfg: params.cfg,
      agentId: params.sessionAgentId,
      runtimeOverride: agentRuntimeOverride,
    }) ?? params.providerOverride);
...
if (!isRawModelRun && isCliProvider(cliExecutionProvider, params.cfg)) {
\`\`\`

**Cron/hook lane** — \`src/cron/isolated-agent/run-executor.ts\` (pre-fix L140) calls \`isCliProvider\` on the raw provider directly, with no rewrite:

\`\`\`ts
if (isCliProvider(providerOverride, params.cfgWithAgentDefaults)) {
\`\`\`

\`resolveCliRuntimeExecutionProvider\` is what reads \`agents.defaults.agentRuntime.id\` (and per-agent overrides) and maps \`anthropic + claude-cli\` to the configured runtime via \`CLI_RUNTIME_BY_PROVIDER\`. Without that rewrite, the cron lane never recognizes the configured cli runtime and always falls through to \`runEmbeddedPiAgent\`.

## Fix

Mirror the Slack lane: call \`resolveCliRuntimeExecutionProvider\` with the same \`?? rawProvider\` fallback right before the cron lane's \`isCliProvider\` branch, and pass the rewritten \`cliExecutionProvider\` into \`getCliSessionId\` and \`runCliAgent\`. The embedded path is unchanged.

\`\`\`ts
const cliExecutionProvider =
  resolveCliRuntimeExecutionProvider({
    provider: providerOverride,
    cfg: params.cfgWithAgentDefaults,
    agentId: params.agentId,
  }) ?? providerOverride;
if (isCliProvider(cliExecutionProvider, params.cfgWithAgentDefaults)) {
  ...
  : await getCliSessionId(params.cronSession.sessionEntry, cliExecutionProvider);
  const result = await runCliAgent({
    ...
    provider: cliExecutionProvider,
\`\`\`

Behavior delta:

- With \`agents.defaults.agentRuntime.id\` set (e.g. \`\"claude-cli\"\`): cron/hook turns now go through \`runCliAgent\` and use the same subscription-quota path as Slack mentions.
- Without it: \`resolveCliRuntimeExecutionProvider\` returns \`undefined\`, the \`?? providerOverride\` fallback preserves the prior raw provider, and \`isCliProvider\` matches whatever it would have matched before. **No behavior change for deployments that don't configure a cli runtime alias.**

The cron lane intentionally omits the Slack lane's \`runtimeOverride: agentRuntimeOverride\` argument because cron sessions don't carry a per-session \`agentRuntimeOverride\` field. \`resolveConfiguredRuntime\` falls through to the per-agent and \`agents.defaults\` config the same way.

## Testing

- [x] Source-level diff review against the Slack lane reference (\`attempt-execution.ts:306-313\` and the \`isCliProvider\` callsites at L331, L334)
- [x] \`resolveCliRuntimeExecutionProvider\` returns \`undefined\` when \`agentRuntime.id\` is unset → \`?? providerOverride\` fallback preserves existing behavior for deployments without cli runtime aliases
- [ ] Local typecheck (\`bun run check\`) — would appreciate CI confirming this; the diff is small enough that I'm reasonably confident but won't claim more than I tested
- [ ] End-to-end with Supabase webhook hook + \`agentRuntime.id: \"claude-cli\"\` — will run on our staging cluster (dits-agent Pilot) once this lands or via patch-package locally

## Context

**AI-assisted** (Claude Code, Anthropic). Investigation, patch, and PR text all authored through an agentic session. The diff is small (+6/-3) and mirrors an existing reference in the same repo, so I'm confident on intent and unlikely to be hallucinating types — but please treat the local-test checkbox accordingly and let CI/maintainers be the arbiters.

Discovered during a Pilot rollout of an autonomous agent on top of OpenClaw (cron + webhook trigger, claude-cli runtime). Happy to share session logs or repro steps if useful.