### PR TITLE
fix(ci): realign check-no-raw-channel-fetch allowlist line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
+- CI/boundaries: align `check-no-raw-channel-fetch` allowlist with `chutes/models.ts` and `huggingface/models.ts` after the line-drift from the provider env-guard refactor (52cd76a9e2), so `lint:tmp:no-raw-channel-fetch` stops false-flagging untouched legacy fetch callsites.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.
 - Gateway/responses: emit every client tool call from `/v1/responses` JSON and SSE responses when the agent invokes multiple client tools in a single turn, so multi-tool plans, graph orchestration calls, and similar batched flows no longer drop every call but the last. Fixes #52288. Thanks @CharZhou and @bonelli.


### PR DESCRIPTION
## Summary

`check-additional-boundaries` is failing on `main` and on every open PR
because `lint:tmp:no-raw-channel-fetch` flags 3 legacy callsites that are
already on the allowlist — they just moved down by one line.

## Root cause

Commit 52cd76a9e2 (`fix(providers): isolate model discovery test env guards`)
inserted one line above the raw `fetch()` callsites in:

- `extensions/chutes/models.ts` — fetch moved 535 → 536 and 542 → 543
- `extensions/huggingface/models.ts` — fetch moved 142 → 143

`scripts/check-no-raw-channel-fetch.mjs` still references the pre-shift
line numbers, so `runCallsiteGuard` sees the fetch at 536/543/143 as "new
raw fetch() in channel/plugin runtime" and aborts.

Reproduce on a clean `main` checkout:

```
git checkout main
node scripts/check-no-raw-channel-fetch.mjs
# Found raw fetch() usage in channel/plugin runtime sources outside allowlist:
# - extensions/chutes/models.ts:536
# - extensions/chutes/models.ts:543
# - extensions/huggingface/models.ts:143
```

## Fix

Bump the 3 allowlist entries by one. Nothing else changes — the fetch
callsites themselves are untouched, and the guard matches callsites by
`{package, file, line}` identity, so a one-line drift is the whole
problem.

## Verification

```
node scripts/check-no-raw-channel-fetch.mjs
echo $?    # 0
```

No fetch callsites were added, moved, or rewritten in this PR.
