### PR TITLE
fix: scope gpt-5.4-mini chat reasoning_effort fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/status: honor explicit `messages.statusReactions.enabled: true` in tool-only guild channels so queued ack reactions can progress through thinking/done lifecycle reactions instead of stopping at the initial emoji. Thanks @Marvinthebored.
-- Agents/OpenAI: omit Chat Completions `reasoning_effort` for `gpt-5.4-mini` while preserving Responses reasoning support, preventing Telegram-routed fallback runs from hanging after OpenAI rejects tool payloads. Fixes #76176. Thanks @ThisIsAdilah and @chinar-amrutkar.
+- Agents/OpenAI: omit Chat Completions `reasoning_effort` for `gpt-5.4-mini` only when function tools are present while preserving tool-free Chat and Responses reasoning support, preventing Telegram-routed fallback runs from hanging after OpenAI rejects tool payloads. Fixes #76176. Thanks @ThisIsAdilah and @chinar-amrutkar.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/status: honor explicit `messages.statusReactions.enabled: true` in tool-only guild channels so queued ack reactions can progress through thinking/done lifecycle reactions instead of stopping at the initial emoji. Thanks @Marvinthebored.
+- Agents/OpenAI: omit Chat Completions `reasoning_effort` for `gpt-5.4-mini` while preserving Responses reasoning support, preventing Telegram-routed fallback runs from hanging after OpenAI rejects tool payloads. Fixes #76176. Thanks @ThisIsAdilah and @chinar-amrutkar.
 - Agents/models: forward model `maxTokens` as the default output-token limit for OpenAI-compatible Responses and Completions transports when no runtime override is provided, preventing provider defaults from silently truncating larger outputs. (#76645) Thanks @joeyfrasier.
 - Control UI/Skills: fix skill detail modal silently failing to open in all browsers by deferring `showModal()` until the dialog element is connected to the DOM; the Lit `ref` callback fired before connection causing a `DOMException: HTMLDialogElement.showModal: Dialog element is not connected` on every skill click. Thanks @nickmopen.
 - Gateway/update: run `doctor --non-interactive --fix` after Control UI global package updates before reporting success, so legacy config is migrated before the gateway restart. Thanks @stevenchouai.

--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -13,10 +13,10 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "xhigh" })).toBe("xhigh");
   });
 
-  it("omits reasoning_effort for gpt-5.4-mini in Chat Completions", () => {
+  it("preserves reasoning_effort metadata for gpt-5.4-mini in Chat Completions", () => {
     const model = { provider: "openai", id: "gpt-5.4-mini", api: "openai-completions" };
-    expect(resolveOpenAISupportedReasoningEfforts(model)).toHaveLength(0);
-    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "medium" })).toBeUndefined();
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toContain("medium");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "medium" })).toBe("medium");
   });
 
   it("preserves reasoning_effort for gpt-5.4-mini in Responses", () => {

--- a/src/agents/openai-reasoning-effort.test.ts
+++ b/src/agents/openai-reasoning-effort.test.ts
@@ -13,6 +13,18 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "xhigh" })).toBe("xhigh");
   });
 
+  it("omits reasoning_effort for gpt-5.4-mini in Chat Completions", () => {
+    const model = { provider: "openai", id: "gpt-5.4-mini", api: "openai-completions" };
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toHaveLength(0);
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "medium" })).toBeUndefined();
+  });
+
+  it("preserves reasoning_effort for gpt-5.4-mini in Responses", () => {
+    const model = { provider: "openai", id: "gpt-5.4-mini", api: "openai-responses" };
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toContain("medium");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "medium" })).toBe("medium");
+  });
+
   it("does not downgrade xhigh when Pi compat metadata declares it explicitly", () => {
     const model = {
       provider: "openai-codex",

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -26,6 +26,11 @@ function normalizeModelId(id: string | null | undefined): string {
   return normalizeLowercaseStringOrEmpty(id ?? "").replace(/-\d{4}-\d{2}-\d{2}$/u, "");
 }
 
+export function isOpenAIGpt54MiniModel(model: OpenAIReasoningModel): boolean {
+  const id = normalizeModelId(typeof model.id === "string" ? model.id : undefined);
+  return /^gpt-5\.4-mini(?:-|$)/u.test(id);
+}
+
 export function normalizeOpenAIReasoningEffort(effort: string): string {
   return effort === "minimal" ? "minimal" : effort;
 }
@@ -79,14 +84,6 @@ export function resolveOpenAISupportedReasoningEfforts(
   }
   if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/u.test(id)) {
     return GPT_PRO_REASONING_EFFORTS;
-  }
-  const api = normalizeLowercaseStringOrEmpty(typeof model.api === "string" ? model.api : "");
-  if (api === "openai-responses" || api === "openai-codex-responses") {
-    if (/^gpt-5\.4-mini(?:-|$)/u.test(id)) {
-      return GPT_52_REASONING_EFFORTS;
-    }
-  } else if (/^gpt-5\.4-mini(?:-|$)/u.test(id)) {
-    return [];
   }
   if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/u.test(id)) {
     return GPT_52_REASONING_EFFORTS;

--- a/src/agents/openai-reasoning-effort.ts
+++ b/src/agents/openai-reasoning-effort.ts
@@ -80,6 +80,14 @@ export function resolveOpenAISupportedReasoningEfforts(
   if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/u.test(id)) {
     return GPT_PRO_REASONING_EFFORTS;
   }
+  const api = normalizeLowercaseStringOrEmpty(typeof model.api === "string" ? model.api : "");
+  if (api === "openai-responses" || api === "openai-codex-responses") {
+    if (/^gpt-5\.4-mini(?:-|$)/u.test(id)) {
+      return GPT_52_REASONING_EFFORTS;
+    }
+  } else if (/^gpt-5\.4-mini(?:-|$)/u.test(id)) {
+    return [];
+  }
   if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/u.test(id)) {
     return GPT_52_REASONING_EFFORTS;
   }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2084,6 +2084,34 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("reasoning_effort");
   });
 
+  it("keeps reasoning_effort for gpt-5.4-mini Chat Completions payloads without tools", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4-mini",
+        name: "GPT-5.4 mini",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toEqual([]);
+    expect(params.reasoning_effort).toBe("medium");
+  });
+
   it("uses provider-native reasoning effort values declared by model compat", () => {
     const baseModel = {
       id: "qwen/qwen3-32b",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2050,6 +2050,40 @@ describe("openai transport stream", () => {
     expect(params.reasoning_effort).toBe("high");
   });
 
+  it("omits reasoning_effort for gpt-5.4-mini Chat Completions tool payloads", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4-mini",
+        name: "GPT-5.4 mini",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 128000,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
+          {
+            name: "lookup_weather",
+            description: "Get forecast",
+            parameters: { type: "object", properties: {}, additionalProperties: false },
+          },
+        ],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; tools?: unknown };
+
+    expect(params.tools).toBeDefined();
+    expect(params).not.toHaveProperty("reasoning_effort");
+  });
+
   it("uses provider-native reasoning effort values declared by model compat", () => {
     const baseModel = {
       id: "qwen/qwen3-32b",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -28,6 +28,7 @@ import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
 import { flattenCompletionMessagesToStringContent } from "./openai-completions-string-content.js";
 import { resolveOpenAIReasoningEffortMap } from "./openai-reasoning-compat.js";
 import {
+  isOpenAIGpt54MiniModel,
   normalizeOpenAIReasoningEffort,
   resolveOpenAIReasoningEffortForModel,
   type OpenAIApiReasoningEffort,
@@ -1899,6 +1900,8 @@ export function buildOpenAICompletionsParams(
         fallbackMap: compat.reasoningEffortMap,
       })
     : undefined;
+  const omitGpt54MiniToolReasoningEffort =
+    isOpenAIGpt54MiniModel(model) && Array.isArray(params.tools) && params.tools.length > 0;
   if (
     compat.thinkingFormat === "openrouter" &&
     model.reasoning &&
@@ -1910,7 +1913,8 @@ export function buildOpenAICompletionsParams(
   } else if (
     resolvedCompletionsReasoningEffort &&
     model.reasoning &&
-    compat.supportsReasoningEffort
+    compat.supportsReasoningEffort &&
+    !omitGpt54MiniToolReasoningEffort
   ) {
     params.reasoning_effort = resolvedCompletionsReasoningEffort;
   }


### PR DESCRIPTION
## Summary

Fixes #76176 by handling a narrow OpenAI API incompatibility for `gpt-5.4-mini` on `/v1/chat/completions`.

`gpt-5.4-mini` does support reasoning effort. The failing case is specifically Chat Completions requests that include both function tools and `reasoning_effort`. OpenAI rejects that combination, which made Telegram-routed fallback runs fail before producing a reply.

## Live Verification

Verified against the OpenAI API on 2026-05-03:

| Request | Result |
| --- | --- |
| Chat Completions + function tools, no `reasoning_effort` | HTTP 200 |
| Chat Completions + function tools + `reasoning_effort` | HTTP 400, `param=reasoning_effort` |
| Chat Completions + `reasoning_effort`, no tools | HTTP 200 |
| Responses + `reasoning.effort` | HTTP 200 |

The OpenAI error for the rejected case says function tools with `reasoning_effort` are not supported for `gpt-5.4-mini` in `/v1/chat/completions` and recommends using `/v1/responses`.

## Root Cause

OpenClaw treated model-level reasoning support as sufficient to always emit Chat Completions `reasoning_effort`. That is correct for tool-free `gpt-5.4-mini` Chat Completions and for Responses, but not for Chat Completions payloads with function tools.

## What Changed

- Keeps `gpt-5.4-mini` reasoning-effort support in the model metadata.
- Keeps `reasoning_effort` on tool-free `gpt-5.4-mini` Chat Completions payloads.
- Keeps `reasoning.effort` on `gpt-5.4-mini` Responses payloads.
- Omits `reasoning_effort` only when a native OpenAI Chat Completions payload for `gpt-5.4-mini` includes function tools.
- Adds regression coverage for both sides of the contract: tool payloads omit the parameter; tool-free payloads keep it.

## Scope

OpenAI Chat Completions payload compatibility only. No Telegram transport behavior, model fallback policy, provider routing, auth, credentials, or Responses behavior changes.

## Test Plan

- Live OpenAI API matrix above.
- `pnpm exec oxfmt --write --threads=1 src/agents/openai-reasoning-effort.ts src/agents/openai-reasoning-effort.test.ts src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts CHANGELOG.md`
- `pnpm test src/agents/openai-reasoning-effort.test.ts src/agents/openai-transport-stream.test.ts -- --reporter=verbose`
- GitHub PR CI: green on `ea3915308c3c12bb6e71cdb5f13471ec0eb5ba53`

## Replacement

Replaces the OpenAI-only portion of closed bundled PR #76326.