### PR TITLE
fix(cli): skip model catalog fetch in agents add wizard (#76284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.
+- Agents/add: skip model catalog network fetch in the `agents add` interactive wizard so the command does not hang when the catalog endpoint is slow or unreachable. Fixes #76284. Thanks @ottodeng.
 - CLI/sessions: keep intentional empty agent replies silent after tool-delivered channel output, instead of surfacing a misleading "No reply from agent." fallback. Thanks @vincentkoc.
 - Config/doctor: cap `.clobbered.*` forensic snapshots per config path and serialize snapshot writes so repeated `doctor --fix` recovery loops cannot flood the config directory. Fixes #76454; carries forward #65649. Thanks @JUSTICEESSIELP, @rsnow, and @vincentkoc.
 - Feishu: suppress duplicate text when replies send native voice media while preserving captions for ordinary audio files and falling back to text plus attachment links when voice uploads fail.

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -15,6 +15,9 @@ const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
 
+const warnIfModelConfigLooksOffMock = vi.hoisted(() => vi.fn(async () => {}));
+const setupChannelsMock = vi.hoisted(() => vi.fn());
+
 vi.mock("../config/config.js", async () => ({
   ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -24,6 +27,15 @@ vi.mock("../config/config.js", async () => ({
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
+}));
+
+vi.mock("./auth-choice.js", () => ({
+  applyAuthChoice: vi.fn(async (a: { config: unknown }) => ({ config: a.config })),
+  warnIfModelConfigLooksOff: warnIfModelConfigLooksOffMock,
+}));
+
+vi.mock("./onboard-channels.js", () => ({
+  setupChannels: setupChannelsMock,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -38,6 +50,8 @@ describe("agents add command", () => {
     writeConfigFileMock.mockClear();
     replaceConfigFileMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    warnIfModelConfigLooksOffMock.mockClear();
+    setupChannelsMock.mockClear();
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -152,5 +166,28 @@ describe("agents add command", () => {
         sourceIsInheritedMain: true,
       }),
     ).toBe('OAuth profiles stay shared from "main" unless this agent signs in separately.');
+  });
+
+  it("passes validateCatalog: false to warnIfModelConfigLooksOff in the interactive wizard", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+    setupChannelsMock.mockRejectedValue(new WizardCancelledError());
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn().mockResolvedValue(undefined),
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("Jon") // agent name
+        .mockResolvedValueOnce("/tmp/work"), // workspace dir
+      confirm: vi.fn().mockResolvedValue(false), // wantsAuth = false
+      note: vi.fn().mockResolvedValue(undefined),
+      outro: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(warnIfModelConfigLooksOffMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ validateCatalog: false }),
+    );
   });
 });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -372,6 +372,7 @@ export async function agentsAddCommand(
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId,
       agentDir,
+      validateCatalog: false,
     });
 
     let selection: ChannelChoice[] = [];


### PR DESCRIPTION
### What

Fixes #76284: `openclaw agents add` interactive wizard hangs/fails when the model catalog endpoint is slow or unreachable.

The wizard called `warnIfModelConfigLooksOff` without `validateCatalog: false`, so the helper performed a network fetch to validate the configured model against the live catalog. When the endpoint was slow/unreachable, the prompt blocked and the user could not finish adding a secondary agent (Jon/Atlas).

### Fix

In `src/commands/agents.commands.add.ts:373`, pass `validateCatalog: false` to the warn helper, matching the non-interactive path. Catalog reachability is not the wizard's responsibility — `doctor`/`models check` validate it explicitly.

### Surface

- Affected: `openclaw agents add` (interactive)
- Module owner: `src/commands/` (core CLI). No extension or SDK contract touched.

### Why this is the best fix

- Root cause is a missing flag at the call site, verified by reading `auth-choice.ts` (the `validateCatalog` branch is the only thing that does network I/O in this path).
- Minimal diff (1 LOC behavior + regression test), no new exports, no boundary crossing.
- Regression test asserts the wizard passes `validateCatalog: false`, locking the contract.
- `pnpm test src/commands/agents.add.test.ts` green locally (6/6).

CHANGELOG entry under `## Unreleased`.
