### PR TITLE
fix(deps): add bottleneck to address bundled telegram channel module-not-found

### DIFF
--- a/extensions/telegram/bottleneck-runtime-dep.test.ts
+++ b/extensions/telegram/bottleneck-runtime-dep.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readPackageJson(relativePath: string): {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+} {
+  return JSON.parse(readFileSync(resolve(REPO_ROOT, relativePath), "utf8")) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+}
+
+function collectRuntimeDeps(packageJson: {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}): Map<string, string> {
+  return new Map([
+    ...Object.entries(packageJson.dependencies ?? {}),
+    ...Object.entries(packageJson.optionalDependencies ?? {}),
+  ]);
+}
+
+describe("telegram bundled channel runtime deps", () => {
+  // The bundled telegram channel re-exports `apiThrottler` from
+  // `@grammyjs/transformer-throttler` (see extensions/telegram/src/bot.runtime.ts).
+  // That module's CommonJS shim does `require("bottleneck")`. When openclaw is
+  // installed via `npm install -g openclaw`, npm's hoisting/dedup decisions can
+  // place the throttler under `node_modules/openclaw/node_modules/...` without
+  // also installing bottleneck where it can be resolved, leaving the channel
+  // failing to load with `Cannot find module 'bottleneck'` at gateway start.
+  //
+  // The durable fix is to list `bottleneck` directly in the openclaw root
+  // package.json `dependencies`, matching the same staged-runtime-deps approach
+  // used for other transitive runtime peers shipped by bundled plugins. This
+  // test guards against regressing on that staging.
+  it("lists bottleneck in openclaw's root dependencies", () => {
+    const rootPackageJson = readPackageJson("package.json");
+    const rootDeps = collectRuntimeDeps(rootPackageJson);
+
+    expect(rootDeps.get("@grammyjs/transformer-throttler")).toBeDefined();
+    expect(rootDeps.has("bottleneck")).toBe(true);
+  });
+});

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
+    "bottleneck": "^2.19.5",
     "grammy": "^1.42.0",
     "typebox": "1.1.37",
     "undici": "8.1.0"

--- a/package.json
+++ b/package.json
@@ -1683,6 +1683,7 @@
     "@slack/types": "^2.20.1",
     "@slack/web-api": "^7.15.1",
     "ajv": "^8.20.0",
+    "bottleneck": "^2.19.5",
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "commander": "^14.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -217,10 +220,6 @@ importers:
       zod:
         specifier: ^4.4.1
         version: 4.4.1
-    optionalDependencies:
-      sqlite-vec:
-        specifier: 0.1.9
-        version: 0.1.9
     devDependencies:
       '@copilotkit/aimock':
         specifier: 1.16.4
@@ -288,6 +287,10 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+    optionalDependencies:
+      sqlite-vec:
+        specifier: 0.1.9
+        version: 0.1.9
 
   extensions/acpx:
     dependencies:
@@ -1357,6 +1360,9 @@ importers:
       '@grammyjs/transformer-throttler':
         specifier: ^1.2.1
         version: 1.2.1(grammy@1.42.0)
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       grammy:
         specifier: ^1.42.0
         version: 1.42.0
@@ -6386,10 +6392,6 @@ packages:
     resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
     engines: {node: ^18 || ^20 || >= 21}
 
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
   node-downloader-helper@2.1.11:
     resolution: {integrity: sha512-882fH2C9AWdiPCwz/2beq5t8FGMZK9Dx8TJUOIxzMCbvG7XUKM5BuJwN5f0NKo4SCQK6jR4p2TPm54mYGdGchQ==}
     engines: {node: '>=14.18'}
@@ -6411,6 +6413,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-sarif-builder@3.4.0:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
@@ -13579,8 +13585,6 @@ snapshots:
 
   node-addon-api@8.7.0: {}
 
-  node-gyp-build@4.8.4: {}
-
   node-downloader-helper@2.1.11: {}
 
   node-edge-tts@1.2.10:
@@ -13602,6 +13606,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4: {}
 
   node-sarif-builder@3.4.0:
     dependencies:
@@ -14597,6 +14603,7 @@ snapshots:
       sqlite-vec-linux-arm64: 0.1.9
       sqlite-vec-linux-x64: 0.1.9
       sqlite-vec-windows-x64: 0.1.9
+    optional: true
 
   stackback@0.0.2: {}
 

--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -61,6 +61,12 @@
       "class": "core-runtime",
       "risk": ["schema-validation"]
     },
+    "bottleneck": {
+      "owner": "plugin:telegram",
+      "class": "plugin-runtime",
+      "activation": ["plugins.entries.telegram.enabled"],
+      "risk": ["transitive-runtime"]
+    },
     "chalk": {
       "owner": "core:cli",
       "class": "core-runtime",


### PR DESCRIPTION
## Summary

Closes #76596.

The bundled telegram channel re-exports `apiThrottler` from `@grammyjs/transformer-throttler`, whose CJS shim does `require(\"bottleneck\")`. After `npm install -g openclaw@2026.5.2`, npm's hoisting/dedup occasionally places the throttler under `node_modules/openclaw/node_modules/...` without resolving bottleneck on disk, so the channel fails to load with `Cannot find module 'bottleneck'` at gateway start.

Same shape as the 2026.4.25-4.26 transitive-dep gap fix (`whatwg-url`). The staged plugin runtime deps pass evidently didn't cover this chain.

## Changes

- `package.json`: add `bottleneck@^2.19.5` to root `dependencies` (between `ajv` and `chalk`).
- `extensions/telegram/package.json`: mirror the declaration so the root-dependency-ownership audit classifies bottleneck as a kept-at-root internalized bundled runtime dep (same treatment as `undici`/`typebox`).
- `extensions/telegram/bottleneck-runtime-dep.test.ts`: new co-located guardrail asserting that whenever root deps include `@grammyjs/transformer-throttler`, they also include `bottleneck`.
- `scripts/lib/dependency-ownership.json`: add the matching SBOM ownership entry (owner=plugin:telegram, class=plugin-runtime).
- `pnpm-lock.yaml`: lockfile refresh.

## Verification

Before fix:

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts \
    extensions/telegram/bottleneck-runtime-dep.test.ts
 FAIL  extensions/telegram/bottleneck-runtime-dep.test.ts > telegram bundled channel runtime deps > lists bottleneck in openclaw's root dependencies
AssertionError: expected false to be true
 ❯ extensions/telegram/bottleneck-runtime-dep.test.ts:46:40
```

After fix:

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts \
    extensions/telegram/bottleneck-runtime-dep.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Plugin-sdk package contract guardrails (15 tests) and the root-dependency-ownership `--check` audit both still pass.

Full extension-telegram suite: 1540 pass, 1 pre-existing failure (`bot-native-commands.session-meta.test.ts`, also fails on unmodified `upstream/main` with the same diff — unrelated to this change).

## Test plan

- [x] New guardrail fails on the broken state, passes after the fix.
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts --maxWorkers=1 src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts` -> 15/15 pass.
- [x] `node scripts/root-dependency-ownership-audit.mjs --check` -> ok (exit 0).
- [x] `node scripts/sbom-risk-report.mjs --check` -> bottleneck no longer flagged as missing ownership.
- [x] Manually verified on a Windows `npm install -g openclaw@2026.5.2` that adding `bottleneck` to that install's local `node_modules` resolves the channel-load failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)