### PR TITLE
fix(media): use r+ instead of r for fs.open to fix EPERM on fsync on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media/Windows: open saved attachment temp files read/write before fsync so Windows WebChat and `chat.send` media offloads no longer fail with EPERM during durability flush. (#76593) Thanks @qq230849622-a11y.
 - Codex plugin: mirror the experimental upstream app-server protocol and format generated TypeScript before drift checks, keeping OpenClaw's `experimentalApi` bridge compatible with latest Codex while preserving formatter gates.
 - Telegram/media: derive no-caption inbound media placeholders from saved MIME metadata instead of the Telegram `photo` shape, so non-image and mixed attachments no longer reach the model as `<media:image>`. Fixes #69793. Thanks @aspalagin.
 - Agents/cache: keep per-turn runtime context out of ordinary chat system prompts while still delivering hidden current-turn context, restoring prompt-cache reuse on chat continuations. Fixes #77431. Thanks @Udjin79.

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -349,7 +349,7 @@ async function writeSavedMediaBuffer(params: {
     const tempDest = path.join(params.dir, `.${params.id}.${crypto.randomUUID()}.tmp`);
     try {
       await fs.writeFile(tempDest, params.buffer, { mode: MEDIA_FILE_MODE });
-      const handle = await fs.open(tempDest, "r");
+      const handle = await fs.open(tempDest, "r+");
       try {
         await syncSavedMediaHandle(handle);
       } finally {


### PR DESCRIPTION
## Problem

On Windows, `fs.open(path, "r")` opens the file with `GENERIC_READ` only. When `handle.sync()` (which calls `FlushFileBuffers` on Windows) is subsequently invoked, it fails with `EPERM` because `FlushFileBuffers` requires `GENERIC_WRITE` access.

This causes `MediaOffloadError: [????] ?????????????EPERM???????fsync` when users send images/attachments via webchat on Windows.

## Root Cause

In `writeSavedMediaBuffer` (`src/media/store.ts`), the temp file is written successfully, then opened read-only with `"r"` mode before calling `fsync`. On Windows, `fsync` on a read-only file handle fails with EPERM.

## Fix

Change `fs.open(tempDest, "r")` to `fs.open(tempDest, "r+")` to open the file with both read and write access, which allows `FlushFileBuffers` to succeed on Windows.

This is safe because:
- The file was just written in the same function, so it always exists
- `r+` opens for reading and writing without truncating
- No actual write operations are performed on the handle ? only `sync()` and `close()`