### PR TITLE
fix(gateway): dedupe active WebChat sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: collapse duplicate in-flight internal text sends onto the active Gateway run so rapid repeat submits do not start fresh `agent:main:main` dispatches. Fixes #75737. Thanks @dsdsddd1 and @BunsDev.
 - Channels/streaming: expose `streaming.progress.label`, `labels`, `maxLines`, and `toolProgress` in bundled channel config metadata so progress draft settings appear in config, docs, and control surfaces. Thanks @vincentkoc.
 - Channels/streaming: normalize whitespace and case for `streaming.progress.label: "auto"` so progress draft labels keep using the built-in label pool instead of rendering a literal `auto` title. Thanks @vincentkoc.
 - Gateway/install: prefer supported system Node over nvm/fnm/volta/asdf/mise when regenerating managed gateway services, so `gateway install --force` no longer recreates service definitions that doctor immediately flags as version-manager-backed. Fixes #76339. Thanks @brokemac79.

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
@@ -234,6 +235,40 @@ type ChatSendOriginatingRoute = {
   messageThreadId?: string | number;
   explicitDeliverRoute: boolean;
 };
+
+const ACTIVE_CHAT_SEND_DEDUPE_PREFIX = "chat:active-send";
+
+function resolveActiveChatSendRunId(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const runId = (value as { runId?: unknown }).runId;
+  return typeof runId === "string" && runId.trim() ? runId : null;
+}
+
+function buildActiveChatSendDedupeKey(params: {
+  attachmentCount: number;
+  explicitDeliverRoute: boolean;
+  message: string;
+  originatingChannel: string;
+  sessionKey: string;
+}): string | null {
+  const message = params.message.trim();
+  if (
+    !message ||
+    message.startsWith("/") ||
+    params.attachmentCount > 0 ||
+    params.explicitDeliverRoute ||
+    normalizeMessageChannel(params.originatingChannel) !== INTERNAL_MESSAGE_CHANNEL
+  ) {
+    return null;
+  }
+  const digest = createHash("sha256")
+    .update(JSON.stringify([params.sessionKey, message]))
+    .digest("hex")
+    .slice(0, 32);
+  return `${ACTIVE_CHAT_SEND_DEDUPE_PREFIX}:${digest}`;
+}
 
 type ChatSendExplicitOrigin = {
   originatingChannel?: string;
@@ -2015,6 +2050,35 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
       return;
     }
+    const clientInfo = client?.connect?.client;
+    const originatingRoute = resolveChatSendOriginatingRoute({
+      client: clientInfo,
+      deliver: p.deliver,
+      entry,
+      explicitOrigin: explicitOriginResult.value,
+      hasConnectedClient: client?.connect !== undefined,
+      mainKey: cfg.session?.mainKey,
+      sessionKey,
+    });
+    const activeChatSendDedupeKey = buildActiveChatSendDedupeKey({
+      attachmentCount: normalizedAttachments.length,
+      explicitDeliverRoute: originatingRoute.explicitDeliverRoute,
+      message: rawMessage,
+      originatingChannel: originatingRoute.originatingChannel,
+      sessionKey,
+    });
+    if (activeChatSendDedupeKey) {
+      const activeRunId = resolveActiveChatSendRunId(
+        context.dedupe.get(activeChatSendDedupeKey)?.payload,
+      );
+      if (activeRunId && context.chatAbortControllers.has(activeRunId)) {
+        respond(true, { runId: activeRunId, status: "in_flight" as const }, undefined, {
+          cached: true,
+          runId: activeRunId,
+        });
+        return;
+      }
+    }
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
@@ -2097,6 +2161,13 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
         return;
       }
+      if (activeChatSendDedupeKey) {
+        context.dedupe.set(activeChatSendDedupeKey, {
+          ts: now,
+          ok: true,
+          payload: { runId: clientRunId },
+        });
+      }
       context.addChatRun(clientRunId, {
         sessionKey,
         clientRunId,
@@ -2126,22 +2197,13 @@ export const chatHandlers: GatewayRequestHandlers = {
       const messageForAgent = systemProvenanceReceipt
         ? [systemProvenanceReceipt, parsedMessage].filter(Boolean).join("\n\n")
         : parsedMessage;
-      const clientInfo = client?.connect?.client;
       const {
         originatingChannel,
         originatingTo,
         accountId,
         messageThreadId,
         explicitDeliverRoute,
-      } = resolveChatSendOriginatingRoute({
-        client: clientInfo,
-        deliver: p.deliver,
-        entry,
-        explicitOrigin: explicitOriginResult.value,
-        hasConnectedClient: client?.connect !== undefined,
-        mainKey: cfg.session?.mainKey,
-        sessionKey,
-      });
+      } = originatingRoute;
       // Inject timestamp so agents know the current date/time.
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
 import { clearConfigCache } from "../config/config.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { __setMaxChatHistoryMessagesBytesForTest } from "./server-constants.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/shared-types.js";
 import {
@@ -319,6 +320,113 @@ describe("gateway server chat", () => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
       expect(context.addChatRun).toHaveBeenCalledTimes(1);
       dispatchRelease.resolve();
+      await vi.waitFor(() => {
+        expect(context.removeChatRun).toHaveBeenCalledTimes(1);
+      }, FAST_WAIT_OPTS);
+    } finally {
+      dispatchRelease.resolve();
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await fs.rm(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  test("chat.send reuses an active internal run for duplicate WebChat text sends", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    const dispatchRelease = createDeferred<void>();
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const responses: Array<{ id: string; ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = {
+        loadGatewayModelCatalog: vi.fn<GatewayRequestContext["loadGatewayModelCatalog"]>(),
+        logGateway: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        agentRunSeq: new Map<string, number>(),
+        chatAbortControllers: new Map(),
+        chatAbortedRuns: new Map(),
+        chatRunBuffers: new Map(),
+        chatDeltaSentAt: new Map(),
+        chatDeltaLastBroadcastLen: new Map(),
+        addChatRun: vi.fn(),
+        removeChatRun: vi.fn(),
+        broadcast: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        registerToolEventRecipient: vi.fn(),
+        dedupe: new Map(),
+      } as unknown as GatewayRequestContext;
+      dispatchInboundMessageMock.mockImplementation(async () => dispatchRelease.promise);
+
+      const { chatHandlers } = await import("./server-methods/chat.js");
+      const callSend = (id: string, idempotencyKey: string) =>
+        chatHandlers["chat.send"]({
+          req: {
+            type: "req",
+            id,
+            method: "chat.send",
+            params: {
+              sessionKey: "main",
+              message: "?",
+              idempotencyKey,
+            },
+          },
+          params: {
+            sessionKey: "main",
+            message: "?",
+            idempotencyKey,
+          },
+          client: {
+            connect: {
+              client: {
+                id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
+                mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+              },
+              scopes: ["operator.write"],
+            },
+          } as never,
+          isWebchatConnect: () => true,
+          respond: ((ok, payload, error) => {
+            responses.push({ id, ok, payload, error });
+          }) as RespondFn,
+          context,
+        });
+
+      const first = Promise.resolve(callSend("first", "idem-active-a"));
+      await vi.waitFor(() => {
+        expect(responses).toContainEqual({
+          id: "first",
+          ok: true,
+          payload: { runId: "idem-active-a", status: "started" },
+          error: undefined,
+        });
+      }, FAST_WAIT_OPTS);
+
+      await callSend("duplicate", "idem-active-b");
+
+      expect(responses).toContainEqual({
+        id: "duplicate",
+        ok: true,
+        payload: { runId: "idem-active-a", status: "in_flight" },
+        error: undefined,
+      });
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      expect(context.addChatRun).toHaveBeenCalledTimes(1);
+
+      dispatchRelease.resolve();
+      await first;
       await vi.waitFor(() => {
         expect(context.removeChatRun).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);


### PR DESCRIPTION
## Summary

- Add an active-run dedupe key for internal `chat.send` text turns so rapid duplicate WebChat/Control UI submits reuse the already-running Gateway run instead of dispatching a fresh `agent:main:main` run.
- Keep the guard intentionally narrow: it only applies while the original run is still active, excludes slash commands, attachments, explicit delivery routes, and non-internal origins, and stores only a short SHA-256 fingerprint plus the active run id in the existing in-memory dedupe map.
- Cover the regression with a Gateway chat test that sends the same WebChat text twice with different idempotency keys and asserts only one inbound dispatch/run registration occurs.
- Add the Unreleased changelog entry with reporter attribution.

Fixes #75737.
Refs #72892.

## Bug Review

Issue #75737 was still open and not already resolved with high-confidence current-shipped proof. Existing mitigations reduce adjacent startup/provider/plugin cost, but the reported repeated fresh WebChat dispatch remained possible when rapid repeated sends arrive with distinct `idempotencyKey` values.

I checked tied/related work before patching:

- No PR directly referenced `#75737`.
- #75776 and #74733 are related WebChat reliability PRs, but they are broader/incomplete and do not close #75737.
- #72892 tracks the closest duplicate/root behavior: duplicate Control UI/WebChat inbound sends can bypass same-id retry dedupe.
- #72314, #75481, #75948, and #67709 cover adjacent but narrower/merged issues and do not make this exact repeated active-send dispatch impossible.
- `gitcrawl` local archive was stale for this issue and `prtags` duplicate writes/searches returned 502, so duplicate metadata tagging could not be completed from the current maintainer tooling run. The related issue/PR evidence is captured here instead.

## Security Review

- No new permissions, scopes, provider calls, external network access, filesystem access, or command execution paths.
- The active-send key uses a SHA-256 digest of `[sessionKey, trimmedMessage]`; the plaintext message is not logged, persisted, or exposed through the Gateway response.
- Dedupe is session-scoped and active-run-gated through `chatAbortControllers.has(runId)`, so an old completed run cannot suppress a later intentional repeat.
- Explicit delivery routes, attachments, slash commands, and non-internal origins are excluded to avoid collapsing semantically distinct sends.

## Validation

- `pnpm docs:list`
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`
- `pnpm check:changelog-attributions`
- `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts -t "duplicate WebChat" -- --reporter=dot`
- `pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts src/auto-reply/reply/inbound-dedupe.test.ts -- --reporter=dot`
- `pnpm test src/gateway/server.chat.gateway-server-chat.test.ts -- --reporter=dot`
- Blacksmith Testbox `OPENCLAW_TESTBOX=1 pnpm check:changed` passed on the final diff: https://github.com/openclaw/openclaw/actions/runs/25269937107
