### PR TITLE
[codex] Add opt-in reaction tool tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
+- Discord/status: let explicit reaction tool calls opt into tracking subsequent tool progress on the reacted message with `trackToolCalls: true`, and use the shared tool display emoji table for status reactions.
 - Gateway/performance: lazy-load early runtime discovery and shutdown-hook helpers, defer maintenance timers until after readiness, and trim duplicate plugin auto-enable work during Gateway startup.
 - QA/Mantis: add a `pnpm openclaw qa mantis discord-smoke` runner and manual GitHub workflow that verify the Mantis Discord bot can see the configured guild/channel, post a smoke message, add a reaction, and upload artifacts.
 - Gateway/performance: lazy-load the heavy cron runtime after the rest of Gateway startup, defer restart-sentinel refresh after readiness, and let the Gateway startup benchmark write per-run V8 CPU profiles with `--cpu-prof-dir`.

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -22,6 +22,9 @@ tool with the `react` action. Reaction behavior varies by channel and transport.
 - `emoji` is required when adding a reaction.
 - Set `emoji` to an empty string (`""`) to remove the bot's reaction(s).
 - Set `remove: true` to remove a specific emoji (requires non-empty `emoji`).
+- On channels that support status reactions, `trackToolCalls: true` on a
+  reaction lets the runtime use that reacted message for subsequent tool
+  progress reactions during the same turn.
 
 ## Channel behavior
 

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -66,6 +66,17 @@ vi.mock("../send.js", () => ({
   },
 }));
 
+const discordTargetMocks = vi.hoisted(() => ({
+  resolveDiscordTargetChannelId: vi.fn(async (target: string) => ({
+    channelId: target === "user:u1" ? "dm-u1" : target,
+  })),
+}));
+
+vi.mock("../send.shared.js", () => ({
+  resolveDiscordTargetChannelId: (target: string, opts: unknown) =>
+    discordTargetMocks.resolveDiscordTargetChannelId(target, opts),
+}));
+
 vi.mock("../send.messages.js", () => ({
   editMessageDiscord: (channelId: string, messageId: string, payload: unknown, opts?: unknown) =>
     deliveryMocks.editMessageDiscord(channelId, messageId, payload, opts),
@@ -315,6 +326,7 @@ beforeEach(() => {
   vi.useRealTimers();
   sendMocks.reactMessageDiscord.mockClear();
   sendMocks.removeReactionDiscord.mockClear();
+  discordTargetMocks.resolveDiscordTargetChannelId.mockClear();
   editMessageDiscord.mockClear();
   deliverDiscordReply.mockClear();
   createDiscordDraftStream.mockClear();
@@ -635,6 +647,43 @@ describe("processDiscordMessage ack reactions", () => {
     expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", "📈"]));
     expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", "✉️"]));
     expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", DEFAULT_EMOJIS.done]));
+  });
+
+  it("resolves tracked reaction to targets like the Discord reaction action", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({
+        name: "message",
+        phase: "start",
+        args: {
+          action: "react",
+          to: "user:u1",
+          messageId: "m1",
+          emoji: "📈",
+          trackToolCalls: true,
+        },
+      });
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      cfg: { messages: { ackReaction: "👀" } },
+    });
+
+    await runProcessDiscordMessage(ctx);
+    await vi.runAllTimersAsync();
+
+    expect(discordTargetMocks.resolveDiscordTargetChannelId).toHaveBeenCalledWith(
+      "user:u1",
+      expect.objectContaining({ accountId: "default" }),
+    );
+    const calls = sendMocks.reactMessageDiscord.mock.calls as unknown as Array<
+      [string, string, string]
+    >;
+    expect(calls).toContainEqual(expect.arrayContaining(["dm-u1", "m1", "📈"]));
+    expect(calls).toContainEqual(expect.arrayContaining(["dm-u1", "m1", "✉️"]));
+    expect(calls).toContainEqual(expect.arrayContaining(["dm-u1", "m1", DEFAULT_EMOJIS.done]));
   });
 
   it("shows stall emojis for long no-progress runs", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_EMOJIS } from "openclaw/plugin-sdk/channel-feedback";
+import { DEFAULT_EMOJIS, DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
@@ -87,7 +87,11 @@ type DispatchInboundParams = {
   replyOptions?: {
     onReasoningStream?: () => Promise<void> | void;
     onReasoningEnd?: () => Promise<void> | void;
-    onToolStart?: (payload: { name?: string }) => Promise<void> | void;
+    onToolStart?: (payload: {
+      name?: string;
+      phase?: string;
+      args?: Record<string, unknown>;
+    }) => Promise<void> | void;
     onItemEvent?: (payload: {
       progressText?: string;
       summary?: string;
@@ -585,7 +589,7 @@ describe("processDiscordMessage ack reactions", () => {
   it("debounces intermediate phase reactions and jumps to done for short runs", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.replyOptions?.onReasoningStream?.();
-      await params?.replyOptions?.onToolStart?.({ name: "exec" });
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
       return createNoQueuedDispatchResult();
     });
 
@@ -598,6 +602,39 @@ describe("processDiscordMessage ack reactions", () => {
     expect(emojis).toContain(DEFAULT_EMOJIS.done);
     expect(emojis).not.toContain(DEFAULT_EMOJIS.thinking);
     expect(emojis).not.toContain(DEFAULT_EMOJIS.coding);
+  });
+
+  it("can bind status reactions to an explicitly tracked reaction target", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({
+        name: "message",
+        phase: "start",
+        args: {
+          action: "react",
+          channelId: "c1",
+          messageId: "m1",
+          emoji: "📈",
+          trackToolCalls: true,
+        },
+      });
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      cfg: { messages: { ackReaction: "👀" } },
+    });
+
+    await runProcessDiscordMessage(ctx);
+    await vi.runAllTimersAsync();
+
+    const calls = sendMocks.reactMessageDiscord.mock.calls as unknown as Array<
+      [string, string, string]
+    >;
+    expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", "📈"]));
+    expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", "✉️"]));
+    expect(calls).toContainEqual(expect.arrayContaining(["c1", "m1", DEFAULT_EMOJIS.done]));
   });
 
   it("shows stall emojis for long no-progress runs", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -67,7 +67,7 @@ vi.mock("../send.js", () => ({
 }));
 
 const discordTargetMocks = vi.hoisted(() => ({
-  resolveDiscordTargetChannelId: vi.fn(async (target: string) => ({
+  resolveDiscordTargetChannelId: vi.fn(async (target: string, _opts?: unknown) => ({
     channelId: target === "user:u1" ? "dm-u1" : target,
   })),
 }));

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -27,6 +27,8 @@ import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
 import { removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
+import { resolveDiscordTargetChannelId } from "../send.shared.js";
+import { resolveDiscordChannelId } from "../targets.js";
 import {
   createDiscordAckReactionAdapter,
   createDiscordAckReactionContext,
@@ -235,7 +237,29 @@ export async function processDiscordMessage(
       });
     },
   });
-  const maybeBindStatusReactionsToToolReaction = (payload: ToolStartPayload) => {
+  const resolveTrackedReactionChannelId = async (
+    args: Record<string, unknown>,
+  ): Promise<string> => {
+    const target =
+      readToolStringArg(args, "channelId") ??
+      readToolStringArg(args, "channel_id") ??
+      readToolStringArg(args, "to");
+    if (!target) {
+      return messageChannelId;
+    }
+    try {
+      return resolveDiscordChannelId(target);
+    } catch {
+      return (
+        await resolveDiscordTargetChannelId(target, {
+          cfg,
+          token,
+          accountId,
+        })
+      ).channelId;
+    }
+  };
+  const maybeBindStatusReactionsToToolReaction = async (payload: ToolStartPayload) => {
     if (
       sourceRepliesAreToolOnly ||
       cfg.messages?.statusReactions?.enabled === false ||
@@ -262,8 +286,18 @@ export async function processDiscordMessage(
     }
     const trackedMessageId =
       readToolStringArg(args, "messageId") ?? readToolStringArg(args, "message_id") ?? message.id;
-    const trackedChannelId =
-      readToolStringArg(args, "channelId") ?? readToolStringArg(args, "to") ?? messageChannelId;
+    let trackedChannelId: string;
+    try {
+      trackedChannelId = await resolveTrackedReactionChannelId(args);
+    } catch (err) {
+      logAckFailure({
+        log: logVerbose,
+        channel: "discord",
+        target: `${readToolStringArg(args, "to") ?? readToolStringArg(args, "channelId") ?? messageChannelId}/${trackedMessageId}`,
+        error: err,
+      });
+      return;
+    }
     statusReactionTarget = `${trackedChannelId}/${trackedMessageId}`;
     if (statusReactionsActive) {
       void statusReactions.clear();
@@ -619,7 +653,7 @@ export async function processDiscordMessage(
                   if (isProcessAborted(abortSignal)) {
                     return;
                   }
-                  maybeBindStatusReactionsToToolReaction(payload);
+                  await maybeBindStatusReactionsToToolReaction(payload);
                   await statusReactions.setTool(payload.name);
                   draftPreview.pushToolProgress(
                     payload.name ? `tool: ${payload.name}` : "tool running",

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -82,6 +82,21 @@ type DiscordMessageProcessObserver = {
   onReplyPlanResolved?: (params: { createdThreadId?: string; sessionKey?: string }) => void;
 };
 
+type ToolStartPayload = {
+  name?: string;
+  phase?: string;
+  args?: Record<string, unknown>;
+};
+
+function readToolStringArg(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readToolBooleanArg(args: Record<string, unknown>, key: string): boolean {
+  return args[key] === true;
+}
+
 export async function processDiscordMessage(
   ctx: DiscordMessagePreflightContext,
   observer?: DiscordMessageProcessObserver,
@@ -203,7 +218,9 @@ export async function processDiscordMessage(
     messageId: message.id,
     reactionContext: ackReactionContext,
   });
-  const statusReactions = createStatusReactionController({
+  let statusReactionTarget = `${messageChannelId}/${message.id}`;
+  let statusReactionsActive = statusReactionsEnabled;
+  let statusReactions = createStatusReactionController({
     enabled: statusReactionsEnabled,
     adapter: discordAdapter,
     initialEmoji: ackReaction,
@@ -213,11 +230,67 @@ export async function processDiscordMessage(
       logAckFailure({
         log: logVerbose,
         channel: "discord",
-        target: `${messageChannelId}/${message.id}`,
+        target: statusReactionTarget,
         error: err,
       });
     },
   });
+  const maybeBindStatusReactionsToToolReaction = (payload: ToolStartPayload) => {
+    if (
+      sourceRepliesAreToolOnly ||
+      cfg.messages?.statusReactions?.enabled === false ||
+      payload.phase !== "start" ||
+      payload.name !== "message" ||
+      !payload.args
+    ) {
+      return;
+    }
+    const args = payload.args;
+    const action = readToolStringArg(args, "action")?.toLowerCase();
+    if (action !== "react") {
+      return;
+    }
+    const shouldTrack =
+      readToolBooleanArg(args, "trackToolCalls") || readToolBooleanArg(args, "track_tool_calls");
+    if (!shouldTrack) {
+      return;
+    }
+    const emoji = readToolStringArg(args, "emoji");
+    const remove = readToolBooleanArg(args, "remove");
+    if (!emoji || remove) {
+      return;
+    }
+    const trackedMessageId =
+      readToolStringArg(args, "messageId") ?? readToolStringArg(args, "message_id") ?? message.id;
+    const trackedChannelId =
+      readToolStringArg(args, "channelId") ?? readToolStringArg(args, "to") ?? messageChannelId;
+    statusReactionTarget = `${trackedChannelId}/${trackedMessageId}`;
+    if (statusReactionsActive) {
+      void statusReactions.clear();
+    }
+    const trackedAdapter = createDiscordAckReactionAdapter({
+      channelId: trackedChannelId,
+      messageId: trackedMessageId,
+      reactionContext: ackReactionContext,
+    });
+    statusReactions = createStatusReactionController({
+      enabled: true,
+      adapter: trackedAdapter,
+      initialEmoji: emoji,
+      emojis: cfg.messages?.statusReactions?.emojis,
+      timing: cfg.messages?.statusReactions?.timing,
+      onError: (err) => {
+        logAckFailure({
+          log: logVerbose,
+          channel: "discord",
+          target: statusReactionTarget,
+          error: err,
+        });
+      },
+    });
+    statusReactionsActive = true;
+    void statusReactions.setQueued();
+  };
   queueInitialDiscordAckReaction({
     enabled: statusReactionsEnabled,
     shouldSendAckReaction,
@@ -546,6 +619,7 @@ export async function processDiscordMessage(
                   if (isProcessAborted(abortSignal)) {
                     return;
                   }
+                  maybeBindStatusReactionsToToolReaction(payload);
                   await statusReactions.setTool(payload.name);
                   draftPreview.pushToolProgress(
                     payload.name ? `tool: ${payload.name}` : "tool running",
@@ -632,7 +706,7 @@ export async function processDiscordMessage(
         markDispatchIdle();
       }
     }
-    if (statusReactionsEnabled) {
+    if (statusReactionsActive) {
       if (dispatchAborted) {
         if (removeAckAfterReply) {
           void statusReactions.clear();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -649,7 +649,12 @@ export function handleToolExecutionStart(
     // Best-effort typing signal; do not block tool summaries on slow emitters.
     void ctx.params.onAgentEvent?.({
       stream: "tool",
-      data: { phase: "start", name: toolName, toolCallId },
+      data: {
+        phase: "start",
+        name: toolName,
+        toolCallId,
+        args: sanitizeToolArgs(args) as Record<string, unknown>,
+      },
     });
 
     if (isExecToolName(toolName)) {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -180,6 +180,17 @@ function buildReactionSchema() {
     ),
     emoji: Type.Optional(Type.String()),
     remove: Type.Optional(Type.Boolean()),
+    trackToolCalls: Type.Optional(
+      Type.Boolean({
+        description:
+          "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+      }),
+    ),
+    track_tool_calls: Type.Optional(
+      Type.Boolean({
+        description: "snake_case alias of trackToolCalls.",
+      }),
+    ),
     targetAuthor: Type.Optional(Type.String()),
     targetAuthorUuid: Type.Optional(Type.String()),
     groupId: Type.Optional(Type.String()),

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -81,7 +81,11 @@ export type GetReplyOptions = {
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
-  onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  onToolStart?: (payload: {
+    name?: string;
+    phase?: string;
+    args?: Record<string, unknown>;
+  }) => Promise<void> | void;
   /** Called when a concrete work item starts, updates, or completes. */
   onItemEvent?: (payload: {
     itemId?: string;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1528,7 +1528,14 @@ export async function runAgentTurnWithFallback(params: {
                     const name = readStringValue(evt.data.name);
                     if (phase === "start" || phase === "update") {
                       await params.typingSignals.signalToolStart();
-                      await params.opts?.onToolStart?.({ name, phase });
+                      await params.opts?.onToolStart?.({
+                        name,
+                        phase,
+                        args:
+                          evt.data.args && typeof evt.data.args === "object"
+                            ? (evt.data.args as Record<string, unknown>)
+                            : undefined,
+                      });
                     }
                   }
                   if (evt.stream === "item") {

--- a/src/channels/status-reactions.slack-lifecycle.test.ts
+++ b/src/channels/status-reactions.slack-lifecycle.test.ts
@@ -5,6 +5,9 @@ import {
   type StatusReactionAdapter,
 } from "./status-reactions.js";
 
+const EXEC_TOOL_EMOJI = "🛠️";
+const WEB_SEARCH_TOOL_EMOJI = "🔎";
+
 function createSlackMockAdapter() {
   const active = new Set<string>();
   const log: string[] = [];
@@ -60,12 +63,12 @@ describe("Slack status reaction lifecycle", () => {
 
     void ctrl.setTool("web_search");
     await vi.advanceTimersByTimeAsync(10);
-    expect(active.has(DEFAULT_EMOJIS.web)).toBe(true);
+    expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(true);
     expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(true);
 
     await ctrl.setDone();
     expect(active.has(DEFAULT_EMOJIS.done)).toBe(true);
-    expect(active.has(DEFAULT_EMOJIS.web)).toBe(false);
+    expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(false);
     expect(active.has(DEFAULT_EMOJIS.thinking)).toBe(false);
 
     await ctrl.clear();
@@ -179,14 +182,14 @@ describe("Slack status reaction lifecycle", () => {
 
     void ctrl.setTool("web_search");
     await vi.advanceTimersByTimeAsync(25);
-    expect(active.has(DEFAULT_EMOJIS.web)).toBe(true);
+    expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(true);
     expect(active.has("eyes")).toBe(true);
 
     void ctrl.setThinking();
     await ctrl.restoreInitial();
 
     expect(active.has("eyes")).toBe(true);
-    expect(active.has(DEFAULT_EMOJIS.web)).toBe(false);
+    expect(active.has(WEB_SEARCH_TOOL_EMOJI)).toBe(false);
     expect(adapter.setReaction).toHaveBeenCalledTimes(2);
   });
 
@@ -257,7 +260,7 @@ describe("Slack status reaction lifecycle", () => {
 
     void ctrl.setTool("exec");
     await vi.advanceTimersByTimeAsync(10);
-    expect(active.has(DEFAULT_EMOJIS.coding)).toBe(true);
+    expect(active.has(EXEC_TOOL_EMOJI)).toBe(true);
     expect(active.has("eyes")).toBe(true);
   });
 });

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -110,6 +110,24 @@ describe("resolveToolEmoji", () => {
       expect(resolveToolEmoji(tool, DEFAULT_EMOJIS)).toBe(expected);
     },
   );
+
+  it("preserves explicit status emoji overrides before exact tool display emojis", () => {
+    const emojis = {
+      ...DEFAULT_EMOJIS,
+      coding: "🧪",
+      web: "🛰️",
+      tool: "🔧",
+    };
+    const overrides = {
+      coding: "🧪",
+      web: "🛰️",
+      tool: "🔧",
+    };
+
+    expect(resolveToolEmoji("exec", emojis, overrides)).toBe("🧪");
+    expect(resolveToolEmoji("web_search", emojis, overrides)).toBe("🛰️");
+    expect(resolveToolEmoji("message", emojis, overrides)).toBe("🔧");
+  });
 });
 
 describe("createStatusReactionController", () => {

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -78,18 +78,19 @@ function expectObjectHasKeys(value: Record<string, unknown>, keys: readonly stri
 
 describe("resolveToolEmoji", () => {
   it.each([
-    { name: "returns coding emoji for exec tool", tool: "exec", expected: DEFAULT_EMOJIS.coding },
+    { name: "returns display emoji for exec tool", tool: "exec", expected: "🛠️" },
     {
-      name: "returns coding emoji for process tool",
+      name: "returns display emoji for process tool",
       tool: "process",
-      expected: DEFAULT_EMOJIS.coding,
+      expected: "🧰",
     },
     {
-      name: "returns web emoji for web_search tool",
+      name: "returns display emoji for web_search tool",
       tool: "web_search",
-      expected: DEFAULT_EMOJIS.web,
+      expected: "🔎",
     },
-    { name: "returns web emoji for browser tool", tool: "browser", expected: DEFAULT_EMOJIS.web },
+    { name: "returns display emoji for browser tool", tool: "browser", expected: "🌐" },
+    { name: "returns display emoji for message tool", tool: "message", expected: "✉️" },
     {
       name: "returns tool emoji for unknown tool",
       tool: "unknown_tool",
@@ -97,7 +98,7 @@ describe("resolveToolEmoji", () => {
     },
     { name: "returns tool emoji for empty string", tool: "", expected: DEFAULT_EMOJIS.tool },
     { name: "returns tool emoji for undefined", tool: undefined, expected: DEFAULT_EMOJIS.tool },
-    { name: "is case-insensitive", tool: "EXEC", expected: DEFAULT_EMOJIS.coding },
+    { name: "is case-insensitive", tool: "EXEC", expected: "🛠️" },
     {
       name: "matches tokens within tool names",
       tool: "my_exec_wrapper",
@@ -174,7 +175,7 @@ describe("createStatusReactionController", () => {
     void controller.setTool("exec");
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    expectSetEmojiCall(calls, DEFAULT_EMOJIS.coding);
+    expectSetEmojiCall(calls, "🛠️");
   });
 
   const immediateTerminalCases = [
@@ -244,9 +245,9 @@ describe("createStatusReactionController", () => {
     void controller.setTool("exec");
     await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
 
-    // Should only have the last one (exec → coding)
+    // Should only have the last one (exec → display emoji)
     const setEmojis = calls.filter((c) => c.method === "set").map((c) => c.emoji);
-    expect(setEmojis).toEqual([DEFAULT_EMOJIS.coding]);
+    expect(setEmojis).toEqual(["🛠️"]);
   });
 
   it("should deduplicate same emoji calls", async () => {
@@ -307,9 +308,7 @@ describe("createStatusReactionController", () => {
     await controller.setDone();
 
     const removeEmojis = calls.filter((call) => call.method === "remove").map((call) => call.emoji);
-    expect(removeEmojis).toEqual(
-      expect.arrayContaining(["👀", DEFAULT_EMOJIS.thinking, DEFAULT_EMOJIS.coding]),
-    );
+    expect(removeEmojis).toEqual(expect.arrayContaining(["👀", DEFAULT_EMOJIS.thinking, "🛠️"]));
     expect(removeEmojis).not.toContain(DEFAULT_EMOJIS.done);
   });
 

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -105,18 +105,28 @@ export const WEB_TOOL_TOKENS: string[] = [
 export function resolveToolEmoji(
   toolName: string | undefined,
   emojis: Required<StatusReactionEmojis>,
+  emojiOverrides?: StatusReactionEmojis,
 ): string {
   const normalized = normalizeOptionalLowercaseString(toolName) ?? "";
   if (!normalized) {
     return emojis.tool;
   }
+
+  const category = WEB_TOOL_TOKENS.some((token) => normalized.includes(token))
+    ? "web"
+    : CODING_TOOL_TOKENS.some((token) => normalized.includes(token))
+      ? "coding"
+      : "tool";
+  if (emojiOverrides?.[category] !== undefined) {
+    return emojis[category];
+  }
   if (Object.hasOwn(TOOL_DISPLAY_CONFIG.tools, normalized)) {
     return resolveToolDisplay({ name: toolName }).emoji;
   }
-  if (WEB_TOOL_TOKENS.some((token) => normalized.includes(token))) {
+  if (category === "web") {
     return emojis.web;
   }
-  if (CODING_TOOL_TOKENS.some((token) => normalized.includes(token))) {
+  if (category === "coding") {
     return emojis.coding;
   }
   return emojis.tool;
@@ -322,7 +332,7 @@ export function createStatusReactionController(params: {
   }
 
   function setTool(toolName?: string): void {
-    const emoji = resolveToolEmoji(toolName, emojis);
+    const emoji = resolveToolEmoji(toolName, emojis, params.emojis);
     scheduleEmoji(emoji);
   }
 

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -1,3 +1,5 @@
+import { TOOL_DISPLAY_CONFIG } from "../agents/tool-display-config.js";
+import { resolveToolDisplay } from "../agents/tool-display.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 
 /**
@@ -107,6 +109,9 @@ export function resolveToolEmoji(
   const normalized = normalizeOptionalLowercaseString(toolName) ?? "";
   if (!normalized) {
     return emojis.tool;
+  }
+  if (Object.hasOwn(TOOL_DISPLAY_CONFIG.tools, normalized)) {
+    return resolveToolDisplay({ name: toolName }).emoji;
   }
   if (WEB_TOOL_TOKENS.some((token) => normalized.includes(token))) {
     return emojis.web;

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1034,6 +1034,14 @@
         "topic": {
           "type": "string"
         },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
+        },
         "type": {
           "type": "number"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1034,6 +1034,14 @@
         "topic": {
           "type": "string"
         },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
+        },
         "type": {
           "type": "number"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1034,6 +1034,14 @@
         "topic": {
           "type": "string"
         },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
+        },
         "type": {
           "type": "number"
         },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -201,8 +201,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 158
   },
   "dynamicToolsJson": {
-    "chars": 50058,
-    "roughTokens": 12515
+    "chars": 50457,
+    "roughTokens": 12615
   },
   "openClawDeveloperInstructions": {
     "chars": 8604,
@@ -213,8 +213,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7939
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81816,
-    "roughTokens": 20454
+    "chars": 82215,
+    "roughTokens": 20554
   },
   "userInputText": {
     "chars": 870,
@@ -962,6 +962,14 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
         },
         "topic": {
           "type": "string"
+        },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
         },
         "type": {
           "type": "number"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -201,8 +201,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 158
   },
   "dynamicToolsJson": {
-    "chars": 49749,
-    "roughTokens": 12438
+    "chars": 50148,
+    "roughTokens": 12537
   },
   "openClawDeveloperInstructions": {
     "chars": 7733,
@@ -213,8 +213,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7597
   },
   "totalWithDynamicToolsJson": {
-    "chars": 80136,
-    "roughTokens": 20034
+    "chars": 80535,
+    "roughTokens": 20134
   },
   "userInputText": {
     "chars": 370,
@@ -939,6 +939,14 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
         },
         "topic": {
           "type": "string"
+        },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
         },
         "type": {
           "type": "number"

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -202,8 +202,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 158
   },
   "dynamicToolsJson": {
-    "chars": 50872,
-    "roughTokens": 12718
+    "chars": 51271,
+    "roughTokens": 12818
   },
   "openClawDeveloperInstructions": {
     "chars": 7733,
@@ -214,8 +214,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7656
   },
   "totalWithDynamicToolsJson": {
-    "chars": 81497,
-    "roughTokens": 20375
+    "chars": 81896,
+    "roughTokens": 20474
   },
   "userInputText": {
     "chars": 608,
@@ -941,6 +941,14 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
         },
         "topic": {
           "type": "string"
+        },
+        "track_tool_calls": {
+          "description": "snake_case alias of trackToolCalls.",
+          "type": "boolean"
+        },
+        "trackToolCalls": {
+          "description": "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "type": "boolean"
         },
         "type": {
           "type": "number"


### PR DESCRIPTION
## Intent

This teaches status reactions to follow a message the agent explicitly chose to react to, instead of requiring automatic ack reactions to already be active on the inbound message. The model can opt in with `trackToolCalls: true` on a `message` tool `react` call; Discord then retargets subsequent tool-progress reactions to that reacted message for the rest of the turn.

It also switches status reaction tool emoji resolution to consult the shared tool display table first, so tool progress can show specific emojis like message/web/exec before falling back to the older broad buckets.

## What changed

- Added `trackToolCalls` / `track_tool_calls` to reaction tool schema and docs.
- Passed sanitized tool-call args through the tool-start progress callback.
- Bound Discord status reactions to an explicitly tracked reaction target when the first `message react` tool call opts in.
- Updated status reaction emoji resolution and tests to use the shared tool display emoji table first.
- Added a changelog entry.

## Validation

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/tools/reactions.md src/channels/status-reactions.ts src/channels/status-reactions.test.ts src/auto-reply/get-reply-options.types.ts src/auto-reply/reply/agent-runner-execution.ts src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/tools/message-tool.ts extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `pnpm test src/channels/status-reactions.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `git diff --check`
- `pnpm check:changed --staged` after commit (no staged paths, but shared sanity lanes passed: conflict markers, changelog attributions, guarded re-export checks, duplicate coverage)
