### PR TITLE
fix(memory): resolve false negative in doctor memory search diagnostic

### DIFF
--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -1,7 +1,12 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { normalizePluginsConfig } from "./config-state.js";
+import { resolveRuntimePluginRegistry } from "./loader.js";
 import { getMemoryRuntime } from "./memory-state.js";
+import {
+  buildPluginRuntimeLoadOptions,
+  resolvePluginRuntimeLoadContext,
+} from "./runtime/load-context.js";
 
 function resolveMemoryRuntimePluginIds(config: OpenClawConfig): string[] {
   const memorySlot = normalizePluginsConfig(config.plugins).slots.memory;
@@ -17,7 +22,12 @@ function ensureMemoryRuntime(cfg?: OpenClawConfig) {
   if (onlyPluginIds.length === 0) {
     return getMemoryRuntime();
   }
-  getLoadedRuntimePluginRegistry({ requiredPluginIds: onlyPluginIds });
+  // Fast path: reuse the active registry if the memory plugin is already loaded.
+  // Falls back to a full load (e.g. doctor CLI, where no registry is active yet).
+  if (!getLoadedRuntimePluginRegistry({ requiredPluginIds: onlyPluginIds })) {
+    const context = resolvePluginRuntimeLoadContext({ config: cfg });
+    resolveRuntimePluginRegistry(buildPluginRuntimeLoadOptions(context, { onlyPluginIds }));
+  }
   return getMemoryRuntime();
 }
 


### PR DESCRIPTION
## What

`openclaw doctor` reports "No active memory plugin is registered for the current config" even when the memory system is working correctly (memory_search returns results, embeddings are cached, Ollama is serving nomic-embed-text).

## Root Cause

A perf refactor ([8283c5d6cc](https://github.com/openclaw/openclaw/commit/8283c5d6cc)) swapped `resolveRuntimePluginRegistry` (which can trigger plugin loading) for `getLoadedRuntimePluginRegistry` (read-only). When the doctor CLI runs as a standalone process, no active plugin registry exists yet, so the read-only lookup returns undefined and the memory runtime is never initialized.

## Fix

If `getLoadedRuntimePluginRegistry` returns undefined (no active registry containing the memory plugin), fall back to `resolveRuntimePluginRegistry` with proper load options. This triggers the plugin's `register()` hook, which initializes the memory runtime.

**Before:**
```ts
getLoadedRuntimePluginRegistry({ requiredPluginIds: onlyPluginIds });
return getMemoryRuntime(); // always undefined in doctor CLI
```

**After:**
```ts
if (!getLoadedRuntimePluginRegistry({ requiredPluginIds: onlyPluginIds })) {
  const context = resolvePluginRuntimeLoadContext({ config: cfg });
  resolveRuntimePluginRegistry(buildPluginRuntimeLoadOptions(context, { onlyPluginIds }));
}
return getMemoryRuntime(); // now works
```

## Testing

- Type-checked via `tsc --noEmit`
- Existing tests pass (happy-path updated to mock registry hit)
- New test: "falls back to resolveRuntimePluginRegistry when the active registry does not contain the memory plugin"

## Reproduction

1. Configure `memorySearch.provider: "ollama"` with `model: "nomic-embed-text:latest"`
2. Verify `memory_search` tool works (returns results)
3. Run `openclaw doctor`
4. Observe: "No active memory plugin is registered for the current config" (false)

## Contributors

- **Jim Dawdy** ([@jimdawdy-hub](https://github.com/jimdawdy-hub)) — reporter, initial fix, PR author
- **Footnote AI** (Culture Drone, OpenClaw agent) — root cause analysis, initial implementation, investigation of compiled JS vs TypeScript source divergence
- **Claude Code** (Anthropic) — code review, final clean implementation, test updates

### Claude Code Review Summary

Claude identified four issues with the initial PR:

| # | Severity | Issue | Resolution |
|---|----------|-------|------------|
| 1 | **Critical** | Fallback was a no-op — `getMemoryRuntime()` called twice with no state mutation between calls (pure getter) | Replaced with `resolveRuntimePluginRegistry()` which triggers actual plugin loading |
| 2 | Bug | Missing null guard on `activeRegistry.plugins` — would throw TypeError if undefined | Removed the block entirely (covered by fix for #1) |
| 3 | Logic | Unscoped fallback checked only `registry.plugins` but the scoped check uses broader `registryContainsPluginIds` | Removed — superseded by the load-triggering fallback |
| 4 | Coverage | No test for fallback path; happy-path tests accidentally hit fallback instead of fast path | Added registry mock to happy-path tests; new test for fallback path |

All 7 tests passed after Claude's changes.

## AI Assistance

This PR was developed with AI assistance:
- **Footnote AI** (OpenClaw agent, Culture Mind register) — investigation and initial implementation
- **Claude Code** (Anthropic) — code review and final implementation

Degree of testing: fully tested (tsc + vitest).
