### PR TITLE
fix(bluebubbles): resolve SecretRef password before trimming in webhook auth

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeSecretInputString } from "./secret-input.js";
 import { resolveBlueBubblesEffectiveAllowPrivateNetwork } from "./accounts.js";
 import { createBlueBubblesDebounceRegistry } from "./monitor-debounce.js";
 import {
@@ -193,7 +194,7 @@ export async function handleBlueBubblesWebhookRequest(
         targets,
         res,
         isMatch: (target) => {
-          const token = target.account.config.password?.trim() ?? "";
+          const token = normalizeSecretInputString(target.account.config.password)?.trim() ?? "";
           return safeEqualAuthToken(guid, token);
         },
       });


### PR DESCRIPTION
The webhook authentication handler in `extensions/bluebubbles/src/monitor.ts` calls `.trim()` directly on `target.account.config.password`. When the password is configured as a SecretRef object instead of a plain string, this throws `TypeError: password.trim is not a function`.

All other consumers of the password field in the bluebubbles extension (`actions.ts`, `probe.ts`, `accounts.ts`, `monitor-processing.ts`) already use `normalizeSecretInputString()` to resolve SecretRef values before operating on them. The webhook auth path was missed.

Added `normalizeSecretInputString` import and wrapped the password access so the SecretRef is resolved to a plain string before `.trim()` is called.

Closes #76369