### PR TITLE
feat(acpx): add args support for agent command overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/ACPX: accept an optional `args` array in `agents.<name>` config so paths and flag values containing spaces stay intact when spawning ACP agent processes. Thanks @TheArchitectit and @BunsDev.
 - Plugins/CLI: add the optional bundled `oc-path` plugin, providing `openclaw path` for surgical `oc://` access to markdown, JSONC, and JSONL workspace files.
 - CLI: make parser, startup, config, guardrail, channel, agent, task, session, and MCP failures explain what happened and point to the next recovery command.
 - GitHub Copilot: refresh the model catalog from `${baseUrl}/models` so per-account entitlement and accurate context windows surface at runtime; static manifest catalog (now including `gpt-5.5`) remains the fallback when discovery is disabled or the API is unreachable.

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -191,6 +191,32 @@ Override the command or version in plugin config:
 - `expectedVersion: "any"` disables strict version matching.
 - Custom `command` paths disable plugin-local auto-install.
 
+Override an individual ACP agent command with structured arguments when a path
+or flag value should remain one argv token:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "acpx": {
+        "enabled": true,
+        "config": {
+          "agents": {
+            "claude": {
+              "command": "node",
+              "args": ["/path/to/custom adapter.mjs", "--verbose"]
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- `agents.<id>.command` is the executable or existing command string for that ACP agent.
+- `agents.<id>.args` is optional. Each array item is shell-quoted before OpenClaw passes it through the current acpx command-string registry.
+
 See [Plugins](/tools/plugin).
 
 ### Automatic dependency install

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -85,6 +85,10 @@
             "command": {
               "type": "string",
               "minLength": 1
+            },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" }
             }
           },
           "required": ["command"]

--- a/extensions/acpx/src/config-schema.ts
+++ b/extensions/acpx/src/config-schema.ts
@@ -33,7 +33,7 @@ export type AcpxPluginConfig = {
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
   mcpServers?: Record<string, McpServerConfig>;
-  agents?: Record<string, { command: string }>;
+  agents?: Record<string, { command: string; args?: string[] }>;
 };
 
 export type ResolvedAcpxPluginConfig = {
@@ -111,6 +111,7 @@ export const AcpxPluginConfigSchema = z.strictObject({
       z.string(),
       z.strictObject({
         command: nonEmptyTrimmedString("agents.<id>.command must be a non-empty string"),
+        args: z.array(z.string({ error: "args must be an array of strings" })).optional(),
       }),
     )
     .optional(),

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -58,6 +58,44 @@ describe("embedded acpx plugin config", () => {
     });
   });
 
+  it("combines agent command with args array", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          claude: {
+            command: "node",
+            args: ["/path/to/adapter.mjs", "--verbose"],
+          },
+          codex: {
+            command: "codex-acp",
+            args: ["--model", "gpt-5"],
+          },
+        },
+      },
+      workspaceDir: "/tmp/openclaw-acpx",
+    });
+
+    expect(resolved.agents).toEqual({
+      claude: "node /path/to/adapter.mjs --verbose",
+      codex: "codex-acp --model gpt-5",
+    });
+  });
+
+  it("handles agent command without args (backward compat)", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          simple: { command: "simple-acp" },
+        },
+      },
+      workspaceDir: "/tmp/openclaw-acpx",
+    });
+
+    expect(resolved.agents).toEqual({
+      simple: "simple-acp",
+    });
+  });
+
   it("leaves probeAgent undefined by default so the runtime picks its built-in probe agent", () => {
     const resolved = resolveAcpxPluginConfig({
       rawConfig: undefined,

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -81,6 +81,24 @@ describe("embedded acpx plugin config", () => {
     });
   });
 
+  it("quotes agent args that need to survive command-line parsing as one token", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          custom: {
+            command: "node",
+            args: ["/tmp/My Adapter.mjs", "--flag=value with spaces", "owner's-choice"],
+          },
+        },
+      },
+      workspaceDir: "/tmp/openclaw-acpx",
+    });
+
+    expect(resolved.agents).toEqual({
+      custom: "node '/tmp/My Adapter.mjs' '--flag=value with spaces' 'owner'\"'\"'s-choice'",
+    });
+  });
+
   it("handles agent command without args (backward compat)", () => {
     const resolved = resolveAcpxPluginConfig({
       rawConfig: {

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -238,10 +238,12 @@ export function resolveAcpxPluginConfig(params: {
     moduleUrl: params.moduleUrl,
   });
   const agents = Object.fromEntries(
-    Object.entries(normalized.agents ?? {}).map(([name, entry]) => [
-      normalizeLowercaseStringOrEmpty(name),
-      entry.command.trim(),
-    ]),
+    Object.entries(normalized.agents ?? {}).map(([name, entry]) => {
+      const cmd = entry.command.trim();
+      const cmdArgs = entry.args ?? [];
+      const fullCommand = cmdArgs.length > 0 ? `${cmd} ${cmdArgs.join(" ")}` : cmd;
+      return [normalizeLowercaseStringOrEmpty(name), fullCommand];
+    }),
   );
 
   // Lowercase probeAgent so lookups match the registry keys built above, which

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -139,6 +139,13 @@ function resolveTsxImportSpecifier(): string {
   }
 }
 
+function shellQuoteCommandArg(arg: string): string {
+  if (!/[\s'"\\$|&;<>{}()*?[\]~`]/.test(arg)) {
+    return arg;
+  }
+  return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+}
+
 function resolvePluginToolsMcpServerConfig(moduleUrl: string = import.meta.url): McpServerConfig {
   const pluginRoot = resolveAcpxPluginRoot(moduleUrl);
   const openClawRoot = resolveOpenClawRoot(pluginRoot);
@@ -241,7 +248,8 @@ export function resolveAcpxPluginConfig(params: {
     Object.entries(normalized.agents ?? {}).map(([name, entry]) => {
       const cmd = entry.command.trim();
       const cmdArgs = entry.args ?? [];
-      const fullCommand = cmdArgs.length > 0 ? `${cmd} ${cmdArgs.join(" ")}` : cmd;
+      const fullCommand =
+        cmdArgs.length > 0 ? `${cmd} ${cmdArgs.map(shellQuoteCommandArg).join(" ")}` : cmd;
       return [normalizeLowercaseStringOrEmpty(name), fullCommand];
     }),
   );


### PR DESCRIPTION
## Summary

Adds `args` support for ACPX agent command overrides so plugin config can keep the executable and argv entries structured instead of requiring one command string.

This PR now includes the original schema/type/config support plus a maintainer follow-up that quotes flattened argv values before handing the command string to `@zed-industries/agent-client-protocol`, preserving arguments that contain spaces or single quotes.

## Behavior changed

- `plugins.entries.acpx.config.agents.<name>.args` is accepted as an optional string array.
- Existing `command`-only config remains supported.
- ACPX combines `command` + `args` into the command string required by the current ACP client API.
- Arguments with spaces, quotes, or shell-sensitive characters are single-quoted during flattening so argv boundaries are not lost.
- ACPX docs and changelog now cover the new config shape.

## Real behavior proof

**Behavior or issue addressed:** ACPX agent command overrides can now use `args` arrays, and OpenClaw accepts/validates a real config where args include spaces and a single quote.

**Real environment tested:** Local OpenClaw checkout on macOS from branch head `da63e9a5cee2e97cf99a285afde5013facb812e7`, Node 22 repo runtime, isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` under `/tmp/openclaw-acpx-proof-*`.

**Exact steps or command run after this patch:**

```sh
state_dir=$(mktemp -d /tmp/openclaw-acpx-proof-XXXXXX)
config_path="$state_dir/openclaw.json"
OPENCLAW_STATE_DIR="$state_dir" OPENCLAW_CONFIG_PATH="$config_path" pnpm openclaw config patch --stdin <<'JSON'
{
  plugins: {
    entries: {
      acpx: {
        enabled: true,
        config: {
          agents: {
            custom: {
              command: "node",
              args: ["/tmp/My Adapter.mjs", "--flag=value with spaces", "owner's-choice"]
            }
          }
        }
      }
    }
  }
}
JSON
OPENCLAW_STATE_DIR="$state_dir" OPENCLAW_CONFIG_PATH="$config_path" pnpm openclaw config validate
OPENCLAW_STATE_DIR="$state_dir" OPENCLAW_CONFIG_PATH="$config_path" pnpm openclaw config get plugins.entries.acpx.config.agents.custom --json
```

**Evidence after fix:** Terminal output from the real OpenClaw CLI run:

```text
Applied 3 config update(s). Restart the gateway to apply.
Config valid: /tmp/openclaw-acpx-proof-66PJ8y/openclaw.json
{
  "command": "node",
  "args": [
    "/tmp/My Adapter.mjs",
    "--flag=value with spaces",
    "owner's-choice"
  ]
}
```

**Observed result after fix:** The isolated OpenClaw config accepted the ACPX plugin `agents.custom.args` array, validated successfully, and preserved the arg values containing spaces and a single quote when reading the configured agent back through `openclaw config get`.

**What was not tested:** No full external ACP child process was launched against a real third-party ACP harness because this change is limited to ACPX config parsing, validation, docs, and command-string preparation.

## Verification

- `pnpm test extensions/acpx/src/config.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/acpx/src/config.ts extensions/acpx/src/config.test.ts docs/tools/acp-agents-setup.md CHANGELOG.md`
- `git diff --check`
- `pnpm check:changed`

## Bug and security review

- The original implementation flattened args with raw string concatenation, which broke argv boundaries for spaces and could produce unsafe shell-sensitive command strings.
- The maintainer follow-up quotes only the appended args; it does not reinterpret the executable command or change existing command-only behavior.
- No credentials, network behavior, provider auth, or runtime permission boundaries are changed.

## Related maintainer queue

PR #76775 is a duplicate/follow-up for the same ACPX args work. If this PR lands, #76775 should be closed as superseded by this canonical PR.

Thanks @TheArchitectit for the original implementation.
