### PR TITLE
docs(active-memory): document setupGraceTimeoutMs and cold-start grace for v2026.5.2 upgraders

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -558,25 +558,25 @@ plugins.entries.active-memory
 
 The most important fields are:
 
-| Key                          | Type                                                                                                 | Meaning                                                                                                |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `enabled`                    | `boolean`                                                                                            | Enables the plugin itself                                                                              |
-| `config.agents`              | `string[]`                                                                                           | Agent ids that may use active memory                                                                   |
-| `config.model`               | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model |
-| `config.allowedChatTypes`    | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                    |
-| `config.allowedChatIds`      | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed      |
-| `config.deniedChatIds`       | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                |
-| `config.queryMode`           | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                      |
-| `config.promptStyle`         | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory   |
-| `config.thinking`            | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                  |
-| `config.promptOverride`      | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                       |
-| `config.promptAppend`        | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                               |
-| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                    |
-| `config.setupGraceTimeoutMs` | `number`                                                                                             | Advanced extra setup budget before the recall timeout expires; defaults to 0 and is capped at 30000 ms |
-| `config.maxSummaryChars`     | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                          |
-| `config.logging`             | `boolean`                                                                                            | Emits active memory logs while tuning                                                                  |
-| `config.persistTranscripts`  | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                     |
-| `config.transcriptDir`       | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                |
+| Key                          | Type                                                                                                 | Meaning                                                                                                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`                    | `boolean`                                                                                            | Enables the plugin itself                                                                                                                                                        |
+| `config.agents`              | `string[]`                                                                                           | Agent ids that may use active memory                                                                                                                                             |
+| `config.model`               | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model                                                                           |
+| `config.allowedChatTypes`    | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                                                                                              |
+| `config.allowedChatIds`      | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed                                                                                |
+| `config.deniedChatIds`       | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                                                                                          |
+| `config.queryMode`           | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                                                                                                |
+| `config.promptStyle`         | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory                                                                             |
+| `config.thinking`            | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                                                                                            |
+| `config.promptOverride`      | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                                                                                                 |
+| `config.promptAppend`        | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                                                                                                         |
+| `config.timeoutMs`           | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                                                                                              |
+| `config.setupGraceTimeoutMs` | `number`                                                                                             | Advanced extra setup budget before the recall timeout expires; defaults to 0 and is capped at 30000 ms. See [Cold-start grace](#cold-start-grace) for v2026.4.x upgrade guidance |
+| `config.maxSummaryChars`     | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                                                                                                    |
+| `config.logging`             | `boolean`                                                                                            | Emits active memory logs while tuning                                                                                                                                            |
+| `config.persistTranscripts`  | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                                                                                               |
+| `config.transcriptDir`       | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                                                                                          |
 
 Useful tuning fields:
 
@@ -624,6 +624,52 @@ Then move to:
 
 - `message` if you want lower latency
 - `full` if you decide extra context is worth the slower blocking memory sub-agent
+
+### Cold-start grace
+
+Before v2026.5.2 the plugin silently extended your configured `timeoutMs` by an
+extra 30000 ms during cold-start so model warm-up, embedding-index load, and
+the first recall could share one larger budget. v2026.5.2 moved that grace
+behind an explicit `setupGraceTimeoutMs` config — your configured `timeoutMs`
+is now the budget by default, unless you opt in.
+
+If you upgraded from v2026.4.x and you set `timeoutMs` to a value tuned for the
+old implicit-grace world (the recommended starter `timeoutMs: 15000` is one
+example), set `setupGraceTimeoutMs: 30000` to extend the prompt-build hook and
+outer watchdog budgets back to the pre-v5.2 effective values:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "active-memory": {
+        config: {
+          timeoutMs: 15000,
+          setupGraceTimeoutMs: 30000,
+        },
+      },
+    },
+  },
+}
+```
+
+Per the v2026.5.2 changelog: _"use the configured recall timeout as the
+blocking prompt-build hook budget by default and move cold-start setup grace
+behind explicit `setupGraceTimeoutMs` config, so the plugin no longer silently
+extends 15000 ms configs to 45000 ms on the main lane."_
+
+The embedded recall runner currently still receives the raw `timeoutMs` value
+as its inner budget; the in-flight fix to extend that with `setupGraceTimeoutMs`
+is tracked at [#74480](https://github.com/openclaw/openclaw/pull/74480). Until
+that lands, very-cold first recalls can still time out at the inner layer even
+with `setupGraceTimeoutMs` set — though the outer-layer setting still
+substantially mitigates the symptom by giving the prompt-build hook room to
+cover the warm-up window.
+
+For resource-tight gateways where cold-start latency is a known trade-off,
+lower values (5000–15000 ms) work too — the trade-off is a higher chance of
+the very first recall after a gateway restart returning empty while warm-up
+finishes.
 
 ## Debugging
 
@@ -679,6 +725,19 @@ default `memory-core` path uses `memory_search`; `memory-lancedb` uses
       and index health.
     - If you use `ollama`, confirm the embedding model is installed
       (`ollama list`).
+  </Accordion>
+
+  <Accordion title="First recall after gateway restart returns `status=timeout`">
+    On v2026.5.2 and later, if cold-start setup (model warm-up + embedding
+    index load) hasn't finished by the time the first recall fires, the run
+    can hit the configured `timeoutMs` budget and return `status=timeout`
+    with empty output. Gateway logs show `active-memory timeout after Nms`
+    around the first eligible reply after a restart.
+
+    See [Cold-start grace](#cold-start-grace) under Recommended setup for the
+    recommended `setupGraceTimeoutMs` value (and the open caveat about the
+    embedded recall budget tracked at #74480).
+
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

- **Problem**: Operators upgrading to v2026.5.2 can hit a silent `status=timeout` on the first active-memory recall after a gateway restart, because v2026.5.2 moved cold-start grace from an implicit `+30000ms` to explicit-opt-in `setupGraceTimeoutMs` config. The CHANGELOG flags the behavior change clearly, but `docs/concepts/active-memory.md` only mentions `setupGraceTimeoutMs` as a one-line entry in the Configuration table — there's no upgrade guidance.
- **What this PR adds** (purely additive docs, no code touched):
  - A new **Cold-start grace (upgraders from v2026.4.x)** subsection under `## Recommended setup` with the recommended `setupGraceTimeoutMs: 30000` snippet and a verbatim CHANGELOG citation
  - A new entry in `## Common issues` (added as a new `<Accordion>` inside the existing `<AccordionGroup>`) for "First recall after gateway restart returns `status=timeout`" that cross-links back to the new subsection
- **What did NOT change**: Configuration table entry for `setupGraceTimeoutMs`, code, examples elsewhere, schema. Happy to expand the table entry inline too if reviewers prefer that to the cross-link approach.

## Why now

The CHANGELOG line for v2026.5.2 (verbatim):

> use the configured recall timeout as the blocking prompt-build hook budget by default and move cold-start setup grace behind explicit `setupGraceTimeoutMs` config, so the plugin no longer silently extends 15000 ms configs to 45000 ms on the main lane.

That line accurately describes the behavior change but lives in the changelog, not in the active-memory concept doc. Operators who:

1. Read `docs/concepts/active-memory.md` for guidance on what to set, **and**
2. Carried over a `timeoutMs: 15000` config from v2026.4.x

…silently get a 15s budget where they used to effectively get 45s. The first recall after a gateway restart often loses that race.

## Verified context

- Filed after first-hand discovery on a v2026.5.2 upgrade from v2026.4.27.
- Cross-checked the related code path:
  - `extensions/active-memory/index.js`: `watchdogTimeoutMs = params.config.timeoutMs + params.config.setupGraceTimeoutMs` (the embedded recall watchdog computation)
  - Plugin manifest: `setupGraceTimeoutMs` integer, `minimum: 0`, `maximum: 30000`
- Cross-referenced existing related work in the repo: closed issue #75843 (the underlying timeout-extension regression that the v5.2 change addressed) and open PR #74480 (`fix(active-memory): preserve setup grace for embedded recall`) — this PR is orthogonal to #74480: that PR makes the embedded runner honor the grace budget; this PR tells operators what budget to configure. Both can land in either order.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (touched areas)

- [x] Docs / concepts

## Test plan

Not applicable — docs-only change. Verified locally that:
- Markdown renders cleanly when previewing the PR diff
- The anchor link `#cold-start-grace-upgraders-from-v202604x` resolves to the new subsection on GitHub's rendered view
- The new `<Accordion>` integrates correctly inside the existing `<AccordionGroup>`

## Compatibility

No code, no schema, no behavior change. Pure docs. Safe to backport to any release branch that already shipped v2026.5.2's `setupGraceTimeoutMs` semantics.
