### PR TITLE
fix(feishu): suppress separate text message for voice-note media sends

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -668,8 +668,12 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
       }
 
-      // Send text first if provided
-      if (text?.trim()) {
+      // Send text first if provided, but skip for voice-note media to avoid duplicate messages
+      const isVoiceAudio =
+        audioAsVoice === true ||
+        (mediaUrl && /\.(ogg|opus|mp3|m4a|aac|amr|wav|webm)$/i.test(mediaUrl));
+
+      if (text?.trim() && !isVoiceAudio) {
         await sendOutboundText({
           cfg,
           to,


### PR DESCRIPTION
## Problem

When the assistant replies with both text content and a voice audio attachment via `sendMedia`, the Feishu channel adapter sends two separate messages:
1. A text-only message
2. A voice/audio file message

This creates a poor UX where the recipient sees duplicate messages, and in some cases both render as voice bubbles.

## Fix

Detect voice media (by `audioAsVoice` flag or file extension) and skip the separate `sendOutboundText` call, letting only the voice message be delivered. Non-voice media and comment targets keep their current caption behavior.



## Checklist

- [x] Scoped narrowly to voice-only sends
- [x] Preserves captions for non-voice media and comment targets
- [ ] Tests added/updated (need maintainer guidance)

Fixes #76440

/cc @vincentkoc @steipete @MonkeyLeeT