### PR TITLE
[codex] Fix group message-tool reply delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -459,6 +459,37 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.hasDeliveredVisibleText()).toBe(false);
   });
 
+  it("routes suppressed ACP final replies through the message tool in message-tool mode", async () => {
+    const dispatcher = createDispatcher();
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      suppressUserDelivery: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+      shouldRouteToOriginating: false,
+      originatingChannel: "visiblechat",
+      originatingTo: "channel:thread-1",
+    });
+
+    const delivered = await coordinator.deliver("final", { text: "done" }, { skipTts: true });
+
+    expect(delivered).toBe(true);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(deliveryMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "done" }),
+        channel: "visiblechat",
+        to: "channel:thread-1",
+      }),
+    );
+  });
+
   it("routes ACP replies through the configured default account when AccountId is omitted", async () => {
     await expectVisibleChatBlockRoutesToAccount(
       createAcpTestConfig({

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -11,6 +11,7 @@ import {
 import { createTtsDirectiveTextStreamCleaner } from "../../tts/directives.js";
 import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode, shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
+import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
@@ -181,6 +182,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   ttsChannel?: string;
   suppressUserDelivery?: boolean;
   suppressReplyLifecycle?: boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   shouldRouteToOriginating: boolean;
   originatingChannel?: string;
   originatingTo?: string;
@@ -197,6 +199,12 @@ export function createAcpDispatchDeliveryCoordinator(params: {
         params.cfg.channels as Record<string, { defaultAccount?: unknown } | undefined> | undefined
       )?.[routedChannel ?? directChannel ?? ""]?.defaultAccount,
     );
+  const shouldRouteSuppressedSourceViaMessageTool = Boolean(
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    params.suppressUserDelivery === true &&
+    routedChannel &&
+    params.originatingTo,
+  );
   const state: AcpDispatchDeliveryState = {
     startedReplyLifecycle: false,
     accumulatedBlockText: "",
@@ -337,7 +345,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       return false;
     }
 
-    if (params.suppressUserDelivery) {
+    if (params.suppressUserDelivery && !shouldRouteSuppressedSourceViaMessageTool) {
       return false;
     }
 
@@ -353,7 +361,11 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       skipTts: meta?.skipTts,
     });
 
-    if (params.shouldRouteToOriginating && params.originatingChannel && params.originatingTo) {
+    if (
+      (params.shouldRouteToOriginating || shouldRouteSuppressedSourceViaMessageTool) &&
+      params.originatingChannel &&
+      params.originatingTo
+    ) {
       const toolCallId = normalizeOptionalString(meta?.toolCallId);
       if (kind === "tool" && meta?.allowEdit === true && toolCallId) {
         const edited = await tryEditToolMessage(ttsPayload, toolCallId);

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -372,6 +372,7 @@ export async function tryDispatchAcpReply(params: {
     ttsChannel: params.ttsChannel,
     suppressUserDelivery: params.suppressUserDelivery,
     suppressReplyLifecycle: params.suppressReplyLifecycle,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     shouldRouteToOriginating: params.shouldRouteToOriginating,
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -858,6 +858,98 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("routes same-provider WhatsApp group final replies through the message tool in message-tool mode", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return { text: "visible group reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        OriginatingChannel: "whatsapp",
+        OriginatingTo: "120363423802442266@g.us",
+        GroupSubject: "Gutsy and Us",
+        AccountId: "default",
+        SessionKey: "agent:main:whatsapp:group:120363423802442266@g.us",
+      }),
+      cfg: {
+        messages: {
+          groupChat: {
+            visibleReplies: "message_tool",
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "visible group reply" }),
+        channel: "whatsapp",
+        to: "120363423802442266@g.us",
+        accountId: "default",
+        isGroup: true,
+        groupId: "120363423802442266@g.us",
+      }),
+    );
+  });
+
+  it("routes same-provider Discord channel final replies through the message tool in message-tool mode", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return { text: "visible channel reply" } satisfies ReplyPayload;
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:1482447219717308539",
+        GroupChannel: "general",
+        GroupSpace: "1482447218894967037",
+        AccountId: "default",
+        SessionKey: "agent:main:discord:channel:1482447219717308539",
+      }),
+      cfg: {
+        messages: {
+          groupChat: {
+            visibleReplies: "message_tool",
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "visible channel reply" }),
+        channel: "discord",
+        to: "channel:1482447219717308539",
+        accountId: "default",
+        isGroup: true,
+        groupId: "channel:1482447219717308539",
+      }),
+    );
+  });
+
   it("routes when OriginatingChannel differs from Provider", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -477,14 +477,15 @@ export async function dispatchReplyFromConfig(
     normalizedCurrentSurface === INTERNAL_MESSAGE_CHANNEL &&
     (normalizedSurfaceChannel === INTERNAL_MESSAGE_CHANNEL || !normalizedSurfaceChannel) &&
     ctx.ExplicitDeliverRoute !== true;
-  const hasRouteReplyCandidate = Boolean(
+  const hasRouteReplyTarget = Boolean(
     !suppressAcpChildUserDelivery &&
     !isInternalWebchatTurn &&
     normalizedRouteReplyChannel &&
-    replyRoute.to &&
-    normalizedRouteReplyChannel !== normalizedCurrentSurface,
+    replyRoute.to,
   );
-  const routeReplyRuntime = hasRouteReplyCandidate ? await loadRouteReplyRuntime() : undefined;
+  const hasRouteReplyCandidate =
+    hasRouteReplyTarget && normalizedRouteReplyChannel !== normalizedCurrentSurface;
+  const routeReplyRuntime = hasRouteReplyTarget ? await loadRouteReplyRuntime() : undefined;
   const {
     originatingChannel: routeReplyChannel,
     currentSurface,
@@ -547,6 +548,38 @@ export async function dispatchReplyFromConfig(
       payload,
       channel: routeReplyChannel,
       to: routeReplyTo,
+      sessionKey: ctx.SessionKey,
+      policySessionKey:
+        ctx.CommandSource === "native"
+          ? (ctx.CommandTargetSessionKey ?? ctx.SessionKey)
+          : ctx.SessionKey,
+      policyConversationType: resolveRoutedPolicyConversationType(ctx),
+      accountId: replyRoute.accountId,
+      requesterSenderId: ctx.SenderId,
+      requesterSenderName: ctx.SenderName,
+      requesterSenderUsername: ctx.SenderUsername,
+      requesterSenderE164: ctx.SenderE164,
+      threadId: routeThreadId,
+      cfg,
+      abortSignal: options?.abortSignal,
+      mirror: options?.mirror,
+      isGroup,
+      groupId,
+    });
+  };
+
+  const routeReplyToSourceViaMessageTool = async (
+    payload: ReplyPayload,
+    options?: { abortSignal?: AbortSignal; mirror?: boolean },
+  ) => {
+    if (!routeReplyRuntime || !normalizedRouteReplyChannel || !replyRoute.to) {
+      return null;
+    }
+    markInboundDedupeReplayUnsafe();
+    return await routeReplyRuntime.routeReply({
+      payload,
+      channel: normalizedRouteReplyChannel,
+      to: replyRoute.to,
       sessionKey: ctx.SessionKey,
       policySessionKey:
         ctx.CommandSource === "native"
@@ -754,6 +787,17 @@ export async function dispatchReplyFromConfig(
     suppressHookUserDelivery,
     suppressHookReplyLifecycle,
   } = sourceReplyPolicy;
+  const shouldDeliverSuppressedSourceViaMessageTool = Boolean(
+    sourceReplyDeliveryMode === "message_tool_only" &&
+    !sourceReplyPolicy.sendPolicyDenied &&
+    (chatType === "group" || chatType === "channel") &&
+    routeReplyRuntime &&
+    normalizedRouteReplyChannel &&
+    replyRoute.to &&
+    routeReplyRuntime.isRoutableChannel(normalizedRouteReplyChannel),
+  );
+  const shouldSuppressDispatcherDelivery =
+    suppressDelivery && !shouldDeliverSuppressedSourceViaMessageTool;
 
   let pluginFallbackReason:
     | "plugin-bound-fallback-missing-plugin"
@@ -762,7 +806,7 @@ export async function dispatchReplyFromConfig(
 
   if (pluginOwnedBinding) {
     touchConversationBindingRecord(pluginOwnedBinding.bindingId);
-    if (suppressDelivery) {
+    if (shouldSuppressDispatcherDelivery) {
       // Plugin-bound inbound handlers typically emit outbound replies we
       // cannot rewind. When automatic delivery is suppressed, skip the plugin
       // claim and fall through to normal suppressed agent processing.
@@ -881,11 +925,13 @@ export async function dispatchReplyFromConfig(
     if (fastAbort.handled) {
       let queuedFinal = false;
       let routedFinalCount = 0;
-      if (!suppressDelivery) {
+      if (!shouldSuppressDispatcherDelivery) {
         const payload = {
           text: formatAbortReplyTextResolver(fastAbort.stoppedSubagents),
         } satisfies ReplyPayload;
-        const result = await routeReplyToOriginating(payload);
+        const result = shouldDeliverSuppressedSourceViaMessageTool
+          ? await routeReplyToSourceViaMessageTool(payload)
+          : await routeReplyToOriginating(payload);
         if (result) {
           queuedFinal = result.ok;
           if (result.ok) {
@@ -936,7 +982,9 @@ export async function dispatchReplyFromConfig(
         accountId: replyRoute.accountId,
       });
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
-      const result = await routeReplyToOriginating(normalizedPayload);
+      const result = shouldDeliverSuppressedSourceViaMessageTool
+        ? await routeReplyToSourceViaMessageTool(normalizedPayload)
+        : await routeReplyToOriginating(normalizedPayload);
       if (result) {
         if (!result.ok) {
           logVerbose(
@@ -979,7 +1027,7 @@ export async function dispatchReplyFromConfig(
         const text = beforeDispatchResult.text;
         let queuedFinal = false;
         let routedFinalCount = 0;
-        if (text && !suppressDelivery) {
+        if (text && !shouldSuppressDispatcherDelivery) {
           const handledReply = await sendFinalPayload({ text });
           queuedFinal = handledReply.queuedFinal;
           routedFinalCount += handledReply.routedFinalCount;
@@ -1033,7 +1081,7 @@ export async function dispatchReplyFromConfig(
     // When automatic source delivery is suppressed, still let the agent process
     // the inbound message (context, memory, tool calls) but suppress automatic
     // outbound source delivery.
-    if (suppressDelivery) {
+    if (shouldSuppressDispatcherDelivery) {
       logVerbose(
         `Delivery suppressed by ${deliverySuppressionReason} for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"} — agent will still process the message`,
       );
@@ -1239,7 +1287,7 @@ export async function dispatchReplyFromConfig(
             if (!suppressAutomaticSourceDelivery) {
               await onToolResultFromReplyOptions?.(payload);
             }
-            if (suppressDelivery) {
+            if (shouldSuppressDispatcherDelivery) {
               return;
             }
             const ttsPayload = await maybeApplyTtsToReplyPayload({
@@ -1273,6 +1321,15 @@ export async function dispatchReplyFromConfig(
             }
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(deliveryPayload, undefined, false);
+            } else if (shouldDeliverSuppressedSourceViaMessageTool) {
+              const result = await routeReplyToSourceViaMessageTool(deliveryPayload, {
+                mirror: false,
+              });
+              if (result && !result.ok) {
+                logVerbose(
+                  `dispatch-from-config: route-reply (tool) failed: ${result.error ?? "unknown error"}`,
+                );
+              }
             } else {
               markInboundDedupeReplayUnsafe();
               dispatcher.sendToolResult(deliveryPayload);
@@ -1334,7 +1391,7 @@ export async function dispatchReplyFromConfig(
             ) {
               markInboundDedupeReplayUnsafe();
             }
-            if (suppressDelivery) {
+            if (shouldSuppressDispatcherDelivery) {
               return;
             }
             // Suppress reasoning payloads — channels using this generic dispatch
@@ -1396,6 +1453,16 @@ export async function dispatchReplyFromConfig(
             const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
+            } else if (shouldDeliverSuppressedSourceViaMessageTool) {
+              const result = await routeReplyToSourceViaMessageTool(normalizedPayload, {
+                abortSignal: context?.abortSignal,
+                mirror: false,
+              });
+              if (result && !result.ok) {
+                logVerbose(
+                  `dispatch-from-config: route-reply (block) failed: ${result.error ?? "unknown error"}`,
+                );
+              }
             } else {
               markInboundDedupeReplayUnsafe();
               dispatcher.sendBlockReply(normalizedPayload);
@@ -1453,7 +1520,7 @@ export async function dispatchReplyFromConfig(
 
     let queuedFinal = false;
     let routedFinalCount = 0;
-    if (!suppressDelivery) {
+    if (!shouldSuppressDispatcherDelivery) {
       for (const reply of replies) {
         // Suppress reasoning payloads from channel delivery — channels using this
         // generic dispatch path do not have a dedicated reasoning lane.
@@ -1500,7 +1567,9 @@ export async function dispatchReplyFromConfig(
               spokenText: accumulatedBlockTtsText,
             };
             const normalizedTtsOnlyPayload = await normalizeReplyMediaPayload(ttsOnlyPayload);
-            const result = await routeReplyToOriginating(normalizedTtsOnlyPayload);
+            const result = shouldDeliverSuppressedSourceViaMessageTool
+              ? await routeReplyToSourceViaMessageTool(normalizedTtsOnlyPayload)
+              : await routeReplyToOriginating(normalizedTtsOnlyPayload);
             if (result) {
               queuedFinal = result.ok || queuedFinal;
               if (result.ok) {


### PR DESCRIPTION
## Summary

Fixes group/channel `message_tool` visible-reply delivery so normal assistant final replies are deterministically routed through the unified message sender instead of being suppressed into transcript-only output.

## Root Cause

`messages.groupChat.visibleReplies = "message_tool"` changed group/channel turns to `message_tool_only`, which suppressed dispatcher-backed automatic delivery. If the model returned a normal final reply instead of explicitly calling `message.send`, the reply was saved in the session transcript but never posted to the source WhatsApp/Discord group.

## Changes

- Load the route-reply runtime for same-provider delivery targets, not only cross-provider routes.
- In group/channel `message_tool_only` mode, route final, block, tool, abort, before-dispatch, and TTS-only payloads through `routeReply` to the source chat.
- Preserve the existing full suppression behavior for send-policy denial and cases without a routable message-tool target.
- Pass `sourceReplyDeliveryMode` into ACP delivery and let suppressed ACP final replies route through the same message-tool path.
- Add regression coverage for WhatsApp groups, Discord channels, and ACP suppressed delivery.

## Validation

- `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts`
- `git diff --check`

`pnpm check` was also attempted; it is blocked by an unrelated local dependency resolution error for `web-tree-sitter` in `src/infra/command-explainer/*` before reaching this change.