### PR TITLE
fix(slack): ignore no_reaction in remove helpers

### DIFF
--- a/extensions/slack/src/actions.reactions.test.ts
+++ b/extensions/slack/src/actions.reactions.test.ts
@@ -1,15 +1,25 @@
 import type { WebClient } from "@slack/web-api";
 import { describe, expect, it, vi } from "vitest";
-import { reactSlackMessage } from "./actions.js";
+import { reactSlackMessage, removeOwnSlackReactions, removeSlackReaction } from "./actions.js";
 
 function createClient() {
   return {
     reactions: {
       add: vi.fn(async () => ({})),
+      remove: vi.fn(async () => ({})),
+      get: vi.fn(async () => ({ message: { reactions: [] } })),
+    },
+    auth: {
+      test: vi.fn(async () => ({ user_id: "U_BOT" })),
     },
   } as unknown as WebClient & {
     reactions: {
       add: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+      get: ReturnType<typeof vi.fn>;
+    };
+    auth: {
+      test: ReturnType<typeof vi.fn>;
     };
   };
 }
@@ -56,5 +66,64 @@ describe("reactSlackMessage", () => {
         error: "invalid_name",
       },
     });
+  });
+});
+
+describe("removeSlackReaction", () => {
+  it("treats no_reaction as idempotent success", async () => {
+    const client = createClient();
+    client.reactions.remove.mockRejectedValueOnce(slackPlatformError("no_reaction"));
+
+    await expect(
+      removeSlackReaction("C1", "123.456", ":white_check_mark:", {
+        client,
+        token: "xoxb-test",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(client.reactions.remove).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "white_check_mark",
+    });
+  });
+
+  it("propagates unrelated reaction remove errors", async () => {
+    const client = createClient();
+    client.reactions.remove.mockRejectedValueOnce(slackPlatformError("channel_not_found"));
+
+    await expect(
+      removeSlackReaction("C1", "123.456", ":x:", {
+        client,
+        token: "xoxb-test",
+      }),
+    ).rejects.toMatchObject({
+      data: {
+        error: "channel_not_found",
+      },
+    });
+  });
+});
+
+describe("removeOwnSlackReactions", () => {
+  it("survives a no_reaction race between list and remove", async () => {
+    const client = createClient();
+    client.reactions.get.mockResolvedValueOnce({
+      message: {
+        reactions: [
+          { name: "thumbsup", users: ["U_BOT"], count: 1 },
+          { name: "eyes", users: ["U_BOT"], count: 1 },
+        ],
+      },
+    });
+    client.reactions.remove
+      .mockRejectedValueOnce(slackPlatformError("no_reaction"))
+      .mockResolvedValueOnce({});
+
+    await expect(
+      removeOwnSlackReactions("C1", "123.456", { client, token: "xoxb-test" }),
+    ).resolves.toEqual(expect.arrayContaining(["thumbsup", "eyes"]));
+
+    expect(client.reactions.remove).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -132,11 +132,18 @@ export async function removeSlackReaction(
   opts: SlackActionClientOpts = {},
 ) {
   const client = await getClient(opts, "write");
-  await client.reactions.remove({
-    channel: channelId,
-    timestamp: messageId,
-    name: normalizeEmoji(emoji),
-  });
+  try {
+    await client.reactions.remove({
+      channel: channelId,
+      timestamp: messageId,
+      name: normalizeEmoji(emoji),
+    });
+  } catch (err) {
+    if (hasSlackPlatformError(err, "no_reaction")) {
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function removeOwnSlackReactions(
@@ -163,11 +170,7 @@ export async function removeOwnSlackReactions(
   }
   await Promise.all(
     Array.from(toRemove, (name) =>
-      client.reactions.remove({
-        channel: channelId,
-        timestamp: messageId,
-        name,
-      }),
+      removeSlackReaction(channelId, messageId, name, { ...opts, client }),
     ),
   );
   return Array.from(toRemove);


### PR DESCRIPTION
## Summary

Symmetric completion of #50733: closes the `no_reaction` half at the helper level by mirroring steipete's `6470a23` `already_reacted` guard pattern.

## Changes

- `removeSlackReaction` (`actions.ts:128-149`): wrap `client.reactions.remove` in `try/catch`; treat `no_reaction` as idempotent success via `hasSlackPlatformError(err, "no_reaction")`; re-throw all other errors. Mirror of `reactSlackMessage`'s `already_reacted` guard at `:107-126`.
- `removeOwnSlackReactions` (`actions.ts:142-178`): delegate parallel removals through `removeSlackReaction(...)` instead of calling `client.reactions.remove` directly. Closes the race-window where one of N parallel removes fails because another process (e.g., a concurrent reset) already removed the reaction. Pre-resolved client is threaded through `{ ...opts, client }` to avoid re-auth (short-circuited at `getClient` `:91-93`).

`dispatch.ts` is intentionally untouched — defense-in-depth from `6470a23` lives there and continues to apply.

## Tests

3 new cases in `actions.reactions.test.ts`, mirroring the existing 2-test `reactSlackMessage` style:
- `removeSlackReaction` treats `no_reaction` as idempotent success.
- `removeSlackReaction` propagates unrelated remove errors (`channel_not_found`).
- `removeOwnSlackReactions` survives a `no_reaction` race between list and remove (first remove → `no_reaction`, second → success; asserts both reactions returned + 2 calls).

## Coordination

Posted a coordination comment on #50881 on 2026-04-30 21:14 UYT offering @Hollychou924 first refusal on the `no_reaction` half. 48h+ no reply; #50881's branch dates from 2026-03-20 and the Codex review on it confirmed the branch is stale relative to steipete's `6470a23` shape. This PR opens with the helper-level scope steipete's pattern set.

Verified against \`upstream/main\` \`9404a4ddcd\`. Fixes the remove-side half of #50733.