### PR TITLE
fix(gateway): skip oversized JSONL lines to prevent event-loop starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat history: preserve oversized transcript turns as explicit omitted-message placeholders while avoiding large JSONL parse stalls. Thanks @Marvinthebored.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1665,7 +1665,7 @@ describe("oversized transcript line guards", () => {
     storePath = nextStorePath;
   });
 
-  test("readRecentSessionMessagesAsync skips oversized JSONL lines", async () => {
+  test("readRecentSessionMessagesAsync replaces oversized JSONL lines with placeholders", async () => {
     const sessionId = "test-oversized-recent";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
     const oversizedContent = "x".repeat(300 * 1024);
@@ -1681,9 +1681,10 @@ describe("oversized transcript line guards", () => {
       maxMessages: 10,
     });
 
-    const contents = out.map((m) => (typeof m.content === "string" ? m.content : ""));
-    expect(contents).not.toContain(oversizedContent);
-    expect(contents).toContain("after oversized");
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain(oversizedContent);
+    expect(serialized).toContain("[chat.history omitted: message too large]");
+    expect(serialized).toContain("after oversized");
   });
 
   test("readRecentSessionUsageFromTranscriptAsync skips oversized lines", async () => {
@@ -1728,7 +1729,11 @@ describe("oversized transcript line guards", () => {
 
   test("readSessionTitleFieldsFromTranscriptAsync delegates to bounded sync reader", async () => {
     const sessionId = "test-async-title-bounded";
-    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId, "User says hi", "Bot says hello"));
+    writeTranscript(
+      tmpDir,
+      sessionId,
+      buildBasicSessionTranscript(sessionId, "User says hi", "Bot says hello"),
+    );
 
     const syncResult = readSessionTitleFieldsFromTranscript(sessionId, storePath);
     const asyncResult = await readSessionTitleFieldsFromTranscriptAsync(sessionId, storePath);

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -24,6 +24,7 @@ import {
   readSessionMessagesAsync,
   readSessionMessages,
   readSessionTitleFieldsFromTranscript,
+  readSessionTitleFieldsFromTranscriptAsync,
   readSessionPreviewItemsFromTranscript,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
@@ -1652,5 +1653,88 @@ describe("archiveSessionTranscripts", () => {
     expect(archived).toHaveLength(1);
     expect(archived[0]).toContain(".deleted.");
     expect(fs.existsSync(transcriptPath)).toBe(false);
+  });
+});
+
+describe("oversized transcript line guards", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore("openclaw-session-fs-oversized-", (nextTmpDir, nextStorePath) => {
+    tmpDir = nextTmpDir;
+    storePath = nextStorePath;
+  });
+
+  test("readRecentSessionMessagesAsync skips oversized JSONL lines", async () => {
+    const sessionId = "test-oversized-recent";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const oversizedContent = "x".repeat(300 * 1024);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({ message: { role: "user", content: "start" } }),
+      JSON.stringify({ message: { role: "assistant", content: oversizedContent } }),
+      JSON.stringify({ message: { role: "user", content: "after oversized" } }),
+    ];
+    fs.writeFileSync(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+
+    const out = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 10,
+    });
+
+    const contents = out.map((m) => (typeof m.content === "string" ? m.content : ""));
+    expect(contents).not.toContain(oversizedContent);
+    expect(contents).toContain("after oversized");
+  });
+
+  test("readRecentSessionUsageFromTranscriptAsync skips oversized lines", async () => {
+    const sessionId = "test-oversized-usage";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const oversizedContent = "y".repeat(300 * 1024);
+    const lines = [
+      JSON.stringify({ type: "session", version: 1, id: sessionId }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          content: oversizedContent,
+          usage: { input: 9999, output: 9999 },
+          provider: "oversized-provider",
+          model: "oversized-model",
+        },
+      }),
+      JSON.stringify({
+        message: {
+          role: "assistant",
+          content: "normal",
+          usage: { input: 100, output: 50 },
+          provider: "test-provider",
+          model: "test-model",
+        },
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+
+    const usage = await readRecentSessionUsageFromTranscriptAsync(
+      sessionId,
+      storePath,
+      undefined,
+      undefined,
+      512 * 1024,
+    );
+
+    expect(usage).not.toBeNull();
+    expect(usage?.modelProvider).not.toBe("oversized-provider");
+    expect(usage?.modelProvider).toBe("test-provider");
+  });
+
+  test("readSessionTitleFieldsFromTranscriptAsync delegates to bounded sync reader", async () => {
+    const sessionId = "test-async-title-bounded";
+    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId, "User says hi", "Bot says hello"));
+
+    const syncResult = readSessionTitleFieldsFromTranscript(sessionId, storePath);
+    const asyncResult = await readSessionTitleFieldsFromTranscriptAsync(sessionId, storePath);
+
+    expect(asyncResult).toEqual(syncResult);
+    expect(asyncResult.firstUserMessage).toBe("User says hi");
+    expect(asyncResult.lastMessagePreview).toBe("Bot says hello");
   });
 });

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -266,9 +266,22 @@ async function readRecentTranscriptTailLinesAsync(
 }
 
 const MAX_TRANSCRIPT_PARSE_LINE_BYTES = 256 * 1024;
+const TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER = "[chat.history omitted: message too large]";
 
 function isOversizedTranscriptLine(line: string): boolean {
   return Buffer.byteLength(line, "utf8") > MAX_TRANSCRIPT_PARSE_LINE_BYTES;
+}
+
+function buildOversizedTranscriptRecord(): TailTranscriptRecord {
+  return {
+    record: {
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: TRANSCRIPT_OVERSIZED_MESSAGE_PLACEHOLDER }],
+        __openclaw: { truncated: true, reason: "oversized" },
+      },
+    },
+  };
 }
 
 function normalizeTailEntryString(value: unknown): string | undefined {
@@ -276,7 +289,9 @@ function normalizeTailEntryString(value: unknown): string | undefined {
 }
 
 function parseTailTranscriptRecord(line: string): TailTranscriptRecord | null {
-  if (isOversizedTranscriptLine(line)) return null;
+  if (isOversizedTranscriptLine(line)) {
+    return buildOversizedTranscriptRecord();
+  }
   try {
     const parsed = JSON.parse(line) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -1000,7 +1015,9 @@ function resolvePositiveUsageNumber(value: unknown): number | undefined {
 function extractUsageSnapshotFromTranscriptLine(
   line: string,
 ): SessionTranscriptUsageSnapshot | null {
-  if (isOversizedTranscriptLine(line)) return null;
+  if (isOversizedTranscriptLine(line)) {
+    return null;
+  }
   try {
     const parsed = JSON.parse(line) as Record<string, unknown>;
     const message =

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -265,11 +265,18 @@ async function readRecentTranscriptTailLinesAsync(
   }
 }
 
+const MAX_TRANSCRIPT_PARSE_LINE_BYTES = 256 * 1024;
+
+function isOversizedTranscriptLine(line: string): boolean {
+  return Buffer.byteLength(line, "utf8") > MAX_TRANSCRIPT_PARSE_LINE_BYTES;
+}
+
 function normalizeTailEntryString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
 function parseTailTranscriptRecord(line: string): TailTranscriptRecord | null {
+  if (isOversizedTranscriptLine(line)) return null;
   try {
     const parsed = JSON.parse(line) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -797,59 +804,7 @@ export async function readSessionTitleFieldsFromTranscriptAsync(
   agentId?: string,
   opts?: { includeInterSession?: boolean },
 ): Promise<SessionTitleFields> {
-  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile, agentId);
-  const filePath = candidates.find((p) => fs.existsSync(p));
-  if (!filePath) {
-    return { firstUserMessage: null, lastMessagePreview: null };
-  }
-  let stat: fs.Stats;
-  try {
-    stat = await fs.promises.stat(filePath);
-  } catch {
-    return { firstUserMessage: null, lastMessagePreview: null };
-  }
-  const cacheKey = readSessionTitleFieldsCacheKey(filePath, opts);
-  const cached = getCachedSessionTitleFields(cacheKey, stat);
-  if (cached) {
-    return cached;
-  }
-  const index = await readSessionTranscriptIndex(filePath);
-  if (!index) {
-    return { firstUserMessage: null, lastMessagePreview: null };
-  }
-
-  let firstUserMessage: string | null = null;
-  for (const entry of index.entries) {
-    const msg = entry.record.message as TranscriptMessage | undefined;
-    if (msg?.role !== "user") {
-      continue;
-    }
-    if (opts?.includeInterSession !== true && hasInterSessionUserProvenance(msg)) {
-      continue;
-    }
-    const text = extractTextFromContent(msg.content);
-    if (text) {
-      firstUserMessage = text;
-      break;
-    }
-  }
-
-  let lastMessagePreview: string | null = null;
-  for (const entry of index.entries.toReversed()) {
-    const msg = entry.record.message as TranscriptMessage | undefined;
-    if (!msg || (msg.role !== "user" && msg.role !== "assistant")) {
-      continue;
-    }
-    const text = extractTextFromContent(msg.content);
-    if (text) {
-      lastMessagePreview = text;
-      break;
-    }
-  }
-
-  const result = { firstUserMessage, lastMessagePreview };
-  setCachedSessionTitleFields(cacheKey, stat, result);
-  return result;
+  return readSessionTitleFieldsFromTranscript(sessionId, storePath, sessionFile, agentId, opts);
 }
 
 function extractTextFromContent(content: TranscriptMessage["content"]): string | null {
@@ -1045,6 +1000,7 @@ function resolvePositiveUsageNumber(value: unknown): number | undefined {
 function extractUsageSnapshotFromTranscriptLine(
   line: string,
 ): SessionTranscriptUsageSnapshot | null {
+  if (isOversizedTranscriptLine(line)) return null;
   try {
     const parsed = JSON.parse(line) as Record<string, unknown>;
     const message =


### PR DESCRIPTION
## Summary

- Skip JSONL transcript lines over 256 KiB in `parseTailTranscriptRecord()` and `extractUsageSnapshotFromTranscriptLine()` to avoid blocking the event loop with multi-MB `JSON.parse` calls
- Replace full transcript index scan in `readSessionTitleFieldsFromTranscriptAsync()` with the existing bounded sync reader (`readSessionTitleFieldsFromTranscript`), which uses fixed-size head/tail chunk reads
- Add tests for oversized-line skipping and async/sync title field parity

## Problem

When transcript JSONL files contain large records (e.g., multi-MB tool results or file content), three code paths parse them on the main thread via `JSON.parse` before any truncation or budget logic can skip them:

1. **`parseTailTranscriptRecord()`** — called by `readRecentSessionMessagesAsync()` for `chat.history`. A single 3-9 MB line blocks the event loop before the response byte budget can reject it.

2. **`extractUsageSnapshotFromTranscriptLine()`** — called by `readRecentSessionUsageFromTranscript()` for session usage fallback. Parses every recent line to extract token counts, even if the line is an oversized tool result with no usage data.

3. **`readSessionTitleFieldsFromTranscriptAsync()`** — builds a full transcript index via `readSessionTranscriptIndex()` to extract the first user message and last message preview. The sync version (`readSessionTitleFieldsFromTranscript`) already uses bounded head/tail chunk reads and is strictly cheaper.

On a production install with 33-51 sessions and transcripts containing 3-9 MB tool result lines:
- `chat.history` took 13-16s (blocked by `parseTailTranscriptRecord` on oversized lines)
- Gateway CPU pinned near 100%, event loop utilization at 0.999
- Discord heartbeat timeouts cascading from the blocked event loop

## Fix

**Oversized line guard (256 KiB threshold):** applied as an early-return before `JSON.parse` in `parseTailTranscriptRecord()` and `extractUsageSnapshotFromTranscriptLine()`. Normal transcript lines (user messages, assistant responses, session metadata, usage records) are well under 256 KiB. Only oversized tool results, file content dumps, and similar payloads are skipped.

**Title field extraction:** `readSessionTitleFieldsFromTranscriptAsync()` now delegates to `readSessionTitleFieldsFromTranscript()`, which uses bounded `readTranscriptHeadChunk` / `readLastMessagePreviewFromOpenTranscript` instead of building the full transcript index. The async wrapper is preserved for API compatibility.

## Measurements (production install, 33 sessions)

| Metric | Before | After |
|--------|--------|-------|
| `chat.history` | 13-16s | ~1.2s |
| Event loop utilization | 0.999 | normal |
| Gateway CPU (steady state) | ~100% | 0.2-0.3% |

## Test plan

- [x] `readRecentSessionMessagesAsync` skips oversized JSONL lines without crashing
- [x] `readRecentSessionUsageFromTranscriptAsync` skips oversized lines, extracts usage from normal-sized lines
- [x] `readSessionTitleFieldsFromTranscriptAsync` returns same results as sync bounded reader
- [ ] Existing `session-utils.fs.test.ts` tests pass (no behavioral regression for normal-sized transcripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)