### PR TITLE
fix(cli): resolve official plugin ids before npm fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/install: resolve official external plugin ids such as `brave` through the catalog before bare npm fallback, so `openclaw plugins install brave` installs `@openclaw/brave-plugin` instead of the unrelated npm package. Fixes #76373. Thanks @BryanTegomoh.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -5,6 +5,7 @@ import {
   resolveBundledInstallPlanForCatalogEntry,
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
+  resolveOfficialExternalInstallPlanBeforeNpm,
 } from "./plugin-install-plan.js";
 
 describe("plugin install plan helpers", () => {
@@ -33,6 +34,35 @@ describe("plugin install plan helpers", () => {
     });
 
     expect(findBundledSource).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it("resolves official external plugin ids before npm fallback", () => {
+    const findOfficialInstall = vi.fn().mockReturnValue({
+      npmSpec: "@openclaw/brave-plugin",
+    });
+
+    const result = resolveOfficialExternalInstallPlanBeforeNpm({
+      rawSpec: "brave",
+      findOfficialInstall,
+    });
+
+    expect(findOfficialInstall).toHaveBeenCalledWith("brave");
+    expect(result).toEqual({
+      pluginId: "brave",
+      npmSpec: "@openclaw/brave-plugin",
+    });
+  });
+
+  it("skips official external plugin resolution for explicit npm specs", () => {
+    const findOfficialInstall = vi.fn();
+
+    const result = resolveOfficialExternalInstallPlanBeforeNpm({
+      rawSpec: "brave@beta",
+      findOfficialInstall,
+    });
+
+    expect(findOfficialInstall).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
 

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -7,9 +7,29 @@ type BundledLookup = (params: {
   value: string;
 }) => BundledPluginSource | undefined;
 
-function isBareNpmPackageName(spec: string): boolean {
+export function isBareNpmPackageName(spec: string): boolean {
   const trimmed = spec.trim();
   return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
+}
+
+export function resolveOfficialExternalInstallPlanBeforeNpm(params: {
+  rawSpec: string;
+  findOfficialInstall: (pluginId: string) =>
+    | {
+        npmSpec?: string;
+      }
+    | null
+    | undefined;
+}): { pluginId: string; npmSpec: string } | null {
+  if (!isBareNpmPackageName(params.rawSpec)) {
+    return null;
+  }
+  const pluginId = params.rawSpec.trim();
+  const npmSpec = params.findOfficialInstall(pluginId)?.npmSpec?.trim();
+  if (!npmSpec) {
+    return null;
+  }
+  return { pluginId, npmSpec };
 }
 
 export function resolveBundledInstallPlanForCatalogEntry(params: {

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -703,6 +703,49 @@ describe("plugins cli install", () => {
     );
   });
 
+  it("installs official external plugin ids through their catalog npm spec", async () => {
+    const cfg = createEmptyPluginConfig();
+    const enabledCfg = createEnabledPluginConfig("brave");
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromNpmSpec.mockResolvedValue(createNpmPluginInstallResult("brave"));
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    const originalBundledDisable = process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+    process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "1";
+    try {
+      await runPluginsCommand(["plugins", "install", "brave"]);
+    } finally {
+      if (originalBundledDisable === undefined) {
+        delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+      } else {
+        process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = originalBundledDisable;
+      }
+    }
+
+    expect(installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@openclaw/brave-plugin",
+      }),
+    );
+    expect(runtimeLogs).toContain(
+      'Using official plugin package @openclaw/brave-plugin for install spec "brave".',
+    );
+    expect(writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({
+      brave: expect.objectContaining({
+        source: "npm",
+        spec: "@openclaw/brave-plugin",
+        installPath: cliInstallPath("brave"),
+        version: "1.2.3",
+      }),
+    });
+    expect(writeConfigFile).toHaveBeenCalledWith(enabledCfg);
+  });
+
   it("installs directly from npm when npm: prefix is used", async () => {
     const cfg = createEmptyPluginConfig();
     const enabledCfg = createEnabledPluginConfig("demo");

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -21,6 +21,10 @@ import {
   installPluginFromMarketplace,
   resolveMarketplaceInstallShortcut,
 } from "../plugins/marketplace.js";
+import {
+  getOfficialExternalPluginCatalogEntry,
+  resolveOfficialExternalPluginInstall,
+} from "../plugins/official-external-plugin-catalog.js";
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
@@ -36,6 +40,7 @@ import {
 import {
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
+  resolveOfficialExternalInstallPlanBeforeNpm,
 } from "./plugin-install-plan.js";
 import {
   createHookPackInstallLogger,
@@ -744,6 +749,33 @@ export async function runPluginInstallCommand(params: {
         pluginId: bundledPreNpmPlan.bundledSource.pluginId,
       },
     );
+    return;
+  }
+
+  const officialPreNpmPlan = resolveOfficialExternalInstallPlanBeforeNpm({
+    rawSpec: raw,
+    findOfficialInstall: (pluginId) => {
+      const entry = getOfficialExternalPluginCatalogEntry(pluginId);
+      return entry ? resolveOfficialExternalPluginInstall(entry) : null;
+    },
+  });
+  if (officialPreNpmPlan) {
+    runtime.log(
+      `Using official plugin package ${officialPreNpmPlan.npmSpec} for install spec "${officialPreNpmPlan.pluginId}".`,
+    );
+    const officialNpmResult = await tryInstallPluginOrHookPackFromNpmSpec({
+      snapshot,
+      installMode,
+      spec: officialPreNpmPlan.npmSpec,
+      pin: opts.pin,
+      safetyOverrides,
+      allowBundledFallback: false,
+      extensionsDir,
+      runtime,
+    });
+    if (!officialNpmResult.ok) {
+      return runtime.exit(1);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw plugins install brave` can fall through to the unrelated `brave` npm package when the bundled Brave plugin is not present in a packaged install.
- Why it matters: users upgrading to 2026.5.2 cannot reinstall the external Brave plugin with the plugin id from the release docs and issue report.
- What changed: bare official plugin ids now resolve through the official external plugin catalog before raw npm fallback, so `brave` installs `@openclaw/brave-plugin`.
- What did NOT change: explicit npm specs such as `npm:brave`, scoped package specs, and bundled source-checkout plugin resolution keep their existing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76373
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: bare plugin ids only checked bundled sources before falling back to npm. In packaged 2026.5.2 installs, Brave is external, so `brave` went to npm as the unscoped package name instead of the official catalog package.
- Missing detection / guardrail: there was no CLI install test for an official external plugin id when no bundled source is available.
- Contributing context: the official catalog already mapped `brave` to `@openclaw/brave-plugin`; the manual install path just did not consult it before npm fallback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/plugin-install-plan.test.ts`, `src/cli/plugins-cli.install.test.ts`
- Scenario the test should lock in: a bare official external plugin id resolves to its catalog npm package when no bundled source is available.
- Why this is the smallest reliable guardrail: the bug is in CLI install resolution, not plugin runtime behavior.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw plugins install brave` now installs the official `@openclaw/brave-plugin` package when Brave is not available as a bundled source.

## Diagram (if applicable)

```text
Before:
openclaw plugins install brave -> npm brave -> invalid OpenClaw plugin package

After:
openclaw plugins install brave -> official catalog -> npm @openclaw/brave-plugin
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.2, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Brave plugin install
- Relevant config (redacted): N/A

### Steps

1. Use a packaged-style install state where Brave is not available as a bundled source.
2. Run `openclaw plugins install brave`.
3. Inspect the npm install spec used by the CLI.

### Expected

- The CLI installs `@openclaw/brave-plugin`.

### Actual

- Before this change, the CLI could fall through to npm package `brave`.

## Evidence

- [x] Failing test/log before + passing after

```text
pnpm test src/cli/plugin-install-plan.test.ts src/cli/plugins-cli.install.test.ts
Test Files  2 passed (2)
Tests  56 passed (56)
```

```text
pnpm check:changed
completed successfully
```

## Human Verification (required)

- Verified scenarios: official external plugin-id resolution for `brave`; explicit npm selector skip behavior; source-checkout bundled precedence remains before official external resolution.
- Edge cases checked: `brave@beta` stays an explicit npm selector path in the plan helper; `npm:brave` remains on the existing explicit npm branch.
- What you did not verify: live install against a fresh packaged Linux host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

None.
