### PR TITLE
feat: add zero-api-key-web-search skill

### DIFF
--- a/skills/zero-api-key-web-search/SKILL.md
+++ b/skills/zero-api-key-web-search/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: zero-api-key-web-search
+description: Free web search, claim verification, and page browsing with optional Bright Data production SERP (7 engines) and Web Unlocker for blocked pages.
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["python3"], "pypi": ["zero-api-key-web-search"] },
+        "install":
+          [
+            {
+              "id": "pip",
+              "kind": "pip",
+              "package": "zero-api-key-web-search",
+              "label": "Install zero-api-key-web-search (pip)",
+            },
+          ],
+      },
+  }
+---
+
+# Zero-API-Key Web Search
+
+Web search, claim verification, and page browsing — free by default, production-ready with Bright Data.
+
+## Install
+
+```bash
+pip install -U zero-api-key-web-search
+```
+
+## Search (Free)
+
+```bash
+python3 -c "from zero_api_key_web_search import UltimateSearcher; s = UltimateSearcher(); print(s.search('python 3.13'))"
+```
+
+## Search (Production — 7 Engines)
+
+```bash
+export ZERO_SEARCH_BRIGHTDATA_API_KEY=your_key
+python3 -c "from zero_api_key_web_search import UltimateSearcher; s = UltimateSearcher(profile='production'); print(s.search('python 3.13'))"
+```
+
+Multi-engine: `providers=['brightdata']` with `engine='bing'`, `'duckduckgo'`, `'yandex'`, `'baidu'`, `'yahoo'`, or `'naver'`.
+
+## Claim Verification
+
+```bash
+python3 -c "from zero_api_key_web_search import UltimateSearcher; s = UltimateSearcher(); print(s.verify_claim('Python 3.13 is the latest stable release'))"
+```
+
+## Browse Page (with Web Unlocker)
+
+```bash
+python3 -c "from zero_api_key_web_search.browse_page import browse; print(browse('https://example.com'))"
+```
+
+Auto-fallback on 403/429 via Bright Data Web Unlocker when configured.
+
+## MCP Server
+
+```bash
+pip install zero-api-key-web-search[mcp]
+zero-api-key-web-search-mcp
+```
+
+8 tools: `search_web`, `search_web_results`, `verify_claim`, `evidence_report`, `browse_page`, `setup_providers`, `list_providers`, `provider_statuses`.
+
+## Provider Profiles
+
+| Profile | Providers | Cost |
+|---------|-----------|------|
+| `free` | DDGS | Free |
+| `default` | DDGS | Free |
+| `free-verified` | DDGS + SearXNG | Free |
+| `production` | Bright Data SERP | Paid |
+| `production-unlock` | Bright Data + Web Unlocker | Paid |
+| `max-evidence` | All providers | Paid |
+
+## Bright Data Setup
+
+1. Sign up at [https://get.brightdata.com/h21j9xz4uxgd](https://get.brightdata.com/h21j9xz4uxgd) — 5000 free credits
+2. Copy API key from dashboard
+3. Set `ZERO_SEARCH_BRIGHTDATA_API_KEY=your_key`
+4. Run `zero-api-key-web-search-mcp` → `setup_providers`


### PR DESCRIPTION
## Summary

Adds a skill for [zero-api-key-web-search](https://pypi.org/project/zero-api-key-web-search/) — a free web search, claim verification, and page browsing library.

- **Free by default** (DuckDuckGo, no API key needed)
- **Production SERP** via Bright Data (7 engines: Google, Bing, DuckDuckGo, Yandex, Baidu, Yahoo, Naver)
- **Web Unlocker** for blocked/CAPTCHA/geo-restricted pages
- **Claim verification** with evidence scoring
- **MCP server** with 8 tools
- **6 provider profiles** from free to max-evidence

## Test plan

- [x] SKILL.md follows OpenClaw skill format (YAML frontmatter + markdown)
- [x] Install command verified (`pip install zero-api-key-web-search`)
- [x] Core functionality tested (search, verify, browse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)