### PR TITLE
fix(provider-transport): pass baseUrl hostname to SSRF guard so fake-IP proxies don't block model API calls

### DIFF
--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../infra/net/ssrf.js";
 import { resolveDebugProxySettings } from "../proxy-capture/env.js";
 import {
   buildProviderRequestDispatcherPolicy,
@@ -267,6 +268,18 @@ export function buildGuardedModelFetch(model: Model<Api>, timeoutMs?: number): t
   const requestConfig = resolveModelRequestPolicy(model);
   const dispatcherPolicy = buildProviderRequestDispatcherPolicy(requestConfig);
   const requestTimeoutMs = resolveModelRequestTimeoutMs(model, timeoutMs);
+  // Allowlist the configured provider hostname so fake-IP DNS proxy setups
+  // (sing-box / Clash / Surge) that resolve foreign provider hosts (e.g.
+  // `api.openai.com`, `generativelanguage.googleapis.com`, an internal
+  // LiteLLM proxy) into the 198.18.0.0/15 RFC 2544 benchmark range — or the
+  // fc00::/7 IPv6 ULA range — short-circuit the SSRF private-IP check.
+  // Matches the per-plugin pattern already used by ElevenLabs, OpenAI TTS,
+  // BlueBubbles, Feishu, Google-Meet and others. The provider hostname is
+  // operator-configured (via `models.providers.<id>.baseUrl` or the
+  // bundled-catalog default), so this is functionally equivalent to those
+  // plugins passing their own resolved base URL through
+  // `ssrfPolicyFromHttpBaseUrlAllowedHostname`.
+  const baseUrlPolicy = ssrfPolicyFromHttpBaseUrlAllowedHostname(model.baseUrl);
   return async (input, init) => {
     const request = input instanceof Request ? new Request(input, init) : undefined;
     const url =
@@ -303,7 +316,14 @@ export function buildGuardedModelFetch(model: Model<Api>, timeoutMs?: number): t
       // Provider transport intentionally keeps the secure default and never
       // replays unsafe request bodies across cross-origin redirects.
       allowCrossOriginUnsafeRedirectReplay: false,
-      ...(requestConfig.allowPrivateNetwork ? { policy: { allowPrivateNetwork: true } } : {}),
+      ...(baseUrlPolicy || requestConfig.allowPrivateNetwork
+        ? {
+            policy: {
+              ...(baseUrlPolicy ?? {}),
+              ...(requestConfig.allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+            },
+          }
+        : {}),
     });
     let response = result.response;
     if (shouldBypassLongSdkRetry(response)) {


### PR DESCRIPTION
## Summary

Companion to #74571 (public `tools.web.fetch` config) and #76530 (trusted web-tools endpoint policy). Fixes the third major fake-IP user-visible failure path: **all model API calls** (LiteLLM proxies, `api.openai.com`, `generativelanguage.googleapis.com`, `api.x.ai`, `api.anthropic.com`, etc).

On fake-IP DNS proxy setups (sing-box / Clash / Surge), every foreign provider hostname resolves into the 198.18.0.0/15 RFC 2544 benchmark range (or fc00::/7 IPv6 ULA). Currently the model transport guarded fetch only opts in via `requestConfig.allowPrivateNetwork`, which exempts RFC1918 private networks but not the fake-IP-only special-use ranges. The schema on `models.providers.<id>.request` doesn't accept `allowRfc2544BenchmarkRange` / `allowIpv6UniqueLocalRange` either, so users have no config-level escape hatch.

Symptom every fake-IP user sees:

```
[security] blocked URL fetch (url-fetch) target=https://api.openai.com/v1/audio/transcriptions
  reason=Blocked: resolves to private/internal/special-use IP address
[security] blocked URL fetch (url-fetch) target=https://generativelanguage.googleapis.com/...
  reason=Blocked: resolves to private/internal/special-use IP address
[image-generation] candidate failed: litellm/gpt-image-2:
  Blocked: resolves to private/internal/special-use IP address
```

## Change

Thread the resolved `model.baseUrl` hostname through `ssrfPolicyFromHttpBaseUrlAllowedHostname()` so the configured provider host short-circuits the SSRF private-IP check via `allowedHostnames`.

```diff
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../infra/net/ssrf.js";
…
+  const baseUrlPolicy = ssrfPolicyFromHttpBaseUrlAllowedHostname(model.baseUrl);
…
-      ...(requestConfig.allowPrivateNetwork ? { policy: { allowPrivateNetwork: true } } : {}),
+      ...(baseUrlPolicy || requestConfig.allowPrivateNetwork
+        ? {
+            policy: {
+              ...(baseUrlPolicy ?? {}),
+              ...(requestConfig.allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+            },
+          }
+        : {}),
```

## Why this is safe

This is the same pattern already used in the codebase by:

- ElevenLabs (`extensions/elevenlabs/speech-provider.ts`)
- OpenAI TTS (`extensions/openai/tts.ts`)
- BlueBubbles (`extensions/bluebubbles/src/client.ts`)
- Feishu (`extensions/feishu/src/streaming-card.ts`)
- Google Meet (`extensions/google-meet/src/oauth.ts`)
- LM Studio (`extensions/lmstudio/src/stream.ts`)
- Slack (`extensions/slack/src/send.ts`)
- Azure Speech, Ollama, GitHub Copilot embeddings, Kilocode

Each of those plugins resolves its own configured base URL and allowlists just that hostname. This commit moves the same allowlist into the shared transport so every provider that goes through `buildGuardedModelFetch` (i.e. all LLM chat / image / embedding / audio) benefits without each plugin having to copy the boilerplate.

The hostname is operator-configured (via `models.providers.<id>.baseUrl` or the bundled-catalog default), so allowlisting just the configured provider host is no broader trust than what the plugins above already grant their own configured hostnames.

## Test plan

- [x] Local repro: chat / image / Whisper calls failed with `SsrFBlockedError` on a fake-IP setup before the patch
- [x] After the patch + rebuild, chat / fallback (`litellm/claude-sonnet-4-6`), image (`litellm/gpt-image-2`), Whisper transcription, and `gemini-3-pro-image-preview` via internal LiteLLM all return real responses
- [x] Re-checked: requests to non-configured hostnames still fall through to the existing private-IP / cloud-metadata block (no regression — `allowedHostnames` only short-circuits the configured base URL host)
- [ ] CI: agent-runner / pi-embedded transport tests (existing test coverage in `provider-transport-fetch.test.ts` should still pass; happy to add a fake-IP regression test if maintainers prefer)

## Refs

- Refs #74351 — original fake-IP IPv6 ULA report
- Companion to #74571 — fixed `tools.web.fetch.ssrfPolicy`
- Companion to #76530 — fixes the trusted-web-tools-endpoint hardcoded policy
- This PR closes the last major fake-IP path: model transport / provider HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)