### PR TITLE
fix(workspace): allow libsignal-node in onlyBuiltDependencies (#76539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/WhatsApp: allow `@whiskeysockets/libsignal-node` in `onlyBuiltDependencies` so pnpm v9+ `blockExoticSubdeps` no longer rejects the baileys git-tarball subdep and silences all inbound agent replies. Fixes #76539. Thanks @ottodeng.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/package.json
+++ b/package.json
@@ -1781,6 +1781,7 @@
       "@tloncorp/api",
       "@tloncorp/tlon-skill",
       "@whiskeysockets/baileys",
+      "@whiskeysockets/libsignal-node",
       "authenticate-pam",
       "esbuild",
       "node-llama-cpp",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,6 +40,7 @@ onlyBuiltDependencies:
   - "@napi-rs/canvas"
   - "@tloncorp/api"
   - "@whiskeysockets/baileys"
+  - "@whiskeysockets/libsignal-node"
   - authenticate-pam
   - esbuild
   - node-llama-cpp


### PR DESCRIPTION
## What bug we're fixing

Issue #76539 — fresh installs of OpenClaw on `pnpm` v9+ silently break the WhatsApp channel:

- `@whiskeysockets/baileys` is bundled as a runtime dep
- baileys pulls `@whiskeysockets/libsignal-node` as a subdep via a `git+tarball` URL (an "exotic" specifier)
- `pnpm` v9+ defaults `blockExoticSubdeps=true`, which rejects exotic subdeps unless explicitly allowed
- result: the native build for libsignal is skipped; the WhatsApp channel registers but never decodes/encrypts; **all inbound agent replies are silently dropped**

## Affected surface

- `package.json` → `pnpm.onlyBuiltDependencies`
- `pnpm-workspace.yaml` → `onlyBuiltDependencies`
- WhatsApp/baileys channel runtime (no source change needed)

## Why this is the best fix

- The repo already exempts `@whiskeysockets/baileys` itself in both files using the exact same `onlyBuiltDependencies` mechanism. We just extend it to the libsignal subdep.
- No core/extension boundary crossed; no public API change; no new exports.
- `onlyBuiltDependencies` is the documented `pnpm` knob for exactly this case (allowing exotic subdeps to install + run their build script). Alternatives — disabling `blockExoticSubdeps` globally, or adding to `minimumReleaseAgeExclude` — would either weaken supply-chain policy across the whole tree or be the wrong policy axis.
- Diff is 3 single-line additions (CHANGELOG entry + 2 manifest entries). Lockfile regeneration not needed; the package is still installed via baileys's own resolution, this just permits its build.

Fixes #76539.
