### PR TITLE
fix(secretrefs): resolve external channel contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/secrets: resolve SecretRef-backed channel credentials through external plugin secret contracts after the plugin split, covering runtime startup, target discovery, webhook auth, disabled-account enumeration, and late-bound web_search config. (#76449) Thanks @joshavant.
 - Docker/Gateway: pass Docker setup `.env` values into gateway and CLI containers and preserve exec SecretRef `passEnv` keys in managed service plans, so 1Password Connect-backed Discord tokens keep resolving after doctor or plugin repair. Thanks @vincentkoc.
 - Control UI/WebChat: explain compaction boundaries in chat history and link directly to session checkpoint controls so pre-compaction turns no longer look silently lost after refresh. Fixes #76415. Thanks @BunsDev.
 - Gateway/sessions: keep async `sessions.list` title and preview hydration bounded to transcript head/tail reads so Control UI polling cannot full-scan large session transcripts every refresh. Thanks @vincentkoc.

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -23,6 +23,7 @@ import {
 } from "./monitor-shared.js";
 import { fetchBlueBubblesServerInfo } from "./probe.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
+import { normalizeSecretInputString } from "./secret-input.js";
 import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
   createFixedWindowRateLimiter,
@@ -193,7 +194,7 @@ export async function handleBlueBubblesWebhookRequest(
         targets,
         res,
         isMatch: (target) => {
-          const token = target.account.config.password?.trim() ?? "";
+          const token = normalizeSecretInputString(target.account.config.password) ?? "";
           return safeEqualAuthToken(guid, token);
         },
       });

--- a/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
+++ b/extensions/bluebubbles/src/monitor.webhook-auth.test.ts
@@ -432,6 +432,16 @@ describe("BlueBubbles webhook monitor", () => {
       );
     });
 
+    it("rejects unresolved SecretRef webhook passwords without crashing", async () => {
+      setupWebhookTarget({
+        account: createMockAccount({
+          password: { source: "exec", provider: "vault", id: "bluebubbles/webhook" } as never,
+        }),
+      });
+
+      await expectProtectedPasswordQueryRequestStatus(401);
+    });
+
     it("rate limits repeated invalid password guesses from the same client", async () => {
       setupWebhookTarget({
         account: createMockAccount({

--- a/extensions/discord/src/setup-account-state.test.ts
+++ b/extensions/discord/src/setup-account-state.test.ts
@@ -88,4 +88,26 @@ describe("discord setup account state", () => {
     expect(inspected.tokenStatus).toBe("missing");
     expect(inspected.configured).toBe(false);
   });
+
+  it("reports unresolved SecretRef account tokens as configured but unavailable", () => {
+    const inspected = inspectDiscordSetupAccount({
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              work: {
+                token: { source: "exec", provider: "vault", id: "discord/work" },
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+    });
+
+    expect(inspected.token).toBe("");
+    expect(inspected.tokenSource).toBe("config");
+    expect(inspected.tokenStatus).toBe("configured_unavailable");
+    expect(inspected.configured).toBe(true);
+  });
 });

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -4,6 +4,7 @@ import { withEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTelegramActionGate,
+  listEnabledTelegramAccounts,
   listTelegramAccountIds,
   mergeTelegramAccountConfig,
   resolveTelegramMediaRuntimeOptions,
@@ -122,6 +123,27 @@ describe("resolveTelegramAccount", () => {
     const lines = warnMock.mock.calls.map(([line]) => String(line));
     expect(lines).toContain("listTelegramAccountIds [ 'work' ]");
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
+  });
+
+  it("does not resolve disabled account tokens when listing enabled accounts", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            disabled: {
+              enabled: false,
+              botToken: { source: "exec", provider: "vault", id: "telegram/disabled" },
+            },
+            work: { botToken: "tok-work" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const accounts = listEnabledTelegramAccounts(cfg);
+
+    expect(accounts.map((account) => account.accountId)).toEqual(["work"]);
+    expect(accounts[0]?.token).toBe("tok-work");
   });
 });
 

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -177,7 +177,11 @@ export function resolveTelegramAccount(params: {
 }
 
 export function listEnabledTelegramAccounts(cfg: OpenClawConfig): ResolvedTelegramAccount[] {
+  const baseEnabled = cfg.channels?.telegram?.enabled !== false;
+  if (!baseEnabled) {
+    return [];
+  }
   return listTelegramAccountIds(cfg)
-    .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
-    .filter((account) => account.enabled);
+    .filter((accountId) => mergeTelegramAccountConfig(cfg, accountId).enabled !== false)
+    .map((accountId) => resolveTelegramAccount({ cfg, accountId }));
 }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveManifestContractOwnerPluginId } from "../../plugins/plugin-registry.js";
 import { getActiveRuntimeWebToolsMetadata } from "../../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebSearchMetadata } from "../../secrets/runtime-web-tools.types.js";
+import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
 import { resolveWebSearchProviderId, runWebSearch } from "../../web-search/runtime.js";
 import type { AnyAgentTool } from "./common.js";
 import { asToolParamsRecord, jsonResult } from "./common.js";
@@ -92,7 +93,10 @@ export function createWebSearchTool(options?: {
           : options?.runtimeWebSearch;
       const runtimeProviderId =
         runtimeWebSearch?.selectedProvider ?? runtimeWebSearch?.providerConfigured;
-      const config = options?.lateBindRuntimeConfig === true ? undefined : options?.config;
+      const config =
+        options?.lateBindRuntimeConfig === true
+          ? (getActiveSecretsRuntimeSnapshot()?.config ?? options?.config)
+          : options?.config;
       const preferRuntimeProviders =
         Boolean(runtimeProviderId) &&
         !resolveManifestContractOwnerPluginId({

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -10,6 +10,13 @@ import { createWebFetchTool, createWebSearchTool } from "./web-tools.js";
 const runWebSearchCalls = vi.hoisted(
   () => [] as Array<{ config?: unknown; runtimeWebSearch?: unknown }>,
 );
+const activeSecretsRuntimeSnapshot = vi.hoisted(() => ({
+  current: null as null | { config: unknown },
+}));
+
+vi.mock("../../secrets/runtime.js", () => ({
+  getActiveSecretsRuntimeSnapshot: () => activeSecretsRuntimeSnapshot.current,
+}));
 
 vi.mock("../../web-search/runtime.js", async () => {
   const { getActivePluginRegistry } = await import("../../plugins/runtime.js");
@@ -68,12 +75,14 @@ vi.mock("../../web-search/runtime.js", async () => {
 beforeEach(() => {
   setActivePluginRegistry(createEmptyPluginRegistry());
   clearActiveRuntimeWebToolsMetadata();
+  activeSecretsRuntimeSnapshot.current = null;
   runWebSearchCalls.length = 0;
 });
 
 afterEach(() => {
   setActivePluginRegistry(createEmptyPluginRegistry());
   clearActiveRuntimeWebToolsMetadata();
+  activeSecretsRuntimeSnapshot.current = null;
 });
 
 describe("web tools defaults", () => {
@@ -196,6 +205,10 @@ describe("web tools defaults", () => {
       },
       diagnostics: [],
     });
+    const runtimeConfig = {
+      tools: { web: { search: { provider: "fresh", fresh: { apiKey: "runtime-key" } } } },
+    };
+    activeSecretsRuntimeSnapshot.current = { config: runtimeConfig };
 
     const tool = createWebSearchTool({
       config: { tools: { web: { search: { provider: "stale" } } } },
@@ -214,7 +227,7 @@ describe("web tools defaults", () => {
 
     expect(result?.details).toMatchObject({ provider: "fresh" });
     expect(runWebSearchCalls).toHaveLength(1);
-    expect(runWebSearchCalls[0]?.config).toBeUndefined();
+    expect(runWebSearchCalls[0]?.config).toBe(runtimeConfig);
     expect(runWebSearchCalls[0]?.runtimeWebSearch).toMatchObject({
       selectedProvider: "fresh",
     });

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -1,6 +1,7 @@
 import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalAccountId } from "../routing/session-key.js";
+import { loadChannelSecretContractApi } from "../secrets/channel-contract-api.js";
 import {
   discoverConfigSecretTargetsByIds,
   listSecretTargetRegistryEntries,
@@ -115,6 +116,20 @@ function getConfiguredChannelSecretTargetIds(
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
   const targetIds = new Set<string>();
+  const channels = config.channels;
+  if (channels && typeof channels === "object" && !Array.isArray(channels)) {
+    for (const channelId of Object.keys(channels)) {
+      if (channelId === "defaults") {
+        continue;
+      }
+      const contract = loadChannelSecretContractApi({ channelId, config, env });
+      for (const entry of contract?.secretTargetRegistryEntries ?? []) {
+        if (isScopedChannelSecretTargetEntry({ entry, pluginChannelId: channelId })) {
+          targetIds.add(entry.id);
+        }
+      }
+    }
+  }
   for (const plugin of listReadOnlyChannelPluginsForConfig(config, {
     env,
     includePersistedAuthState: false,

--- a/src/secrets/channel-contract-api.external.test.ts
+++ b/src/secrets/channel-contract-api.external.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+const { loadPluginMetadataSnapshotMock, loadBundledPluginPublicArtifactModuleSyncMock } =
+  vi.hoisted(() => ({
+    loadPluginMetadataSnapshotMock: vi.fn(),
+    loadBundledPluginPublicArtifactModuleSyncMock: vi.fn(() => {
+      throw new Error(
+        "Unable to resolve bundled plugin public surface discord/secret-contract-api.js",
+      );
+    }),
+  }));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: loadPluginMetadataSnapshotMock,
+}));
+
+vi.mock("../plugins/public-surface-loader.js", () => ({
+  loadBundledPluginPublicArtifactModuleSync: loadBundledPluginPublicArtifactModuleSyncMock,
+}));
+
+import { loadChannelSecretContractApi } from "./channel-contract-api.js";
+
+function writeExternalChannelPlugin(params: { pluginId: string; channelId: string }) {
+  const rootDir = makeTrackedTempDir("openclaw-channel-secret-contract", tempDirs);
+  fs.writeFileSync(
+    path.join(rootDir, "secret-contract-api.cjs"),
+    `
+module.exports = {
+  secretTargetRegistryEntries: [
+    {
+      id: "channels.${params.channelId}.token",
+      targetType: "channels.${params.channelId}.token",
+      configFile: "openclaw.json",
+      pathPattern: "channels.${params.channelId}.token",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true
+    }
+  ],
+  collectRuntimeConfigAssignments(params) {
+    params.context.assignments.push({
+      path: "channels.${params.channelId}.token",
+      ref: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      expected: "string",
+      apply() {}
+    });
+  }
+};
+`,
+    "utf8",
+  );
+  return {
+    id: params.pluginId,
+    origin: "global",
+    channels: [params.channelId],
+    channelConfigs: {},
+    rootDir,
+  };
+}
+
+describe("external channel secret contract api", () => {
+  beforeEach(() => {
+    loadPluginMetadataSnapshotMock.mockReset();
+    loadBundledPluginPublicArtifactModuleSyncMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanupTrackedTempDirs(tempDirs);
+  });
+
+  it("loads root secret-contract-api sidecars for external channel plugins", () => {
+    const record = writeExternalChannelPlugin({ pluginId: "discord", channelId: "discord" });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [record],
+    });
+
+    const api = loadChannelSecretContractApi({
+      channelId: "discord",
+      config: { channels: { discord: {} } },
+      env: {},
+      loadablePluginOrigins: new Map([["discord", "global"]]),
+    });
+
+    expect(api?.secretTargetRegistryEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "channels.discord.token",
+        }),
+      ]),
+    );
+    expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
+  });
+
+  it("skips external channel records outside the loadable plugin origin set", () => {
+    const record = writeExternalChannelPlugin({ pluginId: "discord", channelId: "discord" });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [record],
+    });
+
+    const api = loadChannelSecretContractApi({
+      channelId: "discord",
+      config: { channels: { discord: {} } },
+      env: {},
+      loadablePluginOrigins: new Map([["other", "global"]]),
+    });
+
+    expect(api).toBeUndefined();
+  });
+});

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -1,4 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  createPluginModuleLoaderCache,
+  getCachedPluginModuleLoader,
+  type PluginModuleLoaderCache,
+} from "../plugins/plugin-module-loader-cache.js";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { loadBundledPluginPublicArtifactModuleSync } from "../plugins/public-surface-loader.js";
 import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
 import type { SecretTargetRegistryEntry } from "./target-registry-types.js";
@@ -20,6 +33,13 @@ type BundledChannelContractApi = {
     raw: Record<string, unknown>,
   ) => UnsupportedSecretRefConfigCandidate[];
 };
+
+const CONTRACT_API_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"] as const;
+const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
+const RUNNING_FROM_BUILT_ARTIFACT =
+  CURRENT_MODULE_PATH.includes(`${path.sep}dist${path.sep}`) ||
+  CURRENT_MODULE_PATH.includes(`${path.sep}dist-runtime${path.sep}`);
+const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
 
 function loadBundledChannelPublicArtifact(
   channelId: string,
@@ -58,6 +78,147 @@ export function loadBundledChannelSecretContractApi(
   channelId: string,
 ): BundledChannelSecretContractApi | undefined {
   return loadBundledChannelPublicArtifact(channelId, ["secret-contract-api.js", "contract-api.js"]);
+}
+
+function orderedContractApiExtensions(): readonly string[] {
+  return RUNNING_FROM_BUILT_ARTIFACT
+    ? CONTRACT_API_EXTENSIONS
+    : ([...CONTRACT_API_EXTENSIONS.slice(3), ...CONTRACT_API_EXTENSIONS.slice(0, 3)] as const);
+}
+
+function resolvePluginContractApiPath(rootDir: string): string | null {
+  for (const extension of orderedContractApiExtensions()) {
+    const candidate = path.join(rootDir, `secret-contract-api${extension}`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  for (const extension of orderedContractApiExtensions()) {
+    const candidate = path.join(rootDir, `contract-api${extension}`);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function loadPluginContractModule(modulePath: string): BundledChannelContractApi {
+  return getCachedPluginModuleLoader({
+    cache: moduleLoaders,
+    modulePath,
+    importerUrl: import.meta.url,
+  })(modulePath) as BundledChannelContractApi;
+}
+
+function loadExternalChannelSecretContractFromRecord(
+  record: PluginManifestRecord,
+): BundledChannelSecretContractApi | undefined {
+  const contractPath = resolvePluginContractApiPath(record.rootDir);
+  if (!contractPath) {
+    return undefined;
+  }
+  const opened = openBoundaryFileSync({
+    absolutePath: contractPath,
+    rootPath: record.rootDir,
+    boundaryLabel: "plugin root",
+    rejectHardlinks: record.origin !== "bundled",
+    skipLexicalRootCheck: true,
+  });
+  if (!opened.ok) {
+    return undefined;
+  }
+  const safePath = opened.path;
+  fs.closeSync(opened.fd);
+  try {
+    const mod = loadPluginContractModule(safePath);
+    if (mod.collectRuntimeConfigAssignments || mod.secretTargetRegistryEntries) {
+      return mod;
+    }
+  } catch (error) {
+    if (process.env.OPENCLAW_DEBUG_CHANNEL_CONTRACT_API === "1") {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `[channel-contract-api] failed to load ${record.id} contract ${safePath}: ${detail}\n`,
+      );
+    }
+  }
+  return undefined;
+}
+
+function recordOwnsChannel(record: PluginManifestRecord, channelId: string): boolean {
+  return (
+    record.channels.includes(channelId) ||
+    Object.prototype.hasOwnProperty.call(record.channelConfigs ?? {}, channelId) ||
+    record.channelCatalogMeta?.id === channelId ||
+    record.packageChannel?.id === channelId
+  );
+}
+
+function listChannelSecretContractRecords(params: {
+  channelId: string;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
+}): PluginManifestRecord[] {
+  const workspaceDir = resolveAgentWorkspaceDir(
+    params.config,
+    resolveDefaultAgentId(params.config),
+    params.env,
+  );
+  const snapshot = loadPluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir,
+    env: params.env,
+  });
+  return snapshot.plugins
+    .filter((record) => record.origin !== "bundled")
+    .filter((record) => recordOwnsChannel(record, params.channelId))
+    .filter(
+      (record) => !params.loadablePluginOrigins || params.loadablePluginOrigins.has(record.id),
+    )
+    .toSorted((left, right) => {
+      if (left.id === params.channelId && right.id !== params.channelId) {
+        return -1;
+      }
+      if (right.id === params.channelId && left.id !== params.channelId) {
+        return 1;
+      }
+      return left.id.localeCompare(right.id);
+    });
+}
+
+export function loadChannelSecretContractApi(params: {
+  channelId: string;
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
+}): BundledChannelSecretContractApi | undefined {
+  const bundled = loadBundledChannelSecretContractApi(params.channelId);
+  if (bundled) {
+    return bundled;
+  }
+  const env = params.env ?? process.env;
+  for (const record of listChannelSecretContractRecords({
+    channelId: params.channelId,
+    config: params.config,
+    env,
+    loadablePluginOrigins: params.loadablePluginOrigins,
+  })) {
+    const contract = loadExternalChannelSecretContractFromRecord(record);
+    if (contract) {
+      return contract;
+    }
+  }
+  return undefined;
+}
+
+export function loadChannelSecretContractApiForRecord(
+  record: PluginManifestRecord,
+): BundledChannelSecretContractApi | undefined {
+  if (record.origin === "bundled") {
+    return loadBundledChannelSecretContractApi(record.id);
+  }
+  return loadExternalChannelSecretContractFromRecord(record);
 }
 
 export type BundledChannelSecurityContractApi = Pick<

--- a/src/secrets/runtime-config-collectors-channels.test.ts
+++ b/src/secrets/runtime-config-collectors-channels.test.ts
@@ -3,27 +3,27 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { ResolverContext } from "./runtime-shared.js";
 
 const getBootstrapChannelSecrets = vi.fn();
-const loadBundledChannelSecretContractApi = vi.fn();
+const loadChannelSecretContractApi = vi.fn();
 
 vi.mock("../channels/plugins/bootstrap-registry.js", () => ({
   getBootstrapChannelSecrets,
 }));
 
 vi.mock("./channel-contract-api.js", () => ({
-  loadBundledChannelSecretContractApi,
+  loadChannelSecretContractApi,
 }));
 
 describe("runtime channel config collectors", () => {
   beforeEach(() => {
     getBootstrapChannelSecrets.mockReset();
-    loadBundledChannelSecretContractApi.mockReset();
+    loadChannelSecretContractApi.mockReset();
   });
 
   it("uses the bundled channel contract-api collector when bootstrap secrets are unavailable", async () => {
     const { collectChannelConfigAssignments } =
       await import("./runtime-config-collectors-channels.js");
     const collectRuntimeConfigAssignments = vi.fn();
-    loadBundledChannelSecretContractApi.mockReturnValue({
+    loadChannelSecretContractApi.mockReturnValue({
       collectRuntimeConfigAssignments,
     });
     getBootstrapChannelSecrets.mockReturnValue(undefined);
@@ -42,7 +42,12 @@ describe("runtime channel config collectors", () => {
       context: {} as ResolverContext,
     });
 
-    expect(loadBundledChannelSecretContractApi).toHaveBeenCalledWith("bluebubbles");
+    expect(loadChannelSecretContractApi).toHaveBeenCalledWith({
+      channelId: "bluebubbles",
+      config: expect.any(Object),
+      env: undefined,
+      loadablePluginOrigins: undefined,
+    });
     expect(collectRuntimeConfigAssignments).toHaveBeenCalledOnce();
     expect(getBootstrapChannelSecrets).not.toHaveBeenCalled();
   });
@@ -51,7 +56,7 @@ describe("runtime channel config collectors", () => {
     const { collectChannelConfigAssignments } =
       await import("./runtime-config-collectors-channels.js");
     const collectRuntimeConfigAssignments = vi.fn();
-    loadBundledChannelSecretContractApi.mockReturnValue(undefined);
+    loadChannelSecretContractApi.mockReturnValue(undefined);
     getBootstrapChannelSecrets.mockReturnValue({
       collectRuntimeConfigAssignments,
     });
@@ -66,7 +71,12 @@ describe("runtime channel config collectors", () => {
       context: {} as ResolverContext,
     });
 
-    expect(loadBundledChannelSecretContractApi).toHaveBeenCalledWith("legacy");
+    expect(loadChannelSecretContractApi).toHaveBeenCalledWith({
+      channelId: "legacy",
+      config: expect.any(Object),
+      env: undefined,
+      loadablePluginOrigins: undefined,
+    });
     expect(getBootstrapChannelSecrets).toHaveBeenCalledWith("legacy");
     expect(collectRuntimeConfigAssignments).toHaveBeenCalledOnce();
   });

--- a/src/secrets/runtime-config-collectors-channels.ts
+++ b/src/secrets/runtime-config-collectors-channels.ts
@@ -1,19 +1,26 @@
 import { getBootstrapChannelSecrets } from "../channels/plugins/bootstrap-registry.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadBundledChannelSecretContractApi } from "./channel-contract-api.js";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import { loadChannelSecretContractApi } from "./channel-contract-api.js";
 import { type ResolverContext, type SecretDefaults } from "./runtime-shared.js";
 
 export function collectChannelConfigAssignments(params: {
   config: OpenClawConfig;
   defaults: SecretDefaults | undefined;
   context: ResolverContext;
+  loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
 }): void {
   const channelIds = Object.keys(params.config.channels ?? {});
   if (channelIds.length === 0) {
     return;
   }
   for (const channelId of channelIds) {
-    const contract = loadBundledChannelSecretContractApi(channelId);
+    const contract = loadChannelSecretContractApi({
+      channelId,
+      config: params.config,
+      env: params.context.env,
+      loadablePluginOrigins: params.loadablePluginOrigins,
+    });
     const collectRuntimeConfigAssignments =
       contract?.collectRuntimeConfigAssignments ??
       getBootstrapChannelSecrets(channelId)?.collectRuntimeConfigAssignments;

--- a/src/secrets/runtime-config-collectors.ts
+++ b/src/secrets/runtime-config-collectors.ts
@@ -22,6 +22,7 @@ export function collectConfigAssignments(params: {
     config: params.config,
     defaults,
     context: params.context,
+    loadablePluginOrigins: params.loadablePluginOrigins,
   });
 
   collectPluginConfigAssignments({

--- a/src/secrets/runtime-external-channel-origin-discovery.test.ts
+++ b/src/secrets/runtime-external-channel-origin-discovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { loadPluginMetadataSnapshotMock, loadChannelSecretContractApiMock } = vi.hoisted(() => ({
+  loadPluginMetadataSnapshotMock: vi.fn(),
+  loadChannelSecretContractApiMock: vi.fn(),
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: loadPluginMetadataSnapshotMock,
+  listPluginOriginsFromMetadataSnapshot: (snapshot: {
+    plugins: Array<{ id: string; origin: string }>;
+  }) => new Map(snapshot.plugins.map((record) => [record.id, record.origin])),
+}));
+
+vi.mock("./channel-contract-api.js", () => ({
+  loadChannelSecretContractApi: loadChannelSecretContractApiMock,
+}));
+
+import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
+
+const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
+
+describe("secrets runtime external channel origin discovery", () => {
+  it("discovers loadable plugins for channel SecretRefs when plugins.entries is absent", async () => {
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [{ id: "discord", origin: "global" }],
+    });
+    loadChannelSecretContractApiMock.mockReturnValue({
+      collectRuntimeConfigAssignments: (params: {
+        config: { channels?: { discord?: { token?: unknown } } };
+        context: {
+          assignments: Array<{
+            ref: { source: "env"; provider: "default"; id: string };
+            path: string;
+            expected: "string";
+            apply: (value: unknown) => void;
+          }>;
+        };
+      }) => {
+        const token = params.config.channels?.discord?.token;
+        if (!token || typeof token !== "object" || Array.isArray(token)) {
+          return;
+        }
+        params.context.assignments.push({
+          ref: token as { source: "env"; provider: "default"; id: string },
+          path: "channels.discord.token",
+          expected: "string",
+          apply: (value) => {
+            if (params.config.channels?.discord) {
+              params.config.channels.discord.token = value;
+            }
+          },
+        });
+      },
+    });
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: asConfig({
+        channels: {
+          discord: {
+            token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+          },
+        },
+      }),
+      env: {
+        DISCORD_BOT_TOKEN: "resolved-discord-token",
+      },
+      includeAuthStoreRefs: false,
+    });
+
+    expect(snapshot.config.channels?.discord?.token).toBe("resolved-discord-token");
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalled();
+    expect(loadChannelSecretContractApiMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "discord",
+        loadablePluginOrigins: new Map([["discord", "global"]]),
+      }),
+    );
+  });
+});

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -176,6 +176,16 @@ function hasConfiguredPluginEntries(config: OpenClawConfig): boolean {
   );
 }
 
+function hasConfiguredChannelEntries(config: OpenClawConfig): boolean {
+  const channels = config.channels;
+  return (
+    !!channels &&
+    typeof channels === "object" &&
+    !Array.isArray(channels) &&
+    Object.keys(channels).some((channelId) => channelId !== "defaults")
+  );
+}
+
 function createEmptyRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata {
   return {
     search: {
@@ -365,7 +375,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
   } = await loadRuntimePrepareHelpers();
   const loadablePluginOrigins =
     params.loadablePluginOrigins ??
-    (hasConfiguredPluginEntries(sourceConfig)
+    (hasConfiguredPluginEntries(sourceConfig) || hasConfiguredChannelEntries(sourceConfig)
       ? await resolveLoadablePluginOrigins({ config: sourceConfig, env: runtimeEnv })
       : new Map<string, PluginOrigin>());
   const context = createResolverContext({

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -1,6 +1,6 @@
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { loadBundledChannelSecretContractApi } from "./channel-contract-api.js";
+import { loadChannelSecretContractApiForRecord } from "./channel-contract-api.js";
 import type { SecretTargetRegistryEntry } from "./target-registry-types.js";
 
 const SECRET_INPUT_SHAPE = "secret_input"; // pragma: allowlist secret
@@ -85,20 +85,20 @@ function listBundledPluginConfigSecretTargetRegistryEntries(
 }
 
 function listChannelSecretTargetRegistryEntries(
-  bundledPlugins: readonly PluginManifestRecord[],
+  channelPlugins: readonly PluginManifestRecord[],
 ): SecretTargetRegistryEntry[] {
   const entries: SecretTargetRegistryEntry[] = [];
 
-  for (const record of bundledPlugins) {
+  for (const record of channelPlugins) {
     const channelIds = record.channels;
     if (channelIds.length === 0) {
       continue;
     }
     try {
-      const contractApi = loadBundledChannelSecretContractApi(record.id);
+      const contractApi = loadChannelSecretContractApiForRecord(record);
       entries.push(...(contractApi?.secretTargetRegistryEntries ?? []));
     } catch {
-      // Ignore bundled channels that do not expose a usable secret contract artifact.
+      // Ignore channels that do not expose a usable secret contract artifact.
     }
   }
   return entries;
@@ -449,15 +449,17 @@ export function getSecretTargetRegistry(): SecretTargetRegistryEntry[] {
   if (cachedSecretTargetRegistry) {
     return cachedSecretTargetRegistry;
   }
-  const bundledPlugins = loadPluginMetadataSnapshot({
+  const plugins = loadPluginMetadataSnapshot({
     config: {},
     env: process.env,
-  }).plugins.filter((record) => record.origin === "bundled");
+  }).plugins;
+  const bundledPlugins = plugins.filter((record) => record.origin === "bundled");
+  const channelPlugins = plugins.filter((record) => record.channels.length > 0);
   cachedSecretTargetRegistry = [
     ...CORE_SECRET_TARGET_REGISTRY,
     ...listBundledWebProviderSecretTargetRegistryEntries(bundledPlugins),
     ...listBundledPluginConfigSecretTargetRegistryEntries(bundledPlugins),
-    ...listChannelSecretTargetRegistryEntries(bundledPlugins),
+    ...listChannelSecretTargetRegistryEntries(channelPlugins),
   ];
   return cachedSecretTargetRegistry;
 }

--- a/src/secrets/target-registry-query.ts
+++ b/src/secrets/target-registry-query.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadBundledChannelSecretContractApi } from "./channel-contract-api.js";
+import { loadChannelSecretContractApi } from "./channel-contract-api.js";
 import { getPath } from "./path-utils.js";
 import { getCoreSecretTargetRegistry, getSecretTargetRegistry } from "./target-registry-data.js";
 import {
@@ -32,10 +32,7 @@ let compiledCoreOpenClawTargetState: {
   targetsByType: Map<string, CompiledTargetRegistryEntry[]>;
 } | null = null;
 
-const compiledBundledChannelOpenClawTargets = new Map<
-  string,
-  CompiledTargetRegistryEntry[] | null
->();
+const compiledChannelOpenClawTargets = new Map<string, CompiledTargetRegistryEntry[] | null>();
 
 function buildTargetTypeIndex(
   compiledSecretTargetRegistry: CompiledTargetRegistryEntry[],
@@ -112,21 +109,25 @@ function getCompiledCoreOpenClawTargetState() {
   return compiledCoreOpenClawTargetState;
 }
 
-function getCompiledBundledChannelOpenClawTargets(
+function getCompiledChannelOpenClawTargets(
   channelId: string,
 ): CompiledTargetRegistryEntry[] | null {
   const normalizedChannelId = channelId.trim();
   if (!normalizedChannelId) {
     return null;
   }
-  if (compiledBundledChannelOpenClawTargets.has(normalizedChannelId)) {
-    return compiledBundledChannelOpenClawTargets.get(normalizedChannelId) ?? null;
+  if (compiledChannelOpenClawTargets.has(normalizedChannelId)) {
+    return compiledChannelOpenClawTargets.get(normalizedChannelId) ?? null;
   }
   const compiledEntries =
-    loadBundledChannelSecretContractApi(normalizedChannelId)
+    loadChannelSecretContractApi({
+      channelId: normalizedChannelId,
+      config: {} as OpenClawConfig,
+      env: process.env,
+    })
       ?.secretTargetRegistryEntries?.filter((entry) => entry.configFile === "openclaw.json")
       .map(compileTargetRegistryEntry) ?? null;
-  compiledBundledChannelOpenClawTargets.set(normalizedChannelId, compiledEntries);
+  compiledChannelOpenClawTargets.set(normalizedChannelId, compiledEntries);
   return compiledEntries;
 }
 
@@ -327,12 +328,11 @@ export function resolveConfigSecretTargetByPath(pathSegments: string[]): Resolve
     return resolved;
   }
 
-  const explicitBundledChannelId =
-    pathSegments[0] === "channels" ? (pathSegments[1]?.trim() ?? "") : "";
-  const explicitBundledChannelEntries = explicitBundledChannelId
-    ? getCompiledBundledChannelOpenClawTargets(explicitBundledChannelId)
+  const explicitChannelId = pathSegments[0] === "channels" ? (pathSegments[1]?.trim() ?? "") : "";
+  const explicitChannelEntries = explicitChannelId
+    ? getCompiledChannelOpenClawTargets(explicitChannelId)
     : null;
-  for (const entry of explicitBundledChannelEntries ?? []) {
+  for (const entry of explicitChannelEntries ?? []) {
     if (!entry.includeInPlan) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Problem: after the 2026.5.2 plugin split, channel SecretRef collection still used the bundled-only channel contract loader.
- Why it matters: externalized channel plugins such as Discord and BlueBubbles could leave SecretRefs unresolved at runtime, while related status/setup/tool paths could crash or silently use stale config.
- What changed: added a generic channel secret-contract loader for external plugin root sidecars, wired it into runtime snapshots and secret target discovery, and hardened Telegram disabled-account enumeration, BlueBubbles webhook auth, and late-bound web_search config.
- What did NOT change (scope boundary): no config migration, no changelog entry, no bundled channel-specific behavior moved into core beyond the generic contract loading seam.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #76335
- Fixes #76369
- Fixes #76371
- Fixes #76416
- Related #76383
- Related #76385
- Related #76410
- Related #76411
- Related #76429
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: channel SecretRef materialization still depended on bundled channel public artifacts, while 2026.5.2 externalized multiple channel plugins that publish their secret contracts as plugin package sidecars.
- Missing detection / guardrail: no regression covered channel-only configs without `plugins.entries`, external plugin sidecar secret contracts, or raw SecretRef values reaching late webhook/tool/status paths.
- Contributing context (if known): the broader plugin externalization refactor moved install/runtime ownership without a matching generic channel secret-contract discovery path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/secrets/channel-contract-api.external.test.ts`, `src/secrets/runtime-external-channel-origin-discovery.test.ts`, `extensions/telegram/src/accounts.test.ts`, `extensions/bluebubbles/src/monitor.webhook-auth.test.ts`, `src/agents/tools/web-tools.enabled-defaults.test.ts`.
- Scenario the test should lock in: external channel contract sidecars are loaded, channel-only configs discover plugin origins, disabled Telegram accounts do not resolve tokens, BlueBubbles unresolved webhook password refs fail closed, and late-bound web_search uses the active runtime config.
- Why this is the smallest reliable guardrail: each test isolates one broken seam without needing live Discord, BlueBubbles, Telegram, or Brave credentials.
- Existing test that already covers this (if any): `extensions/discord/src/setup-account-state.test.ts` already covered unresolved Discord setup-state SecretRefs and now keeps that behavior explicit.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

SecretRef-backed channel credentials in externalized plugins resolve through the active runtime snapshot again. BlueBubbles webhook auth rejects unresolved SecretRef passwords without crashing, disabled Telegram accounts are skipped before token resolution, and sub-agent late-bound web_search uses the active runtime config.

## Diagram (if applicable)

```text
Before:
channels.discord.token SecretRef -> bundled-only contract lookup -> no assignment -> unresolved runtime value

After:
channels.discord.token SecretRef -> external plugin sidecar contract -> runtime assignment -> resolved value
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: the loader now reads secret contract sidecars from loadable external channel plugin roots. It uses plugin metadata ownership checks, loadable-origin filtering where available, root boundary checks, and hardlink rejection for non-bundled plugin files.

## Repro + Verification

### Environment

- OS: macOS local, Linux Testbox
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord, BlueBubbles, Telegram, Brave web_search
- Relevant config (redacted): SecretRef-backed channel credentials and web_search provider config

### Steps

1. Apply only the regression tests to the pre-fix merge-base.
2. Run the targeted tests for web_search, Telegram, BlueBubbles, and generic channel contract/runtime discovery.
3. Run the same targeted tests and `pnpm check:changed` after the fix.

### Expected

- Pre-fix tests fail for unresolved external channel contracts/raw SecretRefs.
- Fixed branch passes targeted tests and changed gate.

### Actual

- Pre-fix red proof: web_search passed `config: undefined`; Telegram resolved a disabled account SecretRef; BlueBubbles called `.trim()` on a SecretRef object; generic channel contract tests failed because `loadChannelSecretContractApi` did not exist and runtime still used the bundled-only loader.
- Fixed branch passed the targeted suite and `pnpm check:changed` in Testbox after rebasing onto current `origin/main`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted red/green tests for generic external channel contracts, runtime origin discovery, Telegram disabled accounts, BlueBubbles webhook auth, and late-bound web_search runtime config; broad `pnpm check:changed` in Testbox.
- Edge cases checked: external plugin outside the loadable origin set is skipped; unresolved BlueBubbles webhook SecretRef fails closed; channel-only config without `plugins.entries` still discovers plugin origins.
- What you did **not** verify: live Discord, Telegram, BlueBubbles, or Brave API calls.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: external channel sidecar loading could include the wrong plugin when multiple plugins claim a channel id.
  - Mitigation: prefer exact channel-id ownership ordering and filter by loadable plugin origins when runtime discovery supplies them.
- Risk: raw unresolved SecretRefs could still reach owner-specific runtime paths.
  - Mitigation: added focused guards for the observed BlueBubbles and Telegram paths, plus a broad audit for direct raw SecretInput handling.
