### PR TITLE
fix: harden backend message action gateway routing [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix: harden backend message action gateway routing [AI]. (#76374) Thanks @pgondhi987.
 - Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.
 - Plugins/release: make the published npm runtime verifier reject blank `openclaw.runtimeExtensions` entries instead of treating them as absent and passing via inferred outputs. Thanks @vincentkoc.
 - Web fetch: scope provider fallback cache entries by the selected fetch provider so config reloads cannot reuse another provider's cached fallback payload. Thanks @vincentkoc.

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -10,6 +10,7 @@ import type {
 import type { OpenClawConfig } from "../../config/config.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { runMessageAction } from "./message-action-runner.js";
 import { extractToolPayload } from "./tool-payload.js";
 
@@ -437,6 +438,66 @@ describe("runMessageAction plugin dispatch", () => {
           added: "✅",
         },
       });
+    });
+
+    it("ignores gateway url overrides for backend plugin actions", async () => {
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat backend action test plugin.",
+        actions: ["react"],
+        capabilities: { chatTypes: ["direct"], reactions: true },
+        handleAction: vi.fn(async () => jsonResult({ ok: true, local: true })),
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+        ok: true,
+        added: "ok",
+      });
+
+      await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "react",
+        params: {
+          channel: "gatewaychat",
+          to: "+15551234567",
+          chatJid: "+15551234567",
+          messageId: "wamid.1",
+          emoji: "ok",
+        },
+        gateway: {
+          url: "ws://127.0.0.1:18789",
+          token: "configured-token",
+          timeoutMs: 5000,
+          clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        },
+        dryRun: false,
+      });
+
+      expect(mocks.callGatewayLeastPrivilege).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: undefined,
+          token: "configured-token",
+          timeoutMs: 5000,
+          clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        }),
+      );
     });
 
     it("routes gateway-executed plugin sends through gateway RPC instead of local dispatch", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -172,8 +172,13 @@ export function getToolResult(
 }
 
 function resolveGatewayActionOptions(gateway?: MessageActionRunnerGateway) {
+  const url =
+    gateway?.mode === GATEWAY_CLIENT_MODES.BACKEND ||
+    gateway?.clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT
+      ? undefined
+      : gateway?.url;
   return {
-    url: gateway?.url,
+    url,
     token: gateway?.token,
     timeoutMs:
       typeof gateway?.timeoutMs === "number" && Number.isFinite(gateway.timeoutMs)


### PR DESCRIPTION
## Summary

- Problem: backend gateway-executed message actions could forward a caller-supplied gateway URL while using backend gateway client identity.
- Why it matters: backend message actions should use the configured gateway target consistently with the normal outbound message sender.
- What changed: message action gateway option resolution now drops explicit URLs for backend or gateway-client callers before invoking the gateway RPC helper.
- What did NOT change (scope boundary): no message tool schema, gateway allowlist, token, or channel action behavior was otherwise changed.

This PR was prepared with AI assistance.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A in public PR metadata
- [x] This PR addresses a bug or regression

## Root Cause (if applicable)

- Root cause: the gateway-executed message action path normalized gateway options separately from the normal outbound send path and did not apply the same backend caller URL override rule.
- Missing detection / guardrail: gateway action dispatch tests covered RPC forwarding but did not assert backend URL override handling.
- Contributing context (if known): send and action paths share similar gateway option concepts but had separate normalization helpers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- Scenario the test should lock in: a gateway-executed plugin action in backend mode with an explicit gateway URL calls `callGatewayLeastPrivilege` with `url: undefined` while preserving token, timeout, client name, and mode.
- Why this is the smallest reliable guardrail: it exercises the action runner gateway dispatch seam directly with the gateway runtime mocked.
- Existing test that already covers this (if any): outbound send coverage already covered the normal message sender path, but not gateway-executed message actions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Backend message action calls no longer honor explicit gateway URL overrides; they use the configured gateway target. No config or CLI behavior changes were added.

## Diagram (if applicable)

```text
Before:
[backend message action] -> [caller gateway URL] -> [gateway RPC]

After:
[backend message action] -> [configured gateway target] -> [gateway RPC]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: backend message action gateway RPCs now ignore caller-supplied gateway URLs, reducing target confusion while preserving existing least-privilege gateway scopes and configured-token behavior.

## Repro + Verification

### Environment

- OS: Not run locally
- Runtime/container: Not run locally
- Model/provider: N/A
- Integration/channel (if any): gateway-executed message action plugin path
- Relevant config (redacted): backend gateway client with configured token and explicit gateway URL override

### Steps

1. Configure a gateway-executed message action plugin.
2. Invoke `runMessageAction` for that action with backend gateway client options and an explicit gateway URL.
3. Inspect the mocked `callGatewayLeastPrivilege` call.

### Expected

- The gateway RPC receives `url: undefined` for backend or gateway-client callers.
- Token, timeout, client name, and mode are still forwarded.

### Actual

- The new regression test asserts the expected normalized gateway call shape.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation commands were not run in this drafting step.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: static review of the normalization change and regression test scenario.
- Edge cases checked: backend mode and gateway-client identity both use the same URL-drop condition in production code.
- What you did **not** verify: local test execution, build, typecheck, and CI.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an internal backend caller that intentionally relied on explicit gateway URL overrides for message actions will now use configured gateway routing.
  - Mitigation: this matches the existing normal outbound message sender behavior for backend callers and leaves non-backend URL override behavior unchanged.
