### PR TITLE
fix(telegram): force fresh final after visible intermediate output (#76529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/providers: preserve scoped cold-load fallback for enabled external manifest-contract capability providers missing from the startup registry, so providers such as Fish Audio can resolve on request without requiring `activation.onStartup` for correctness. (#76536) Thanks @Conan-Scott.
 - Gateway/update: carry `continuationMessage` from `update.run` into successful restart sentinels so session-scoped self-updates can resume one follow-up turn after the Gateway restarts. Refs #71178. (#74362) Thanks @100menotu001, @HeilbronAILabs, and @artnking.
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
+- Channels/Telegram: force a fresh final message when a visible non-preview bubble (tool/block/error) was delivered after the active answer preview, so multi-step assistant replies no longer end up with the final answer above intermediate output. Fixes #76529. Thanks @jack-stormentswe.
 
 ## 2026.5.2
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -303,7 +303,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     For text-only replies:
 
-    - short DM/group/topic previews: OpenClaw keeps the same preview message and performs a final edit in place
+    - short DM/group/topic previews: OpenClaw keeps the same preview message and performs a final edit in place, unless a visible non-preview message was sent after the preview appeared
+    - previews followed by visible non-preview output: OpenClaw sends the completed reply as a fresh final message and cleans up the older preview, so the final answer appears after intermediate output
     - previews older than about one minute: OpenClaw sends the completed reply as a fresh final message and then cleans up the preview, so Telegram's visible timestamp reflects completion time instead of the preview creation time
 
     For complex replies (for example media payloads), OpenClaw falls back to normal final delivery and then cleans up the preview message.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3179,8 +3179,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("handles error block + response final — error delivered, response finalizes preview", async () => {
-    const draftStream = createDraftStream(999);
+  it("sends a fresh final after a visible error block bubble pushes the preview up", async () => {
+    const draftStream = createTestDraftStream({
+      messageId: 999,
+      visibleSinceMs: Date.now() - 1_000,
+    });
     createTelegramDraftStream.mockReturnValue(draftStream);
     editMessageTelegram.mockResolvedValue({ ok: true });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -3201,16 +3204,18 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext() });
 
-    // Block error went through deliverReplies
-    expect(deliverReplies).toHaveBeenCalledTimes(1);
-    // Final was finalized via preview edit
-    expect(editMessageTelegram).toHaveBeenCalledWith(
-      123,
-      999,
-      "The command timed out. Here's what I found...",
-      expect.any(Object),
+    // Error block + fresh final both went through deliverReplies; preview was
+    // not edited in place and the stale preview was cleared.
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({ text: "The command timed out. Here's what I found..." }),
+        ],
+      }),
     );
-    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalled();
   });
 
   // #76529: when a visible non-final message is delivered after the answer

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3213,6 +3213,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).not.toHaveBeenCalled();
   });
 
+  // #76529: when a visible non-final message is delivered after the answer
+  // preview is already on screen, finalizing the preview by edit puts the
+  // final answer above the intermediate output. Force a fresh send instead.
+  it("sends a fresh final after a visible block bubble pushes the preview up (#76529)", async () => {
+    // Preview was already on screen before the block bubble was sent.
+    const draftStream = createTestDraftStream({
+      messageId: 999,
+      visibleSinceMs: Date.now() - 1_000,
+    });
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    editMessageTelegram.mockResolvedValue({ ok: true });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Checked maxDBdays..." });
+        await dispatcherOptions.deliver(
+          { text: "Changed maxDBdays from 91 → 14" },
+          { kind: "block" },
+        );
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    // Block + fresh final both went through deliverReplies; preview was not
+    // edited in place and the stale preview was cleared.
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "Done" })],
+      }),
+    );
+    expect(draftStream.clear).toHaveBeenCalled();
+  });
+
   it("cleans up preview even when fallback delivery throws (double failure)", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -729,6 +729,7 @@ export const dispatchTelegramMessage = async ({
       }
       return { ...payload, replyToId: implicitQuoteReplyTargetId };
     };
+    let lastVisibleNonPreviewDeliveryAtMs: number | undefined;
     const sendPayload = async (payload: ReplyPayload) => {
       if (isDispatchSuperseded()) {
         return false;
@@ -742,6 +743,7 @@ export const dispatchTelegramMessage = async ({
       });
       if (result.delivered) {
         deliveryState.markDelivered();
+        lastVisibleNonPreviewDeliveryAtMs = Date.now();
       }
       return result.delivered;
     };
@@ -794,6 +796,7 @@ export const dispatchTelegramMessage = async ({
       markDelivered: () => {
         deliveryState.markDelivered();
       },
+      getLastVisibleNonPreviewDeliveryAtMs: () => lastVisibleNonPreviewDeliveryAtMs,
     });
 
     if (isDmTopic) {

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -95,6 +95,10 @@ type CreateLaneTextDelivererParams = {
   log: (message: string) => void;
   markDelivered: () => void;
   now?: () => number;
+  // Force fresh final when a visible non-preview message has been delivered
+  // since the active preview was created, even if the preview is younger
+  // than the long-lived threshold (#76529).
+  getLastVisibleNonPreviewDeliveryAtMs?: () => number | undefined;
 };
 
 type DeliverLaneTextParams = {
@@ -204,10 +208,25 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     params.retainPreviewOnCleanupByLane[laneName] = true;
   };
   const isMessagePreviewLane = (lane: DraftLaneState) => lane.stream != null;
-  const shouldUseFreshFinalForLane = (lane: DraftLaneState) =>
-    isMessagePreviewLane(lane) && isLongLivedPreview(lane.stream?.visibleSinceMs?.(), readNow());
+  const wasVisiblyOverwrittenSince = (visibleSinceMs: number | undefined): boolean => {
+    if (typeof visibleSinceMs !== "number") {
+      return false;
+    }
+    const lastNonPreviewAt = params.getLastVisibleNonPreviewDeliveryAtMs?.();
+    return typeof lastNonPreviewAt === "number" && lastNonPreviewAt > visibleSinceMs;
+  };
+  const shouldUseFreshFinalForLane = (lane: DraftLaneState) => {
+    if (!isMessagePreviewLane(lane)) {
+      return false;
+    }
+    const visibleSinceMs = lane.stream?.visibleSinceMs?.();
+    return (
+      isLongLivedPreview(visibleSinceMs, readNow()) || wasVisiblyOverwrittenSince(visibleSinceMs)
+    );
+  };
   const shouldUseFreshFinalForPreview = (lane: DraftLaneState, visibleSinceMs?: number) =>
-    isMessagePreviewLane(lane) && isLongLivedPreview(visibleSinceMs, readNow());
+    isMessagePreviewLane(lane) &&
+    (isLongLivedPreview(visibleSinceMs, readNow()) || wasVisiblyOverwrittenSince(visibleSinceMs));
   const clearActivePreviewAfterFreshFinal = async (lane: DraftLaneState, laneName: LaneName) => {
     try {
       await lane.stream?.clear();


### PR DESCRIPTION
Fixes #76529.

Telegram preview finalization only forces a fresh final when the preview has been visible for 60s. When tool/block bubbles are delivered between preview creation and the final answer, editing the preview in place puts the final above the intermediate output (the user sees "Done" at the top, not the bottom).

Track the timestamp of the most recent visible non-preview delivery in the dispatcher and force fresh-final when that timestamp is newer than the active preview's `visibleSinceMs`, regardless of preview age.

Acceptance:
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` — 108/108
- `pnpm test extensions/telegram/src/lane-delivery.test.ts` — 27/27
- `pnpm tsgo:extensions:all` clean
- `pnpm exec oxfmt --check` clean