### PR TITLE
fix(media/store): treat EPERM from fsync as best-effort on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/Sessions: avoid full `sessions.list` reloads for chat-turn `sessions.changed` payloads, so large session stores no longer add multi-second delays while chat responses are being delivered. (#76676) Thanks @VACInc.
+- Media/store: treat `EPERM` from `fsync` as a best-effort flush on Windows, preventing Telegram media downloads from failing when the file system or antivirus software blocks sync operations. Fixes #76640. Thanks @chinar-amrutkar.
 - Doctor/Telegram: warn when selected Telegram quote replies can suppress `streaming.preview.toolProgress`, and document the `replyToMode` trade-off without changing runtime delivery. Fixes #73487. Thanks @GodsBoy.
 - Discord/status: honor explicit `messages.statusReactions.enabled: true` in tool-only guild channels so queued ack reactions can progress through thinking/done lifecycle reactions instead of stopping at the initial emoji. Thanks @Marvinthebored.
 - Discord/native commands: compare Discord-normalized slash-command descriptions and localized descriptions during reconcile so CJK or multiline command text no longer triggers redundant startup PATCH bursts and rate-limit 429s. Fixes #76587. Thanks @zhengsx.

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -352,6 +352,12 @@ async function writeSavedMediaBuffer(params: {
       const handle = await fs.open(tempDest, "r");
       try {
         await handle.sync();
+      } catch (syncErr) {
+        // Best-effort fsync on platforms (e.g. Windows, certain network mounts)
+        // where the operation may fail with EPERM without indicating a real problem.
+        if ((syncErr as NodeJS.ErrnoException).code !== "EPERM") {
+          throw syncErr;
+        }
       } finally {
         await handle.close();
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram media downloads fail on Windows with `EPERM: operation not permitted, fsync` when the file system or antivirus software blocks `fsync` operations.
- Why it matters: Voice messages and media attachments cannot be processed on Windows, breaking core functionality.
- What changed: Added EPERM guard around `fsync` in `writeSavedMediaBuffer` — treats it as best-effort flush rather than fatal error.
- What did NOT change: Media file permissions, write path, rename behavior.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #76640

## Root Cause

- Root cause: Windows file systems and antivirus software can block `fsync` with `EPERM` even when the preceding `writeFile` succeeded. The code was treating sync failures as fatal.
- Missing detection/guardrail: No `EPERM` handling around `handle.sync()` in `writeSavedMediaBuffer`.
- Contributing context: Same pattern was already used in `extensions/whatsapp/src/creds-persistence.ts:syncDirectory` but was missing from media store.

## Regression Test Plan

- Coverage level that should have caught this: End-to-end test
- Scenario the test should lock in: Telegram voice message download on Windows with antivirus/file system blocking sync
- Why this is the smallest reliable guardrail: Requires actual Windows environment with restrictive file system
- Existing test that already covers this (if any): None
- If no new test is added, why not: Cannot reliably simulate Windows fsync restrictions in test environment

## User-visible / Behavior Changes

- Telegram media downloads on Windows no longer fail with fsync EPERM errors when the file write succeeded.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

- Verified scenarios: Code review of EPERM handling matches existing pattern in syncDirectory
- Edge cases checked: Only EPERM is swallowed; other errors still propagate
- What you did **not** verify: Cannot test on actual Windows environment
