### PR TITLE
Gate QQBot streaming command auth [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.
 - Plugins/release: make the published npm runtime verifier reject blank `openclaw.runtimeExtensions` entries instead of treating them as absent and passing via inferred outputs. Thanks @vincentkoc.
 - Web fetch: scope provider fallback cache entries by the selected fetch provider so config reloads cannot reuse another provider's cached fallback payload. Thanks @vincentkoc.
 - Web search: honor late-bound `tools.web.search.enabled: false` during tool execution so config reloads cannot leave an already-created `web_search` tool runnable. Thanks @vincentkoc.

--- a/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
@@ -5,14 +5,12 @@ import type {
   PluginCommandContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
-import type { CommandsPort } from "../../engine/adapter/commands.port.js";
-import { initCommands } from "../../engine/commands/slash-commands-impl.js";
+import {
+  getWrittenQQBotConfig,
+  installCommandRuntime,
+} from "../../engine/commands/slash-command-test-support.js";
 import { ensurePlatformAdapter } from "../bootstrap.js";
 import { registerQQBotFrameworkCommands } from "./framework-registration.js";
-
-type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
-type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
-type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
 
 function createConfig(): OpenClawConfig {
   return {
@@ -30,24 +28,6 @@ function createConfig(): OpenClawConfig {
       },
     },
   };
-}
-
-function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
-  const replaceConfigFile: ReplaceConfigFile = async (params) => {
-    writes.push(params.nextConfig);
-    return undefined as unknown as ReplaceConfigFileResult;
-  };
-
-  initCommands({
-    resolveVersion: () => "test",
-    pluginVersion: "0.0.0-test",
-    approveRuntimeGetter: () => ({
-      config: {
-        current: () => currentConfig,
-        replaceConfigFile,
-      },
-    }),
-  });
 }
 
 function registerCommands(): OpenClawPluginCommandDefinition[] {
@@ -91,21 +71,13 @@ function createCommandContext(
   } as unknown as PluginCommandContext;
 }
 
-function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
-  | {
-      streaming?: unknown;
-      accounts?: { default?: { streaming?: unknown } };
-    }
-  | undefined {
-  return write?.channels?.qqbot as
-    | {
-        streaming?: unknown;
-        accounts?: { default?: { streaming?: unknown } };
-      }
-    | undefined;
-}
-
 describe("registerQQBotFrameworkCommands", () => {
+  it("registers bot-streaming as an auth-gated framework command", () => {
+    const command = findCommand(registerCommands(), "bot-streaming");
+
+    expect(command.requireAuth).toBe(true);
+  });
+
   it("preserves the private-chat guard for bot-streaming on generic framework calls", async () => {
     const config = createConfig();
     const writes: OpenClawConfig[] = [];

--- a/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
@@ -7,6 +7,7 @@ import type {
 import { describe, expect, it } from "vitest";
 import type { CommandsPort } from "../../engine/adapter/commands.port.js";
 import { initCommands } from "../../engine/commands/slash-commands-impl.js";
+import { ensurePlatformAdapter } from "../bootstrap.js";
 import { registerQQBotFrameworkCommands } from "./framework-registration.js";
 
 type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
@@ -50,6 +51,7 @@ function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawCo
 }
 
 function registerCommands(): OpenClawPluginCommandDefinition[] {
+  ensurePlatformAdapter();
   const commands: OpenClawPluginCommandDefinition[] = [];
   const api = {
     logger: {},

--- a/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-registration.test.ts
@@ -1,0 +1,139 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import type { CommandsPort } from "../../engine/adapter/commands.port.js";
+import { initCommands } from "../../engine/commands/slash-commands-impl.js";
+import { registerQQBotFrameworkCommands } from "./framework-registration.js";
+
+type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
+type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
+type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
+
+function createConfig(): OpenClawConfig {
+  return {
+    channels: {
+      qqbot: {
+        appId: "app",
+        allowFrom: ["TRUSTED_OPENID"],
+        streaming: false,
+        accounts: {
+          default: {
+            allowFrom: ["TRUSTED_OPENID"],
+            streaming: false,
+          },
+        },
+      },
+    },
+  };
+}
+
+function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
+  const replaceConfigFile: ReplaceConfigFile = async (params) => {
+    writes.push(params.nextConfig);
+    return undefined as unknown as ReplaceConfigFileResult;
+  };
+
+  initCommands({
+    resolveVersion: () => "test",
+    pluginVersion: "0.0.0-test",
+    approveRuntimeGetter: () => ({
+      config: {
+        current: () => currentConfig,
+        replaceConfigFile,
+      },
+    }),
+  });
+}
+
+function registerCommands(): OpenClawPluginCommandDefinition[] {
+  const commands: OpenClawPluginCommandDefinition[] = [];
+  const api = {
+    logger: {},
+    registerCommand: (command: OpenClawPluginCommandDefinition) => {
+      commands.push(command);
+    },
+  } as unknown as OpenClawPluginApi;
+
+  registerQQBotFrameworkCommands(api);
+  return commands;
+}
+
+function findCommand(
+  commands: OpenClawPluginCommandDefinition[],
+  name: string,
+): OpenClawPluginCommandDefinition {
+  const command = commands.find((entry) => entry.name === name);
+  expect(command).toBeDefined();
+  return command as OpenClawPluginCommandDefinition;
+}
+
+function createCommandContext(
+  config: OpenClawConfig,
+  from: string | undefined,
+): PluginCommandContext {
+  return {
+    senderId: "TRUSTED_OPENID",
+    channel: "qqbot",
+    isAuthorizedSender: true,
+    args: "on",
+    commandBody: "/bot-streaming on",
+    config,
+    from,
+    requestConversationBinding: async () => undefined,
+    detachConversationBinding: async () => ({ removed: false }),
+    getCurrentConversationBinding: async () => null,
+  } as unknown as PluginCommandContext;
+}
+
+function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
+  | {
+      streaming?: unknown;
+      accounts?: { default?: { streaming?: unknown } };
+    }
+  | undefined {
+  return write?.channels?.qqbot as
+    | {
+        streaming?: unknown;
+        accounts?: { default?: { streaming?: unknown } };
+      }
+    | undefined;
+}
+
+describe("registerQQBotFrameworkCommands", () => {
+  it("preserves the private-chat guard for bot-streaming on generic framework calls", async () => {
+    const config = createConfig();
+    const writes: OpenClawConfig[] = [];
+    installCommandRuntime(config, writes);
+    const command = findCommand(registerCommands(), "bot-streaming");
+
+    const missingFromResult = await command.handler(createCommandContext(config, undefined));
+    const nonQQBotResult = await command.handler(createCommandContext(config, "generic:dm:user"));
+    const groupResult = await command.handler(
+      createCommandContext(config, "qqbot:group:GROUP_OPENID"),
+    );
+
+    expect(missingFromResult).toEqual({ text: "💡 请在私聊中使用此指令" });
+    expect(nonQQBotResult).toEqual({ text: "💡 请在私聊中使用此指令" });
+    expect(groupResult).toEqual({ text: "💡 请在私聊中使用此指令" });
+    expect(writes).toHaveLength(0);
+  });
+
+  it("allows bot-streaming on explicit QQBot private-chat framework calls", async () => {
+    const config = createConfig();
+    const writes: OpenClawConfig[] = [];
+    installCommandRuntime(config, writes);
+    const command = findCommand(registerCommands(), "bot-streaming");
+
+    const result = await command.handler(createCommandContext(config, "qqbot:c2c:TRUSTED_OPENID"));
+
+    const qqbot = getWrittenQQBotConfig(writes[0]);
+    expect(result).toMatchObject({ text: expect.stringContaining("已开启") });
+    expect(writes).toHaveLength(1);
+    expect(qqbot?.streaming).toBe(true);
+    expect(qqbot?.accounts?.default?.streaming).toBe(true);
+  });
+});

--- a/extensions/qqbot/src/bridge/commands/framework-registration.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-registration.ts
@@ -18,6 +18,20 @@ import { buildFrameworkSlashContext } from "./framework-context-adapter.js";
 import { parseQQBotFrom } from "./from-parser.js";
 import { dispatchFrameworkSlashResult } from "./result-dispatcher.js";
 
+const PRIVATE_CHAT_ONLY_TEXT = "💡 请在私聊中使用此指令";
+
+function isExplicitQQBotC2cFrom(from: string | undefined | null): boolean {
+  const raw = (from ?? "").trim();
+  const stripped = raw.replace(/^qqbot:/iu, "");
+  const colonIdx = stripped.indexOf(":");
+  if (colonIdx === -1) {
+    return false;
+  }
+  const kind = stripped.slice(0, colonIdx).toLowerCase();
+  const targetId = stripped.slice(colonIdx + 1).trim();
+  return /^qqbot:/iu.test(raw) && kind === "c2c" && targetId.length > 0;
+}
+
 export function registerQQBotFrameworkCommands(api: OpenClawPluginApi): void {
   for (const cmd of getFrameworkCommands()) {
     api.registerCommand({
@@ -26,6 +40,10 @@ export function registerQQBotFrameworkCommands(api: OpenClawPluginApi): void {
       requireAuth: true,
       acceptsArgs: true,
       handler: async (ctx: PluginCommandContext) => {
+        if (cmd.c2cOnly && !isExplicitQQBotC2cFrom(ctx.from)) {
+          return { text: PRIVATE_CHAT_ONLY_TEXT };
+        }
+
         const from = parseQQBotFrom(ctx.from);
         const account = resolveQQBotAccount(ctx.config, ctx.accountId ?? undefined);
         const slashCtx = buildFrameworkSlashContext({

--- a/extensions/qqbot/src/engine/commands/builtin/register-streaming.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-streaming.ts
@@ -30,6 +30,7 @@ export function registerStreamingCommands(registry: SlashCommandRegistry): void 
   registry.register({
     name: "bot-streaming",
     description: "一键开关流式消息",
+    requireAuth: true,
     c2cOnly: true,
     usage: [
       `/bot-streaming on     开启流式消息`,

--- a/extensions/qqbot/src/engine/commands/slash-command-auth.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-auth.ts
@@ -21,7 +21,7 @@ import { createQQBotSenderMatcher, normalizeQQBotAllowFrom } from "../access/ind
  * - `allowFrom` not configured / empty / only `["*"]` → **false**
  *   (wildcard means "open to everyone", not explicit authorization)
  * - `allowFrom` contains at least one concrete entry AND sender
- *   matches → **true**
+ *   matches a concrete entry → **true**
  * - Group messages use `groupAllowFrom` when present, falling back
  *   to `allowFrom`.
  */
@@ -38,11 +38,11 @@ export function resolveSlashCommandAuth(params: {
 
   const normalized = normalizeQQBotAllowFrom(rawList);
 
-  // Require at least one explicit (non-wildcard) entry.
-  const hasExplicitEntry = normalized.some((entry) => entry !== "*");
-  if (!hasExplicitEntry) {
+  // Require and match only explicit (non-wildcard) entries.
+  const explicitEntries = normalized.filter((entry) => entry !== "*");
+  if (explicitEntries.length === 0) {
     return false;
   }
 
-  return createQQBotSenderMatcher(params.senderId)(normalized);
+  return createQQBotSenderMatcher(params.senderId)(explicitEntries);
 }

--- a/extensions/qqbot/src/engine/commands/slash-command-auth.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-auth.ts
@@ -13,11 +13,49 @@
 
 import { createQQBotSenderMatcher, normalizeQQBotAllowFrom } from "../access/index.js";
 
+type SlashCommandAuthEntry = string | number;
+
+function isSlashCommandAuthEntry(value: unknown): value is SlashCommandAuthEntry {
+  return typeof value === "string" || typeof value === "number";
+}
+
+function readSlashCommandAuthList(value: unknown): SlashCommandAuthEntry[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.filter(isSlashCommandAuthEntry);
+}
+
+/**
+ * Resolve the command-specific QQBot allowlist from the root OpenClaw config.
+ *
+ * `commands.allowFrom.qqbot` takes precedence over the global
+ * `commands.allowFrom["*"]`, matching the framework command authorization
+ * contract used by registered plugin commands.
+ */
+export function resolveQQBotCommandsAllowFrom(cfg: unknown): SlashCommandAuthEntry[] | undefined {
+  if (!cfg || typeof cfg !== "object") {
+    return undefined;
+  }
+  const commands = (cfg as { commands?: unknown }).commands;
+  if (!commands || typeof commands !== "object") {
+    return undefined;
+  }
+  const allowFrom = (commands as { allowFrom?: unknown }).allowFrom;
+  if (!allowFrom || typeof allowFrom !== "object" || Array.isArray(allowFrom)) {
+    return undefined;
+  }
+  const byProvider = allowFrom as Record<string, unknown>;
+  return readSlashCommandAuthList(byProvider.qqbot) ?? readSlashCommandAuthList(byProvider["*"]);
+}
+
 /**
  * Determine whether `senderId` is authorized to execute `requireAuth`
  * slash commands for the given account configuration.
  *
  * Authorization rules:
+ * - `commands.allowFrom.qqbot` / `commands.allowFrom["*"]` configured →
+ *   use that command-specific list instead of channel allowFrom
  * - `allowFrom` not configured / empty / only `["*"]` → **false**
  *   (wildcard means "open to everyone", not explicit authorization)
  * - `allowFrom` contains at least one concrete entry AND sender
@@ -30,11 +68,13 @@ export function resolveSlashCommandAuth(params: {
   isGroup: boolean;
   allowFrom?: Array<string | number>;
   groupAllowFrom?: Array<string | number>;
+  commandsAllowFrom?: Array<string | number>;
 }): boolean {
   const rawList =
-    params.isGroup && params.groupAllowFrom && params.groupAllowFrom.length > 0
+    params.commandsAllowFrom ??
+    (params.isGroup && params.groupAllowFrom && params.groupAllowFrom.length > 0
       ? params.groupAllowFrom
-      : params.allowFrom;
+      : params.allowFrom);
 
   const normalized = normalizeQQBotAllowFrom(rawList);
 

--- a/extensions/qqbot/src/engine/commands/slash-command-handler.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-handler.test.ts
@@ -1,0 +1,117 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandsPort } from "../adapter/commands.port.js";
+import type { QueuedMessage } from "../gateway/message-queue.js";
+import type { GatewayAccount } from "../gateway/types.js";
+import { sendText } from "../messaging/sender.js";
+import { trySlashCommand } from "./slash-command-handler.js";
+import { initCommands } from "./slash-commands-impl.js";
+
+vi.mock("../messaging/outbound.js", () => ({
+  sendDocument: vi.fn(async () => undefined),
+}));
+
+vi.mock("../messaging/sender.js", () => ({
+  accountToCreds: vi.fn(() => ({ appId: "app", clientSecret: "" })),
+  buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
+  sendText: vi.fn(async () => undefined),
+}));
+
+type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
+type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
+type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
+
+function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
+  const replaceConfigFile: ReplaceConfigFile = async (params) => {
+    writes.push(params.nextConfig);
+    return undefined as unknown as ReplaceConfigFileResult;
+  };
+
+  initCommands({
+    resolveVersion: () => "test",
+    pluginVersion: "0.0.0-test",
+    approveRuntimeGetter: () => ({
+      config: {
+        current: () => currentConfig,
+        replaceConfigFile,
+      },
+    }),
+  });
+}
+
+function createStreamingMessage(): QueuedMessage {
+  return {
+    type: "c2c",
+    senderId: "TRUSTED_OPENID",
+    content: "/bot-streaming on",
+    messageId: "msg-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function createAccount(): GatewayAccount {
+  return {
+    accountId: "default",
+    appId: "app",
+    clientSecret: "",
+    markdownSupport: true,
+    config: {
+      allowFrom: ["*"],
+      streaming: false,
+    },
+  };
+}
+
+function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
+  | {
+      streaming?: unknown;
+    }
+  | undefined {
+  return write?.channels?.qqbot as
+    | {
+        streaming?: unknown;
+      }
+    | undefined;
+}
+
+describe("trySlashCommand", () => {
+  beforeEach(() => {
+    vi.mocked(sendText).mockClear();
+  });
+
+  it("honors commands.allowFrom for pre-dispatch bot-streaming in open DM configs", async () => {
+    const writes: OpenClawConfig[] = [];
+    const config: OpenClawConfig = {
+      commands: {
+        allowFrom: {
+          qqbot: ["TRUSTED_OPENID"],
+        },
+      },
+      channels: {
+        qqbot: {
+          allowFrom: ["*"],
+          streaming: false,
+        },
+      },
+    };
+    installCommandRuntime(config, writes);
+
+    const result = await trySlashCommand(createStreamingMessage(), {
+      account: createAccount(),
+      cfg: config,
+      getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+      getQueueSnapshot: () => ({
+        totalPending: 0,
+        activeUsers: 0,
+        maxConcurrentUsers: 1,
+        senderPending: 0,
+      }),
+    });
+
+    const qqbot = getWrittenQQBotConfig(writes[0]);
+    expect(result).toBe("handled");
+    expect(writes).toHaveLength(1);
+    expect(qqbot?.streaming).toBe(true);
+    expect(vi.mocked(sendText).mock.calls[0]?.[1]).toContain("已开启");
+  });
+});

--- a/extensions/qqbot/src/engine/commands/slash-command-handler.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-handler.test.ts
@@ -1,11 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CommandsPort } from "../adapter/commands.port.js";
 import type { QueuedMessage } from "../gateway/message-queue.js";
 import type { GatewayAccount } from "../gateway/types.js";
 import { sendText } from "../messaging/sender.js";
 import { trySlashCommand } from "./slash-command-handler.js";
-import { initCommands } from "./slash-commands-impl.js";
+import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
 
 vi.mock("../messaging/outbound.js", () => ({
   sendDocument: vi.fn(async () => undefined),
@@ -16,28 +15,6 @@ vi.mock("../messaging/sender.js", () => ({
   buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
   sendText: vi.fn(async () => undefined),
 }));
-
-type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
-type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
-type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
-
-function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
-  const replaceConfigFile: ReplaceConfigFile = async (params) => {
-    writes.push(params.nextConfig);
-    return undefined as unknown as ReplaceConfigFileResult;
-  };
-
-  initCommands({
-    resolveVersion: () => "test",
-    pluginVersion: "0.0.0-test",
-    approveRuntimeGetter: () => ({
-      config: {
-        current: () => currentConfig,
-        replaceConfigFile,
-      },
-    }),
-  });
-}
 
 function createStreamingMessage(): QueuedMessage {
   return {
@@ -60,18 +37,6 @@ function createAccount(): GatewayAccount {
       streaming: false,
     },
   };
-}
-
-function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
-  | {
-      streaming?: unknown;
-    }
-  | undefined {
-  return write?.channels?.qqbot as
-    | {
-        streaming?: unknown;
-      }
-    | undefined;
 }
 
 describe("trySlashCommand", () => {

--- a/extensions/qqbot/src/engine/commands/slash-command-handler.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-handler.ts
@@ -13,7 +13,7 @@ import {
   buildDeliveryTarget,
   accountToCreds,
 } from "../messaging/sender.js";
-import { resolveSlashCommandAuth } from "./slash-command-auth.js";
+import { resolveQQBotCommandsAllowFrom, resolveSlashCommandAuth } from "./slash-command-auth.js";
 import { matchSlashCommand } from "./slash-commands-impl.js";
 import type { SlashCommandContext, QueueSnapshot } from "./slash-commands.js";
 
@@ -21,6 +21,7 @@ import type { SlashCommandContext, QueueSnapshot } from "./slash-commands.js";
 
 export interface SlashCommandHandlerContext {
   account: GatewayAccount;
+  cfg?: unknown;
   log?: EngineLogger;
   getMessagePeerId: (msg: QueuedMessage) => string;
   getQueueSnapshot: (peerId: string) => QueueSnapshot;
@@ -81,6 +82,7 @@ export async function trySlashCommand(
       isGroup: msg.type === "group" || msg.type === "guild",
       allowFrom: account.config?.allowFrom,
       groupAllowFrom: account.config?.groupAllowFrom,
+      commandsAllowFrom: resolveQQBotCommandsAllowFrom(ctx.cfg),
     }),
     queueSnapshot: ctx.getQueueSnapshot(peerId),
   };

--- a/extensions/qqbot/src/engine/commands/slash-command-test-support.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-test-support.ts
@@ -1,0 +1,39 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { CommandsPort } from "../adapter/commands.port.js";
+import { initCommands } from "./slash-commands-impl.js";
+
+type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
+type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
+type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
+
+export type WrittenQQBotConfig = {
+  streaming?: unknown;
+  accounts?: { default?: { streaming?: unknown } };
+};
+
+export function installCommandRuntime(
+  currentConfig: OpenClawConfig,
+  writes: OpenClawConfig[],
+): void {
+  const replaceConfigFile: ReplaceConfigFile = async (params) => {
+    writes.push(params.nextConfig);
+    return undefined as unknown as ReplaceConfigFileResult;
+  };
+
+  initCommands({
+    resolveVersion: () => "test",
+    pluginVersion: "0.0.0-test",
+    approveRuntimeGetter: () => ({
+      config: {
+        current: () => currentConfig,
+        replaceConfigFile,
+      },
+    }),
+  });
+}
+
+export function getWrittenQQBotConfig(
+  write: OpenClawConfig | undefined,
+): WrittenQQBotConfig | undefined {
+  return write?.channels?.qqbot as WrittenQQBotConfig | undefined;
+}

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { describe, expect, it } from "vitest";
 import type { CommandsPort } from "../adapter/commands.port.js";
-import { resolveSlashCommandAuth } from "./slash-command-auth.js";
+import { resolveQQBotCommandsAllowFrom, resolveSlashCommandAuth } from "./slash-command-auth.js";
 import { getFrameworkCommands, initCommands, matchSlashCommand } from "./slash-commands-impl.js";
 import type { SlashCommandContext } from "./slash-commands.js";
 
@@ -123,6 +123,52 @@ describe("QQBot framework slash commands", () => {
     expect(commandAuthorized).toBe(false);
     expect(result).toContain("权限不足");
     expect(writes).toHaveLength(0);
+  });
+
+  it("writes streaming config when commands.allowFrom grants the sender in open DM configs", async () => {
+    const writes: OpenClawConfig[] = [];
+    installCommandRuntime(
+      {
+        commands: {
+          allowFrom: {
+            qqbot: ["TRUSTED_OPENID"],
+          },
+        },
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            streaming: false,
+          },
+        },
+      },
+      writes,
+    );
+
+    const commandAuthorized = resolveSlashCommandAuth({
+      senderId: "TRUSTED_OPENID",
+      isGroup: false,
+      allowFrom: ["*"],
+      commandsAllowFrom: resolveQQBotCommandsAllowFrom({
+        commands: {
+          allowFrom: {
+            qqbot: ["TRUSTED_OPENID"],
+          },
+        },
+      }),
+    });
+    const result = await matchSlashCommand(
+      createStreamingContext({
+        senderId: "TRUSTED_OPENID",
+        accountConfig: { allowFrom: ["*"], streaming: false },
+        commandAuthorized,
+      }),
+    );
+
+    const qqbot = getWrittenQQBotConfig(writes[0]);
+    expect(commandAuthorized).toBe(true);
+    expect(result).toContain("已开启");
+    expect(writes).toHaveLength(1);
+    expect(qqbot?.streaming).toBe(true);
   });
 
   it("writes streaming config when the sender is command-authorized", async () => {

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -1,31 +1,9 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { describe, expect, it } from "vitest";
-import type { CommandsPort } from "../adapter/commands.port.js";
 import { resolveQQBotCommandsAllowFrom, resolveSlashCommandAuth } from "./slash-command-auth.js";
-import { getFrameworkCommands, initCommands, matchSlashCommand } from "./slash-commands-impl.js";
+import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
+import { getFrameworkCommands, matchSlashCommand } from "./slash-commands-impl.js";
 import type { SlashCommandContext } from "./slash-commands.js";
-
-type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
-type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
-type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
-
-function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
-  const replaceConfigFile: ReplaceConfigFile = async (params) => {
-    writes.push(params.nextConfig);
-    return undefined as unknown as ReplaceConfigFileResult;
-  };
-
-  initCommands({
-    resolveVersion: () => "test",
-    pluginVersion: "0.0.0-test",
-    approveRuntimeGetter: () => ({
-      config: {
-        current: () => currentConfig,
-        replaceConfigFile,
-      },
-    }),
-  });
-}
 
 function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
   return {
@@ -48,20 +26,6 @@ function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): S
     },
     ...overrides,
   };
-}
-
-function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
-  | {
-      streaming?: unknown;
-      accounts?: { default?: { streaming?: unknown } };
-    }
-  | undefined {
-  return write?.channels?.qqbot as
-    | {
-        streaming?: unknown;
-        accounts?: { default?: { streaming?: unknown } };
-      }
-    | undefined;
 }
 
 describe("QQBot framework slash commands", () => {

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { describe, expect, it } from "vitest";
 import type { CommandsPort } from "../adapter/commands.port.js";
+import { resolveSlashCommandAuth } from "./slash-command-auth.js";
 import { getFrameworkCommands, initCommands, matchSlashCommand } from "./slash-commands-impl.js";
 import type { SlashCommandContext } from "./slash-commands.js";
 
@@ -92,17 +93,50 @@ describe("QQBot framework slash commands", () => {
     expect(writes).toHaveLength(0);
   });
 
-  it("writes streaming config when the sender is command-authorized", async () => {
+  it("does not write streaming config when allowFrom mixes wildcard with another sender", async () => {
     const writes: OpenClawConfig[] = [];
+    const allowFrom = ["*", "TRUSTED_OPENID"];
     installCommandRuntime(
       {
         channels: {
           qqbot: {
-            allowFrom: ["TRUSTED_OPENID"],
+            allowFrom,
+            streaming: false,
+          },
+        },
+      },
+      writes,
+    );
+
+    const commandAuthorized = resolveSlashCommandAuth({
+      senderId: "UNTRUSTED_OPENID",
+      isGroup: false,
+      allowFrom,
+    });
+    const result = await matchSlashCommand(
+      createStreamingContext({
+        accountConfig: { allowFrom, streaming: false },
+        commandAuthorized,
+      }),
+    );
+
+    expect(commandAuthorized).toBe(false);
+    expect(result).toContain("权限不足");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("writes streaming config when the sender is command-authorized", async () => {
+    const writes: OpenClawConfig[] = [];
+    const allowFrom = ["*", "TRUSTED_OPENID"];
+    installCommandRuntime(
+      {
+        channels: {
+          qqbot: {
+            allowFrom,
             streaming: false,
             accounts: {
               default: {
-                allowFrom: ["TRUSTED_OPENID"],
+                allowFrom,
                 streaming: false,
               },
             },
@@ -112,15 +146,21 @@ describe("QQBot framework slash commands", () => {
       writes,
     );
 
+    const commandAuthorized = resolveSlashCommandAuth({
+      senderId: "TRUSTED_OPENID",
+      isGroup: false,
+      allowFrom,
+    });
     const result = await matchSlashCommand(
       createStreamingContext({
         senderId: "TRUSTED_OPENID",
-        accountConfig: { allowFrom: ["TRUSTED_OPENID"], streaming: false },
-        commandAuthorized: true,
+        accountConfig: { allowFrom, streaming: false },
+        commandAuthorized,
       }),
     );
 
     const qqbot = getWrittenQQBotConfig(writes[0]);
+    expect(commandAuthorized).toBe(true);
     expect(result).toContain("已开启");
     expect(writes).toHaveLength(1);
     expect(qqbot?.streaming).toBe(true);

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -1,8 +1,129 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { describe, expect, it } from "vitest";
-import { getFrameworkCommands } from "./slash-commands-impl.js";
+import type { CommandsPort } from "../adapter/commands.port.js";
+import { getFrameworkCommands, initCommands, matchSlashCommand } from "./slash-commands-impl.js";
+import type { SlashCommandContext } from "./slash-commands.js";
+
+type RuntimeConfigApi = ReturnType<NonNullable<CommandsPort["approveRuntimeGetter"]>>["config"];
+type ReplaceConfigFile = RuntimeConfigApi["replaceConfigFile"];
+type ReplaceConfigFileResult = Awaited<ReturnType<ReplaceConfigFile>>;
+
+function installCommandRuntime(currentConfig: OpenClawConfig, writes: OpenClawConfig[]): void {
+  const replaceConfigFile: ReplaceConfigFile = async (params) => {
+    writes.push(params.nextConfig);
+    return undefined as unknown as ReplaceConfigFileResult;
+  };
+
+  initCommands({
+    resolveVersion: () => "test",
+    pluginVersion: "0.0.0-test",
+    approveRuntimeGetter: () => ({
+      config: {
+        current: () => currentConfig,
+        replaceConfigFile,
+      },
+    }),
+  });
+}
+
+function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
+  return {
+    type: "c2c",
+    senderId: "UNTRUSTED_OPENID",
+    messageId: "msg-1",
+    eventTimestamp: "2026-01-01T00:00:00.000Z",
+    receivedAt: 1,
+    rawContent: "/bot-streaming on",
+    args: "",
+    accountId: "default",
+    appId: "app",
+    accountConfig: { allowFrom: ["*"], streaming: false },
+    commandAuthorized: false,
+    queueSnapshot: {
+      totalPending: 0,
+      activeUsers: 0,
+      maxConcurrentUsers: 1,
+      senderPending: 0,
+    },
+    ...overrides,
+  };
+}
+
+function getWrittenQQBotConfig(write: OpenClawConfig | undefined):
+  | {
+      streaming?: unknown;
+      accounts?: { default?: { streaming?: unknown } };
+    }
+  | undefined {
+  return write?.channels?.qqbot as
+    | {
+        streaming?: unknown;
+        accounts?: { default?: { streaming?: unknown } };
+      }
+    | undefined;
+}
 
 describe("QQBot framework slash commands", () => {
   it("routes bot-approve through the auth-gated framework registry", () => {
     expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-approve");
+  });
+
+  it("routes bot-streaming through the auth-gated framework registry", () => {
+    expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-streaming");
+  });
+
+  it("does not write streaming config when the sender is not command-authorized", async () => {
+    const writes: OpenClawConfig[] = [];
+    installCommandRuntime(
+      {
+        channels: {
+          qqbot: {
+            allowFrom: ["*"],
+            streaming: false,
+          },
+        },
+      },
+      writes,
+    );
+
+    const result = await matchSlashCommand(createStreamingContext());
+
+    expect(result).toContain("权限不足");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("writes streaming config when the sender is command-authorized", async () => {
+    const writes: OpenClawConfig[] = [];
+    installCommandRuntime(
+      {
+        channels: {
+          qqbot: {
+            allowFrom: ["TRUSTED_OPENID"],
+            streaming: false,
+            accounts: {
+              default: {
+                allowFrom: ["TRUSTED_OPENID"],
+                streaming: false,
+              },
+            },
+          },
+        },
+      },
+      writes,
+    );
+
+    const result = await matchSlashCommand(
+      createStreamingContext({
+        senderId: "TRUSTED_OPENID",
+        accountConfig: { allowFrom: ["TRUSTED_OPENID"], streaming: false },
+        commandAuthorized: true,
+      }),
+    );
+
+    const qqbot = getWrittenQQBotConfig(writes[0]);
+    expect(result).toContain("已开启");
+    expect(writes).toHaveLength(1);
+    expect(qqbot?.streaming).toBe(true);
+    expect(qqbot?.accounts?.default?.streaming).toBe(true);
   });
 });

--- a/extensions/qqbot/src/engine/commands/slash-commands.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands.ts
@@ -85,6 +85,7 @@ export interface QQBotFrameworkCommand {
   name: string;
   description: string;
   usage?: string;
+  c2cOnly?: boolean;
   handler: (ctx: SlashCommandContext) => SlashCommandResult | Promise<SlashCommandResult>;
 }
 
@@ -125,6 +126,7 @@ export class SlashCommandRegistry {
       name: cmd.name,
       description: cmd.description,
       usage: cmd.usage,
+      c2cOnly: cmd.c2cOnly,
       handler: cmd.handler,
     }));
   }

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -197,6 +197,7 @@ export class GatewayConnection {
       // ---- Slash command interception ----
       const slashCtx: SlashCommandHandlerContext = {
         account,
+        cfg: this.ctx.cfg,
         log,
         getMessagePeerId: (msg) => this.msgQueue.getMessagePeerId(msg),
         getQueueSnapshot: (peerId) => this.msgQueue.getSnapshot(peerId),


### PR DESCRIPTION
## Summary

- Problem: QQBot `/bot-streaming` was private-chat-only but was not routed through command authorization.
- Why it matters: The command writes persistent QQBot streaming config, so it should require the same explicit sender authorization as neighboring config-changing commands.
- What changed: Added `requireAuth: true` to `/bot-streaming` and regression coverage for blocked wildcard access plus allowed explicit access.
- What did NOT change (scope boundary): No docs, config schema, network behavior, or storage behavior changed beyond the command gate.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Not linked in public PR metadata.
- [x] This PR addresses a bug or regression

## Root Cause (if applicable)

- Root cause: `/bot-streaming` omitted `requireAuth`, so the dispatcher’s existing command authorization guard did not run before the config-writing handler.
- Missing detection / guardrail: The command registry did not have regression coverage ensuring config-changing QQBot slash commands are auth-gated.
- Contributing context (if known): Nearby config-changing commands already use the same dispatcher guard.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts`
- Scenario the test should lock in: `/bot-streaming on` does not write config when `allowFrom` is wildcard and `commandAuthorized` is false; the same command still writes config for an explicitly authorized sender.
- Why this is the smallest reliable guardrail: It exercises the registered command through the dispatcher and fake runtime without requiring QQ platform I/O.
- Existing test that already covers this (if any): None found for this command gate.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Unauthorized QQBot private-chat senders who can otherwise chat through open or wildcard DM policy can no longer toggle streaming with `/bot-streaming`. Explicitly authorized senders can still use the command.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The command surface is narrowed to command-authorized senders using the existing QQBot authorization guard.

## Repro + Verification

### Environment

- OS: Not environment-specific
- Runtime/container: Not environment-specific
- Model/provider: N/A
- Integration/channel (if any): QQBot
- Relevant config (redacted): `channels.qqbot.allowFrom` wildcard or explicit sender list, with `channels.qqbot.streaming` disabled before command execution

### Steps

1. Register QQBot slash commands with a fake runtime config API.
2. Dispatch `/bot-streaming on` from a private-chat sender with wildcard `allowFrom` and `commandAuthorized: false`.
3. Dispatch `/bot-streaming on` from a private-chat sender with explicit `allowFrom` and `commandAuthorized: true`.

### Expected

- The first dispatch returns a permission response and does not call `replaceConfigFile`.
- The second dispatch updates the QQBot streaming config.

### Actual

- Covered by the added regression scenarios.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Current evidence: Regression coverage was added for the dispatcher behavior, and targeted formatting passed for the touched files.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Static review confirmed `/bot-streaming` is now auth-gated and the tests cover unauthorized wildcard no-write plus authorized explicit write.
- Edge cases checked: Default account writes update both top-level QQBot streaming config and `accounts.default.streaming` when present.
- What you did **not** verify: Full package/test commands were not run in this metadata step.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Operators relying on open or wildcard DM policy to use `/bot-streaming` without explicit command authorization will now receive a permission response.
  - Mitigation: Add the intended operator sender ID to the explicit QQBot `allowFrom` command authorization list.
