### PR TITLE
fix(pr): prefer verified GitHub commits for prep pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Gateway/responses: emit every client tool call from `/v1/responses` JSON and SSE responses when the agent invokes multiple client tools in a single turn, so multi-tool plans, graph orchestration calls, and similar batched flows no longer drop every call but the last. Fixes #52288. Thanks @CharZhou and @bonelli.
 - Control UI/Gateway: avoid full session-list reloads for locally applied message-phase session updates, carry known session keys through transcript-file update events, and defer media provider listing when explicit generation model config is present. Refs #76236, #76203, #76188, #76107, and #76166. Thanks @BunsDev.
 - Install/update: prune the obsolete `plugin-runtime-deps` state directory during packaged postinstall so upgrades from pre-2026.5.2 releases reclaim old bundled-plugin dependency caches without touching external plugin installs.

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -202,6 +202,27 @@ resolve_prhead_remote_sha() {
   printf '%s\n' "$remote_sha"
 }
 
+push_prep_head_once() {
+  local pr_head="$1"
+  local lease_sha="$2"
+  local prep_head_sha="$3"
+
+  if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ] && [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" != "git" ]; then
+    echo "Pushing PR branch through GitHub createCommitOnBranch so the prepared commit is verified." >&2
+    graphql_push_to_fork "${PR_HEAD_OWNER}/${PR_HEAD_REPO_NAME}" "$pr_head" "$lease_sha"
+    return $?
+  fi
+
+  if [ "${OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH:-}" != "1" ]; then
+    echo "Refusing git-protocol PR branch push because it can publish unsigned commits." >&2
+    echo "Use the default GitHub createCommitOnBranch path, or set OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1 for an explicit manual override." >&2
+    return 2
+  fi
+
+  git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head >&2
+  printf '%s\n' "$prep_head_sha"
+}
+
 push_prep_head_to_pr_branch() {
   local pr="$1"
   local pr_head="$2"
@@ -226,9 +247,7 @@ push_prep_head_to_pr_branch() {
     fi
     pushed_from_sha="$lease_sha"
     local push_output
-    if ! push_output=$(
-      git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head 2>&1
-    ); then
+    if ! push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
       echo "Push failed: $push_output"
 
       if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
@@ -253,9 +272,7 @@ push_prep_head_to_pr_branch() {
           run_prepare_push_retry_gates "$docs_only"
         fi
 
-        if ! push_output=$(
-          git push --force-with-lease=refs/heads/$pr_head:$lease_sha prhead HEAD:$pr_head 2>&1
-        ); then
+        if ! push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
           echo "Retry push failed: $push_output"
           if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
             echo "Retry failed; trying GraphQL createCommitOnBranch fallback..."
@@ -266,8 +283,12 @@ push_prep_head_to_pr_branch() {
             echo "Git push failed and no fork owner/repo info for GraphQL fallback."
             exit 1
           fi
+        else
+          prep_head_sha=$(printf '%s\n' "$push_output" | tail -n 1)
         fi
       fi
+    else
+      prep_head_sha=$(printf '%s\n' "$push_output" | tail -n 1)
     fi
   fi
 


### PR DESCRIPTION
## Summary

- route maintainer prepare pushes through GitHub `createCommitOnBranch` by default when PR head repo metadata is available
- require an explicit `OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1` override before falling back to git-protocol PR branch pushes
- add changelog attribution for the verified-commit guard

## Root Cause

The maintainer prepare path created local commits and then used git-protocol force pushes whenever the PR head was writable. In this checkout, a repo-local Git config override had disabled signing, so Codex/local repair commits were accepted on PR branches as unsigned commits.

## Local config remediation

This checkout now has repo-local signing re-enabled:

- `commit.gpgsign=true`
- `rebase.gpgsign=true`

## Validation

- `bash -n scripts/pr-lib/push.sh`
- `git diff --check`
- `pnpm check:changelog-attributions`
