### PR TITLE
fix(plugins): warn when npm install is shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.
 - Gateway/cron: stop a lazy cron startup that loses a hot-reload race, preventing the old cron service from starting after reload has already replaced cron state.
+- CLI/plugins: warn when npm plugin installs remain shadowed by a failing config-selected source and surface the repair path in `plugins doctor`. Thanks @LindalyX-Lee.
 - Active Memory: apply `setupGraceTimeoutMs` to the embedded recall runner as well as the outer prompt-build watchdog, so very-cold first recalls keep the configured setup grace end-to-end. (#74480) Thanks @volcano303.
 - CLI/config: keep JSON dry-run patches validating touched channel configuration against bundled channel schemas even when the patch only contains SecretRef objects.
 - Plugins/tools: keep disabled bundled tool plugins out of explicit runtime allowlist ownership and fall back from loaded-but-empty channel registries to tool-bearing plugin registries, so Active Memory can use bundled `memory-core` search/get tools even when `memory-lancedb` is disabled. Fixes #76603. Thanks @jwong-art.

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -78,6 +78,40 @@ describe("plugins cli list", () => {
     expect(runtimeLogs).toContain("No plugin issues detected.");
   });
 
+  it("reports config-selected plugin source shadowing in doctor output", async () => {
+    buildPluginDiagnosticsReport.mockReturnValue({
+      plugins: [
+        createPluginRecord({
+          id: "discord",
+          origin: "config",
+          source: "/tmp/openclaw-upstream/extensions/discord/index.ts",
+          status: "error",
+          error: "Cannot find module 'chalk'",
+        }),
+      ],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "discord",
+          source: "/tmp/openclaw/npm/node_modules/@openclaw/discord/index.ts",
+          message:
+            "duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (/tmp/openclaw-upstream/extensions/discord/index.ts)",
+        },
+      ],
+    });
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain("Plugin source shadowing:");
+    expect(output).toContain(
+      "discord: duplicate plugin id resolved by explicit config-selected plugin",
+    );
+    expect(output).toContain("active: /tmp/openclaw-upstream/extensions/discord/index.ts");
+    expect(output).toContain("shadowed: /tmp/openclaw/npm/node_modules/@openclaw/discord/index.ts");
+    expect(output).toContain("openclaw plugins registry --refresh");
+  });
+
   it("reports persisted plugin registry state without refreshing", async () => {
     inspectPluginRegistry.mockResolvedValue({
       state: "stale",

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -112,6 +112,32 @@ describe("plugins cli list", () => {
     expect(output).toContain("openclaw plugins registry --refresh");
   });
 
+  it("does not report healthy config-selected plugin source shadowing as doctor issue", async () => {
+    buildPluginDiagnosticsReport.mockReturnValue({
+      plugins: [
+        createPluginRecord({
+          id: "discord",
+          origin: "config",
+          source: "/tmp/openclaw-upstream/extensions/discord/index.ts",
+          status: "loaded",
+        }),
+      ],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "discord",
+          source: "/tmp/openclaw/npm/node_modules/@openclaw/discord/index.ts",
+          message:
+            "duplicate plugin id resolved by explicit config-selected plugin; global plugin will be overridden by config plugin (/tmp/openclaw-upstream/extensions/discord/index.ts)",
+        },
+      ],
+    });
+
+    await runPluginsCommand(["plugins", "doctor"]);
+
+    expect(runtimeLogs).toContain("No plugin issues detected.");
+  });
+
   it("reports persisted plugin registry state without refreshing", async () => {
     inspectPluginRegistry.mockResolvedValue({
       state: "stale",

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -5,6 +5,7 @@ import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trac
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
+import { shortenHomeInString } from "../utils.js";
 import type { PluginInspectOptions } from "./plugins-inspect-command.js";
 import type { PluginsListOptions } from "./plugins-list-command.js";
 import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
@@ -60,6 +61,14 @@ function reportMissingPlugin(id: string) {
 
 function matchesPluginId(plugin: { id: string }, id: string) {
   return plugin.id === id;
+}
+
+function isConfigSelectedShadowDiagnostic(entry: { level?: string; message?: string }): boolean {
+  return (
+    entry.level === "warn" &&
+    typeof entry.message === "string" &&
+    entry.message.includes("duplicate plugin id resolved by explicit config-selected plugin")
+  );
 }
 
 export function registerPluginsCli(program: Command) {
@@ -336,9 +345,15 @@ export function registerPluginsCli(program: Command) {
       const report = buildPluginDiagnosticsReport({ effectiveOnly: true });
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
+      const shadowed = report.diagnostics.filter(isConfigSelectedShadowDiagnostic);
       const compatibility = buildPluginCompatibilityNotices({ report });
 
-      if (errors.length === 0 && diags.length === 0 && compatibility.length === 0) {
+      if (
+        errors.length === 0 &&
+        diags.length === 0 &&
+        shadowed.length === 0 &&
+        compatibility.length === 0
+      ) {
         defaultRuntime.log("No plugin issues detected.");
         return;
       }
@@ -359,6 +374,31 @@ export function registerPluginsCli(program: Command) {
         for (const diag of diags) {
           const target = diag.pluginId ? `${diag.pluginId}: ` : "";
           lines.push(`- ${target}${diag.message}`);
+        }
+      }
+      if (shadowed.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Plugin source shadowing:"));
+        for (const diag of shadowed) {
+          const active = report.plugins.find((plugin) => plugin.id === diag.pluginId);
+          const target = diag.pluginId ? `${diag.pluginId}: ` : "";
+          lines.push(`- ${target}${diag.message}`);
+          if (active) {
+            lines.push(`  active: ${shortenHomeInString(active.source)} (${active.origin})`);
+            if (active.status === "error") {
+              lines.push(`  active status: error${active.error ? `: ${active.error}` : ""}`);
+            }
+          }
+          if (diag.source) {
+            lines.push(`  shadowed: ${shortenHomeInString(diag.source)}`);
+          }
+          lines.push("  repair:");
+          lines.push("    openclaw plugins inspect " + (diag.pluginId ?? "<plugin-id>"));
+          lines.push("    edit or remove the config-selected plugin source");
+          lines.push("    openclaw plugins registry --refresh");
+          lines.push("    openclaw gateway restart --force");
         }
       }
       if (compatibility.length > 0) {

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -71,6 +71,21 @@ function isConfigSelectedShadowDiagnostic(entry: { level?: string; message?: str
   );
 }
 
+function isErroredConfigSelectedShadowDiagnostic(params: {
+  entry: { level?: string; message?: string; pluginId?: string };
+  plugins: readonly { id: string; origin: string; status: string }[];
+}): boolean {
+  if (!params.entry.pluginId || !isConfigSelectedShadowDiagnostic(params.entry)) {
+    return false;
+  }
+  return params.plugins.some(
+    (plugin) =>
+      plugin.id === params.entry.pluginId &&
+      plugin.origin === "config" &&
+      plugin.status === "error",
+  );
+}
+
 export function registerPluginsCli(program: Command) {
   const plugins = program
     .command("plugins")
@@ -345,7 +360,9 @@ export function registerPluginsCli(program: Command) {
       const report = buildPluginDiagnosticsReport({ effectiveOnly: true });
       const errors = report.plugins.filter((p) => p.status === "error");
       const diags = report.diagnostics.filter((d) => d.level === "error");
-      const shadowed = report.diagnostics.filter(isConfigSelectedShadowDiagnostic);
+      const shadowed = report.diagnostics.filter((entry) =>
+        isErroredConfigSelectedShadowDiagnostic({ entry, plugins: report.plugins }),
+      );
       const compatibility = buildPluginCompatibilityNotices({ report });
 
       if (

--- a/src/cli/plugins-install-persist.test.ts
+++ b/src/cli/plugins-install-persist.test.ts
@@ -183,6 +183,49 @@ describe("persistPluginInstall", () => {
     expect(runtimeLogs.join("\n")).toContain("openclaw plugins doctor");
   });
 
+  it("does not warn when the config-selected source is inside the npm install path", async () => {
+    const { persistPluginInstall } = await import("./plugins-install-persist.js");
+    const baseConfig = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledConfig = {
+      plugins: {
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+    enablePluginInConfig.mockReturnValue({ config: enabledConfig });
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "config",
+          source: "/tmp/openclaw/npm/node_modules/@openclaw/discord/dist/index.js",
+          status: "loaded",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    await persistPluginInstall({
+      snapshot: {
+        config: baseConfig,
+        baseHash: "config-1",
+      },
+      pluginId: "discord",
+      install: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: "/tmp/openclaw/npm/node_modules/@openclaw/discord",
+      },
+    });
+
+    expect(runtimeLogs.join("\n")).not.toContain("is not the active source");
+  });
+
   it("invalidates runtime cache even when registry refresh fails", async () => {
     const { persistPluginInstall } = await import("./plugins-install-persist.js");
     const baseConfig = {

--- a/src/cli/plugins-install-persist.test.ts
+++ b/src/cli/plugins-install-persist.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   applyExclusiveSlotSelection,
   buildPluginDiagnosticsReport,
+  buildPluginSnapshotReport,
   clearPluginRegistryLoadCache,
   enablePluginInConfig,
   loadPluginManifestRegistry,
@@ -122,6 +123,64 @@ describe("persistPluginInstall", () => {
     expect(
       runtimeLogs.some((line) => line.includes("Plugin runtime cache invalidation failed")),
     ).toBe(true);
+  });
+
+  it("warns when an installed npm plugin remains shadowed by a config-selected source", async () => {
+    const { persistPluginInstall } = await import("./plugins-install-persist.js");
+    const baseConfig = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledConfig = {
+      plugins: {
+        entries: {
+          discord: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+    enablePluginInConfig.mockReturnValue({ config: enabledConfig });
+    buildPluginSnapshotReport.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "config",
+          source: "/tmp/openclaw-upstream/extensions/discord/index.ts",
+          status: "error",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const next = await persistPluginInstall({
+      snapshot: {
+        config: baseConfig,
+        baseHash: "config-1",
+      },
+      pluginId: "discord",
+      install: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: "/tmp/openclaw/npm/node_modules/@openclaw/discord/index.ts",
+      },
+    });
+
+    expect(next).toEqual(enabledConfig);
+    expect(buildPluginSnapshotReport).toHaveBeenCalledWith({
+      config: enabledConfig,
+      effectiveOnly: true,
+      onlyPluginIds: ["discord"],
+    });
+    expect(runtimeLogs.join("\n")).toContain(
+      'Warning: installed plugin "discord" is not the active source',
+    );
+    expect(runtimeLogs.join("\n")).toContain(
+      "active config source: /tmp/openclaw-upstream/extensions/discord/index.ts",
+    );
+    expect(runtimeLogs.join("\n")).toContain(
+      "installed npm source: /tmp/openclaw/npm/node_modules/@openclaw/discord/index.ts",
+    );
+    expect(runtimeLogs.join("\n")).toContain("openclaw plugins doctor");
   });
 
   it("invalidates runtime cache even when registry refresh fails", async () => {

--- a/src/cli/plugins-install-persist.ts
+++ b/src/cli/plugins-install-persist.ts
@@ -1,6 +1,7 @@
 import { replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { type HookInstallUpdate, recordHookInstall } from "../hooks/installs.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import {
   loadInstalledPluginIndexInstallRecords,
@@ -12,7 +13,7 @@ import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trac
 import { buildPluginSnapshotReport } from "../plugins/status.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
-import { shortenHomePath } from "../utils.js";
+import { resolveUserPath, shortenHomePath } from "../utils.js";
 import {
   applySlotSelectionForPlugin,
   enableInternalHookEntries,
@@ -60,6 +61,16 @@ export type ConfigSnapshotForInstallPersist = {
   baseHash: string | undefined;
 };
 
+function sourceMatchesInstalledPath(params: {
+  activeSource: string;
+  installedSource: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const activeSource = resolveUserPath(params.activeSource, params.env);
+  const installedSource = resolveUserPath(params.installedSource, params.env);
+  return activeSource === installedSource || isPathInside(installedSource, activeSource);
+}
+
 function logShadowedNpmInstallWarning(params: {
   config: OpenClawConfig;
   pluginId: string;
@@ -79,7 +90,11 @@ function logShadowedNpmInstallWarning(params: {
     onlyPluginIds: [params.pluginId],
   });
   const active = report.plugins.find((plugin) => plugin.id === params.pluginId);
-  if (!active || active.origin !== "config" || active.source === installedSource) {
+  if (
+    !active ||
+    active.origin !== "config" ||
+    sourceMatchesInstalledPath({ activeSource: active.source, installedSource })
+  ) {
     return;
   }
 

--- a/src/cli/plugins-install-persist.ts
+++ b/src/cli/plugins-install-persist.ts
@@ -9,8 +9,10 @@ import {
 } from "../plugins/installed-plugin-index-records.js";
 import type { PluginInstallUpdate } from "../plugins/installs.js";
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
+import { buildPluginSnapshotReport } from "../plugins/status.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
+import { shortenHomePath } from "../utils.js";
 import {
   applySlotSelectionForPlugin,
   enableInternalHookEntries,
@@ -57,6 +59,41 @@ export type ConfigSnapshotForInstallPersist = {
   config: OpenClawConfig;
   baseHash: string | undefined;
 };
+
+function logShadowedNpmInstallWarning(params: {
+  config: OpenClawConfig;
+  pluginId: string;
+  install: Omit<PluginInstallUpdate, "pluginId">;
+  runtime: RuntimeEnv;
+}): void {
+  if (params.install.source !== "npm") {
+    return;
+  }
+  const installedSource = params.install.installPath ?? params.install.sourcePath;
+  if (!installedSource) {
+    return;
+  }
+  const report = buildPluginSnapshotReport({
+    config: params.config,
+    effectiveOnly: true,
+    onlyPluginIds: [params.pluginId],
+  });
+  const active = report.plugins.find((plugin) => plugin.id === params.pluginId);
+  if (!active || active.origin !== "config" || active.source === installedSource) {
+    return;
+  }
+
+  params.runtime.log(
+    theme.warn(
+      [
+        `Warning: installed plugin "${params.pluginId}" is not the active source because a config-selected plugin with the same id is currently selected:`,
+        `  active config source: ${shortenHomePath(active.source)}`,
+        `  installed npm source: ${shortenHomePath(installedSource)}`,
+        "Run `openclaw plugins doctor` for repair options.",
+      ].join("\n"),
+    ),
+  );
+}
 
 export async function persistPluginInstall(params: {
   snapshot: ConfigSnapshotForInstallPersist;
@@ -127,6 +164,12 @@ export async function persistPluginInstall(params: {
     runtime.log(theme.warn(params.warningMessage));
   }
   runtime.log(params.successMessage ?? `Installed plugin: ${params.pluginId}`);
+  logShadowedNpmInstallWarning({
+    config: next,
+    pluginId: params.pluginId,
+    install: params.install,
+    runtime,
+  });
   runtime.log("Restart the gateway to load plugins.");
   return next;
 }


### PR DESCRIPTION
## Summary

Note: This does not treat intentional config-selected overrides as invalid; it only makes the precedence visible when a newly installed npm source is not active.
- warn after `plugins install` when the just-installed npm source is still shadowed by an explicit config-selected plugin with the same id
- add `plugins doctor` diagnostics for config-selected plugin source shadowing, including active/shadowed paths and conservative repair hints
- keep plugin precedence/loading semantics unchanged

Fixes #76605

## Tests
- `pnpm exec oxfmt --check src/cli/plugins-install-persist.ts src/cli/plugins-cli.ts src/cli/plugins-install-persist.test.ts src/cli/plugins-cli.list.test.ts`
- `pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/cli/plugins-cli.ts src/cli/plugins-install-persist.ts src/cli/plugins-install-persist.test.ts src/cli/plugins-cli.list.test.ts`
- `node scripts/run-vitest.mjs run --config /tmp/vitest.config.openclaw-cli-isolated.ts src/cli/plugins-install-persist.test.ts src/cli/plugins-cli.list.test.ts`

Note: `pnpm tsgo:core:test` currently fails on existing broad repo/dependency baseline errors outside this patch (for example missing `typebox` / `@mariozechner/pi-ai/oauth` and unrelated model/test typing errors).