### PR TITLE
fix(postinstall): skip EACCES/EPERM compile cache prune warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,7 @@ Docs: https://docs.openclaw.ai
 - Config/recovery: chmod restored `openclaw.json` back to owner-only (`0600`) after suspicious-read backup recovery on POSIX hosts, so a previously world-readable config mode cannot persist into a freshly restored credential-bearing config. (#77488) Thanks @drobison00.
 - Memory/dreaming: persist last dreaming-ingestion calendar day per daily note in `daily-ingestion.json` so unchanged notes are still re-ingested once per dreaming day for promotion signals toward deep thresholds. Fixes #76225. (#76359) Thanks @neeravmakwana.
 - Agents/embed: keep message_end safety delivery armed when a silent text_end chunk produces no block reply, fixing dropped Telegram/forum replies. Fixes #77833. (#77840) Thanks @neeravmakwana.
+- Install/postinstall: skip noisy compile-cache prune warnings when `EACCES`/`EPERM` prevent removing shared `/tmp/node-compile-cache` entries owned by another user. Fixes #76353. (#76362) Thanks @RayWoo and @neeravmakwana.
 
 ## 2026.5.3-1
 

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -814,6 +814,10 @@ function shouldRunBundledPluginPostinstall(params) {
   return true;
 }
 
+function isCompileCachePrunePermissionDenied(error) {
+  return error?.code === "EACCES" || error?.code === "EPERM";
+}
+
 export function pruneOpenClawCompileCache(params = {}) {
   const env = params.env ?? process.env;
   const pathExists = params.existsSync ?? existsSync;
@@ -842,10 +846,16 @@ export function pruneOpenClawCompileCache(params = {}) {
             retryDelay: 100,
           });
         } catch (error) {
+          if (isCompileCachePrunePermissionDenied(error)) {
+            continue;
+          }
           log.warn?.(`[postinstall] could not prune OpenClaw compile cache: ${String(error)}`);
         }
       }
     } catch (error) {
+      if (isCompileCachePrunePermissionDenied(error)) {
+        continue;
+      }
       log.warn?.(`[postinstall] could not prune OpenClaw compile cache: ${String(error)}`);
     }
   }

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -147,6 +147,57 @@ describe("bundled plugin postinstall", () => {
     );
   });
 
+  it("does not warn when compile-cache pruning hits EACCES or EPERM (shared caches)", () => {
+    const base = path.join("/tmp", "openclaw-shared-compile-cache");
+    const dirA = path.join(base, "v22.13.1-x64-efe9a9df-1001");
+    const dirB = path.join(base, "v22.13.1-x64-efe9a9df-1002");
+    const warn = vi.fn();
+    const rmSync = vi.fn((value: string) => {
+      if (value === dirA) {
+        throw Object.assign(new Error(`permission denied pruning ${value}`), { code: "EACCES" });
+      }
+      if (value === dirB) {
+        throw Object.assign(new Error(`operation not permitted pruning ${value}`), {
+          code: "EPERM",
+        });
+      }
+    });
+
+    pruneOpenClawCompileCache({
+      env: { NODE_COMPILE_CACHE: base },
+      existsSync: vi.fn((value: string) => value === base),
+      readdirSync: vi.fn(() => [
+        { name: path.basename(dirA), isDirectory: () => true },
+        { name: path.basename(dirB), isDirectory: () => true },
+      ]),
+      rmSync,
+      log: { warn },
+    });
+
+    expect(rmSync).toHaveBeenCalledTimes(2);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when the compile-cache base directory cannot be listed (EACCES)", () => {
+    const base = path.join("/tmp", "openclaw-compile-cache-no-list");
+    const warn = vi.fn();
+    const rmSync = vi.fn();
+    const err = Object.assign(new Error(`EACCES: ${base}`), { code: "EACCES" });
+
+    pruneOpenClawCompileCache({
+      env: { NODE_COMPILE_CACHE: base },
+      existsSync: vi.fn(() => true),
+      readdirSync: vi.fn(() => {
+        throw err;
+      }),
+      rmSync,
+      log: { warn },
+    });
+
+    expect(rmSync).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("does not classify published packages with source files as source checkouts", () => {
     const packageRoot = "/pkg";
     const existingPaths = new Set([


### PR DESCRIPTION
## Root cause

`pruneOpenClawCompileCache` removes Node version-shaped directories under `$NODE_COMPILE_CACHE` and under the default `$TMPDIR/node-compile-cache`. On shared hosts, those bases can belong to another user (for example after a root-owned global install, then manual postinstall as a normal user). `rmSync` / `readdirSync` then fail with `EACCES` or `EPERM`. Postinstall still succeeds, but the catch block always emitted `[postinstall] could not prune OpenClaw compile cache`, which reads like a correctness problem.

## Linked issue

Fixes #76353.

## Why this fix is safe

Only the diagnostic path changes: permission-denied errors are treated as an expected outcome for shared cache layouts. Removal is still attempted with the same options; unexpected errors continue to warn. No pruning success is asserted for those directories.

## Real behavior proof

- **Behavior addressed:** postinstall compile-cache pruning no longer prints a scary warning when the configured compile-cache base cannot be listed because of `EACCES`.
- **Real setup tested:** local OpenClaw checkout on macOS, running the PR head with a real temporary `$NODE_COMPILE_CACHE` directory whose permissions were changed to `000` so the real filesystem `readdirSync` path returns `EACCES`.
- **Exact steps or command run after the patch:** `node --input-type=module` imported `pruneOpenClawCompileCache` from `./scripts/postinstall-bundled-plugins.mjs`, pointed it at the chmod-000 temp compile-cache directory, and captured `log.warn` output.
- **Evidence after fix:** copied terminal output from the rebased PR worktree:

```text
real behavior proof: EACCES base listing suppressed
cache_base=/var/folders/67/txrk93md25lbjhk6jk4nxvrr0000gn/T/openclaw-proof-compile-cache-oMaXEE
warnings=0
```

- **Observed result after fix:** the prune path completed without emitting `[postinstall] could not prune OpenClaw compile cache` for the permission-denied directory-listing failure.
- **What was not tested:** the full root-owned global npm install handoff from the issue was not rerun; this proof exercises the same real filesystem `EACCES` behavior at the fixed postinstall prune boundary.

## Security / runtime controls (unchanged)

No changes to sandboxing, config validation, install trust scanners, credential handling, gateway policies, CLI permissions, or any behavior that replaces runtime enforcement with wording in prompts.

## Tests run

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md scripts/postinstall-bundled-plugins.mjs test/scripts/postinstall-bundled-plugins.test.ts`
- `pnpm test test/scripts/postinstall-bundled-plugins.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Out of scope

- Per-user UID-scoped default compile-cache paths under `/tmp` (alternative suggested on the issue)
- Changes to Node compile-cache location or pruning strategy beyond warning behavior
