### PR TITLE
test(auto-reply): guard message-tool-only reply privacy

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -471,6 +471,31 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
   });
 
+  it("keeps same-provider tool-only ACP final replies private when an origin route exists", async () => {
+    setReadyAcpResolution();
+    mockVisibleTextTurn("hidden final");
+    const onReplyStart = vi.fn();
+    const { dispatcher } = createDispatcher();
+
+    const result = await runDispatch({
+      bodyForAgent: "reply via message tool if needed",
+      dispatcher,
+      onReplyStart,
+      suppressUserDelivery: true,
+      suppressReplyLifecycle: false,
+      sourceReplyDeliveryMode: "message_tool_only",
+      shouldRouteToOriginating: true,
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+    });
+
+    expect(result?.queuedFinal).toBe(false);
+    expect(onReplyStart).toHaveBeenCalledTimes(1);
+    expect(routeMocks.routeReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+  });
+
   it("edits ACP tool lifecycle updates in place when supported", async () => {
     setReadyAcpResolution();
     mockToolLifecycleTurn("call-1");

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4502,6 +4502,35 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("does not auto-route same-provider group/channel final replies in message-tool-only mode", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("message_tool_only");
+      return { text: "final reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "channel",
+        Provider: "discord",
+        Surface: "discord",
+        OriginatingChannel: "discord",
+        OriginatingTo: "channel:C1",
+        SessionKey: "test:discord:channel:C1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).not.toHaveBeenCalled();
+  });
+
   it("uses harness defaults for direct source delivery when config is unset", async () => {
     setNoAbort();
     registerAgentHarness({


### PR DESCRIPTION
## Summary

- Problem: #76647 attempted to fix group/channel `message_tool` replies by auto-routing normal final output, but that changes the documented delivery contract.
- Why it matters: in `message_tool_only`, final/block/tool output is transcript-private; visible group/channel replies must come from the explicit `message` tool so send policy, tool auditability, and duplicate suppression stay intact.
- What changed: added regression coverage for same-provider group/channel final replies and same-provider ACP final replies when an origin route exists.
- What did NOT change (scope boundary): no runtime dispatch changes; this PR intentionally preserves the current message-tool-only privacy model.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #76647
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A; this is a guardrail PR for the existing delivery contract.
- Missing detection / guardrail: existing tests covered suppressed final delivery, but not the same-provider `OriginatingChannel`/`OriginatingTo` route shape from #76647.
- Contributing context: explicit `message(action=send)` already has same-origin target inference through the message tool context; normal final replies must remain private in `message_tool_only` mode.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/auto-reply/reply/dispatch-acp.test.ts`
- Scenario the test should lock in: same-provider group/channel origin routes do not make `message_tool_only` final ACP or normal dispatch replies visible.
- Why this is the smallest reliable guardrail: it exercises the central dispatch seams that decide whether to call the dispatcher or `routeReply`.
- Existing test that already covers this (if any): existing tests covered private `message_tool_only` turns without the same-provider origin route.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
message_tool_only final reply -> transcript/private result -> no dispatcher/routeReply delivery
message(action=send)          -> message tool target inference -> visible source chat delivery
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local; Linux Testbox
- Runtime/container: repo `pnpm` test wrapper
- Model/provider: N/A
- Integration/channel (if any): auto-reply group/channel dispatch, ACP dispatch
- Relevant config (redacted): default `message_tool_only` group/channel delivery

### Steps

1. Run focused auto-reply dispatch tests.
2. Run changed tests in Blacksmith Testbox.

### Expected

- Same-provider group/channel `message_tool_only` final replies are not queued through dispatcher or `routeReply`.
- ACP `message_tool_only` final replies stay private even when an origin route exists.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: local focused tests and Testbox changed test gate.
- Edge cases checked: same-provider origin route for normal dispatch and ACP dispatch.
- What you did **not** verify: live Discord/WhatsApp delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
