### PR TITLE
fix(memory): preserve active recall tool agent context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/plugins: update configured plugin installs whose stale manifests still declare channels without `channelConfigs`, so beta upgrades repair old Discord-style package payloads during `doctor --fix`.
 - Doctor/plugins: repair configured external plugin installs whose persisted install record points at a missing package directory, so upgrades reconcile phantom npm metadata before plugin runtime validation. Thanks @vincentkoc.
 - Active Memory: keep non-empty `memory_search` results from being fast-failed as empty when debug telemetry reports zero hits.
+- Active Memory: preserve the target agent context when building embedded recall plugin tools so `memory_search` and `memory_get` stay available for explicit recall sessions. Fixes #76343. Thanks @Countermarch.
 - Plugins/externalization: repair missing configured plugin installs from npm by default, reserve ClawHub downloads for explicit `clawhubSpec` metadata, and cover agent-runtime/env-selected plugin repair. Thanks @vincentkoc.
 - Plugins/install: allow official catalog-matched npm channel plugins such as Feishu to pass the trusted install scanner path while keeping spoofed package names blocked. Thanks @vincentkoc.
 - Feishu: keep timeout env parsing separate from the HTTP client wrapper so package security scans no longer report a false env-harvesting hit during install. Thanks @vincentkoc.

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,7 +1,7 @@
 import {
   jsonResult,
   resolveMemorySearchConfig,
-  resolveSessionAgentId,
+  resolveSessionAgentIds,
   type MemoryPluginRuntime,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
@@ -23,6 +23,7 @@ type RuntimeProviderModule = typeof import("./src/runtime-provider.js");
 type MemoryToolOptions = {
   config?: OpenClawConfig;
   getConfig?: () => OpenClawConfig | undefined;
+  agentId?: string;
   agentSessionKey?: string;
   sandboxed?: boolean;
 };
@@ -49,9 +50,10 @@ function hasMemoryToolContext(options: MemoryToolOptions): boolean {
   if (!cfg) {
     return false;
   }
-  const agentId = resolveSessionAgentId({
+  const { sessionAgentId: agentId } = resolveSessionAgentIds({
     sessionKey: options.agentSessionKey,
     config: cfg,
+    agentId: options.agentId,
   });
   return Boolean(resolveMemorySearchConfig(cfg, agentId));
 }
@@ -145,6 +147,7 @@ function resolveMemoryToolOptions(ctx: OpenClawPluginToolContext): MemoryToolOpt
   return {
     config: getConfig(),
     getConfig,
+    agentId: ctx.agentId,
     agentSessionKey: ctx.sessionKey,
     sandboxed: ctx.sandboxed,
   };

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -52,7 +52,7 @@ const stubManager = {
   close: vi.fn(),
 };
 
-const getMemorySearchManagerMock = vi.fn(async (_params: { cfg?: unknown }) => ({
+const getMemorySearchManagerMock = vi.fn(async (_params: { cfg?: unknown; agentId?: string }) => ({
   manager: stubManager,
 }));
 const readAgentMemoryFileMock = vi.fn(
@@ -116,6 +116,10 @@ export function getMemorySearchManagerMockCalls(): number {
 
 export function getMemorySearchManagerMockConfigs(): unknown[] {
   return getMemorySearchManagerMock.mock.calls.map(([params]) => params.cfg);
+}
+
+export function getMemorySearchManagerMockParams(): Array<{ cfg?: unknown; agentId?: string }> {
+  return getMemorySearchManagerMock.mock.calls.map(([params]) => params);
 }
 
 export function getReadAgentMemoryFileMockCalls(): number {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,7 +1,7 @@
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
-  resolveSessionAgentId,
+  resolveSessionAgentIds,
   type MemoryCorpusSearchResult,
   type AnyAgentTool,
   type OpenClawConfig,
@@ -16,6 +16,7 @@ type MemorySearchManagerResult = Awaited<
 type MemoryToolOptions = {
   config?: OpenClawConfig;
   getConfig?: () => OpenClawConfig | undefined;
+  agentId?: string;
   agentSessionKey?: string;
 };
 
@@ -54,9 +55,10 @@ function resolveMemoryToolContext(options: MemoryToolOptions) {
   if (!cfg) {
     return null;
   }
-  const agentId = resolveSessionAgentId({
+  const { sessionAgentId: agentId } = resolveSessionAgentIds({
     sessionKey: options.agentSessionKey,
     config: cfg,
+    agentId: options.agentId,
   });
   if (!resolveMemorySearchConfig(cfg, agentId)) {
     return null;

--- a/extensions/memory-core/src/tools.test-helpers.ts
+++ b/extensions/memory-core/src/tools.test-helpers.ts
@@ -12,10 +12,12 @@ export function createDefaultMemoryToolConfig(): OpenClawConfig {
 
 export function createMemorySearchToolOrThrow(params?: {
   config?: OpenClawConfig;
+  agentId?: string;
   agentSessionKey?: string;
 }) {
   const tool = createMemorySearchTool({
     config: params?.config ?? createDefaultMemoryToolConfig(),
+    ...(params?.agentId ? { agentId: params.agentId } : {}),
     ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
   });
   if (!tool) {

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getMemorySearchManagerMockConfigs,
+  getMemorySearchManagerMockParams,
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
@@ -105,6 +106,25 @@ describe("memory_search unavailable payloads", () => {
     expect((result.details as { debug?: { searchMs?: number } }).debug?.searchMs).toEqual(
       expect.any(Number),
     );
+  });
+
+  it("uses explicit plugin context agent over synthetic active-memory session keys", async () => {
+    const tool = createMemorySearchToolOrThrow({
+      config: asOpenClawConfig({
+        agents: {
+          list: [
+            { id: "main", default: true, memorySearch: { enabled: false } },
+            { id: "recall", memorySearch: { enabled: true } },
+          ],
+        },
+      }),
+      agentId: "recall",
+      agentSessionKey: "explicit:user-session:active-memory:abc123",
+    });
+
+    await tool.execute("recall", { query: "favorite food" });
+
+    expect(getMemorySearchManagerMockParams().at(-1)?.agentId).toBe("recall");
   });
 
   it("re-resolves config when executing a previously created tool", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -183,6 +183,7 @@ async function executeMemoryReadResult<T>(params: {
 export function createMemorySearchTool(options: {
   config?: OpenClawConfig;
   getConfig?: () => OpenClawConfig | undefined;
+  agentId?: string;
   agentSessionKey?: string;
   sandboxed?: boolean;
 }) {
@@ -346,6 +347,7 @@ export function createMemorySearchTool(options: {
 export function createMemoryGetTool(options: {
   config?: OpenClawConfig;
   getConfig?: () => OpenClawConfig | undefined;
+  agentId?: string;
   agentSessionKey?: string;
 }) {
   return createMemoryTool({

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -109,6 +109,34 @@ describe("openclaw plugin tool context", () => {
     );
   });
 
+  it("uses requester agent override for synthetic embedded session keys", () => {
+    const recallWorkspace = path.join(process.cwd(), "tmp-recall-workspace");
+    const config = {
+      agents: {
+        defaults: { workspace: path.join(process.cwd(), "tmp-default-workspace") },
+        list: [
+          { id: "main", default: true },
+          { id: "recall", workspace: recallWorkspace },
+        ],
+      },
+    } as never;
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config,
+        agentSessionKey: "explicit:user-session:active-memory:abc123",
+        requesterAgentIdOverride: "recall",
+      },
+      resolvedConfig: config,
+    });
+
+    expect(result.context).toEqual(
+      expect.objectContaining({
+        agentId: "recall",
+        workspaceDir: recallWorkspace,
+      }),
+    );
+  });
+
   it("forwards browser session wiring", () => {
     const result = resolveOpenClawPluginToolInputs({
       options: {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
@@ -16,6 +16,7 @@ export type OpenClawPluginToolOptions = {
   config?: OpenClawConfig;
   fsPolicy?: ToolFsPolicy;
   requesterSenderId?: string | null;
+  requesterAgentIdOverride?: string;
   senderIsOwner?: boolean;
   sessionId?: string;
   sandboxBrowserBridgeUrl?: string;
@@ -31,9 +32,10 @@ export function resolveOpenClawPluginToolInputs(params: {
   getRuntimeConfig?: () => OpenClawConfig | undefined;
 }) {
   const { options, resolvedConfig, runtimeConfig, getRuntimeConfig } = params;
-  const sessionAgentId = resolveSessionAgentId({
+  const { sessionAgentId } = resolveSessionAgentIds({
     sessionKey: options?.agentSessionKey,
     config: resolvedConfig,
+    agentId: options?.requesterAgentIdOverride,
   });
   const inferredWorkspaceDir =
     options?.workspaceDir || !resolvedConfig

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -8,7 +8,11 @@ export {
   type AnyAgentTool,
 } from "../agents/tools/common.js";
 export { resolveCronStyleNow } from "../agents/current-time.js";
-export { resolveDefaultAgentId, resolveSessionAgentId } from "../agents/agent-scope.js";
+export {
+  resolveDefaultAgentId,
+  resolveSessionAgentId,
+  resolveSessionAgentIds,
+} from "../agents/agent-scope.js";
 export { resolveMemorySearchConfig } from "../agents/memory-search.js";
 export { parseNonNegativeByteSize } from "../config/byte-size.js";
 export { getRuntimeConfig, loadConfig } from "../config/config.js";


### PR DESCRIPTION
## Summary

Fixes https://github.com/openclaw/openclaw/issues/76343.

Active Memory runs a small embedded recall agent before the main reply. That embedded run uses a synthetic session key containing `:active-memory:`, while the real target agent is passed separately through the runtime as the resolved agent id.

Before this change, plugin tool context exposed the synthetic session key to memory-core, and memory-core re-derived the agent from that key. For explicit/web sessions, that could resolve to the default or parsed session agent instead of the intended target agent. When the wrong agent had no memory config, `memory_search` and `memory_get` disappeared from the embedded recall runtime. When both agents had memory config, recall could search the wrong memory store.

This PR fixes both halves of that path:

- `resolveOpenClawPluginToolInputs()` now honors the trusted requester agent override when building plugin context.
- memory-core carries `ctx.agentId` into lazy tool availability and concrete tool execution.
- the synthetic session key is still preserved for session-specific behavior, including Active Memory qmd overrides.
- regression coverage proves a synthetic Active Memory session key uses the explicit plugin-context agent for memory search execution.

## Validation

- `pnpm test extensions/memory-core/src/tools.test.ts src/agents/openclaw-tools.plugin-context.test.ts src/agents/pi-embedded-runner/run/attempt.tools-allow-regression.test.ts extensions/active-memory/index.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/openclaw-tools.plugin-context.ts src/agents/openclaw-tools.plugin-context.test.ts src/plugin-sdk/memory-core-host-runtime-core.ts extensions/memory-core/index.ts extensions/memory-core/src/tools.shared.ts extensions/memory-core/src/tools.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/tools.test-helpers.ts extensions/memory-core/src/memory-tool-manager-mock.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `pnpm plugin-sdk:api:check`

`pnpm check:changed` was not run locally because changed lanes include broad core/extension/plugin-contract coverage and repo guidance routes that gate through Testbox; `blacksmith` is not available in this environment.
