### PR TITLE
[codex] Fix Discord SecretRef configured state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord: report unresolved SecretRef bot tokens as configured but unavailable in status snapshots without treating them as runtime-startable tokens.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.

--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -22,6 +22,7 @@ export type ResolvedDiscordAccount = {
   name?: string;
   token: string;
   tokenSource: "env" | "config" | "none";
+  tokenStatus: "available" | "configured_unavailable" | "missing";
   config: DiscordAccountConfig;
 };
 
@@ -114,6 +115,7 @@ export function resolveDiscordAccount(params: {
     name: normalizeOptionalString(merged.name),
     token: tokenResolution.token,
     tokenSource: tokenResolution.source,
+    tokenStatus: tokenResolution.tokenStatus,
     config: merged,
   };
 }

--- a/extensions/discord/src/client.test.ts
+++ b/extensions/discord/src/client.test.ts
@@ -58,7 +58,7 @@ describe("createDiscordRestClient", () => {
     expect(result.account.config.retry).toMatchObject({ attempts: 7 });
   });
 
-  it("still throws when no explicit token is provided and config token is unresolved", () => {
+  it("throws a missing token error when no explicit token is provided and config token is unresolved", () => {
     const cfg = {
       channels: {
         discord: {
@@ -71,6 +71,8 @@ describe("createDiscordRestClient", () => {
       },
     } as OpenClawConfig;
 
-    expect(() => createDiscordRestClient({ cfg, rest: fakeRest })).toThrow(/unresolved SecretRef/i);
+    expect(() => createDiscordRestClient({ cfg, rest: fakeRest })).toThrow(
+      /Discord bot token missing/,
+    );
   });
 });

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -92,6 +92,7 @@ function resolveAccountWithoutToken(params: {
     name: normalizeOptionalString(merged.name),
     token: "",
     tokenSource: "none",
+    tokenStatus: "missing",
     config: merged,
   };
 }

--- a/extensions/discord/src/security-audit.test.ts
+++ b/extensions/discord/src/security-audit.test.ts
@@ -22,6 +22,7 @@ function createAccount(
     enabled: true,
     token: "t",
     tokenSource: "config",
+    tokenStatus: "available",
     config,
   };
 }

--- a/extensions/discord/src/shared.test.ts
+++ b/extensions/discord/src/shared.test.ts
@@ -62,6 +62,29 @@ describe("createDiscordPluginBase", () => {
     );
     expect(plugin.config.isEnabled?.(workAccount, cfg)).toBe(true);
   });
+
+  it("does not treat unavailable SecretRef tokens as runtime configured", async () => {
+    const plugin = createDiscordPluginBase({ setup: {} as never });
+    const cfg = {
+      channels: {
+        discord: {
+          token: {
+            source: "env",
+            provider: "default",
+            id: "DISCORD_BOT_TOKEN",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = plugin.config.resolveAccount(cfg, "default");
+
+    expect(await plugin.config.isConfigured?.(account, cfg)).toBe(false);
+    expect(plugin.config.describeAccount?.(account, cfg)).toMatchObject({
+      configured: true,
+      tokenStatus: "configured_unavailable",
+    });
+  });
 });
 
 describe("discordConfigAdapter", () => {

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -149,13 +149,14 @@ export function createDiscordPluginBase(params: {
         typeof env?.DISCORD_BOT_TOKEN === "string" && env.DISCORD_BOT_TOKEN.trim().length > 0,
       isEnabled: (account, cfg) => isDiscordAccountEnabledForRuntime(account, cfg),
       disabledReason: (account, cfg) => resolveDiscordAccountDisabledReason(account, cfg),
-      isConfigured: (account) => Boolean(account.token?.trim()),
+      isConfigured: (account) => account.tokenStatus === "available",
       describeAccount: (account) =>
         describeAccountSnapshot({
           account,
-          configured: Boolean(account.token?.trim()),
+          configured: account.tokenStatus !== "missing",
           extra: {
             tokenSource: account.tokenSource,
+            tokenStatus: account.tokenStatus,
           },
         }),
     },

--- a/extensions/discord/src/token.test.ts
+++ b/extensions/discord/src/token.test.ts
@@ -91,7 +91,7 @@ describe("resolveDiscordToken", () => {
     expect(res.source).toBe("config");
   });
 
-  it("throws when token is an unresolved SecretRef object", () => {
+  it("marks unresolved SecretRef token as configured unavailable", () => {
     const cfg = {
       channels: {
         discord: {
@@ -100,8 +100,27 @@ describe("resolveDiscordToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveDiscordToken(cfg)).toThrow(
-      /channels\.discord\.token: unresolved SecretRef/i,
-    );
+    const res = resolveDiscordToken(cfg);
+    expect(res.token).toBe("");
+    expect(res.source).toBe("config");
+    expect(res.tokenStatus).toBe("configured_unavailable");
+  });
+
+  it("marks explicit blank account token as missing without falling back", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "base-token",
+          accounts: {
+            work: { token: "" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const res = resolveDiscordToken(cfg, { accountId: "work" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+    expect(res.tokenStatus).toBe("missing");
   });
 });

--- a/extensions/discord/src/token.ts
+++ b/extensions/discord/src/token.ts
@@ -2,12 +2,18 @@ import type { BaseTokenResolution } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import {
+  normalizeResolvedSecretInputString,
+  resolveSecretInputString,
+  type SecretInputStringResolution,
+} from "openclaw/plugin-sdk/secret-input";
 
 type DiscordTokenSource = "env" | "config" | "none";
+type DiscordCredentialStatus = SecretInputStringResolution["status"];
 
 export type DiscordTokenResolution = BaseTokenResolution & {
   source: DiscordTokenSource;
+  tokenStatus: DiscordCredentialStatus;
 };
 
 export function normalizeDiscordToken(raw: unknown, path: string): string | undefined {
@@ -16,6 +22,20 @@ export function normalizeDiscordToken(raw: unknown, path: string): string | unde
     return undefined;
   }
   return trimmed.replace(/^Bot\s+/i, "");
+}
+
+function inspectDiscordToken(
+  raw: unknown,
+  path: string,
+): {
+  token: string;
+  tokenStatus: DiscordCredentialStatus;
+} {
+  const resolved = resolveSecretInputString({ value: raw, path, mode: "inspect" });
+  if (resolved.status !== "available") {
+    return { token: "", tokenStatus: resolved.status };
+  }
+  return { token: resolved.value.replace(/^Bot\s+/i, ""), tokenStatus: "available" };
 }
 
 export function resolveDiscordToken(
@@ -29,23 +49,41 @@ export function resolveDiscordToken(
     accountCfg &&
     Object.prototype.hasOwnProperty.call(accountCfg as Record<string, unknown>, "token"),
   );
-  const accountToken = normalizeDiscordToken(
-    (accountCfg as { token?: unknown } | undefined)?.token ?? undefined,
+  const inspectedAccountToken = inspectDiscordToken(
+    (accountCfg as { token?: unknown } | undefined)?.token,
     `channels.discord.accounts.${accountId}.token`,
   );
+  const accountToken = inspectedAccountToken.token;
   if (accountToken) {
-    return { token: accountToken, source: "config" };
+    return {
+      token: accountToken,
+      source: "config",
+      tokenStatus: inspectedAccountToken.tokenStatus,
+    };
   }
   if (hasAccountToken) {
-    return { token: "", source: "none" };
+    return {
+      token: inspectedAccountToken.token,
+      source: inspectedAccountToken.tokenStatus === "configured_unavailable" ? "config" : "none",
+      tokenStatus: inspectedAccountToken.tokenStatus,
+    };
   }
 
-  const configToken = normalizeDiscordToken(
-    discordCfg?.token ?? undefined,
-    "channels.discord.token",
-  );
+  const inspectedConfigToken = inspectDiscordToken(discordCfg?.token, "channels.discord.token");
+  const configToken = inspectedConfigToken.token;
   if (configToken) {
-    return { token: configToken, source: "config" };
+    return {
+      token: configToken,
+      source: "config",
+      tokenStatus: inspectedConfigToken.tokenStatus,
+    };
+  }
+  if (inspectedConfigToken.tokenStatus === "configured_unavailable") {
+    return {
+      token: inspectedConfigToken.token,
+      source: "config",
+      tokenStatus: "configured_unavailable",
+    };
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
@@ -53,8 +91,8 @@ export function resolveDiscordToken(
     ? normalizeDiscordToken(opts.envToken ?? process.env.DISCORD_BOT_TOKEN, "DISCORD_BOT_TOKEN")
     : undefined;
   if (envToken) {
-    return { token: envToken, source: "env" };
+    return { token: envToken, source: "env", tokenStatus: "available" };
   }
 
-  return { token: "", source: "none" };
+  return { token: "", source: "none", tokenStatus: "missing" };
 }


### PR DESCRIPTION
## Summary

- Problem: Discord config/status paths used strict token normalization, so unresolved SecretRef bot tokens threw before they could be represented as configured-but-unavailable.
- Why it matters: SecretRef-backed Discord configs could fail read-only/status handling instead of showing the operator that the token is configured but unavailable.
- What changed: Discord token resolution now carries tokenStatus, uses inspect-mode SecretRef handling for config/status paths, and reports configured_unavailable in snapshots.
- What did NOT change (scope boundary): Runtime startup still requires an available token and will not start Discord with an unresolved/empty token.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Discord token resolution used strict `normalizeResolvedSecretInputString` for unresolved SecretRef config values, which throws before read-only status/config paths can preserve configured credential metadata.
- Missing detection / guardrail: Discord tests covered the strict throw behavior but did not cover the configured_unavailable status snapshot path for unresolved token SecretRefs.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Discord token, client, shared plugin-base, and channel contract tests.
- Scenario the test should lock in: unresolved Discord token SecretRefs report `configured_unavailable` in status snapshots while runtime startup remains gated on available tokens.
- Why this is the smallest reliable guardrail: it exercises the token resolver and plugin config boundary where the incorrect strict behavior occurred.
- Existing test that already covers this (if any): existing Discord SecretRef/action discovery tests covered adjacent read-only behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord status/config-only surfaces can now show a Discord bot token SecretRef as configured but unavailable instead of throwing during read-only token inspection. Runtime startup still requires a resolved token.

## Diagram (if applicable)

```text
Before:
[Discord token SecretRef unresolved] -> [strict token read] -> [throw]

After:
[Discord token SecretRef unresolved] -> [inspect token read] -> [configured_unavailable snapshot]
[Discord runtime startup] -> [requires available token] -> [does not start with empty token]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: SecretRef inspection now preserves configured_unavailable metadata without resolving or exposing secret values; runtime startup remains gated on an available token.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord token configured as SecretRef

### Steps

1. Configure `channels.discord.token` or `channels.discord.accounts.<id>.token` as an unresolved SecretRef.
2. Build Discord account/status snapshot data.
3. Attempt runtime startup without a resolved token.

### Expected

- Read-only/status paths report `tokenStatus: "configured_unavailable"`.
- Runtime startup/configured checks require an available token.

### Actual

- Before this change, strict normalization threw for unresolved Discord token SecretRefs.
- After this change, status preserves `configured_unavailable` while startup remains unavailable until the token resolves.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unresolved SecretRef token status, blank account token fallback behavior, client missing-token behavior, Discord extension suite, channel contracts, extension typechecks, changelog attribution.
- Edge cases checked: account-scoped unresolved SecretRef, top-level unresolved SecretRef, explicit blank account token, runtime configured gating.
- What you did **not** verify: full repo-wide `pnpm build && pnpm check && pnpm test`; live Discord network behavior for this exact branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Status may mark a token as configured even when the secret value is unavailable.
  - Mitigation: The snapshot includes `tokenStatus: configured_unavailable`, and runtime startup still requires `tokenStatus: available`.

AI-assisted: yes, prepared with Codex and locally reviewed.