### PR TITLE
fix(whatsapp): use registry libsignal for Baileys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp/install: resolve Baileys' `libsignal` dependency from the npm registry so installs with pnpm `block-exotic-subdeps=true` no longer fail on a transitive GitHub tarball. Fixes #76539.
 - Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
 - Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.
 - Gateway/sessions: keep `sessions.list` polling responsive on large session stores by reusing list-safe session cache/indexes and returning a lightweight compaction checkpoint preview instead of heavyweight summaries. Thanks @rolandrscheel.

--- a/package.json
+++ b/package.json
@@ -1741,6 +1741,7 @@
       "hono": "4.12.14",
       "@hono/node-server": "1.19.14",
       "@aws-sdk/client-bedrock-runtime": "3.1024.0",
+      "@whiskeysockets/baileys@7.0.0-rc.9>libsignal": "2.0.1",
       "axios": "1.15.0",
       "follow-redirects": "1.16.0",
       "defu": "6.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   hono: 4.12.14
   '@hono/node-server': 1.19.14
   '@aws-sdk/client-bedrock-runtime': 3.1024.0
+  '@whiskeysockets/baileys@7.0.0-rc.9>libsignal': 2.0.1
   axios: 1.15.0
   follow-redirects: 1.16.0
   defu: 6.1.5
@@ -4492,10 +4493,6 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
-    version: 2.0.1
-
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     resolution: {integrity: sha512-RvTXH21sLpswEo8xLeQXcA/uWZauyNP1y+WI6b355+/o7sQ5wrvBkxt+NyhaJXJIQvbfdpl04LND4cmM+DTcNg==}
     cpu: [arm64]
@@ -5023,9 +5020,6 @@ packages:
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
-
-  curve25519-js@0.0.4:
-    resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -5930,6 +5924,9 @@ packages:
 
   koffi@2.16.1:
     resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
+
+  libsignal@2.0.1:
+    resolution: {integrity: sha512-kqdl/BK5i0WCa4NxhtiBsjSzztB/FtUp3mVVLKBFicWH8rDsq95tEIqNcCaVlflLxOm6T/HRb/zv8IsCe7aopA==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -11315,7 +11312,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: 2.0.1
       lru-cache: 11.3.5
       music-metadata: 11.12.3
       p-queue: 9.2.0
@@ -11330,11 +11327,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    dependencies:
-      curve25519-js: 0.0.4
-      protobufjs: 7.5.5
 
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
     optional: true
@@ -11832,8 +11824,6 @@ snapshots:
   css-what@6.2.2: {}
 
   cssom@0.5.0: {}
-
-  curve25519-js@0.0.4: {}
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -12956,6 +12946,10 @@ snapshots:
 
   koffi@2.16.1:
     optional: true
+
+  libsignal@2.0.1:
+    dependencies:
+      protobufjs: 7.5.5
 
   lie@3.3.0:
     dependencies:

--- a/test/scripts/baileys-pnpm-exotic-subdep.test.ts
+++ b/test/scripts/baileys-pnpm-exotic-subdep.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type RootPackageManifest = {
+  pnpm?: {
+    overrides?: Record<string, string>;
+  };
+};
+
+function readRootPackageManifest(): RootPackageManifest {
+  return JSON.parse(
+    fs.readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
+  ) as RootPackageManifest;
+}
+
+function readRootLockfile(): string {
+  return fs.readFileSync(path.resolve(process.cwd(), "pnpm-lock.yaml"), "utf8");
+}
+
+describe("Baileys pnpm dependency guardrail", () => {
+  it("keeps Baileys libsignal on a registry resolution for block-exotic-subdeps installs", () => {
+    const manifest = readRootPackageManifest();
+    const lockfile = readRootLockfile();
+
+    expect(manifest.pnpm?.overrides).toMatchObject({
+      "@whiskeysockets/baileys@7.0.0-rc.9>libsignal": "2.0.1",
+    });
+    expect(lockfile).toContain("'@whiskeysockets/baileys@7.0.0-rc.9>libsignal': 2.0.1");
+    expect(lockfile).toContain("libsignal: 2.0.1");
+    expect(lockfile).toContain("libsignal@2.0.1:");
+    expect(lockfile).not.toContain("@whiskeysockets/libsignal-node@https://codeload.github.com");
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: Baileys resolves its transitive `libsignal` dependency from a GitHub tarball, which fails installs when pnpm `block-exotic-subdeps=true` is enabled.
- Why it matters: a fresh install can fail before OpenClaw can reply to inbound messages, even when WhatsApp is not actively configured.
- What changed: added a scoped pnpm override so `@whiskeysockets/baileys@7.0.0-rc.9` resolves `libsignal` from the npm registry at `2.0.1`, refreshed the lockfile, and added a guardrail test.
- What did NOT change (scope boundary): no WhatsApp runtime behavior, channel setup flow, or Baileys source patch logic was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #76539
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Baileys 7.0.0-rc.9 depends on `libsignal` through a GitHub tarball resolution. pnpm treats that as an exotic transitive dependency and rejects it when `block-exotic-subdeps=true` is enabled.
- Missing detection / guardrail: the lockfile allowed the GitHub tarball resolution and had no test ensuring the bundled WhatsApp dependency graph stays registry-resolved for that package.
- Contributing context (if known): pnpm 10.26 added `blockExoticSubdeps`, and users can enable it in their install environment.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/baileys-pnpm-exotic-subdep.test.ts`
- Scenario the test should lock in: Baileys keeps `libsignal` on a registry lockfile entry and does not reintroduce the GitHub tarball resolution.
- Why this is the smallest reliable guardrail: the bug is in package resolution metadata, so asserting the manifest override and lockfile shape catches the regression without needing a live WhatsApp session.
- Existing test that already covers this (if any): N/A

## User-visible / Behavior Changes

Fresh installs using pnpm with `block-exotic-subdeps=true` should no longer fail on Baileys' transitive `libsignal` dependency.

## Diagram (if applicable)

```text
Before:
pnpm install -> Baileys -> libsignal GitHub tarball -> ERR_PNPM_EXOTIC_SUBDEP

After:
pnpm install -> Baileys -> libsignal@2.0.1 from npm registry -> install can continue
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0
- Runtime/container: Node v24.13.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): WhatsApp dependency graph
- Relevant config (redacted): pnpm `block-exotic-subdeps=true`

### Steps

1. In a temp package, install `@whiskeysockets/baileys@7.0.0-rc.9` with `pnpm install --config.block-exotic-subdeps=true --ignore-scripts --lockfile-only`.
2. Observe the install fail before this fix because `libsignal` resolves through a GitHub tarball.
3. Add the scoped override from this PR and rerun the same install command.

### Expected

- Baileys resolves `libsignal` from the npm registry and the install completes.

### Actual

- Before this fix, pnpm rejected the GitHub tarball as `ERR_PNPM_EXOTIC_SUBDEP`.
- After this fix, the temp install completed and the lockfile used `libsignal@2.0.1`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

```text
pnpm test test/scripts/baileys-pnpm-exotic-subdep.test.ts
pnpm test src/plugins/contracts/package-manifest.contract.test.ts
pnpm test:extension whatsapp
pnpm deps:root-ownership:check
pnpm plugins:sync:check
pnpm exec oxfmt --check --threads=1 package.json test/scripts/baileys-pnpm-exotic-subdep.test.ts CHANGELOG.md
git diff --check
```

Also verified in a temp package that `pnpm install --config.block-exotic-subdeps=true --ignore-scripts --lockfile-only` completes with the scoped override and resolves `libsignal@2.0.1`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted lockfile guardrail test, package manifest contract test, full WhatsApp extension test lane, dependency ownership guardrail, plugin version sync check, formatting, and diff whitespace.
- Edge cases checked: the lockfile no longer contains the `@whiskeysockets/libsignal-node` GitHub tarball resolution, and `pnpm why libsignal --filter ./extensions/whatsapp` points through Baileys to `libsignal@2.0.1`.
- What you did **not** verify: full `pnpm check:changed`, because these root package and lockfile changes select broad all-lane validation and no Testbox environment was available locally. I also did not run a live WhatsApp login session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the registry `libsignal@2.0.1` package differs from the GitHub tarball package metadata and may not exactly match Baileys' expected dependency internals.
  - Mitigation: Baileys imports the package as `libsignal`, the registry package exposes the expected package name, and the WhatsApp extension test lane passes.

AI-assisted: yes. I reviewed the diff and verified the behavior above before opening this PR.
