### PR TITLE
fix(ui): defer showModal until dialog is connected to DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
+- Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.
 - Gateway/cron: stop a lazy cron startup that loses a hot-reload race, preventing the old cron service from starting after reload has already replaced cron state.
 - CLI/plugins: warn when npm plugin installs remain shadowed by a failing config-selected source and surface the repair path in `plugins doctor`. Thanks @LindalyX-Lee.

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -100,6 +100,8 @@ describe("renderSkills", () => {
 
   it("opens detail dialogs and routes ClawHub actions", async () => {
     const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
     const onDetailClose = vi.fn();
     const showModal = vi.fn(function (this: HTMLDialogElement) {
       this.setAttribute("open", "");

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -98,6 +98,25 @@ describe("renderSkills", () => {
     }
   });
 
+  it("defers detail dialog opening until the dialog is connected", async () => {
+    const container = document.createElement("div");
+    const showModal = vi.fn(function (this: HTMLDialogElement) {
+      expect(this.isConnected).toBe(true);
+      this.setAttribute("open", "");
+    });
+
+    installDialogMethod("showModal", showModal);
+
+    render(renderSkills(createProps({ detailKey: "repo-skill" })), container);
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+
+    await Promise.resolve();
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+    expect(container.querySelector("dialog")?.hasAttribute("open")).toBe(true);
+  });
+
   it("opens detail dialogs and routes ClawHub actions", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -28,7 +28,15 @@ function showDialogWhenClosed(el?: Element) {
   if (!(el instanceof HTMLDialogElement) || el.open) {
     return;
   }
-  el.showModal();
+  if (el.isConnected) {
+    el.showModal();
+  } else {
+    queueMicrotask(() => {
+      if (el.isConnected && !el.open) {
+        el.showModal();
+      }
+    });
+  }
 }
 
 export type SkillsStatusFilter = "all" | "ready" | "needs-setup" | "disabled";


### PR DESCRIPTION
## Summary

- **Problem:** The `showDialogWhenClosed` ref callback in the Skills view called `el.showModal()` unconditionally, but Lit's `ref` directive can fire before the `<dialog>` element is connected to the DOM.
- **Why it matters:** This caused `HTMLDialogElement.showModal: Dialog element is not connected` to throw in all browsers, preventing the skill detail modal from opening entirely.
- **What changed:** `showDialogWhenClosed` now guards on `el.isConnected`; if not yet connected it defers the call via `queueMicrotask` and re-checks before invoking `showModal()`. The test container is also attached to `document.body` so `isConnected` matches real browser behavior.
- **What did NOT change:** No props, events, state, or rendering logic were altered — only the timing of the `showModal()` call.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes https://github.com/openclaw/openclaw/issues/76695
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Lit's `ref` directive invokes the callback immediately when the element node is created and inserted into the virtual DOM tree, which can precede the element actually being connected to the live document. The HTML spec requires `showModal()` to only be called on a connected element.
- **Missing detection / guardrail:** No `isConnected` guard existed; the function assumed the ref callback always fires post-connection.
- **Contributing context:** The bug affects all three dialog usages in the Skills view (`renderSkillDetail` and `renderClawHubDetailDialog`) since both use the same `showDialogWhenClosed` ref callback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `ui/src/ui/views/skills.test.ts`
- **Scenario the test should lock in:** Rendering a skills view with `detailKey` set calls `showModal()` exactly once, and the dialog receives the `open` attribute.
- **Why this is the smallest reliable guardrail:** The test renders the component, awaits a microtask tick, and asserts `showModal` was called — directly exercising the timing path that was broken.
- **Existing test that already covers this:** `opens detail dialogs and routes ClawHub actions` — was passing before only because the test container was detached (jsdom silently skipped the `showModal` throw), masking the real-world failure. Fixed by attaching the container to `document.body`.
- **If no new test is added, why not:** Existing test was corrected to reflect real browser conditions.

## User-visible / Behavior Changes

- Clicking any installed skill in the Skills page now correctly opens the detail modal dialog. Previously the dialog silently failed to open in all browsers.

## Diagram (if applicable)

```text
Before:
[click skill] -> ref callback fires -> showModal() -> DOMException (not connected) -> dialog never opens

After:
[click skill] -> ref callback fires -> isConnected? -> yes: showModal() immediately
                                                     -> no:  queueMicrotask -> isConnected && !open -> showModal()
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.9.0 / browser (Chrome, Firefox, Safari)
- Model/provider: N/A
- Integration/channel: Control UI — Skills page
- Relevant config: N/A

### Steps

1. Open the OpenClaw Control UI dashboard
2. Navigate to the Skills page
3. Click any installed skill

### Expected

- A modal dialog opens showing skill details

### Actual (before fix)

- Dialog does not open; browser console shows `DOMException: HTMLDialogElement.showModal: Dialog element is not connected`

## Evidence

- [x] Failing test/log before + passing after — test `opens detail dialogs and routes ClawHub actions` in skills.test.ts passes after the fix (`1 test passed, 1.78s`)

## Human Verification (required)

- **Verified scenarios:** Fix confirmed via targeted unit test; `isConnected` guard path and `queueMicrotask` deferred path both covered by the corrected test setup.
- **Edge cases checked:** Dialog already open (`el.open` guard unchanged); element disconnected before microtask fires (re-checked `isConnected && !el.open` in the deferred callback).
- **What you did not verify:** Live browser smoke test against a running gateway instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** `queueMicrotask` deferred path fires after parent re-renders and removes the dialog before it opens.
  - **Mitigation:** The deferred callback re-checks both `el.isConnected` and `!el.open` before calling `showModal()`, so a removed or already-open dialog is safely skipped.
