### PR TITLE
fix(ui): stop large session lists adding 15+ second chat delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Sessions: avoid full `sessions.list` reloads for chat-turn `sessions.changed` payloads, so large session stores no longer add multi-second delays while chat responses are being delivered. (#76676) Thanks @VACInc.
 - Discord/status: honor explicit `messages.statusReactions.enabled: true` in tool-only guild channels so queued ack reactions can progress through thinking/done lifecycle reactions instead of stopping at the initial emoji. Thanks @Marvinthebored.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -150,7 +150,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 
-  it("reloads sessions when an applied message-phase event inserts a session row", () => {
+  it("does not reload sessions when a message-phase event inserts a session row", () => {
     loadSessionsMock.mockReset();
     applySessionsChangedEventMock
       .mockReset()
@@ -170,11 +170,10 @@ describe("handleGatewayEvent sessions.changed", () => {
     });
 
     expect(applySessionsChangedEventMock).toHaveBeenCalledTimes(1);
-    expect(loadSessionsMock).toHaveBeenCalledTimes(1);
-    expect(loadSessionsMock).toHaveBeenCalledWith(host);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 
-  it("reloads sessions when a message-phase event cannot patch local state", () => {
+  it("does not reload sessions when a message-phase event cannot patch local state", () => {
     loadSessionsMock.mockReset();
     applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: false });
     const host = createHost();
@@ -186,8 +185,39 @@ describe("handleGatewayEvent sessions.changed", () => {
       seq: 1,
     });
 
-    expect(loadSessionsMock).toHaveBeenCalledTimes(1);
-    expect(loadSessionsMock).toHaveBeenCalledWith(host);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reload sessions for chat lifecycle events", () => {
+    loadSessionsMock.mockReset();
+    applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: true, change: "updated" });
+    const host = createHost();
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: "agent:main:main", phase: "start", runId: "run-1" },
+      seq: 1,
+    });
+
+    expect(applySessionsChangedEventMock).toHaveBeenCalledTimes(1);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not reload sessions for chat send acknowledgement events", () => {
+    loadSessionsMock.mockReset();
+    applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: true, change: "updated" });
+    const host = createHost();
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "sessions.changed",
+      payload: { sessionKey: "agent:main:main", reason: "send" },
+      seq: 1,
+    });
+
+    expect(applySessionsChangedEventMock).toHaveBeenCalledTimes(1);
+    expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -156,12 +156,18 @@ function isTerminalChatState(
   return state === "final" || state === "aborted" || state === "error";
 }
 
-function isSessionMessagePhasePayload(payload: unknown): boolean {
+function isChatTurnSessionChangedPayload(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return false;
+  }
+  const record = payload as { phase?: unknown; reason?: unknown };
   return (
-    Boolean(payload) &&
-    typeof payload === "object" &&
-    !Array.isArray(payload) &&
-    (payload as { phase?: unknown }).phase === "message"
+    record.phase === "start" ||
+    record.phase === "message" ||
+    record.phase === "end" ||
+    record.phase === "error" ||
+    record.reason === "send" ||
+    record.reason === "steer"
   );
 }
 
@@ -749,12 +755,8 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   }
 
   if (evt.event === "sessions.changed") {
-    const applyResult = applySessionsChangedEvent(host as unknown as SessionsState, evt.payload);
-    if (
-      applyResult.applied &&
-      applyResult.change === "updated" &&
-      isSessionMessagePhasePayload(evt.payload)
-    ) {
+    applySessionsChangedEvent(host as unknown as SessionsState, evt.payload);
+    if (isChatTurnSessionChangedPayload(evt.payload)) {
       return;
     }
     void loadSessions(host as unknown as SessionsState);


### PR DESCRIPTION
## Summary
- Stop Control UI `sessions.changed` chat-turn events from triggering a full `sessions.list` reload.
- Keep applying the pushed session row payload locally for chat lifecycle/message/send/steer events instead of asking the gateway to rebuild a large session list.
- Preserve full session-list reloads for non-chat session changes such as patch/delete/compact/restore paths.

## Why
Large session lists can make `sessions.list` take 15+ seconds, and local investigation saw repeated `sessions.list` calls in the chat-response window. Those control-plane list reloads are not required to deliver Discord or Telegram chat responses, but they can still compete with inbound response delivery and make turns feel dramatically slower than the LLM runtime itself.

## Relation to existing upstream fixes
Current `main` already includes #76277 / `05c9492bff` (`fix: reduce WebUI session latency churn`), which added local row patching and skipped reloads for updated message-phase rows. This PR covers the remaining chat-turn gaps still present on current `origin/main`: inserted or unpatchable message-phase events, lifecycle start/end/error events, and send/steer acknowledgement events still fall back to full `sessions.list` reloads.

## Root Cause
The gateway broadcasts `sessions.changed` during every chat turn so subscribed clients can keep session metadata fresh. The Control UI already knows how to patch rows from those event payloads, but it still fell back to a full `sessions.list` reload for inserted rows, missing local state, lifecycle start/end/error, and send/steer acknowledgements. On installs with large session stores, that means chat turns can repeatedly trigger expensive session-list work even when no user is looking at or refreshing the full session list.

## Validation
- `pnpm test ui/src/ui/app-gateway.sessions.node.test.ts`
- `pnpm changed:lanes --json`
- `pnpm check:changed` locally after rebasing onto current `origin/main`

Testbox note: attempted the preferred Testbox changed gate, but the local Blacksmith CLI is not authenticated in this session, so validation fell back to the local changed gate.