### PR TITLE
Fix Telegram long-poll reconnect after health-monitor stop timeout

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -301,7 +301,7 @@ describe("server-channels auto restart", () => {
     }
   });
 
-  it("does not allow a second account task to start when stop times out", async () => {
+  it("forgets a timed-out stop so health restarts can replace wedged long-poll providers", async () => {
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>
         await new Promise<void>(() => {
@@ -323,10 +323,43 @@ describe("server-channels auto restart", () => {
 
     const snapshot = manager.getRuntimeSnapshot();
     const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
-    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(startAccount).toHaveBeenCalledTimes(2);
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
-    expect(account?.lastError).toContain("channel stop timed out");
+    expect(account?.lastError).toBeNull();
+  });
+
+  it("does not let an old timed-out lifecycle mark its replacement stopped", async () => {
+    const firstLifecycleDone = createDeferred();
+    const startAccount = vi
+      .fn()
+      .mockImplementationOnce(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+        abortSignal.addEventListener("abort", () => {}, { once: true });
+        await firstLifecycleDone.promise;
+      })
+      .mockImplementationOnce(
+        async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+          await new Promise<void>(() => {
+            abortSignal.addEventListener("abort", () => {}, { once: true });
+          }),
+      );
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    firstLifecycleDone.resolve();
+    await flushMicrotasks();
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.lastError).toBeNull();
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -538,11 +538,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             })
             .finally(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
-              setRuntime(channelId, id, {
-                accountId: id,
-                running: false,
-                lastStopAt: Date.now(),
-              });
+              // A timed-out stop may intentionally forget this lifecycle and start
+              // a replacement provider. Do not let the old task settle later and
+              // clobber the replacement account runtime back to stopped.
+              if (store.tasks.get(id) === trackedPromise || store.aborts.get(id) === abort) {
+                setRuntime(channelId, id, {
+                  accountId: id,
+                  running: false,
+                  lastStopAt: Date.now(),
+                });
+              }
             })
             .then(async () => {
               if (manuallyStopped.has(rKey)) {
@@ -679,12 +684,19 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         );
         if (!stoppedCleanly) {
           log.warn?.(
-            `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
+            `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; forgetting timed-out lifecycle so a replacement can start`,
           );
+          if (store.aborts.get(id) === abort) {
+            store.aborts.delete(id);
+          }
+          if (store.tasks.get(id) === task) {
+            store.tasks.delete(id);
+          }
           setRuntime(channelId, id, {
             accountId: id,
-            running: true,
+            running: false,
             restartPending: false,
+            lastStopAt: Date.now(),
             lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
           });
           return;


### PR DESCRIPTION
## Summary\n- allow channel health restarts to replace a provider whose abort/stop lifecycle timed out\n- prevent an old timed-out provider lifecycle from later marking the replacement runtime as stopped\n- add regression coverage for timed-out stop replacement and late old-lifecycle settlement\n\n## Tests\n- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-channels.test.ts src/gateway/channel-health-policy.test.ts