### PR TITLE
test: harden flaky CI assertions

### DIFF
--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -158,6 +158,46 @@ function buildSnapshot(params: {
   });
 }
 
+function buildDefaultSnapshot(): ConfigFileSnapshot {
+  return buildSnapshot({
+    valid: true,
+    raw: `${JSON.stringify(validConfig)}\n`,
+    config: validConfig,
+  });
+}
+
+function installConfigIoMockDefaults() {
+  const readSnapshot = vi.mocked(configIo.readConfigFileSnapshot);
+  const readSnapshotWithPluginMetadata = vi.mocked(
+    configIo.readConfigFileSnapshotWithPluginMetadata,
+  );
+  const recoverLastKnownGood = vi.mocked(configIo.recoverConfigFromLastKnownGood);
+  const recoverJsonRootSuffix = vi.mocked(configIo.recoverConfigFromJsonRootSuffix);
+  const writeConfig = vi.mocked(configIo.writeConfigFile);
+
+  readSnapshot.mockReset();
+  readSnapshotWithPluginMetadata.mockReset();
+  recoverLastKnownGood.mockReset();
+  recoverJsonRootSuffix.mockReset();
+  writeConfig.mockReset();
+
+  const defaultSnapshot = buildDefaultSnapshot();
+  readSnapshot.mockResolvedValue(defaultSnapshot);
+  readSnapshotWithPluginMetadata.mockImplementation(async () => {
+    const snapshot = (await readSnapshot()) as ConfigFileSnapshot | undefined;
+    if (!snapshot) {
+      throw new Error(
+        "configIo.readConfigFileSnapshot mock returned no snapshot; " +
+          "mock readConfigFileSnapshotWithPluginMetadata with { snapshot, pluginMetadataSnapshot }.",
+      );
+    }
+    return snapshot.valid ? { snapshot, pluginMetadataSnapshot } : { snapshot };
+  });
+  recoverLastKnownGood.mockResolvedValue(false);
+  recoverJsonRootSuffix.mockResolvedValue(false);
+  writeConfig.mockResolvedValue(undefined);
+}
+
 describe("gateway startup config recovery", () => {
   beforeAll(async () => {
     ({ loadGatewayStartupConfigSnapshot } = await import("./server-startup-config.js"));
@@ -169,9 +209,7 @@ describe("gateway startup config recovery", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     configMocks.isNixMode.value = false;
-    vi.mocked(configIo.readConfigFileSnapshotWithPluginMetadata).mockImplementation(async () => ({
-      snapshot: await vi.mocked(configIo.readConfigFileSnapshot)(),
-    }));
+    installConfigIoMockDefaults();
   });
 
   it("runs startup plugin auto-enable against source config without persisting runtime defaults", async () => {
@@ -418,6 +456,7 @@ describe("gateway startup config recovery", () => {
     ).resolves.toEqual({
       snapshot: recoveredSnapshot,
       wroteConfig: true,
+      pluginMetadataSnapshot,
     });
 
     expect(configIo.recoverConfigFromLastKnownGood).toHaveBeenCalledWith({
@@ -720,6 +759,7 @@ describe("gateway startup config recovery", () => {
     ).resolves.toEqual({
       snapshot: repairedSnapshot,
       wroteConfig: true,
+      pluginMetadataSnapshot,
     });
 
     expect(configIo.recoverConfigFromJsonRootSuffix).toHaveBeenCalledWith(invalidSnapshot);

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -411,7 +411,10 @@ describe("gateway server agent", () => {
       ],
       idempotencyKey: "idem-agent-attachments",
     });
-    expect(res.ok).toBe(true);
+    expect(
+      res,
+      `agent RPC failed before forwarding image attachment: ${JSON.stringify(res)}`,
+    ).toMatchObject({ ok: true });
 
     const call = await waitForAgentCommandCall("idem-agent-attachments");
     expect(call.sessionKey).toBe("agent:main:main");
@@ -419,12 +422,22 @@ describe("gateway server agent", () => {
     expect(typeof call.message).toBe("string");
     expect(call.message).toContain("what is in the image?");
 
-    const images = call.images as Array<Record<string, unknown>>;
-    expect(Array.isArray(images)).toBe(true);
-    expect(images.length).toBe(1);
-    expect(images[0]?.type).toBe("image");
-    expect(images[0]?.mimeType).toBe("image/png");
-    expect(images[0]?.data).toBe(BASE_IMAGE_PNG);
+    expect(
+      {
+        rpcResult: res,
+        commandImages: call.images,
+      },
+      "agent command should include one forwarded image attachment",
+    ).toEqual({
+      rpcResult: expect.objectContaining({ ok: true }),
+      commandImages: [
+        expect.objectContaining({
+          type: "image",
+          mimeType: "image/png",
+          data: BASE_IMAGE_PNG,
+        }),
+      ],
+    });
   });
 
   test("agent errors when delivery requested and no last channel exists", async () => {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1556,8 +1556,11 @@ describe("runGatewayUpdate", () => {
           "utf-8",
         );
         await writeBundledRuntimeSidecars(pkgRoot);
-        await writePackageDistInventory(pkgRoot);
-        await fs.rm(path.join(pkgRoot, MATRIX_HELPER_API), { force: true });
+        const inventory = await writePackageDistInventory(pkgRoot);
+        expect(inventory).toContain(MATRIX_HELPER_API);
+        const matrixHelperApiPath = path.join(pkgRoot, MATRIX_HELPER_API);
+        await expect(pathExists(matrixHelperApiPath)).resolves.toBe(true);
+        await fs.rm(matrixHelperApiPath);
       },
     });
 


### PR DESCRIPTION
## Summary
- Reset startup config IO mocks explicitly and reinstall safe defaults each test.
- Make the global update sidecar-missing fixture fail clearly if the chosen packaged file is not inventoried.
- Add diagnostic context to the agent image attachment forwarding assertion.

These changes make recurring CI failures easier to diagnose and prevent fixture drift from looking like unrelated product failures.