### PR TITLE
Inject OpenClaw bootstrap only as Codex developer instructions

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -265,12 +265,19 @@ does not write synthetic Codex project-doc files or depend on Codex fallback
 filenames for persona files, because Codex fallbacks only apply when
 `AGENTS.md` is missing.
 
-For OpenClaw workspace parity, the Codex harness resolves the other bootstrap
-files (`SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`,
-`BOOTSTRAP.md`, and `MEMORY.md` when present) and forwards them through Codex
-developer instructions on `thread/start` and `thread/resume`. This keeps
-`SOUL.md` and related workspace persona/profile context visible on the native
-Codex behavior-shaping lane without duplicating `AGENTS.md`.
+For OpenClaw workspace parity, the Codex harness resolves the available
+bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`,
+`HEARTBEAT.md`, `BOOTSTRAP.md`, and `MEMORY.md` when present) and injects the
+non-missing files into Codex developer instructions on `thread/start` and
+`thread/resume`. Developer instructions are the highest-signal app-server lane
+OpenClaw controls below the native Codex/system contract, so bootstrap context
+is injected there once instead of being duplicated through Codex config
+instructions.
+
+The injected bootstrap remains user-editable workspace context. It does not
+override higher-priority OpenClaw or Codex instructions, tool/security policy,
+repository owner rules, or explicit user instructions in the current
+conversation.
 
 ## Add Codex alongside other models
 
@@ -499,6 +506,7 @@ To opt in to Codex guardian-reviewed approvals, set `appServer.mode:
           appServer: {
             mode: "guardian",
             serviceTier: "fast",
+            personality: "friendly",
           },
         },
       },
@@ -520,6 +528,13 @@ Individual policy fields still override `mode`, so advanced deployments can mix
 the preset with explicit choices. The older `guardian_subagent` reviewer value is
 still accepted as a compatibility alias, but new configs should use
 `auto_review`.
+
+`appServer.personality` is an optional native Codex app-server personality
+override. Use `"friendly"` when you want Codex runtime turns to preserve the
+warmer OpenClaw GPT-5 interaction style, `"pragmatic"` for a more utilitarian
+Codex tone, or `"none"` to disable Codex's native personality layer. The value is
+sent on thread start, thread resume, and each turn. Existing sessions may need
+`/new` or `/reset` before the updated native thread settings are observable.
 
 For an already-running app-server, use WebSocket transport:
 
@@ -638,6 +653,7 @@ Supported `appServer` fields:
 | `sandbox`                     | `"danger-full-access"`                   | Native Codex sandbox mode sent to thread start/resume.                                                                                                                                                                               |
 | `approvalsReviewer`           | `"user"`                                 | Use `"auto_review"` to let Codex review native approval prompts. `guardian_subagent` remains a legacy alias.                                                                                                                         |
 | `serviceTier`                 | unset                                    | Optional Codex app-server service tier: `"fast"`, `"flex"`, or `null`. Invalid legacy values are ignored.                                                                                                                            |
+| `personality`                 | unset                                    | Optional native Codex personality override: `"friendly"`, `"pragmatic"`, or `"none"`.                                                                                                                                                |
 
 OpenClaw-owned dynamic tool calls are bounded independently from
 `appServer.requestTimeoutMs`: each Codex `item/tool/call` request must receive

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -148,6 +148,10 @@
             "enum": ["user", "auto_review", "guardian_subagent"]
           },
           "serviceTier": { "type": ["string", "null"], "enum": ["fast", "flex", null] },
+          "personality": {
+            "type": "string",
+            "enum": ["none", "friendly", "pragmatic"]
+          },
           "defaultWorkspaceDir": {
             "type": "string"
           }
@@ -298,6 +302,11 @@
     "appServer.serviceTier": {
       "label": "Service Tier",
       "help": "Optional Codex app-server service tier. Use fast, flex, or null.",
+      "advanced": true
+    },
+    "appServer.personality": {
+      "label": "Personality",
+      "help": "Optional native Codex app-server personality override sent to thread start, resume, and turns.",
       "advanced": true
     },
     "appServer.defaultWorkspaceDir": {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -23,6 +23,7 @@ describe("Codex app-server config", () => {
           approvalsReviewer: "guardian_subagent",
           serviceTier: "flex",
           turnCompletionIdleTimeoutMs: 120_000,
+          personality: "friendly",
         },
       },
       env: {
@@ -38,6 +39,7 @@ describe("Codex app-server config", () => {
         approvalsReviewer: "guardian_subagent",
         serviceTier: "flex",
         turnCompletionIdleTimeoutMs: 120_000,
+        personality: "friendly",
         start: expect.objectContaining({
           transport: "websocket",
           url: "ws://127.0.0.1:39175",
@@ -100,6 +102,15 @@ describe("Codex app-server config", () => {
       }),
     );
     expect(runtime).not.toHaveProperty("serviceTier");
+  });
+
+  it("falls back to the environment Codex personality when config omits it", () => {
+    expect(
+      resolveCodexAppServerRuntimeOptions({
+        pluginConfig: {},
+        env: { OPENCLAW_CODEX_APP_SERVER_PERSONALITY: "pragmatic" },
+      }).personality,
+    ).toBe("pragmatic");
   });
 
   it("rejects malformed plugin config instead of treating freeform strings as control values", () => {
@@ -429,5 +440,6 @@ describe("Codex app-server config", () => {
     expect(appServerProperties.approvalPolicy?.default).toBeUndefined();
     expect(appServerProperties.sandbox?.default).toBeUndefined();
     expect(appServerProperties.approvalsReviewer?.default).toBeUndefined();
+    expect(appServerProperties.personality?.default).toBeUndefined();
   });
 });

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomBytes } from "node:crypto";
 import { z } from "zod";
-import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
+import type { CodexPersonality, CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET = randomBytes(32);
 
@@ -54,6 +54,7 @@ export type CodexAppServerRuntimeOptions = {
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
+  personality?: CodexPersonality;
 };
 
 export type CodexPluginConfig = {
@@ -79,6 +80,7 @@ export type CodexPluginConfig = {
     sandbox?: CodexAppServerSandboxMode;
     approvalsReviewer?: CodexAppServerApprovalsReviewer;
     serviceTier?: CodexServiceTier | null;
+    personality?: CodexPersonality;
     defaultWorkspaceDir?: string;
   };
 };
@@ -98,6 +100,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "sandbox",
   "approvalsReviewer",
   "serviceTier",
+  "personality",
   "defaultWorkspaceDir",
 ] as const;
 
@@ -126,6 +129,7 @@ const codexAppServerApprovalPolicySchema = z.enum([
 ]);
 const codexAppServerSandboxSchema = z.enum(["read-only", "workspace-write", "danger-full-access"]);
 const codexAppServerApprovalsReviewerSchema = z.enum(["user", "auto_review", "guardian_subagent"]);
+const codexAppServerPersonalitySchema = z.enum(["none", "friendly", "pragmatic"]);
 const codexDynamicToolsProfileSchema = z.enum(["native-first", "openclaw-compat"]);
 const codexAppServerServiceTierSchema = z
   .preprocess(
@@ -174,6 +178,7 @@ const codexPluginConfigSchema = z
         sandbox: codexAppServerSandboxSchema.optional(),
         approvalsReviewer: codexAppServerApprovalsReviewerSchema.optional(),
         serviceTier: codexAppServerServiceTierSchema,
+        personality: codexAppServerPersonalitySchema.optional(),
         defaultWorkspaceDir: z.string().optional(),
       })
       .strict()
@@ -213,6 +218,9 @@ export function resolveCodexAppServerRuntimeOptions(
     resolvePolicyMode(env.OPENCLAW_CODEX_APP_SERVER_MODE) ??
     "yolo";
   const serviceTier = resolveServiceTier(config.serviceTier);
+  const personality =
+    resolvePersonality(config.personality) ??
+    resolvePersonality(env.OPENCLAW_CODEX_APP_SERVER_PERSONALITY);
   if (transport === "websocket" && !url) {
     throw new Error(
       "plugins.entries.codex.config.appServer.url is required when appServer.transport is websocket",
@@ -247,6 +255,7 @@ export function resolveCodexAppServerRuntimeOptions(
       resolveApprovalsReviewer(config.approvalsReviewer) ??
       (policyMode === "guardian" ? "auto_review" : "user"),
     ...(serviceTier ? { serviceTier } : {}),
+    ...(personality ? { personality } : {}),
   };
 }
 
@@ -381,6 +390,10 @@ function resolveApprovalsReviewer(value: unknown): CodexAppServerApprovalsReview
 
 function resolveServiceTier(value: unknown): CodexServiceTier | undefined {
   return value === "fast" || value === "flex" ? value : undefined;
+}
+
+function resolvePersonality(value: unknown): CodexPersonality | undefined {
+  return value === "none" || value === "friendly" || value === "pragmatic" ? value : undefined;
 }
 
 function normalizePositiveNumber(value: unknown, fallback: number): number {

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -1,6 +1,7 @@
 export type JsonValue = null | boolean | number | string | JsonValue[] | JsonObject;
 export type JsonObject = { [key: string]: JsonValue };
 export type CodexServiceTier = string;
+export type CodexPersonality = "none" | "friendly" | "pragmatic";
 
 export type CodexAppServerRequestMethod = keyof CodexAppServerRequestResultMap | (string & {});
 export type CodexAppServerRequestParams<M extends CodexAppServerRequestMethod> =

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -453,7 +453,10 @@ describe("runCodexAppServerAttempt", () => {
   it("starts Codex threads without duplicate OpenClaw workspace tools by default", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
-    const appServer = createThreadLifecycleAppServerOptions();
+    const appServer = {
+      ...createThreadLifecycleAppServerOptions(),
+      personality: "friendly" as const,
+    };
     const request = vi.fn(async (method: string, _params: unknown) => {
       if (method === "thread/start") {
         return threadStartResult();
@@ -491,6 +494,7 @@ describe("runCodexAppServerAttempt", () => {
 
     expect(dynamicToolNames).toContain("message");
     expect(dynamicToolNames).toContain("web_search");
+    expect(startRequest?.[1]).toEqual(expect.objectContaining({ personality: "friendly" }));
     expect(dynamicToolNames).not.toEqual(
       expect.arrayContaining([
         "read",
@@ -1097,12 +1101,14 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("make the default webpage openclaw");
   });
 
-  it("passes OpenClaw bootstrap files through Codex developer instructions", async () => {
+  it("passes OpenClaw bootstrap files through Codex developer instructions only", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await fs.mkdir(workspaceDir, { recursive: true });
     await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "Follow AGENTS guidance.");
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Soul voice goes here.");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "User preferences go here.");
+    await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), "Tool notes go here.");
     const harness = createStartedThreadHarness();
 
     const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir));
@@ -1112,18 +1118,16 @@ describe("runCodexAppServerAttempt", () => {
     await run;
 
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
-    const params = threadStart?.params as {
-      config?: { instructions?: string };
-      developerInstructions?: string;
-    };
-    const config = params.config;
-
-    // Regression for #77363: persona/style bootstrap (SOUL.md) must reach the
-    // explicit developerInstructions field, not config.instructions.
-    expect(params.developerInstructions).toContain("Soul voice goes here.");
-    expect(params.developerInstructions).toContain("Codex loads AGENTS.md natively");
-    expect(params.developerInstructions).not.toContain("Follow AGENTS guidance.");
+    const threadStartParams = threadStart?.params as
+      | { config?: { instructions?: string }; developerInstructions?: string }
+      | undefined;
+    const config = threadStartParams?.config;
     expect(config?.instructions).toBeUndefined();
+    expect(threadStartParams?.developerInstructions).toContain("OpenClaw Workspace Bootstrap");
+    expect(threadStartParams?.developerInstructions).toContain("Follow AGENTS guidance.");
+    expect(threadStartParams?.developerInstructions).toContain("Soul voice goes here.");
+    expect(threadStartParams?.developerInstructions).toContain("User preferences go here.");
+    expect(threadStartParams?.developerInstructions).toContain("Tool notes go here.");
   });
 
   it("fires llm_input, llm_output, and agent_end hooks for codex turns", async () => {
@@ -2759,7 +2763,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/start"]);
   });
 
-  it("passes configured app-server policy, sandbox, service tier, and model on resume", async () => {
+  it("passes configured app-server policy, sandbox, service tier, personality, and model on resume", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeExistingBinding(sessionFile, workspaceDir, { model: "gpt-5.2" });
@@ -2772,6 +2776,7 @@ describe("runCodexAppServerAttempt", () => {
           approvalsReviewer: "guardian_subagent",
           sandbox: "danger-full-access",
           serviceTier: "fast",
+          personality: "friendly",
         },
       },
     });
@@ -2786,6 +2791,7 @@ describe("runCodexAppServerAttempt", () => {
       approvalsReviewer: "guardian_subagent",
       sandbox: "danger-full-access",
       serviceTier: "fast",
+      personality: "friendly",
       developerInstructions: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
       persistExtendedHistory: true,
     });
@@ -2798,6 +2804,7 @@ describe("runCodexAppServerAttempt", () => {
             approvalsReviewer: "guardian_subagent",
             sandboxPolicy: { type: "dangerFullAccess" },
             serviceTier: "fast",
+            personality: "friendly",
             model: "gpt-5.4-codex",
           }),
         },
@@ -2849,6 +2856,7 @@ describe("runCodexAppServerAttempt", () => {
       approvalsReviewer: "guardian_subagent" as const,
       sandbox: "danger-full-access" as const,
       serviceTier: "flex" as const,
+      personality: "friendly" as const,
     };
 
     expect(buildThreadResumeParams(params, { threadId: "thread-1", appServer })).toEqual({
@@ -2858,6 +2866,7 @@ describe("runCodexAppServerAttempt", () => {
       approvalsReviewer: "guardian_subagent",
       sandbox: "danger-full-access",
       serviceTier: "flex",
+      personality: "friendly",
       developerInstructions: expect.stringContaining(CODEX_GPT5_BEHAVIOR_CONTRACT),
       persistExtendedHistory: true,
     });
@@ -2880,6 +2889,7 @@ describe("runCodexAppServerAttempt", () => {
             developer_instructions: null,
           },
         },
+        personality: "friendly",
       }),
     );
   });

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -128,6 +128,7 @@ const CODEX_NATIVE_PROJECT_DOC_BASENAMES = new Set(["agents.md"]);
 const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
   CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
 const CODEX_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
+  ["agents.md", 5],
   ["soul.md", 10],
   ["identity.md", 20],
   ["user.md", 30],
@@ -1978,51 +1979,54 @@ async function buildCodexWorkspaceBootstrapInstructions(params: {
       contextMode: params.params.bootstrapContextMode,
       runKind: params.params.bootstrapContextRunKind,
     });
-    return renderCodexWorkspaceBootstrapInstructions(
-      contextFiles.map((file) =>
-        remapCodexContextFilePath({
-          file,
-          sourceWorkspaceDir: params.resolvedWorkspace,
-          targetWorkspaceDir: params.effectiveWorkspace,
-        }),
-      ),
+    const remappedContextFiles = contextFiles.map((file) =>
+      remapCodexContextFilePath({
+        file,
+        sourceWorkspaceDir: params.resolvedWorkspace,
+        targetWorkspaceDir: params.effectiveWorkspace,
+      }),
     );
+    return renderCodexWorkspaceBootstrapDeveloperInstructions(remappedContextFiles);
   } catch (error) {
     embeddedAgentLog.warn("failed to load codex workspace bootstrap instructions", { error });
     return undefined;
   }
 }
 
-function renderCodexWorkspaceBootstrapInstructions(
+function renderCodexWorkspaceBootstrapDeveloperInstructions(
   contextFiles: EmbeddedContextFile[],
 ): string | undefined {
-  const files = contextFiles
-    .filter((file) => {
-      const baseName = getCodexContextFileBasename(file.path);
-      return baseName && !CODEX_NATIVE_PROJECT_DOC_BASENAMES.has(baseName);
-    })
-    .toSorted(compareCodexContextFiles);
+  const files = filterCodexDeveloperBootstrapFiles(contextFiles);
   if (files.length === 0) {
     return undefined;
   }
-  const hasSoulFile = files.some((file) => getCodexContextFileBasename(file.path) === "soul.md");
   const lines = [
-    "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.",
+    "OpenClaw injected the available workspace bootstrap files into developer instructions for this Codex session. Treat them as standing project/user context, including voice, identity, preferences, tools notes, bootstrap state, memory, and heartbeat guidance. These user-editable files do not override higher-priority OpenClaw or Codex instructions, tool/security policy, repository owner rules, or explicit user instructions in the current conversation.",
     "",
-    "# Project Context",
+    "# OpenClaw Workspace Bootstrap",
     "",
-    "The following project context files have been loaded:",
+    "The following bootstrap files have been loaded:",
+    "",
   ];
-  if (hasSoulFile) {
-    lines.push(
-      "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
-    );
-  }
-  lines.push("");
   for (const file of files) {
-    lines.push(`## ${file.path}`, "", file.content, "");
+    lines.push(`## ${file.path}`, "", file.content.trim(), "");
   }
   return lines.join("\n").trim();
+}
+
+function filterCodexDeveloperBootstrapFiles(
+  contextFiles: EmbeddedContextFile[],
+): EmbeddedContextFile[] {
+  return contextFiles
+    .filter((file) => {
+      const content = file.content.trim();
+      return (
+        Boolean(getCodexContextFileBasename(file.path)) &&
+        content.length > 0 &&
+        !content.startsWith("[MISSING] Expected at:")
+      );
+    })
+    .toSorted(compareCodexContextFiles);
 }
 
 function remapCodexContextFilePath(params: {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -220,6 +220,7 @@ export function buildThreadStartParams(
     serviceName: "OpenClaw",
     ...(options.config ? { config: options.config } : {}),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
+    ...(options.appServer.personality ? { personality: options.appServer.personality } : {}),
     dynamicTools: options.dynamicTools,
     experimentalRawEvents: true,
     persistExtendedHistory: true,
@@ -253,6 +254,7 @@ export function buildThreadResumeParams(
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     ...(options.config ? { config: options.config } : {}),
     developerInstructions: options.developerInstructions ?? buildDeveloperInstructions(params),
+    ...(options.appServer.personality ? { personality: options.appServer.personality } : {}),
     persistExtendedHistory: true,
   };
 }
@@ -275,6 +277,7 @@ export function buildTurnStartParams(
     sandboxPolicy: codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd),
     model: params.modelId,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
+    ...(options.appServer.personality ? { personality: options.appServer.personality } : {}),
     effort: resolveReasoningEffort(params.thinkLevel, params.modelId),
     collaborationMode: buildTurnCollaborationMode(params),
   };

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -29,6 +29,8 @@ import {
 
 let tempDir: string;
 
+const friendlyPluginConfig = { appServer: { personality: "friendly" } };
+
 describe("codex conversation binding", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-binding-"));
@@ -55,6 +57,129 @@ describe("codex conversation binding", () => {
     agentRuntimeMocks.resolveAuthProfileOrder.mockReturnValue([]);
     agentRuntimeMocks.resolveDefaultAgentDir.mockReturnValue("/agent");
     agentRuntimeMocks.resolveProviderIdForAuth.mockImplementation((provider: string) => provider);
+  });
+
+  it("passes configured personality when creating a bound Codex thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const request = vi.fn(async () => ({
+      thread: { id: "thread-1", cwd: tempDir },
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+
+    await startCodexConversationThread({
+      pluginConfig: friendlyPluginConfig,
+      sessionFile,
+      workspaceDir: tempDir,
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "thread/start",
+      expect.objectContaining({ personality: "friendly" }),
+      expect.anything(),
+    );
+  });
+
+  it("passes configured personality when attaching an existing bound Codex thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const request = vi.fn(async () => ({
+      thread: { id: "thread-1", cwd: tempDir },
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+
+    await startCodexConversationThread({
+      pluginConfig: friendlyPluginConfig,
+      sessionFile,
+      workspaceDir: tempDir,
+      threadId: "thread-1",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "thread/resume",
+      expect.objectContaining({ personality: "friendly" }),
+      expect.anything(),
+    );
+  });
+
+  it("passes configured personality on bound Codex turns", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        model: "gpt-5.5",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "turn/start") {
+        setImmediate(() =>
+          notificationHandler?.({
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turn: {
+                id: "turn-1",
+                status: "completed",
+                items: [{ type: "agentMessage", id: "message-1", text: "done" }],
+              },
+            },
+          }),
+        );
+        return { turn: { id: "turn-1" } };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request,
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "run this",
+        channel: "discord",
+        isGroup: true,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "discord",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel-1",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { pluginConfig: friendlyPluginConfig },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(request).toHaveBeenCalledWith(
+      "turn/start",
+      expect.objectContaining({ personality: "friendly" }),
+      expect.anything(),
+    );
   });
 
   it("uses the default Codex auth profile and omits the public OpenAI provider for new binds", async () => {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -219,6 +219,7 @@ async function attachExistingThread(params: {
       ...((params.serviceTier ?? runtime.serviceTier)
         ? { serviceTier: params.serviceTier ?? runtime.serviceTier }
         : {}),
+      ...(runtime.personality ? { personality: runtime.personality } : {}),
       persistExtendedHistory: true,
     },
     { timeoutMs: runtime.requestTimeoutMs },
@@ -283,6 +284,7 @@ async function createThread(params: {
       ...((params.serviceTier ?? runtime.serviceTier)
         ? { serviceTier: params.serviceTier ?? runtime.serviceTier }
         : {}),
+      ...(runtime.personality ? { personality: runtime.personality } : {}),
       developerInstructions:
         "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
       experimentalRawEvents: true,
@@ -393,6 +395,7 @@ async function runBoundTurn(params: {
         ...((binding.serviceTier ?? runtime.serviceTier)
           ? { serviceTier: binding.serviceTier ?? runtime.serviceTier }
           : {}),
+        ...(runtime.personality ? { personality: runtime.personality } : {}),
       },
       { timeoutMs: runtime.requestTimeoutMs },
     );

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -240,6 +240,7 @@ async function resumeThreadWithOverrides(params: {
       sandbox: params.sandbox ?? runtime.sandbox,
       approvalsReviewer: runtime.approvalsReviewer,
       ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
+      ...(runtime.personality ? { personality: runtime.personality } : {}),
       persistExtendedHistory: true,
     },
     { timeoutMs: runtime.requestTimeoutMs },


### PR DESCRIPTION
## High Signal

Codex app-server turns were not keeping OpenClaw bootstrap files high-signal enough during real work. Important standing instructions and identity/profile/tool context lived in workspace bootstrap files, but the Codex harness was underweighting them compared with the thread-level instruction lane. In practice that let the model flatten personality, forget explicit bootstrap facts, and trip over instructions the workspace had already stated clearly.

This PR injects the resolved, non-missing OpenClaw bootstrap bundle into Codex `developerInstructions` on `thread/start` and `thread/resume`. It does **not** also send that bootstrap bundle through Codex `config.instructions`, so the content is not duplicated through two OpenClaw injection paths. It also exposes native Codex `appServer.personality` so deployments can request the friendlier Codex runtime persona directly.

## Core Issues Addressed

- Instructions and important information in bootstrap files were not high-signal enough in Codex runtime turns.
- Codex runtime personality could become extremely flat despite OpenClaw's warmer GPT-5 prompt overlay.
- Codex/model turns could forget or underweight what `AGENTS.md`, `SOUL.md`, `USER.md`, `TOOLS.md`, and other bootstrap files clearly state, causing repeated mistakes during longer work.

## What Changed

- Adds `plugins.entries.codex.config.appServer.personality` for native Codex app-server personality overrides.
- Forwards the native personality value on thread start, thread resume, and turn start for both Codex harness runs and bound `/codex` conversation threads.
- Injects resolved, non-missing workspace bootstrap files into Codex `developerInstructions`, including `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `BOOTSTRAP.md`, `MEMORY.md`, and `HEARTBEAT.md` when present.
- Removes the duplicate Codex `config.instructions` bootstrap injection path; native hook relay config can still use Codex config, but bootstrap content now goes through developer instructions only.
- Wraps injected bootstrap with explicit priority guardrails: user-editable bootstrap context does not override higher-priority OpenClaw/Codex instructions, tool/security policy, repository owner rules, or the user's current explicit request.
- Documents that `developerInstructions` is the highest-signal app-server lane OpenClaw controls below the native Codex/system contract.

## Why This Shape

`developerInstructions` is the higher-signal app-server lane OpenClaw controls. Putting the bootstrap bundle there makes standing project/user context visible where the model is less likely to forget it. Removing the config-instruction copy avoids overstuffing the prompt with the same bootstrap content twice.

## Validation

- `pnpm docs:list`
- `pnpm exec oxfmt --check --threads=1 docs/plugins/codex-harness.md extensions/codex/openclaw.plugin.json extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/protocol.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-control.ts`
- `git diff --check -- docs/plugins/codex-harness.md extensions/codex/openclaw.plugin.json extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/config.ts extensions/codex/src/app-server/protocol.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/thread-lifecycle.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-binding.ts extensions/codex/src/conversation-control.ts`
- `pnpm test extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-control.test.ts -- --reporter=verbose`
- `pnpm exec oxfmt --check --threads=1 docs/plugins/codex-harness.md extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check -- docs/plugins/codex-harness.md extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm test extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose`
