### PR TITLE
fix(tool-policy): deny write no longer silently hides apply_patch

### DIFF
--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -16,9 +16,6 @@ function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
     if (matchesAnyGlobPattern(normalized, deny)) {
       return false;
     }
-    if (normalized === "apply_patch" && matchesAnyGlobPattern("write", deny)) {
-      return false;
-    }
     if (allow.length === 0) {
       return true;
     }

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { TOOL_POLICY_CONFORMANCE } from "./tool-policy.conformance.js";
 import {
   applyOwnerOnlyToolPolicy,
@@ -262,5 +263,25 @@ describe("resolveSandboxToolPolicyForAgent", () => {
     const resolved = resolveSandboxToolPolicyForAgent(cfg, undefined);
     expect(resolved.allow).toEqual(["read"]);
     expect(resolved.deny).toEqual(["image"]);
+  });
+});
+
+describe("isToolAllowedByPolicyName — apply_patch / write deny decoupling (#76749)", () => {
+  it("does not deny apply_patch when write is denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write"] })).toBe(true);
+  });
+
+  it("still denies apply_patch when apply_patch is explicitly denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["apply_patch"] })).toBe(false);
+  });
+
+  it("still allows apply_patch via write in the allow list", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { allow: ["write"], deny: [] })).toBe(true);
+  });
+
+  it("denies apply_patch when both write and apply_patch are denied", () => {
+    expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write", "apply_patch"] })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Fixes #76749.

## Problem

`makeToolPolicyMatcher` contained an asymmetric coupling: if `write` appeared in the **deny** list, `apply_patch` was also silently denied — even when the caller never listed `apply_patch` in deny.

The allow side already has symmetric coupling (deny `write` ≠ deny `apply_patch`; allow `write` ⇒ allow `apply_patch`). This made the deny side inconsistent and surprising.

## Fix

Remove the three lines that caused `deny: ["write"]` to also block `apply_patch`:

```ts
// removed:
if (normalized === "apply_patch" && matchesAnyGlobPattern("write", deny)) {
  return false;
}
```

The allow coupling at the bottom of the function is preserved — `allow: ["write"]` still grants `apply_patch`.

## Tests

Four regression tests added to `tool-policy.test.ts`:
- `deny: ["write"]` leaves `apply_patch` accessible ← the bug
- `deny: ["apply_patch"]` still denies directly
- `allow: ["write"]` still grants `apply_patch`
- `deny: ["write", "apply_patch"]` still denies when both explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)