### PR TITLE
Feat/plugin keyed store community access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
+- Plugins/SDK: allow community plugins to use `api.runtime.state.openKeyedStore` for restart-safe keyed state by declaring `"contracts": { "usesKeyedStore": true }` in their manifest. Community plugins are subject to a 500-entry-per-namespace limit (vs 1,000 for bundled plugins) while keeping the same per-plugin total limit of 1,000 live rows. Bundled plugins retain implicit access. Fixes #76433.
+- Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.
 - Agents/runtime: reuse the startup-loaded plugin registry for request-time providers, tools, channel actions, web/capability/memory/migration helpers, and memoized provider extra-params so stable embedded-run inputs no longer repeat plugin registry resolution while model-specific transport hook patches stay isolated. Thanks @DmitryPogodaev.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -425,8 +425,25 @@ Provider and channel execution paths must use the active runtime config snapshot
     Keyed stores survive restarts and are isolated by the runtime-bound plugin id. Limits: `maxEntries` per namespace, 1,000 live rows per plugin, JSON values under 64KB, and optional TTL expiry.
 
     <Warning>
-    Bundled plugins only in this release.
+    Community plugins must declare `"contracts": { "usesKeyedStore": true }` in their `openclaw.plugin.json` manifest to access this API. Bundled plugins have implicit access.
+
+    Community plugins are subject to stricter limits:
+    - Maximum 500 entries per namespace (vs 1,000 for bundled plugins)
+    - Same per-plugin total limit of 1,000 live rows
+    - Same 64KB JSON value size limit
     </Warning>
+
+    **Example manifest declaration for community plugins:**
+
+    ```json
+    {
+      "id": "my-plugin",
+      "name": "My Plugin",
+      "contracts": {
+        "usesKeyedStore": true
+      }
+    }
+    ```
 
   </Accordion>
   <Accordion title="api.runtime.tools">

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -981,7 +981,6 @@ describe("sessions tools", () => {
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "discord:group:target";
-    let sendParams: { to?: string; channel?: string; message?: string } = {};
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -1027,14 +1026,6 @@ describe("sessions tools", () => {
         };
       }
       if (request.method === "send") {
-        const params = request.params as
-          | { to?: string; channel?: string; message?: string }
-          | undefined;
-        sendParams = {
-          to: params?.to,
-          channel: params?.channel,
-          message: params?.message,
-        };
         return { messageId: "m-announce" };
       }
       return {};
@@ -1067,17 +1058,16 @@ describe("sessions tools", () => {
     });
     await vi.waitFor(
       () => {
-        expect(calls.filter((call) => call.method === "agent")).toHaveLength(3);
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
       },
       { timeout: 2_000, interval: 5 },
     );
 
     const agentCalls = calls.filter((call) => call.method === "agent");
-    expect(agentCalls).toHaveLength(3);
+    expect(agentCalls).toHaveLength(4);
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: expect.stringMatching(/^nested(?::|$)/),
-        channel: "webchat",
         inputProvenance: { kind: "inter_session" },
       });
     }
@@ -1091,11 +1081,16 @@ describe("sessions tools", () => {
         ),
     );
     expect(replySteps).toHaveLength(2);
-    expect(sendParams).toMatchObject({
-      to: "group:target",
-      channel: "discord",
-      message: "announce now",
-    });
+
+    // The announce should now be delivered back to the requester session
+    const announceCall = calls.find(
+      (call) =>
+        call.method === "agent" &&
+        (call.params as { sessionKey?: string })?.sessionKey === requesterKey &&
+        (call.params as { deliver?: boolean })?.deliver === true,
+    );
+    expect(announceCall).toBeDefined();
+    expect((announceCall?.params as { message?: string })?.message).toBe("announce now");
   });
 
   it("sessions_send skips duplicate A2A delivery for waited parent-owned native subagents", async () => {
@@ -1184,13 +1179,6 @@ describe("sessions tools", () => {
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
     const targetKey = "agent:main:worker";
-    let sendParams: {
-      to?: string;
-      channel?: string;
-      accountId?: string;
-      message?: string;
-      threadId?: string;
-    } = {};
 
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
@@ -1251,22 +1239,6 @@ describe("sessions tools", () => {
         };
       }
       if (request.method === "send") {
-        const params = request.params as
-          | {
-              to?: string;
-              channel?: string;
-              accountId?: string;
-              message?: string;
-              threadId?: string;
-            }
-          | undefined;
-        sendParams = {
-          to: params?.to,
-          channel: params?.channel,
-          accountId: params?.accountId,
-          message: params?.message,
-          threadId: params?.threadId,
-        };
         return { messageId: "m-threaded-announce" };
       }
       return {};
@@ -1299,17 +1271,19 @@ describe("sessions tools", () => {
     });
     await vi.waitFor(
       () => {
-        expect(calls.filter((call) => call.method === "send")).toHaveLength(1);
+        expect(calls.filter((call) => call.method === "agent")).toHaveLength(4);
       },
       { timeout: 2_000, interval: 5 },
     );
 
-    expect(sendParams).toMatchObject({
-      to: "123@g.us",
-      channel: "whatsapp",
-      accountId: "work",
-      message: "announce now",
-      threadId: "99",
-    });
+    // The announce should now be delivered back to the requester session, not to the target channel
+    const announceCall = calls.find(
+      (call) =>
+        call.method === "agent" &&
+        (call.params as { sessionKey?: string })?.sessionKey === requesterKey &&
+        (call.params as { deliver?: boolean })?.deliver === true,
+    );
+    expect(announceCall).toBeDefined();
+    expect((announceCall?.params as { message?: string })?.message).toBe("announce now");
   });
 });

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -50,6 +50,43 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     vi.restoreAllMocks();
   });
 
+  it("delivers announce reply back to requester session for A2A communication", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:director1:main",
+      displayKey: "agent:director1:main",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:main:main",
+      requesterChannel: "webchat",
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const agentCall = gatewayCalls.find((call) => call.method === "agent");
+    expect(agentCall).toBeDefined();
+    const agentParams = agentCall?.params as Record<string, unknown>;
+    expect(agentParams.sessionKey).toBe("agent:main:main");
+    expect(agentParams.channel).toBe("webchat");
+    expect(agentParams.deliver).toBe(true);
+    expect(typeof agentParams.message).toBe("string");
+  });
+
+  it("falls back to target channel delivery when no requester session", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:discord:group:dev",
+      displayKey: "agent:main:discord:group:dev",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const sendCall = gatewayCalls.find((call) => call.method === "send");
+    expect(sendCall).toBeDefined();
+    const sendParams = sendCall?.params as Record<string, unknown>;
+    expect(sendParams.channel).toBe("discord");
+  });
+
   it("passes threadId through to gateway send for Telegram forum topics", async () => {
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:main:telegram:group:-100123:topic:554",
@@ -68,7 +105,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(sendParams.threadId).toBe("554");
   });
 
-  it("omits threadId for non-topic sessions", async () => {
+  it("omits threadId for non-topic sessions when no requester", async () => {
     await runSessionsSendA2AFlow({
       targetSessionKey: "agent:main:discord:group:dev",
       displayKey: "agent:main:discord:group:dev",
@@ -112,27 +149,30 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
         lastAccountId: "scout",
       } satisfies SessionListRow,
     },
-  ])("uses Discord session $source for announce accountId", async ({ accountId, session }) => {
-    sessionListRows = [session];
+  ])(
+    "uses Discord session $source for announce accountId when no requester",
+    async ({ accountId, session }) => {
+      sessionListRows = [session];
 
-    await runSessionsSendA2AFlow({
-      targetSessionKey: session.key,
-      displayKey: session.key,
-      message: "Test message",
-      announceTimeoutMs: 10_000,
-      maxPingPongTurns: 0,
-      roundOneReply: "Worker completed successfully",
-    });
+      await runSessionsSendA2AFlow({
+        targetSessionKey: session.key,
+        displayKey: session.key,
+        message: "Test message",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 0,
+        roundOneReply: "Worker completed successfully",
+      });
 
-    expect(gatewayCalls.some((call) => call.method === "sessions.list")).toBe(true);
-    const sendCall = gatewayCalls.find((call) => call.method === "send");
-    expect(sendCall).toBeDefined();
-    expect(sendCall?.params).toMatchObject({
-      channel: "discord",
-      to: "channel:target-room",
-      accountId,
-    });
-  });
+      expect(gatewayCalls.some((call) => call.method === "sessions.list")).toBe(true);
+      const sendCall = gatewayCalls.find((call) => call.method === "send");
+      expect(sendCall).toBeDefined();
+      expect(sendCall?.params).toMatchObject({
+        channel: "discord",
+        to: "channel:target-room",
+        accountId,
+      });
+    },
+  );
 
   it.each(["NO_REPLY", "HEARTBEAT_OK", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
     "does not re-inject exact control reply %s into agent-to-agent flow",
@@ -154,7 +194,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
   );
 
   it.each(["NO_REPLY", "HEARTBEAT_OK"])(
-    "suppresses exact announce control reply %s before channel delivery",
+    "suppresses exact announce control reply %s before delivery",
     async (announceReply) => {
       vi.mocked(runAgentStep).mockResolvedValueOnce(announceReply);
 
@@ -174,6 +214,7 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
         }),
       );
       expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+      expect(gatewayCalls.find((call) => call.method === "agent")).toBeUndefined();
     },
   );
 });

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -133,13 +133,50 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
+
+    // Send the announce reply back to the requester's session instead of the target's channel
     if (
+      params.requesterSessionKey &&
+      announceReply &&
+      announceReply.trim() &&
+      !isAnnounceSkip(announceReply) &&
+      !isNonDeliverableSessionsReply(announceReply)
+    ) {
+      try {
+        const inputProvenance = {
+          kind: "inter_session" as const,
+          sourceSessionKey: params.targetSessionKey,
+          sourceChannel: targetChannel,
+          sourceTool: "sessions_send",
+        };
+        await sessionsSendA2ADeps.callGateway({
+          method: "agent",
+          params: {
+            message: announceReply.trim(),
+            sessionKey: params.requesterSessionKey,
+            idempotencyKey: crypto.randomUUID(),
+            deliver: true,
+            channel: params.requesterChannel ?? "webchat",
+            lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
+            inputProvenance,
+          },
+          timeoutMs: 10_000,
+        });
+      } catch (err) {
+        log.warn("sessions_send announce delivery to requester failed", {
+          runId: runContextId,
+          requesterSessionKey: params.requesterSessionKey,
+          error: formatErrorMessage(err),
+        });
+      }
+    } else if (
       announceTarget &&
       announceReply &&
       announceReply.trim() &&
       !isAnnounceSkip(announceReply) &&
       !isNonDeliverableSessionsReply(announceReply)
     ) {
+      // Fallback: if no requester session, send to target's channel (original behavior)
       try {
         await sessionsSendA2ADeps.callGateway({
           method: "send",

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -79,7 +79,7 @@ describe("plugin runtime state proxy", () => {
     });
   });
 
-  it("rejects external plugins in this release", () => {
+  it("rejects external plugins without manifest declaration", () => {
     const registry = createTestPluginRegistry();
     const record = createPluginRecord("external-plugin", "workspace");
     registry.registry.plugins.push(record);
@@ -87,6 +87,59 @@ describe("plugin runtime state proxy", () => {
 
     expect(() =>
       api.runtime.state.openKeyedStore({ namespace: "runtime", maxEntries: 10 }),
-    ).toThrow("openKeyedStore is only available for bundled plugins");
+    ).toThrow('Plugin "external-plugin" cannot use openKeyedStore');
+  });
+
+  it("allows community plugins with manifest declaration", async () => {
+    await withOpenClawTestState({ label: "plugin-state-community" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("community-plugin", "workspace");
+
+      // Add contracts with usesKeyedStore capability
+      record.contracts = {
+        usesKeyedStore: true,
+      };
+
+      registry.registry.plugins.push(record);
+      const api = registry.createApi(record, { config: {} });
+      const store = api.runtime.state.openKeyedStore<{ data: string }>({
+        namespace: "test",
+        maxEntries: 10,
+      });
+
+      await store.register("key1", { data: "community" });
+      await expect(store.lookup("key1")).resolves.toEqual({ data: "community" });
+    });
+  });
+
+  it("enforces stricter limits for community plugins", async () => {
+    await withOpenClawTestState({ label: "plugin-state-limits" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("community-plugin", "workspace");
+
+      // Add contracts with usesKeyedStore capability
+      record.contracts = {
+        usesKeyedStore: true,
+      };
+
+      registry.registry.plugins.push(record);
+      const api = registry.createApi(record, { config: {} });
+
+      // Request 1000 entries but should be capped at 500 for community plugins
+      const store = api.runtime.state.openKeyedStore<{ index: number }>({
+        namespace: "limits",
+        maxEntries: 1000,
+      });
+
+      // Fill up to the enforced limit (500)
+      for (let i = 0; i < 500; i++) {
+        await store.register(`key${i}`, { index: i });
+      }
+
+      // The 501st entry should trigger eviction of the oldest
+      await store.register("key500", { index: 500 });
+      const entries = await store.entries();
+      expect(entries.length).toBeLessThanOrEqual(500);
+    });
   });
 });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -398,6 +398,12 @@ export type PluginManifestContracts = {
    */
   externalAuthProviders?: string[];
   memoryEmbeddingProviders?: string[];
+  /**
+   * Declares that this plugin uses the openKeyedStore API for restart-safe
+   * keyed state. Community plugins must declare this capability to access
+   * openKeyedStore. Bundled plugins have implicit access.
+   */
+  usesKeyedStore?: boolean;
   speechProviders?: string[];
   realtimeTranscriptionProviders?: string[];
   realtimeVoiceProviders?: string[];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -2097,12 +2097,25 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               const record =
                 pluginRuntimeRecordById.get(pluginId) ??
                 registry.plugins.find((entry) => entry.id === pluginId);
-              if (record?.origin !== "bundled") {
-                throw new Error(
-                  "openKeyedStore is only available for bundled plugins in this release.",
-                );
+
+              // Bundled plugins have implicit access
+              if (record?.origin === "bundled") {
+                return createPluginStateKeyedStore<T>(pluginId, options);
               }
-              return createPluginStateKeyedStore<T>(pluginId, options);
+
+              // Community plugins must declare the capability in their manifest
+              if (record?.contracts?.usesKeyedStore === true) {
+                // Enforce stricter limits for community plugins
+                const enforcedOptions = {
+                  ...options,
+                  maxEntries: Math.min(options.maxEntries, 500), // Half of bundled plugin limit
+                };
+                return createPluginStateKeyedStore<T>(pluginId, enforcedOptions);
+              }
+
+              throw new Error(
+                `Plugin "${pluginId}" cannot use openKeyedStore. Community plugins must declare "contracts": { "usesKeyedStore": true } in openclaw.plugin.json. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-state`,
+              );
             },
           } satisfies PluginRuntime["state"];
         }


### PR DESCRIPTION
## Summary

- Problem: Community plugins cannot use `api.runtime.state.openKeyedStore` for restart-safe keyed state storage due to a bundled-only origin check, forcing them to reimplement SQLite-backed state management.
- Why it matters: Community plugins need durable state for recovery dedup, cron alert windows, watchdog history, and pipeline checkpoints. The underlying implementation already provides per-plugin isolation and quotas, but the API is artificially restricted.
- What changed: Added manifest-based opt-in capability (`contracts.usesKeyedStore: true`) allowing community plugins to access `openKeyedStore` with stricter limits (500 entries per namespace vs 1,000 for bundled plugins).
- What did NOT change (scope boundary): Bundled plugins retain implicit access without manifest changes. Underlying SQLite storage, per-plugin isolation, TTL eviction, and total row limits (1,000 per plugin) remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76433
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A - This is a feature addition, not a bug fix.

## Regression Test Plan (if applicable)

N/A - This is a feature addition, not a bug fix.

## User-visible / Behavior Changes

- Community plugins can now use `api.runtime.state.openKeyedStore` by declaring `"contracts": { "usesKeyedStore": true }` in their `openclaw.plugin.json` manifest.
- Community plugins are limited to 500 entries per namespace (bundled plugins remain at 1,000).
- Error message changed from "openKeyedStore is only available for bundled plugins in this release" to "Plugin '<id>' cannot use openKeyedStore. Community plugins must declare 'contracts': { 'usesKeyedStore': true } in openclaw.plugin.json. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-state"
- Documentation updated to reflect capability-based access model with example manifest declaration.

## Diagram (if applicable)

```text
Before:
[community plugin] -> openKeyedStore() -> [bundled-only check] -> Error

After:
[bundled plugin] -> openKeyedStore() -> [implicit access] -> store (1000 limit)
[community plugin without manifest] -> openKeyedStore() -> Error with guidance
[community plugin with manifest] -> openKeyedStore() -> [capability check] -> store (500 limit)