### PR TITLE
feat(memory-core/dreaming): make NARRATIVE_TIMEOUT_MS env-overridable, raise default to 240s

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -783,7 +783,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(subagent.waitForRun.mock.calls[0][0]).toMatchObject({ timeoutMs: 60_000 });
+    expect(subagent.waitForRun.mock.calls[0][0]).toMatchObject({ timeoutMs: 240_000 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed for rem phase"),
     );

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -92,10 +92,29 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart.
+//
+// Default raised to 240 s (4 min) after field reports of reliable timeouts on
+// hosts with 15+ workspaces where embedded-agent prep alone consumes 13-22 s
+// before any token can be streamed (see github.com/openclaw/openclaw#76333).
+// The cap can be overridden per-host via the `OPENCLAW_DREAMING_NARRATIVE_TIMEOUT_MS`
+// environment variable for operators who need a tighter or looser budget
+// without rebuilding.
+const DEFAULT_NARRATIVE_TIMEOUT_MS = 240_000;
+
+function resolveNarrativeTimeoutMs(): number {
+  const raw = process.env.OPENCLAW_DREAMING_NARRATIVE_TIMEOUT_MS;
+  if (raw === undefined || raw === "") {
+    return DEFAULT_NARRATIVE_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_NARRATIVE_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+const NARRATIVE_TIMEOUT_MS = resolveNarrativeTimeoutMs();
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;


### PR DESCRIPTION
## Summary

Closes #76333.

The hardcoded 60s `NARRATIVE_TIMEOUT_MS` in `extensions/memory-core/src/dreaming-narrative.ts` is empirically too tight on hosts with many workspaces where embedded-agent prep alone consumes 13-22s before any token can be streamed. Every dreaming run on a 15-workspace host hit `status=timeout` for all three phases (light / REM / deep) from 2026-04-28 onward, silently breaking `DREAMS.md` while `MEMORY.md` promotions still worked.

## Changes

- Raise the default to `240_000` ms (4 min). Gives realistic latency headroom on warm gateways with realistic workspace counts; still bounded so a stalled subagent does not stall the cron job indefinitely.
- Allow operators to override at runtime via `OPENCLAW_DREAMING_NARRATIVE_TIMEOUT_MS`. Invalid / non-positive values fall back to the default. No recompile needed for tuning per host.
- Update the `timeoutMs` cleanup test to assert the new `240_000` default.

## Why env-var, not config-schema field

A config-schema knob (`dreaming.execution.defaults.narrativeTimeoutMs`) is an option, but: (a) the config surface is part of the public plugin contract and changes need docs/changelog/tests across more files; (b) operators most often need to tune timeouts in response to host pressure, not per-workspace config; (c) env-var keeps this tightly scoped to the bug. Happy to extend to a config field in a follow-up if a maintainer prefers — let me know.

## Field evidence

From #76333 (OpenClaw 2026.4.29, 15 active workspaces):

```
2026-04-28T03:00:15 narrative generation ended with status=timeout for light phase.
2026-04-29T03:00:15..16 timeout for light + rem.
2026-04-30T03:00:15..18 timeout for all three phases.
2026-05-01..02..03  same pattern, every day.
```

Embedded-run prep stages observed in the same gateway run:

```
[trace:embedded-run] prep stages: phase=stream-ready totalMs=13543
  workspace-sandbox:4ms, skills:1ms, core-plugin-tools:4466ms,
  bootstrap-context:7ms, bundle-tools:745ms, system-prompt:3563ms,
  session-resource-loader:1638ms, agent-session:2ms, stream-setup:3117ms

[trace:embedded-run] prep stages: phase=stream-ready totalMs=16290
```

13-22s eaten before any tokens stream, leaving `< 41s` of the old 60s budget — with multi-paragraph creative-write narrative + 15 workspaces, a hard fail every time.

## Test plan

- [x] `pnpm test extensions/memory-core/src/dreaming-narrative.test.ts` — updated cleanup test passes against new default.
- [ ] Manual verification on the reporter's host: drop the env-var, run `openclaw dreaming run-once`, confirm `DREAMS.md` populates for all three phases instead of `status=timeout` warnings.

Tagged reviewers per the codex review on #76333: @steipete (recent maintainer of `dreaming-narrative.ts`), @jalehman / @mjamiv (adjacent dreaming work).