### PR TITLE
test(gateway): align store-rpc test with lightweight sessions.list rows

### DIFF
--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -369,7 +369,9 @@ test("lists and patches session store via sessions.* RPC", async () => {
   );
   expect(mainAfterModelPatch?.modelProvider).toBe("openai");
   expect(mainAfterModelPatch?.model).toBe("gpt-test-a");
-  expect(mainAfterModelPatch?.agentRuntime).toEqual({ id: "pi", source: "implicit" });
+  // sessions.list returns lightweight rows that omit agentRuntime; the
+  // resolved value is asserted on the sessions.patch response above.
+  expect(mainAfterModelPatch?.agentRuntime).toBeUndefined();
 
   const compacted = await directSessionReq<{ ok: true; compacted: boolean }>("sessions.compact", {
     key: "agent:main:main",


### PR DESCRIPTION
## Summary

`sessions.list` returns lightweight rows that intentionally omit `agentRuntime` (see `7fe4ba013f` — "fix(gateway): add lightweight row path for sessions.list to reduce event-loop blocking"). The companion test cleanup in `a7d3da71f7` ("test(gateway): expect lightweight session list rows") updated `session-utils.test.ts` and `server.sessions.list-changed.test.ts` to use `toBeUndefined()` for the dropped fields, but missed an analogous assertion in `src/gateway/server.sessions.store-rpc.test.ts:372`, which still expected the full `agentRuntime` object.

The result is that every PR rebased onto current `main` fails the `checks-node-agentic-control-plane-agent-chat` shard with:

```
AssertionError: expected undefined to deeply equal { id: 'pi', source: 'implicit' }
 ❯ src/gateway/server.sessions.store-rpc.test.ts:372:45
```

This PR updates the missed assertion to `toBeUndefined()`, matching the established lightweight semantics. The full `agentRuntime` resolution is still asserted on the `sessions.patch` response a few lines above, which uses the non-lightweight path.

## Test plan

- [x] `pnpm test src/gateway/server.sessions.store-rpc.test.ts` — was failing on `origin/main`, now passes
- [x] Diff is one assertion + a clarifying comment; no production code change
- [x] Same pattern as `session-utils.test.ts` (line 1184 in `a7d3da71f7`): `expect(...sessions[0]?.agentRuntime).toBeUndefined();`

## Why a separate PR

Discovered while triaging CI failures on #76322 (security: bootstrap token DoS); the failure is unrelated to that branch's auth changes. Splitting it out so the fix can land independently and unblock all currently-red PRs.