### PR TITLE
fix(heartbeat): align response tool prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat history: preserve oversized transcript turns as explicit omitted-message placeholders while avoiding large JSONL parse stalls. Thanks @Marvinthebored and @vincentkoc.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Heartbeats/Codex: stop sending the legacy `HEARTBEAT_OK` prompt instruction when heartbeat turns have the structured `heartbeat_respond` tool, while keeping the text sentinel for legacy automatic heartbeat replies. Thanks @pashpashpash.
-- Heartbeats/Codex: keep structured heartbeat prompts aligned with actual `heartbeat_respond` tool availability and keep tool-disabled commitment check-ins on the legacy ack path. Thanks @pashpashpash.
+- Heartbeats/Codex: keep structured heartbeat prompts aligned with actual `heartbeat_respond` tool availability and keep tool-disabled commitment check-ins on the legacy ack path. Thanks @pashpashpash and @vincentkoc.
 - Agent runtimes: fail explicit plugin runtime selections honestly when the requested harness is unavailable instead of silently falling back to the embedded PI runtime. Thanks @pashpashpash.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat history: preserve oversized transcript turns as explicit omitted-message placeholders while avoiding large JSONL parse stalls. Thanks @Marvinthebored and @vincentkoc.
 - Gateway: preserve stack diagnostics when `chat.send` or agent attachment parsing/staging fails, improving image-send failure triage. Refs #63432. (#75135) Thanks @keen0206.
 - Heartbeats/Codex: stop sending the legacy `HEARTBEAT_OK` prompt instruction when heartbeat turns have the structured `heartbeat_respond` tool, while keeping the text sentinel for legacy automatic heartbeat replies. Thanks @pashpashpash.
+- Heartbeats/Codex: keep structured heartbeat prompts aligned with actual `heartbeat_respond` tool availability and keep tool-disabled commitment check-ins on the legacy ack path. Thanks @pashpashpash.
 - Agent runtimes: fail explicit plugin runtime selections honestly when the requested harness is unavailable instead of silently falling back to the embedded PI runtime. Thanks @pashpashpash.
 - Maintainer workflow: push prepared PR heads through GitHub's verified commit API by default and require an explicit override before git-protocol pushes can publish unsigned commits. Thanks @BunsDev.
 - Feishu: resolve setup/status probes through the selected/default account so multi-account configs with account-scoped app credentials show as configured and probeable. Fixes #72930. Thanks @brokemac79.

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -53,7 +53,6 @@ describe("qa scenario catalog", () => {
     const codexLeakConfig = readQaScenarioExecutionConfig("codex-harness-no-meta-leak") as
       | {
           harnessRuntime?: string;
-          harnessFallback?: string;
           expectedReply?: string;
           forbiddenReplySubstrings?: string[];
         }
@@ -73,7 +72,6 @@ describe("qa scenario catalog", () => {
     );
     expect(codexLeak.title).toBe("Codex harness no meta leak");
     expect(codexLeakConfig?.harnessRuntime).toBe("codex");
-    expect(codexLeakConfig?.harnessFallback).toBe("none");
     expect(JSON.stringify(codexLeak.execution.flow)).toContain("agentRuntime");
     expect(JSON.stringify(codexLeak.execution.flow)).not.toContain("embeddedHarness");
     expect(codexLeakConfig?.expectedReply).toBe("QA_LEAK_OK");

--- a/qa/scenarios/models/codex-harness-no-meta-leak.md
+++ b/qa/scenarios/models/codex-harness-no-meta-leak.md
@@ -11,7 +11,7 @@ coverage:
     - runtime.no-meta-leak
 objective: Verify the Codex app-server harness keeps coordination/meta chatter out of the visible reply.
 successCriteria:
-  - The scenario forces the Codex embedded harness and disables PI fallback.
+  - The scenario forces the Codex embedded harness.
   - The final visible reply includes the requested confirmation token.
   - The visible reply does not include internal coordination or progress chatter.
 docsRefs:
@@ -29,7 +29,6 @@ execution:
     requiredProvider: codex
     requiredModel: gpt-5.5
     harnessRuntime: codex
-    harnessFallback: none
     expectedReply: QA_LEAK_OK
     prompt: |-
       Think through your answer privately, but do not expose any internal planning, thread-context checks, or progress narration.
@@ -76,8 +75,6 @@ steps:
                         agentRuntime:
                           id:
                             expr: config.harnessRuntime
-                          fallback:
-                            expr: config.harnessFallback
             - call: waitForGatewayHealthy
               args:
                 - ref: env
@@ -94,11 +91,7 @@ steps:
                 expr: "snapshot.config.agents?.defaults?.agentRuntime?.id === config.harnessRuntime"
                 message:
                   expr: "`expected agentRuntime.id=${config.harnessRuntime}, got ${JSON.stringify(snapshot.config.agents?.defaults?.agentRuntime)}`"
-            - assert:
-                expr: "snapshot.config.agents?.defaults?.agentRuntime?.fallback === config.harnessFallback"
-                message:
-                  expr: "`expected agentRuntime.fallback=${config.harnessFallback}, got ${JSON.stringify(snapshot.config.agents?.defaults?.agentRuntime)}`"
-    detailsExpr: "env.providerMode === 'live-frontier' ? `provider=${selected?.provider} model=${selected?.model} runtime=${snapshot.config.agents?.defaults?.agentRuntime?.id} fallback=${snapshot.config.agents?.defaults?.agentRuntime?.fallback}` : `mock mode: parsed ${scenario.id}`"
+    detailsExpr: "env.providerMode === 'live-frontier' ? `provider=${selected?.provider} model=${selected?.model} runtime=${snapshot.config.agents?.defaults?.agentRuntime?.id}` : `mock mode: parsed ${scenario.id}`"
   - name: keeps codex coordination chatter out of the visible reply
     actions:
       - if:

--- a/qa/scenarios/workspace/medium-game-plan-codex-harness.md
+++ b/qa/scenarios/workspace/medium-game-plan-codex-harness.md
@@ -12,7 +12,7 @@ coverage:
 objective: Verify the Codex app-server harness can plan and build a medium-complex self-contained browser game.
 successCriteria:
   - A live-frontier run fails fast unless the selected primary model is openai/gpt-5.5 with the Codex harness forced.
-  - The scenario forces the Codex embedded harness and disables PI fallback.
+  - The scenario forces the Codex embedded harness.
   - The prompt explicitly asks the agent to enter plan mode before editing.
   - The agent writes a self-contained HTML game with a canvas loop, controls, scoring, waves, pause, and restart.
 docsRefs:
@@ -30,7 +30,6 @@ execution:
     requiredProvider: codex
     requiredModel: gpt-5.5
     harnessRuntime: codex
-    harnessFallback: none
     artifactFile: star-garden-defenders-codex.html
     gameTitle: Star Garden Defenders
     minBytes: 5000
@@ -81,8 +80,6 @@ steps:
                         agentRuntime:
                           id:
                             expr: config.harnessRuntime
-                          fallback:
-                            expr: config.harnessFallback
             - call: waitForGatewayHealthy
               args:
                 - ref: env
@@ -99,11 +96,7 @@ steps:
                 expr: "snapshot.config.agents?.defaults?.agentRuntime?.id === config.harnessRuntime"
                 message:
                   expr: "`expected agentRuntime.id=${config.harnessRuntime}, got ${JSON.stringify(snapshot.config.agents?.defaults?.agentRuntime)}`"
-            - assert:
-                expr: "snapshot.config.agents?.defaults?.agentRuntime?.fallback === config.harnessFallback"
-                message:
-                  expr: "`expected agentRuntime.fallback=${config.harnessFallback}, got ${JSON.stringify(snapshot.config.agents?.defaults?.agentRuntime)}`"
-    detailsExpr: "env.providerMode === 'live-frontier' ? `provider=${selected?.provider} model=${selected?.model} runtime=${snapshot.config.agents?.defaults?.agentRuntime?.id} fallback=${snapshot.config.agents?.defaults?.agentRuntime?.fallback}` : `mock mode: parsed ${scenario.id}`"
+    detailsExpr: "env.providerMode === 'live-frontier' ? `provider=${selected?.provider} model=${selected?.model} runtime=${snapshot.config.agents?.defaults?.agentRuntime?.id}` : `mock mode: parsed ${scenario.id}`"
   - name: builds the medium game artifact
     actions:
       - if:

--- a/qa/scenarios/workspace/medium-game-plan-pi-harness.md
+++ b/qa/scenarios/workspace/medium-game-plan-pi-harness.md
@@ -30,7 +30,6 @@ execution:
     requiredProvider: openai
     requiredModel: gpt-5.5
     harnessRuntime: pi
-    harnessFallback: pi
     artifactFile: star-garden-defenders-pi.html
     gameTitle: Star Garden Defenders
     minBytes: 5000
@@ -81,8 +80,6 @@ steps:
                         agentRuntime:
                           id:
                             expr: config.harnessRuntime
-                          fallback:
-                            expr: config.harnessFallback
             - call: waitForGatewayHealthy
               args:
                 - ref: env

--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -66,7 +66,7 @@ function configure() {
     defaults: {
       ...cfg.agents?.defaults,
       model: { primary: modelRef, fallbacks: [] },
-      agentRuntime: { id: "codex", fallback: "none" },
+      agentRuntime: { id: "codex" },
       workspace: path.join(state, "workspace"),
       skipBootstrap: true,
       timeoutSeconds: 420,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1116,6 +1116,8 @@ export async function runEmbeddedPiAgent(
             ownerOnlyToolAllowlist: params.ownerOnlyToolAllowlist,
             disableMessageTool: params.disableMessageTool,
             forceMessageTool: params.forceMessageTool,
+            enableHeartbeatTool: params.enableHeartbeatTool,
+            forceHeartbeatTool: params.forceHeartbeatTool,
             requireExplicitMessageTarget: params.requireExplicitMessageTarget,
             internalEvents: params.internalEvents,
             bootstrapPromptWarningSignaturesSeen,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -924,6 +924,8 @@ export async function runEmbeddedAttempt(
                 params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
               disableMessageTool: params.disableMessageTool,
               forceMessageTool: params.forceMessageTool,
+              enableHeartbeatTool: params.enableHeartbeatTool,
+              forceHeartbeatTool: params.forceHeartbeatTool,
               authProfileStore: params.authProfileStore,
               recordToolPrepStage: (name) => corePluginToolStages.mark(name),
               onYield: (message) => {

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -85,6 +85,10 @@ export type RunEmbeddedPiAgentParams = {
   promptMode?: PromptMode;
   /** Keep the message tool available even when a narrow profile would omit it. */
   forceMessageTool?: boolean;
+  /** Include the heartbeat response tool for structured heartbeat outcomes. */
+  enableHeartbeatTool?: boolean;
+  /** Keep the heartbeat response tool available even when a narrow profile would omit it. */
+  forceHeartbeatTool?: boolean;
   /** Allow runtime plugins for this run to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
   sessionFile: string;

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -59,6 +59,10 @@ export type GetReplyOptions = {
   suppressToolErrorWarnings?: boolean;
   /** If true, run the model without OpenClaw tools for this turn. */
   disableTools?: boolean;
+  /** If true, include the heartbeat response tool for structured heartbeat outcomes. */
+  enableHeartbeatTool?: boolean;
+  /** If true, keep the heartbeat response tool available even under narrow tool profiles. */
+  forceHeartbeatTool?: boolean;
   /**
    * If true, dispatch skips default tool/progress text messages and expects the
    * channel to surface progress via its own streaming/edit UX.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1441,6 +1441,8 @@ export async function runAgentTurnWithFallback(params: {
                 })(),
                 suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
                 disableTools: params.opts?.disableTools,
+                enableHeartbeatTool: params.opts?.enableHeartbeatTool,
+                forceHeartbeatTool: params.opts?.forceHeartbeatTool,
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
                 bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
                 images: params.opts?.images,

--- a/src/infra/heartbeat-runner.commitments.test.ts
+++ b/src/infra/heartbeat-runner.commitments.test.ts
@@ -67,6 +67,7 @@ describe("runHeartbeatOnce commitments", () => {
     sourceUserText?: string;
     sourceAssistantText?: string;
     legacyRawSourceText?: boolean;
+    visibleReplies?: "automatic" | "message_tool";
   }) {
     return await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       vi.stubEnv("OPENCLAW_STATE_DIR", tmpDir);
@@ -81,6 +82,7 @@ describe("runHeartbeatOnce commitments", () => {
             },
           },
         },
+        ...(params?.visibleReplies ? { messages: { visibleReplies: params.visibleReplies } } : {}),
         channels: { telegram: { allowFrom: ["*"] } },
         session: { store: storePath },
         commitments: { enabled: true },
@@ -125,6 +127,8 @@ describe("runHeartbeatOnce commitments", () => {
           expect(ctx.Body).not.toContain(
             params?.sourceAssistantText ?? "Good luck, I hope it goes well.",
           );
+          expect(ctx.Body).toContain(HEARTBEAT_TOKEN);
+          expect(ctx.Body).not.toContain("heartbeat_respond");
           expect(ctx.OriginatingChannel).toBe("telegram");
           expect(ctx.OriginatingTo).toBe("155462274");
           expect(opts?.disableTools).toBe(true);
@@ -378,6 +382,22 @@ describe("runHeartbeatOnce commitments", () => {
 
   it("dismisses a due commitment when the heartbeat model declines to send a check-in", async () => {
     const { result, sendTelegram, store } = await setupCommitmentCase({
+      replyText: HEARTBEAT_TOKEN,
+    });
+
+    expect(result.status).toBe("ran");
+    expect(sendTelegram).not.toHaveBeenCalled();
+    expect(store.commitments[0]).toMatchObject({
+      id: "cm_interview",
+      status: "dismissed",
+      attempts: 1,
+      dismissedAtMs: nowMs,
+    });
+  });
+
+  it("keeps due commitment heartbeats on the text ack while tools are disabled", async () => {
+    const { result, sendTelegram, store } = await setupCommitmentCase({
+      visibleReplies: "message_tool",
       replyText: HEARTBEAT_TOKEN,
     });
 

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -133,9 +133,15 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("heartbeat_respond");
       expect(calledCtx.Body).toContain("notify=false");
       expect(calledCtx.Body).not.toContain("HEARTBEAT_OK");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
     });
   });
 
@@ -163,8 +169,14 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("heartbeat_respond");
       expect(calledCtx.Body).not.toContain("HEARTBEAT_OK");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
     });
   });
 
@@ -196,8 +208,14 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("heartbeat_respond");
       expect(calledCtx.Body).not.toContain("HEARTBEAT_OK");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
     });
   });
 
@@ -225,8 +243,14 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("heartbeat_respond");
       expect(calledCtx.Body).not.toContain("HEARTBEAT_OK");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
     });
   });
 
@@ -262,10 +286,16 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("Run the following periodic tasks");
       expect(calledCtx.Body).toContain("Check deployment status");
       expect(calledCtx.Body).toContain("heartbeat_respond");
       expect(calledCtx.Body).not.toContain("HEARTBEAT_OK");
+      expect(calledOpts.enableHeartbeatTool).toBe(true);
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
     });
   });
 
@@ -292,8 +322,14 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       });
 
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+      const calledOpts = replySpy.mock.calls[0]?.[1] as {
+        enableHeartbeatTool?: boolean;
+        forceHeartbeatTool?: boolean;
+      };
       expect(calledCtx.Body).toContain("HEARTBEAT_OK");
       expect(calledCtx.Body).not.toContain("heartbeat_respond");
+      expect(calledOpts.enableHeartbeatTool).toBeUndefined();
+      expect(calledOpts.forceHeartbeatTool).toBeUndefined();
     });
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -957,6 +957,7 @@ type HeartbeatPromptResolution = {
   hasRelayableExecCompletion: boolean;
   hasCronEvents: boolean;
   hasDueCommitments: boolean;
+  usesHeartbeatResponseTool: boolean;
 };
 
 function resolveDueHeartbeatTasks(
@@ -1047,7 +1048,7 @@ function resolveHeartbeatRunPrompt(params: {
   const hasCronEvents = cronEvents.length > 0;
   const commitmentPrompt = buildCommitmentHeartbeatPrompt({
     commitments: params.preflight.dueCommitments,
-    useHeartbeatResponseTool: params.useHeartbeatResponseTool,
+    useHeartbeatResponseTool: false,
   });
   const hasDueCommitments = Boolean(commitmentPrompt);
 
@@ -1077,6 +1078,7 @@ ${completionInstruction}`;
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
         hasDueCommitments: false,
+        usesHeartbeatResponseTool: params.useHeartbeatResponseTool,
       };
     }
     if (commitmentPrompt) {
@@ -1086,6 +1088,7 @@ ${completionInstruction}`;
         hasRelayableExecCompletion: false,
         hasCronEvents: false,
         hasDueCommitments,
+        usesHeartbeatResponseTool: false,
       };
     }
     return {
@@ -1094,20 +1097,22 @@ ${completionInstruction}`;
       hasRelayableExecCompletion: false,
       hasCronEvents: false,
       hasDueCommitments: false,
+      usesHeartbeatResponseTool: false,
     };
   }
 
+  const baseUsesHeartbeatResponseTool = params.useHeartbeatResponseTool && !commitmentPrompt;
   const basePrompt = hasExecCompletion
     ? buildExecEventPrompt(execEvents, {
         deliverToUser: params.canRelayToUser,
-        useHeartbeatResponseTool: params.useHeartbeatResponseTool,
+        useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
       })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, {
           deliverToUser: params.canRelayToUser,
-          useHeartbeatResponseTool: params.useHeartbeatResponseTool,
+          useHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
         })
-      : params.useHeartbeatResponseTool
+      : baseUsesHeartbeatResponseTool
         ? resolveHeartbeatResponseToolPrompt(params.cfg, params.heartbeat)
         : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
   const prompt = commitmentPrompt
@@ -1120,6 +1125,7 @@ ${completionInstruction}`;
     hasRelayableExecCompletion,
     hasCronEvents,
     hasDueCommitments,
+    usesHeartbeatResponseTool: baseUsesHeartbeatResponseTool,
   };
 }
 
@@ -1318,6 +1324,7 @@ export async function runHeartbeatOnce(opts: {
     hasRelayableExecCompletion,
     hasCronEvents,
     hasDueCommitments,
+    usesHeartbeatResponseTool,
   } = resolveHeartbeatRunPrompt({
     cfg,
     heartbeat,
@@ -1577,6 +1584,7 @@ export async function runHeartbeatOnce(opts: {
       isHeartbeat: true,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
       suppressToolErrorWarnings,
+      ...(usesHeartbeatResponseTool ? { enableHeartbeatTool: true, forceHeartbeatTool: true } : {}),
       ...(hasDueCommitments ? { disableTools: true, skillFilter: [] } : {}),
       // Heartbeat timeout is a per-run override so user turns keep the global default.
       timeoutOverrideSeconds,


### PR DESCRIPTION
## Summary

- Problem: #76338 can put heartbeat runs into `heartbeat_respond` prompt mode even when the runtime has not enabled the `heartbeat_respond` tool.
- Why it matters: Codex/provider-Codex heartbeats and commitment-only check-ins can be told to call a tool that is unavailable, so quiet `notify=false` outcomes stop being reliable.
- What changed: response-tool heartbeat prompts now explicitly enable/force the heartbeat tool through reply options, and commitment-only heartbeats stay on the legacy `HEARTBEAT_OK` ack path because that path intentionally disables tools.
- What did NOT change: due heartbeat tasks remain tool-capable, and the retired `agentRuntime.fallback` config key remains retired.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/76338 - landed regression this PR repairs.
- Related https://github.com/openclaw/openclaw/pull/75765 - original structured `heartbeat_respond` / Codex tool-reply foundation.
- Related https://github.com/openclaw/openclaw/pull/73785 - overlapping open no-op/sentinel suppression work; this PR does not replace it.
- Related https://github.com/openclaw/openclaw/issues/73149 - underlying no-op heartbeat leakage issue tracked by #73785; this PR does not close it.
- Related https://github.com/openclaw/openclaw/pull/74768 - open Codex app-server spawn compatibility work that touches legacy runtime fallback assumptions; this PR keeps fallback retired.
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: #76338 changed the heartbeat prompt contract without carrying the matching heartbeat-tool availability through `GetReplyOptions` into embedded PI tool construction, and without accounting for commitment-only runs that deliberately set `disableTools: true`.
- Missing detection / guardrail: tests checked prompt text but not the reply option/tool availability contract, and live Codex fixtures still wrote the removed `agentRuntime.fallback` key.
- Contributing context: Codex app-server heartbeat runs already force the tool internally, but provider-Codex/PI paths need the explicit option wiring.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/heartbeat-runner.tool-response.test.ts`, `src/infra/heartbeat-runner.commitments.test.ts`, `extensions/qa-lab/src/scenario-catalog.test.ts`
- Scenario the test should lock in: structured heartbeat prompts carry `enableHeartbeatTool`/`forceHeartbeatTool`; tool-disabled commitment prompts do not mention `heartbeat_respond`; QA/live Codex fixtures no longer write removed fallback config.
- Why this is the smallest reliable guardrail: it covers the prompt/options seam at the heartbeat runner boundary and keeps live scenario config parseable without running a full live Codex harness.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Heartbeat quiet/no-notify paths are more reliable for Codex/provider-Codex runs. Live Codex QA fixtures use the current `agentRuntime: { id: "codex" }` shape.

## Diagram (if applicable)

```text
Before:
heartbeat prompt -> asks for heartbeat_respond -> tool may be unavailable
commitment prompt -> asks for heartbeat_respond -> tools disabled

After:
structured heartbeat prompt -> enables heartbeat_respond -> structured notify result
commitment-only prompt -> HEARTBEAT_OK -> tools disabled remains safe
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk + mitigation: heartbeat runs that already use the structured heartbeat prompt now explicitly receive only the matching heartbeat response tool availability. Commitment-only runs keep tools disabled and use the text ack path.

## Repro + Verification

### Environment

- OS: macOS local; Linux Blacksmith Testbox
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A for unit coverage
- Integration/channel (if any): heartbeat runner, Telegram test harness, QA scenario catalog
- Relevant config (redacted): `messages.visibleReplies: "message_tool"`, `agentRuntime.id: "codex"`

### Steps

1. Run focused heartbeat tests.
2. Run QA scenario catalog test.
3. Run changed-file gate in Blacksmith Testbox.

### Expected

- Structured heartbeat prompts receive the heartbeat tool option plumbing.
- Commitment-only prompts do not request unavailable tools.
- QA Codex fixtures do not write removed fallback config.

### Actual

- Fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test:serial src/infra/heartbeat-runner.tool-response.test.ts src/infra/heartbeat-runner.commitments.test.ts -- --reporter=verbose`
  - `pnpm test:serial extensions/qa-lab/src/scenario-catalog.test.ts -- --reporter=verbose`
  - `OPENCLAW_TESTBOX=1 pnpm check:changed` via Testbox `tbx_01kqp3gh7gxvw8dv8qp2z2yqr6`
- Edge cases checked: message-tool mode, Codex harness session, auto-selected Codex model, env-forced Codex runtime, due heartbeat tasks, commitment-only heartbeat with tools disabled, QA scenario config parsing.
- What you did **not** verify: live Codex app-server run against a real account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: none; this updates repo-owned live fixtures to the current `agentRuntime.id`-only schema after #76338 retired `fallback`.

## Risks and Mitigations

- Risk: allowing the heartbeat tool in structured heartbeat runs could widen tools for commitment content.
  - Mitigation: commitment-only runs keep `disableTools: true` and use `HEARTBEAT_OK`; only structured heartbeat prompts enable the heartbeat response tool.
