### PR TITLE
fix(agents): block message sends through exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/exec: block OpenClaw message delivery commands from agent `exec`, keeping visible provider delivery on the tracked reply/message-tool path so auto-reply sessions do not send a real chat answer and then a second status reply. Thanks @rubencu.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -80,6 +80,7 @@ Notes:
   prevent binary hijacking or injected code.
 - OpenClaw sets `OPENCLAW_SHELL=exec` in the spawned command environment (including PTY and sandbox execution) so shell/profile rules can detect exec-tool context.
 - `openclaw channels login` is blocked from `exec` because it is an interactive channel-auth flow; run it in a terminal on the gateway host, or use the channel-native login tool from chat when one exists.
+- OpenClaw message delivery commands such as `openclaw message send`, `broadcast`, `poll`, thread replies, and sticker sends are blocked from `exec` because provider messaging must flow through the current chat reply path or the `message` tool. Shell-backed sends are not tracked as visible delivery and can otherwise create duplicate auto-replies.
 - Important: sandboxing is **off by default**. If sandboxing is off, implicit `host=auto`
   resolves to `gateway`. Explicit `host=sandbox` still fails closed instead of silently
   running on the gateway host. Enable sandboxing or use `host=gateway` with approvals.

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -25,6 +25,7 @@ const isWin = process.platform === "win32";
 const describeNonWin = isWin ? describe.skip : describe;
 const describeWin = isWin ? describe : describe.skip;
 const parseOpenClawChannelsLoginShellCommand = __testing.parseOpenClawChannelsLoginShellCommand;
+const parseOpenClawMessageDeliveryShellCommand = __testing.parseOpenClawMessageDeliveryShellCommand;
 const validateExecScriptPreflight = __testing.validateScriptFileForShellBleed;
 const createPreflightTool = () =>
   createExecTool({ host: "gateway", security: "full", ask: "on-miss" });
@@ -93,6 +94,650 @@ describe("exec interactive OpenClaw channel login guard", () => {
         command: "sudo -u openclaw bash -lc 'openclaw channels login --channel whatsapp'",
       }),
     ).rejects.toThrow(/exec cannot run interactive OpenClaw channel login commands/);
+  });
+});
+
+describe("exec OpenClaw message delivery guard", () => {
+  it("recognizes real message delivery commands before execution", () => {
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "corepack pnpm openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm exec openclaw message send --channel telegram --target 123 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "./openclaw.mjs message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "node openclaw.mjs message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm exec node openclaw.mjs message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm exec node dist/entry.js message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm -c exec 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm --shell-mode exec 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm dlx openclaw@latest message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "/usr/bin/env openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "/usr/bin/env -S openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "/usr/bin/env -S'openclaw message send' --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "/usr/bin/env -iS'openclaw message send' --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "echo hi > /tmp/openclaw-message-send-preflight; openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "> /tmp/openclaw-message-send-preflight openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "2>/tmp/openclaw-message-send-preflight.err openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "echo ok > /tmp/openclaw-message-send-preflight; printf hi | openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        'echo "<<EOF"\nopenclaw message send --channel whatsapp --target +1555 --message hi',
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "echo $(openclaw message send --channel whatsapp --target +1555 --message hi)",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat <(openclaw message send --channel whatsapp --target +1555 --message hi)",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        'powershell -Command "openclaw message send --channel whatsapp --target +1555 --message hi"',
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cmd /c openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "sh <<'EOF'\nopenclaw message send --channel whatsapp --target +1555 --message hi\nEOF",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat <<'EOF' | sh\nopenclaw message send --channel whatsapp --target +1555 --message hi\nEOF",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat <<'EOF' | sudo sh\nopenclaw message send --channel whatsapp --target +1555 --message hi\nEOF",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "bash <<< 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat <<< 'openclaw message send --channel whatsapp --target +1555 --message hi' | sh",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "(openclaw message send --channel whatsapp --target +1555 --message hi)",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "( openclaw message send --channel whatsapp --target +1555 --message hi )",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "{ openclaw message send --channel whatsapp --target +1555 --message hi; }",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "if true; then openclaw message send --channel whatsapp --target +1555 --message hi; fi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "sleep 1 & openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "! openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message \\\nsend --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm openclaw message \\\nsend --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message s\\\nend --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm openclaw --profile work message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm -s --dir . openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm --loglevel silent openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm --reporter append-only openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpm exec -w openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm --prefix . run openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm --loglevel silent exec openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm exec openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm run-script openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm x openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm -w apps/cli run openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm --workspace apps/cli run openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "yarn workspace app openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "yarn openclaw -- message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "bun run openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm exec -c 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm exec -c 'OPENCLAW_GATEWAY_TOKEN=secret openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npm exec -c 'sudo -u openclaw openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "sudo env -S 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        'npm exec --call="openclaw message send --channel whatsapp --target +1555 --message hi"',
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "npx -c 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "pnpx openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "eval 'openclaw message send --channel whatsapp --target +1555 --message hi'",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "eval openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message --profile work send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "sudo -Eu openclaw openclaw message send --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message send --channel whatsapp --target +1555 --message --help",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message send --channel whatsapp --target +1555 --message --dry-run",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message send --channel whatsapp --target +1555 --message=-h",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message broadcast --targets +1555 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message poll --channel telegram --target 123 --poll-question Snack --poll-option Pizza --poll-option Sushi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message thread reply --channel discord --target thread:123 --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message thread create --channel discord --target channel:123 --thread-name Updates --message hi",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message sticker send --channel discord --target channel:123 --sticker-id 456",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message broadcast --targets +1555 --message --help",
+      ),
+    ).toBe(true);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message poll --channel telegram --target 123 --poll-question Snack --poll-option --dry-run --poll-option Sushi",
+      ),
+    ).toBe(true);
+    expect(parseOpenClawMessageDeliveryShellCommand("openclaw message --help")).toBe(false);
+    expect(parseOpenClawMessageDeliveryShellCommand("openclaw message send --help")).toBe(false);
+    expect(parseOpenClawMessageDeliveryShellCommand("openclaw message broadcast --help")).toBe(
+      false,
+    );
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message send --dry-run --channel whatsapp --target +1555 --message hi",
+      ),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "openclaw message poll --dry-run --channel telegram --target 123 --poll-question Snack --poll-option Pizza --poll-option Sushi",
+      ),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat > send.sh <<'EOF'\nopenclaw message send --channel whatsapp --target +1555 --message hi\nEOF",
+      ),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand(
+        "cat > send.sh <<'EOF'\necho $(openclaw message send --channel whatsapp --target +1555 --message hi)\nEOF",
+      ),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand("openclaw message read --target channel:123"),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand("openclaw message search --guild-id 1 --query hi"),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand("openclaw message thread list --guild-id 1"),
+    ).toBe(false);
+    expect(
+      parseOpenClawMessageDeliveryShellCommand("openclaw --profile work message read --target 123"),
+    ).toBe(false);
+  });
+
+  it("blocks message delivery commands from exec", async () => {
+    const tool = createPreflightTool();
+
+    await expect(
+      tool.execute("call-openclaw-message-send", {
+        command:
+          'OPENCLAW_GATEWAY_TOKEN=secret pnpm openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-wrapped-openclaw-message-send", {
+        command:
+          "sudo -u openclaw bash -lc 'openclaw message send --channel whatsapp --target +1555 --message hello'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-broadcast", {
+        command: 'openclaw message broadcast --targets +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-poll", {
+        command:
+          'openclaw message poll --channel telegram --target 123 --poll-question "Snack?" --poll-option Pizza --poll-option Sushi',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-thread-reply", {
+        command: 'openclaw message thread reply --target thread:123 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-thread-create", {
+        command:
+          'openclaw message thread create --target channel:123 --thread-name Updates --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-sticker-send", {
+        command: "openclaw message sticker send --target channel:123 --sticker-id 456",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-npm-call", {
+        command:
+          'npm exec --call="openclaw message send --channel whatsapp --target +1555 --message hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-npm-call-env", {
+        command:
+          "npm exec -c 'OPENCLAW_GATEWAY_TOKEN=secret openclaw message send --channel whatsapp --target +1555 --message hello'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-pnpm-shell-mode", {
+        command:
+          "pnpm -c exec 'openclaw message send --channel whatsapp --target +1555 --message hello'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-pnpm-dlx-versioned", {
+        command:
+          'pnpm dlx openclaw@latest message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-sudo-env-split", {
+        command:
+          "sudo env -S 'openclaw message send --channel whatsapp --target +1555 --message hello'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-path-env", {
+        command:
+          '/usr/bin/env openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-after-redirect", {
+        command:
+          'echo hi > /tmp/openclaw-message-send-preflight; openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-command-substitution", {
+        command:
+          'echo $(openclaw message send --channel whatsapp --target +1555 --message "hello")',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-process-substitution", {
+        command: 'cat <(openclaw message send --channel whatsapp --target +1555 --message "hello")',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-powershell", {
+        command:
+          'powershell -Command "openclaw message send --channel whatsapp --target +1555 --message hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-cmd", {
+        command: 'cmd /c openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-shell-heredoc", {
+        command:
+          "sh <<'EOF'\nopenclaw message send --channel whatsapp --target +1555 --message \"hello\"\nEOF",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-piped-shell-heredoc", {
+        command:
+          "cat <<'EOF' | sh\nopenclaw message send --channel whatsapp --target +1555 --message \"hello\"\nEOF",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-shell-here-string", {
+        command:
+          "bash <<< 'openclaw message send --channel whatsapp --target +1555 --message \"hello\"'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-piped-shell-here-string", {
+        command:
+          "cat <<< 'openclaw message send --channel whatsapp --target +1555 --message \"hello\"' | sh",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-grouped", {
+        command: '(openclaw message send --channel whatsapp --target +1555 --message "hello")',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-spaced-grouped", {
+        command: '( openclaw message send --channel whatsapp --target +1555 --message "hello" )',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-braced", {
+        command: '{ openclaw message send --channel whatsapp --target +1555 --message "hello"; }',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-if-then", {
+        command:
+          'if true; then openclaw message send --channel whatsapp --target +1555 --message "hello"; fi',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-after-background", {
+        command:
+          'sleep 1 & openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-negated", {
+        command: '! openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-line-continuation", {
+        command: 'openclaw message \\\nsend --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-root-terminator", {
+        command: 'openclaw -- message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-node-mjs", {
+        command:
+          'node openclaw.mjs message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-pnpm-node-mjs", {
+        command:
+          'pnpm exec node openclaw.mjs message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-leading-redirection", {
+        command:
+          '> /tmp/openclaw-message-send-preflight openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-bun-run", {
+        command:
+          'bun run openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-npm-run-script", {
+        command:
+          'npm run-script openclaw -- message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-eval", {
+        command:
+          "eval 'openclaw message send --channel whatsapp --target +1555 --message \"hello\"'",
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-pnpx", {
+        command: 'pnpx openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-corepack-pnpm", {
+        command:
+          'corepack pnpm openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    await expect(
+      tool.execute("call-openclaw-message-send-sudo-clustered-user", {
+        command:
+          'sudo -Eu openclaw openclaw message send --channel whatsapp --target +1555 --message "hello"',
+      }),
+    ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
   });
 });
 
@@ -385,6 +1030,88 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
+  it("blocks OpenClaw message delivery commands inside shell scripts before execution", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(
+        path.join(tmp, "send.sh"),
+        [
+          "#!/usr/bin/env bash",
+          'openclaw message send --channel whatsapp --target +1555 --message "hello"',
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const tool = createPreflightTool();
+      await expect(
+        tool.execute("call-shell-script-send", {
+          command: "bash send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-sh-script-send", {
+          command: "sh ./send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-chained-shell-script-send", {
+          command: "true && sh send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-shell-payload-script-send", {
+          command: "bash -c './send.sh'",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-direct-shell-script-send", {
+          command: "./send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-source-shell-script-send", {
+          command: "source ./send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+      await expect(
+        tool.execute("call-dot-source-shell-script-send", {
+          command: ". ./send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+
+      await fs.writeFile(path.join(tmp, "ok.js"), "console.log('ok')", "utf-8");
+      await expect(
+        tool.execute("call-mixed-node-and-shell-script-send", {
+          command: "node ok.js && sh send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    });
+  });
+
+  it("validates shell script targets reached through env split-string", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(
+        path.join(tmp, "send.sh"),
+        'openclaw message send --channel whatsapp --target +1555 --message "hello"',
+        "utf-8",
+      );
+
+      await expect(
+        validateExecScriptPreflight({
+          command: 'env -S "bash send.sh"',
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+    });
+  });
+
   it("skips script-file preflight in yolo host mode", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const jsPath = path.join(tmp, "bad.js");
@@ -406,6 +1133,18 @@ describeNonWin("exec script preflight", () => {
       expect(result.details).toMatchObject({
         status: expect.stringMatching(/completed|failed/),
       });
+
+      await fs.writeFile(
+        path.join(tmp, "send.sh"),
+        'openclaw message send --channel whatsapp --target +1555 --message "hello"',
+        "utf-8",
+      );
+      await expect(
+        tool.execute("call-yolo-shell-message-send", {
+          command: "sh send.sh",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
     });
   });
 
@@ -435,6 +1174,33 @@ describeNonWin("exec script preflight", () => {
       await expect(
         validateExecScriptPreflight({
           command: "node ../outside.js",
+          workdir,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("validates readable shell script paths outside the workdir", async () => {
+    await withTempDir("openclaw-exec-preflight-parent-", async (parent) => {
+      const workdir = path.join(parent, "workdir");
+      await fs.mkdir(workdir, { recursive: true });
+      await fs.writeFile(
+        path.join(parent, "send.sh"),
+        'openclaw message send --channel whatsapp --target +1555 --message "hello"',
+        "utf-8",
+      );
+
+      await expect(
+        validateExecScriptPreflight({
+          command: "bash ../send.sh",
+          workdir,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+
+      await fs.writeFile(path.join(parent, "safe.sh"), "echo ok", "utf-8");
+      await expect(
+        validateExecScriptPreflight({
+          command: "bash ../safe.sh",
           workdir,
         }),
       ).resolves.toBeUndefined();

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -1072,6 +1072,23 @@ describeNonWin("exec script preflight", () => {
           workdir: tmp,
         }),
       ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+
+      await fs.writeFile(
+        path.join(tmp, "send-message"),
+        [
+          "#!/usr/bin/env bash",
+          'openclaw message send --channel whatsapp --target +1555 --message "hello"',
+        ].join("\n"),
+        "utf-8",
+      );
+      await fs.chmod(path.join(tmp, "send-message"), 0o755);
+      await expect(
+        tool.execute("call-direct-extensionless-shell-script-send", {
+          command: "./send-message",
+          workdir: tmp,
+        }),
+      ).rejects.toThrow(/exec cannot run OpenClaw message delivery commands/);
+
       await expect(
         tool.execute("call-source-shell-script-send", {
           command: "source ./send.sh",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { analyzeShellCommand } from "../infra/exec-approvals-analysis.js";
+import { consumeRootOptionToken } from "../infra/cli-root-options.js";
+import {
+  analyzeShellCommand,
+  splitCommandChainWithOperators,
+} from "../infra/exec-approvals-analysis.js";
 import {
   type ExecAsk,
   type ExecHost,
@@ -159,6 +163,11 @@ function resolvePreflightRelativePath(params: { rootDir: string; absPath: string
   return /^~(?:$|[\\/])/u.test(relative) ? `.${path.sep}${relative}` : relative;
 }
 
+type ExecPreflightScriptTarget =
+  | { kind: "node"; relOrAbsPaths: string[] }
+  | { kind: "python"; relOrAbsPaths: string[] }
+  | { kind: "shell"; relOrAbsPaths: string[] };
+
 function isShellEnvAssignmentToken(token: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*=.*$/u.test(token);
 }
@@ -312,7 +321,7 @@ function findNodeScriptArgs(tokens: string[]): string[] {
 
 function extractInterpreterScriptTargetFromArgv(
   argv: string[] | null,
-): { kind: "python"; relOrAbsPaths: string[] } | { kind: "node"; relOrAbsPaths: string[] } | null {
+): Extract<ExecPreflightScriptTarget, { kind: "node" | "python" }> | null {
   if (!argv || argv.length === 0) {
     return null;
   }
@@ -358,7 +367,7 @@ function extractInterpreterScriptPathsFromSegment(rawSegment: string): string[] 
 
 function extractScriptTargetFromCommand(
   command: string,
-): { kind: "python"; relOrAbsPaths: string[] } | { kind: "node"; relOrAbsPaths: string[] } | null {
+): Extract<ExecPreflightScriptTarget, { kind: "node" | "python" }> | null {
   const raw = command.trim();
   const splitShellArgsPreservingBackslashes = (value: string): string[] | null => {
     const tokens: string[] = [];
@@ -429,6 +438,182 @@ function extractScriptTargetFromCommand(
     }
   }
   return null;
+}
+
+function findShellScriptArg(tokens: string[]): string | null {
+  const shellOptionsWithSeparateValues = new Set([
+    "-O",
+    "-o",
+    "--init-file",
+    "--login-file",
+    "--rcfile",
+  ]);
+
+  for (let idx = 0; idx < tokens.length; idx += 1) {
+    const token = tokens[idx];
+    if (!token) {
+      continue;
+    }
+    if (token === "--") {
+      const script = tokens[idx + 1];
+      return script && script !== "-" ? script : null;
+    }
+    if (token === "-") {
+      return null;
+    }
+    if (!token.startsWith("-")) {
+      return token;
+    }
+    if (
+      token === "-c" ||
+      token === "--command" ||
+      token === "--command-string" ||
+      token === "--execute"
+    ) {
+      return null;
+    }
+    if (
+      (!token.startsWith("--") && token.slice(1).includes("c")) ||
+      token.startsWith("-c") ||
+      token.startsWith("--command=") ||
+      token.startsWith("--command-string=") ||
+      token.startsWith("--execute=")
+    ) {
+      return null;
+    }
+    if (
+      token === "-s" ||
+      (token.startsWith("-") && !token.startsWith("--") && token.includes("s"))
+    ) {
+      return null;
+    }
+
+    const optionName = token.split("=", 1)[0];
+    if (shellOptionsWithSeparateValues.has(optionName) && !token.includes("=")) {
+      idx += 1;
+      continue;
+    }
+    if (
+      !token.startsWith("--") &&
+      token.length > 2 &&
+      (token.endsWith("O") || token.endsWith("o"))
+    ) {
+      idx += 1;
+    }
+  }
+  return null;
+}
+
+function extractShellScriptTargetFromArgv(
+  argv: string[] | null,
+): Extract<ExecPreflightScriptTarget, { kind: "shell" }> | null {
+  if (!argv || argv.length === 0) {
+    return null;
+  }
+  const stripped = stripOpenClawControlCommandPrefixes(
+    stripOpenClawControlLeadingRedirections(stripPreflightEnvPrefix(argv)),
+  );
+  if (!OPENCLAW_CONTROL_SHELL_WRAPPERS.has(normalizeCommandBaseName(stripped[0]))) {
+    return null;
+  }
+  const script = findShellScriptArg(stripped.slice(1));
+  return script ? { kind: "shell", relOrAbsPaths: [script] } : null;
+}
+
+function extractDirectShellScriptTargetFromArgv(
+  argv: string[] | null,
+): Extract<ExecPreflightScriptTarget, { kind: "shell" }> | null {
+  if (!argv || argv.length === 0) {
+    return null;
+  }
+  const stripped = stripOpenClawControlCommandPrefixes(
+    stripOpenClawControlLeadingRedirections(stripPreflightEnvPrefix(argv)),
+  );
+  const command = stripped[0];
+  if (!command || command.startsWith("-")) {
+    return null;
+  }
+  const commandName = normalizeCommandBaseName(command);
+  if (!/\.(?:bash|command|fish|ksh|sh|zsh)$/iu.test(commandName)) {
+    return null;
+  }
+  return { kind: "shell", relOrAbsPaths: [command] };
+}
+
+function extractSourcedShellScriptTargetFromArgv(
+  argv: string[] | null,
+): Extract<ExecPreflightScriptTarget, { kind: "shell" }> | null {
+  if (!argv || argv.length === 0) {
+    return null;
+  }
+  const stripped = stripOpenClawControlCommandPrefixes(
+    stripOpenClawControlLeadingRedirections(stripPreflightEnvPrefix(argv)),
+  );
+  const commandName = normalizeCommandBaseName(stripped[0]);
+  if (commandName !== "." && commandName !== "source") {
+    return null;
+  }
+  const script = stripped[1] === "--" ? stripped[2] : stripped[1];
+  return script && script !== "-" ? { kind: "shell", relOrAbsPaths: [script] } : null;
+}
+
+function collectShellScriptTargetPathsFromArgv(argv: string[], depth: number): string[] {
+  const paths: string[] = [];
+  const directTargets = [
+    extractShellScriptTargetFromArgv(argv),
+    extractDirectShellScriptTargetFromArgv(argv),
+    extractSourcedShellScriptTargetFromArgv(argv),
+  ];
+  for (const target of directTargets) {
+    if (target) {
+      paths.push(...target.relOrAbsPaths);
+    }
+  }
+
+  if (depth <= 0) {
+    return paths;
+  }
+
+  const stripped = stripOpenClawControlCommandPrefixes(
+    stripOpenClawControlLeadingRedirections(stripPreflightEnvPrefix(argv)),
+  );
+  const payloads = [
+    ...extractOpenClawControlEnvSplitStringPayload(argv),
+    ...extractOpenClawControlShellWrapperPayload(stripped),
+  ];
+  for (const payload of payloads) {
+    const target = extractShellScriptTargetFromCommand(payload, depth - 1);
+    if (target) {
+      paths.push(...target.relOrAbsPaths);
+    }
+  }
+  return paths;
+}
+
+function extractShellScriptTargetFromCommand(
+  command: string,
+  depth = 4,
+): Extract<ExecPreflightScriptTarget, { kind: "shell" }> | null {
+  const raw = command.trim();
+  const argv = splitShellArgs(raw);
+  const paths: string[] = [];
+  if (argv) {
+    paths.push(...collectShellScriptTargetPathsFromArgv(argv, depth));
+  }
+
+  const analysis = analyzeShellCommand({ command: raw });
+  const segmentArgvs = analysis.ok
+    ? analysis.segments.map((segment) => segment.argv)
+    : extractOpenClawControlFallbackLines(raw)
+        .flatMap(splitOpenClawControlFallbackSegments)
+        .map(splitShellArgs)
+        .filter((segmentArgv): segmentArgv is string[] => segmentArgv !== null);
+  for (const segmentArgv of segmentArgvs) {
+    paths.push(...collectShellScriptTargetPathsFromArgv(segmentArgv, depth));
+  }
+
+  const uniquePaths = Array.from(new Set(paths));
+  return uniquePaths.length > 0 ? { kind: "shell", relOrAbsPaths: uniquePaths } : null;
 }
 
 function extractUnquotedShellText(raw: string): string | null {
@@ -943,10 +1128,17 @@ function shouldFailClosedInterpreterPreflight(command: string): {
 
 async function validateScriptFileForShellBleed(params: {
   command: string;
+  skipLanguageHeuristics?: boolean;
   workdir: string;
 }): Promise<void> {
-  const target = extractScriptTargetFromCommand(params.command);
-  if (!target) {
+  const targets = [
+    ...(params.skipLanguageHeuristics ? [] : [extractScriptTargetFromCommand(params.command)]),
+    extractShellScriptTargetFromCommand(params.command),
+  ].filter((target): target is ExecPreflightScriptTarget => target !== null);
+  if (targets.length === 0) {
+    if (params.skipLanguageHeuristics) {
+      return;
+    }
     const {
       hasInterpreterInvocation,
       hasComplexSyntax,
@@ -973,74 +1165,87 @@ async function validateScriptFileForShellBleed(params: {
   }
 
   const { SafeOpenError, readFileWithinRoot } = await loadFsSafeModule();
-  for (const relOrAbsPath of target.relOrAbsPaths) {
-    const absPath = path.isAbsolute(relOrAbsPath)
-      ? path.resolve(relOrAbsPath)
-      : path.resolve(params.workdir, relOrAbsPath);
-    const relativePath = resolvePreflightRelativePath({
-      rootDir: params.workdir,
-      absPath,
-    });
-    if (!relativePath) {
-      continue;
-    }
-
-    // Best-effort: only validate files that safely resolve within workdir and
-    // are reasonably small. This keeps preflight checks on a pinned file
-    // identity instead of trusting mutable pathnames across multiple ops.
-    // Use non-blocking open to avoid stalls if a path is swapped to a FIFO.
-    let content: string;
-    try {
-      const safeRead = await readFileWithinRoot({
+  for (const target of targets) {
+    for (const relOrAbsPath of target.relOrAbsPaths) {
+      const absPath = path.isAbsolute(relOrAbsPath)
+        ? path.resolve(relOrAbsPath)
+        : path.resolve(params.workdir, relOrAbsPath);
+      const relativePath = resolvePreflightRelativePath({
         rootDir: params.workdir,
-        relativePath,
-        nonBlockingRead: true,
-        allowSymlinkTargetWithinRoot: true,
-        maxBytes: 512 * 1024,
+        absPath,
       });
-      content = safeRead.buffer.toString("utf-8");
-    } catch (error) {
-      if (shouldSkipScriptPreflightPathError(error, SafeOpenError)) {
-        // Preflight validation is best-effort: skip path/read failures and
-        // continue to execute the command normally.
+      const scriptRootDir =
+        target.kind === "shell" && !relativePath ? path.dirname(absPath) : params.workdir;
+      const scriptRelativePath =
+        target.kind === "shell" && !relativePath ? path.basename(absPath) : relativePath;
+      if (!scriptRelativePath) {
         continue;
       }
-      throw error;
-    }
 
-    // Common failure mode: shell env var syntax leaking into Python/JS.
-    // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
-    const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
-    const first = envVarRegex.exec(content);
-    if (first) {
-      const idx = first.index;
-      const before = content.slice(0, idx);
-      const line = before.split("\n").length;
-      const token = first[0];
-      throw new Error(
-        [
-          `exec preflight: detected likely shell variable injection (${token}) in ${target.kind} script: ${path.basename(
-            absPath,
-          )}:${line}.`,
-          target.kind === "python"
-            ? `In Python, use os.environ.get(${JSON.stringify(token.slice(1))}) instead of raw ${token}.`
-            : `In Node.js, use process.env[${JSON.stringify(token.slice(1))}] instead of raw ${token}.`,
-          "(If this is inside a string literal on purpose, escape it or restructure the code.)",
-        ].join("\n"),
-      );
-    }
+      // Best-effort: validate safely resolved script files that are reasonably
+      // small. This keeps preflight checks on a pinned file identity instead of
+      // trusting mutable pathnames across multiple ops.
+      // Use non-blocking open to avoid stalls if a path is swapped to a FIFO.
+      let content: string;
+      try {
+        const safeRead = await readFileWithinRoot({
+          rootDir: scriptRootDir,
+          relativePath: scriptRelativePath,
+          nonBlockingRead: true,
+          allowSymlinkTargetWithinRoot: true,
+          maxBytes: 512 * 1024,
+        });
+        content = safeRead.buffer.toString("utf-8");
+      } catch (error) {
+        if (shouldSkipScriptPreflightPathError(error, SafeOpenError)) {
+          // Preflight validation is best-effort: skip path/read failures and
+          // continue to execute the command normally.
+          continue;
+        }
+        throw error;
+      }
 
-    // Another recurring pattern from the issue: shell commands accidentally emitted as JS.
-    if (target.kind === "node") {
-      const firstNonEmpty = content
-        .split(/\r?\n/)
-        .map((l) => l.trim())
-        .find((l) => l.length > 0);
-      if (firstNonEmpty && /^NODE\b/.test(firstNonEmpty)) {
+      if (target.kind === "shell") {
+        if (parseOpenClawMessageDeliveryShellCommand(content)) {
+          throw new Error(OPENCLAW_MESSAGE_DELIVERY_EXEC_ERROR);
+        }
+        continue;
+      }
+
+      // Common failure mode: shell env var syntax leaking into Python/JS.
+      // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
+      const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
+      const first = envVarRegex.exec(content);
+      if (first) {
+        const idx = first.index;
+        const before = content.slice(0, idx);
+        const line = before.split("\n").length;
+        const token = first[0];
         throw new Error(
-          `exec preflight: JS file starts with shell syntax (${firstNonEmpty}). ` +
-            `This looks like a shell command, not JavaScript.`,
+          [
+            `exec preflight: detected likely shell variable injection (${token}) in ${target.kind} script: ${path.basename(
+              absPath,
+            )}:${line}.`,
+            target.kind === "python"
+              ? `In Python, use os.environ.get(${JSON.stringify(token.slice(1))}) instead of raw ${token}.`
+              : `In Node.js, use process.env[${JSON.stringify(token.slice(1))}] instead of raw ${token}.`,
+            "(If this is inside a string literal on purpose, escape it or restructure the code.)",
+          ].join("\n"),
         );
+      }
+
+      // Another recurring pattern from the issue: shell commands accidentally emitted as JS.
+      if (target.kind === "node") {
+        const firstNonEmpty = content
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .find((l) => l.length > 0);
+        if (firstNonEmpty && /^NODE\b/.test(firstNonEmpty)) {
+          throw new Error(
+            `exec preflight: JS file starts with shell syntax (${firstNonEmpty}). ` +
+              `This looks like a shell command, not JavaScript.`,
+          );
+        }
       }
     }
   }
@@ -1081,7 +1286,280 @@ function normalizeCommandBaseName(token: string | undefined): string {
     return "";
   }
   const base = normalizeLowercaseStringOrEmpty(token.split(/[\\/]/u).at(-1));
-  return base.replace(/\.(?:cmd|exe)$/u, "");
+  return base
+    .replace(/^[({]+/u, "")
+    .replace(/[)}]+$/u, "")
+    .replace(/\.(?:cmd|exe)$/u, "");
+}
+
+const OPENCLAW_CONTROL_SHELL_KEYWORD_PREFIXES = new Set([
+  "if",
+  "then",
+  "do",
+  "elif",
+  "else",
+  "while",
+  "until",
+  "time",
+  "{",
+  "(",
+  "!",
+]);
+
+const OPENCLAW_PACKAGE_RUNNERS = new Set(["bun", "pnpm", "npm", "yarn"]);
+const OPENCLAW_PACKAGE_RUNNER_SUBCOMMANDS = new Set(["dlx", "exec", "run", "run-script", "x"]);
+const PACKAGE_RUNNER_OPTIONS_WITH_VALUES = new Set([
+  "-C",
+  "-F",
+  "-p",
+  "--cache",
+  "--cache-dir",
+  "--config",
+  "--cwd",
+  "--dir",
+  "--filter",
+  "--filter-prod",
+  "--modules-folder",
+  "--package",
+  "--prefix",
+  "--registry",
+  "--reporter",
+  "--store-dir",
+  "--userconfig",
+  "--loglevel",
+]);
+
+function packageRunnerOptionTakesValue(runner: string, optionName: string): boolean {
+  if ((optionName === "-w" || optionName === "--workspace") && runner === "npm") {
+    return true;
+  }
+  return PACKAGE_RUNNER_OPTIONS_WITH_VALUES.has(optionName);
+}
+
+function isPackageRunnerCommandBoundary(token: string | undefined): boolean {
+  const commandName = normalizeCommandBaseName(token);
+  return (
+    commandName === "openclaw" ||
+    OPENCLAW_PACKAGE_RUNNER_SUBCOMMANDS.has(token ?? "") ||
+    token === "workspace"
+  );
+}
+
+function skipPackageRunnerOptions(argv: string[], startIndex: number, runner: string): number {
+  let idx = startIndex;
+  while (idx < argv.length) {
+    const token = argv[idx];
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      return idx + 1;
+    }
+    if (!token.startsWith("-") || token === "-") {
+      return idx;
+    }
+    const optionName = token.split("=", 1)[0];
+    idx += 1;
+    if (
+      packageRunnerOptionTakesValue(runner, optionName) &&
+      !token.includes("=") &&
+      idx < argv.length
+    ) {
+      idx += 1;
+      continue;
+    }
+    if (
+      !token.includes("=") &&
+      argv[idx] &&
+      !argv[idx].startsWith("-") &&
+      isPackageRunnerCommandBoundary(argv[idx + 1])
+    ) {
+      idx += 1;
+    }
+  }
+  return idx;
+}
+
+function collectPackageRunnerCallPayloads(
+  argv: string[],
+  startIndex: number,
+  runner: string,
+): string[] {
+  const payloads: string[] = [];
+  for (let idx = startIndex; idx < argv.length; idx += 1) {
+    const token = argv[idx];
+    if (!token) {
+      continue;
+    }
+    if (token === "--") {
+      break;
+    }
+    if (token === "-c" || token === "--call") {
+      const payload = argv[idx + 1];
+      if (payload?.trim()) {
+        payloads.push(payload);
+      }
+      idx += 1;
+      continue;
+    }
+    if (token.startsWith("--call=")) {
+      const payload = token.slice("--call=".length);
+      if (payload.trim()) {
+        payloads.push(payload);
+      }
+      continue;
+    }
+    if (token.startsWith("-c") && token.length > 2) {
+      const payload = token.slice(2);
+      if (payload.trim()) {
+        payloads.push(payload);
+      }
+      continue;
+    }
+    if (!token.startsWith("-") || token === "-") {
+      break;
+    }
+    const optionName = token.split("=", 1)[0];
+    if (packageRunnerOptionTakesValue(runner, optionName) && !token.includes("=")) {
+      idx += 1;
+    }
+  }
+  return payloads;
+}
+
+function extractPackageRunnerShellPayloads(argv: string[]): string[] {
+  const commandName = normalizeCommandBaseName(argv[0]);
+  if (commandName === "corepack") {
+    return extractPackageRunnerShellPayloads(argv.slice(1));
+  }
+  if (commandName === "npx" || commandName === "pnpx") {
+    return collectPackageRunnerCallPayloads(argv, 1, "npm");
+  }
+  if (commandName === "pnpm") {
+    const beforeSubcommand = scanPnpmShellModeOptions(argv, 1);
+    const subcommand = argv[beforeSubcommand.idx];
+    if (subcommand !== "exec") {
+      return [];
+    }
+    const afterSubcommand = scanPnpmShellModeOptions(argv, beforeSubcommand.idx + 1);
+    if (!beforeSubcommand.shellMode && !afterSubcommand.shellMode) {
+      return [];
+    }
+    const payloadArgv = argv.slice(afterSubcommand.idx).filter((token) => token !== "--");
+    const payload = payloadArgv.length === 1 ? payloadArgv[0] : payloadArgv.join(" ");
+    return payload.trim() ? [payload] : [];
+  }
+  if (commandName !== "npm") {
+    return [];
+  }
+  const idx = skipPackageRunnerOptions(argv, 1, commandName);
+  const subcommand = argv[idx];
+  if (subcommand !== "exec" && subcommand !== "x") {
+    return [];
+  }
+  return collectPackageRunnerCallPayloads(argv, idx + 1, commandName);
+}
+
+function isOpenClawCliEntrypoint(token: string | undefined): boolean {
+  const commandName = normalizeCommandBaseName(token);
+  return (
+    commandName === "openclaw" ||
+    commandName.startsWith("openclaw@") ||
+    commandName === "openclaw.mjs" ||
+    commandName === "entry.js" ||
+    commandName === "entry.mjs"
+  );
+}
+
+function normalizeOpenClawPackageRunnerArgv(argv: string[]): string[] {
+  const normalizedArgv = isOpenClawCliEntrypoint(argv[0]) ? ["openclaw", ...argv.slice(1)] : argv;
+  return normalizedArgv[1] === "--"
+    ? [normalizedArgv[0], ...normalizedArgv.slice(2)]
+    : normalizedArgv;
+}
+
+function normalizeOpenClawPackageRunnerCommandArgv(argv: string[]): string[] | null {
+  const normalizedArgv = stripOpenClawCliLauncher(argv);
+  return normalizeCommandBaseName(normalizedArgv[0]) === "openclaw" ? normalizedArgv : null;
+}
+
+function stripOpenClawCliLauncher(argv: string[]): string[] {
+  if (isOpenClawCliEntrypoint(argv[0])) {
+    return normalizeOpenClawPackageRunnerArgv(argv);
+  }
+
+  const commandName = normalizeCommandBaseName(argv[0]);
+  if (commandName !== "node") {
+    return argv;
+  }
+
+  let idx = 1;
+  const nodeOptionsWithValues = new Set([
+    "-r",
+    "--require",
+    "--import",
+    "--loader",
+    "--experimental-loader",
+    "--env-file",
+  ]);
+  while (idx < argv.length) {
+    const token = argv[idx];
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      break;
+    }
+    if (!token.startsWith("-") || token === "-") {
+      break;
+    }
+    const optionName = token.split("=", 1)[0];
+    idx += 1;
+    if (nodeOptionsWithValues.has(optionName) && !token.includes("=")) {
+      idx += 1;
+    }
+  }
+
+  if (isOpenClawCliEntrypoint(argv[idx])) {
+    return normalizeOpenClawPackageRunnerArgv(["openclaw", ...argv.slice(idx + 1)]);
+  }
+  return argv;
+}
+
+function scanPnpmShellModeOptions(
+  argv: string[],
+  startIndex: number,
+): { idx: number; shellMode: boolean } {
+  let idx = startIndex;
+  let shellMode = false;
+  while (idx < argv.length) {
+    const token = argv[idx];
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      return { idx: idx + 1, shellMode };
+    }
+    if (!token.startsWith("-") || token === "-") {
+      return { idx, shellMode };
+    }
+    const optionName = token.split("=", 1)[0];
+    if (optionName === "-c" || optionName === "--shell-mode") {
+      const value = token.includes("=") ? token.slice(token.indexOf("=") + 1) : "";
+      shellMode = value !== "false" && value !== "0";
+      idx += 1;
+      continue;
+    }
+    idx += 1;
+    if (packageRunnerOptionTakesValue("pnpm", optionName) && !token.includes("=")) {
+      idx += 1;
+    }
+  }
+  return { idx, shellMode };
 }
 
 function stripOpenClawPackageRunner(argv: string[]): string[] {
@@ -1089,20 +1567,32 @@ function stripOpenClawPackageRunner(argv: string[]): string[] {
   if (commandName === "openclaw") {
     return argv;
   }
-  if (
-    (commandName === "pnpm" || commandName === "npm" || commandName === "yarn") &&
-    normalizeCommandBaseName(argv[1]) === "openclaw"
-  ) {
-    return argv.slice(1);
+  if (commandName === "corepack") {
+    return stripOpenClawPackageRunner(argv.slice(1));
   }
-  if (
-    (commandName === "pnpm" || commandName === "npm" || commandName === "yarn") &&
-    (argv[1] === "exec" || argv[1] === "dlx" || argv[1] === "run") &&
-    normalizeCommandBaseName(argv[2]) === "openclaw"
-  ) {
-    return argv.slice(2);
+  if (OPENCLAW_PACKAGE_RUNNERS.has(commandName)) {
+    let idx = skipPackageRunnerOptions(argv, 1, commandName);
+    const directCommand = normalizeOpenClawPackageRunnerCommandArgv(argv.slice(idx));
+    if (directCommand) {
+      return directCommand;
+    }
+    const subcommand = argv[idx];
+    if (commandName === "yarn" && subcommand === "workspace" && argv[idx + 1]) {
+      idx = skipPackageRunnerOptions(argv, idx + 2, commandName);
+      const workspaceCommand = normalizeOpenClawPackageRunnerCommandArgv(argv.slice(idx));
+      if (workspaceCommand) {
+        return workspaceCommand;
+      }
+    }
+    if (subcommand && OPENCLAW_PACKAGE_RUNNER_SUBCOMMANDS.has(subcommand)) {
+      idx = skipPackageRunnerOptions(argv, idx + 1, commandName);
+      const subcommandCommand = normalizeOpenClawPackageRunnerCommandArgv(argv.slice(idx));
+      if (subcommandCommand) {
+        return subcommandCommand;
+      }
+    }
   }
-  if (commandName === "npx" || commandName === "bunx") {
+  if (commandName === "npx" || commandName === "pnpx" || commandName === "bunx") {
     let idx = 1;
     while (idx < argv.length) {
       const token = argv[idx];
@@ -1118,23 +1608,1283 @@ function stripOpenClawPackageRunner(argv: string[]): string[] {
         idx += 1;
       }
     }
-    if (normalizeCommandBaseName(argv[idx]) === "openclaw") {
-      return argv.slice(idx);
+    const packageCommand = normalizeOpenClawPackageRunnerCommandArgv(argv.slice(idx));
+    if (packageCommand) {
+      return packageCommand;
     }
   }
   return argv;
 }
 
-function parseOpenClawChannelsLoginShellCommand(raw: string): boolean {
-  const argv = splitShellArgs(raw);
-  if (!argv) {
+function stripOpenClawRootOptions(argv: string[]): string[] {
+  if (normalizeCommandBaseName(argv[0]) !== "openclaw") {
+    return argv;
+  }
+  const out = [argv[0]];
+  const args = argv.slice(1);
+  for (let idx = 0; idx < args.length; idx += 1) {
+    const arg = args[idx];
+    if (!arg) {
+      continue;
+    }
+    if (arg === "--") {
+      out.push(...(out.length === 1 ? args.slice(idx + 1) : [arg, ...args.slice(idx + 1)]));
+      break;
+    }
+    const consumed = consumeRootOptionToken(args, idx);
+    if (consumed > 0) {
+      idx += consumed - 1;
+      continue;
+    }
+    out.push(arg);
+  }
+  return out;
+}
+
+type OpenClawControlShellCommandCandidate = { raw: string; argv?: string[] };
+
+const OPENCLAW_CONTROL_SHELL_WRAPPERS = new Set(["bash", "dash", "fish", "ksh", "sh", "zsh"]);
+const OPENCLAW_CONTROL_COMMAND_STANDALONE_OPTIONS = new Set(["-p", "-v", "-V"]);
+const OPENCLAW_CONTROL_ENV_OPTIONS_WITH_VALUES = new Set([
+  "-C",
+  "-S",
+  "-u",
+  "--argv0",
+  "--block-signal",
+  "--chdir",
+  "--default-signal",
+  "--ignore-signal",
+  "--split-string",
+  "--unset",
+]);
+const OPENCLAW_CONTROL_EXEC_OPTIONS_WITH_VALUES = new Set(["-a"]);
+const OPENCLAW_CONTROL_EXEC_STANDALONE_OPTIONS = new Set(["-c", "-l"]);
+const OPENCLAW_CONTROL_SUDO_OPTIONS_WITH_VALUES = new Set([
+  "-C",
+  "-D",
+  "-g",
+  "-p",
+  "-R",
+  "-T",
+  "-U",
+  "-u",
+  "--chdir",
+  "--close-from",
+  "--group",
+  "--host",
+  "--other-user",
+  "--prompt",
+  "--role",
+  "--type",
+  "--user",
+]);
+const OPENCLAW_CONTROL_SUDO_STANDALONE_OPTIONS = new Set([
+  "-A",
+  "-E",
+  "--askpass",
+  "--preserve-env",
+]);
+const OPENCLAW_CONTROL_SUDO_CLUSTER_VALUE_OPTIONS = new Set([
+  "C",
+  "D",
+  "g",
+  "h",
+  "p",
+  "R",
+  "T",
+  "U",
+  "u",
+]);
+
+function openClawControlSudoClusterConsumesNext(option: string): boolean {
+  if (!option.startsWith("-") || option.startsWith("--") || option.length <= 2) {
     return false;
   }
-  const openclawArgv = stripOpenClawPackageRunner(argv);
+  const lastFlag = option.at(-1);
+  return Boolean(lastFlag && OPENCLAW_CONTROL_SUDO_CLUSTER_VALUE_OPTIONS.has(lastFlag));
+}
+
+const isOpenClawControlEnvAssignmentToken = (token: string): boolean =>
+  /^[A-Za-z_][A-Za-z0-9_]*=.*$/u.test(token);
+
+function extractOpenClawControlEnvSplitStringPayload(argv: string[]): string[] {
+  const remaining = [...argv];
+  while (remaining.length > 0) {
+    while (remaining[0] && isOpenClawControlEnvAssignmentToken(remaining[0])) {
+      remaining.shift();
+    }
+    const token = remaining[0];
+    const commandName = normalizeCommandBaseName(token);
+    if (!token || commandName === "env") {
+      break;
+    }
+    if (commandName === "command" || commandName === "builtin") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        if (!OPENCLAW_CONTROL_COMMAND_STANDALONE_OPTIONS.has(option.split("=", 1)[0])) {
+          continue;
+        }
+      }
+      continue;
+    }
+    if (commandName === "exec") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        const normalized = option.split("=", 1)[0];
+        if (OPENCLAW_CONTROL_EXEC_STANDALONE_OPTIONS.has(normalized)) {
+          continue;
+        }
+        if (
+          OPENCLAW_CONTROL_EXEC_OPTIONS_WITH_VALUES.has(normalized) &&
+          !option.includes("=") &&
+          remaining[0]
+        ) {
+          remaining.shift();
+        }
+      }
+      continue;
+    }
+    if (commandName === "sudo") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        const normalized = option.split("=", 1)[0];
+        if (OPENCLAW_CONTROL_SUDO_STANDALONE_OPTIONS.has(normalized)) {
+          continue;
+        }
+        if (openClawControlSudoClusterConsumesNext(option) && remaining[0]) {
+          remaining.shift();
+          continue;
+        }
+        if (
+          OPENCLAW_CONTROL_SUDO_OPTIONS_WITH_VALUES.has(normalized) &&
+          !option.includes("=") &&
+          remaining[0]
+        ) {
+          remaining.shift();
+        }
+      }
+      continue;
+    }
+    break;
+  }
+  if (normalizeCommandBaseName(remaining[0]) !== "env") {
+    return [];
+  }
+  remaining.shift();
+  const payloads: string[] = [];
+  const takeSplitStringPayload = (option: string): string | undefined => {
+    if (option === "-S" || option === "--split-string") {
+      return remaining.shift();
+    }
+    if (option.startsWith("--split-string=")) {
+      return option.slice("--split-string=".length);
+    }
+    if (!option.startsWith("--")) {
+      const splitIndex = option.indexOf("S");
+      if (splitIndex > 0) {
+        return option.slice(splitIndex + 1) || remaining.shift();
+      }
+    }
+    return undefined;
+  };
+  while (remaining.length > 0) {
+    while (remaining[0] && isOpenClawControlEnvAssignmentToken(remaining[0])) {
+      remaining.shift();
+    }
+    const token: string | undefined = remaining[0];
+    if (!token) {
+      break;
+    }
+    if (token === "--") {
+      remaining.shift();
+      continue;
+    }
+    if (!token.startsWith("-") || token === "-") {
+      break;
+    }
+    const option = remaining.shift()!;
+    const normalized = option.split("=", 1)[0];
+    const splitString = takeSplitStringPayload(option);
+    if (splitString !== undefined) {
+      const value = [splitString, ...remaining].filter((part) => part.length > 0).join(" ");
+      if (value?.trim()) {
+        payloads.push(value);
+      }
+      break;
+    }
+    if (
+      OPENCLAW_CONTROL_ENV_OPTIONS_WITH_VALUES.has(normalized) &&
+      !option.includes("=") &&
+      remaining[0]
+    ) {
+      remaining.shift();
+    }
+  }
+  return payloads;
+}
+
+function stripOpenClawControlCommandPrefixes(argv: string[]): string[] {
+  const remaining = [...argv];
+  while (remaining.length > 0) {
+    while (remaining[0] && isOpenClawControlEnvAssignmentToken(remaining[0])) {
+      remaining.shift();
+    }
+
+    const token = remaining[0];
+    if (!token) {
+      break;
+    }
+    if (token === "--") {
+      remaining.shift();
+      continue;
+    }
+    const commandName = normalizeCommandBaseName(token);
+    if (commandName === "env") {
+      remaining.shift();
+      while (remaining.length > 0) {
+        while (remaining[0] && isOpenClawControlEnvAssignmentToken(remaining[0])) {
+          remaining.shift();
+        }
+        const envToken = remaining[0];
+        if (!envToken) {
+          break;
+        }
+        if (envToken === "--") {
+          remaining.shift();
+          continue;
+        }
+        if (!envToken.startsWith("-") || envToken === "-") {
+          break;
+        }
+        const option = remaining.shift()!;
+        const normalized = option.split("=", 1)[0];
+        if (
+          OPENCLAW_CONTROL_ENV_OPTIONS_WITH_VALUES.has(normalized) &&
+          !option.includes("=") &&
+          remaining[0]
+        ) {
+          remaining.shift();
+        }
+      }
+      continue;
+    }
+    if (commandName === "command" || commandName === "builtin") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        if (!OPENCLAW_CONTROL_COMMAND_STANDALONE_OPTIONS.has(option.split("=", 1)[0])) {
+          continue;
+        }
+      }
+      continue;
+    }
+    if (commandName === "exec") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        const normalized = option.split("=", 1)[0];
+        if (OPENCLAW_CONTROL_EXEC_STANDALONE_OPTIONS.has(normalized)) {
+          continue;
+        }
+        if (
+          OPENCLAW_CONTROL_EXEC_OPTIONS_WITH_VALUES.has(normalized) &&
+          !option.includes("=") &&
+          remaining[0]
+        ) {
+          remaining.shift();
+        }
+      }
+      continue;
+    }
+    if (commandName === "sudo") {
+      remaining.shift();
+      while (remaining[0]?.startsWith("-")) {
+        const option = remaining.shift()!;
+        if (option === "--") {
+          break;
+        }
+        const normalized = option.split("=", 1)[0];
+        if (OPENCLAW_CONTROL_SUDO_STANDALONE_OPTIONS.has(normalized)) {
+          continue;
+        }
+        if (openClawControlSudoClusterConsumesNext(option) && remaining[0]) {
+          remaining.shift();
+          continue;
+        }
+        if (
+          OPENCLAW_CONTROL_SUDO_OPTIONS_WITH_VALUES.has(normalized) &&
+          !option.includes("=") &&
+          remaining[0]
+        ) {
+          remaining.shift();
+        }
+      }
+      continue;
+    }
+    break;
+  }
+  return remaining;
+}
+
+function classifyOpenClawControlLeadingRedirection(
+  token: string | undefined,
+): "attached" | "standalone" | null {
+  if (!token || token.startsWith("<(") || token.startsWith(">(")) {
+    return null;
+  }
+  const redirectionOperator = "(?:\\d+)?(?:<>|<<-?|<<<|>>|>\\||>|<|<&|>&)|&>>|&>";
+  if (new RegExp(`^(?:${redirectionOperator})$`, "u").test(token)) {
+    return "standalone";
+  }
+  if (new RegExp(`^(?:${redirectionOperator}).+`, "u").test(token)) {
+    return "attached";
+  }
+  return null;
+}
+
+function stripOpenClawControlLeadingRedirections(argv: string[]): string[] {
+  let idx = 0;
+  while (idx < argv.length) {
+    const redirection = classifyOpenClawControlLeadingRedirection(argv[idx]);
+    if (!redirection) {
+      break;
+    }
+    idx += redirection === "standalone" && idx + 1 < argv.length ? 2 : 1;
+  }
+  return idx > 0 ? argv.slice(idx) : argv;
+}
+
+function extractOpenClawControlShellWrapperPayload(argv: string[]): string[] {
+  const [commandName, ...rest] = argv;
+  const normalizedCommandName = normalizeCommandBaseName(commandName);
+  if (normalizedCommandName === "cmd") {
+    for (let i = 0; i < rest.length; i += 1) {
+      const token = normalizeLowercaseStringOrEmpty(rest[i]);
+      if (token === "/c" || token === "/k") {
+        const payload = rest.slice(i + 1).join(" ");
+        return payload.trim() ? [payload] : [];
+      }
+    }
+    return [];
+  }
+  if (normalizedCommandName === "powershell" || normalizedCommandName === "pwsh") {
+    for (let i = 0; i < rest.length; i += 1) {
+      const token = normalizeLowercaseStringOrEmpty(rest[i]);
+      if (token === "-command" || token === "-commandwithargs" || token === "-c") {
+        const payload = rest.slice(i + 1).join(" ");
+        return payload.trim() ? [payload] : [];
+      }
+    }
+    return [];
+  }
+  if (!commandName || !OPENCLAW_CONTROL_SHELL_WRAPPERS.has(normalizedCommandName)) {
+    return [];
+  }
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (!token) {
+      continue;
+    }
+    if (token === "-c" || token === "-lc" || token === "-ic" || token === "-xc") {
+      return rest[i + 1] ? [rest[i + 1]] : [];
+    }
+    if (/^-[^-]*c[^-]*$/u.test(token)) {
+      return rest[i + 1] ? [rest[i + 1]] : [];
+    }
+  }
+  return [];
+}
+
+function extractOpenClawControlEvalPayload(argv: string[]): string[] {
+  const [commandName, ...rest] = argv;
+  if (normalizeCommandBaseName(commandName) !== "eval") {
+    return [];
+  }
+  const payloadArgv = rest[0] === "--" ? rest.slice(1) : rest;
+  const payload = payloadArgv.join(" ");
+  return payload.trim() ? [payload] : [];
+}
+
+function buildOpenClawControlCandidatesFromArgv(
+  argv: string[],
+): OpenClawControlShellCommandCandidate[] {
+  const firstToken = argv[0] ?? "";
+  const shellKeywordCandidates =
+    OPENCLAW_CONTROL_SHELL_KEYWORD_PREFIXES.has(firstToken) ||
+    OPENCLAW_CONTROL_SHELL_KEYWORD_PREFIXES.has(normalizeCommandBaseName(firstToken))
+      ? buildOpenClawControlCandidatesFromArgv(argv.slice(1))
+      : [];
+  const envSplitCandidates = extractOpenClawControlEnvSplitStringPayload(argv).flatMap(
+    (payload) => {
+      const innerArgv = splitShellArgs(payload);
+      return innerArgv ? buildOpenClawControlCandidatesFromArgv(innerArgv) : [{ raw: payload }];
+    },
+  );
+  const prefixStripped = stripOpenClawControlCommandPrefixes(argv);
+  const redirectionStripped = stripOpenClawControlLeadingRedirections(prefixStripped);
+  const redirectionCandidates =
+    redirectionStripped === prefixStripped
+      ? []
+      : buildOpenClawControlCandidatesFromArgv(redirectionStripped);
+  const stripped = stripOpenClawControlCommandPrefixes(redirectionStripped);
+  const shellWrapperCandidates = extractOpenClawControlShellWrapperPayload(stripped).flatMap(
+    (payload) => {
+      const innerArgv = splitShellArgs(payload);
+      return innerArgv ? buildOpenClawControlCandidatesFromArgv(innerArgv) : [{ raw: payload }];
+    },
+  );
+  const evalCandidates = extractOpenClawControlEvalPayload(stripped).flatMap((payload) => {
+    const innerArgv = splitShellArgs(payload);
+    return innerArgv ? buildOpenClawControlCandidatesFromArgv(innerArgv) : [{ raw: payload }];
+  });
+  return [
+    ...(stripped.length > 0 ? [{ raw: stripped.join(" "), argv: stripped }] : []),
+    ...shellKeywordCandidates,
+    ...envSplitCandidates,
+    ...redirectionCandidates,
+    ...shellWrapperCandidates,
+    ...evalCandidates,
+  ];
+}
+
+function extractOpenClawControlHeredocsFromLine(
+  line: string,
+): { delimiter: string; stripTabs: boolean; startIndex: number; quoted: boolean }[] {
+  const specs: { delimiter: string; stripTabs: boolean; startIndex: number; quoted: boolean }[] =
+    [];
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = line[i + 1];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (!inSingle && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (ch === '"') {
+        inDouble = false;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /\s/u.test(line[i - 1] ?? ""))) {
+      break;
+    }
+    if (ch !== "<" || next !== "<" || line[i + 2] === "<") {
+      continue;
+    }
+
+    const startIndex = i;
+    let scanIndex = i + 2;
+    let stripTabs = false;
+    if (line[scanIndex] === "-") {
+      stripTabs = true;
+      scanIndex += 1;
+    }
+    while (line[scanIndex] === " " || line[scanIndex] === "\t") {
+      scanIndex += 1;
+    }
+
+    const first = line[scanIndex];
+    if (first === "'" || first === '"') {
+      const quote = first;
+      scanIndex += 1;
+      let delimiter = "";
+      while (scanIndex < line.length) {
+        const current = line[scanIndex];
+        if (quote === '"' && current === "\\" && scanIndex + 1 < line.length) {
+          delimiter += line[scanIndex + 1];
+          scanIndex += 2;
+          continue;
+        }
+        if (current === quote) {
+          specs.push({ delimiter, stripTabs, startIndex, quoted: true });
+          i = scanIndex;
+          break;
+        }
+        delimiter += current;
+        scanIndex += 1;
+      }
+      continue;
+    }
+
+    let delimiter = "";
+    while (scanIndex < line.length) {
+      const current = line[scanIndex];
+      if (/\s/u.test(current) || "|&;<>".includes(current)) {
+        break;
+      }
+      delimiter += current;
+      scanIndex += 1;
+    }
+    if (delimiter) {
+      specs.push({ delimiter, stripTabs, startIndex, quoted: false });
+      i = scanIndex - 1;
+    }
+  }
+
+  return specs;
+}
+
+function extractOpenClawControlFallbackLines(rawCommand: string): string[] {
+  const out: string[] = [];
+  const pendingDelimiters: { delimiter: string; stripTabs: boolean }[] = [];
+
+  const extractHeredocsFromLine = (line: string): { delimiter: string; stripTabs: boolean }[] => {
+    const specs: { delimiter: string; stripTabs: boolean }[] = [];
+    let inSingle = false;
+    let inDouble = false;
+    let escaped = false;
+
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i];
+      const next = line[i + 1];
+
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (!inSingle && ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (inSingle) {
+        if (ch === "'") {
+          inSingle = false;
+        }
+        continue;
+      }
+      if (inDouble) {
+        if (ch === '"') {
+          inDouble = false;
+        }
+        continue;
+      }
+      if (ch === "'") {
+        inSingle = true;
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = true;
+        continue;
+      }
+      if (ch === "#" && (i === 0 || /\s/u.test(line[i - 1] ?? ""))) {
+        break;
+      }
+      if (ch !== "<" || next !== "<" || line[i + 2] === "<") {
+        continue;
+      }
+
+      let scanIndex = i + 2;
+      let stripTabs = false;
+      if (line[scanIndex] === "-") {
+        stripTabs = true;
+        scanIndex += 1;
+      }
+      while (line[scanIndex] === " " || line[scanIndex] === "\t") {
+        scanIndex += 1;
+      }
+
+      const first = line[scanIndex];
+      if (first === "'" || first === '"') {
+        const quote = first;
+        scanIndex += 1;
+        let delimiter = "";
+        while (scanIndex < line.length) {
+          const current = line[scanIndex];
+          if (quote === '"' && current === "\\" && scanIndex + 1 < line.length) {
+            delimiter += line[scanIndex + 1];
+            scanIndex += 2;
+            continue;
+          }
+          if (current === quote) {
+            specs.push({ delimiter, stripTabs });
+            i = scanIndex;
+            break;
+          }
+          delimiter += current;
+          scanIndex += 1;
+        }
+        continue;
+      }
+
+      let delimiter = "";
+      while (scanIndex < line.length) {
+        const current = line[scanIndex];
+        if (/\s/u.test(current) || "|&;<>".includes(current)) {
+          break;
+        }
+        delimiter += current;
+        scanIndex += 1;
+      }
+      if (delimiter) {
+        specs.push({ delimiter, stripTabs });
+        i = scanIndex - 1;
+      }
+    }
+
+    return specs;
+  };
+
+  for (const rawLine of rawCommand.split(/\r?\n/)) {
+    if (pendingDelimiters.length > 0) {
+      const current = pendingDelimiters[0];
+      const delimiterLine = current.stripTabs ? rawLine.replace(/^\t+/u, "") : rawLine;
+      if (delimiterLine === current.delimiter) {
+        pendingDelimiters.shift();
+      }
+      continue;
+    }
+
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    out.push(line);
+
+    for (const heredoc of extractHeredocsFromLine(line)) {
+      pendingDelimiters.push(heredoc);
+    }
+  }
+
+  return out;
+}
+
+function splitOpenClawControlFallbackPipelines(line: string): string[] {
+  const out: string[] = [];
+  let buffer = "";
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  const pushBuffer = () => {
+    const trimmed = buffer.trim();
+    if (trimmed) {
+      out.push(trimmed);
+    }
+    buffer = "";
+  };
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = line[i + 1];
+
+    if (escaped) {
+      buffer += ch;
+      escaped = false;
+      continue;
+    }
+    if (!inSingle && ch === "\\") {
+      buffer += ch;
+      escaped = true;
+      continue;
+    }
+    if (inSingle) {
+      buffer += ch;
+      if (ch === "'") {
+        inSingle = false;
+      }
+      continue;
+    }
+    if (inDouble) {
+      buffer += ch;
+      if (ch === '"') {
+        inDouble = false;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      buffer += ch;
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      buffer += ch;
+      inDouble = true;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /\s/u.test(line[i - 1] ?? ""))) {
+      buffer += line.slice(i);
+      break;
+    }
+    if (ch === "|") {
+      pushBuffer();
+      if (next === "&") {
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "&" && next !== "&") {
+      pushBuffer();
+      continue;
+    }
+    buffer += ch;
+  }
+
+  pushBuffer();
+  return out.length > 0 ? out : [line];
+}
+
+function splitOpenClawControlFallbackSegments(line: string): string[] {
+  const chainParts = splitCommandChainWithOperators(line)?.map((part) => part.part) ?? [line];
+  return chainParts.flatMap(splitOpenClawControlFallbackPipelines);
+}
+
+function stripQuotedHeredocBodiesForOpenClawControlSubstitutions(rawCommand: string): string {
+  const out: string[] = [];
+  const pendingDelimiters: { delimiter: string; stripTabs: boolean; quoted: boolean }[] = [];
+
+  for (const rawLine of rawCommand.split(/\r?\n/)) {
+    if (pendingDelimiters.length > 0) {
+      const current = pendingDelimiters[0];
+      const delimiterLine = current.stripTabs ? rawLine.replace(/^\t+/u, "") : rawLine;
+      if (delimiterLine === current.delimiter) {
+        pendingDelimiters.shift();
+        continue;
+      }
+      if (!current.quoted) {
+        out.push(rawLine);
+      }
+      continue;
+    }
+
+    out.push(rawLine);
+    const line = rawLine.trim();
+    for (const heredoc of extractOpenClawControlHeredocsFromLine(line)) {
+      pendingDelimiters.push(heredoc);
+    }
+  }
+
+  return out.join("\n");
+}
+
+function extractOpenClawControlCommandSubstitutionPayloads(rawCommand: string): string[] {
+  const command = stripQuotedHeredocBodiesForOpenClawControlSubstitutions(rawCommand);
+  const payloads: string[] = [];
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  const readParenPayload = (startIndex: number): { payload: string; endIndex: number } | null => {
+    let depth = 1;
+    let nestedSingle = false;
+    let nestedDouble = false;
+    let nestedEscaped = false;
+    const payloadStart = startIndex + 2;
+
+    for (let i = payloadStart; i < command.length; i += 1) {
+      const ch = command[i];
+      const next = command[i + 1];
+
+      if (nestedEscaped) {
+        nestedEscaped = false;
+        continue;
+      }
+      if (!nestedSingle && ch === "\\") {
+        nestedEscaped = true;
+        continue;
+      }
+      if (nestedSingle) {
+        if (ch === "'") {
+          nestedSingle = false;
+        }
+        continue;
+      }
+      if (nestedDouble) {
+        if (ch === '"') {
+          nestedDouble = false;
+        }
+        continue;
+      }
+      if (ch === "'") {
+        nestedSingle = true;
+        continue;
+      }
+      if (ch === '"') {
+        nestedDouble = true;
+        continue;
+      }
+      if (ch === "$" && next === "(") {
+        depth += 1;
+        i += 1;
+        continue;
+      }
+      if ((ch === "<" || ch === ">") && next === "(") {
+        depth += 1;
+        i += 1;
+        continue;
+      }
+      if (ch === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          return { payload: command.slice(payloadStart, i), endIndex: i };
+        }
+      }
+    }
+    return null;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    const next = command[i + 1];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (!inSingle && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (ch === '"') {
+        inDouble = false;
+        continue;
+      }
+      if (ch === "$" && next === "(") {
+        const parsed = readParenPayload(i);
+        if (parsed) {
+          payloads.push(parsed.payload);
+          i = parsed.endIndex;
+        }
+        continue;
+      }
+      if (ch === "`") {
+        let payload = "";
+        for (let j = i + 1; j < command.length; j += 1) {
+          const current = command[j];
+          if (current === "\\" && j + 1 < command.length) {
+            payload += command[j + 1];
+            j += 1;
+            continue;
+          }
+          if (current === "`") {
+            payloads.push(payload);
+            i = j;
+            break;
+          }
+          payload += current;
+        }
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (ch === "$" && next === "(") {
+      const parsed = readParenPayload(i);
+      if (parsed) {
+        payloads.push(parsed.payload);
+        i = parsed.endIndex;
+      }
+      continue;
+    }
+    if ((ch === "<" || ch === ">") && next === "(") {
+      const parsed = readParenPayload(i);
+      if (parsed) {
+        payloads.push(parsed.payload);
+        i = parsed.endIndex;
+      }
+      continue;
+    }
+    if (ch === "`") {
+      let payload = "";
+      for (let j = i + 1; j < command.length; j += 1) {
+        const current = command[j];
+        if (current === "\\" && j + 1 < command.length) {
+          payload += command[j + 1];
+          j += 1;
+          continue;
+        }
+        if (current === "`") {
+          payloads.push(payload);
+          i = j;
+          break;
+        }
+        payload += current;
+      }
+    }
+  }
+
+  return payloads;
+}
+
+function openClawControlArgvRunsShell(argv: string[]): boolean {
+  const stripped = stripOpenClawControlCommandPrefixes(argv);
+  return OPENCLAW_CONTROL_SHELL_WRAPPERS.has(normalizeCommandBaseName(stripped[0]));
+}
+
+function openClawControlLineRunsShellHeredoc(line: string): boolean {
+  const chainParts = splitCommandChainWithOperators(line)?.map((part) => part.part) ?? [line];
+  for (const chainPart of chainParts) {
+    const segments = splitOpenClawControlFallbackPipelines(chainPart);
+    for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex += 1) {
+      const segment = segments[segmentIndex] ?? "";
+      const heredoc = extractOpenClawControlHeredocsFromLine(segment)[0];
+      if (!heredoc) {
+        continue;
+      }
+      const prefixArgv = splitShellArgs(segment.slice(0, heredoc.startIndex).trim());
+      if (prefixArgv && openClawControlArgvRunsShell(prefixArgv)) {
+        return true;
+      }
+      for (const consumer of segments.slice(segmentIndex + 1)) {
+        const consumerArgv = splitShellArgs(consumer);
+        if (consumerArgv && openClawControlArgvRunsShell(consumerArgv)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+function extractOpenClawControlHereStringsFromLine(
+  line: string,
+): { payload: string; startIndex: number }[] {
+  const specs: { payload: string; startIndex: number }[] = [];
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = line[i + 1];
+    const afterNext = line[i + 2];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (!inSingle && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      }
+      continue;
+    }
+    if (inDouble) {
+      if (ch === '"') {
+        inDouble = false;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inSingle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /\s/u.test(line[i - 1] ?? ""))) {
+      break;
+    }
+    if (ch !== "<" || next !== "<" || afterNext !== "<" || line[i + 3] === "<") {
+      continue;
+    }
+
+    const wordArgv = splitShellArgs(line.slice(i + 3).trim());
+    const payload = wordArgv?.[0];
+    if (payload) {
+      specs.push({ payload, startIndex: i });
+    }
+  }
+  return specs;
+}
+
+function extractOpenClawControlShellHereStringPayloads(rawCommand: string): string[] {
+  const payloads: string[] = [];
+  for (const rawLine of rawCommand.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    const chainParts = splitCommandChainWithOperators(line)?.map((part) => part.part) ?? [line];
+    for (const chainPart of chainParts) {
+      const segments = splitOpenClawControlFallbackPipelines(chainPart);
+      for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex += 1) {
+        const segment = segments[segmentIndex] ?? "";
+        for (const hereString of extractOpenClawControlHereStringsFromLine(segment)) {
+          const prefixArgv = splitShellArgs(segment.slice(0, hereString.startIndex).trim());
+          const shellConsumesHereString =
+            Boolean(prefixArgv && openClawControlArgvRunsShell(prefixArgv)) ||
+            segments.slice(segmentIndex + 1).some((consumer) => {
+              const consumerArgv = splitShellArgs(consumer);
+              return Boolean(consumerArgv && openClawControlArgvRunsShell(consumerArgv));
+            });
+          if (shellConsumesHereString) {
+            payloads.push(hereString.payload);
+          }
+        }
+      }
+    }
+  }
+  return payloads;
+}
+
+function extractOpenClawControlShellHeredocPayloads(rawCommand: string): string[] {
+  const payloads: string[] = [];
+  const pendingDelimiters: {
+    delimiter: string;
+    stripTabs: boolean;
+    capture: boolean;
+    body: string[];
+  }[] = [];
+
+  for (const rawLine of rawCommand.split(/\r?\n/)) {
+    if (pendingDelimiters.length > 0) {
+      const current = pendingDelimiters[0];
+      const delimiterLine = current.stripTabs ? rawLine.replace(/^\t+/u, "") : rawLine;
+      if (delimiterLine === current.delimiter) {
+        const done = pendingDelimiters.shift();
+        if (done?.capture && done.body.length > 0) {
+          payloads.push(done.body.join("\n"));
+        }
+        continue;
+      }
+      if (current.capture) {
+        current.body.push(rawLine);
+      }
+      continue;
+    }
+
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    const capture = openClawControlLineRunsShellHeredoc(line);
+    for (const heredoc of extractOpenClawControlHeredocsFromLine(line)) {
+      pendingDelimiters.push({ ...heredoc, capture, body: [] });
+    }
+  }
+
+  return payloads;
+}
+
+function normalizeOpenClawControlLineContinuations(command: string): string {
+  let out = "";
+  let inSingle = false;
+
+  for (let i = 0; i < command.length; i += 1) {
+    const ch = command[i];
+    const next = command[i + 1];
+    const afterNext = command[i + 2];
+
+    if (ch === "'") {
+      inSingle = !inSingle;
+      out += ch;
+      continue;
+    }
+    if (!inSingle && ch === "\\" && next === "\r" && afterNext === "\n") {
+      i += 2;
+      continue;
+    }
+    if (!inSingle && ch === "\\" && (next === "\n" || next === "\r")) {
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+
+  return out;
+}
+
+function buildOpenClawControlCandidatesFromRaw(
+  command: string,
+): OpenClawControlShellCommandCandidate[] {
+  const rawCommand = normalizeOpenClawControlLineContinuations(command).trim();
+  const nestedCandidates = [
+    ...extractOpenClawControlCommandSubstitutionPayloads(rawCommand),
+    ...extractOpenClawControlShellHeredocPayloads(rawCommand),
+    ...extractOpenClawControlShellHereStringPayloads(rawCommand),
+  ]
+    .map((payload) => payload.trim())
+    .filter((payload) => payload && payload !== rawCommand)
+    .flatMap(buildOpenClawControlCandidatesFromRaw);
+  const analysis = analyzeShellCommand({ command: rawCommand });
+  const directCandidates = analysis.ok
+    ? analysis.segments.flatMap((segment) => buildOpenClawControlCandidatesFromArgv(segment.argv))
+    : extractOpenClawControlFallbackLines(rawCommand)
+        .flatMap(splitOpenClawControlFallbackSegments)
+        .flatMap((line) => {
+          const argv = splitShellArgs(line);
+          return argv ? buildOpenClawControlCandidatesFromArgv(argv) : [{ raw: line }];
+        });
+  return [...nestedCandidates, ...directCandidates];
+}
+
+function parseOpenClawChannelsLoginArgv(argv: string[]): boolean {
+  if (extractPackageRunnerShellPayloads(argv).some(parseOpenClawChannelsLoginShellCommand)) {
+    return true;
+  }
+  const openclawArgv = stripOpenClawRootOptions(
+    stripOpenClawCliLauncher(stripOpenClawPackageRunner(argv)),
+  );
   return (
     normalizeCommandBaseName(openclawArgv[0]) === "openclaw" &&
     (openclawArgv[1] === "channels" || openclawArgv[1] === "channel") &&
     openclawArgv[2] === "login"
+  );
+}
+
+function parseOpenClawChannelsLoginShellCommand(raw: string): boolean {
+  return buildOpenClawControlCandidatesFromRaw(raw).some((candidate) =>
+    candidate.argv ? parseOpenClawChannelsLoginArgv(candidate.argv) : false,
+  );
+}
+
+function parseOpenClawMessageDeliveryArgv(argv: string[]): boolean {
+  if (extractPackageRunnerShellPayloads(argv).some(parseOpenClawMessageDeliveryShellCommand)) {
+    return true;
+  }
+  const openclawArgv = stripOpenClawRootOptions(
+    stripOpenClawCliLauncher(stripOpenClawPackageRunner(argv)),
+  );
+  const delivery = parseOpenClawMessageDeliveryCommand(openclawArgv);
+  return Boolean(
+    delivery &&
+    !isOpenClawMessageDeliveryNonDelivering(openclawArgv.slice(delivery.argsStartIndex)),
+  );
+}
+
+const OPENCLAW_MESSAGE_DELIVERY_TOP_LEVEL_COMMANDS = new Set(["broadcast", "poll", "send"]);
+const OPENCLAW_MESSAGE_DELIVERY_THREAD_COMMANDS = new Set(["create", "reply"]);
+const OPENCLAW_MESSAGE_DELIVERY_EXEC_ERROR = [
+  "exec cannot run OpenClaw message delivery commands.",
+  "Reply normally to the current conversation, or use the message tool when an explicit cross-channel send is needed.",
+].join(" ");
+
+function parseOpenClawMessageDeliveryCommand(
+  openclawArgv: string[],
+): { argsStartIndex: number } | null {
+  if (normalizeCommandBaseName(openclawArgv[0]) !== "openclaw" || openclawArgv[1] !== "message") {
+    return null;
+  }
+  if (OPENCLAW_MESSAGE_DELIVERY_TOP_LEVEL_COMMANDS.has(openclawArgv[2])) {
+    return { argsStartIndex: 3 };
+  }
+  if (
+    openclawArgv[2] === "thread" &&
+    OPENCLAW_MESSAGE_DELIVERY_THREAD_COMMANDS.has(openclawArgv[3])
+  ) {
+    return { argsStartIndex: 4 };
+  }
+  if (openclawArgv[2] === "sticker" && openclawArgv[3] === "send") {
+    return { argsStartIndex: 4 };
+  }
+  return null;
+}
+
+const OPENCLAW_MESSAGE_DELIVERY_VALUE_OPTIONS = new Set([
+  "-m",
+  "--account",
+  "--auto-archive-min",
+  "--channel",
+  "--delivery",
+  "--media",
+  "--message",
+  "--message-id",
+  "--presentation",
+  "--poll-duration-hours",
+  "--poll-duration-seconds",
+  "--poll-option",
+  "--poll-question",
+  "--reply-to",
+  "--sticker-id",
+  "--target",
+  "--targets",
+  "--thread-id",
+  "--thread-name",
+  "-t",
+]);
+
+function isOpenClawMessageDeliveryNonDelivering(args: string[]): boolean {
+  for (let idx = 0; idx < args.length; idx += 1) {
+    const arg = args[idx];
+    if (!arg) {
+      continue;
+    }
+    if (arg === "--") {
+      break;
+    }
+    const optionName = arg.split("=", 1)[0];
+    if (OPENCLAW_MESSAGE_DELIVERY_VALUE_OPTIONS.has(optionName)) {
+      if (!arg.includes("=")) {
+        idx += 1;
+      }
+      continue;
+    }
+    if (arg === "-h" || arg === "--help") {
+      return true;
+    }
+    if (arg === "--dry-run") {
+      return true;
+    }
+    if (arg.startsWith("--dry-run=")) {
+      const value = normalizeLowercaseStringOrEmpty(arg.slice("--dry-run=".length));
+      return value !== "false" && value !== "0";
+    }
+  }
+  return false;
+}
+
+function parseOpenClawMessageDeliveryShellCommand(raw: string): boolean {
+  return buildOpenClawControlCandidatesFromRaw(raw).some((candidate) =>
+    candidate.argv ? parseOpenClawMessageDeliveryArgv(candidate.argv) : false,
   );
 }
 
@@ -1179,14 +2929,84 @@ function rejectUnsafeControlShellCommand(command: string): void {
   const sudoStandaloneOptions = new Set(["-A", "-E", "--askpass", "--preserve-env"]);
   const extractEnvSplitStringPayload = (argv: string[]): string[] => {
     const remaining = [...argv];
-    while (remaining[0] && isEnvAssignmentToken(remaining[0])) {
-      remaining.shift();
+    while (remaining.length > 0) {
+      while (remaining[0] && isEnvAssignmentToken(remaining[0])) {
+        remaining.shift();
+      }
+      const token = remaining[0];
+      const commandName = normalizeCommandBaseName(token);
+      if (!token || commandName === "env") {
+        break;
+      }
+      if (commandName === "command" || commandName === "builtin") {
+        remaining.shift();
+        while (remaining[0]?.startsWith("-")) {
+          const option = remaining.shift()!;
+          if (option === "--") {
+            break;
+          }
+          if (!commandStandaloneOptions.has(option.split("=", 1)[0])) {
+            continue;
+          }
+        }
+        continue;
+      }
+      if (commandName === "exec") {
+        remaining.shift();
+        while (remaining[0]?.startsWith("-")) {
+          const option = remaining.shift()!;
+          if (option === "--") {
+            break;
+          }
+          const normalized = option.split("=", 1)[0];
+          if (execStandaloneOptions.has(normalized)) {
+            continue;
+          }
+          if (execOptionsWithValues.has(normalized) && !option.includes("=") && remaining[0]) {
+            remaining.shift();
+          }
+        }
+        continue;
+      }
+      if (commandName === "sudo") {
+        remaining.shift();
+        while (remaining[0]?.startsWith("-")) {
+          const option = remaining.shift()!;
+          if (option === "--") {
+            break;
+          }
+          const normalized = option.split("=", 1)[0];
+          if (sudoStandaloneOptions.has(normalized)) {
+            continue;
+          }
+          if (sudoOptionsWithValues.has(normalized) && !option.includes("=") && remaining[0]) {
+            remaining.shift();
+          }
+        }
+        continue;
+      }
+      break;
     }
-    if (remaining[0] !== "env") {
+    if (normalizeCommandBaseName(remaining[0]) !== "env") {
       return [];
     }
     remaining.shift();
     const payloads: string[] = [];
+    const takeSplitStringPayload = (option: string): string | undefined => {
+      if (option === "-S" || option === "--split-string") {
+        return remaining.shift();
+      }
+      if (option.startsWith("--split-string=")) {
+        return option.slice("--split-string=".length);
+      }
+      if (!option.startsWith("--")) {
+        const splitIndex = option.indexOf("S");
+        if (splitIndex > 0) {
+          return option.slice(splitIndex + 1) || remaining.shift();
+        }
+      }
+      return undefined;
+    };
     while (remaining.length > 0) {
       while (remaining[0] && isEnvAssignmentToken(remaining[0])) {
         remaining.shift();
@@ -1204,14 +3024,13 @@ function rejectUnsafeControlShellCommand(command: string): void {
       }
       const option = remaining.shift()!;
       const normalized = option.split("=", 1)[0];
-      if (normalized === "-S" || normalized === "--split-string") {
-        const value = option.includes("=")
-          ? option.slice(option.indexOf("=") + 1)
-          : remaining.shift();
+      const splitString = takeSplitStringPayload(option);
+      if (splitString !== undefined) {
+        const value = [splitString, ...remaining].filter((part) => part.length > 0).join(" ");
         if (value?.trim()) {
           payloads.push(value);
         }
-        continue;
+        break;
       }
       if (envOptionsWithValues.has(normalized) && !option.includes("=") && remaining[0]) {
         remaining.shift();
@@ -1234,7 +3053,8 @@ function rejectUnsafeControlShellCommand(command: string): void {
         remaining.shift();
         continue;
       }
-      if (token === "env") {
+      const commandName = normalizeCommandBaseName(token);
+      if (commandName === "env") {
         remaining.shift();
         while (remaining.length > 0) {
           while (remaining[0] && isEnvAssignmentToken(remaining[0])) {
@@ -1259,7 +3079,7 @@ function rejectUnsafeControlShellCommand(command: string): void {
         }
         continue;
       }
-      if (token === "command" || token === "builtin") {
+      if (commandName === "command" || commandName === "builtin") {
         remaining.shift();
         while (remaining[0]?.startsWith("-")) {
           const option = remaining.shift()!;
@@ -1272,7 +3092,7 @@ function rejectUnsafeControlShellCommand(command: string): void {
         }
         continue;
       }
-      if (token === "exec") {
+      if (commandName === "exec") {
         remaining.shift();
         while (remaining[0]?.startsWith("-")) {
           const option = remaining.shift()!;
@@ -1289,7 +3109,7 @@ function rejectUnsafeControlShellCommand(command: string): void {
         }
         continue;
       }
-      if (token === "sudo") {
+      if (commandName === "sudo") {
         remaining.shift();
         while (remaining[0]?.startsWith("-")) {
           const option = remaining.shift()!;
@@ -1312,7 +3132,7 @@ function rejectUnsafeControlShellCommand(command: string): void {
   };
   const extractShellWrapperPayload = (argv: string[]): string[] => {
     const [commandName, ...rest] = argv;
-    if (!commandName || !shellWrappers.has(path.basename(commandName))) {
+    if (!commandName || !shellWrappers.has(normalizeCommandBaseName(commandName))) {
       return [];
     }
     for (let i = 0; i < rest.length; i += 1) {
@@ -1329,37 +3149,48 @@ function rejectUnsafeControlShellCommand(command: string): void {
     }
     return [];
   };
-  const buildCandidates = (argv: string[]): string[] => {
+  type UnsafeShellCommandCandidate = { raw: string; argv?: string[] };
+  const buildCandidates = (argv: string[]): UnsafeShellCommandCandidate[] => {
     const envSplitCandidates = extractEnvSplitStringPayload(argv).flatMap((payload) => {
       const innerArgv = splitShellArgs(payload);
-      return innerArgv ? buildCandidates(innerArgv) : [payload];
+      return innerArgv ? buildCandidates(innerArgv) : [{ raw: payload }];
     });
     const stripped = stripApprovalCommandPrefixes(argv);
     const shellWrapperCandidates = extractShellWrapperPayload(stripped).flatMap((payload) => {
       const innerArgv = splitShellArgs(payload);
-      return innerArgv ? buildCandidates(innerArgv) : [payload];
+      return innerArgv ? buildCandidates(innerArgv) : [{ raw: payload }];
     });
     return [
-      ...(stripped.length > 0 ? [stripped.join(" ")] : []),
+      ...(stripped.length > 0 ? [{ raw: stripped.join(" "), argv: stripped }] : []),
       ...envSplitCandidates,
       ...shellWrapperCandidates,
     ];
   };
 
   const rawCommand = command.trim();
+  if (parseOpenClawChannelsLoginShellCommand(rawCommand)) {
+    throw new Error(
+      [
+        "exec cannot run interactive OpenClaw channel login commands.",
+        "Run `openclaw channels login` in a terminal on the gateway host, or use the channel-specific login agent tool when available (for WhatsApp: `whatsapp_login`).",
+      ].join(" "),
+    );
+  }
+  if (parseOpenClawMessageDeliveryShellCommand(rawCommand)) {
+    throw new Error(OPENCLAW_MESSAGE_DELIVERY_EXEC_ERROR);
+  }
   const analysis = analyzeShellCommand({ command: rawCommand });
-  const candidates = analysis.ok
+  const candidates: UnsafeShellCommandCandidate[] = analysis.ok
     ? analysis.segments.flatMap((segment) => buildCandidates(segment.argv))
-    : rawCommand
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
+    : extractOpenClawControlFallbackLines(rawCommand)
+        .flatMap(splitOpenClawControlFallbackSegments)
         .flatMap((line) => {
           const argv = splitShellArgs(line);
-          return argv ? buildCandidates(argv) : [line];
+          return argv ? buildCandidates(argv) : [{ raw: line }];
         });
   for (const candidate of candidates) {
-    if (parseExecApprovalShellCommand(candidate)) {
+    const candidateRaw = candidate.raw;
+    if (parseExecApprovalShellCommand(candidateRaw)) {
       throw new Error(
         [
           "exec cannot run /approve commands.",
@@ -1367,13 +3198,22 @@ function rejectUnsafeControlShellCommand(command: string): void {
         ].join(" "),
       );
     }
-    if (parseOpenClawChannelsLoginShellCommand(candidate)) {
+    if (
+      parseOpenClawChannelsLoginShellCommand(candidateRaw) ||
+      (candidate.argv ? parseOpenClawChannelsLoginArgv(candidate.argv) : false)
+    ) {
       throw new Error(
         [
           "exec cannot run interactive OpenClaw channel login commands.",
           "Run `openclaw channels login` in a terminal on the gateway host, or use the channel-specific login agent tool when available (for WhatsApp: `whatsapp_login`).",
         ].join(" "),
       );
+    }
+    if (
+      parseOpenClawMessageDeliveryShellCommand(candidateRaw) ||
+      (candidate.argv ? parseOpenClawMessageDeliveryArgv(candidate.argv) : false)
+    ) {
+      throw new Error(OPENCLAW_MESSAGE_DELIVERY_EXEC_ERROR);
     }
   }
 }
@@ -1710,14 +3550,15 @@ export function createExecTool(
         });
       }
 
-      if (!workdir) {
+      const localWorkdir = workdir;
+      if (!localWorkdir) {
         throw new Error("exec internal error: local execution requires a resolved workdir");
       }
 
       if (host === "gateway" && !bypassApprovals) {
         const gatewayResult = await processGatewayAllowlist({
           command: params.command,
-          workdir,
+          workdir: localWorkdir,
           env,
           requestedEnv: params.env,
           pty: params.pty === true && !sandbox,
@@ -1760,16 +3601,18 @@ export function createExecTool(
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 
-      // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
-      // before we execute and burn tokens in cron loops.
-      if (!shouldSkipExecScriptPreflight({ host, security, ask })) {
-        await validateScriptFileForShellBleed({ command: params.command, workdir });
-      }
+      // Preflight: block untracked message delivery from shell scripts, and
+      // catch shell syntax leaking into Python/JS sources when that heuristic is enabled.
+      await validateScriptFileForShellBleed({
+        command: params.command,
+        skipLanguageHeuristics: shouldSkipExecScriptPreflight({ host, security, ask }),
+        workdir: localWorkdir,
+      });
 
       const run = await runExecProcess({
         command: params.command,
         execCommand: execCommandOverride,
-        workdir,
+        workdir: localWorkdir,
         env,
         sandbox,
         containerWorkdir,
@@ -1893,5 +3736,6 @@ export const execTool = createExecTool();
 
 export const __testing = {
   parseOpenClawChannelsLoginShellCommand,
+  parseOpenClawMessageDeliveryShellCommand,
   validateScriptFileForShellBleed,
 };

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -534,7 +534,16 @@ function extractDirectShellScriptTargetFromArgv(
     return null;
   }
   const commandName = normalizeCommandBaseName(command);
-  if (!/\.(?:bash|command|fish|ksh|sh|zsh)$/iu.test(commandName)) {
+  const isAbsoluteShellWrapperPath =
+    OPENCLAW_CONTROL_SHELL_WRAPPERS.has(commandName) &&
+    (path.isAbsolute(command) || /^[A-Za-z]:[\\/]/u.test(command) || command.startsWith("\\\\"));
+  if (isAbsoluteShellWrapperPath) {
+    return null;
+  }
+  const hasShellScriptSuffix = /\.(?:bash|command|fish|ksh|sh|zsh)$/iu.test(commandName);
+  const isPathLikeExtensionlessCommand =
+    !commandName.includes(".") && (command.includes("/") || command.includes("\\"));
+  if (!hasShellScriptSuffix && !isPathLikeExtensionlessCommand) {
     return null;
   }
   return { kind: "shell", relOrAbsPaths: [command] };


### PR DESCRIPTION
## Summary

- Problem: Agent `exec` could run `openclaw message ...` delivery commands and send a real provider message outside the tracked reply/message-tool path; the observed duplicate was WhatsApp, but the bug was generic to message delivery commands.
- Why it matters: Auto-reply sessions can otherwise produce one normal agent reply plus a second untracked chat/status message.
- What changed: `exec` now rejects OpenClaw message delivery commands across direct CLI, package-runner, shell-wrapper, heredoc/here-string, and shell-script forms, while preserving non-delivery commands like help, dry-run, read, search, and thread list.
- What did NOT change (scope boundary): This does not change the message tool, normal chat replies, channel transports, or message CLI behavior outside `exec`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `exec` classified interactive approval/channel-login commands as unsafe, but did not classify OpenClaw message CLI delivery as unsafe even though it can deliver provider messages outside the current reply path.
- Missing detection / guardrail: The guard did not inspect delivery commands hidden behind package runners, shell wrappers, shell stdin, or shell script files.
- Contributing context (if known): The reported WhatsApp duplicate came from an agent sending through the CLI and then reporting that it had sent the answer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bash-tools.exec.script-preflight.test.ts`
- Scenario the test should lock in: `exec` rejects message delivery commands across direct, wrapped, package-runner, heredoc/here-string, shell script, sourced script, chained script, outside-workdir readable script, and full gateway exec modes.
- Why this is the smallest reliable guardrail: The bug is in the exec command/preflight boundary, so focused parser/preflight tests cover the delivery bypass without needing live channel sends.
- Existing test that already covers this (if any): Existing login/approval exec guard tests covered adjacent unsafe command blocking, not message delivery.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`exec` now refuses OpenClaw message delivery commands. Agents should reply normally in the current conversation or use the `message` tool for explicit cross-channel sends.

## Diagram (if applicable)

```text
Before:
agent exec -> openclaw message send -> provider delivery outside tracked reply path -> duplicate/status reply risk

After:
agent exec -> OpenClaw message delivery guard -> rejected with guidance to reply normally or use message tool
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The exec surface is narrowed for OpenClaw message delivery commands so provider sends stay on tracked reply/message-tool paths.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ repo runtime
- Model/provider: N/A
- Integration/channel (if any): WhatsApp symptom, generic message CLI surface
- Relevant config (redacted): N/A

### Steps

1. Ask an agent with `exec` to send a response via `openclaw message send`.
2. Hide the same send behind a package runner, shell wrapper, heredoc/here-string, or shell script.
3. Run the focused exec preflight tests.

### Expected

- `exec` rejects real message delivery commands and instructs the agent to reply normally or use the message tool.
- Help, dry-run, read, search, and list forms remain allowed.

### Actual

- Before this change, those commands could reach provider delivery from `exec`.
- After this change, the focused tests reject the delivery forms and preserve non-delivery forms.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation:
- `pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.script-preflight.test.ts docs/tools/exec.md CHANGELOG.md`
- `git diff --check`
- `pnpm test src/agents/bash-tools.exec.script-preflight.test.ts`
- `pnpm tsgo:core`
- `pnpm changed:lanes --json`
- `codex review --base origin/main` clean
- Broad validation: GitHub PR CI.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Direct CLI sends, package-runner forms, shell wrappers, shell stdin heredocs/here-strings, shell script files, sourced scripts, chained scripts, outside-workdir readable scripts, full gateway exec mode, and dry-run/help/read/search non-delivery cases through targeted tests.
- Edge cases checked: `env -S`, sudo, npm/pnpm/yarn/bun/npx/pnpx/corepack, line continuations, command/process substitutions, grouping, root options, and readable external shell scripts.
- What you did **not** verify: User manual verification: owner performs final manual verification outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: The parser may miss an obscure shell form.
  - Mitigation: Coverage includes direct CLI, package runners, shell wrappers, command substitution, process substitution, heredocs, here-strings, sourced scripts, direct/chained scripts, and local Codex review iterations against bypass cases.


## Real behavior proof

- Behavior or issue addressed: Agent `exec` now refuses OpenClaw message delivery commands, including direct CLI, package-runner, shell-wrapper, generated shell, heredoc, here-string, and script-file variants.
- Real environment tested: macOS local OpenClaw source worktree, Node 22, pnpm, after rebasing the PR branch onto current `origin/main`.
- Exact steps or command run after this patch: Ran `pnpm test src/agents/bash-tools.exec.script-preflight.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/bash-tools.exec-host-gateway.test.ts` in the local OpenClaw checkout.
- Evidence after fix: Terminal output from the local source checkout: `Test Files 3 passed`; `131 passed`, `4 skipped`, total `135` tests in the exec preflight/path/gateway group.
- Observed result after fix: The exec preflight rejects OpenClaw message delivery attempts across the covered direct, wrapped, generated, and file-backed command forms while preserving non-delivery command paths.
- What was not tested: No additional gaps.
