### PR TITLE
fix(memory-core): wire runtime config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: allow the runtime `memory-core` plugin entry to validate the same dreaming config schema as its manifest, so documented `plugins.entries.memory-core.config` settings are accepted.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { describe, expect, it } from "vitest";
+import memoryCoreEntry from "./index.js";
 import {
   buildMemoryFlushPlan,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
@@ -7,6 +8,61 @@ import {
   DEFAULT_MEMORY_FLUSH_SOFT_TOKENS,
 } from "./src/flush-plan.js";
 import { buildPromptSection } from "./src/prompt-section.js";
+
+function parseMemoryCoreConfig(value: unknown) {
+  const { safeParse } = memoryCoreEntry.configSchema;
+  if (!safeParse) {
+    throw new Error("memory-core config schema is missing safeParse");
+  }
+  return safeParse(value);
+}
+
+describe("memory-core plugin entry", () => {
+  it("accepts configured dreaming settings", () => {
+    const result = parseMemoryCoreConfig({
+      dreaming: {
+        enabled: true,
+        timezone: "Europe/London",
+        storage: {
+          mode: "both",
+        },
+        phases: {
+          deep: {
+            enabled: true,
+            minRecallCount: 3,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        dreaming: {
+          enabled: true,
+          timezone: "Europe/London",
+          storage: {
+            mode: "both",
+          },
+          phases: {
+            deep: {
+              enabled: true,
+              minRecallCount: 3,
+            },
+          },
+        },
+      });
+    }
+  });
+
+  it("rejects unknown memory-core config keys", () => {
+    const result = parseMemoryCoreConfig({
+      typo: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("buildPromptSection", () => {
   it("returns empty when no memory tools are available", () => {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,3 +1,4 @@
+import type { JsonSchemaObject } from "openclaw/plugin-sdk/config-schema";
 import {
   jsonResult,
   resolveMemorySearchConfig,
@@ -7,11 +8,13 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { resolveMemoryBackendConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
+  buildJsonPluginConfigSchema,
   definePluginEntry,
   type AnyAgentTool,
   type OpenClawPluginToolContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { Type } from "typebox";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { registerShortTermPromotionDreaming } from "./src/dreaming.js";
 import { buildMemoryFlushPlan } from "./src/flush-plan.js";
 import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-adapters.js";
@@ -80,6 +83,13 @@ const MemoryGetSchema = Type.Object({
     Type.Union([Type.Literal("memory"), Type.Literal("wiki"), Type.Literal("all")]),
   ),
 });
+
+const memoryCoreConfigSchema = buildJsonPluginConfigSchema(
+  manifest.configSchema as JsonSchemaObject,
+  {
+    cacheKey: "memory-core.plugin-config",
+  },
+);
 
 function createLazyMemoryTool(params: {
   options: MemoryToolOptions;
@@ -171,6 +181,7 @@ export default definePluginEntry({
   name: "Memory (Core)",
   description: "File-backed memory search tools and CLI",
   kind: "memory",
+  configSchema: memoryCoreConfigSchema,
   register(api) {
     registerBuiltInMemoryEmbeddingProviders(api);
     registerShortTermPromotionDreaming(api);


### PR DESCRIPTION
## Summary

- Wire the existing memory-core manifest config schema into the runtime plugin entry
- Reuse the manifest JSON schema so runtime validation matches the packaged plugin metadata
- Add regression coverage that dreaming config is accepted and unknown memory-core config keys are rejected

Fixes #76357.

## Test plan

- pnpm test extensions/memory-core/index.test.ts extensions/memory-core/src/config.test.ts
- pnpm exec oxfmt --check --threads=1 extensions/memory-core/index.ts extensions/memory-core/index.test.ts extensions/memory-core/src/config.test.ts
- pnpm check:changed
