### PR TITLE
test(session): prevent regression where session repair trims final assistant response after tool usage

### DIFF
--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -465,6 +465,60 @@ describe("repairSessionFileIfNeeded", () => {
     expect(after).toBe(original);
   });
 
+  it("preserves final text assistant turn that follows a tool-call/tool-result pair", async () => {
+    // Regression: a trailing assistant message with stopReason "stop" that follows a
+    // tool-call turn and its matching tool-result must never be trimmed by the repair
+    // pass. This is the exact sequence produced by any agent run that calls at least
+    // one tool before returning a final text response, and it must survive intact so
+    // subsequent user messages are parented to the correct leaf node.
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const toolCallAssistant = {
+      type: "message",
+      id: "msg-asst-tc",
+      parentId: "msg-1",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "get_tasks", input: {} }],
+        stopReason: "toolUse",
+      },
+    };
+    const toolResult = {
+      type: "message",
+      id: "msg-tool-result",
+      parentId: "msg-asst-tc",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "get_tasks",
+        content: [{ type: "text", text: "Task A, Task B" }],
+        isError: false,
+      },
+    };
+    const finalAssistant = {
+      type: "message",
+      id: "msg-asst-final",
+      parentId: "msg-tool-result",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here are your tasks: Task A, Task B." }],
+        stopReason: "stop",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(toolCallAssistant)}\n${JSON.stringify(toolResult)}\n${JSON.stringify(finalAssistant)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+
+    expect(result.repaired).toBe(false);
+
+    const after = await fs.readFile(file, "utf-8");
+    expect(after).toBe(original);
+  });
+
   it("preserves assistant-only session history after the header", async () => {
     const { file } = await createTempSessionPath();
     const { header } = buildSessionHeaderAndMessage();


### PR DESCRIPTION
## TL;DR

Adds a regression test to ensure `repairSessionFileIfNeeded` does **not**
remove valid assistant responses (`stopReason="stop"`), which would otherwise
break multi-turn conversation continuity after tool usage.

---

## Problem

A previously identified bug in session repair logic could remove the final
assistant message in flows involving tool calls:

```
user → assistant(toolCall) → toolResult → assistant(stop)
```

If this final assistant message is trimmed, subsequent user messages are
attached to the `toolResult` node instead of the actual assistant response,
breaking conversation continuity.

---

## Invariant

> A completed assistant message (`stopReason="stop"`) must never be removed during session repair.

---

## What this PR does

Adds a regression test covering the exact failing sequence:

```
session-header
user
assistant(toolCall, stopReason=toolUse)
toolResult
assistant(text, stopReason=stop)  ← must be preserved
```

Verifies:
- `repairSessionFileIfNeeded` returns `repaired = false`
- Session file remains byte-identical after repair

---

## Why this matters

### User impact

- Prevents loss of conversation context after tool usage
- Avoids repeated or hallucinated responses in follow-up turns
- Ensures session integrity for real-world agent workflows

### System impact

- Guards against silent session state corruption
- Locks expected behavior for session repair logic

---

## Before vs After

### Before (buggy behavior)

```
assistant(stop) → ❌ trimmed
→ next user attaches to toolResult
→ context lost
```

### After (expected behavior)

```
assistant(stop) → ✅ preserved
→ next user attaches correctly
→ context intact
```

---

## Why existing tests were insufficient

The existing test `"preserves adjacent trailing tool-call and text assistant messages"` does not include a `toolResult` entry between the two assistant messages:

```
assistant(toolCall) → assistant(stop)   ← existing test
assistant(toolCall) → toolResult → assistant(stop)   ← real-world sequence (this PR)
```

Without the `toolResult` entry, the existing test does not cover the actual JSONL structure that triggers the regression.

---

## Safety

- No production code changes
- Only adds regression coverage
- Fully backward-compatible
- Narrow scope (session repair behavior only)

---

## Test plan

```
pnpm test src/agents/session-file-repair.test.ts
```

- All tests pass
- New test validates non-trimming of completed assistant messages after tool usage

---

## Related

- Bug report: `fix-trailing-assistant-trim-bug.md`
- Root cause: `isTrimmableTrailingAssistantEntry` predicate was too broad — did not guard `stopReason === "stop"`