### PR TITLE
fix(openai-codex): honor providerConfig.baseUrl in dynamic-model synthesis fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/externalization: keep official external install docs, update examples, and live Codex npm checks on default npm tags instead of `@beta`. Thanks @vincentkoc.
 - Plugins/externalization: keep ACPX, Google Chat, and LINE publishable plugin dist trees out of the core npm package file list.
 - Plugins/ClawHub: fall back to version metadata when the artifact resolver route is missing and keep the Docker ClawHub fixture aligned with npm-pack artifact resolution, avoiding false version-not-found failures during plugin install validation. Thanks @vincentkoc.
+- Providers/openai-codex: honor `providerConfig.baseUrl` in the dynamic-model synthesis fallback so codex providers configured with a custom upstream (for example a forwarding proxy) no longer silently bypass the configured URL when the registry has no template row to clone for the requested model id. (#76428) Thanks @arniesaha.
 - Status/channels: show configured channels in `openclaw status` and config-only `openclaw channels status` output even when the Gateway is unreachable, avoiding empty Channels tables on WSL and other no-Gateway paths. Thanks @vincentkoc.
 - Plugins/ClawHub: explain unavailable explicit ClawHub ClawPack artifact downloads with a temporary npm install hint while ClawHub artifact routing rolls out. Thanks @vincentkoc.
 - Media: accept home-relative `MEDIA:~/...` attachment paths while preserving existing file-read policy, traversal checks, and media type validation. Fixes #73796. Thanks @fabkury.

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -405,6 +405,43 @@ describe("openai codex provider", () => {
     });
   });
 
+  it("honors providerConfig.baseUrl in the gpt-5.5 synthesis fallback", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.5",
+      modelRegistry: createSingleModelRegistry(createCodexTemplate({}), null) as never,
+      providerConfig: { baseUrl: "http://proxy.local:30400" },
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.5",
+      api: "openai-codex-responses",
+      baseUrl: "http://proxy.local:30400",
+    });
+  });
+
+  it("honors providerConfig.baseUrl in the gpt-5.4 synthesis fallback", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const emptyRegistry = { find: () => null };
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai-codex",
+      modelId: "gpt-5.4",
+      modelRegistry: emptyRegistry as never,
+      providerConfig: { baseUrl: "http://proxy.local:30400" },
+    });
+
+    expect(model).toMatchObject({
+      id: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "http://proxy.local:30400",
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
+  });
+
   it("resolves gpt-5.4-pro from a gpt-5.4 runtime template when legacy codex rows are absent", () => {
     const provider = buildOpenAICodexProviderPlugin();
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -172,6 +172,7 @@ function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeMo
 function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext) {
   const trimmedModelId = ctx.modelId.trim();
   const lower = normalizeLowercaseStringOrEmpty(trimmedModelId);
+  const synthBaseUrl = ctx.providerConfig?.baseUrl ?? OPENAI_CODEX_BASE_URL;
 
   if (lower === OPENAI_CODEX_GPT_55_MODEL_ID) {
     const model = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId) as
@@ -188,7 +189,7 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
         name: trimmedModelId,
         api: "openai-codex-responses",
         provider: PROVIDER_ID,
-        baseUrl: OPENAI_CODEX_BASE_URL,
+        baseUrl: synthBaseUrl,
         reasoning: true,
         input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -264,7 +265,7 @@ function resolveCodexForwardCompatModel(ctx: ProviderResolveDynamicModelContext)
           : trimmedModelId,
       api: "openai-codex-responses",
       provider: PROVIDER_ID,
-      baseUrl: OPENAI_CODEX_BASE_URL,
+      baseUrl: synthBaseUrl,
       reasoning: true,
       input: ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },


### PR DESCRIPTION
## Summary

When the `openai-codex` provider is configured with a custom `baseUrl` (e.g. a local proxy that forwards Codex traffic) **and** the model registry has no template row to clone for the requested id, `resolveCodexForwardCompatModel` synthesizes a `ProviderRuntimeModel` with a hardcoded `OPENAI_CODEX_BASE_URL`. The configured proxy URL is silently dropped, traffic goes to `chatgpt.com` / `api.openai.com` directly, and the call typically fails the auth contract — without any `model.attempt` event reaching the user (since the failure happens before `session.started`).

## Fix

`resolveCodexForwardCompatModel` now reads `ctx.providerConfig?.baseUrl` and uses it as the synthesis baseUrl when present, falling back to `OPENAI_CODEX_BASE_URL` when not. This affects both synthesis fallbacks in the function (the gpt-5.5 path and the gpt-5.4/pro/mini/legacy path).

```ts
const synthBaseUrl = ctx.providerConfig?.baseUrl ?? OPENAI_CODEX_BASE_URL;
```

The template-clone (`cloneFirstTemplateModel`) and registry-find (`ctx.modelRegistry.find`) paths are unchanged — they already inherit the configured `baseUrl` through the cloned/found model. This is the smallest fix that closes the silent-bypass behavior without touching catalog or transport normalization.

## Why now

Reproduced on a real deployment: a custom `~/.openclaw/agents/<id>/agent/models.json` with `providers["openai-codex"].baseUrl = "http://192.168.1.70:30400"` and `models = []`. With this config the gateway silently routed every call to chatgpt.com instead of the proxy, then fell back to a different provider after the codex attempt failed — with no observable trajectory event explaining why. After the patch, traffic flows through the configured proxy as expected.

## Test plan

- [x] Added two unit tests in `openai-codex-provider.test.ts`:
  - `honors providerConfig.baseUrl in the gpt-5.5 synthesis fallback`
  - `honors providerConfig.baseUrl in the gpt-5.4 synthesis fallback`
- [x] Existing 29 codex-provider tests still pass (31 total in file).
- [x] `pnpm tsgo:extensions` clean.
- [x] `pnpm lint` clean (extensions + core + scripts shards).
- [x] `pnpm exec oxfmt --check` clean.
- [x] `pnpm check:import-cycles` clean.
- [x] Verified end-to-end against the affected deployment — `POST /codex/responses 200 OK` now lands at the configured proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)