### PR TITLE
fix(agents): substitute provider id into model-idle-timeout error message (#76331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/idle-timeout: substitute the actual provider id into the model-idle-timeout error's config-path hint instead of leaving the literal `<id>` placeholder, so the message says (for example) `models.providers.openai.timeoutSeconds` and is copy-pasteable. The placeholder shorthand was being rendered to end users and read as if no such config path existed. Fixes #76331. Thanks @cldmarketinggigi-commits.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -238,7 +238,7 @@ describe("timeout-triggered compaction", () => {
     expect(result.payloads?.[0]?.text).toContain("timed out");
   });
 
-  it("points idle-timeout errors at the provider timeout config key", async () => {
+  it("points idle-timeout errors at the provider timeout config key with the actual provider id substituted (#76331)", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         timedOut: true,
@@ -253,7 +253,13 @@ describe("timeout-triggered compaction", () => {
 
     expect(mockedCompactDirect).not.toHaveBeenCalled();
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("models.providers.<id>.timeoutSeconds");
+    // The harness default provider is "anthropic" (run.overflow-compaction.harness.ts).
+    // The error message must substitute the actual provider id into the
+    // config-path hint so the user can copy-paste it directly. The literal
+    // `<id>` placeholder is documentation shorthand and does not exist as a
+    // real config key, which confused the reporter on #76331.
+    expect(result.payloads?.[0]?.text).toContain("models.providers.anthropic.timeoutSeconds");
+    expect(result.payloads?.[0]?.text).not.toContain("models.providers.<id>.timeoutSeconds");
     expect(result.payloads?.[0]?.text).not.toContain("agents.defaults.timeoutSeconds");
   });
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2087,9 +2087,15 @@ export async function runEmbeddedPiAgent(
             !timedOutDuringToolExecution &&
             !payloadsWithToolMedia?.length
           ) {
+            // Substitute the actual provider id into the config-path hint so
+            // the user can copy-paste it directly. The literal `<id>`
+            // placeholder confused at least one user (#76331) who could not
+            // find that exact path in their config and assumed it did not
+            // exist. `provider` is in scope from the run-loop binding and is
+            // already used in surrounding error messages.
             const timeoutText = idleTimedOut
-              ? "The model did not produce a response before the model idle timeout. " +
-                "Please try again, or increase `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers."
+              ? `The model did not produce a response before the model idle timeout. ` +
+                `Please try again, or increase \`models.providers.${provider}.timeoutSeconds\` for slow local or self-hosted providers.`
               : "Request timed out before a response was generated. " +
                 "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
             const replayInvalid = resolveReplayInvalidForAttempt(null);


### PR DESCRIPTION
## What

When an embedded agent run aborts on idle timeout, the error surfaced to the caller said:

> increase \`models.providers.<id>.timeoutSeconds\` for slow local or self-hosted providers

The literal `<id>` is documentation shorthand and not a real config key. The reporter on #76331 read it that way (\"that path does not exist in config structure\") and dug through their auth-profile JSON looking for it instead of treating `<id>` as a placeholder for their actual provider id.

This PR substitutes the actual provider id (from the run-loop scope) into the hint so the error reads (for example):

> increase \`models.providers.openai.timeoutSeconds\` for slow local or self-hosted providers

Copy-pasteable, no placeholder confusion.

## Scope

One production change at `src/agents/pi-embedded-runner/run.ts` (the timeout-error builder). The `provider` binding is already in scope at this point and is used the same way in surrounding error messages in this file.

The pedagogical `<id>` placeholder in `src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts` and `src/commands/doctor/shared/deprecation-compat.ts` is intentionally left alone, because those messages teach about a class of config keys rather than flag a specific runtime failure where the provider id is known.

## Tests

Updated the existing \"points idle-timeout errors at the provider timeout config key\" case in `src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts` to:
- Assert the substituted form (`models.providers.anthropic.timeoutSeconds`, since the harness default provider is `anthropic` per `run.overflow-compaction.harness.ts`)
- Assert the literal `<id>` placeholder no longer leaks through

Diff: +17 / -4 across 3 files.

## What I haven't verified

I'm working from a sandbox without pnpm installed, so I haven't been able to run `pnpm test` locally. Test updated and reviewed by hand against the harness defaults. Relying on PR CI.

## AI / vibe-coding disclosure

- AI-assisted with Claude Opus 4.7
- Lightly tested: existing test updated, hand-reviewed against the wrapper logic; not validated against a live model run
- Will resolve clawsweeper review conversations as they come in

Closes #76331