### PR TITLE
fix(discord): resolve env-backed SecretRefs in startup token path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: resolve `channels.discord` env-backed `SecretRef` tokens against `secrets.providers`/allowlists during channel startup instead of rejecting them as unresolved strict refs before env fallback ran. Fixes #76371.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/extensions/discord/src/token.test.ts
+++ b/extensions/discord/src/token.test.ts
@@ -91,7 +91,8 @@ describe("resolveDiscordToken", () => {
     expect(res.source).toBe("config");
   });
 
-  it("throws when token is an unresolved SecretRef object", () => {
+  it("resolves env-backed SecretRefs from process.env", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "secretref-env-token");
     const cfg = {
       channels: {
         discord: {
@@ -100,8 +101,23 @@ describe("resolveDiscordToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveDiscordToken(cfg)).toThrow(
-      /channels\.discord\.token: unresolved SecretRef/i,
-    );
+    expect(resolveDiscordToken(cfg)).toEqual({
+      token: "secretref-env-token",
+      source: "config",
+    });
+  });
+
+  it("does not fall back when an explicit env SecretRef is configured but unavailable", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "fallback-env-token");
+    vi.stubEnv("DISCORD_REF_TOKEN", "");
+    const cfg = {
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_REF_TOKEN" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(resolveDiscordToken(cfg)).toEqual({ token: "", source: "none" });
   });
 });

--- a/extensions/discord/src/token.ts
+++ b/extensions/discord/src/token.ts
@@ -1,8 +1,16 @@
 import type { BaseTokenResolution } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
-import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  resolveAccountEntry,
+} from "openclaw/plugin-sdk/routing";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveSecretInputString,
+} from "openclaw/plugin-sdk/secret-input";
 
 type DiscordTokenSource = "env" | "config" | "none";
 
@@ -10,12 +18,76 @@ export type DiscordTokenResolution = BaseTokenResolution & {
   source: DiscordTokenSource;
 };
 
+const stripDiscordBotPrefix = (value: string) => value.replace(/^Bot\s+/i, "");
+
 export function normalizeDiscordToken(raw: unknown, path: string): string | undefined {
   const trimmed = normalizeResolvedSecretInputString({ value: raw, path });
-  if (!trimmed) {
-    return undefined;
+  return trimmed ? stripDiscordBotPrefix(trimmed) : undefined;
+}
+
+function resolveDiscordEnvSecretRefValue(params: {
+  cfg?: Pick<OpenClawConfig, "secrets">;
+  provider: string;
+  id: string;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const prov = params.cfg?.secrets?.providers?.[params.provider];
+  if (prov) {
+    if (prov.source !== "env") {
+      throw new Error(
+        `Secret provider "${params.provider}" has source "${prov.source}" but ref requests "env".`,
+      );
+    }
+    if (prov.allowlist && !prov.allowlist.includes(params.id)) {
+      throw new Error(
+        `Environment variable "${params.id}" is not allowlisted in secrets.providers.${params.provider}.allowlist.`,
+      );
+    }
+  } else if (
+    params.provider !== resolveDefaultSecretProviderAlias({ secrets: params.cfg?.secrets }, "env")
+  ) {
+    throw new Error(
+      `Secret provider "${params.provider}" is not configured (ref: env:${params.provider}:${params.id}).`,
+    );
   }
-  return trimmed.replace(/^Bot\s+/i, "");
+  return normalizeSecretInputString((params.env ?? process.env)[params.id]);
+}
+
+function resolveDiscordConfiguredToken(params: {
+  cfg?: Pick<OpenClawConfig, "secrets">;
+  value: unknown;
+  path: string;
+}) {
+  const d = params.cfg?.secrets?.defaults;
+  const r = resolveSecretInputString({
+    value: params.value,
+    path: params.path,
+    defaults: d,
+    mode: "inspect",
+  });
+  if (r.status === "available") {
+    return { status: "available" as const, value: stripDiscordBotPrefix(r.value) };
+  }
+  if (r.status === "missing") {
+    return { status: "missing" as const };
+  }
+  if (r.ref.source !== "env") {
+    resolveSecretInputString({
+      value: params.value,
+      path: params.path,
+      defaults: d,
+      mode: "strict",
+    });
+    return { status: "configured_unavailable" as const };
+  }
+  const envVal = resolveDiscordEnvSecretRefValue({
+    cfg: params.cfg,
+    provider: r.ref.provider,
+    id: r.ref.id,
+  });
+  return envVal
+    ? { status: "available" as const, value: stripDiscordBotPrefix(envVal) }
+    : { status: "configured_unavailable" as const };
 }
 
 export function resolveDiscordToken(
@@ -29,32 +101,31 @@ export function resolveDiscordToken(
     accountCfg &&
     Object.prototype.hasOwnProperty.call(accountCfg as Record<string, unknown>, "token"),
   );
-  const accountToken = normalizeDiscordToken(
-    (accountCfg as { token?: unknown } | undefined)?.token ?? undefined,
-    `channels.discord.accounts.${accountId}.token`,
-  );
-  if (accountToken) {
-    return { token: accountToken, source: "config" };
+  const accountResolved = resolveDiscordConfiguredToken({
+    cfg,
+    value: (accountCfg as { token?: unknown } | undefined)?.token,
+    path: `channels.discord.accounts.${accountId}.token`,
+  });
+  if (accountResolved.status === "available") {
+    return { token: accountResolved.value, source: "config" };
   }
-  if (hasAccountToken) {
+  if (accountResolved.status === "configured_unavailable" || hasAccountToken) {
     return { token: "", source: "none" };
   }
-
-  const configToken = normalizeDiscordToken(
-    discordCfg?.token ?? undefined,
-    "channels.discord.token",
-  );
-  if (configToken) {
-    return { token: configToken, source: "config" };
+  const channelResolved = resolveDiscordConfiguredToken({
+    cfg,
+    value: discordCfg?.token ?? undefined,
+    path: "channels.discord.token",
+  });
+  if (channelResolved.status === "available") {
+    return { token: channelResolved.value, source: "config" };
   }
-
+  if (channelResolved.status === "configured_unavailable") {
+    return { token: "", source: "none" };
+  }
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
   const envToken = allowEnv
     ? normalizeDiscordToken(opts.envToken ?? process.env.DISCORD_BOT_TOKEN, "DISCORD_BOT_TOKEN")
     : undefined;
-  if (envToken) {
-    return { token: envToken, source: "env" };
-  }
-
-  return { token: "", source: "none" };
+  return envToken ? { token: envToken, source: "env" } : { token: "", source: "none" };
 }


### PR DESCRIPTION
## Problem

Discord channel startup failed when `channels.discord.token` used an env-backed `SecretRef`: `normalizeDiscordToken` called `normalizeResolvedSecretInputString` on raw config and threw (`env:default:DISCORD_BOT_TOKEN` unresolved) before Gateway secrets/runtime resolution ran. Telegram already handled this pattern via `inspect` + env lookup.

## Root cause

`resolveDiscordToken` normalized account/channel tokens through the strict secret-input helper, which treats unresolved refs as fatal instead of resolving `source: "env"` refs against `secrets.providers`, allowlists, and `process.env` (same chain as Telegram’s bot token resolver).

## Fix

- Resolve Discord account and channel tokens with `resolveSecretInputString(..., mode: "inspect")`, then follow env `SecretRef`s through the same provider/allowlist/default-alias rules as Telegram (`resolveDefaultSecretProviderAlias`, allowlist errors, non-env provider source mismatch throws).
- Preserve “explicit env ref but empty” semantics: no fallback to bare `DISCORD_BOT_TOKEN` when a different ref id was configured.

## Why this is safe

Behavior is aligned with `extensions/telegram/src/token.ts` for env-backed refs: same validation surface, same failure modes for misconfigured providers, and strict resolution still applies to non-env refs via the existing `mode: "strict"` path.

## Security / runtime controls (unchanged)

- Env provider allowlists still enforced.
- Unconfigured/non-env-backed providers still error as before when an env ref names them.
- Non-env unresolved `SecretRef`s still resolve through strict mode (throw), not silently dropped.

## Tests run

- `pnpm exec vitest run extensions/discord/src/token.test.ts`
- `pnpm test:extension discord`
- `pnpm check:changed`

## Follow-ups (out of scope)

- Embedded-reply paths and other callers still using strict normalization on raw config (#75433 class).
- Other externalized plugins (e.g. BlueBubbles webhook auth #76369).

Fixes https://github.com/openclaw/openclaw/issues/76371

---

- [x] AI-assisted (implementation and validation)
- [x] Testing: `pnpm test:extension discord` + targeted token tests + `pnpm check:changed`
