### PR TITLE
fix(ui): surface compaction checkpoints in chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docker/Gateway: pass Docker setup `.env` values into gateway and CLI containers and preserve exec SecretRef `passEnv` keys in managed service plans, so 1Password Connect-backed Discord tokens keep resolving after doctor or plugin repair. Thanks @vincentkoc.
+- Control UI/WebChat: explain compaction boundaries in chat history and link directly to session checkpoint controls so pre-compaction turns no longer look silently lost after refresh. Fixes #76415.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - CLI/plugins: reject missing plugin ids before config writes in `plugins enable` and `plugins disable` so a typo no longer persists a stale config entry. (#73554) Thanks @ai-hpc.
 - Agents/sessions: preserve delivered trailing assistant replies during session-file repair so Telegram/WebChat history is not rewritten to drop already-delivered responses. Fixes #76329. Thanks @obviyus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Docker/Gateway: pass Docker setup `.env` values into gateway and CLI containers and preserve exec SecretRef `passEnv` keys in managed service plans, so 1Password Connect-backed Discord tokens keep resolving after doctor or plugin repair. Thanks @vincentkoc.
-- Control UI/WebChat: explain compaction boundaries in chat history and link directly to session checkpoint controls so pre-compaction turns no longer look silently lost after refresh. Fixes #76415.
+- Control UI/WebChat: explain compaction boundaries in chat history and link directly to session checkpoint controls so pre-compaction turns no longer look silently lost after refresh. Fixes #76415. Thanks @BunsDev.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.
 - CLI/plugins: reject missing plugin ids before config writes in `plugins enable` and `plugins disable` so a typo no longer persists a stale config entry. (#73554) Thanks @ai-hpc.
 - Agents/sessions: preserve delivered trailing assistant replies during session-file repair so Telegram/WebChat history is not rewritten to drop already-delivered responses. Fixes #76329. Thanks @obviyus.

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -25,6 +25,7 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
 - The UI connects to the Gateway WebSocket and uses `chat.history`, `chat.send`, and `chat.inject`.
 - `chat.history` is bounded for stability: Gateway may truncate long text fields, omit heavy metadata, and replace oversized entries with `[chat.history omitted: message too large]`.
 - `chat.history` follows the active transcript branch for modern append-only session files, so abandoned rewrite branches and superseded prompt copies are not rendered in WebChat.
+- Compaction entries render as an explicit compacted-history divider. The divider explains that earlier turns are preserved in a checkpoint and links to the Sessions checkpoint controls, where operators can branch or restore the pre-compaction view when their permissions allow it.
 - Control UI remembers the backing Gateway `sessionId` returned by `chat.history` and includes it on follow-up `chat.send` calls, so reconnects and page refreshes continue the same stored conversation unless the user starts or resets a session.
 - Control UI coalesces duplicate in-flight submits for the same session, message, and attachments before generating a new `chat.send` run id; the Gateway still dedupes repeated requests that reuse the same idempotency key.
 - `chat.history` is also display-normalized: runtime-only OpenClaw context,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -112,15 +112,19 @@
 
 /* Chat divider (e.g., compaction marker) */
 .chat-divider {
-  display: flex;
-  align-items: center;
+  display: grid;
   gap: 10px;
   margin: 18px 8px;
   color: var(--muted);
   font-size: 11px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: 0;
   user-select: none;
+}
+
+.chat-divider__rule {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .chat-divider__line {
@@ -135,6 +139,29 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.02);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.chat-divider__details {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 16px;
+  text-align: center;
+}
+
+.chat-divider__description {
+  max-width: min(620px, 100%);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.chat-divider__action {
+  white-space: nowrap;
 }
 
 /* Avatar Styles */

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2372,6 +2372,16 @@ export function renderApp(state: AppViewState) {
               onAttachmentsChange: (next) => (state.chatAttachments = next),
               onSend: () => state.handleSendChat(),
               onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
+              onOpenSessionCheckpoints: () => {
+                state.sessionsExpandedCheckpointKey = state.sessionKey;
+                state.setTab("sessions" as import("./navigation.ts").Tab);
+                void loadSessions(state, {
+                  activeMinutes: 0,
+                  limit: 0,
+                  includeGlobal: true,
+                  includeUnknown: true,
+                });
+              },
               onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
               canAbort: hasAbortableSessionRun(state),
               onAbort: () => void state.handleAbortChat(),

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -183,6 +183,35 @@ describe("buildChatItems", () => {
       },
     });
   });
+
+  it("explains compaction boundaries and exposes the checkpoint action", () => {
+    const items = buildChatItems(
+      createProps({
+        messages: [
+          {
+            role: "system",
+            timestamp: 2_000,
+            __openclaw: {
+              kind: "compaction",
+              id: "checkpoint-1",
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "divider",
+      label: "Compacted history",
+      description:
+        "Earlier turns are preserved in a compaction checkpoint. Open session checkpoints to branch or restore that pre-compaction view.",
+      action: {
+        kind: "session-checkpoints",
+        label: "Open checkpoints",
+      },
+    });
+  });
 });
 
 function isCanvasBlock(block: unknown): boolean {

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -223,7 +223,13 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           typeof marker.id === "string"
             ? `divider:compaction:${marker.id}`
             : `divider:compaction:${normalized.timestamp}:${i}`,
-        label: "Compaction",
+        label: "Compacted history",
+        description:
+          "Earlier turns are preserved in a compaction checkpoint. Open session checkpoints to branch or restore that pre-compaction view.",
+        action: {
+          kind: "session-checkpoints",
+          label: "Open checkpoints",
+        },
         timestamp: normalized.timestamp ?? Date.now(),
       });
       continue;

--- a/ui/src/ui/types/chat-types.ts
+++ b/ui/src/ui/types/chat-types.ts
@@ -5,7 +5,14 @@
 /** Union type for items in the chat thread */
 export type ChatItem =
   | { kind: "message"; key: string; message: unknown }
-  | { kind: "divider"; key: string; label: string; timestamp: number }
+  | {
+      kind: "divider";
+      key: string;
+      label: string;
+      description?: string;
+      action?: { kind: "session-checkpoints"; label: string };
+      timestamp: number;
+    }
   | { kind: "stream"; key: string; text: string; startedAt: number }
   | { kind: "reading-indicator"; key: string };
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -53,6 +53,29 @@ vi.mock("../chat/build-chat-items.ts", () => ({
     stream: string | null;
     streamStartedAt: number | null;
   }) => {
+    if (
+      props.messages.some(
+        (message) =>
+          typeof message === "object" &&
+          message !== null &&
+          (message as { __testDivider?: unknown }).__testDivider === true,
+      )
+    ) {
+      return [
+        {
+          kind: "divider",
+          key: "divider:compaction:test",
+          label: "Compacted history",
+          description:
+            "Earlier turns are preserved in a compaction checkpoint. Open session checkpoints to branch or restore that pre-compaction view.",
+          action: {
+            kind: "session-checkpoints",
+            label: "Open checkpoints",
+          },
+          timestamp: 1,
+        },
+      ];
+    }
     if (props.messages.length > 0) {
       return [
         {
@@ -372,6 +395,7 @@ function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {
       onDismissSideResult: () => undefined,
       onNewSession: () => undefined,
       onClearHistory: () => undefined,
+      onOpenSessionCheckpoints: () => undefined,
       agentsList: null,
       currentAgentId: "main",
       onAgentChange: () => undefined,
@@ -388,6 +412,25 @@ function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {
   );
   return container;
 }
+
+describe("chat compaction divider", () => {
+  it("renders checkpoint recovery copy and action", () => {
+    const onOpenSessionCheckpoints = vi.fn();
+    const container = renderChatView({
+      messages: [{ __testDivider: true }],
+      onOpenSessionCheckpoints,
+    });
+
+    expect(container.textContent).toContain("Compacted history");
+    expect(container.textContent).toContain("Earlier turns are preserved");
+    const button = container.querySelector<HTMLButtonElement>(".chat-divider__action");
+    expect(button?.textContent).toContain("Open checkpoints");
+
+    button?.click();
+
+    expect(onOpenSessionCheckpoints).toHaveBeenCalledTimes(1);
+  });
+});
 
 afterEach(() => {
   loadSessionsMock.mockClear();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -109,6 +109,7 @@ export type ChatProps = {
   onHistoryKeydown?: (input: ChatInputHistoryKeyInput) => ChatInputHistoryKeyResult;
   onSend: () => void;
   onCompact?: () => void | Promise<void>;
+  onOpenSessionCheckpoints?: () => void | Promise<void>;
   onToggleRealtimeTalk?: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
@@ -906,10 +907,35 @@ export function renderChat(props: ChatProps) {
           (item) => {
             if (item.kind === "divider") {
               return html`
-                <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
-                  <span class="chat-divider__line"></span>
-                  <span class="chat-divider__label">${item.label}</span>
-                  <span class="chat-divider__line"></span>
+                <div class="chat-divider" data-ts=${String(item.timestamp)}>
+                  <div class="chat-divider__rule" role="separator" aria-label=${item.label}>
+                    <span class="chat-divider__line"></span>
+                    <span class="chat-divider__label">${item.label}</span>
+                    <span class="chat-divider__line"></span>
+                  </div>
+                  ${item.description || item.action
+                    ? html`
+                        <div class="chat-divider__details">
+                          ${item.description
+                            ? html`<span class="chat-divider__description">
+                                ${item.description}
+                              </span>`
+                            : nothing}
+                          ${item.action?.kind === "session-checkpoints" &&
+                          props.onOpenSessionCheckpoints
+                            ? html`
+                                <button
+                                  type="button"
+                                  class="btn btn--subtle btn--sm chat-divider__action"
+                                  @click=${() => props.onOpenSessionCheckpoints?.()}
+                                >
+                                  ${item.action.label}
+                                </button>
+                              `
+                            : nothing}
+                        </div>
+                      `
+                    : nothing}
                 </div>
               `;
             }


### PR DESCRIPTION
## Summary

Fixes #76415 by making compaction boundaries explicit in Control UI/WebChat history instead of letting refreshes look like earlier turns silently disappeared.

The narrow product choice here is to preserve the current bounded active-transcript `chat.history` behavior and add a chat-level recovery affordance:

- render compaction transcript entries as `Compacted history` dividers instead of a generic `Compaction` label
- explain that earlier turns are preserved in a compaction checkpoint
- add an `Open checkpoints` action that switches to the Sessions view, expands the active session's checkpoint panel, and refreshes checkpoint metadata
- keep checkpoint branch/restore permissions enforced by the existing Sessions APIs
- document the behavior in WebChat docs and add a user-facing changelog entry

## Bug / Current Behavior

Issue #76415 reports that after automatic compaction, a long Control UI/WebChat session reloads from the compacted successor transcript. The old full turn-by-turn transcript is retained in checkpoint/reset files, but normal chat history can make earlier messages look lost after refresh.

I verified the issue is still open and not already closed by a linked PR. `closedByPullRequestsReferences` is empty.

## Related PR Review

I checked related live PRs before opening this one:

- #68765 directly attempts checkpoint-chain transcript stitching, but ClawSweeper found P1/security blockers around active-branch reads, reset/restore epoch replay, untrimmed compaction tails, and uncontained checkpoint paths.
- #73883 and #60409 address reset/archive opt-in or fallback behavior, not this default visible compaction-boundary UX.
- #70348 filters internal compaction artifacts, which is adjacent but does not explain or recover pre-compaction history.
- #75776 is broader WebChat reliability work and is not a focused checkpoint-boundary fix.

`gitcrawl` was stale for #76415 (local store last updated before the issue existed), so I fell back to live GitHub search. `prtags` was installed and authenticated, but the prtags API returned 502 for list/search/write attempts, so duplicate-group writes could not be completed in this run.

## Security / Privacy

This PR intentionally does not read, stitch, replay, or expose archived/checkpoint transcript bytes through `chat.history`.

Security-relevant boundaries preserved:

- no new filesystem reads
- no checkpoint-path trust changes
- no reset/restore epoch replay by default
- no dependency, workflow, lockfile, or secret-handling changes
- branch/restore remains behind the existing `sessions.compaction.*` methods and server-side permissions

## Tests

RED proof first:

- `pnpm test ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/views/chat.test.ts` failed before implementation because the builder emitted only `Compaction` and the view rendered no explanation/action.

Passing proof:

- `pnpm test ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/views/chat.test.ts` — 27 tests passed
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/web/webchat.md ui/src/styles/chat/grouped.css ui/src/ui/app-render.ts ui/src/ui/types/chat-types.ts ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/views/chat.ts ui/src/ui/views/chat.test.ts` — passed
- `git diff --check` — passed
- Blacksmith Testbox `tbx_01kqp0e8zndm2cng8ky8d9jpan`: `OPENCLAW_TESTBOX=1 pnpm check:changed` — passed (`core`, `coreTests`, `docs` lanes)

## Docs

Updated WebChat docs: https://docs.openclaw.ai/web/webchat
