### PR TITLE
BlueBubbles: webhook auth for SecretRef passwords (#76369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles: resolve `channels.bluebubbles` SecretRef-backed webhook passwords via the gateway secret pipeline instead of calling `.trim` on unresolved objects, restoring inbound webhook delivery. Fixes #76369.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveBlueBubblesEffectiveAllowPrivateNetwork } from "./accounts.js";
@@ -23,6 +24,7 @@ import {
 } from "./monitor-shared.js";
 import { fetchBlueBubblesServerInfo } from "./probe.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
+import { normalizeSecretInputString } from "./secret-input.js";
 import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   createFixedWindowRateLimiter,
@@ -30,7 +32,7 @@ import {
   registerWebhookTargetWithPluginRoute,
   readWebhookBodyOrReject,
   resolveRequestClientIp,
-  resolveWebhookTargetWithAuthOrRejectSync,
+  resolveWebhookTargetWithAuthOrReject,
   withResolvedWebhookRequestPipeline,
 } from "./webhook-ingress.js";
 
@@ -189,12 +191,20 @@ export async function handleBlueBubblesWebhookRequest(
         req.headers["x-bluebubbles-guid"] ??
         req.headers["authorization"];
       const guid = (Array.isArray(headerToken) ? headerToken[0] : headerToken) ?? guidParam ?? "";
-      const target = resolveWebhookTargetWithAuthOrRejectSync({
+      const target = await resolveWebhookTargetWithAuthOrReject({
         targets,
         res,
-        isMatch: (target) => {
-          const token = target.account.config.password?.trim() ?? "";
-          return safeEqualAuthToken(guid, token);
+        isMatch: (target): boolean | Promise<boolean> => {
+          const direct = normalizeSecretInputString(target.account.config.password);
+          if (direct) {
+            return safeEqualAuthToken(guid, direct);
+          }
+          return resolveConfiguredSecretInputString({
+            config: target.config,
+            env: process.env,
+            value: target.account.config.password,
+            path: `channels.bluebubbles.accounts.${target.account.accountId}.password`,
+          }).then((resolved) => safeEqualAuthToken(guid, resolved.value ?? ""));
         },
       });
       if (!target) {

--- a/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
+++ b/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
@@ -1,3 +1,4 @@
+import * as secretInputRuntimeModule from "openclaw/plugin-sdk/secret-input-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedBlueBubblesAccount } from "./accounts.js";
 import { fetchBlueBubblesHistory } from "./history.js";
@@ -411,7 +412,48 @@ describe("BlueBubbles webhook monitor", () => {
     });
 
     it("authenticates via password query parameter", async () => {
-      await expectProtectedWebhookRequestStatus(createProtectedPasswordQueryRequestParams(), 200);
+      const resolveSpy = vi.spyOn(secretInputRuntimeModule, "resolveConfiguredSecretInputString");
+      try {
+        await expectProtectedWebhookRequestStatus(createProtectedPasswordQueryRequestParams(), 200);
+        expect(resolveSpy).not.toHaveBeenCalled();
+      } finally {
+        resolveSpy.mockRestore();
+      }
+    });
+
+    describe("configured SecretRef password", () => {
+      it("authenticates inbound webhooks via runtime-resolved SecretRef password", async () => {
+        const resolveSpy = vi.spyOn(secretInputRuntimeModule, "resolveConfiguredSecretInputString");
+        resolveSpy.mockResolvedValue({ value: TEST_WEBHOOK_PASSWORD });
+        try {
+          setupWebhookTarget({
+            account: createMockAccount({
+              // @ts-expect-error SecretRef is accepted at runtime for gateway-merged account config.
+              password: { source: "exec", provider: "op-bb-password", id: "value" }, // pragma: allowlist secret
+            }),
+          });
+
+          await expectWebhookRequestStatusForTest(
+            createProtectedPasswordQueryRequestParams(TEST_WEBHOOK_PASSWORD),
+            200,
+            "ok",
+          );
+
+          expect(resolveSpy).toHaveBeenCalledTimes(1);
+          expect(resolveSpy.mock.calls[0]?.[0]).toMatchObject({
+            config: expect.any(Object),
+            env: expect.any(Object),
+            value: expect.objectContaining({
+              source: "exec",
+              provider: "op-bb-password",
+              id: "value",
+            }), // pragma: allowlist secret
+            path: "channels.bluebubbles.accounts.default.password",
+          });
+        } finally {
+          resolveSpy.mockRestore();
+        }
+      });
     });
 
     it("authenticates via x-password header", async () => {

--- a/extensions/bluebubbles/src/monitor.webhook.test-helpers.ts
+++ b/extensions/bluebubbles/src/monitor.webhook.test-helpers.ts
@@ -118,8 +118,9 @@ export function createMockRequest(
   req.headers = headers;
   (req as unknown as { socket: { remoteAddress: string } }).socket = { remoteAddress };
 
-  // Emit body data after a microtask.
-  void Promise.resolve().then(() => {
+  // Defer emission until after microtasks drain so webhook handlers that
+  // authenticate asynchronously can attach HTTP body listeners first.
+  setImmediate(() => {
     const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
     req.emit("data", Buffer.from(bodyStr));
     req.emit("end");

--- a/extensions/bluebubbles/src/runtime-api.ts
+++ b/extensions/bluebubbles/src/runtime-api.ts
@@ -51,6 +51,7 @@ export {
   readWebhookBodyOrReject,
   registerWebhookTargetWithPluginRoute,
   resolveRequestClientIp,
+  resolveWebhookTargetWithAuthOrReject,
   resolveWebhookTargetWithAuthOrRejectSync,
   withResolvedWebhookRequestPipeline,
 } from "openclaw/plugin-sdk/webhook-ingress";

--- a/extensions/bluebubbles/src/webhook-ingress.ts
+++ b/extensions/bluebubbles/src/webhook-ingress.ts
@@ -5,6 +5,7 @@ export {
   registerWebhookTargetWithPluginRoute,
   readWebhookBodyOrReject,
   resolveRequestClientIp,
+  resolveWebhookTargetWithAuthOrReject,
   resolveWebhookTargetWithAuthOrRejectSync,
   withResolvedWebhookRequestPipeline,
 } from "openclaw/plugin-sdk/webhook-ingress";

--- a/src/plugin-sdk/webhook-targets.ts
+++ b/src/plugin-sdk/webhook-targets.ts
@@ -211,11 +211,13 @@ export function resolveSingleWebhookTarget<T>(
 /** Async variant of single-target resolution for auth checks that need I/O. */
 export async function resolveSingleWebhookTargetAsync<T>(
   targets: readonly T[],
-  isMatch: (target: T) => Promise<boolean>,
+  isMatch: (target: T) => boolean | Promise<boolean>,
 ): Promise<WebhookTargetMatchResult<T>> {
   let matched: T | undefined;
   for (const target of targets) {
-    if (!(await isMatch(target))) {
+    const verdict = isMatch(target);
+    const ok = typeof verdict === "boolean" ? verdict : await verdict;
+    if (!ok) {
       continue;
     }
     const updated = updateMatchedWebhookTarget(matched, target);
@@ -237,9 +239,7 @@ export async function resolveWebhookTargetWithAuthOrReject<T>(params: {
   ambiguousStatusCode?: number;
   ambiguousMessage?: string;
 }): Promise<T | null> {
-  const match = await resolveSingleWebhookTargetAsync(params.targets, async (target) =>
-    params.isMatch(target),
-  );
+  const match = await resolveSingleWebhookTargetAsync(params.targets, params.isMatch);
   return resolveWebhookTargetMatchOrReject(params, match);
 }
 


### PR DESCRIPTION
## Summary

Fix inbound BlueBubbles webhook authentication when `channels.bluebubbles.password` (or account-scoped password) is configured as a **SecretRef** instead of an inline string. Resolves `#76369`.

## Root cause

The webhook `isMatch` path used `account.config.password?.trim()`, assuming a string. `SecretRef` is an object without `.trim`, which threw **`TypeError: ... trim is not a function`** and caused the gateway to reject every POST (“plugin http route failed”).

Outbound paths already resolve secrets via the shared gateway resolver; webhook auth omitted that coercion.

## What changed

- **BlueBubbles** (`monitor.ts`): After extracting the presented token (`guid`/query/header/`Authorization`), match it with `normalizeSecretInputString(password)` when the password is an inline non-empty string; otherwise resolve `password` via `resolveConfiguredSecretInputString` (same secret pipeline used elsewhere).
- **Plugin SDK** (`webhook-targets.ts`): When `resolveSingleWebhookTargetAsync` evaluates `isMatch`, **if the matcher returns a plain `boolean`, use it synchronously**; only await when it returns a `Promise<boolean>`. Combined with forwarding `params.isMatch` directly from `resolveWebhookTargetWithAuthOrReject`, this avoids an extra async wrapper hop.
- **Tests** (`monitor.webhook-auth.test.ts`): Assert plaintext passwords do **not** call `resolveConfiguredSecretInputString`; SecretRef-shaped config drives one resolver invocation and succeeds when the mocked resolved value matches the presented webhook token (with `#ts-expect-error` noting runtime SecretRef merges vs the narrow bundled `BlueBubblesAccountConfig` typings).
- **Test harness** (`monitor.webhook.test-helpers.ts`): Emit mock request bodies on **`setImmediate`** so simulated POST bodies arrive **after** microtasks servicing async auth completion (same ordering as slow real HTTP adapters). Prevents flaky hangs when webhook auth awaits I/O-backed secret resolution.

## Why this fix is safe

- **No weakening of auth semantics**: Comparisons remain **constant-time** via existing `safeEqualSecret`/`safeEqualAuthToken` parity with prior behavior once the resolved password string is obtained.
- **Same secret resolution semantics** as outbound and other bundled BlueBubbles call sites (`resolveConfiguredSecretInputString`): exec/file/env refs still obey gateway policy and provider configs.
- **Explicitly unchanged security/runtime posture**:
  - Gateway plugin HTTP routing, rate limiting (`WEBHOOK_RATE_LIMIT_DEFAULTS`), in-flight guards, SSRF allowances, and Trusted proxy / loopback webhook rules are untouched.
  - BlueBubbles **API** client SSRF/cache behavior unchanged.
  - No new logging of raw secrets beyond existing masked query logging.

## Tests run

```bash
git diff --check
pnpm exec vitest run src/plugin-sdk/webhook-targets.test.ts --pool=forks --maxWorkers=1
pnpm exec vitest run --config test/vitest/vitest.extension-bluebubbles.config.ts \
  extensions/bluebubbles/src/monitor.webhook-auth.test.ts \
  --pool=threads --maxWorkers=1
pnpm check:changed
```

## Out of scope / follow-ups

- BlueBubbles **catchup** path errors when secrets are unresolved at snapshot time (#76369 notes)—not addressed here.
- Broadening `BlueBubblesAccountConfig.password` to **`SecretInput` in typings** ripples multiple call sites; left as a typings follow-up. Runtime already accepts refs from merged gateway config.

## AI-assisted checklist (CONTRIBUTING)

- [ ] Mark as AI-assisted in the PR description (this note).
- [ ] Testing noted above (`pnpm check:changed`, targeted Vitest).
- [ ] Changes understood; production behavior is coercion + resolver parity for webhook tokens only.

Fixes https://github.com/openclaw/openclaw/issues/76369
