### PR TITLE
fix(discord): normalize CJK/whitespace in slash-command description comparison to prevent spurious reconcile PATCH + 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/status: honor explicit `messages.statusReactions.enabled: true` in tool-only guild channels so queued ack reactions can progress through thinking/done lifecycle reactions instead of stopping at the initial emoji. Thanks @Marvinthebored.
+- Discord/native commands: compare Discord-normalized slash-command descriptions and localized descriptions during reconcile so CJK or multiline command text no longer triggers redundant startup PATCH bursts and rate-limit 429s. Fixes #76587. Thanks @zhengsx.
 - Agents/OpenAI: omit Chat Completions `reasoning_effort` for `gpt-5.4-mini` only when function tools are present while preserving tool-free Chat and Responses reasoning support, preventing Telegram-routed fallback runs from hanging after OpenAI rejects tool payloads. Fixes #76176. Thanks @ThisIsAdilah and @chinar-amrutkar.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -103,6 +103,62 @@ describe("commandsEqual", () => {
     expect(commandsEqual(current, desired)).toBe(true);
   });
 
+  test("treats localized descriptions with CJK whitespace as equal to Discord's collapsed form", () => {
+    const current = currentFromDiscord({
+      description_localizations: {
+        "zh-CN": "第一行说明。第二行说明。",
+      },
+    });
+    const desired = desiredFromLocal({
+      description_localizations: {
+        "zh-CN": "第一行说明。\n第二行说明。",
+      },
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
+  test("treats option localized descriptions with CJK whitespace as equal to Discord's collapsed form", () => {
+    const current = currentFromDiscord({
+      name: "skill",
+      description: "Run a skill.",
+      options: [
+        {
+          type: 3,
+          name: "name",
+          description: "Skill name",
+          description_localizations: { "zh-CN": "技能名称。直接输入。" },
+        } as any,
+      ],
+    });
+    const desired = desiredFromLocal({
+      name: "skill",
+      description: "Run a skill.",
+      options: [
+        {
+          name: "name",
+          description: "Skill name",
+          description_localizations: { "zh-CN": "技能名称。\n直接输入。" },
+          type: 3,
+        },
+      ],
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
+  test("keeps localized substantive description differences meaningful", () => {
+    const current = currentFromDiscord({
+      description_localizations: {
+        "zh-CN": "旧说明",
+      },
+    });
+    const desired = desiredFromLocal({
+      description_localizations: {
+        "zh-CN": "新说明",
+      },
+    });
+    expect(commandsEqual(current, desired)).toBe(false);
+  });
+
   test("keeps substantive description differences meaningful", () => {
     const current = currentFromDiscord({ description: "old text" });
     const desired = desiredFromLocal({ description: "new text" });

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -1,0 +1,121 @@
+import type { APIApplicationCommand } from "discord-api-types/v10";
+import { describe, expect, test } from "vitest";
+import { __testing } from "./command-deploy.js";
+
+const { commandsEqual } = __testing;
+
+/**
+ * Regression tests for Discord slash-command reconcile/deploy equality.
+ *
+ * These protect against a class of bugs where Discord's server-side storage
+ * normalization causes our desired descriptor to re-compare unequal to the
+ * command Discord returns, which leads to a spurious `PATCH` on every
+ * gateway startup and, under the per-application rate limit, a cascade of
+ * `429` responses that silently drop some commands until the next restart.
+ */
+describe("commandsEqual", () => {
+  // Shape of what Discord returns on `GET /applications/{appId}/commands`.
+  // Fields like `version`, `dm_permission`, `nsfw`, `application_id` are
+  // always present on the server side but absent from our locally-serialized
+  // desired descriptors — they must therefore be ignored by the comparator.
+  function currentFromDiscord(
+    overrides: Partial<APIApplicationCommand> = {},
+  ): APIApplicationCommand {
+    return {
+      id: "cmd-1",
+      application_id: "app",
+      type: 1,
+      name: "ping",
+      description: "ping the bot",
+      version: "v1",
+      default_member_permissions: null,
+      dm_permission: true,
+      nsfw: false,
+      ...overrides,
+    } as APIApplicationCommand;
+  }
+
+  // Shape of what a `BaseCommand.serialize()` produces locally.
+  function desiredFromLocal(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      name: "ping",
+      description: "ping the bot",
+      type: 1,
+      default_member_permissions: null,
+      ...overrides,
+    };
+  }
+
+  test("ignores Discord server-side default fields (dm_permission, nsfw, version, id, application_id)", () => {
+    expect(commandsEqual(currentFromDiscord(), desiredFromLocal())).toBe(true);
+  });
+
+  test("treats `required: false` on an option as equivalent to field absent", () => {
+    const current = currentFromDiscord({
+      name: "skill",
+      description: "Run a skill.",
+      options: [{ type: 3, name: "name", description: "Skill name" } as any],
+    });
+    const desired = desiredFromLocal({
+      name: "skill",
+      description: "Run a skill.",
+      options: [{ name: "name", description: "Skill name", type: 3, required: false }],
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
+  test("keeps `required: true` meaningful", () => {
+    const current = currentFromDiscord({
+      name: "skill",
+      description: "Run a skill.",
+      options: [{ type: 3, name: "name", description: "Skill name" } as any],
+    });
+    const desired = desiredFromLocal({
+      name: "skill",
+      description: "Run a skill.",
+      options: [{ name: "name", description: "Skill name", type: 3, required: true }],
+    });
+    expect(commandsEqual(current, desired)).toBe(false);
+  });
+
+  test("treats CJK descriptions with `\\n` separators as equal to Discord's collapsed form", () => {
+    // Discord server collapses whitespace between CJK characters when storing
+    // command descriptions, so our local desired `\n`-separated description
+    // round-trips back without the newline.
+    const current = currentFromDiscord({
+      description:
+        "将任意文本转化为杂志质感 HTML 信息卡片，并自动截图保存为图片。支持直接输入 URL。",
+    });
+    const desired = desiredFromLocal({
+      description:
+        "将任意文本转化为杂志质感 HTML 信息卡片，并自动截图保存为图片。\n支持直接输入 URL。",
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
+  test("treats mixed CJK/ASCII descriptions with consecutive whitespace as equal to collapsed form", () => {
+    const current = currentFromDiscord({
+      description: "联网操作策略框架。访问需登录站点时触发。",
+    });
+    const desired = desiredFromLocal({
+      description: "联网操作策略框架。\n\n访问需登录站点时触发。",
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
+  test("keeps substantive description differences meaningful", () => {
+    const current = currentFromDiscord({ description: "old text" });
+    const desired = desiredFromLocal({ description: "new text" });
+    expect(commandsEqual(current, desired)).toBe(false);
+  });
+
+  test("treats ASCII `\\n` as whitespace and collapses it to space for comparison", () => {
+    // For pure ASCII descriptions, `\n` collapses to a single space so
+    // "ping the bot" == "ping\nthe bot". The contract is: whitespace
+    // differences (ASCII or CJK-boundary) are never substantive after
+    // Discord's server normalization.
+    const current = currentFromDiscord({ description: "ping the bot" });
+    const desired = desiredFromLocal({ description: "ping\nthe bot" });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+});

--- a/extensions/discord/src/internal/command-deploy.test.ts
+++ b/extensions/discord/src/internal/command-deploy.test.ts
@@ -50,6 +50,26 @@ describe("commandsEqual", () => {
     expect(commandsEqual(currentFromDiscord(), desiredFromLocal())).toBe(true);
   });
 
+  test("ignores Discord null localization maps when local command omits them", () => {
+    const current = currentFromDiscord({
+      name_localizations: null,
+      description_localizations: null,
+      options: [
+        {
+          type: 3,
+          name: "name",
+          name_localizations: null,
+          description: "Skill name",
+          description_localizations: null,
+        } as any,
+      ],
+    });
+    const desired = desiredFromLocal({
+      options: [{ name: "name", description: "Skill name", type: 3 }],
+    });
+    expect(commandsEqual(current, desired)).toBe(true);
+  });
+
   test("treats `required: false` on an option as equivalent to field absent", () => {
     const current = currentFromDiscord({
       name: "skill",

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -277,13 +277,58 @@ function stableComparableObject(value: unknown, path: string[] = []): unknown {
         return true;
       })
       .toSorted(([a], [b]) => a.localeCompare(b))
-      .map(([key, entry]) => [key, stableComparableObject(entry, [...path, key])]),
+      .map(([key, entry]) => [
+        key,
+        key === "description" && typeof entry === "string"
+          ? normalizeDescriptionForComparison(entry)
+          : stableComparableObject(entry, [...path, key]),
+      ]),
   );
+}
+
+/**
+ * Normalize a Discord command description for equality comparison.
+ *
+ * Discord's server-side storage performs two transformations that our local
+ * desired descriptors do not:
+ *
+ * 1. Consecutive whitespace (including `\n`) is collapsed to a single space.
+ * 2. Whitespace between two CJK (Chinese, Japanese, Korean) characters is
+ *    removed entirely. So a local description `"第一行。\n第二行。"` is stored
+ *    as `"第一行。第二行。"` on Discord and returned without the `\n`.
+ *
+ * Without this normalization every startup for any CJK-heavy deployment reads
+ * back Discord's collapsed form, computes a diff against the local `\n`-form,
+ * decides the command needs updating, and issues a `PATCH`. Under the global
+ * per-application rate limit this quickly produces 429 bursts and some
+ * commands silently fail to register (see the Discord deploy 429 reports).
+ *
+ * Applying the same transformation to both sides before comparison makes the
+ * equality check match Discord's storage semantics and prevents spurious
+ * reconcile writes on every startup.
+ */
+function normalizeDescriptionForComparison(description: string): string {
+  const collapsed = description.replace(/\s+/g, " ");
+  // Matches whitespace surrounded by CJK code points. Run twice because a
+  // single `replace` consumes the boundary characters, which can leave
+  // adjacent matches (e.g. "字 字 字") partially unhandled.
+  const cjkBoundaryWhitespace =
+    /([\u3000-\u303F\u4E00-\u9FFF\uFF00-\uFFEF])\s+([\u3000-\u303F\u4E00-\u9FFF\uFF00-\uFFEF])/g;
+  return collapsed
+    .replace(cjkBoundaryWhitespace, "$1$2")
+    .replace(cjkBoundaryWhitespace, "$1$2")
+    .trim();
 }
 
 function commandsEqual(a: unknown, b: unknown) {
   return JSON.stringify(comparableCommand(a)) === JSON.stringify(comparableCommand(b));
 }
+
+export const __testing = {
+  commandsEqual,
+  comparableCommand,
+  normalizeDescriptionForComparison,
+} as const;
 
 function stableCommandSetHash(commands: SerializedCommand[]): string {
   const stable = commands

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -242,6 +242,7 @@ const optionComparisonOmittedFields = new Set([
   "integration_types",
   "name_localized",
 ]);
+const nullableLocalizationFields = new Set(["description_localizations", "name_localizations"]);
 
 function stableComparableObject(value: unknown, path: string[] = []): unknown {
   if (Array.isArray(value)) {
@@ -266,6 +267,9 @@ function stableComparableObject(value: unknown, path: string[] = []): unknown {
     Object.entries(value as Record<string, unknown>)
       .filter(([key, entry]) => {
         if (entry === undefined) {
+          return false;
+        }
+        if (entry === null && nullableLocalizationFields.has(key)) {
           return false;
         }
         if (path.includes("options") && optionComparisonOmittedFields.has(key)) {

--- a/extensions/discord/src/internal/command-deploy.ts
+++ b/extensions/discord/src/internal/command-deploy.ts
@@ -279,10 +279,21 @@ function stableComparableObject(value: unknown, path: string[] = []): unknown {
       .toSorted(([a], [b]) => a.localeCompare(b))
       .map(([key, entry]) => [
         key,
-        key === "description" && typeof entry === "string"
+        shouldNormalizeDescriptionValue(path, key, entry)
           ? normalizeDescriptionForComparison(entry)
           : stableComparableObject(entry, [...path, key]),
       ]),
+  );
+}
+
+function shouldNormalizeDescriptionValue(
+  path: string[],
+  key: string,
+  entry: unknown,
+): entry is string {
+  return (
+    typeof entry === "string" &&
+    (key === "description" || path.at(-1) === "description_localizations")
   );
 }
 


### PR DESCRIPTION
## What bug / behavior are we fixing

Discord slash-command `reconcile` issues a `PATCH` for every command on every gateway startup when command descriptions contain CJK characters with `\n` between them, or any consecutive whitespace. Under Discord's per-application rate limit this produces a burst of 429s and some commands silently fail to register until the next restart.

Closes #76587.

## Surface affected

- Endpoint: `PATCH /applications/{application.id}/commands/{command.id}` (Discord native slash-command deploy REST path).
- Code: `extensions/discord/src/internal/command-deploy.ts` — `comparableCommand` / `stableComparableObject` / `commandsEqual`.

## Root cause

Discord's server-side storage normalizes command `description` strings before persisting. Our comparator compares verbatim, so the round-tripped description always diffs from the local desired descriptor.

Two specific server-side transformations cause the diff:

1. Consecutive whitespace (including `\n`) collapsed to a single space.
2. Whitespace between two adjacent CJK code points removed entirely.

Example: local desired `"图片。\n支持直接输入 URL..."` round-trips as `"图片。支持直接输入 URL..."`.

`stableComparableObject` already strips server-only fields and normalizes `required: false`, but it did not touch description content.

## Fix

Add `normalizeDescriptionForComparison(description)` and apply it inside `stableComparableObject` when projecting string values under the `description` key. The normalization:

- `replace(/\s+/g, " ")` — collapse whitespace, matching Discord's server-side handling.
- `replace(/([CJK])\s+([CJK])/g, "$1$2")` run twice — drop whitespace between CJK boundary characters. Run twice because one pass consumes boundary characters and can miss adjacent matches (e.g. `"字 字 字"`).

This is applied symmetrically to both `current` and `desired` inside `commandsEqual`, so the comparator now reflects Discord's storage semantics.

## Is this the best fix

Yes, at this layer. Alternatives considered:

1. **Normalize on the write path** — pre-collapse desired descriptions before `createApplicationCommand` / `editApplicationCommand`. Rejected: that would mutate what the user authored, and users reasonably use `\n` in descriptions as an authoring aid.
2. **Fix it on the persisted-hash cache (#75888 / #75961).** Rejected: that cache handles restart-stickiness but still relies on `commandsEqual` being correct for the in-process reconcile path. Both improvements are complementary.
3. **Normalize everything via a `Set`-based boundary check** — the current regex approach is the clearest specification of Discord's observed behavior.

## Evidence

Tested on a real deployment with 77 predominantly-Chinese slash commands.

**Before the fix (every gateway restart):**
```
native-slash-command-deploy-rest:patch:error ... 429 (retry_after=0.392)
native-slash-command-deploy-rest:patch:error ... 429 (retry_after=2.571)
native-slash-command-deploy-rest:patch:error ... 429 (retry_after=1.602)
[discord] native slash command deploy warning (not message send): You are being rate limited.
```

Instrumented diff showed every description was flagged as changed.

**After the fix (same deployment, same restart):**
```
reconcile DONE creates=0 edits=0 deletes=0 unchanged=77
```

Zero PATCH calls, zero 429s.

## Test coverage

Added `extensions/discord/src/internal/command-deploy.test.ts` with regressions for:

- Server-side default fields (`dm_permission`, `nsfw`, `version`, `id`, `application_id`) are ignored.
- Option `required: false` is treated as absent (existing behavior locked in).
- Option `required: true` still flagged as substantive.
- CJK descriptions with `\n` separators compare equal to Discord's collapsed form.
- Mixed CJK/ASCII descriptions with consecutive whitespace compare equal to collapsed form.
- Substantive description differences still flagged as not-equal.
- ASCII `\n` whitespace normalizes to space.

All 7 tests pass (`pnpm test extensions/discord/src/internal/command-deploy.test.ts`).

## Ownership / scope

This is a focused behavior fix inside `extensions/discord/src/internal/`. No changes to core, plugin-SDK, config schema, or public contracts. No AGENTS.md CODEOWNERS ambiguity.

## Notes

- No changelog entry added — happy to add one under the usual format if maintainers prefer.
- The `__testing` named export on the module is test-only; if a different convention is preferred (e.g. extracting helpers) I can refactor.
