### PR TITLE
feat(clawhub): surface rate-limit headers and sign-in hint on 429s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
 - Agents/sandbox: store sandbox container and browser registry entries as per-runtime shard files, reducing unrelated session lock contention while `openclaw doctor --fix` migrates legacy monolithic registry files. (#74831) Thanks @luckylhb90.
+- Plugins/ClawHub: surface `RateLimit-*` headers in 429 errors from ClawHub, and append a `Sign in for higher rate limits.` hint when the request was unauthenticated, so users can see why downloads were throttled and how to lift the cap. Thanks @romneyda.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.
 - Agents/sandbox: store sandbox container and browser registry entries as per-runtime shard files, reducing unrelated session lock contention while `openclaw doctor --fix` migrates legacy monolithic registry files. (#74831) Thanks @luckylhb90.
-- Plugins/ClawHub: surface `RateLimit-*` headers in 429 errors from ClawHub, and append a `Sign in for higher rate limits.` hint when the request was unauthenticated, so users can see why downloads were throttled and how to lift the cap. Thanks @romneyda.
+- Plugins/ClawHub: annotate 429 errors from ClawHub with the reset window from `RateLimit-Reset`/`Retry-After` and append a `Sign in for higher rate limits.` hint when the request was unauthenticated, so users can see when downloads will recover and how to lift the cap. Thanks @romneyda.
 
 ### Fixes
 

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -434,6 +434,16 @@ describe("clawhub helpers", () => {
     );
   });
 
+  it("degrades gracefully on 429 when the response carries no rate-limit headers", async () => {
+    process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () => new Response("Rate limit exceeded", { status: 429 }),
+      }),
+    ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
+  });
+
   it("annotates 429 errors with rate-limit headers but no sign-in hint when authenticated", async () => {
     process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
     await expect(

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -414,7 +414,7 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/declared sha256/);
   });
 
-  it("annotates 429 errors with rate-limit headers and a sign-in hint when unauthenticated", async () => {
+  it("annotates 429 errors with the reset hint and a sign-in hint when unauthenticated", async () => {
     process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
     await expect(
       searchClawHubSkills({
@@ -429,9 +429,7 @@ describe("clawhub helpers", () => {
             },
           }),
       }),
-    ).rejects.toThrow(
-      /Rate limit exceeded \(rate limit: limit 30\/min, remaining 0, resets in 42s\) Sign in for higher rate limits\./,
-    );
+    ).rejects.toThrow(/Rate limit exceeded \(resets in 42s\) Sign in for higher rate limits\.$/);
   });
 
   it("degrades gracefully on 429 when the response carries no rate-limit headers", async () => {
@@ -444,7 +442,7 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/Rate limit exceeded Sign in for higher rate limits\.$/);
   });
 
-  it("annotates 429 errors with rate-limit headers but no sign-in hint when authenticated", async () => {
+  it("annotates 429 errors with the reset hint but no sign-in hint when authenticated", async () => {
     process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
     await expect(
       searchClawHubSkills({
@@ -459,7 +457,21 @@ describe("clawhub helpers", () => {
             },
           }),
       }),
-    ).rejects.toThrow(/\(rate limit: limit 180\/min, remaining 0, resets in 10s\)$/);
+    ).rejects.toThrow(/Rate limit exceeded \(resets in 10s\)$/);
+  });
+
+  it("skips the reset suffix on 429 when Retry-After is an HTTP-date", async () => {
+    process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () =>
+          new Response("Rate limit exceeded", {
+            status: 429,
+            headers: { "Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT" },
+          }),
+      }),
+    ).rejects.toThrow(/Rate limit exceeded$/);
   });
 
   it("downloads skill archives to sanitized temp paths and cleans them up", async () => {

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -414,6 +414,44 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/declared sha256/);
   });
 
+  it("annotates 429 errors with rate-limit headers and a sign-in hint when unauthenticated", async () => {
+    process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () =>
+          new Response("Rate limit exceeded", {
+            status: 429,
+            headers: {
+              "RateLimit-Limit": "30",
+              "RateLimit-Remaining": "0",
+              "RateLimit-Reset": "42",
+            },
+          }),
+      }),
+    ).rejects.toThrow(
+      /Rate limit exceeded \(rate limit: limit 30\/min, remaining 0, resets in 42s\) Sign in for higher rate limits\./,
+    );
+  });
+
+  it("annotates 429 errors with rate-limit headers but no sign-in hint when authenticated", async () => {
+    process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
+    await expect(
+      searchClawHubSkills({
+        query: "calendar",
+        fetchImpl: async () =>
+          new Response("Rate limit exceeded", {
+            status: 429,
+            headers: {
+              "RateLimit-Limit": "180",
+              "RateLimit-Remaining": "0",
+              "RateLimit-Reset": "10",
+            },
+          }),
+      }),
+    ).rejects.toThrow(/\(rate limit: limit 180\/min, remaining 0, resets in 10s\)$/);
+  });
+
   it("downloads skill archives to sanitized temp paths and cleans them up", async () => {
     const archive = await downloadClawHubSkillArchive({
       slug: "agentreceipt",

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -608,28 +608,12 @@ async function buildClawHubError(
 }
 
 function formatRateLimitSuffix(headers: Headers, hasToken: boolean): string {
-  const limit =
-    normalizeHeaderValue(headers.get("RateLimit-Limit")) ??
-    normalizeHeaderValue(headers.get("X-RateLimit-Limit"));
-  const remaining =
-    normalizeHeaderValue(headers.get("RateLimit-Remaining")) ??
-    normalizeHeaderValue(headers.get("X-RateLimit-Remaining"));
   const reset =
     normalizeHeaderValue(headers.get("RateLimit-Reset")) ??
     normalizeHeaderValue(headers.get("Retry-After"));
-  const parts: string[] = [];
-  if (limit) {
-    parts.push(`limit ${limit}/min`);
-  }
-  if (remaining) {
-    parts.push(`remaining ${remaining}`);
-  }
-  if (reset) {
-    parts.push(`resets in ${reset}s`);
-  }
   const segments: string[] = [];
-  if (parts.length > 0) {
-    segments.push(`(rate limit: ${parts.join(", ")})`);
+  if (reset && Number.isFinite(Number(reset))) {
+    segments.push(`(resets in ${reset}s)`);
   }
   if (!hasToken) {
     segments.push("Sign in for higher rate limits.");

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -555,7 +555,7 @@ function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "searc
 
 async function clawhubRequest(
   params: ClawHubRequestParams,
-): Promise<{ response: Response; url: URL }> {
+): Promise<{ response: Response; url: URL; hasToken: boolean }> {
   const url = buildUrl(params);
   const token = normalizeOptionalString(params.token) || (await resolveClawHubAuthToken());
   const controller = new AbortController();
@@ -573,7 +573,7 @@ async function clawhubRequest(
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       signal: controller.signal,
     });
-    return { response, url };
+    return { response, url, hasToken: Boolean(token) };
   } finally {
     clearTimeout(timeout);
   }
@@ -588,14 +588,59 @@ async function readErrorBody(response: Response): Promise<string> {
   }
 }
 
+async function buildClawHubError(
+  response: Response,
+  url: URL,
+  hasToken: boolean,
+): Promise<ClawHubRequestError> {
+  let body = await readErrorBody(response);
+  if (response.status === 429) {
+    const suffix = formatRateLimitSuffix(response.headers, hasToken);
+    if (suffix) {
+      body = `${body} ${suffix}`;
+    }
+  }
+  return new ClawHubRequestError({
+    path: url.pathname,
+    status: response.status,
+    body,
+  });
+}
+
+function formatRateLimitSuffix(headers: Headers, hasToken: boolean): string {
+  const limit =
+    normalizeHeaderValue(headers.get("RateLimit-Limit")) ??
+    normalizeHeaderValue(headers.get("X-RateLimit-Limit"));
+  const remaining =
+    normalizeHeaderValue(headers.get("RateLimit-Remaining")) ??
+    normalizeHeaderValue(headers.get("X-RateLimit-Remaining"));
+  const reset =
+    normalizeHeaderValue(headers.get("RateLimit-Reset")) ??
+    normalizeHeaderValue(headers.get("Retry-After"));
+  const parts: string[] = [];
+  if (limit) {
+    parts.push(`limit ${limit}/min`);
+  }
+  if (remaining) {
+    parts.push(`remaining ${remaining}`);
+  }
+  if (reset) {
+    parts.push(`resets in ${reset}s`);
+  }
+  const segments: string[] = [];
+  if (parts.length > 0) {
+    segments.push(`(rate limit: ${parts.join(", ")})`);
+  }
+  if (!hasToken) {
+    segments.push("Sign in for higher rate limits.");
+  }
+  return segments.join(" ");
+}
+
 async function fetchJson<T>(params: ClawHubRequestParams): Promise<T> {
-  const { response, url } = await clawhubRequest(params);
+  const { response, url, hasToken } = await clawhubRequest(params);
   if (!response.ok) {
-    throw new ClawHubRequestError({
-      path: url.pathname,
-      status: response.status,
-      body: await readErrorBody(response),
-    });
+    throw await buildClawHubError(response, url, hasToken);
   }
   return (await response.json()) as T;
 }
@@ -854,7 +899,7 @@ export async function downloadClawHubPackageArchive(params: {
     if (!params.version) {
       throw new Error("ClawPack package downloads require an explicit version.");
     }
-    const { response, url } = await clawhubRequest({
+    const { response, url, hasToken } = await clawhubRequest({
       baseUrl: params.baseUrl,
       path: `/api/v1/packages/${encodeURIComponent(params.name)}/versions/${encodeURIComponent(
         params.version,
@@ -864,11 +909,7 @@ export async function downloadClawHubPackageArchive(params: {
       fetchImpl: params.fetchImpl,
     });
     if (!response.ok) {
-      throw new ClawHubRequestError({
-        path: url.pathname,
-        status: response.status,
-        body: await readErrorBody(response),
-      });
+      throw await buildClawHubError(response, url, hasToken);
     }
     const bytes = new Uint8Array(await response.arrayBuffer());
     const sha256Hex = formatSha256Hex(bytes);
@@ -934,7 +975,7 @@ export async function downloadClawHubPackageArchive(params: {
     : params.tag
       ? { tag: params.tag }
       : undefined;
-  const { response, url } = await clawhubRequest({
+  const { response, url, hasToken } = await clawhubRequest({
     baseUrl: params.baseUrl,
     path: `/api/v1/packages/${encodeURIComponent(params.name)}/download`,
     search,
@@ -943,11 +984,7 @@ export async function downloadClawHubPackageArchive(params: {
     fetchImpl: params.fetchImpl,
   });
   if (!response.ok) {
-    throw new ClawHubRequestError({
-      path: url.pathname,
-      status: response.status,
-      body: await readErrorBody(response),
-    });
+    throw await buildClawHubError(response, url, hasToken);
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   const sha256Hex = formatSha256Hex(bytes);
@@ -975,7 +1012,7 @@ export async function downloadClawHubSkillArchive(params: {
   timeoutMs?: number;
   fetchImpl?: FetchLike;
 }): Promise<ClawHubDownloadResult> {
-  const { response, url } = await clawhubRequest({
+  const { response, url, hasToken } = await clawhubRequest({
     baseUrl: params.baseUrl,
     path: "/api/v1/download",
     token: params.token,
@@ -988,11 +1025,7 @@ export async function downloadClawHubSkillArchive(params: {
     },
   });
   if (!response.ok) {
-    throw new ClawHubRequestError({
-      path: url.pathname,
-      status: response.status,
-      body: await readErrorBody(response),
-    });
+    throw await buildClawHubError(response, url, hasToken);
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   const sha256Hex = formatSha256Hex(bytes);


### PR DESCRIPTION
## Summary
- ClawHub rate-limit 429s now include the `RateLimit-Limit`/`Remaining`/`Reset` (and `Retry-After`) values in the error message.
- When the request was unauthenticated, the message also appends `Sign in for higher rate limits.` so users know how to lift the cap.
- Centralized via a new `buildClawHubError` helper used by `fetchJson` and all download paths in `src/infra/clawhub.ts`.

## Test plan
- [x] `pnpm test src/infra/clawhub.test.ts` (33 passed; new cases cover authenticated and unauthenticated 429 messages)
- [x] `pnpm check:changed` (lanes: core, coreTests)