### PR TITLE
perf(reply-path): reuse prepared runtime surfaces across reply execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Telegraph style. Root rules only. Read scoped `AGENTS.md` before subtree work.
 - Gateway protocol changes: additive first; incompatible needs versioning/docs/client follow-through.
 - Config contract: exported types, schema/help, metadata, baselines, docs aligned. Retired public keys stay retired; compat in raw migration/doctor.
 - Direction: manifest-first control plane; targeted runtime loaders; no hidden contract bypasses; broad mutable registries transitional.
+- Request-time runtime resolution: when a path already knows the capability family, provider id, model ref, or attachment class, keep resolution scoped to that fact. Prefer prepared-runtime helpers, active/runtime registries, manifest/public-artifact lookups, single-provider resolvers, and lazy registry construction. Do not broad-load a whole provider/plugin family at request time just to find one explicit provider/model, and do not build multimodal/provider registries for document-only or otherwise non-participating paths.
 - Prompt cache: deterministic ordering for maps/sets/registries/plugin lists/files/network results before model/tool payloads. Preserve old transcript bytes when possible.
 
 ## Commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/performance: defer non-readiness sidecars until after the ready signal, avoid hot-path channel plugin barrel imports, and fast-path trusted bundled plugin metadata during Gateway startup.
 - Gateway/performance: avoid importing `jiti` on native-loadable plugin startup paths, so compiled bundled plugin surfaces do not pay source-transform loader cost unless fallback loading is actually needed.
 - Plugins/loader: preserve real compiled plugin module evaluation errors on the native fast path instead of treating every thrown `.js` module as a source-transform fallback miss. Thanks @vincentkoc.
+- Agents/Gateway performance: reuse prepared runtime model/auth/provider state across reply execution, compaction, BTW side questions, TTS summarization, PDF/image understanding, and configured capability provider lookup to cut repeated request-time discovery and plugin loading. Thanks @mcaxtr.
 - QA/Mantis: add a `pnpm openclaw qa mantis discord-smoke` runner and manual GitHub workflow that verify the Mantis Discord bot can see the configured guild/channel, post a smoke message, add a reaction, and upload artifacts.
 - QA/Mantis: add `pnpm openclaw qa mantis slack-desktop-smoke` to run Slack live QA inside a Crabbox VNC desktop, open Slack Web, and capture desktop screenshots beside the Slack QA artifacts.
 - QA/Mantis: pass the runtime env through desktop-browser Crabbox and artifact-copy child commands, so embedded Mantis callers can provide Crabbox credentials without mutating the parent process. Thanks @vincentkoc.

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -20,6 +20,7 @@ import {
 } from "../navigation-guard.js";
 import { getBrowserProfileCapabilities } from "../profile-capabilities.js";
 import type { BrowserRouteContext } from "../server-context.js";
+import { resolveTargetIdFromTabs } from "../target-id.js";
 import { matchBrowserUrlPattern } from "../url-pattern.js";
 import { registerBrowserAgentActDownloadRoutes } from "./agent.act.download.js";
 import {
@@ -424,12 +425,18 @@ export function registerBrowserAgentActRoutes(
             });
           };
           if (action.targetId && action.targetId !== tab.targetId) {
-            return jsonActError(
-              res,
-              403,
-              ACT_ERROR_CODES.targetIdMismatch,
-              "action targetId must match request targetId",
+            const resolvedActionTarget = resolveTargetIdFromTabs(
+              action.targetId,
+              await profileCtx.listTabs(),
             );
+            if (!resolvedActionTarget.ok || resolvedActionTarget.targetId !== tab.targetId) {
+              return jsonActError(
+                res,
+                403,
+                ACT_ERROR_CODES.targetIdMismatch,
+                "action targetId must match request targetId",
+              );
+            }
           }
           const profileName = profileCtx.profile.name;
           if (isExistingSession) {

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -196,6 +196,31 @@ describe("browser control server", () => {
   );
 
   it(
+    "accepts tab handle aliases that resolve to the selected tab target",
+    async () => {
+      const base = await startServerAndBase();
+      const response = await postJson<{ ok: boolean; targetId?: string }>(`${base}/act`, {
+        kind: "hover",
+        ref: "2",
+        targetId: "t1",
+      });
+
+      expect(response).toMatchObject({
+        ok: true,
+        targetId: "abcd1234",
+      });
+      expect(pwMocks.hoverViaPlaywright).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpUrl: state.cdpBaseUrl,
+          targetId: "abcd1234",
+          ref: "2",
+        }),
+      );
+    },
+    slowTimeoutMs,
+  );
+
+  it(
     "returns ACT_SELECTOR_UNSUPPORTED for selector on unsupported action kinds",
     async () => {
       const base = await startServerAndBase();

--- a/extensions/speech-core/api.ts
+++ b/extensions/speech-core/api.ts
@@ -10,6 +10,7 @@ export {
   formatProviderErrorPayload,
   formatProviderHttpErrorMessage,
   getSpeechProvider,
+  listLoadedSpeechProviders,
   listSpeechProviders,
   normalizeApplyTextNormalization,
   normalizeLanguageCode,

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -30,6 +30,7 @@ const prepareSynthesisMock = vi.hoisted(() =>
   vi.fn(async (_ctx: SpeechProviderPrepareSynthesisContext) => undefined),
 );
 
+const listLoadedSpeechProvidersMock = vi.hoisted(() => vi.fn());
 const listSpeechProvidersMock = vi.hoisted(() => vi.fn());
 const getSpeechProviderMock = vi.hoisted(() => vi.fn());
 const transcodeAudioBufferMock = vi.hoisted(() =>
@@ -90,6 +91,7 @@ vi.mock("../api.js", async () => {
     prepareSynthesis: prepareSynthesisMock,
     synthesize: synthesizeMock,
   };
+  listLoadedSpeechProvidersMock.mockImplementation(() => [mockProvider]);
   listSpeechProvidersMock.mockImplementation(() => [mockProvider]);
   getSpeechProviderMock.mockImplementation((providerId: string) =>
     providerId === "mock" ? mockProvider : null,
@@ -101,6 +103,7 @@ vi.mock("../api.js", async () => {
     normalizeSpeechProviderId: (providerId: string | undefined) =>
       providerId?.trim().toLowerCase() || undefined,
     getSpeechProvider: getSpeechProviderMock,
+    listLoadedSpeechProviders: listLoadedSpeechProvidersMock,
     listSpeechProviders: listSpeechProvidersMock,
     scheduleCleanup: vi.fn(),
   };
@@ -111,6 +114,7 @@ const {
   getTtsPersona,
   getTtsProvider,
   maybeApplyTtsToPayload,
+  resolveTtsProviderOrder,
   resolveTtsConfig,
   synthesizeSpeech,
   textToSpeechTelephony,
@@ -141,6 +145,7 @@ function createMockSpeechProvider(
 }
 
 function installSpeechProviders(providers: SpeechProviderPlugin[]): void {
+  listLoadedSpeechProvidersMock.mockImplementation(() => providers);
   listSpeechProvidersMock.mockImplementation(() => providers);
   getSpeechProviderMock.mockImplementation(
     (providerId: string) => providers.find((provider) => provider.id === providerId) ?? null,
@@ -477,6 +482,31 @@ describe("speech-core native voice-note routing", () => {
 
     expect(getTtsPersona(config, prefsPath)?.id).toBe("alfred");
     expect(getTtsProvider(config, prefsPath)).toBe("mock");
+  });
+
+  it("uses loaded speech providers for auto selection and fallback ordering", async () => {
+    const mockProvider = createMockSpeechProvider("mock", { autoSelectOrder: 1 });
+    const backupProvider = createMockSpeechProvider("backup", { autoSelectOrder: 2 });
+    listLoadedSpeechProvidersMock.mockImplementation(() => [mockProvider, backupProvider]);
+    listSpeechProvidersMock.mockImplementation(() => {
+      throw new Error("broad speech provider listing should not run");
+    });
+    getSpeechProviderMock.mockImplementation(
+      (providerId: string) =>
+        [mockProvider, backupProvider].find((provider) => provider.id === providerId) ?? null,
+    );
+
+    const config = resolveTtsConfig({
+      messages: {
+        tts: {
+          enabled: true,
+          prefsPath: "/tmp/openclaw-speech-core-loaded-only.json",
+        },
+      },
+    });
+
+    expect(getTtsProvider(config, "/tmp/openclaw-speech-core-loaded-only.json")).toBe("mock");
+    expect(resolveTtsProviderOrder("mock", config.sourceConfig)).toEqual(["mock", "backup"]);
   });
 
   it("merges active persona provider binding into synthesis config", async () => {

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -509,6 +509,29 @@ describe("speech-core native voice-note routing", () => {
     expect(resolveTtsProviderOrder("mock", config.sourceConfig)).toEqual(["mock", "backup"]);
   });
 
+  it("falls back to configured speech provider discovery when no providers are loaded", async () => {
+    const mockProvider = createMockSpeechProvider("mock", { autoSelectOrder: 1 });
+    const backupProvider = createMockSpeechProvider("backup", { autoSelectOrder: 2 });
+    listLoadedSpeechProvidersMock.mockImplementation(() => []);
+    listSpeechProvidersMock.mockImplementation(() => [mockProvider, backupProvider]);
+    getSpeechProviderMock.mockImplementation(
+      (providerId: string) =>
+        [mockProvider, backupProvider].find((provider) => provider.id === providerId) ?? null,
+    );
+
+    const config = resolveTtsConfig({
+      messages: {
+        tts: {
+          enabled: true,
+          prefsPath: "/tmp/openclaw-speech-core-configured-auto.json",
+        },
+      },
+    });
+
+    expect(getTtsProvider(config, "/tmp/openclaw-speech-core-configured-auto.json")).toBe("mock");
+    expect(resolveTtsProviderOrder("mock", config.sourceConfig)).toEqual(["mock", "backup"]);
+  });
+
   it("merges active persona provider binding into synthesis config", async () => {
     const cfg: OpenClawConfig = {
       messages: {

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -241,6 +241,11 @@ function sortSpeechProvidersForAutoSelection(
   });
 }
 
+function resolveSpeechProvidersForAutoSelection(cfg?: OpenClawConfig) {
+  const loadedProviders = sortSpeechProvidersForAutoSelection(cfg, { loadedOnly: true });
+  return loadedProviders.length > 0 ? loadedProviders : sortSpeechProvidersForAutoSelection(cfg);
+}
+
 function resolveTtsRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
   return (
     selectApplicableRuntimeConfig({
@@ -629,7 +634,7 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   }
 
   const effectiveCfg = config.sourceConfig;
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, { loadedOnly: true })) {
+  for (const provider of resolveSpeechProvidersForAutoSelection(effectiveCfg)) {
     if (
       provider.isConfigured({
         cfg: effectiveCfg,
@@ -840,7 +845,7 @@ export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConf
   const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
   const normalizedPrimary = canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
   const ordered = new Set<TtsProvider>([normalizedPrimary]);
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, { loadedOnly: true })) {
+  for (const provider of resolveSpeechProvidersForAutoSelection(effectiveCfg)) {
     const normalized = provider.id;
     if (normalized !== normalizedPrimary) {
       ordered.add(normalized);

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -42,6 +42,7 @@ import {
 import {
   canonicalizeSpeechProviderId,
   getSpeechProvider,
+  listLoadedSpeechProviders,
   listSpeechProviders,
   normalizeSpeechProviderId,
   normalizeTtsAutoMode,
@@ -225,8 +226,12 @@ function resolveModelOverridePolicy(
   };
 }
 
-function sortSpeechProvidersForAutoSelection(cfg?: OpenClawConfig) {
-  return listSpeechProviders(cfg).toSorted((left, right) => {
+function sortSpeechProvidersForAutoSelection(
+  cfg?: OpenClawConfig,
+  options?: { loadedOnly?: boolean },
+) {
+  const providers = options?.loadedOnly ? listLoadedSpeechProviders(cfg) : listSpeechProviders(cfg);
+  return providers.toSorted((left, right) => {
     const leftOrder = left.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
     const rightOrder = right.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
     if (leftOrder !== rightOrder) {
@@ -234,10 +239,6 @@ function sortSpeechProvidersForAutoSelection(cfg?: OpenClawConfig) {
     }
     return left.id.localeCompare(right.id);
   });
-}
-
-function _resolveRegistryDefaultSpeechProviderId(cfg?: OpenClawConfig): TtsProvider {
-  return sortSpeechProvidersForAutoSelection(cfg)[0]?.id ?? "";
 }
 
 function resolveTtsRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
@@ -628,7 +629,7 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   }
 
   const effectiveCfg = config.sourceConfig;
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg)) {
+  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, { loadedOnly: true })) {
     if (
       provider.isConfigured({
         cfg: effectiveCfg,
@@ -839,7 +840,7 @@ export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConf
   const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
   const normalizedPrimary = canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
   const ordered = new Set<TtsProvider>([normalizedPrimary]);
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg)) {
+  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, { loadedOnly: true })) {
     const normalized = provider.id;
     if (normalized !== normalizedPrimary) {
       ordered.add(normalized);

--- a/extensions/telegram/src/bot-message-dispatch.agent.runtime.ts
+++ b/extensions/telegram/src/bot-message-dispatch.agent.runtime.ts
@@ -3,5 +3,6 @@ export {
   loadModelCatalog,
   modelSupportsVision,
   resolveAgentDir,
+  resolveModelCatalogScope,
   resolveDefaultModelForAgent,
 } from "openclaw/plugin-sdk/agent-runtime";

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -61,6 +61,12 @@ const loadModelCatalog = vi.hoisted(() => vi.fn(async () => ({})));
 const findModelInCatalog = vi.hoisted(() => vi.fn(() => null));
 const modelSupportsVision = vi.hoisted(() => vi.fn(() => false));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent"));
+const resolveModelCatalogScope = vi.hoisted(() =>
+  vi.fn(({ provider, model }: { provider: string; model: string }) => ({
+    providerRefs: [provider],
+    modelRefs: [`${provider}/${model}`, model],
+  })),
+);
 const resolveDefaultModelForAgent = vi.hoisted(() =>
   vi.fn(() => ({ provider: "openai", model: "gpt-test" })),
 );
@@ -116,6 +122,7 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
   loadModelCatalog,
   modelSupportsVision,
   resolveAgentDir,
+  resolveModelCatalogScope,
   resolveDefaultModelForAgent,
 }));
 
@@ -3804,6 +3811,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
     releaseCatalogLoad();
     await Promise.all([firstPromise, abortPromise]);
 
+    expect(loadModelCatalog).toHaveBeenCalledWith({
+      config: expect.any(Object),
+      providerRefs: ["openai"],
+      modelRefs: ["openai/gpt-test", "gpt-test"],
+    });
     expect(deliverReplies).not.toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [{ text: "Old reply final" }],

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -45,6 +45,7 @@ import {
   loadModelCatalog,
   modelSupportsVision,
   resolveAgentDir,
+  resolveModelCatalogScope,
   resolveDefaultModelForAgent,
 } from "./bot-message-dispatch.agent.runtime.js";
 import { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
@@ -102,8 +103,15 @@ const DRAFT_MIN_INITIAL_CHARS = 30;
 
 async function resolveStickerVisionSupport(cfg: OpenClawConfig, agentId: string) {
   try {
-    const catalog = await loadModelCatalog({ config: cfg });
     const defaultModel = resolveDefaultModelForAgent({ cfg, agentId });
+    const catalog = await loadModelCatalog({
+      config: cfg,
+      ...resolveModelCatalogScope({
+        cfg,
+        provider: defaultModel.provider,
+        model: defaultModel.model,
+      }),
+    });
     const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
     if (!entry) {
       return false;

--- a/extensions/telegram/src/sticker-cache.ts
+++ b/extensions/telegram/src/sticker-cache.ts
@@ -4,6 +4,7 @@ import {
   findModelInCatalog,
   loadModelCatalog,
   modelSupportsVision,
+  resolveModelCatalogScope,
 } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
@@ -43,10 +44,23 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
   const { imagePath, cfg, agentDir, agentId } = params;
 
   const defaultModel = resolveDefaultModelForAgent({ cfg, agentId });
+  const autoProviders = resolveAutoMediaKeyProviders({
+    cfg,
+    capability: "image",
+  });
   let activeModel = undefined as { provider: string; model: string } | undefined;
   let catalog: ModelCatalogEntry[] = [];
   try {
-    catalog = await loadModelCatalog({ config: cfg });
+    const defaultModelScope = resolveModelCatalogScope({
+      cfg,
+      provider: defaultModel.provider,
+      model: defaultModel.model,
+    });
+    catalog = await loadModelCatalog({
+      config: cfg,
+      providerRefs: [...new Set([...defaultModelScope.providerRefs, ...autoProviders])],
+      modelRefs: defaultModelScope.modelRefs,
+    });
     const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
     const supportsVision = modelSupportsVision(entry);
     if (supportsVision) {
@@ -64,11 +78,6 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
       return false;
     }
   };
-
-  const autoProviders = resolveAutoMediaKeyProviders({
-    cfg,
-    capability: "image",
-  });
 
   const selectCatalogModel = (provider: string) => {
     const entries = catalog.filter(

--- a/extensions/telegram/src/sticker-vision.runtime.ts
+++ b/extensions/telegram/src/sticker-vision.runtime.ts
@@ -2,6 +2,7 @@ import {
   findModelInCatalog,
   loadModelCatalog,
   modelSupportsVision,
+  resolveModelCatalogScope,
   resolveDefaultModelForAgent,
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
@@ -10,10 +11,17 @@ export async function resolveStickerVisionSupportRuntime(params: {
   cfg: OpenClawConfig;
   agentId?: string;
 }): Promise<boolean> {
-  const catalog = await loadModelCatalog({ config: params.cfg });
   const defaultModel = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: params.agentId,
+  });
+  const catalog = await loadModelCatalog({
+    config: params.cfg,
+    ...resolveModelCatalogScope({
+      cfg: params.cfg,
+      provider: defaultModel.provider,
+      model: defaultModel.model,
+    }),
   });
   const entry = findModelInCatalog(catalog, defaultModel.provider, defaultModel.model);
   if (!entry) {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -887,33 +887,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(state.clearSessionAuthProfileOverrideMock).not.toHaveBeenCalled();
   });
 
-  it("hydrates stripped persisted skill snapshots before running the CLI path", async () => {
+  it("passes stripped persisted skill snapshots without eager hydration", async () => {
     const persistedSnapshot = {
       prompt: "persisted prompt",
       skills: [{ name: "cli-skill" }],
       skillFilter: ["cli-skill"],
       version: 0,
     };
-    const rebuiltSkills = [
-      {
-        name: "cli-skill",
-        description: "CLI skill",
-        filePath: "/tmp/workspace/skills/cli-skill/SKILL.md",
-        baseDir: "/tmp/workspace/skills/cli-skill",
-        source: "# CLI skill",
-      },
-    ];
     state.sessionEntryMock = {
       sessionId: "session-1",
       updatedAt: Date.now(),
       skillsSnapshot: persistedSnapshot,
     };
-    state.buildWorkspaceSkillSnapshotMock.mockReturnValue({
-      prompt: "rebuilt prompt",
-      skills: [{ name: "different-skill" }],
-      resolvedSkills: rebuiltSkills,
-      version: 99,
-    });
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
       const result = await params.run(params.provider, params.model);
       return {
@@ -935,9 +920,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       skills: [{ name: "cli-skill" }],
       skillFilter: ["cli-skill"],
       version: 0,
-      resolvedSkills: rebuiltSkills,
     });
-    expect(state.buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(attemptParams?.skillsSnapshot).not.toHaveProperty("resolvedSkills");
+    expect(state.buildWorkspaceSkillSnapshotMock).not.toHaveBeenCalled();
   });
 
   it("classifies empty embedded run results before model fallback accepts them", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -66,7 +66,6 @@ import {
 } from "./model-selection.js";
 import { classifyEmbeddedPiRunResultForModelFallback } from "./pi-embedded-runner/result-fallback-classifier.js";
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
-import { hydrateResolvedSkillsAsync } from "./skills/snapshot-hydration.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
@@ -665,7 +664,7 @@ async function agentCommandInternal(
       ? await buildSkillsSnapshot()
       : !currentSkillsSnapshot
         ? undefined
-        : await hydrateResolvedSkillsAsync(currentSkillsSnapshot, buildSkillsSnapshot);
+        : currentSkillsSnapshot;
 
     if (skillsSnapshot && sessionStore && sessionKey && needsSkillsSnapshot) {
       const now = Date.now();

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -348,6 +348,25 @@ describe("external cli oauth resolution", () => {
     expect(mocks.readMiniMaxCliCredentialsCached).not.toHaveBeenCalled();
   });
 
+  it("does not read bootstrap-only external CLI credentials when local oauth exists", () => {
+    const profiles = resolveExternalCliAuthProfiles(
+      makeStore(
+        OPENAI_CODEX_DEFAULT_PROFILE_ID,
+        makeOAuthCredential({
+          provider: "openai-codex",
+          access: "local-access",
+          refresh: "local-refresh",
+        }),
+      ),
+      {
+        providerIds: ["openai-codex"],
+      },
+    );
+
+    expect(profiles).toEqual([]);
+    expect(mocks.readCodexCliCredentialsCached).not.toHaveBeenCalled();
+  });
+
   it("does not scan missing external CLI profiles without an explicit scope", () => {
     mocks.readClaudeCliCredentialsCached.mockReturnValue({
       type: "oauth",

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -16,7 +16,11 @@ export {
   type ExternalCliAuthDiscovery,
 } from "./auth-profiles/external-cli-discovery.js";
 export { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
-export { resolveAuthProfileEligibility, resolveAuthProfileOrder } from "./auth-profiles/order.js";
+export {
+  preferAuthProfileFirst,
+  resolveAuthProfileEligibility,
+  resolveAuthProfileOrder,
+} from "./auth-profiles/order.js";
 export {
   resolveAuthStatePathForDisplay,
   resolveAuthStorePathForDisplay,
@@ -25,6 +29,7 @@ export {
   dedupeProfileIds,
   listProfilesForProvider,
   markAuthProfileGood,
+  markAuthProfileSuccess,
   setAuthProfileOrder,
   upsertAuthProfile,
   upsertAuthProfileWithLock,

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -235,12 +235,6 @@ export function resolveExternalCliAuthProfiles(
     if (!isExternalCliProviderInScope({ providerConfig, store, options })) {
       continue;
     }
-    const creds = providerConfig.readCredentials({
-      allowKeychainPrompt: options?.allowKeychainPrompt,
-    });
-    if (!creds) {
-      continue;
-    }
     const existing = store.profiles[providerConfig.profileId];
     const existingOAuth =
       existing?.type === "oauth" && existing.provider === providerConfig.provider
@@ -256,10 +250,12 @@ export function resolveExternalCliAuthProfiles(
       continue;
     }
     if (providerConfig.bootstrapOnly && existingOAuth) {
-      log.debug("kept local oauth over external cli bootstrap-only provider", {
-        profileId: providerConfig.profileId,
-        provider: providerConfig.provider,
-      });
+      continue;
+    }
+    const creds = providerConfig.readCredentials({
+      allowKeychainPrompt: options?.allowKeychainPrompt,
+    });
+    if (!creds) {
       continue;
     }
     if (existingOAuth && !isSafeToUseExternalCliCredential(existingOAuth, creds)) {

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "./types.js";
 
@@ -9,11 +9,14 @@ vi.mock("../cli-credentials.js", () => ({
   resetCliCredentialCachesForTest: () => undefined,
 }));
 
-vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
-  formatProviderAuthProfileApiKeyWithPlugin: async (params: { context?: { access?: string } }) =>
-    params.context?.access,
-  refreshProviderOAuthCredentialWithPlugin: async () => null,
+const providerRuntimeMocks = vi.hoisted(() => ({
+  formatProviderAuthProfileApiKeyWithPlugin: vi.fn(
+    async (params: { context?: { access?: string } }) => params.context?.access,
+  ),
+  refreshProviderOAuthCredentialWithPlugin: vi.fn(async () => null),
 }));
+
+vi.mock("../../plugins/provider-runtime.runtime.js", () => providerRuntimeMocks);
 
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
 
@@ -112,6 +115,15 @@ async function expectResolvedApiKey(params: {
 
 beforeAll(loadOAuthModuleForTest);
 
+beforeEach(() => {
+  providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
+  providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockImplementation(
+    async (params: { context?: { access?: string } }) => params.context?.access,
+  );
+  providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockReset();
+  providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockResolvedValue(null);
+});
+
 afterAll(() => {
   vi.doUnmock("../cli-credentials.js");
   vi.doUnmock("../../plugins/provider-runtime.runtime.js");
@@ -203,6 +215,46 @@ describe("resolveApiKeyForProfile config compatibility", () => {
       apiKey: "access-123", // pragma: allowlist secret
       provider: "anthropic",
       email: undefined,
+    });
+  });
+
+  it("uses provider plugin formatters for non-Google OAuth access tokens", async () => {
+    const profileId = "anthropic:oauth";
+    const cfg = cfgFor(profileId, "anthropic", "oauth");
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider: "anthropic",
+          access: "access-123",
+          refresh: "refresh-123",
+          expires: createUsableOAuthExpiry(),
+        },
+      },
+    };
+    providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockResolvedValueOnce(
+      "formatted-access-123",
+    );
+
+    const result = await resolveApiKeyForProfile({
+      cfg,
+      store,
+      profileId,
+    });
+
+    expect(result).toEqual({
+      apiKey: "formatted-access-123", // pragma: allowlist secret
+      provider: "anthropic",
+      email: undefined,
+    });
+    expect(providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin).toHaveBeenCalledWith({
+      provider: "anthropic",
+      config: cfg,
+      context: expect.objectContaining({
+        access: "access-123",
+        provider: "anthropic",
+      }),
     });
   });
 });

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -12,9 +12,12 @@ import {
   formatProviderAuthProfileApiKeyWithPlugin,
   refreshProviderOAuthCredentialWithPlugin,
 } from "../../plugins/provider-runtime.runtime.js";
+import { getActivePluginGatewayRuntimeRegistry } from "../../plugins/runtime.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
 import { resolveSecretRefString, type SecretRefResolveCache } from "../../secrets/resolve.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
+import { normalizeProviderId } from "../provider-id.js";
 import { log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
@@ -98,12 +101,45 @@ async function buildOAuthApiKey(
   credentials: OAuthCredential,
   context: { cfg?: OpenClawConfig },
 ): Promise<string> {
+  const loadedFormatter = resolveLoadedOAuthApiKeyFormatter(provider);
+  if (loadedFormatter) {
+    const formatted = loadedFormatter(credentials);
+    if (typeof formatted === "string" && formatted.length > 0) {
+      return formatted;
+    }
+  }
   const formatted = await formatProviderAuthProfileApiKeyWithPlugin({
     provider,
     config: context.cfg,
     context: credentials,
   });
   return typeof formatted === "string" && formatted.length > 0 ? formatted : credentials.access;
+}
+
+function resolveLoadedOAuthApiKeyFormatter(
+  provider: string,
+): ProviderPlugin["formatApiKey"] | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!normalizedProvider) {
+    return undefined;
+  }
+  for (const entry of getActivePluginGatewayRuntimeRegistry()?.providers ?? []) {
+    const plugin = entry.provider;
+    if (!providerPluginMatchesId(plugin, normalizedProvider)) {
+      continue;
+    }
+    return plugin.formatApiKey;
+  }
+  return undefined;
+}
+
+function providerPluginMatchesId(plugin: ProviderPlugin, normalizedProvider: string): boolean {
+  if (normalizeProviderId(plugin.id) === normalizedProvider) {
+    return true;
+  }
+  return [...(plugin.aliases ?? []), ...(plugin.hookAliases ?? [])].some(
+    (alias) => normalizeProviderId(alias) === normalizedProvider,
+  );
 }
 
 function buildApiKeyProfileResult(params: { apiKey: string; provider: string; email?: string }) {

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -16,6 +16,7 @@ const loadPluginManifestRegistry = vi.hoisted(() =>
     diagnostics: [],
   })),
 );
+const shouldPersistExternalAuthProfile = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("../../plugins/manifest-registry.js", () => ({
   loadPluginManifestRegistry,
@@ -23,7 +24,7 @@ vi.mock("../../plugins/manifest-registry.js", () => ({
 
 vi.mock("./external-auth.js", () => ({
   overlayExternalAuthProfiles: <T>(store: T) => store,
-  shouldPersistExternalAuthProfile: () => true,
+  shouldPersistExternalAuthProfile,
 }));
 
 async function importAuthProfileModulesWithAliasRegistry() {
@@ -31,16 +32,15 @@ async function importAuthProfileModulesWithAliasRegistry() {
   vi.doMock("../../plugins/manifest-registry.js", () => ({
     loadPluginManifestRegistry,
   }));
-  const [{ resolveAuthProfileOrder }, { markAuthProfileGood }] = await Promise.all([
-    import("./order.js"),
-    import("./profiles.js"),
-  ]);
-  return { markAuthProfileGood, resolveAuthProfileOrder };
+  const [{ resolveAuthProfileOrder }, { markAuthProfileGood, markAuthProfileSuccess }] =
+    await Promise.all([import("./order.js"), import("./profiles.js")]);
+  return { markAuthProfileGood, markAuthProfileSuccess, resolveAuthProfileOrder };
 }
 
 describe("resolveAuthProfileOrder", () => {
   beforeEach(() => {
     loadPluginManifestRegistry.mockClear();
+    shouldPersistExternalAuthProfile.mockClear();
   });
 
   afterEach(() => {
@@ -247,6 +247,54 @@ describe("resolveAuthProfileOrder", () => {
       expect(store.lastGood).toEqual({
         "fixture-provider": "fixture-provider:default",
       });
+    } finally {
+      await rm(agentDir, { force: true, recursive: true });
+    }
+  });
+
+  it("marks profile success with one canonical last-good and usage update", async () => {
+    const { markAuthProfileSuccess } = await importAuthProfileModulesWithAliasRegistry();
+    const agentDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-auth-profile-success-"));
+    try {
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "fixture-provider:default": {
+            type: "oauth",
+            provider: "fixture-provider",
+            access: "token",
+            refresh: "refresh",
+            expires: Date.now() + 60_000,
+          },
+        },
+        usageStats: {
+          "fixture-provider:default": {
+            errorCount: 3,
+            cooldownUntil: Date.now() + 60_000,
+            cooldownReason: "rate_limit",
+          },
+        },
+      };
+      saveAuthProfileStore(store, agentDir);
+      shouldPersistExternalAuthProfile.mockClear();
+
+      await markAuthProfileSuccess({
+        store,
+        provider: "fixture-provider-plan",
+        profileId: "fixture-provider:default",
+        agentDir,
+      });
+
+      expect(store.lastGood).toEqual({
+        "fixture-provider": "fixture-provider:default",
+      });
+      expect(store.usageStats?.["fixture-provider:default"]).toMatchObject({
+        errorCount: 0,
+        cooldownUntil: undefined,
+        cooldownReason: undefined,
+      });
+      expect(store.usageStats?.["fixture-provider:default"]?.lastUsed).toEqual(expect.any(Number));
+      expect(shouldPersistExternalAuthProfile).toHaveBeenCalledTimes(1);
     } finally {
       await rm(agentDir, { force: true, recursive: true });
     }

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -24,6 +24,15 @@ export type AuthProfileEligibility = {
   reasonCode: AuthProfileEligibilityReasonCode;
 };
 
+export function preferAuthProfileFirst(
+  preferredProfile: string | undefined,
+  orderedProfiles: readonly string[],
+): string[] {
+  return preferredProfile && orderedProfiles.includes(preferredProfile)
+    ? [preferredProfile, ...orderedProfiles.filter((profileId) => profileId !== preferredProfile)]
+    : [...orderedProfiles];
+}
+
 export function resolveAuthProfileEligibility(params: {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
@@ -145,23 +154,14 @@ export function resolveAuthProfileOrder(params: {
 
     const ordered = [...available, ...cooldownSorted];
 
-    // Still put preferredProfile first if specified
-    if (preferredProfile && ordered.includes(preferredProfile)) {
-      return [preferredProfile, ...ordered.filter((e) => e !== preferredProfile)];
-    }
-    return ordered;
+    return preferAuthProfileFirst(preferredProfile, ordered);
   }
 
   // Otherwise, use round-robin: sort by lastUsed (oldest first)
   // preferredProfile goes first if specified (for explicit user choice)
   // lastGood is NOT prioritized - that would defeat round-robin
   const sorted = orderProfilesByMode(deduped, store);
-
-  if (preferredProfile && sorted.includes(preferredProfile)) {
-    return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
-  }
-
-  return sorted;
+  return preferAuthProfileFirst(preferredProfile, sorted);
 }
 
 function resolveAuthOrder(

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -9,6 +9,7 @@ import {
   updateAuthProfileStoreWithLock,
 } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+import { resetUsageStats, updateUsageStatsEntry } from "./usage-state.js";
 export { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
 
 export async function setAuthProfileOrder(params: {
@@ -185,5 +186,42 @@ export async function markAuthProfileGood(params: {
     return;
   }
   store.lastGood = { ...store.lastGood, [providerKey]: profileId };
+  saveAuthProfileStore(store, agentDir);
+}
+
+export async function markAuthProfileSuccess(params: {
+  store: AuthProfileStore;
+  provider: string;
+  profileId: string;
+  agentDir?: string;
+}): Promise<void> {
+  const { store, provider, profileId, agentDir } = params;
+  const providerKey = resolveProviderIdForAuth(provider);
+  const lastUsed = Date.now();
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    updater: (freshStore) => {
+      const profile = freshStore.profiles[profileId];
+      if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+        return false;
+      }
+      freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
+      updateUsageStatsEntry(freshStore, profileId, (existing) =>
+        resetUsageStats(existing, { lastUsed }),
+      );
+      return true;
+    },
+  });
+  if (updated) {
+    store.lastGood = updated.lastGood;
+    store.usageStats = updated.usageStats;
+    return;
+  }
+  const profile = store.profiles[profileId];
+  if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+    return;
+  }
+  store.lastGood = { ...store.lastGood, [providerKey]: profileId };
+  updateUsageStatsEntry(store, profileId, (existing) => resetUsageStats(existing, { lastUsed }));
   saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,7 +6,10 @@ import {
   type OpenClawTestState,
   withOpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
-import { resolveSessionAuthProfileOverride } from "./session-override.js";
+import {
+  resolveSessionAuthProfileOverride,
+  resolveSessionAuthProfileOverrideState,
+} from "./session-override.js";
 import type { AuthProfileStore } from "./types.js";
 
 const authStoreMocks = vi.hoisted(() => {
@@ -18,6 +21,7 @@ const authStoreMocks = vi.hoisted(() => {
   return {
     state,
     ensureAuthProfileStore: vi.fn(() => state.store),
+    ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => state.store),
     hasAnyAuthProfileStoreSource: vi.fn(() => state.hasSource),
     isProfileInCooldown: vi.fn((_store: AuthProfileStore, _profileId: string) => false),
     reset() {
@@ -43,6 +47,8 @@ const authStoreMocks = vi.hoisted(() => {
 
 vi.mock("./store.js", () => ({
   ensureAuthProfileStore: authStoreMocks.ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles:
+    authStoreMocks.ensureAuthProfileStoreWithoutExternalProfiles,
   hasAnyAuthProfileStoreSource: authStoreMocks.hasAnyAuthProfileStoreSource,
 }));
 
@@ -154,6 +160,79 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("returns the auth store loaded while resolving the override", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStore();
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        authProfileOverride: "zai:work",
+        authProfileOverrideSource: "user",
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverrideState({
+        cfg: {} as OpenClawConfig,
+        provider: "z.ai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved.authProfileId).toBe("zai:work");
+      expect(resolved.authProfileOrder).toEqual(["zai:work"]);
+      expect(resolved.authStore).toBe(authStoreMocks.state.store);
+      expect(authStoreMocks.ensureAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledTimes(1);
+      expect(authStoreMocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+    });
+  });
+
+  it("hydrates external auth only when persisted profiles cannot satisfy selection", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      const persistedStore: AuthProfileStore = {
+        version: 1,
+        profiles: {},
+      };
+      const externalStore = createAuthStore();
+      authStoreMocks.ensureAuthProfileStoreWithoutExternalProfiles.mockReturnValueOnce(
+        persistedStore,
+      );
+      authStoreMocks.ensureAuthProfileStore.mockReturnValueOnce(externalStore);
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverrideState({
+        cfg: {} as OpenClawConfig,
+        provider: "z.ai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved.authProfileId).toBe("zai:work");
+      expect(resolved.authStore).toBe(externalStore);
+      expect(authStoreMocks.ensureAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledTimes(1);
+      expect(authStoreMocks.ensureAuthProfileStore).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -2,13 +2,23 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
-import { ensureAuthProfileStore, hasAnyAuthProfileStoreSource } from "../auth-profiles/store.js";
+import {
+  ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  hasAnyAuthProfileStoreSource,
+} from "../auth-profiles/store.js";
 import { isProfileInCooldown } from "../auth-profiles/usage.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 
 const sessionStoreRuntimeLoader = createLazyImportLoader(
   () => import("../../config/sessions/store.runtime.js"),
 );
+
+export type ResolvedSessionAuthProfileOverride = {
+  authProfileId?: string;
+  authProfileOrder?: string[];
+  authStore?: ReturnType<typeof ensureAuthProfileStore>;
+};
 
 function loadSessionStoreRuntime() {
   return sessionStoreRuntimeLoader.load();
@@ -49,7 +59,7 @@ export async function clearSessionAuthProfileOverride(params: {
   }
 }
 
-export async function resolveSessionAuthProfileOverride(params: {
+export async function resolveSessionAuthProfileOverrideState(params: {
   cfg: OpenClawConfig;
   provider: string;
   agentDir: string;
@@ -58,7 +68,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   sessionKey?: string;
   storePath?: string;
   isNewSession: boolean;
-}): Promise<string | undefined> {
+}): Promise<ResolvedSessionAuthProfileOverride> {
   const {
     cfg,
     provider,
@@ -70,7 +80,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     isNewSession,
   } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
-    return sessionEntry?.authProfileOverride;
+    return { authProfileId: sessionEntry?.authProfileOverride };
   }
 
   const hasConfiguredAuthProfiles =
@@ -81,12 +91,23 @@ export async function resolveSessionAuthProfileOverride(params: {
     !hasConfiguredAuthProfiles &&
     !hasAnyAuthProfileStoreSource(agentDir)
   ) {
-    return undefined;
+    return {};
   }
 
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-  const order = resolveAuthProfileOrder({ cfg, store, provider });
+  const baseStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+    allowKeychainPrompt: false,
+  });
+  let store = baseStore;
+  let order = resolveAuthProfileOrder({ cfg, store, provider });
   let current = sessionEntry.authProfileOverride?.trim();
+  if ((current && !store.profiles[current]) || order.length === 0) {
+    const externalStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+    const externalOrder = resolveAuthProfileOrder({ cfg, store: externalStore, provider });
+    if ((current && externalStore.profiles[current]) || externalOrder.length > 0) {
+      store = externalStore;
+      order = externalOrder;
+    }
+  }
   const source =
     sessionEntry.authProfileOverrideSource ??
     (typeof sessionEntry.authProfileOverrideCompactionCount === "number"
@@ -112,7 +133,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   if (order.length === 0) {
-    return undefined;
+    return { authProfileOrder: [], authStore: store };
   }
 
   const pickFirstAvailable = () =>
@@ -144,7 +165,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     current = undefined;
   }
   if (source === "user" && current && !isNewSession) {
-    return current;
+    return { authProfileId: current, authProfileOrder: order, authStore: store };
   }
 
   let next = current;
@@ -159,7 +180,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   if (!next) {
-    return current;
+    return { authProfileId: current, authProfileOrder: order, authStore: store };
   }
   const shouldPersist =
     next !== sessionEntry.authProfileOverride ||
@@ -180,5 +201,18 @@ export async function resolveSessionAuthProfileOverride(params: {
     }
   }
 
-  return next;
+  return { authProfileId: next, authProfileOrder: order, authStore: store };
+}
+
+export async function resolveSessionAuthProfileOverride(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  agentDir: string;
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+  isNewSession: boolean;
+}): Promise<string | undefined> {
+  return (await resolveSessionAuthProfileOverrideState(params)).authProfileId;
 }

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -1,6 +1,32 @@
 import { normalizeProviderId } from "../provider-id.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 
+export function resetUsageStats(
+  existing: ProfileUsageStats | undefined,
+  overrides?: Partial<ProfileUsageStats>,
+): ProfileUsageStats {
+  return {
+    ...existing,
+    errorCount: 0,
+    cooldownUntil: undefined,
+    cooldownReason: undefined,
+    cooldownModel: undefined,
+    disabledUntil: undefined,
+    disabledReason: undefined,
+    failureCounts: undefined,
+    ...overrides,
+  };
+}
+
+export function updateUsageStatsEntry(
+  store: AuthProfileStore,
+  profileId: string,
+  updater: (existing: ProfileUsageStats | undefined) => ProfileUsageStats,
+): void {
+  store.usageStats = store.usageStats ?? {};
+  store.usageStats[profileId] = updater(store.usageStats[profileId]);
+}
+
 export function isAuthCooldownBypassedForProvider(provider: string | undefined): boolean {
   const normalized = normalizeProviderId(provider ?? "");
   return normalized === "openrouter" || normalized === "kilocode";

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -9,7 +9,9 @@ import {
   isActiveUnusableWindow,
   isAuthCooldownBypassedForProvider,
   isProfileInCooldown,
+  resetUsageStats,
   resolveProfileUnusableUntil,
+  updateUsageStatsEntry,
 } from "./usage-state.js";
 export {
   clearExpiredCooldowns,
@@ -497,32 +499,6 @@ export function resolveProfileUnusableUntilForDisplay(
     return null;
   }
   return resolveProfileUnusableUntil(stats);
-}
-
-function resetUsageStats(
-  existing: ProfileUsageStats | undefined,
-  overrides?: Partial<ProfileUsageStats>,
-): ProfileUsageStats {
-  return {
-    ...existing,
-    errorCount: 0,
-    cooldownUntil: undefined,
-    cooldownReason: undefined,
-    cooldownModel: undefined,
-    disabledUntil: undefined,
-    disabledReason: undefined,
-    failureCounts: undefined,
-    ...overrides,
-  };
-}
-
-function updateUsageStatsEntry(
-  store: AuthProfileStore,
-  profileId: string,
-  updater: (existing: ProfileUsageStats | undefined) => ProfileUsageStats,
-): void {
-  store.usageStats = store.usageStats ?? {};
-  store.usageStats[profileId] = updater(store.usageStats[profileId]);
 }
 
 function keepActiveWindowOrRecompute(params: {

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -6,10 +6,7 @@ const readFileMock = vi.fn();
 const parseSessionEntriesMock = vi.fn();
 const migrateSessionEntriesMock = vi.fn();
 const buildSessionContextMock = vi.fn();
-const ensureOpenClawModelsJsonMock = vi.fn();
-const discoverAuthStorageMock = vi.fn();
-const discoverModelsMock = vi.fn();
-const resolveModelWithRegistryMock = vi.fn();
+const resolveModelAsyncMock = vi.fn();
 const getApiKeyForModelMock = vi.fn();
 const requireApiKeyMock = vi.fn();
 const resolveSessionAuthProfileOverrideMock = vi.fn();
@@ -43,17 +40,8 @@ vi.mock("@mariozechner/pi-coding-agent", () => ({
   parseSessionEntries: (...args: unknown[]) => parseSessionEntriesMock(...args),
 }));
 
-vi.mock("./models-config.js", () => ({
-  ensureOpenClawModelsJson: (...args: unknown[]) => ensureOpenClawModelsJsonMock(...args),
-}));
-
-vi.mock("./pi-model-discovery.js", () => ({
-  discoverAuthStorage: (...args: unknown[]) => discoverAuthStorageMock(...args),
-  discoverModels: (...args: unknown[]) => discoverModelsMock(...args),
-}));
-
 vi.mock("./pi-embedded-runner/model.js", () => ({
-  resolveModelWithRegistry: (...args: unknown[]) => resolveModelWithRegistryMock(...args),
+  resolveModelAsync: (...args: unknown[]) => resolveModelAsyncMock(...args),
 }));
 
 vi.mock("./model-auth.js", () => ({
@@ -285,10 +273,7 @@ describe("runBtwSideQuestion", () => {
     parseSessionEntriesMock.mockReset();
     migrateSessionEntriesMock.mockReset();
     buildSessionContextMock.mockReset();
-    ensureOpenClawModelsJsonMock.mockReset();
-    discoverAuthStorageMock.mockReset();
-    discoverModelsMock.mockReset();
-    resolveModelWithRegistryMock.mockReset();
+    resolveModelAsyncMock.mockReset();
     getApiKeyForModelMock.mockReset();
     requireApiKeyMock.mockReset();
     resolveSessionAuthProfileOverrideMock.mockReset();
@@ -318,10 +303,14 @@ describe("runBtwSideQuestion", () => {
     buildSessionContextMock.mockImplementation((entries: Array<{ message?: unknown }> = []) => {
       return { messages: entries.flatMap((entry) => (entry.message ? [entry.message] : [])) };
     });
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "anthropic",
-      id: "claude-sonnet-4-6",
-      api: "anthropic-messages",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+      },
+      authStorage: {},
+      modelRegistry: {},
     });
     getApiKeyForModelMock.mockResolvedValue({ apiKey: "secret", mode: "api-key", source: "test" });
     requireApiKeyMock.mockReturnValue("secret");
@@ -420,11 +409,15 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("applies provider runtime auth before streaming github-copilot BTW questions", async () => {
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "github-copilot",
-      id: "gpt-5.4",
-      api: "openai-responses",
-      baseUrl: "https://api.individual.githubcopilot.com",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "github-copilot",
+        id: "gpt-5.4",
+        api: "openai-responses",
+        baseUrl: "https://api.individual.githubcopilot.com",
+      },
+      authStorage: {},
+      modelRegistry: {},
     });
     getApiKeyForModelMock.mockResolvedValue({
       apiKey: "github-token",
@@ -475,11 +468,15 @@ describe("runBtwSideQuestion", () => {
     // bypassed the provider's createStreamFn/wrapStreamFn hooks. That caused
     // Ollama Cloud (api: "openai-completions", baseUrl: "https://ollama.com/")
     // to hit the marketing site instead of /v1/chat/completions.
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "ollama",
-      id: "glm-5.1",
-      api: "openai-completions",
-      baseUrl: "https://ollama.com/",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "ollama",
+        id: "glm-5.1",
+        api: "openai-completions",
+        baseUrl: "https://ollama.com/",
+      },
+      authStorage: {},
+      modelRegistry: {},
     });
     const providerStreamFn = vi
       .fn()
@@ -529,10 +526,14 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("allows Bedrock /btw runs to proceed without a static api key in aws-sdk mode", async () => {
-    resolveModelWithRegistryMock.mockReturnValue({
-      provider: "amazon-bedrock",
-      id: "us.anthropic.claude-sonnet-4-5-v1:0",
-      api: "anthropic-messages",
+    resolveModelAsyncMock.mockResolvedValue({
+      model: {
+        provider: "amazon-bedrock",
+        id: "us.anthropic.claude-sonnet-4-5-v1:0",
+        api: "anthropic-messages",
+      },
+      authStorage: {},
+      modelRegistry: {},
     });
     getApiKeyForModelMock.mockResolvedValue({
       apiKey: undefined,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -22,12 +22,10 @@ import {
   type ImageSanitizationLimits,
 } from "./image-sanitization.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
-import { ensureOpenClawModelsJson } from "./models-config.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
-import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
+import { resolveModelAsync } from "./pi-embedded-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
 import { streamWithPayloadPatch } from "./pi-embedded-runner/stream-payload-utils.js";
-import { discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
@@ -226,15 +224,15 @@ async function resolveRuntimeModel(params: {
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
 }> {
-  await ensureOpenClawModelsJson(params.cfg, params.agentDir);
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir);
-  const model = resolveModelWithRegistry({
-    provider: params.provider,
-    modelId: params.model,
-    modelRegistry,
-    cfg: params.cfg,
-  });
+  const { model } = await resolveModelAsync(
+    params.provider,
+    params.model,
+    params.agentDir,
+    params.cfg,
+    {
+      skipPiDiscovery: true,
+    },
+  );
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -410,6 +410,65 @@ describe("runCliAgent spawn path", () => {
     }
   });
 
+  it("hydrates stripped skill snapshots only when the Claude plugin needs files", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-skills-"));
+    const skillDir = path.join(workspaceDir, "skills", "weather");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: weather",
+        "description: Use weather tools for forecasts.",
+        "---",
+        "",
+        "Read forecast data before replying.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    let pluginDir = "";
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      const pluginArgIndex = input.argv?.indexOf("--plugin-dir") ?? -1;
+      expect(pluginArgIndex).toBeGreaterThanOrEqual(0);
+      pluginDir = input.argv?.[pluginArgIndex + 1] ?? "";
+      await expect(
+        fs.readFile(path.join(pluginDir, "skills", "weather", "SKILL.md"), "utf-8"),
+      ).resolves.toContain("Read forecast data before replying.");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    try {
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "claude-cli",
+          model: "sonnet",
+          runId: "run-claude-skills-plugin-stripped",
+          workspaceDir,
+          skillsSnapshot: {
+            prompt: "persisted skill prompt",
+            skills: [{ name: "weather" }],
+            skillFilter: ["weather"],
+            version: 0,
+          },
+        }),
+      );
+      await expect(fs.access(pluginDir)).rejects.toThrow();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("injects skill env overrides into CLI child env and restores host env", async () => {
     const previousEnvValue = process.env.CLI_SKILL_API_KEY;
     delete process.env.CLI_SKILL_API_KEY;

--- a/src/agents/cli-runner/claude-skills-plugin.ts
+++ b/src/agents/cli-runner/claude-skills-plugin.ts
@@ -78,12 +78,17 @@ async function linkOrCopySkillDir(params: { sourceDir: string; targetDir: string
 export async function prepareClaudeCliSkillsPlugin(params: {
   backendId: string;
   skillsSnapshot?: SkillSnapshot;
+  hydrateSkillsSnapshot?: () => SkillSnapshot | undefined | Promise<SkillSnapshot | undefined>;
 }): Promise<{ args: string[]; cleanup: () => Promise<void>; pluginDir?: string }> {
   if (normalizeLowercaseStringOrEmpty(params.backendId) !== CLAUDE_CLI_BACKEND_ID) {
     return { args: [], cleanup: async () => {} };
   }
 
-  const skills = await collectClaudePluginSkills(params.skillsSnapshot);
+  const skillsSnapshot =
+    params.skillsSnapshot?.resolvedSkills === undefined && params.hydrateSkillsSnapshot
+      ? ((await params.hydrateSkillsSnapshot()) ?? params.skillsSnapshot)
+      : params.skillsSnapshot;
+  const skills = await collectClaudePluginSkills(skillsSnapshot);
   if (skills.length === 0) {
     return { args: [], cleanup: async () => {} };
   }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -17,7 +17,8 @@ import {
 import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import { classifyFailoverReason } from "../pi-embedded-helpers.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
-import { applySkillEnvOverridesFromSnapshot } from "../skills.js";
+import { applySkillEnvOverridesFromSnapshot, buildWorkspaceSkillSnapshot } from "../skills.js";
+import { hydrateResolvedSkills } from "../skills/snapshot-hydration.js";
 import { runClaudeLiveSessionTurn, shouldUseClaudeLiveSession } from "./claude-live-session.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import {
@@ -277,6 +278,17 @@ export async function executePreparedCliRun(
   const claudeSkillsPlugin = await prepareClaudeCliSkillsPlugin({
     backendId: context.backendResolved.id,
     skillsSnapshot: params.skillsSnapshot,
+    hydrateSkillsSnapshot: () =>
+      params.skillsSnapshot
+        ? hydrateResolvedSkills(params.skillsSnapshot, () =>
+            buildWorkspaceSkillSnapshot(context.workspaceDir, {
+              config: context.params.config,
+              agentId: context.params.agentId,
+              snapshotVersion: params.skillsSnapshot?.version,
+              skillFilter: params.skillsSnapshot?.skillFilter,
+            }),
+          )
+        : undefined,
   });
   let claudeSkillsPluginCleanupOwned = false;
   const args = buildCliArgs({

--- a/src/agents/context-runtime-state.ts
+++ b/src/agents/context-runtime-state.ts
@@ -1,5 +1,4 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { createLazyImportLoader, type LazyPromiseLoader } from "../shared/lazy-promise.js";
 import { MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
 
 const CONTEXT_WINDOW_RUNTIME_STATE_KEY = Symbol.for("openclaw.contextWindowRuntimeState");
@@ -9,7 +8,6 @@ type ContextWindowRuntimeState = {
   configuredConfig: OpenClawConfig | undefined;
   configLoadFailures: number;
   nextConfigLoadAttemptAtMs: number;
-  modelsConfigRuntimeLoader: LazyPromiseLoader<typeof import("./models-config.runtime.js")>;
 };
 
 export const CONTEXT_WINDOW_RUNTIME_STATE = (() => {
@@ -22,7 +20,6 @@ export const CONTEXT_WINDOW_RUNTIME_STATE = (() => {
       configuredConfig: undefined,
       configLoadFailures: 0,
       nextConfigLoadAttemptAtMs: 0,
-      modelsConfigRuntimeLoader: createLazyImportLoader(() => import("./models-config.runtime.js")),
     };
   }
   return globalState[CONTEXT_WINDOW_RUNTIME_STATE_KEY];
@@ -33,6 +30,5 @@ export function resetContextWindowCacheForTest(): void {
   CONTEXT_WINDOW_RUNTIME_STATE.configuredConfig = undefined;
   CONTEXT_WINDOW_RUNTIME_STATE.configLoadFailures = 0;
   CONTEXT_WINDOW_RUNTIME_STATE.nextConfigLoadAttemptAtMs = 0;
-  CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimeLoader.clear();
   MODEL_CONTEXT_TOKEN_CACHE.clear();
 }

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -286,6 +286,17 @@ describe("lookupContextTokens", () => {
     expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(128_000);
   });
 
+  it("does not refresh models.json during context-window warmup", async () => {
+    mockDiscoveryDeps([{ id: "gpt-5.4", contextWindow: 272_000 }]);
+
+    const { lookupContextTokens } = await importContextModule();
+    lookupContextTokens("gpt-5.4");
+    await flushAsyncWarmup();
+
+    expect(contextTestState.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    expect(lookupContextTokens("gpt-5.4")).toBe(272_000);
+  });
+
   it("skips model normalization during warmup but preserves provider-owned context metadata", async () => {
     mockDiscoveryDeps([
       {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -105,10 +105,6 @@ export function applyConfiguredContextWindows(params: {
   }
 }
 
-function loadModelsConfigRuntime() {
-  return CONTEXT_WINDOW_RUNTIME_STATE.modelsConfigRuntimeLoader.load();
-}
-
 function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
   const entryBasename = normalizeLowercaseStringOrEmpty(path.basename(argv[1] ?? ""));
   return (
@@ -231,12 +227,6 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
   }
 
   CONTEXT_WINDOW_RUNTIME_STATE.loadPromise = (async () => {
-    try {
-      await (await loadModelsConfigRuntime()).ensureOpenClawModelsJson(cfg);
-    } catch {
-      // Continue with best-effort discovery/overrides.
-    }
-
     try {
       const { discoverAuthStorage, discoverModels } =
         await import("./pi-model-discovery-runtime.js");

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -175,6 +175,15 @@ vi.mock("./model-auth-env-vars.js", () => {
   };
 });
 
+const providerRuntimeMocks = vi.hoisted(() => ({
+  shouldDeferProviderSyntheticProfileAuthWithPlugin: vi.fn(
+    (params: { provider: string; context: { resolvedApiKey?: string } }) => {
+      const expectedMarker = params.provider === "demo-local" ? "demo-local" : undefined;
+      return Boolean(expectedMarker && params.context.resolvedApiKey?.trim() === expectedMarker);
+    },
+  ),
+}));
+
 vi.mock("../plugins/provider-runtime.js", () => ({
   buildProviderMissingAuthMessageWithPlugin: (params: {
     provider: string;
@@ -209,13 +218,8 @@ vi.mock("../plugins/provider-runtime.js", () => ({
     };
   },
   resolveExternalAuthProfilesWithPlugins: () => [],
-  shouldDeferProviderSyntheticProfileAuthWithPlugin: (params: {
-    provider: string;
-    context: { resolvedApiKey?: string };
-  }) => {
-    const expectedMarker = params.provider === "demo-local" ? "demo-local" : undefined;
-    return Boolean(expectedMarker && params.context.resolvedApiKey?.trim() === expectedMarker);
-  },
+  shouldDeferProviderSyntheticProfileAuthWithPlugin:
+    providerRuntimeMocks.shouldDeferProviderSyntheticProfileAuthWithPlugin,
 }));
 
 vi.mock("../plugins/providers.js", () => ({
@@ -238,6 +242,12 @@ beforeEach(() => {
   cliCredentialMocks.readClaudeCliCredentialsCached.mockReset().mockReturnValue(null);
   cliCredentialMocks.readCodexCliCredentialsCached.mockReset().mockReturnValue(null);
   cliCredentialMocks.readMiniMaxCliCredentialsCached.mockReset().mockReturnValue(null);
+  providerRuntimeMocks.shouldDeferProviderSyntheticProfileAuthWithPlugin
+    .mockReset()
+    .mockImplementation((params: { provider: string; context: { resolvedApiKey?: string } }) => {
+      const expectedMarker = params.provider === "demo-local" ? "demo-local" : undefined;
+      return Boolean(expectedMarker && params.context.resolvedApiKey?.trim() === expectedMarker);
+    });
 });
 
 afterEach(() => {
@@ -869,6 +879,43 @@ describe("getApiKeyForModel", () => {
     expect(resolved.apiKey).toBe("stored-demo-key");
     expect(resolved.source).toBe("profile:demo-local:default");
     expect(resolved.profileId).toBe("demo-local:default");
+  });
+
+  it("does not consult synthetic deferral hooks for real stored profile keys", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "demo-local",
+      profileId: "demo-local:default",
+      store: buildDemoLocalStore(["real-demo-key"]),
+      cfg: buildDemoLocalProviderCfg("DEMO_LOCAL_API_KEY"),
+    });
+
+    expect(resolved.apiKey).toBe("real-demo-key");
+    expect(
+      providerRuntimeMocks.shouldDeferProviderSyntheticProfileAuthWithPlugin,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not consult synthetic deferral hooks for token profiles", async () => {
+    const resolved = await resolveApiKeyForProvider({
+      provider: "demo-local",
+      profileId: "demo-local:token",
+      store: {
+        version: 1,
+        profiles: {
+          "demo-local:token": {
+            type: "token",
+            provider: "demo-local",
+            token: "real-demo-token",
+          },
+        },
+      },
+      cfg: buildDemoLocalProviderCfg("DEMO_LOCAL_API_KEY"),
+    });
+
+    expect(resolved.apiKey).toBe("real-demo-token");
+    expect(
+      providerRuntimeMocks.shouldDeferProviderSyntheticProfileAuthWithPlugin,
+    ).not.toHaveBeenCalled();
   });
 
   it("defers every stored synthetic local profile until real auth sources are checked", async () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -485,8 +485,18 @@ function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
 function shouldDeferSyntheticProfileAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  profileType: "api_key" | "token" | "oauth" | undefined;
   resolvedApiKey: string | undefined;
 }): boolean {
+  if (
+    params.profileType !== "api_key" ||
+    !isSyntheticProfileMarkerCandidate({
+      provider: params.provider,
+      resolvedApiKey: params.resolvedApiKey,
+    })
+  ) {
+    return false;
+  }
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   return (
     shouldDeferProviderSyntheticProfileAuthWithPlugin({
@@ -500,6 +510,20 @@ function shouldDeferSyntheticProfileAuth(params: {
       },
     }) === true
   );
+}
+
+function isSyntheticProfileMarkerCandidate(params: {
+  provider: string;
+  resolvedApiKey: string | undefined;
+}): boolean {
+  const trimmed = params.resolvedApiKey?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (isNonSecretApiKeyMarker(trimmed)) {
+    return true;
+  }
+  return normalizeProviderId(trimmed) === normalizeProviderId(params.provider);
 }
 
 function resolveScopedAuthProfileStore(params: {
@@ -565,6 +589,7 @@ export async function resolveApiKeyForProvider(params: {
       shouldDeferSyntheticProfileAuth({
         cfg,
         provider,
+        profileType: mode,
         resolvedApiKey: resolved.apiKey,
       })
     ) {
@@ -661,6 +686,7 @@ export async function resolveApiKeyForProvider(params: {
           shouldDeferSyntheticProfileAuth({
             cfg,
             provider,
+            profileType: mode,
             resolvedApiKey: resolved.apiKey,
           })
         ) {

--- a/src/agents/model-catalog-scope.ts
+++ b/src/agents/model-catalog-scope.ts
@@ -1,0 +1,51 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
+
+function dedupeCatalogScopeRefs(values: Array<string | undefined>): string[] {
+  const refs = new Set<string>();
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      refs.add(trimmed);
+    }
+  }
+  return [...refs];
+}
+
+function providerFromModelRef(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(trimmed.slice(0, slash));
+  return provider || undefined;
+}
+
+export function resolveModelCatalogScope(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  model: string;
+}): { providerRefs: string[]; modelRefs: string[] } {
+  const provider = params.provider.trim();
+  const model = params.model.trim();
+  const providerConfig = findNormalizedProviderValue(params.cfg?.models?.providers, provider);
+  return {
+    providerRefs: dedupeCatalogScopeRefs([provider, providerConfig?.api]),
+    modelRefs: dedupeCatalogScopeRefs([provider && model ? `${provider}/${model}` : model, model]),
+  };
+}
+
+export function resolveProviderDiscoveryProviderIdsForCatalogScope(params: {
+  providerRefs?: readonly string[];
+  modelRefs?: readonly string[];
+}): string[] | undefined {
+  const providerIds = dedupeCatalogScopeRefs([
+    ...(params.providerRefs ?? []),
+    ...(params.modelRefs ?? []).map(providerFromModelRef),
+  ]);
+  return providerIds.length > 0 ? providerIds : undefined;
+}

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -187,6 +187,64 @@ describe("loadModelCatalog", () => {
     });
   });
 
+  it("keeps scoped plugin catalog loads out of the full catalog cache", async () => {
+    mockSingleOpenAiCatalogModel();
+    const cfg = {} as OpenClawConfig;
+
+    await loadModelCatalog({ config: cfg });
+    augmentCatalogMock.mockClear();
+
+    await loadModelCatalog({
+      config: cfg,
+      workspaceDir: "/workspace",
+      providerRefs: ["openrouter"],
+      modelRefs: ["openrouter/x-ai/grok-4"],
+    });
+    await loadModelCatalog({
+      config: cfg,
+      workspaceDir: "/workspace",
+      providerRefs: ["anthropic"],
+      modelRefs: ["anthropic/claude-sonnet-4-6"],
+    });
+
+    expect(augmentCatalogMock).toHaveBeenCalledTimes(2);
+    expect(augmentCatalogMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        workspaceDir: "/workspace",
+        providerRefs: ["openrouter"],
+        modelRefs: ["openrouter/x-ai/grok-4"],
+      }),
+    );
+    expect(augmentCatalogMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        workspaceDir: "/workspace",
+        providerRefs: ["anthropic"],
+        modelRefs: ["anthropic/claude-sonnet-4-6"],
+      }),
+    );
+
+    augmentCatalogMock.mockClear();
+    await loadModelCatalog({ config: cfg });
+    expect(augmentCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("scopes models.json provider discovery to requested catalog providers", async () => {
+    mockSingleOpenAiCatalogModel();
+    const cfg = {} as OpenClawConfig;
+
+    await loadModelCatalog({
+      config: cfg,
+      providerRefs: ["openai-codex"],
+      modelRefs: ["openai-codex/gpt-5.4", "gpt-5.4"],
+    });
+
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(cfg, undefined, {
+      providerDiscoveryProviderIds: ["openai-codex"],
+    });
+  });
+
   it("returns partial results on discovery errors", async () => {
     setLoggerOverride({ level: "silent", consoleLevel: "warn" });
     try {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -15,6 +15,7 @@ import {
 } from "../shared/string-coerce.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { modelSupportsInput as modelCatalogEntrySupportsInput } from "./model-catalog-lookup.js";
+import { resolveProviderDiscoveryProviderIdsForCatalogScope } from "./model-catalog-scope.js";
 import type { ModelCatalogEntry, ModelInputType } from "./model-catalog.types.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
@@ -289,6 +290,9 @@ export async function loadModelCatalog(params?: {
   config?: OpenClawConfig;
   useCache?: boolean;
   readOnly?: boolean;
+  workspaceDir?: string;
+  providerRefs?: string[];
+  modelRefs?: string[];
 }): Promise<ModelCatalogEntry[]> {
   const readOnly = params?.readOnly === true;
   if (readOnly) {
@@ -300,10 +304,14 @@ export async function loadModelCatalog(params?: {
       return loadReadOnlyStaticModelCatalog(params);
     }
   }
-  if (!readOnly && params?.useCache === false) {
+  const scopedCatalog =
+    Boolean(params?.workspaceDir) ||
+    Boolean(params?.providerRefs?.length) ||
+    Boolean(params?.modelRefs?.length);
+  if (!readOnly && !scopedCatalog && params?.useCache === false) {
     modelCatalogPromise = null;
   }
-  if (!readOnly && modelCatalogPromise) {
+  if (!readOnly && !scopedCatalog && modelCatalogPromise) {
     return modelCatalogPromise;
   }
 
@@ -322,7 +330,13 @@ export async function loadModelCatalog(params?: {
     try {
       const cfg = params?.config ?? getRuntimeConfig();
       if (!readOnly) {
-        await ensureOpenClawModelsJson(cfg);
+        const providerDiscoveryProviderIds = resolveProviderDiscoveryProviderIdsForCatalogScope({
+          providerRefs: params?.providerRefs,
+          modelRefs: params?.modelRefs,
+        });
+        await ensureOpenClawModelsJson(cfg, undefined, {
+          ...(providerDiscoveryProviderIds ? { providerDiscoveryProviderIds } : {}),
+        });
         logStage("models-json-ready");
       }
       // IMPORTANT: keep the dynamic import *inside* the try/catch.
@@ -376,10 +390,14 @@ export async function loadModelCatalog(params?: {
       if (!readOnly) {
         const supplemental = await augmentModelCatalogWithProviderPlugins({
           config: cfg,
+          workspaceDir: params?.workspaceDir,
+          providerRefs: params?.providerRefs,
+          modelRefs: params?.modelRefs,
           env: process.env,
           context: {
             config: cfg,
             agentDir,
+            workspaceDir: params?.workspaceDir,
             env: process.env,
             entries: [...models],
           },
@@ -422,7 +440,7 @@ export async function loadModelCatalog(params?: {
     }
   };
 
-  if (readOnly) {
+  if (readOnly || scopedCatalog) {
     return loadCatalog();
   }
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -346,6 +346,51 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
   });
 
+  it("reuses a prepared auth store instead of bootstrapping one again", async () => {
+    const run = vi.fn().mockResolvedValueOnce("ok");
+    const authStore: AuthProfileStore = {
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai:local": {
+          provider: "openai",
+          type: "api_key",
+        },
+      },
+    };
+
+    const result = await runWithModelFallback({
+      cfg: makeCfg(),
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      agentDir: "/tmp/openclaw-prepared-auth-profiles",
+      authStore,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(authSourceCheckMock.hasAnyAuthProfileStoreSource).not.toHaveBeenCalled();
+    expect(authRuntimeMock.runtime.ensureAuthProfileStore).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+  });
+
+  it("skips auth cooldown preflight when the caller owns runtime auth resolution", async () => {
+    const run = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg: makeCfg(),
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      agentDir: "/tmp/openclaw-runtime-owned-auth",
+      preflightAuthCooldown: false,
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(authSourceCheckMock.hasAnyAuthProfileStoreSource).not.toHaveBeenCalled();
+    expect(authRuntimeMock.runtime.ensureAuthProfileStore).not.toHaveBeenCalled();
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini");
+  });
+
   it("keeps openai gpt-5.3 codex on the openai provider before running", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockResolvedValueOnce("ok");

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -786,6 +786,8 @@ export async function runWithModelFallback<T>(params: {
   sessionId?: string;
   lane?: string;
   agentDir?: string;
+  authStore?: AuthProfileStore;
+  preflightAuthCooldown?: boolean;
   /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
   fallbacksOverride?: string[];
   run: ModelFallbackRunFn<T>;
@@ -799,17 +801,21 @@ export async function runWithModelFallback<T>(params: {
     model: params.model,
     fallbacksOverride: params.fallbacksOverride,
   });
+  const shouldPreflightAuthCooldown = params.preflightAuthCooldown !== false;
   const authRuntime =
-    params.cfg && hasAnyAuthProfileStoreSource(params.agentDir)
+    shouldPreflightAuthCooldown &&
+    params.cfg &&
+    (params.authStore || hasAnyAuthProfileStoreSource(params.agentDir))
       ? await loadModelFallbackAuthRuntime()
       : null;
   const authStore = authRuntime
-    ? authRuntime.ensureAuthProfileStore(params.agentDir, {
+    ? (params.authStore ??
+      authRuntime.ensureAuthProfileStore(params.agentDir, {
         externalCli: externalCliDiscoveryForProviders({
           cfg: params.cfg,
           providers: candidates.map((candidate) => candidate.provider),
         }),
-      })
+      }))
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;

--- a/src/agents/model-selection-resolve.ts
+++ b/src/agents/model-selection-resolve.ts
@@ -13,6 +13,7 @@ export {
   buildConfiguredAllowlistKeys,
   buildModelAliasIndex,
   normalizeModelSelection,
+  inferUniqueProviderFromConfiguredModels,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
   resolveModelRefFromString,

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -21,6 +21,7 @@ import {
   normalizeProviderId,
   parseModelRef,
 } from "./model-selection-normalize.js";
+import { getProviderModelNormalizationRuntimeCacheKey } from "./provider-model-normalization.runtime.js";
 
 let log: ReturnType<typeof createSubsystemLogger> | null = null;
 
@@ -39,7 +40,15 @@ export type ModelAliasIndex = {
 type ManifestNormalizationContext = {
   manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
 };
+type ModelSelectionConfigIndex = {
+  aliasIndex: ModelAliasIndex;
+  allowlistKeys: Set<string> | null;
+};
 
+const modelSelectionConfigIndexCache = new WeakMap<
+  OpenClawConfig,
+  Map<string, ModelSelectionConfigIndex>
+>();
 function sanitizeModelWarningValue(value: string): string {
   const stripped = value ? stripAnsi(value) : "";
   let controlBoundary = -1;
@@ -336,23 +345,12 @@ export function buildConfiguredAllowlistKeys(params: {
   cfg: OpenClawConfig | undefined;
   defaultProvider: string;
 }): Set<string> | null {
-  const rawAllowlist = Object.keys(params.cfg?.agents?.defaults?.models ?? {});
-  if (rawAllowlist.length === 0) {
-    return null;
-  }
-
-  const keys = new Set<string>();
-  for (const raw of rawAllowlist) {
-    const key = resolveAllowlistModelKey({
+  return cloneAllowlistKeys(
+    resolveModelSelectionConfigIndex({
       cfg: params.cfg,
-      raw,
       defaultProvider: params.defaultProvider,
-    });
-    if (key) {
-      keys.add(key);
-    }
-  }
-  return keys.size > 0 ? keys : null;
+    }).allowlistKeys,
+  );
 }
 
 export function buildModelAliasIndex(
@@ -363,10 +361,73 @@ export function buildModelAliasIndex(
     allowPluginNormalization?: boolean;
   } & ManifestNormalizationContext,
 ): ModelAliasIndex {
+  return cloneModelAliasIndex(
+    resolveModelSelectionConfigIndex({
+      cfg: params.cfg,
+      defaultProvider: params.defaultProvider,
+      allowManifestNormalization: params.allowManifestNormalization,
+      allowPluginNormalization: params.allowPluginNormalization,
+      manifestPlugins: params.manifestPlugins,
+    }).aliasIndex,
+  );
+}
+
+function cloneAllowlistKeys(keys: Set<string> | null): Set<string> | null {
+  return keys && keys.size > 0 ? new Set(keys) : null;
+}
+
+function cloneModelAliasIndex(index: ModelAliasIndex): ModelAliasIndex {
+  return {
+    byAlias: new Map(index.byAlias),
+    byKey: new Map([...index.byKey].map(([key, aliases]) => [key, aliases.slice()])),
+  };
+}
+
+function resolveModelSelectionConfigIndex(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    defaultProvider: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
+  } & ManifestNormalizationContext,
+): ModelSelectionConfigIndex {
+  if (!params.cfg) {
+    return {
+      aliasIndex: { byAlias: new Map(), byKey: new Map() },
+      allowlistKeys: null,
+    };
+  }
+  const rawModels = params.cfg.agents?.defaults?.models ?? {};
+  const signature = Object.entries(rawModels)
+    .map(
+      ([key, entry]) =>
+        `${key}\u0001${normalizeOptionalString((entry as { alias?: string } | undefined)?.alias) ?? ""}`,
+    )
+    .join("\u0002");
+  const cacheKey = JSON.stringify({
+    defaultProvider: params.defaultProvider,
+    allowManifestNormalization: params.allowManifestNormalization ?? null,
+    allowPluginNormalization: params.allowPluginNormalization ?? null,
+    manifestPlugins: params.manifestPlugins ?? null,
+    providerRuntime:
+      params.allowPluginNormalization === false
+        ? "disabled"
+        : getProviderModelNormalizationRuntimeCacheKey(),
+    signature,
+  });
+  let configCache = modelSelectionConfigIndexCache.get(params.cfg);
+  if (!configCache) {
+    configCache = new Map();
+    modelSelectionConfigIndexCache.set(params.cfg, configCache);
+  }
+  const cached = configCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
   const byAlias = new Map<string, { alias: string; ref: ModelRef }>();
   const byKey = new Map<string, string[]>();
+  const allowlistKeys = new Set<string>();
 
-  const rawModels = params.cfg.agents?.defaults?.models ?? {};
   for (const [keyRaw, entryRaw] of Object.entries(rawModels)) {
     const parsed = parseModelRefWithCompatAlias({
       cfg: params.cfg,
@@ -379,6 +440,7 @@ export function buildModelAliasIndex(
     if (!parsed) {
       continue;
     }
+    allowlistKeys.add(modelKey(parsed.provider, parsed.model));
     const alias =
       normalizeOptionalString((entryRaw as { alias?: string } | undefined)?.alias) ?? "";
     if (!alias) {
@@ -392,7 +454,12 @@ export function buildModelAliasIndex(
     byKey.set(key, existing);
   }
 
-  return { byAlias, byKey };
+  const resolved = {
+    aliasIndex: { byAlias, byKey },
+    allowlistKeys: allowlistKeys.size > 0 ? allowlistKeys : null,
+  };
+  configCache.set(cacheKey, resolved);
+  return resolved;
 }
 
 type ModelCatalogMetadata = {
@@ -518,18 +585,22 @@ export function resolveConfiguredModelRef(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
   defaultModel: string;
+  primaryModelOverride?: string;
   allowManifestNormalization?: boolean;
   allowPluginNormalization?: boolean;
 }): ModelRef {
-  const rawModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
+  const rawModel =
+    params.primaryModelOverride ??
+    resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ??
+    "";
   if (rawModel) {
     const trimmed = rawModel.trim();
-    const aliasIndex = buildModelAliasIndex({
+    const aliasIndex = resolveModelSelectionConfigIndex({
       cfg: params.cfg,
       defaultProvider: params.defaultProvider,
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
-    });
+    }).aliasIndex;
     const aliasKey = normalizeLowercaseStringOrEmpty(trimmed);
     const aliasMatch = aliasIndex.byAlias.get(aliasKey);
     if (aliasMatch) {

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.js";
 
 const normalizeProviderModelIdWithPluginMock = vi.fn();
 
 vi.mock("./provider-model-normalization.runtime.js", () => ({
+  getProviderModelNormalizationRuntimeCacheKey: () => "test-runtime",
   normalizeProviderModelIdWithRuntime: (params: unknown) =>
     normalizeProviderModelIdWithPluginMock(params),
 }));
@@ -51,5 +53,52 @@ describe("model-selection plugin runtime normalization", () => {
       model: "gemini-3.1-pro-preview",
     });
     expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses config model-selection indexes across alias and allowlist builders", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ context }) => {
+      const modelId = (context as { modelId?: string }).modelId;
+      return modelId === "custom-legacy-model" ? "custom-modern-model" : undefined;
+    });
+    const { buildConfiguredAllowlistKeys, buildModelAliasIndex, modelKey } =
+      await import("./model-selection.js");
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom-provider/custom-legacy-model": { alias: "legacy" },
+            "custom-provider/custom-other-model": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const firstAliases = buildModelAliasIndex({
+      cfg,
+      defaultProvider: "custom-provider",
+    });
+    const firstAllowlist = buildConfiguredAllowlistKeys({
+      cfg,
+      defaultProvider: "custom-provider",
+    });
+    firstAliases.byAlias.clear();
+    firstAllowlist?.clear();
+
+    const secondAliases = buildModelAliasIndex({
+      cfg,
+      defaultProvider: "custom-provider",
+    });
+    const secondAllowlist = buildConfiguredAllowlistKeys({
+      cfg,
+      defaultProvider: "custom-provider",
+    });
+
+    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalledTimes(2);
+    expect(secondAliases.byAlias.get("legacy")?.ref).toEqual({
+      provider: "custom-provider",
+      model: "custom-modern-model",
+    });
+    expect(secondAllowlist?.has(modelKey("custom-provider", "custom-modern-model"))).toBe(true);
+    expect(secondAllowlist?.has(modelKey("custom-provider", "custom-other-model"))).toBe(true);
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,7 +1,6 @@
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
-  toAgentModelListLike,
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -211,26 +210,11 @@ export function resolveDefaultModelForAgent(params: {
   const agentModelOverride = params.agentId
     ? resolveAgentEffectiveModelPrimary(params.cfg, params.agentId)
     : undefined;
-  const cfg =
-    agentModelOverride && agentModelOverride.length > 0
-      ? {
-          ...params.cfg,
-          agents: {
-            ...params.cfg.agents,
-            defaults: {
-              ...params.cfg.agents?.defaults,
-              model: {
-                ...toAgentModelListLike(params.cfg.agents?.defaults?.model),
-                primary: agentModelOverride,
-              },
-            },
-          },
-        }
-      : params.cfg;
   return resolveConfiguredModelRef({
-    cfg,
+    cfg: params.cfg,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    ...(agentModelOverride ? { primaryModelOverride: agentModelOverride } : {}),
   });
 }
 

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -4,6 +4,7 @@ import {
   getRuntimeConfigSourceSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { listProfilesForProvider } from "./auth-profiles.js";
@@ -13,6 +14,7 @@ import {
   type OpenClawPluginToolOptions,
 } from "./openclaw-tools.plugin-context.js";
 import { applyPluginToolDeliveryDefaults } from "./plugin-tool-delivery-defaults.js";
+import type { PreparedOpenClawToolPlanning } from "./runtime-plan/types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
@@ -30,6 +32,7 @@ type ResolveOpenClawPluginToolsOptions = OpenClawPluginToolOptions & {
   disableMessageTool?: boolean;
   disablePluginTools?: boolean;
   authProfileStore?: AuthProfileStore;
+  preparedToolPlanning?: PreparedOpenClawToolPlanning;
 };
 
 function resolveApplicablePluginRuntimeConfig(
@@ -57,6 +60,8 @@ export function resolveOpenClawPluginToolsForOptions(params: {
   options?: ResolveOpenClawPluginToolsOptions;
   resolvedConfig?: OpenClawConfig;
   existingToolNames?: Set<string>;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }): AnyAgentTool[] {
   if (params.options?.disablePluginTools) {
     return [];
@@ -84,6 +89,14 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     toolAllowlist: params.options?.pluginToolAllowlist,
     toolDenylist: params.options?.pluginToolDenylist,
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,
+    ...(params.options?.preparedToolPlanning?.metadataSnapshot
+      ? { metadataSnapshot: params.options.preparedToolPlanning.metadataSnapshot }
+      : {}),
+    ...(params.options?.preparedToolPlanning?.loadMetadataSnapshot
+      ? { loadMetadataSnapshot: params.options.preparedToolPlanning.loadMetadataSnapshot }
+      : {}),
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+    ...(params.loadMetadataSnapshot ? { loadMetadataSnapshot: params.loadMetadataSnapshot } : {}),
     ...(authProfileStore
       ? {
           hasAuthForProvider: (providerId) =>

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 
@@ -140,6 +141,31 @@ describe("createOpenClawTools browser plugin integration", () => {
         allowGatewaySubagentBinding: true,
       }),
     );
+  });
+
+  it("forwards a shared metadata snapshot loader to plugin resolution", () => {
+    hoisted.resolvePluginTools.mockReturnValue([]);
+    const config = {
+      plugins: {
+        allow: ["browser"],
+      },
+    } as OpenClawConfig;
+    const loadMetadataSnapshot = vi.fn(
+      () => ({ plugins: [], index: {} }) as PluginMetadataSnapshot,
+    );
+
+    resolveOpenClawPluginToolsForOptions({
+      options: { config },
+      resolvedConfig: config,
+      loadMetadataSnapshot,
+    });
+
+    expect(hoisted.resolvePluginTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loadMetadataSnapshot,
+      }),
+    );
+    expect(loadMetadataSnapshot).not.toHaveBeenCalled();
   });
 
   it("forwards plugin tool deny policy to plugin resolution", () => {

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -218,6 +218,54 @@ describe("optional media tool factory planning", () => {
     });
   });
 
+  it("does not load capability metadata when explicit model configs decide the plan", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+          videoGenerationModel: { primary: "video-owner/model" },
+          musicGenerationModel: { primary: "music-owner/model" },
+          pdfModel: { primary: "media-owner/model" },
+        },
+      },
+    };
+    const loadCapabilitySnapshot = vi.fn<() => Pick<PluginMetadataSnapshot, "index" | "plugins">>(
+      () => {
+        throw new Error("capability metadata should not load for explicit model configs");
+      },
+    );
+
+    expect(
+      __testing.resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(),
+        loadCapabilitySnapshot,
+      }),
+    ).toEqual({
+      imageGenerate: true,
+      videoGenerate: true,
+      musicGenerate: true,
+      pdf: true,
+    });
+    expect(loadCapabilitySnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not load capability metadata for media tools excluded by core policy", () => {
+    const loadMetadataSnapshot = vi.fn<() => PluginMetadataSnapshot>(() => {
+      throw new Error("metadata should not load for excluded media tools");
+    });
+
+    const tools = createOpenClawTools({
+      config: {},
+      coreToolAllowlist: ["sessions_list"],
+      preparedToolPlanning: { loadMetadataSnapshot },
+      disablePluginTools: true,
+    }).map((tool) => tool.name);
+
+    expect(tools).toEqual(["sessions_list"]);
+    expect(loadMetadataSnapshot).not.toHaveBeenCalled();
+  });
+
   it("skips tools that the resolved allowlist cannot expose", () => {
     const config: OpenClawConfig = {};
     installSnapshot(config, [

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -26,6 +26,7 @@ const resolveEnvApiKeyMock = vi.hoisted(() =>
 const resolveUsableCustomProviderApiKeyMock = vi.hoisted(() =>
   vi.fn((_params?: { provider?: string }) => null as { apiKey: string; source: string } | null),
 );
+const loadModelCatalogMock = vi.hoisted(() => vi.fn());
 
 const createMockConfig = () => ({
   session: { mainKey: "main", scope: "per-sender" },
@@ -130,21 +131,7 @@ async function createConfigModuleMock() {
 
 function createModelCatalogModuleMock() {
   return {
-    loadModelCatalog: async () => [
-      {
-        provider: "anthropic",
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        contextWindow: 200000,
-      },
-      {
-        provider: "openai",
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
-        contextWindow: 400000,
-      },
-    ],
+    loadModelCatalog: loadModelCatalogMock,
   };
 }
 
@@ -241,6 +228,7 @@ vi.mock("../gateway/session-utils.js", createGatewaySessionUtilsModuleMock);
 vi.mock("../config/config.js", createConfigModuleMock);
 vi.mock("../agents/model-catalog.js", createModelCatalogModuleMock);
 vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  getProviderModelNormalizationRuntimeCacheKey: () => "test-runtime",
   normalizeProviderModelIdWithRuntime: () => undefined,
 }));
 // Keep provider-runtime/plugin activation out of this focused tool test. The
@@ -291,6 +279,22 @@ function resetSessionStore(store: Record<string, SessionEntry>) {
   resolveEnvApiKeyMock.mockReturnValue(null);
   resolveUsableCustomProviderApiKeyMock.mockReset();
   resolveUsableCustomProviderApiKeyMock.mockReturnValue(null);
+  loadModelCatalogMock.mockReset();
+  loadModelCatalogMock.mockResolvedValue([
+    {
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      contextWindow: 200000,
+    },
+    {
+      provider: "openai",
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      reasoning: true,
+      contextWindow: 400000,
+    },
+  ]);
   loadSessionStoreMock.mockClear();
   updateSessionStoreMock.mockClear();
   callGatewayMock.mockClear();
@@ -730,6 +734,11 @@ describe("session_status tool", () => {
     );
     expect(saved.sessionId).toEqual(expect.any(String));
     expect(saved.sessionId.trim().length).toBeGreaterThan(0);
+    expect(loadModelCatalogMock).toHaveBeenCalledWith({
+      config: mockConfig,
+      providerRefs: ["anthropic"],
+      modelRefs: ["anthropic/claude-sonnet-4-6", "claude-sonnet-4-6"],
+    });
   });
 
   it("materializes a valid persisted session entry when the default implicit current fallback mutates model state", async () => {
@@ -1214,6 +1223,11 @@ describe("session_status tool", () => {
           }),
         }),
       );
+      expect(loadModelCatalogMock).toHaveBeenCalledWith({
+        config: mockConfig,
+        providerRefs: ["openai"],
+        modelRefs: ["openai/gpt-5.4", "gpt-5.4"],
+      });
     } finally {
       mockConfig = savedConfig;
     }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -3,6 +3,7 @@ import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   getActiveRuntimeWebToolsMetadata,
@@ -19,10 +20,11 @@ import {
   collectPresentOpenClawTools,
   isUpdatePlanToolEnabledForOpenClawTools,
 } from "./openclaw-tools.registration.js";
+import type { PreparedOpenClawToolPlanning } from "./runtime-plan/types.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { createToolPolicyMatcher } from "./tool-policy-match.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -36,7 +38,7 @@ import { createImageTool } from "./tools/image-tool.js";
 import {
   hasSnapshotCapabilityAvailability,
   hasSnapshotProviderEnvAvailability,
-  loadCapabilityMetadataSnapshot,
+  type CapabilityContractKey,
 } from "./tools/manifest-capability-availability.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { coerceToolModelConfig, hasToolModelConfig } from "./tools/model-config.helpers.js";
@@ -74,6 +76,13 @@ type OptionalMediaToolFactoryPlan = {
   musicGenerate: boolean;
   pdf: boolean;
 };
+type CapabilityMetadataSnapshot = Pick<PluginMetadataSnapshot, "index" | "plugins">;
+type CapabilityMetadataSnapshotLoader = () => CapabilityMetadataSnapshot;
+
+function mergeFactoryPolicyList(base?: string[], extra?: string[]): string[] | undefined {
+  const merged = [...(base ?? []), ...(extra ?? [])].filter(Boolean);
+  return merged.length > 0 ? merged : undefined;
+}
 
 function hasExplicitToolModelConfig(modelConfig: AgentModelConfig | undefined): boolean {
   return hasToolModelConfig(coerceToolModelConfig(modelConfig));
@@ -82,28 +91,13 @@ function hasExplicitToolModelConfig(modelConfig: AgentModelConfig | undefined): 
 function hasExplicitImageModelConfig(config: OpenClawConfig | undefined): boolean {
   return hasToolModelConfig(coerceImageModelConfig(config));
 }
-
-function isToolAllowedByFactoryPolicy(params: {
-  toolName: string;
-  allowlist?: string[];
-  denylist?: string[];
-}): boolean {
-  return isToolAllowedByPolicyName(params.toolName, {
-    allow: params.allowlist,
-    deny: params.denylist,
-  });
-}
-
-function mergeFactoryPolicyList(...lists: Array<string[] | undefined>): string[] | undefined {
-  const merged = lists.flatMap((list) => (Array.isArray(list) ? list : []));
-  return merged.length > 0 ? Array.from(new Set(merged)) : undefined;
-}
-
 function resolveImageToolFactoryAvailable(params: {
   config?: OpenClawConfig;
   agentDir?: string;
   modelHasVision?: boolean;
   authStore?: AuthProfileStore;
+  workspaceDir?: string;
+  loadCapabilitySnapshot?: CapabilityMetadataSnapshotLoader;
 }): boolean {
   if (!params.agentDir?.trim()) {
     return false;
@@ -111,9 +105,12 @@ function resolveImageToolFactoryAvailable(params: {
   if (params.modelHasVision || hasExplicitImageModelConfig(params.config)) {
     return true;
   }
-  const snapshot = loadCapabilityMetadataSnapshot({
-    config: params.config,
-  });
+  const snapshot =
+    params.loadCapabilitySnapshot?.() ??
+    loadManifestMetadataSnapshot({
+      config: params.config,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    });
   return (
     hasSnapshotCapabilityAvailability({
       snapshot,
@@ -166,32 +163,42 @@ function resolveOptionalMediaToolFactoryPlan(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   authStore?: AuthProfileStore;
+  coreToolAllowlist?: string[];
   toolAllowlist?: string[];
   toolDenylist?: string[];
+  loadCapabilitySnapshot?: CapabilityMetadataSnapshotLoader;
 }): OptionalMediaToolFactoryPlan {
   const defaults = params.config?.agents?.defaults;
-  const toolAllowlist = mergeFactoryPolicyList(params.config?.tools?.allow, params.toolAllowlist);
-  const toolDenylist = mergeFactoryPolicyList(params.config?.tools?.deny, params.toolDenylist);
-  const allowImageGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "image_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
+  const mergedCoreToolAllowlist = mergeFactoryPolicyList(
+    params.config?.tools?.allow,
+    params.coreToolAllowlist,
+  );
+  const mergedToolAllowlist = mergeFactoryPolicyList(
+    params.config?.tools?.allow,
+    params.toolAllowlist,
+  );
+  const mergedToolDenylist = mergeFactoryPolicyList(
+    params.config?.tools?.deny,
+    params.toolDenylist,
+  );
+  const coreToolAllowed = createToolPolicyMatcher(
+    mergedCoreToolAllowlist || mergedToolDenylist
+      ? {
+          allow: mergedCoreToolAllowlist,
+          deny: mergedToolDenylist,
+        }
+      : undefined,
+  );
+  const pluginToolAllowed = createToolPolicyMatcher({
+    allow: mergedToolAllowlist,
+    deny: mergedToolDenylist,
   });
-  const allowVideoGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "video_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
-  const allowMusicGenerate = isToolAllowedByFactoryPolicy({
-    toolName: "music_generate",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
-  const allowPdf = isToolAllowedByFactoryPolicy({
-    toolName: "pdf",
-    allowlist: toolAllowlist,
-    denylist: toolDenylist,
-  });
+  const isOptionalMediaToolAllowed = (toolName: string) =>
+    coreToolAllowed(toolName) && pluginToolAllowed(toolName);
+  const allowImageGenerate = isOptionalMediaToolAllowed("image_generate");
+  const allowVideoGenerate = isOptionalMediaToolAllowed("video_generate");
+  const allowMusicGenerate = isOptionalMediaToolAllowed("music_generate");
+  const allowPdf = isOptionalMediaToolAllowed("pdf");
   const explicitImageGeneration = hasExplicitToolModelConfig(defaults?.imageGenerationModel);
   const explicitVideoGeneration = hasExplicitToolModelConfig(defaults?.videoGenerationModel);
   const explicitMusicGeneration = hasExplicitToolModelConfig(defaults?.musicGenerationModel);
@@ -206,52 +213,75 @@ function resolveOptionalMediaToolFactoryPlan(params: {
       pdf: false,
     };
   }
-  const snapshot = loadCapabilityMetadataSnapshot({
-    config: params.config,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-  });
+  const needsSnapshot =
+    (allowImageGenerate && !explicitImageGeneration) ||
+    (allowVideoGenerate && !explicitVideoGeneration) ||
+    (allowMusicGenerate && !explicitMusicGeneration) ||
+    (allowPdf && !explicitPdf);
+  const snapshot =
+    needsSnapshot &&
+    (params.loadCapabilitySnapshot?.() ??
+      loadManifestMetadataSnapshot({
+        config: params.config,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      }));
+  const hasCapability = (key: CapabilityContractKey) =>
+    !!snapshot &&
+    hasSnapshotCapabilityAvailability({
+      snapshot,
+      authStore: params.authStore,
+      key,
+      config: params.config,
+    });
   return {
     imageGenerate:
-      allowImageGenerate &&
-      (explicitImageGeneration ||
-        hasSnapshotCapabilityAvailability({
-          snapshot,
-          authStore: params.authStore,
-          key: "imageGenerationProviders",
-          config: params.config,
-        })),
+      allowImageGenerate && (explicitImageGeneration || hasCapability("imageGenerationProviders")),
     videoGenerate:
-      allowVideoGenerate &&
-      (explicitVideoGeneration ||
-        hasSnapshotCapabilityAvailability({
-          snapshot,
-          authStore: params.authStore,
-          key: "videoGenerationProviders",
-          config: params.config,
-        })),
+      allowVideoGenerate && (explicitVideoGeneration || hasCapability("videoGenerationProviders")),
     musicGenerate:
-      allowMusicGenerate &&
-      (explicitMusicGeneration ||
-        hasSnapshotCapabilityAvailability({
-          snapshot,
-          authStore: params.authStore,
-          key: "musicGenerationProviders",
-          config: params.config,
-        })),
+      allowMusicGenerate && (explicitMusicGeneration || hasCapability("musicGenerationProviders")),
     pdf:
       allowPdf &&
       (explicitPdf ||
-        hasSnapshotCapabilityAvailability({
-          snapshot,
-          authStore: params.authStore,
-          key: "mediaUnderstandingProviders",
-          config: params.config,
-        }) ||
-        hasConfiguredVisionModelAuthSignal({
-          config: params.config,
-          snapshot,
-          authStore: params.authStore,
-        })),
+        hasCapability("mediaUnderstandingProviders") ||
+        (!!snapshot &&
+          hasConfiguredVisionModelAuthSignal({
+            config: params.config,
+            snapshot,
+            authStore: params.authStore,
+          }))),
+  };
+}
+
+function createCoreToolMaterializer(coreToolAllowlist?: string[]) {
+  const coreToolAllowPolicy =
+    coreToolAllowlist && coreToolAllowlist.length > 0 ? { allow: coreToolAllowlist } : undefined;
+  const isCoreToolAllowed = createToolPolicyMatcher(coreToolAllowPolicy);
+  const selectedTools = new Map<string, boolean>();
+  const isSelected = (name: string) => {
+    const cached = selectedTools.get(name);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const selected = isCoreToolAllowed(name);
+    selectedTools.set(name, selected);
+    return selected;
+  };
+
+  const optional = <Tool extends AnyAgentTool>(
+    name: string,
+    createTool: () => Tool | null | undefined,
+  ): Tool | null => (isSelected(name) ? (createTool() ?? null) : null);
+
+  return {
+    optional,
+    list<Tool extends AnyAgentTool>(
+      name: string,
+      createTool: () => Tool | null | undefined,
+    ): Tool[] {
+      const tool = optional(name, createTool);
+      return tool ? [tool] : [];
+    },
   };
 }
 
@@ -279,6 +309,8 @@ export function createOpenClawTools(
     fsPolicy?: ToolFsPolicy;
     sandboxed?: boolean;
     config?: OpenClawConfig;
+    /** Explicit core tool allowlist already resolved by the caller's runtime policy. */
+    coreToolAllowlist?: string[];
     pluginToolAllowlist?: string[];
     pluginToolDenylist?: string[];
     /** Current channel ID for auto-threading. */
@@ -313,6 +345,8 @@ export function createOpenClawTools(
     disablePluginTools?: boolean;
     /** Records hot-path tool-prep stages for reply startup diagnostics. */
     recordToolPrepStage?: (name: string) => void;
+    /** Prepared request-scoped plugin metadata for tool planning. */
+    preparedToolPlanning?: PreparedOpenClawToolPlanning;
     /** Trusted sender id from inbound context (not tool args). */
     requesterSenderId?: string | null;
     /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
@@ -363,75 +397,120 @@ export function createOpenClawTools(
     accountId: options?.agentAccountId,
     threadId: options?.agentThreadId,
   });
-  const runtimeWebTools = getActiveRuntimeWebToolsMetadata();
+  const coreTools = createCoreToolMaterializer(options?.coreToolAllowlist);
+  let runtimeWebTools: ReturnType<typeof getActiveRuntimeWebToolsMetadata> | undefined;
+  const resolveRuntimeWebTools = () => {
+    if (runtimeWebTools === undefined) {
+      runtimeWebTools = getActiveRuntimeWebToolsMetadata();
+    }
+    return runtimeWebTools;
+  };
   const sandbox =
     options?.sandboxRoot && options?.sandboxFsBridge
       ? { root: options.sandboxRoot, bridge: options.sandboxFsBridge }
       : undefined;
+  let mediaCapabilitySnapshot: CapabilityMetadataSnapshot | undefined;
+  let toolPlanningMetadataSnapshot = options?.preparedToolPlanning?.metadataSnapshot;
+  const loadToolPlanningMetadataSnapshot = () => {
+    toolPlanningMetadataSnapshot ??=
+      options?.preparedToolPlanning?.loadMetadataSnapshot?.() ??
+      loadManifestMetadataSnapshot({
+        config: resolvedConfig,
+        ...(workspaceDir ? { workspaceDir } : {}),
+      });
+    return toolPlanningMetadataSnapshot;
+  };
+  const loadMediaCapabilitySnapshot = () => {
+    const mediaConfig = availabilityConfig ?? resolvedConfig;
+    if (mediaConfig === resolvedConfig) {
+      mediaCapabilitySnapshot ??= loadToolPlanningMetadataSnapshot();
+      return mediaCapabilitySnapshot;
+    }
+    mediaCapabilitySnapshot ??= loadManifestMetadataSnapshot({
+      config: mediaConfig,
+      ...(workspaceDir ? { workspaceDir } : {}),
+    });
+    return mediaCapabilitySnapshot;
+  };
   const optionalMediaTools = resolveOptionalMediaToolFactoryPlan({
     config: availabilityConfig ?? resolvedConfig,
     workspaceDir,
     authStore: options?.authProfileStore,
+    coreToolAllowlist: options?.coreToolAllowlist,
     toolAllowlist: options?.pluginToolAllowlist,
     toolDenylist: options?.pluginToolDenylist,
+    loadCapabilitySnapshot: loadMediaCapabilitySnapshot,
   });
   const imageToolAgentDir = options?.agentDir;
-  const imageTool = resolveImageToolFactoryAvailable({
-    config: availabilityConfig ?? resolvedConfig,
-    agentDir: imageToolAgentDir,
-    modelHasVision: options?.modelHasVision,
-    authStore: options?.authProfileStore,
-  })
-    ? createImageTool({
-        config: availabilityConfig ?? options?.config,
-        agentDir: imageToolAgentDir!,
-        authProfileStore: options?.authProfileStore,
-        workspaceDir,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-        modelHasVision: options?.modelHasVision,
-        deferAutoModelResolution: true,
-      })
-    : null;
+  const imageTool = coreTools.optional("image", () =>
+    resolveImageToolFactoryAvailable({
+      config: availabilityConfig ?? resolvedConfig,
+      agentDir: imageToolAgentDir,
+      modelHasVision: options?.modelHasVision,
+      authStore: options?.authProfileStore,
+      workspaceDir,
+      loadCapabilitySnapshot: loadMediaCapabilitySnapshot,
+    })
+      ? createImageTool({
+          config: availabilityConfig ?? options?.config,
+          agentDir: imageToolAgentDir!,
+          authProfileStore: options?.authProfileStore,
+          workspaceDir,
+          sandbox,
+          fsPolicy: options?.fsPolicy,
+          modelHasVision: options?.modelHasVision,
+          deferAutoModelResolution: true,
+        })
+      : null,
+  );
   options?.recordToolPrepStage?.("openclaw-tools:image-tool");
-  const imageGenerateTool = optionalMediaTools.imageGenerate
-    ? createImageGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        workspaceDir,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-      })
-    : null;
+  const imageGenerateTool = coreTools.optional("image_generate", () =>
+    optionalMediaTools.imageGenerate
+      ? createImageGenerateTool({
+          config: options?.config,
+          agentDir: options?.agentDir,
+          authProfileStore: options?.authProfileStore,
+          workspaceDir,
+          sandbox,
+          fsPolicy: options?.fsPolicy,
+          precomputedAvailability: optionalMediaTools.imageGenerate,
+        })
+      : null,
+  );
   options?.recordToolPrepStage?.("openclaw-tools:image-generate-tool");
-  const videoGenerateTool = optionalMediaTools.videoGenerate
-    ? createVideoGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        agentSessionKey: options?.agentSessionKey,
-        requesterOrigin: deliveryContext ?? undefined,
-        workspaceDir,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-      })
-    : null;
+  const videoGenerateTool = coreTools.optional("video_generate", () =>
+    optionalMediaTools.videoGenerate
+      ? createVideoGenerateTool({
+          config: options?.config,
+          agentDir: options?.agentDir,
+          authProfileStore: options?.authProfileStore,
+          agentSessionKey: options?.agentSessionKey,
+          requesterOrigin: deliveryContext ?? undefined,
+          workspaceDir,
+          sandbox,
+          fsPolicy: options?.fsPolicy,
+          precomputedAvailability: optionalMediaTools.videoGenerate,
+        })
+      : null,
+  );
   options?.recordToolPrepStage?.("openclaw-tools:video-generate-tool");
-  const musicGenerateTool = optionalMediaTools.musicGenerate
-    ? createMusicGenerateTool({
-        config: options?.config,
-        agentDir: options?.agentDir,
-        authProfileStore: options?.authProfileStore,
-        agentSessionKey: options?.agentSessionKey,
-        requesterOrigin: deliveryContext ?? undefined,
-        workspaceDir,
-        sandbox,
-        fsPolicy: options?.fsPolicy,
-      })
-    : null;
+  const musicGenerateTool = coreTools.optional("music_generate", () =>
+    optionalMediaTools.musicGenerate
+      ? createMusicGenerateTool({
+          config: options?.config,
+          agentDir: options?.agentDir,
+          authProfileStore: options?.authProfileStore,
+          agentSessionKey: options?.agentSessionKey,
+          requesterOrigin: deliveryContext ?? undefined,
+          workspaceDir,
+          sandbox,
+          fsPolicy: options?.fsPolicy,
+          precomputedAvailability: optionalMediaTools.musicGenerate,
+        })
+      : null,
+  );
   options?.recordToolPrepStage?.("openclaw-tools:music-generate-tool");
-  const pdfTool =
+  const pdfTool = coreTools.optional("pdf", () =>
     optionalMediaTools.pdf && options?.agentDir?.trim()
       ? createPdfTool({
           config: options?.config,
@@ -442,58 +521,73 @@ export function createOpenClawTools(
           fsPolicy: options?.fsPolicy,
           deferAutoModelResolution: true,
         })
-      : null;
+      : null,
+  );
   options?.recordToolPrepStage?.("openclaw-tools:pdf-tool");
-  const webSearchTool = createWebSearchTool({
-    config: options?.config,
-    sandboxed: options?.sandboxed,
-    runtimeWebSearch: runtimeWebTools?.search,
-    lateBindRuntimeConfig: true,
+  const webSearchTool = coreTools.optional("web_search", () => {
+    const metadata = resolveRuntimeWebTools();
+    return createWebSearchTool({
+      config: options?.config,
+      sandboxed: options?.sandboxed,
+      runtimeWebSearch: metadata?.search,
+      lateBindRuntimeConfig: true,
+    });
   });
   options?.recordToolPrepStage?.("openclaw-tools:web-search-tool");
-  const webFetchTool = createWebFetchTool({
-    config: options?.config,
-    sandboxed: options?.sandboxed,
-    runtimeWebFetch: runtimeWebTools?.fetch,
-    lateBindRuntimeConfig: true,
+  const webFetchTool = coreTools.optional("web_fetch", () => {
+    const metadata = resolveRuntimeWebTools();
+    return createWebFetchTool({
+      config: options?.config,
+      sandboxed: options?.sandboxed,
+      runtimeWebFetch: metadata?.fetch,
+      lateBindRuntimeConfig: true,
+    });
   });
   options?.recordToolPrepStage?.("openclaw-tools:web-fetch-tool");
-  const messageTool = options?.disableMessageTool
-    ? null
-    : createMessageTool({
-        agentAccountId: options?.agentAccountId,
-        agentSessionKey: options?.agentSessionKey,
-        sessionId: options?.sessionId,
-        config: options?.config,
-        currentChannelId: options?.currentChannelId,
-        currentChannelProvider: options?.agentChannel,
-        currentThreadTs: options?.currentThreadTs,
-        currentMessageId: options?.currentMessageId,
-        replyToMode: options?.replyToMode,
-        hasRepliedRef: options?.hasRepliedRef,
-        sandboxRoot: options?.sandboxRoot,
-        requireExplicitTarget: options?.requireExplicitMessageTarget,
-        requesterSenderId: options?.requesterSenderId ?? undefined,
-        senderIsOwner: options?.senderIsOwner,
-      });
-  const heartbeatTool = options?.enableHeartbeatTool ? createHeartbeatResponseTool() : null;
+  const messageTool = coreTools.optional("message", () =>
+    options?.disableMessageTool
+      ? null
+      : createMessageTool({
+          agentAccountId: options?.agentAccountId,
+          agentSessionKey: options?.agentSessionKey,
+          sessionId: options?.sessionId,
+          config: options?.config,
+          currentChannelId: options?.currentChannelId,
+          currentChannelProvider: options?.agentChannel,
+          currentThreadTs: options?.currentThreadTs,
+          currentMessageId: options?.currentMessageId,
+          replyToMode: options?.replyToMode,
+          hasRepliedRef: options?.hasRepliedRef,
+          sandboxRoot: options?.sandboxRoot,
+          requireExplicitTarget: options?.requireExplicitMessageTarget,
+          requesterSenderId: options?.requesterSenderId ?? undefined,
+          senderIsOwner: options?.senderIsOwner,
+        }),
+  );
   options?.recordToolPrepStage?.("openclaw-tools:message-tool");
-  const nodesToolBase = createNodesTool({
-    agentSessionKey: options?.agentSessionKey,
-    agentChannel: options?.agentChannel,
-    agentAccountId: options?.agentAccountId,
-    currentChannelId: options?.currentChannelId,
-    currentThreadTs: options?.currentThreadTs,
-    config: options?.config,
-    modelHasVision: options?.modelHasVision,
-    allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-  });
-  const nodesTool = applyNodesToolWorkspaceGuard(nodesToolBase, {
-    fsPolicy: options?.fsPolicy,
-    sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
-    sandboxRoot: options?.sandboxRoot,
-    workspaceDir,
-  });
+  const heartbeatTool = coreTools.optional("heartbeat_respond", () =>
+    options?.enableHeartbeatTool ? createHeartbeatResponseTool() : null,
+  );
+  const nodesTool = coreTools.optional("nodes", () =>
+    applyNodesToolWorkspaceGuard(
+      createNodesTool({
+        agentSessionKey: options?.agentSessionKey,
+        agentChannel: options?.agentChannel,
+        agentAccountId: options?.agentAccountId,
+        currentChannelId: options?.currentChannelId,
+        currentThreadTs: options?.currentThreadTs,
+        config: options?.config,
+        modelHasVision: options?.modelHasVision,
+        allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
+      }),
+      {
+        fsPolicy: options?.fsPolicy,
+        sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
+        sandboxRoot: options?.sandboxRoot,
+        workspaceDir,
+      },
+    ),
+  );
   options?.recordToolPrepStage?.("openclaw-tools:nodes-tool");
   const embedded = isEmbeddedMode();
   const effectiveCallGateway = embedded
@@ -503,102 +597,126 @@ export function createOpenClawTools(
     ...(embedded
       ? []
       : [
-          createCanvasTool({ config: options?.config }),
-          nodesTool,
-          createCronTool({
-            agentSessionKey: options?.agentSessionKey,
-            currentDeliveryContext: {
-              channel: options?.agentChannel,
-              to: options?.currentChannelId ?? options?.agentTo,
-              accountId: options?.agentAccountId,
-              threadId: options?.currentThreadTs ?? options?.agentThreadId,
-            },
-            ...(options?.cronSelfRemoveOnlyJobId
-              ? { selfRemoveOnlyJobId: options.cronSelfRemoveOnlyJobId }
-              : {}),
-          }),
+          ...coreTools.list("canvas", () => createCanvasTool({ config: options?.config })),
+          ...collectPresentOpenClawTools([nodesTool]),
+          ...coreTools.list("cron", () =>
+            createCronTool({
+              agentSessionKey: options?.agentSessionKey,
+              currentDeliveryContext: {
+                channel: options?.agentChannel,
+                to: options?.currentChannelId ?? options?.agentTo,
+                accountId: options?.agentAccountId,
+                threadId: options?.currentThreadTs ?? options?.agentThreadId,
+              },
+              ...(options?.cronSelfRemoveOnlyJobId
+                ? { selfRemoveOnlyJobId: options.cronSelfRemoveOnlyJobId }
+                : {}),
+            }),
+          ),
         ]),
     ...(!embedded && messageTool ? [messageTool] : []),
     ...collectPresentOpenClawTools([heartbeatTool]),
-    createTtsTool({
-      agentChannel: options?.agentChannel,
-      config: resolvedConfig,
-      agentId: sessionAgentId,
-      agentAccountId: options?.agentAccountId,
-    }),
+    ...coreTools.list("tts", () =>
+      createTtsTool({
+        agentChannel: options?.agentChannel,
+        config: resolvedConfig,
+        agentId: sessionAgentId,
+        agentAccountId: options?.agentAccountId,
+      }),
+    ),
     ...collectPresentOpenClawTools([imageGenerateTool, musicGenerateTool, videoGenerateTool]),
     ...(embedded
       ? []
       : [
-          createGatewayTool({
-            agentSessionKey: options?.agentSessionKey,
-            config: options?.config,
-          }),
+          ...coreTools.list("gateway", () =>
+            createGatewayTool({
+              agentSessionKey: options?.agentSessionKey,
+              config: options?.config,
+            }),
+          ),
         ]),
-    createAgentsListTool({
-      agentSessionKey: options?.agentSessionKey,
-      requesterAgentIdOverride: options?.requesterAgentIdOverride,
-    }),
-    ...(isUpdatePlanToolEnabledForOpenClawTools({
-      config: resolvedConfig,
-      agentSessionKey: options?.agentSessionKey,
-      agentId: options?.requesterAgentIdOverride,
-      modelProvider: options?.modelProvider,
-      modelId: options?.modelId,
-    })
-      ? [createUpdatePlanTool()]
-      : []),
-    createSessionsListTool({
-      agentSessionKey: options?.agentSessionKey,
-      sandboxed: options?.sandboxed,
-      config: resolvedConfig,
-      callGateway: effectiveCallGateway,
-    }),
-    createSessionsHistoryTool({
-      agentSessionKey: options?.agentSessionKey,
-      sandboxed: options?.sandboxed,
-      config: resolvedConfig,
-      callGateway: effectiveCallGateway,
-    }),
+    ...coreTools.list("agents_list", () =>
+      createAgentsListTool({
+        agentSessionKey: options?.agentSessionKey,
+        requesterAgentIdOverride: options?.requesterAgentIdOverride,
+      }),
+    ),
+    ...coreTools.list("update_plan", () =>
+      isUpdatePlanToolEnabledForOpenClawTools({
+        config: resolvedConfig,
+        agentSessionKey: options?.agentSessionKey,
+        agentId: options?.requesterAgentIdOverride,
+        modelProvider: options?.modelProvider,
+        modelId: options?.modelId,
+      })
+        ? createUpdatePlanTool()
+        : null,
+    ),
+    ...coreTools.list("sessions_list", () =>
+      createSessionsListTool({
+        agentSessionKey: options?.agentSessionKey,
+        sandboxed: options?.sandboxed,
+        config: resolvedConfig,
+        callGateway: effectiveCallGateway,
+      }),
+    ),
+    ...coreTools.list("sessions_history", () =>
+      createSessionsHistoryTool({
+        agentSessionKey: options?.agentSessionKey,
+        sandboxed: options?.sandboxed,
+        config: resolvedConfig,
+        callGateway: effectiveCallGateway,
+      }),
+    ),
     ...(embedded
       ? []
       : [
-          createSessionsSendTool({
-            agentSessionKey: options?.agentSessionKey,
-            agentChannel: options?.agentChannel,
-            sandboxed: options?.sandboxed,
-            config: resolvedConfig,
-            callGateway: openClawToolsDeps.callGateway,
-          }),
-          createSessionsSpawnTool({
-            agentSessionKey: options?.agentSessionKey,
-            agentChannel: options?.agentChannel,
-            agentAccountId: options?.agentAccountId,
-            agentTo: options?.agentTo,
-            agentThreadId: options?.agentThreadId,
-            agentGroupId: options?.agentGroupId,
-            agentGroupChannel: options?.agentGroupChannel,
-            agentGroupSpace: options?.agentGroupSpace,
-            agentMemberRoleIds: options?.agentMemberRoleIds,
-            sandboxed: options?.sandboxed,
-            config: resolvedConfig,
-            requesterAgentIdOverride: options?.requesterAgentIdOverride,
-            workspaceDir: spawnWorkspaceDir,
-          }),
+          ...coreTools.list("sessions_send", () =>
+            createSessionsSendTool({
+              agentSessionKey: options?.agentSessionKey,
+              agentChannel: options?.agentChannel,
+              sandboxed: options?.sandboxed,
+              config: resolvedConfig,
+              callGateway: openClawToolsDeps.callGateway,
+            }),
+          ),
+          ...coreTools.list("sessions_spawn", () =>
+            createSessionsSpawnTool({
+              agentSessionKey: options?.agentSessionKey,
+              agentChannel: options?.agentChannel,
+              agentAccountId: options?.agentAccountId,
+              agentTo: options?.agentTo,
+              agentThreadId: options?.agentThreadId,
+              agentGroupId: options?.agentGroupId,
+              agentGroupChannel: options?.agentGroupChannel,
+              agentGroupSpace: options?.agentGroupSpace,
+              agentMemberRoleIds: options?.agentMemberRoleIds,
+              sandboxed: options?.sandboxed,
+              config: resolvedConfig,
+              requesterAgentIdOverride: options?.requesterAgentIdOverride,
+              workspaceDir: spawnWorkspaceDir,
+            }),
+          ),
         ]),
-    createSessionsYieldTool({
-      sessionId: options?.sessionId,
-      onYield: options?.onYield,
-    }),
-    createSubagentsTool({
-      agentSessionKey: options?.agentSessionKey,
-    }),
-    createSessionStatusTool({
-      agentSessionKey: options?.agentSessionKey,
-      runSessionKey: options?.runSessionKey,
-      config: resolvedConfig,
-      sandboxed: options?.sandboxed,
-    }),
+    ...coreTools.list("sessions_yield", () =>
+      createSessionsYieldTool({
+        sessionId: options?.sessionId,
+        onYield: options?.onYield,
+      }),
+    ),
+    ...coreTools.list("subagents", () =>
+      createSubagentsTool({
+        agentSessionKey: options?.agentSessionKey,
+      }),
+    ),
+    ...coreTools.list("session_status", () =>
+      createSessionStatusTool({
+        agentSessionKey: options?.agentSessionKey,
+        runSessionKey: options?.runSessionKey,
+        config: resolvedConfig,
+        sandboxed: options?.sandboxed,
+      }),
+    ),
     ...collectPresentOpenClawTools([webSearchTool, webFetchTool, imageTool, pdfTool]),
   ];
   options?.recordToolPrepStage?.("openclaw-tools:core-tool-list");
@@ -611,6 +729,8 @@ export function createOpenClawTools(
     options,
     resolvedConfig,
     existingToolNames: new Set(tools.map((tool) => tool.name)),
+    ...(toolPlanningMetadataSnapshot ? { metadataSnapshot: toolPlanningMetadataSnapshot } : {}),
+    loadMetadataSnapshot: loadToolPlanningMetadataSnapshot,
   });
   options?.recordToolPrepStage?.("openclaw-tools:plugin-tools");
 

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -16,6 +16,14 @@ const mocks = vi.hoisted(() => {
   return {
     stubTool,
     createCronToolOptions: vi.fn(),
+    createImageGenerateTool: vi.fn(() => stubTool("image_generate")),
+    createImageTool: vi.fn(() => stubTool("image")),
+    createMusicGenerateTool: vi.fn(() => stubTool("music_generate")),
+    createPdfTool: vi.fn(() => stubTool("pdf")),
+    createVideoGenerateTool: vi.fn(() => stubTool("video_generate")),
+    createWebFetchTool: vi.fn(() => stubTool("web_fetch")),
+    createWebSearchTool: vi.fn(() => stubTool("web_search")),
+    getActiveRuntimeWebToolsMetadata: vi.fn(() => null),
     textToSpeech: vi.fn(async () => ({
       success: true,
       audioPath: "/tmp/openclaw/tts-config-test.opus",
@@ -53,11 +61,11 @@ vi.mock("./tools/gateway-tool.js", () => ({
 }));
 
 vi.mock("./tools/image-generate-tool.js", () => ({
-  createImageGenerateTool: () => mocks.stubTool("image_generate"),
+  createImageGenerateTool: mocks.createImageGenerateTool,
 }));
 
 vi.mock("./tools/image-tool.js", () => ({
-  createImageTool: () => mocks.stubTool("image"),
+  createImageTool: mocks.createImageTool,
 }));
 
 vi.mock("./tools/message-tool.js", () => ({
@@ -65,7 +73,7 @@ vi.mock("./tools/message-tool.js", () => ({
 }));
 
 vi.mock("./tools/music-generate-tool.js", () => ({
-  createMusicGenerateTool: () => mocks.stubTool("music_generate"),
+  createMusicGenerateTool: mocks.createMusicGenerateTool,
 }));
 
 vi.mock("./tools/nodes-tool.js", () => ({
@@ -73,7 +81,7 @@ vi.mock("./tools/nodes-tool.js", () => ({
 }));
 
 vi.mock("./tools/pdf-tool.js", () => ({
-  createPdfTool: () => mocks.stubTool("pdf"),
+  createPdfTool: mocks.createPdfTool,
 }));
 
 vi.mock("./tools/session-status-tool.js", () => ({
@@ -109,12 +117,17 @@ vi.mock("./tools/update-plan-tool.js", () => ({
 }));
 
 vi.mock("./tools/video-generate-tool.js", () => ({
-  createVideoGenerateTool: () => mocks.stubTool("video_generate"),
+  createVideoGenerateTool: mocks.createVideoGenerateTool,
 }));
 
 vi.mock("./tools/web-tools.js", () => ({
-  createWebFetchTool: () => mocks.stubTool("web_fetch"),
-  createWebSearchTool: () => mocks.stubTool("web_search"),
+  createWebFetchTool: mocks.createWebFetchTool,
+  createWebSearchTool: mocks.createWebSearchTool,
+}));
+
+vi.mock("../secrets/runtime.js", () => ({
+  getActiveRuntimeWebToolsMetadata: mocks.getActiveRuntimeWebToolsMetadata,
+  getActiveSecretsRuntimeSnapshot: () => undefined,
 }));
 
 vi.mock("../tts/tts.js", () => ({
@@ -124,7 +137,63 @@ vi.mock("../tts/tts.js", () => ({
 describe("createOpenClawTools TTS config wiring", () => {
   beforeEach(() => {
     mocks.createCronToolOptions.mockClear();
+    mocks.createImageGenerateTool.mockClear();
+    mocks.createImageTool.mockClear();
+    mocks.createMusicGenerateTool.mockClear();
+    mocks.createPdfTool.mockClear();
+    mocks.createVideoGenerateTool.mockClear();
+    mocks.createWebFetchTool.mockClear();
+    mocks.createWebSearchTool.mockClear();
+    mocks.getActiveRuntimeWebToolsMetadata.mockClear();
     mocks.textToSpeech.mockClear();
+  });
+
+  it("does not materialize optional core tools outside an explicit allowlist", async () => {
+    const { createOpenClawTools } = await import("./openclaw-tools.js");
+
+    const tools = createOpenClawTools({
+      coreToolAllowlist: ["sessions_list"],
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["sessions_list"]);
+    expect(mocks.createImageGenerateTool).not.toHaveBeenCalled();
+    expect(mocks.createImageTool).not.toHaveBeenCalled();
+    expect(mocks.createMusicGenerateTool).not.toHaveBeenCalled();
+    expect(mocks.createPdfTool).not.toHaveBeenCalled();
+    expect(mocks.createVideoGenerateTool).not.toHaveBeenCalled();
+    expect(mocks.createWebFetchTool).not.toHaveBeenCalled();
+    expect(mocks.createWebSearchTool).not.toHaveBeenCalled();
+    expect(mocks.getActiveRuntimeWebToolsMetadata).not.toHaveBeenCalled();
+  });
+
+  it("passes planned generation availability into media tool factories", async () => {
+    const { createOpenClawTools } = await import("./openclaw-tools.js");
+
+    createOpenClawTools({
+      config: {
+        agents: {
+          defaults: {
+            imageGenerationModel: { primary: "image-owner/model" },
+            videoGenerationModel: { primary: "video-owner/model" },
+            musicGenerationModel: { primary: "music-owner/model" },
+          },
+        },
+      },
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createImageGenerateTool).toHaveBeenCalledWith(
+      expect.objectContaining({ precomputedAvailability: true }),
+    );
+    expect(mocks.createVideoGenerateTool).toHaveBeenCalledWith(
+      expect.objectContaining({ precomputedAvailability: true }),
+    );
+    expect(mocks.createMusicGenerateTool).toHaveBeenCalledWith(
+      expect.objectContaining({ precomputedAvailability: true }),
+    );
   });
 
   it("passes the resolved shared config into the tts tool", async () => {

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -130,6 +130,40 @@ const installRunEmbeddedMocks = () => {
       ...actual,
       resolveModelAsync: (...args: Parameters<typeof resolveModelAsyncMock>) =>
         resolveModelAsyncMock(...args),
+      preparePreparedRuntimeModelAsync: async (
+        _provider: string,
+        agentDirArg?: string,
+        cfg?: unknown,
+        options?: {
+          workspaceDir?: string;
+          providerDiscoveryProviderIds?: readonly string[];
+          providerDiscoveryTimeoutMs?: number;
+          providerDiscoveryEntriesOnly?: boolean;
+        },
+      ) =>
+        ensureOpenClawModelsJsonMock(cfg, agentDirArg, {
+          ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+          ...(options?.providerDiscoveryProviderIds
+            ? { providerDiscoveryProviderIds: options.providerDiscoveryProviderIds }
+            : {}),
+          ...(options?.providerDiscoveryTimeoutMs !== undefined
+            ? { providerDiscoveryTimeoutMs: options.providerDiscoveryTimeoutMs }
+            : {}),
+          ...(options?.providerDiscoveryEntriesOnly === true
+            ? { providerDiscoveryEntriesOnly: true }
+            : {}),
+        }),
+      resolvePreparedRuntimeModelAsync: (
+        provider: string,
+        modelId: string,
+        agentDirArg?: string,
+        cfg?: unknown,
+        options?: Record<string, unknown>,
+      ) =>
+        resolveModelAsyncMock(provider, modelId, agentDirArg, cfg, {
+          ...options,
+          skipPiDiscovery: true,
+        }),
     };
   });
   vi.doMock("./pi-embedded-runner/run/auth-controller.js", () => ({
@@ -319,6 +353,42 @@ describe("runEmbeddedPiAgent", () => {
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
       "openrouter",
       "openrouter/auto",
+      agentDir,
+      cfg,
+      expect.objectContaining({ skipPiDiscovery: true }),
+    );
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps prepared-runtime model resolution out of the reply path for configured providers", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedPiRunnerOpenAiConfig(["gpt-5.4"]);
+    runEmbeddedAttemptMock.mockResolvedValueOnce(
+      makeEmbeddedRunnerAttempt({
+        assistantTexts: ["ok"],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          content: [{ type: "text", text: "ok" }],
+        }),
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      sessionId: "scoped-models-json",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("scoped-models-json"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+      "openai-codex",
+      "gpt-5.4",
       agentDir,
       cfg,
       expect.objectContaining({ skipPiDiscovery: true }),

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -2,6 +2,10 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, UserMessage, Usage } from "@mariozechner/pi-ai";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  sanitizeProviderReplayHistoryWithPlugin,
+  validateProviderReplayTurnsWithPlugin,
+} from "../plugins/provider-runtime.js";
+import {
   expectOpenAIResponsesStrictSanitizeCall,
   loadSanitizeSessionHistoryWithCleanMocks,
   makeMockSessionManager,
@@ -322,6 +326,36 @@ describe("sanitizeSessionHistory", () => {
     expect(
       sessionEntries.some((entry) => entry.customType === "google-turn-ordering-bootstrap"),
     ).toBe(true);
+  });
+
+  it("passes prepared provider runtime handles to provider replay hooks", async () => {
+    const runtimeHandle = {
+      provider: "google-vertex",
+      plugin: {},
+    } as never;
+
+    await sanitizeSessionHistory({
+      messages: mockMessages,
+      modelApi: "google-generative-ai",
+      provider: "google-vertex",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+      runtimeHandle,
+    });
+    expect(sanitizeProviderReplayHistoryWithPlugin).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runtimeHandle }),
+    );
+
+    await validateReplayTurns({
+      messages: mockMessages,
+      modelApi: "google-generative-ai",
+      provider: "google-vertex",
+      sessionId: TEST_SESSION_ID,
+      runtimeHandle,
+    });
+    expect(validateProviderReplayTurnsWithPlugin).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runtimeHandle }),
+    );
   });
 
   it("passes simple user-only history through for Mistral models", async () => {

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -1,3 +1,4 @@
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import { resolveProviderCacheTtlEligibility } from "../../plugins/provider-runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -28,11 +29,21 @@ export function isCacheTtlEligibleProvider(
   provider: string,
   modelId: string,
   modelApi?: string,
+  options?: {
+    config?: Parameters<typeof resolveProviderCacheTtlEligibility>[0]["config"];
+    workspaceDir?: string;
+    env?: NodeJS.ProcessEnv;
+    runtimeHandle?: ProviderRuntimePluginHandle;
+  },
 ): boolean {
   const normalizedProvider = normalizeLowercaseStringOrEmpty(provider);
   const normalizedModelId = normalizeLowercaseStringOrEmpty(modelId);
   const pluginEligibility = resolveProviderCacheTtlEligibility({
     provider: normalizedProvider,
+    config: options?.config,
+    workspaceDir: options?.workspaceDir,
+    env: options?.env,
+    runtimeHandle: options?.runtimeHandle,
     context: {
       provider: normalizedProvider,
       modelId: normalizedModelId,

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -3,7 +3,7 @@ import { clearAgentHarnesses } from "../harness/registry.js";
 import type { CompactionTranscriptRotation } from "./compaction-successor-transcript.js";
 
 type MockResolvedModel = {
-  model: { provider: string; api: string; id: string; input: unknown[] };
+  model: { provider: string; api: string; id: string; input: unknown[]; compat?: unknown };
   error: null;
   authStorage: { setRuntimeApiKey: Mock<(provider?: string, apiKey?: string) => void> };
   modelRegistry: Record<string, never>;
@@ -279,11 +279,31 @@ export async function loadCompactHooksHarness(): Promise<{
       };
       return { session };
     }),
-    DefaultResourceLoader: function DefaultResourceLoader() {
-      return {
-        reload: vi.fn(async () => undefined),
-      };
-    },
+    createEventBus: vi.fn(() => ({})),
+    createExtensionRuntime: vi.fn(() => ({
+      flagValues: new Map(),
+      pendingProviderRegistrations: [],
+      refreshTools: vi.fn(),
+      sendMessage: vi.fn(),
+      sendUserMessage: vi.fn(),
+      appendEntry: vi.fn(),
+      setSessionName: vi.fn(),
+      getSessionName: vi.fn(),
+      setLabel: vi.fn(),
+      getActiveTools: vi.fn(() => []),
+      getAllTools: vi.fn(() => []),
+      setActiveTools: vi.fn(),
+      getCommands: vi.fn(() => []),
+      setModel: vi.fn(async () => true),
+      getThinkingLevel: vi.fn(() => "medium"),
+      setThinkingLevel: vi.fn(),
+      registerProvider: vi.fn(),
+      unregisterProvider: vi.fn(),
+    })),
+    createSyntheticSourceInfo: vi.fn((path: string, info: Record<string, unknown>) => ({
+      path,
+      ...info,
+    })),
     SessionManager: {
       open: vi.fn(() => ({})),
     },
@@ -317,7 +337,6 @@ export async function loadCompactHooksHarness(): Promise<{
     applyLocalNoAuthHeaderOverride: vi.fn((model: unknown) => model),
     ensureAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({})),
     getApiKeyForModel: vi.fn(async () => ({ apiKey: "test", mode: "env" })),
-    resolveModelAuthMode: vi.fn(() => "env"),
   }));
 
   vi.doMock("../sandbox.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -241,6 +241,12 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       },
       messages: [{ role: "user", content: "hello" }],
     };
+    const runtimePlan = {
+      prompt: {},
+      transport: {
+        resolveExtraParams: vi.fn(() => ({})),
+      },
+    };
 
     compactTesting.prepareCompactionSessionAgent({
       session: session as never,
@@ -258,6 +264,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       sessionAgentId: "main",
       effectiveWorkspace: "/tmp/workspace",
       agentDir: "/tmp/workspace",
+      runtimePlan: runtimePlan as never,
     });
 
     expect(resolveEmbeddedAgentStreamFnMock).toHaveBeenCalledWith(
@@ -284,7 +291,9 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       }),
       "/tmp/workspace",
       undefined,
-      undefined,
+      expect.objectContaining({
+        preparedExtraParams: {},
+      }),
     );
   });
 
@@ -307,6 +316,29 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         senderE164: "+15551234567",
       }),
     );
+  });
+
+  it("does not materialize compaction tools when the model cannot use tools", async () => {
+    resolveModelMock.mockReturnValue({
+      model: {
+        provider: "openai",
+        api: "responses",
+        id: "fake",
+        input: [],
+        compat: { supportsTools: false },
+      },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    });
+
+    await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(createOpenClawCodingToolsMock).not.toHaveBeenCalled();
   });
 
   it("uses the session model fallback chain when implicit compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -74,6 +74,9 @@ export async function compactEmbeddedPiSession(
       ceModelId,
       agentDir,
       params.config,
+      {
+        skipPiDiscovery: true,
+      },
     );
     const ceRuntimeModel = ceModel as ProviderRuntimeModel | undefined;
     contextTokenBudget = resolveContextWindowInfo({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1,12 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  estimateTokens,
-  SessionManager,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, estimateTokens, SessionManager } from "@mariozechner/pi-coding-agent";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
@@ -24,11 +19,7 @@ import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
-import {
-  prepareProviderRuntimeAuth,
-  resolveProviderTextTransforms,
-  transformProviderSystemPrompt,
-} from "../../plugins/provider-runtime.js";
+import { prepareProviderRuntimeAuth } from "../../plugins/provider-runtime.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { resolveUserPath } from "../../utils.js";
@@ -60,11 +51,9 @@ import {
   applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
-  resolveModelAuthMode,
 } from "../model-auth.js";
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
 import { supportsModelTools } from "../model-tool-support.js";
-import { ensureOpenClawModelsJson } from "../models-config.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
 import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
 import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
@@ -75,11 +64,6 @@ import {
   setCompactionSafeguardCancelReason,
 } from "../pi-hooks/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
-import {
-  applyPiAutoCompactionGuard,
-  applyPiCompactionSettingsFromConfig,
-  isSilentOverflowProneModel,
-} from "../pi-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
@@ -136,9 +120,11 @@ import { log } from "./logger.js";
 import { hardenManualCompactionBoundary } from "./manual-compaction-boundary.js";
 import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-discovery-input.js";
 import { readPiModelContextTokens } from "./model-context-tokens.js";
-import { buildModelAliasLines, resolveModelAsync } from "./model.js";
+import { buildModelAliasLines, resolvePreparedRuntimeModelAsync } from "./model.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
+import { createEmbeddedPiResourceLoader } from "./resource-loader.js";
 import { shouldUseOpenAIWebSocketTransport } from "./run/attempt.thread-helpers.js";
+import { shouldPersistStrictTurnSessionRepair } from "./run/attempt.transcript-policy.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import { resolveEmbeddedRunSkillEntries } from "./skills-runtime.js";
@@ -193,7 +179,7 @@ function prepareCompactionSessionAgent(params: {
   sessionAgentId: string;
   effectiveWorkspace: string;
   agentDir: string;
-  runtimePlan?: AgentRuntimePlan;
+  runtimePlan: AgentRuntimePlan;
 }) {
   params.session.agent.streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: resolveEmbeddedAgentBaseStreamFn({ session: params.session as never }),
@@ -205,21 +191,17 @@ function prepareCompactionSessionAgent(params: {
     model: params.effectiveModel,
     resolvedApiKey: params.resolvedApiKey,
     authStorage: params.authStorage as never,
+    providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
   });
-  const providerTextTransforms = resolveProviderTextTransforms({
-    provider: params.provider,
-    config: params.config,
-    workspaceDir: params.effectiveWorkspace,
-  });
-  if (providerTextTransforms) {
+  if (params.runtimePlan.prompt.textTransforms) {
     params.session.agent.streamFn = wrapStreamFnTextTransforms({
       streamFn: params.session.agent.streamFn as never,
-      input: providerTextTransforms.input,
-      output: providerTextTransforms.output,
+      input: params.runtimePlan.prompt.textTransforms.input,
+      output: params.runtimePlan.prompt.textTransforms.output,
       transformSystemPrompt: false,
     }) as never;
   }
-  const preparedRuntimeExtraParams = params.runtimePlan?.transport.resolveExtraParams({
+  const preparedRuntimeExtraParams = params.runtimePlan.transport.resolveExtraParams({
     thinkingLevel: params.thinkLevel,
     agentId: params.sessionAgentId,
     workspaceDir: params.effectiveWorkspace,
@@ -237,7 +219,10 @@ function prepareCompactionSessionAgent(params: {
     params.effectiveModel,
     params.agentDir,
     undefined,
-    preparedRuntimeExtraParams ? { preparedExtraParams: preparedRuntimeExtraParams } : undefined,
+    {
+      preparedExtraParams: preparedRuntimeExtraParams,
+      providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
+    },
   );
 }
 
@@ -246,12 +231,14 @@ function resolveCompactionProviderStream(params: {
   config?: OpenClawConfig;
   agentDir: string;
   effectiveWorkspace: string;
+  runtimePlan?: Pick<AgentRuntimePlan, "providerRuntimeHandle">;
 }) {
   return registerProviderStreamForModel({
     model: params.effectiveModel,
     cfg: params.config,
     agentDir: params.agentDir,
     workspaceDir: params.effectiveWorkspace,
+    providerRuntimeHandle: params.runtimePlan?.providerRuntimeHandle,
   });
 }
 
@@ -482,8 +469,7 @@ async function compactEmbeddedPiSessionDirectOnce(
     };
   };
   const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-  await ensureOpenClawModelsJson(params.config, agentDir);
-  const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+  const { model, error, authStorage, modelRegistry } = await resolvePreparedRuntimeModelAsync(
     provider,
     modelId,
     agentDir,
@@ -656,44 +642,44 @@ async function compactEmbeddedPiSessionDirectOnce(
       });
 
     const runAbortController = new AbortController();
-    const toolsRaw = createOpenClawCodingTools({
-      exec: {
-        elevated: params.bashElevated,
-      },
-      sandbox,
-      messageProvider: resolvedMessageProvider,
-      agentAccountId: params.agentAccountId,
-      sessionKey: sandboxSessionKey,
-      runSessionKey:
-        params.sessionKey && params.sessionKey !== sandboxSessionKey
-          ? params.sessionKey
-          : undefined,
-      sessionId: params.sessionId,
-      runId: params.runId,
-      groupId: params.groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      spawnedBy: params.spawnedBy,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-      senderIsOwner: params.senderIsOwner,
-      allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-      agentDir,
-      workspaceDir: effectiveWorkspace,
-      config: params.config,
-      abortSignal: runAbortController.signal,
-      modelProvider: model.provider,
-      modelId,
-      modelCompat: extractModelCompat(effectiveModel),
-      modelApi: model.api,
-      modelContextWindowTokens: ctxInfo.tokens,
-      modelAuthMode: resolveModelAuthMode(model.provider, params.config, undefined, {
-        workspaceDir: effectiveWorkspace,
-      }),
-    });
     const toolsEnabled = supportsModelTools(runtimeModel);
+    const toolsRaw = toolsEnabled
+      ? createOpenClawCodingTools({
+          exec: {
+            elevated: params.bashElevated,
+          },
+          sandbox,
+          messageProvider: resolvedMessageProvider,
+          agentAccountId: params.agentAccountId,
+          sessionKey: sandboxSessionKey,
+          runSessionKey:
+            params.sessionKey && params.sessionKey !== sandboxSessionKey
+              ? params.sessionKey
+              : undefined,
+          sessionId: params.sessionId,
+          runId: params.runId,
+          groupId: params.groupId,
+          groupChannel: params.groupChannel,
+          groupSpace: params.groupSpace,
+          spawnedBy: params.spawnedBy,
+          senderId: params.senderId,
+          senderName: params.senderName,
+          senderUsername: params.senderUsername,
+          senderE164: params.senderE164,
+          senderIsOwner: params.senderIsOwner,
+          allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+          agentDir,
+          workspaceDir: effectiveWorkspace,
+          config: params.config,
+          abortSignal: runAbortController.signal,
+          modelProvider: model.provider,
+          modelId,
+          modelCompat: extractModelCompat(effectiveModel),
+          modelApi: model.api,
+          modelContextWindowTokens: ctxInfo.tokens,
+          preparedToolPlanning: runtimePlan.tools.preparedPlanning,
+        })
+      : [];
     const runtimePlanModelContext = {
       workspaceDir: effectiveWorkspace,
       modelApi: model.api,
@@ -890,22 +876,17 @@ async function compactEmbeddedPiSessionDirectOnce(
           promptContribution,
         });
       return createSystemPromptOverride(
-        transformProviderSystemPrompt({
-          provider,
+        runtimePlan.prompt.transformSystemPrompt({
           config: params.config,
+          agentDir,
           workspaceDir: effectiveWorkspace,
-          context: {
-            config: params.config,
-            agentDir,
-            workspaceDir: effectiveWorkspace,
-            provider,
-            modelId,
-            promptMode,
-            runtimeChannel,
-            runtimeCapabilities,
-            agentId: sessionAgentId,
-            systemPrompt: builtSystemPrompt,
-          },
+          provider,
+          modelId,
+          promptMode,
+          runtimeChannel,
+          runtimeCapabilities,
+          agentId: sessionAgentId,
+          systemPrompt: builtSystemPrompt,
         }),
       );
     };
@@ -919,13 +900,14 @@ async function compactEmbeddedPiSessionDirectOnce(
       }),
     });
     try {
+      const transcriptPolicy = runtimePlan.transcript.resolvePolicy(runtimePlanModelContext);
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
         debug: (message) => log.debug(message),
+        trimTrailingAssistantMessages: shouldPersistStrictTurnSessionRepair(transcriptPolicy),
         warn: (message) => log.warn(message),
       });
       await prewarmSessionFile(params.sessionFile);
-      const transcriptPolicy = runtimePlan.transcript.resolvePolicy(runtimePlanModelContext);
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
@@ -960,35 +942,14 @@ async function compactEmbeddedPiSessionDirectOnce(
         provider,
         modelId,
         model,
+        workspaceDir: effectiveWorkspace,
+        env: process.env,
+        providerRuntimeHandle: runtimePlan.providerRuntimeHandle,
       });
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
+      const resourceLoader = createEmbeddedPiResourceLoader({
         extensionFactories,
       });
       await resourceLoader.reload();
-      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
-      // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
-      // both guards. effectiveModel.baseUrl matches the surrounding scope so
-      // auth-profile-injected baseUrls reach the endpoint-class detector.
-      applyPiCompactionSettingsFromConfig({
-        settingsManager,
-        cfg: params.config,
-        contextTokenBudget: ctxInfo.tokens,
-      });
-      // contextEngineInfo is intentionally omitted: this guard runs inside the
-      // compaction LLM session, which is not the user-facing agent session and
-      // has no associated context engine.
-      applyPiAutoCompactionGuard({
-        settingsManager,
-        silentOverflowProneProvider: isSilentOverflowProneModel({
-          provider,
-          modelId,
-          baseUrl: effectiveModel.baseUrl ?? undefined,
-        }),
-      });
 
       const { customTools } = splitSdkTools({
         tools: effectiveTools,
@@ -1003,6 +964,7 @@ async function compactEmbeddedPiSessionDirectOnce(
         config: params.config,
         agentDir,
         effectiveWorkspace,
+        runtimePlan,
       });
       const shouldUseWebSocketTransport = shouldUseOpenAIWebSocketTransport({
         provider,
@@ -1078,6 +1040,7 @@ async function compactEmbeddedPiSessionDirectOnce(
             sessionManager,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            runtimeHandle: runtimePlan.providerRuntimeHandle,
           });
           const validated = await validateReplayTurns({
             messages: prior,
@@ -1090,6 +1053,7 @@ async function compactEmbeddedPiSessionDirectOnce(
             model,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            runtimeHandle: runtimePlan.providerRuntimeHandle,
           });
           const dedupedValidated = dedupeDuplicateUserMessagesForCompaction(validated);
           // Apply validated transcript to the live session even when no history limit is configured,

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -7,8 +7,19 @@ import compactionSafeguardExtension from "../pi-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../pi-hooks/context-pruning.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 
+const providerRuntimeMocks = vi.hoisted(() => ({
+  resolveProviderCacheTtlEligibility: vi.fn(
+    (params: {
+      runtimeHandle?: {
+        plugin?: { isCacheTtlEligible?: (ctx: unknown) => boolean | undefined };
+      };
+      context: unknown;
+    }) => params.runtimeHandle?.plugin?.isCacheTtlEligible?.(params.context),
+  ),
+}));
+
 vi.mock("../../plugins/provider-runtime.js", () => ({
-  resolveProviderCacheTtlEligibility: () => undefined,
+  resolveProviderCacheTtlEligibility: providerRuntimeMocks.resolveProviderCacheTtlEligibility,
   resolveProviderRuntimePlugin: () => undefined,
 }));
 
@@ -116,5 +127,41 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
 
     expect(factories).toContain(contextPruningExtension);
+  });
+
+  it("reuses the prepared provider runtime handle for cache-ttl eligibility", () => {
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: {
+        agents: {
+          defaults: {
+            contextPruning: {
+              mode: "cache-ttl",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionManager: {} as SessionManager,
+      provider: "custom-cacheable",
+      modelId: "custom-model",
+      model: { api: "openai-compatible", contextWindow: 200_000 } as Model<Api>,
+      providerRuntimeHandle: {
+        provider: "custom-cacheable",
+        plugin: {
+          id: "custom-cacheable",
+          label: "Custom Cacheable",
+          auth: [],
+          isCacheTtlEligible: () => true,
+        },
+      },
+    });
+
+    expect(factories).toContain(contextPruningExtension);
+    expect(providerRuntimeMocks.resolveProviderCacheTtlEligibility).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeHandle: expect.objectContaining({
+          provider: "custom-cacheable",
+        }),
+      }),
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -90,12 +91,26 @@ function buildContextPruningFactory(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
+  cacheTtlProviderEligible?: boolean;
 }): ExtensionFactory | undefined {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
     return undefined;
   }
-  if (!isCacheTtlEligibleProvider(params.provider, params.modelId, params.model?.api)) {
+  if (
+    !(
+      params.cacheTtlProviderEligible ??
+      isCacheTtlEligibleProvider(params.provider, params.modelId, params.model?.api, {
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+        runtimeHandle: params.providerRuntimeHandle,
+      })
+    )
+  ) {
     return undefined;
   }
 
@@ -138,6 +153,10 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
+  cacheTtlProviderEligible?: boolean;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -6,6 +6,7 @@ import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   prepareProviderExtraParams as prepareProviderExtraParamsRuntime,
+  type ProviderRuntimePluginHandle,
   resolveProviderExtraParamsForTransport as resolveProviderExtraParamsForTransportRuntime,
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
@@ -206,6 +207,7 @@ export function resolvePreparedExtraParams(params: {
   resolvedExtraParams?: Record<string, unknown>;
   model?: ProviderRuntimeModel;
   resolvedTransport?: SupportedTransport;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 }): Record<string, unknown> {
   const resolvedExtraParams =
     params.resolvedExtraParams ??
@@ -252,6 +254,7 @@ export function resolvePreparedExtraParams(params: {
       provider: params.provider,
       config: params.cfg,
       workspaceDir: params.workspaceDir,
+      runtimeHandle: params.providerRuntimeHandle,
       context: {
         config: params.cfg,
         agentDir: params.agentDir,
@@ -266,6 +269,7 @@ export function resolvePreparedExtraParams(params: {
     provider: params.provider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
+    runtimeHandle: params.providerRuntimeHandle,
     context: {
       config: params.cfg,
       agentDir: params.agentDir,
@@ -653,6 +657,7 @@ type ApplyExtraParamsContext = {
   effectiveExtraParams: Record<string, unknown>;
   resolvedExtraParams?: Record<string, unknown>;
   override?: Record<string, unknown>;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 };
 
 function applyPrePluginStreamWrappers(ctx: ApplyExtraParamsContext): void {
@@ -770,14 +775,20 @@ export function applyExtraParamsToAgent(
   model?: ProviderRuntimeModel,
   agentDir?: string,
   resolvedTransport?: SupportedTransport,
-  options?: { preparedExtraParams?: Record<string, unknown> },
+  options?: {
+    preparedExtraParams?: Record<string, unknown>;
+    providerRuntimeHandle?: ProviderRuntimePluginHandle;
+  },
 ): { effectiveExtraParams: Record<string, unknown> } {
-  const resolvedExtraParams = resolveExtraParams({
-    cfg,
-    provider,
-    modelId,
-    agentId,
-  });
+  const resolvedExtraParams =
+    options?.preparedExtraParams === undefined
+      ? resolveExtraParams({
+          cfg,
+          provider,
+          modelId,
+          agentId,
+        })
+      : undefined;
   const override =
     extraParamsOverride && Object.keys(extraParamsOverride).length > 0
       ? Object.fromEntries(
@@ -798,6 +809,7 @@ export function applyExtraParamsToAgent(
       resolvedExtraParams,
       model,
       resolvedTransport,
+      providerRuntimeHandle: options?.providerRuntimeHandle,
     });
   const wrapperContext: ApplyExtraParamsContext = {
     agent,
@@ -811,12 +823,14 @@ export function applyExtraParamsToAgent(
     effectiveExtraParams,
     resolvedExtraParams,
     override,
+    providerRuntimeHandle: options?.providerRuntimeHandle,
   };
 
   const providerStreamBase = agent.streamFn;
   const pluginWrappedStreamFn = providerRuntimeDeps.wrapProviderStreamFn({
     provider,
     config: cfg,
+    runtimeHandle: options?.providerRuntimeHandle,
     context: {
       config: cfg,
       agentDir,

--- a/src/agents/pi-embedded-runner/model.skip-pi-discovery-hooks.test.ts
+++ b/src/agents/pi-embedded-runner/model.skip-pi-discovery-hooks.test.ts
@@ -76,4 +76,30 @@ describe("resolveModelAsync skipPiDiscovery runtime hooks", () => {
     expect(mocks.applyProviderResolvedTransportWithPlugin).not.toHaveBeenCalled();
     expect(mocks.normalizeProviderTransportWithPlugin).not.toHaveBeenCalled();
   });
+
+  it("reuses successful target-provider dynamic model resolution", async () => {
+    const options = { skipPiDiscovery: true } as const;
+
+    const first = await resolveModelAsync(
+      "ollama",
+      "llama3.2:cache",
+      "/tmp/agent-cache",
+      undefined,
+      options,
+    );
+    const second = await resolveModelAsync(
+      "ollama",
+      "llama3.2:cache",
+      "/tmp/agent-cache",
+      undefined,
+      options,
+    );
+
+    expect(first.model).toMatchObject({ provider: "ollama", id: "llama3.2:cache" });
+    expect(second.model).toBe(first.model);
+    expect(mocks.discoverAuthStorage).not.toHaveBeenCalled();
+    expect(mocks.discoverModels).not.toHaveBeenCalled();
+    expect(mocks.prepareProviderDynamicModel).toHaveBeenCalledTimes(1);
+    expect(mocks.runProviderDynamicModel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/pi-embedded-runner/model.startup-retry.test.ts
+++ b/src/agents/pi-embedded-runner/model.startup-retry.test.ts
@@ -6,6 +6,16 @@ const discoverAuthStorageMock = vi.fn<(agentDir?: string) => { mocked: true }>((
 const discoverModelsMock = vi.fn<
   (authStorage: unknown, agentDir: string) => { find: ReturnType<typeof vi.fn> }
 >(() => ({ find: vi.fn(() => null) }));
+const ensureOpenClawModelsJsonMock = vi.fn<
+  (
+    cfg?: unknown,
+    agentDir?: string,
+    options?: unknown,
+  ) => Promise<{ agentDir: string; wrote: boolean }>
+>(async (_cfg, agentDir) => ({
+  agentDir: typeof agentDir === "string" ? agentDir : "/tmp/agent",
+  wrote: true,
+}));
 
 const prepareProviderDynamicModelMock = vi.fn<(params: unknown) => Promise<void>>(async () => {});
 let dynamicAttempts = 0;
@@ -26,9 +36,28 @@ const runProviderDynamicModelMock = vi.fn<(params: unknown) => unknown>(() =>
     : undefined,
 );
 
+function makeDynamicModel(provider = "openai-codex", modelId = "gpt-5.4") {
+  return {
+    id: modelId,
+    name: modelId,
+    provider,
+    api: "openai-codex-responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+  };
+}
+
 vi.mock("../pi-model-discovery.js", () => ({
   discoverAuthStorage: discoverAuthStorageMock,
   discoverModels: discoverModelsMock,
+}));
+
+vi.mock("../models-config.js", () => ({
+  ensureOpenClawModelsJson: (...args: unknown[]) => ensureOpenClawModelsJsonMock(...args),
 }));
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
@@ -54,6 +83,7 @@ describe("resolveModelAsync startup retry", () => {
   };
 
   beforeEach(() => {
+    const modelTesting = vi.importActual<typeof import("./model.js")>("./model.js");
     dynamicAttempts = 0;
     prepareProviderDynamicModelMock.mockClear();
     prepareProviderDynamicModelMock.mockImplementation(async () => {
@@ -62,6 +92,10 @@ describe("resolveModelAsync startup retry", () => {
     runProviderDynamicModelMock.mockClear();
     discoverAuthStorageMock.mockClear();
     discoverModelsMock.mockClear();
+    ensureOpenClawModelsJsonMock.mockClear();
+    return modelTesting.then(({ __testing }) => {
+      __testing.clearSkipPiDiscoveryModelCacheForTest();
+    });
   });
 
   it("retries once after a transient provider-runtime miss", async () => {
@@ -103,5 +137,74 @@ describe("resolveModelAsync startup retry", () => {
     expect(result.error).toBe("Unknown model: openai-codex/gpt-5.4");
     expect(prepareProviderDynamicModelMock).toHaveBeenCalledTimes(1);
     expect(runProviderDynamicModelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares models.json explicitly for prepared-runtime resolution", async () => {
+    const { preparePreparedRuntimeModelAsync } = await import("./model.js");
+
+    await preparePreparedRuntimeModelAsync(
+      "acme",
+      "/tmp/agent",
+      {},
+      {
+        workspaceDir: "/tmp/workspace",
+        providerDiscoveryProviderIds: ["acme"],
+        providerDiscoveryTimeoutMs: 1234,
+        providerDiscoveryEntriesOnly: true,
+      },
+    );
+
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith({}, "/tmp/agent", {
+      workspaceDir: "/tmp/workspace",
+      providerDiscoveryProviderIds: ["acme"],
+      providerDiscoveryTimeoutMs: 1234,
+      providerDiscoveryEntriesOnly: true,
+    });
+  });
+
+  it("keeps prepared-runtime resolution on the lean path", async () => {
+    runProviderDynamicModelMock.mockImplementation(() =>
+      dynamicAttempts > 0 ? makeDynamicModel("acme", "special") : undefined,
+    );
+    const { resolvePreparedRuntimeModelAsync } = await import("./model.js");
+
+    const result = await resolvePreparedRuntimeModelAsync(
+      "acme",
+      "special",
+      "/tmp/agent",
+      {},
+      {
+        runtimeHooks,
+      },
+    );
+
+    expect(result.model).toMatchObject({
+      provider: "acme",
+      id: "special",
+      api: "openai-codex-responses",
+    });
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareProviderDynamicModelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the lean-path miss without hidden models.json fallback", async () => {
+    runProviderDynamicModelMock.mockImplementation(() => undefined);
+    const { resolvePreparedRuntimeModelAsync } = await import("./model.js");
+
+    const result = await resolvePreparedRuntimeModelAsync(
+      "acme",
+      "special",
+      "/tmp/agent",
+      {},
+      {
+        runtimeHooks,
+      },
+    );
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: acme/special");
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(prepareProviderDynamicModelMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -27,6 +27,7 @@ import {
   shouldSuppressBuiltInModel,
   shouldUnconditionallySuppress,
 } from "../model-suppression.js";
+import { ensureOpenClawModelsJson } from "../models-config.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 import {
   attachModelProviderRequestTransport,
@@ -116,6 +117,97 @@ function createEmptyPiDiscoveryStores(): {
       : PiModelRegistryClass.create(authStorage);
   return { authStorage, modelRegistry };
 }
+
+type ResolvedModelAsyncResult = {
+  model?: Model<Api>;
+  error?: string;
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+};
+
+type ResolveModelAsyncOptions = {
+  authStorage?: AuthStorage;
+  modelRegistry?: ModelRegistry;
+  retryTransientProviderRuntimeMiss?: boolean;
+  runtimeHooks?: ProviderRuntimeHooks;
+  skipProviderRuntimeHooks?: boolean;
+  skipPiDiscovery?: boolean;
+};
+
+type PreparePreparedRuntimeModelOptions = {
+  workspaceDir?: string;
+  providerDiscoveryProviderIds?: readonly string[];
+  providerDiscoveryTimeoutMs?: number;
+  providerDiscoveryEntriesOnly?: boolean;
+};
+
+type ResolvePreparedRuntimeModelOptions = Omit<ResolveModelAsyncOptions, "skipPiDiscovery">;
+
+const SKIP_PI_DISCOVERY_MODEL_CACHE_MAX = 128;
+const skipPiDiscoveryModelCache = new Map<string, Promise<ResolvedModelAsyncResult>>();
+
+function resolveSkipPiDiscoveryModelCacheKey(params: {
+  provider: string;
+  modelId: string;
+  agentDir: string;
+  cfg?: OpenClawConfig;
+}): string {
+  const providerConfig = JSON.stringify(
+    resolveConfiguredProviderConfig(params.cfg, params.provider) ?? null,
+  );
+  return [params.provider, params.modelId, params.agentDir, providerConfig].join("\0");
+}
+
+function shouldCacheSkipPiDiscoveryModelResolution(options?: {
+  authStorage?: AuthStorage;
+  modelRegistry?: ModelRegistry;
+  retryTransientProviderRuntimeMiss?: boolean;
+  runtimeHooks?: ProviderRuntimeHooks;
+  skipProviderRuntimeHooks?: boolean;
+  skipPiDiscovery?: boolean;
+}): boolean {
+  return (
+    options?.skipPiDiscovery === true &&
+    !options.authStorage &&
+    !options.modelRegistry &&
+    !options.retryTransientProviderRuntimeMiss &&
+    !options.runtimeHooks &&
+    options.skipProviderRuntimeHooks !== true
+  );
+}
+
+function rememberSkipPiDiscoveryModelResolution(
+  key: string,
+  promise: Promise<ResolvedModelAsyncResult>,
+): Promise<ResolvedModelAsyncResult> {
+  skipPiDiscoveryModelCache.set(key, promise);
+  while (skipPiDiscoveryModelCache.size > SKIP_PI_DISCOVERY_MODEL_CACHE_MAX) {
+    const oldestKey = skipPiDiscoveryModelCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    skipPiDiscoveryModelCache.delete(oldestKey);
+  }
+  return promise
+    .then((result) => {
+      if (!result.model && skipPiDiscoveryModelCache.get(key) === promise) {
+        skipPiDiscoveryModelCache.delete(key);
+      }
+      return result;
+    })
+    .catch((error) => {
+      if (skipPiDiscoveryModelCache.get(key) === promise) {
+        skipPiDiscoveryModelCache.delete(key);
+      }
+      throw error;
+    });
+}
+
+export const __testing = {
+  clearSkipPiDiscoveryModelCacheForTest(): void {
+    skipPiDiscoveryModelCache.clear();
+  },
+} as const;
 
 function resolveRuntimeHooks(params?: {
   runtimeHooks?: ProviderRuntimeHooks;
@@ -1023,14 +1115,7 @@ export async function resolveModelAsync(
   modelId: string,
   agentDir?: string,
   cfg?: OpenClawConfig,
-  options?: {
-    authStorage?: AuthStorage;
-    modelRegistry?: ModelRegistry;
-    retryTransientProviderRuntimeMiss?: boolean;
-    runtimeHooks?: ProviderRuntimeHooks;
-    skipProviderRuntimeHooks?: boolean;
-    skipPiDiscovery?: boolean;
-  },
+  options?: ResolveModelAsyncOptions,
 ): Promise<{
   model?: Model<Api>;
   error?: string;
@@ -1042,28 +1127,100 @@ export async function resolveModelAsync(
     model: normalizeStaticProviderModelId(normalizeProviderId(provider), modelId),
   };
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
-  const emptyDiscoveryStores =
-    options?.skipPiDiscovery && (!options.authStorage || !options.modelRegistry)
-      ? createEmptyPiDiscoveryStores()
-      : undefined;
-  const authStorage =
-    options?.authStorage ??
-    emptyDiscoveryStores?.authStorage ??
-    discoverAuthStorage(resolvedAgentDir);
-  const modelRegistry =
-    options?.modelRegistry ??
-    emptyDiscoveryStores?.modelRegistry ??
-    discoverModels(authStorage, resolvedAgentDir);
-  const runtimeHooks = resolveRuntimeHooks(options);
-  const explicitModel = resolveExplicitModelWithRegistry({
-    provider: normalizedRef.provider,
-    modelId: normalizedRef.model,
-    modelRegistry,
-    cfg,
-    agentDir: resolvedAgentDir,
-    runtimeHooks,
-  });
-  if (explicitModel?.kind === "suppressed") {
+  const cacheKey = shouldCacheSkipPiDiscoveryModelResolution(options)
+    ? resolveSkipPiDiscoveryModelCacheKey({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        agentDir: resolvedAgentDir,
+        cfg,
+      })
+    : undefined;
+  if (cacheKey) {
+    const cached = skipPiDiscoveryModelCache.get(cacheKey);
+    if (cached) {
+      return await cached;
+    }
+  }
+  const resolveUncached = async (): Promise<ResolvedModelAsyncResult> => {
+    const emptyDiscoveryStores =
+      options?.skipPiDiscovery && (!options.authStorage || !options.modelRegistry)
+        ? createEmptyPiDiscoveryStores()
+        : undefined;
+    const authStorage =
+      options?.authStorage ??
+      emptyDiscoveryStores?.authStorage ??
+      discoverAuthStorage(resolvedAgentDir);
+    const modelRegistry =
+      options?.modelRegistry ??
+      emptyDiscoveryStores?.modelRegistry ??
+      discoverModels(authStorage, resolvedAgentDir);
+    const runtimeHooks = resolveRuntimeHooks(options);
+    const explicitModel = resolveExplicitModelWithRegistry({
+      provider: normalizedRef.provider,
+      modelId: normalizedRef.model,
+      modelRegistry,
+      cfg,
+      agentDir: resolvedAgentDir,
+      runtimeHooks,
+    });
+    if (explicitModel?.kind === "suppressed") {
+      return {
+        error: buildUnknownModelError({
+          provider: normalizedRef.provider,
+          modelId: normalizedRef.model,
+          cfg,
+          agentDir: resolvedAgentDir,
+          runtimeHooks,
+        }),
+        authStorage,
+        modelRegistry,
+      };
+    }
+
+    const providerConfig = resolveConfiguredProviderConfig(cfg, normalizedRef.provider);
+    const resolveDynamicAttempt = async () => {
+      await runtimeHooks.prepareProviderDynamicModel({
+        provider: normalizedRef.provider,
+        config: cfg,
+        context: {
+          config: cfg,
+          agentDir: resolvedAgentDir,
+          provider: normalizedRef.provider,
+          modelId: normalizedRef.model,
+          modelRegistry,
+          providerConfig,
+        },
+      });
+      return resolveModelWithRegistry({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        modelRegistry,
+        cfg,
+        agentDir: resolvedAgentDir,
+        runtimeHooks,
+      });
+    };
+    let model =
+      explicitModel?.kind === "resolved" &&
+      !shouldCompareProviderRuntimeResolvedModel({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        cfg,
+        agentDir: resolvedAgentDir,
+        runtimeHooks,
+      })
+        ? explicitModel.model
+        : await resolveDynamicAttempt();
+    if (!model && !explicitModel && options?.retryTransientProviderRuntimeMiss) {
+      // Startup can race the first provider-runtime snapshot load on a fresh
+      // gateway boot. Retry once before surfacing a user-visible "Unknown model"
+      // that disappears on the next message.
+      model = await resolveDynamicAttempt();
+    }
+    if (model) {
+      return { model, authStorage, modelRegistry };
+    }
+
     return {
       error: buildUnknownModelError({
         provider: normalizedRef.provider,
@@ -1075,62 +1232,46 @@ export async function resolveModelAsync(
       authStorage,
       modelRegistry,
     };
-  }
-  const providerConfig = resolveConfiguredProviderConfig(cfg, normalizedRef.provider);
-  const resolveDynamicAttempt = async () => {
-    await runtimeHooks.prepareProviderDynamicModel({
-      provider: normalizedRef.provider,
-      config: cfg,
-      context: {
-        config: cfg,
-        agentDir: resolvedAgentDir,
-        provider: normalizedRef.provider,
-        modelId: normalizedRef.model,
-        modelRegistry,
-        providerConfig,
-      },
-    });
-    return resolveModelWithRegistry({
-      provider: normalizedRef.provider,
-      modelId: normalizedRef.model,
-      modelRegistry,
-      cfg,
-      agentDir: resolvedAgentDir,
-      runtimeHooks,
-    });
   };
-  let model =
-    explicitModel?.kind === "resolved" &&
-    !shouldCompareProviderRuntimeResolvedModel({
-      provider: normalizedRef.provider,
-      modelId: normalizedRef.model,
-      cfg,
-      agentDir: resolvedAgentDir,
-      runtimeHooks,
-    })
-      ? explicitModel.model
-      : await resolveDynamicAttempt();
-  if (!model && !explicitModel && options?.retryTransientProviderRuntimeMiss) {
-    // Startup can race the first provider-runtime snapshot load on a fresh
-    // gateway boot. Retry once before surfacing a user-visible "Unknown model"
-    // that disappears on the next message.
-    model = await resolveDynamicAttempt();
-  }
-  if (model) {
-    return { model, authStorage, modelRegistry };
-  }
+  const resolved = resolveUncached();
+  return cacheKey
+    ? await rememberSkipPiDiscoveryModelResolution(cacheKey, resolved)
+    : await resolved;
+}
 
-  return {
-    error: buildUnknownModelError({
-      provider: normalizedRef.provider,
-      modelId: normalizedRef.model,
-      cfg,
-      agentDir: resolvedAgentDir,
-      runtimeHooks,
-    }),
-    authStorage,
-    modelRegistry,
-  };
+export async function preparePreparedRuntimeModelAsync(
+  provider: string,
+  agentDir?: string,
+  cfg?: OpenClawConfig,
+  options?: PreparePreparedRuntimeModelOptions,
+): Promise<void> {
+  const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
+  const {
+    workspaceDir,
+    providerDiscoveryProviderIds,
+    providerDiscoveryTimeoutMs,
+    providerDiscoveryEntriesOnly,
+  } = options ?? {};
+  await ensureOpenClawModelsJson(cfg, resolvedAgentDir, {
+    ...(workspaceDir ? { workspaceDir } : {}),
+    ...(providerDiscoveryProviderIds ? { providerDiscoveryProviderIds } : {}),
+    ...(providerDiscoveryTimeoutMs !== undefined ? { providerDiscoveryTimeoutMs } : {}),
+    ...(providerDiscoveryEntriesOnly === true ? { providerDiscoveryEntriesOnly: true } : {}),
+  });
+}
+
+export async function resolvePreparedRuntimeModelAsync(
+  provider: string,
+  modelId: string,
+  agentDir?: string,
+  cfg?: OpenClawConfig,
+  options?: ResolvePreparedRuntimeModelOptions,
+): Promise<ResolvedModelAsyncResult> {
+  const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
+  return await resolveModelAsync(provider, modelId, resolvedAgentDir, cfg, {
+    ...(options ?? {}),
+    skipPiDiscovery: true,
+  });
 }
 
 /**

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   sanitizeProviderReplayHistoryWithPlugin,
@@ -68,6 +69,7 @@ type ProviderReplayHookParams = {
   modelApi?: string | null;
   model?: ProviderRuntimeModel;
   sessionId?: string;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 };
 
 function createProviderReplayPluginParams(params: ProviderReplayHookParams) {
@@ -86,6 +88,7 @@ function createProviderReplayPluginParams(params: ProviderReplayHookParams) {
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    runtimeHandle: params.runtimeHandle,
     context,
   };
 }
@@ -593,6 +596,7 @@ export async function sanitizeSessionHistory(params: {
   sessionManager: SessionManager;
   sessionId: string;
   policy?: TranscriptPolicy;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 }): Promise<AgentMessage[]> {
   // Keep docs/reference/transcript-hygiene.md in sync with any logic changes here.
   const policy =
@@ -749,6 +753,7 @@ export async function validateReplayTurns(params: {
   model?: ProviderRuntimeModel;
   sessionId?: string;
   policy?: TranscriptPolicy;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 }): Promise<AgentMessage[]> {
   const policy =
     params.policy ??

--- a/src/agents/pi-embedded-runner/resource-loader.test.ts
+++ b/src/agents/pi-embedded-runner/resource-loader.test.ts
@@ -1,0 +1,38 @@
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { createEmbeddedPiResourceLoader } from "./resource-loader.js";
+
+describe("embedded Pi resource loader", () => {
+  it("loads only inline lifecycle extensions", async () => {
+    const extensionFactories: ExtensionFactory[] = [
+      (pi) => {
+        pi.on("turn_start", () => undefined);
+      },
+    ];
+
+    const loader = createEmbeddedPiResourceLoader({
+      extensionFactories,
+    });
+    await loader.reload();
+
+    const extensions = loader.getExtensions();
+    expect(extensions.errors).toEqual([]);
+    expect(extensions.extensions).toHaveLength(1);
+    expect(extensions.extensions[0]?.path).toBe("<inline:1>");
+    expect(extensions.extensions[0]?.handlers.has("turn_start")).toBe(true);
+  });
+
+  it("keeps Gateway-managed reply resources out of Pi resource discovery", async () => {
+    const loader = createEmbeddedPiResourceLoader({
+      extensionFactories: [],
+    });
+    await loader.reload();
+
+    expect(loader.getSkills()).toEqual({ skills: [], diagnostics: [] });
+    expect(loader.getPrompts()).toEqual({ prompts: [], diagnostics: [] });
+    expect(loader.getThemes()).toEqual({ themes: [], diagnostics: [] });
+    expect(loader.getAgentsFiles()).toEqual({ agentsFiles: [] });
+    expect(loader.getSystemPrompt()).toBeUndefined();
+    expect(loader.getAppendSystemPrompt()).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/resource-loader.ts
+++ b/src/agents/pi-embedded-runner/resource-loader.ts
@@ -1,0 +1,117 @@
+import {
+  createEventBus,
+  createExtensionRuntime,
+  createSyntheticSourceInfo,
+  type EventBus,
+  type ExtensionFactory,
+  type Extension,
+  type ExtensionAPI,
+  type ResourceLoader,
+} from "@mariozechner/pi-coding-agent";
+
+export type EmbeddedPiResourceLoaderParams = {
+  extensionFactories: readonly ExtensionFactory[];
+};
+
+function unavailableDuringLoad(): never {
+  throw new Error("Embedded Pi resource loader only supports lifecycle event registration.");
+}
+
+function createEmbeddedExtensionApi(params: {
+  eventBus: EventBus;
+  extension: Extension;
+}): ExtensionAPI {
+  const apiTarget = {
+    on(event: string, handler: unknown): void {
+      const handlers = params.extension.handlers.get(event) ?? [];
+      handlers.push(handler as (typeof handlers)[number]);
+      params.extension.handlers.set(event, handlers);
+    },
+    events: params.eventBus,
+  };
+  return new Proxy(apiTarget, {
+    get(target, property) {
+      if (property in target) {
+        return target[property as keyof typeof target];
+      }
+      return unavailableDuringLoad;
+    },
+  }) as ExtensionAPI;
+}
+
+function createInlineExtension(params: {
+  eventBus: EventBus;
+  factory: ExtensionFactory;
+  extensionPath: string;
+}): Promise<Extension> | Extension {
+  const extension: Extension = {
+    path: params.extensionPath,
+    resolvedPath: params.extensionPath,
+    sourceInfo: createSyntheticSourceInfo(params.extensionPath, {
+      source: "inline",
+      scope: "temporary",
+      origin: "top-level",
+    }),
+    handlers: new Map(),
+    tools: new Map(),
+    messageRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  };
+  const api = createEmbeddedExtensionApi({
+    eventBus: params.eventBus,
+    extension,
+  });
+  return Promise.resolve(params.factory(api)).then(() => extension);
+}
+
+export function createEmbeddedPiResourceLoader(
+  params: EmbeddedPiResourceLoaderParams,
+): ResourceLoader {
+  let extensionsResult: ReturnType<ResourceLoader["getExtensions"]> = {
+    extensions: [],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {
+      // Embedded replies use OpenClaw-managed prompt, tool, and context resources.
+    },
+    async reload() {
+      const runtime = createExtensionRuntime();
+      const eventBus = createEventBus();
+      const extensions: Extension[] = [];
+      const errors: ReturnType<ResourceLoader["getExtensions"]>["errors"] = [];
+      for (const [index, factory] of params.extensionFactories.entries()) {
+        const extensionPath = `<inline:${index + 1}>`;
+        try {
+          extensions.push(
+            await createInlineExtension({
+              eventBus,
+              factory,
+              extensionPath,
+            }),
+          );
+        } catch (error) {
+          errors.push({
+            path: extensionPath,
+            error: error instanceof Error ? error.message : "failed to load extension",
+          });
+        }
+      }
+      extensionsResult = {
+        extensions,
+        errors,
+        runtime,
+      };
+    },
+  };
+}

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -437,6 +437,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isProfileInCooldown: vi.fn(() => false),
     markAuthProfileFailure: vi.fn(async () => {}),
     markAuthProfileGood: vi.fn(async () => {}),
+    markAuthProfileSuccess: vi.fn(async () => {}),
     markAuthProfileUsed: vi.fn(async () => {}),
     resolveProfilesUnavailableReason: vi.fn(() => undefined),
   }));

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -9,9 +9,10 @@ import { emitAgentPlanEvent } from "../../infra/agent-events.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { freezeDiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { createStageTracker, emitStageSummary } from "../../infra/stage-timing.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { resolveProviderAuthProfileId } from "../../plugins/provider-runtime.js";
+import { resolveProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import type { CommandQueueEnqueueOptions } from "../../process/command-queue.types.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -27,11 +28,8 @@ import {
 } from "../agent-scope.js";
 import {
   type AuthProfileFailureReason,
-  type AuthProfileStore,
   markAuthProfileFailure,
-  resolveAuthProfileEligibility,
-  markAuthProfileGood,
-  markAuthProfileUsed,
+  markAuthProfileSuccess,
 } from "../auth-profiles.js";
 import {
   resolveSessionKeyForRequest,
@@ -51,12 +49,8 @@ import { shouldSwitchToLiveModel, clearLiveModelSwitchPending } from "../live-mo
 import {
   applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
-  ensureAuthProfileStoreWithoutExternalProfiles,
   type ResolvedProviderAuth,
-  resolveAuthProfileOrder,
-  shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
-import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   retireSessionMcpRuntime,
   retireSessionMcpRuntimeForSessionKey,
@@ -77,9 +71,7 @@ import {
   parseImageSizeError,
   pickFallbackThinkingLevel,
 } from "../pi-embedded-helpers.js";
-import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
-import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
@@ -91,17 +83,14 @@ import { hasMessagingToolDeliveryEvidence } from "./delivery-evidence.js";
 import { resolveEmbeddedRunFailureSignal } from "./failure-signal.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
-import { resolveModelAsync } from "./model.js";
+import { resolvePreparedRuntimeModelAsync } from "./model.js";
 import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-state.js";
 import { handleAssistantFailover } from "./run/assistant-failover.js";
-import {
-  createEmbeddedRunStageTracker,
-  formatEmbeddedRunStageSummary,
-  shouldWarnEmbeddedRunStageSummary,
-} from "./run/attempt-stage-timing.js";
+import { EmbeddedRunStageName } from "./run/attempt-stage-timing.js";
 import { forgetPromptBuildDrainCacheForRun } from "./run/attempt.prompt-helpers.js";
 import { createEmbeddedRunAuthController } from "./run/auth-controller.js";
 import { resolveAuthProfileFailureReason } from "./run/auth-profile-failure-policy.js";
+import { prepareEmbeddedRunAuthSelection } from "./run/auth-selection.js";
 import { runEmbeddedAttemptWithBackend } from "./run/backend.js";
 import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
@@ -175,6 +164,18 @@ const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
 
+function resolveRequestShapingAuthMode(params: {
+  runtimeAuthState: RuntimeAuthState | null;
+  apiKeyInfo: ApiKeyInfo | null;
+  lastProfileId?: string;
+}): string | undefined {
+  return (
+    params.runtimeAuthState?.authMode ??
+    params.apiKeyInfo?.mode ??
+    (params.lastProfileId ? "auth-profile" : undefined)
+  );
+}
+
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return undefined;
@@ -229,13 +230,6 @@ function hasCompletedModelProgressForIdleBreaker(attempt: EmbeddedRunAttemptForR
     hasMessagingToolDeliveryEvidence(attempt) ||
     attempt.itemLifecycle.completedCount > 0
   );
-}
-
-function createEmptyAuthProfileStore(): AuthProfileStore {
-  return {
-    version: 1,
-    profiles: {},
-  };
 }
 
 function buildTraceToolSummary(params: {
@@ -375,23 +369,14 @@ export async function runEmbeddedPiAgent(
     return enqueueGlobal(async () => {
       throwIfAborted();
       const started = Date.now();
-      const startupStages = createEmbeddedRunStageTracker();
+      const startupStages = createStageTracker();
       let startupStagesEmitted = false;
       const emitStartupStageSummary = (phase: string) => {
-        const summary = startupStages.snapshot();
-        const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);
-        if (!shouldWarn && !log.isEnabled("trace")) {
-          return;
-        }
-        const message = formatEmbeddedRunStageSummary(
-          `[trace:embedded-run] startup stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
-          summary,
-        );
-        if (shouldWarn) {
-          log.warn(message);
-        } else {
-          log.trace(message);
-        }
+        emitStageSummary({
+          logger: log,
+          prefix: `[timing:embedded-run] startup stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
+          summary: startupStages.snapshot(),
+        });
       };
       params.onExecutionStarted?.();
       const workspaceResolution = resolveRunWorkspaceDir({
@@ -413,13 +398,13 @@ export async function runEmbeddedPiAgent(
           `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
         );
       }
-      startupStages.mark("workspace");
+      startupStages.mark(EmbeddedRunStageName.workspaceSessionPrep);
       ensureRuntimePluginsLoaded({
         config: params.config,
         workspaceDir: resolvedWorkspace,
         allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
       });
-      startupStages.mark("runtime-plugins");
+      startupStages.mark(EmbeddedRunStageName.pluginRuntimeLoading);
 
       let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
       let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
@@ -477,7 +462,7 @@ export async function runEmbeddedPiAgent(
       provider = hookSelection.provider;
       modelId = hookSelection.modelId;
       const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
-      startupStages.mark("hooks");
+      startupStages.mark(EmbeddedRunStageName.replyHooks);
       const agentHarness = selectAgentHarness({
         provider,
         modelId,
@@ -486,26 +471,14 @@ export async function runEmbeddedPiAgent(
         sessionKey: params.sessionKey,
         agentHarnessId: params.agentHarnessId,
       });
+      startupStages.mark(EmbeddedRunStageName.harnessPrep);
       const pluginHarnessOwnsTransport = agentHarness.id !== "pi";
-      const dynamicModelResolution = await resolveModelAsync(
+      const modelResolution = await resolvePreparedRuntimeModelAsync(
         provider,
         modelId,
         agentDir,
         params.config,
-        {
-          // Plugin dynamic model hooks can resolve explicit model refs without
-          // first generating PI models.json. This keeps one-shot model runs from
-          // blocking on unrelated provider discovery.
-          skipPiDiscovery: true,
-        },
       );
-      const modelResolution =
-        dynamicModelResolution.model || pluginHarnessOwnsTransport
-          ? dynamicModelResolution
-          : await (async () => {
-              await ensureOpenClawModelsJson(params.config, agentDir);
-              return await resolveModelAsync(provider, modelId, agentDir, params.config);
-            })();
       const { model, error, authStorage, modelRegistry } = modelResolution;
       if (!model) {
         throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
@@ -526,141 +499,35 @@ export async function runEmbeddedPiAgent(
       });
       const ctxInfo = resolvedRuntimeModel.ctxInfo;
       let effectiveModel = resolvedRuntimeModel.effectiveModel;
-      startupStages.mark("model-resolution");
+      startupStages.mark(EmbeddedRunStageName.modelSelection);
+      const providerRuntimeHandle = resolveProviderRuntimePluginHandle({
+        provider: runtimeModel.provider,
+        config: params.config,
+        env: process.env,
+      });
+      startupStages.mark(EmbeddedRunStageName.providerRuntimeLookup);
 
-      const authStore = pluginHarnessOwnsTransport
-        ? createEmptyAuthProfileStore()
-        : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-            allowKeychainPrompt: false,
-          });
-      const requestedProfileId = params.authProfileId?.trim();
-      const resolvePluginHarnessPreferredProfileId = (): string | undefined => {
-        if (requestedProfileId) {
-          return requestedProfileId;
-        }
-        if (!pluginHarnessOwnsTransport) {
-          return undefined;
-        }
-        const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
-          provider,
-          config: params.config,
-          workspaceDir: resolvedWorkspace,
-          harnessId: agentHarness.id,
-          harnessRuntime: agentHarness.id,
-          allowHarnessAuthProfileForwarding: true,
-        });
-        const harnessAuthProvider = runtimeAuthPlan.harnessAuthProvider;
-        if (!harnessAuthProvider) {
-          return undefined;
-        }
-        const harnessAuthStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-          allowKeychainPrompt: false,
-        });
-        return resolveAuthProfileOrder({
-          cfg: params.config,
-          store: harnessAuthStore,
-          provider: harnessAuthProvider,
-        })[0]?.trim();
-      };
-      const preferredProfileId = pluginHarnessOwnsTransport
-        ? resolvePluginHarnessPreferredProfileId()
-        : requestedProfileId;
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      const canForwardPluginHarnessAuthProfile = (
-        profileId: string | undefined,
-      ): profileId is string => {
-        if (!pluginHarnessOwnsTransport || !profileId) {
-          return false;
-        }
-        const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
-          provider,
-          authProfileProvider: profileId.split(":", 1)[0],
-          sessionAuthProfileId: profileId,
-          config: params.config,
-          workspaceDir: resolvedWorkspace,
-          harnessId: agentHarness.id,
-          harnessRuntime: agentHarness.id,
-          allowHarnessAuthProfileForwarding: true,
-        });
-        return runtimeAuthPlan.forwardedAuthProfileId === profileId;
-      };
-      if (lockedProfileId) {
-        if (pluginHarnessOwnsTransport) {
-          if (!canForwardPluginHarnessAuthProfile(lockedProfileId)) {
-            lockedProfileId = undefined;
-          }
-        } else {
-          const lockedProfile = authStore.profiles[lockedProfileId];
-          const lockedProfileProvider = lockedProfile
-            ? resolveProviderIdForAuth(lockedProfile.provider, {
-                config: params.config,
-                workspaceDir: resolvedWorkspace,
-              })
-            : undefined;
-          const runProvider = resolveProviderIdForAuth(provider, {
-            config: params.config,
-            workspaceDir: resolvedWorkspace,
-          });
-          if (!lockedProfile || !lockedProfileProvider || lockedProfileProvider !== runProvider) {
-            lockedProfileId = undefined;
-          }
-        }
-      }
-      const forwardedPluginHarnessProfileId =
-        pluginHarnessOwnsTransport &&
-        !lockedProfileId &&
-        canForwardPluginHarnessAuthProfile(preferredProfileId)
-          ? preferredProfileId
-          : undefined;
-      if (lockedProfileId && !pluginHarnessOwnsTransport) {
-        const eligibility = resolveAuthProfileEligibility({
-          cfg: params.config,
-          store: authStore,
-          provider,
-          profileId: lockedProfileId,
-        });
-        if (!eligibility.eligible) {
-          throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
-        }
-      }
-      const profileOrder = shouldPreferExplicitConfigApiKeyAuth(params.config, provider)
-        ? []
-        : resolveAuthProfileOrder({
-            cfg: params.config,
-            store: authStore,
-            provider,
-            preferredProfile: preferredProfileId,
-          });
-      const providerPreferredProfileId = lockedProfileId
-        ? undefined
-        : resolveProviderAuthProfileId({
-            provider,
-            config: params.config,
-            workspaceDir: resolvedWorkspace,
-            context: {
-              config: params.config,
-              agentDir,
-              workspaceDir: resolvedWorkspace,
-              provider,
-              modelId,
-              preferredProfileId,
-              lockedProfileId,
-              profileOrder,
-              authStore,
-            },
-          });
-      const providerOrderedProfiles =
-        providerPreferredProfileId && profileOrder.includes(providerPreferredProfileId)
-          ? [
-              providerPreferredProfileId,
-              ...profileOrder.filter((profileId) => profileId !== providerPreferredProfileId),
-            ]
-          : profileOrder;
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : providerOrderedProfiles.length > 0
-          ? providerOrderedProfiles
-          : [undefined];
+      const {
+        authStore,
+        lockedProfileId,
+        preferredProfileId,
+        forwardedPluginHarnessProfileId,
+        profileCandidates,
+      } = prepareEmbeddedRunAuthSelection({
+        config: params.config,
+        agentDir,
+        workspaceDir: resolvedWorkspace,
+        provider,
+        modelId,
+        authProfileId: params.authProfileId,
+        authProfileIdSource: params.authProfileIdSource,
+        authProfileOrder: params.authProfileOrder,
+        authStore: params.authProfileStore,
+        providerRuntimeHandle,
+        harnessId: agentHarness.id,
+        pluginHarnessOwnsTransport,
+      });
+      startupStages.mark(EmbeddedRunStageName.authSelection);
       let profileIndex = 0;
       const traceAttempts: TraceAttempt[] = [];
 
@@ -682,6 +549,7 @@ export async function runEmbeddedPiAgent(
         workspaceDir: resolvedWorkspace,
         authStore,
         authStorage,
+        providerRuntimeHandle,
         profileCandidates,
         lockedProfileId,
         initialThinkLevel,
@@ -723,6 +591,7 @@ export async function runEmbeddedPiAgent(
         },
         log,
       });
+      startupStages.mark(EmbeddedRunStageName.authControllerCreate);
 
       // Plugin harnesses own their model transport/auth. Running PI's generic
       // auth bootstrap here can turn synthetic provider markers into real
@@ -734,7 +603,8 @@ export async function runEmbeddedPiAgent(
       } else if (forwardedPluginHarnessProfileId) {
         lastProfileId = forwardedPluginHarnessProfileId;
       }
-      startupStages.mark("auth");
+      startupStages.mark(EmbeddedRunStageName.authProfileInitialize);
+      startupStages.mark(EmbeddedRunStageName.authResolution);
       const { sessionAgentId } = resolveSessionAgentIds({
         sessionKey: params.sessionKey,
         config: params.config,
@@ -899,7 +769,7 @@ export async function runEmbeddedPiAgent(
         agentDir,
         workspaceDir: resolvedWorkspace,
       });
-      startupStages.mark("context-engine");
+      startupStages.mark(EmbeddedRunStageName.contextEnginePrep);
       try {
         const resolveActiveHookContext = () => ({
           ...hookCtx,
@@ -1060,14 +930,15 @@ export async function runEmbeddedPiAgent(
             workspaceDir: resolvedWorkspace,
             agentDir,
             agentId: workspaceResolution.agentId,
+            providerRuntimeHandle,
             thinkingLevel: thinkLevel,
             extraParamsOverride: {
               ...params.streamParams,
               fastMode: params.fastMode,
             },
           });
+          startupStages.mark(EmbeddedRunStageName.retryAttemptPrep);
           if (!startupStagesEmitted) {
-            startupStages.mark("attempt-dispatch");
             emitStartupStageSummary("attempt-dispatch");
             startupStagesEmitted = true;
           }
@@ -1171,6 +1042,7 @@ export async function runEmbeddedPiAgent(
             promptMode: params.promptMode,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
+            skipProviderRuntimeHints: params.skipProviderRuntimeHints,
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
@@ -2651,14 +2523,9 @@ export async function runEmbeddedPiAgent(
             `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
           );
           if (lastProfileId) {
-            await markAuthProfileGood({
+            await markAuthProfileSuccess({
               store: authStore,
               provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
               profileId: lastProfileId,
               agentDir: params.agentDir,
             });
@@ -2686,6 +2553,11 @@ export async function runEmbeddedPiAgent(
             livenessState,
             stopReason,
             yielded: attempt.yieldDetected === true,
+          });
+          const requestShapingAuthMode = resolveRequestShapingAuthMode({
+            runtimeAuthState,
+            apiKeyInfo,
+            lastProfileId,
           });
           return {
             payloads: terminalPayloads?.length ? terminalPayloads : undefined,
@@ -2737,7 +2609,7 @@ export async function runEmbeddedPiAgent(
                 runner: "embedded",
               },
               requestShaping: {
-                ...(lastProfileId ? { authMode: "auth-profile" } : {}),
+                ...(requestShapingAuthMode ? { authMode: requestShapingAuthMode } : {}),
                 ...(thinkLevel ? { thinking: thinkLevel } : {}),
                 ...(params.reasoningLevel ? { reasoning: params.reasoningLevel } : {}),
                 ...(params.verboseLevel ? { verbose: params.verboseLevel } : {}),

--- a/src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts
@@ -1,69 +1,21 @@
 import { describe, expect, it } from "vitest";
-import {
-  createEmbeddedRunStageTracker,
-  formatEmbeddedRunStageSummary,
-  shouldWarnEmbeddedRunStageSummary,
-} from "./attempt-stage-timing.js";
+import { EmbeddedRunStageName } from "./attempt-stage-timing.js";
 
 describe("embedded run stage timing", () => {
-  it("captures stage duration and elapsed time", () => {
-    let clock = 10;
-    const tracker = createEmbeddedRunStageTracker({ now: () => clock });
-
-    clock = 25;
-    tracker.mark("workspace");
-    clock = 40;
-    tracker.mark("tools");
-    clock = 45;
-
-    expect(tracker.snapshot()).toEqual({
-      totalMs: 35,
-      stages: [
-        { name: "workspace", durationMs: 15, elapsedMs: 15 },
-        { name: "tools", durationMs: 15, elapsedMs: 30 },
-      ],
-    });
-  });
-
-  it("warns only for very slow stage summaries by default", () => {
-    expect(
-      shouldWarnEmbeddedRunStageSummary({
-        totalMs: 9_999,
-        stages: [{ name: "auth", durationMs: 4_999, elapsedMs: 4_999 }],
-      }),
-    ).toBe(false);
-    expect(shouldWarnEmbeddedRunStageSummary({ totalMs: 10_000, stages: [] })).toBe(true);
-    expect(
-      shouldWarnEmbeddedRunStageSummary({
-        totalMs: 10,
-        stages: [{ name: "auth", durationMs: 5_000, elapsedMs: 5_000 }],
-      }),
-    ).toBe(true);
-  });
-
-  it("supports custom warning thresholds", () => {
-    expect(
-      shouldWarnEmbeddedRunStageSummary(
-        {
-          totalMs: 2_000,
-          stages: [{ name: "auth", durationMs: 10, elapsedMs: 10 }],
-        },
-        { totalThresholdMs: 2_000, stageThresholdMs: 1_000 },
-      ),
-    ).toBe(true);
-  });
-
-  it("formats summaries compactly for logs", () => {
-    expect(
-      formatEmbeddedRunStageSummary("embedded run startup stages: runId=r1", {
-        totalMs: 80,
-        stages: [
-          { name: "workspace", durationMs: 25, elapsedMs: 25 },
-          { name: "tools", durationMs: 55, elapsedMs: 80 },
-        ],
-      }),
-    ).toBe(
-      "embedded run startup stages: runId=r1 totalMs=80 stages=workspace:25ms@25ms,tools:55ms@80ms",
+  it("keeps required reply prep stage names stable", () => {
+    expect(Object.values(EmbeddedRunStageName)).toEqual(
+      expect.arrayContaining([
+        "model-selection",
+        "auth-resolution",
+        "provider-runtime-lookup",
+        "tool-planning",
+        "tool-materialization",
+        "plugin-capability-loading",
+        "workspace-session-prep",
+        "harness-prep",
+        "active-run-registration",
+        "model-execution",
+      ]),
     );
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt-stage-timing.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-stage-timing.ts
@@ -1,75 +1,54 @@
-export type EmbeddedRunStageTiming = {
-  name: string;
-  durationMs: number;
-  elapsedMs: number;
-};
+import {
+  type StageSummary,
+  type StageTiming,
+  type StageTracker,
+} from "../../../infra/stage-timing.js";
 
-export type EmbeddedRunStageSummary = {
-  totalMs: number;
-  stages: EmbeddedRunStageTiming[];
-};
+export type EmbeddedRunStageTiming = StageTiming;
+export type EmbeddedRunStageSummary = StageSummary;
+export type EmbeddedRunStageTracker = StageTracker;
 
-export type EmbeddedRunStageTracker = {
-  mark: (name: string) => void;
-  snapshot: () => EmbeddedRunStageSummary;
-};
-
-const EMBEDDED_RUN_STAGE_WARN_TOTAL_MS = 10_000;
-const EMBEDDED_RUN_STAGE_WARN_STAGE_MS = 5_000;
-
-export function createEmbeddedRunStageTracker(options?: {
-  now?: () => number;
-}): EmbeddedRunStageTracker {
-  const now = options?.now ?? Date.now;
-  const startedAt = now();
-  let previousAt = startedAt;
-  const stages: EmbeddedRunStageTiming[] = [];
-
-  const toMs = (value: number) => Math.max(0, Math.round(value));
-
-  return {
-    mark(name) {
-      const currentAt = now();
-      stages.push({
-        name,
-        durationMs: toMs(currentAt - previousAt),
-        elapsedMs: toMs(currentAt - startedAt),
-      });
-      previousAt = currentAt;
-    },
-    snapshot() {
-      return {
-        totalMs: toMs(now() - startedAt),
-        stages: stages.slice(),
-      };
-    },
-  };
-}
-
-export function shouldWarnEmbeddedRunStageSummary(
-  summary: EmbeddedRunStageSummary,
-  options?: {
-    totalThresholdMs?: number;
-    stageThresholdMs?: number;
-  },
-): boolean {
-  const totalThresholdMs = options?.totalThresholdMs ?? EMBEDDED_RUN_STAGE_WARN_TOTAL_MS;
-  const stageThresholdMs = options?.stageThresholdMs ?? EMBEDDED_RUN_STAGE_WARN_STAGE_MS;
-  return (
-    summary.totalMs >= totalThresholdMs ||
-    summary.stages.some((stage) => stage.durationMs >= stageThresholdMs)
-  );
-}
-
-export function formatEmbeddedRunStageSummary(
-  prefix: string,
-  summary: EmbeddedRunStageSummary,
-): string {
-  const stages =
-    summary.stages.length > 0
-      ? summary.stages
-          .map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`)
-          .join(",")
-      : "none";
-  return `${prefix} totalMs=${summary.totalMs} stages=${stages}`;
-}
+export const EmbeddedRunStageName = {
+  workspaceSessionPrep: "workspace-session-prep",
+  pluginRuntimeLoading: "plugin-runtime-loading",
+  replyHooks: "reply-hooks",
+  harnessPrep: "harness-prep",
+  modelSelection: "model-selection",
+  authSelection: "auth-selection",
+  authControllerCreate: "auth-controller-create",
+  authProfileInitialize: "auth-profile-initialize",
+  authResolution: "auth-resolution",
+  contextEnginePrep: "context-engine-prep",
+  retryAttemptPrep: "retry-attempt-prep",
+  providerRuntimeLookup: "provider-runtime-lookup",
+  skillPrep: "skill-prep",
+  toolPlanning: "tool-planning",
+  toolMaterialization: "tool-materialization",
+  bootstrapContext: "bootstrap-context",
+  pluginCapabilityLoading: "plugin-capability-loading",
+  systemPrompt: "system-prompt",
+  sessionWriteLock: "session-write-lock",
+  sessionTranscriptRepair: "session-transcript-repair",
+  sessionManagerOpen: "session-manager-open",
+  contextEngineBootstrap: "context-engine-bootstrap",
+  sessionManagerPrepare: "session-manager-prepare",
+  piSettings: "pi-settings",
+  extensionFactoryBuild: "extension-factory-build",
+  resourceLoaderCreate: "resource-loader-create",
+  sessionResourceLoader: "session-resource-loader",
+  agentSession: "agent-session",
+  streamSetup: "stream-setup",
+  promptCacheTraceSetup: "prompt-cache-trace-setup",
+  streamWrapperSetup: "stream-wrapper-setup",
+  sessionHistoryPrepare: "session-history-prepare",
+  subscriptionSetup: "subscription-setup",
+  activeRunRegistration: "active-run-registration",
+  modelRequestPrep: "model-request-prep",
+  modelExecution: "model-execution",
+  promptFinalization: "prompt-finalization",
+  compactionRetryWait: "compaction-retry-wait",
+  attemptStateCapture: "attempt-state-capture",
+  contextEngineFinalize: "context-engine-finalize",
+  subscriptionCleanup: "subscription-cleanup",
+  attemptResultBuild: "attempt-result-build",
+} as const;

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -40,7 +40,10 @@ export async function resolveAttemptBootstrapContext<TBootstrapFile, TContextFil
     params.bootstrapContextRunKind !== "heartbeat" &&
     (await params.hasCompletedBootstrapTurn(params.sessionFile));
   const shouldSkipBootstrapInjection =
-    params.contextInjectionMode === "never" || isContinuationTurn;
+    params.contextInjectionMode === "never" ||
+    isContinuationTurn ||
+    (params.bootstrapContextMode === "lightweight" &&
+      params.bootstrapContextRunKind !== "heartbeat");
   const shouldRecordCompletedBootstrapTurn =
     !shouldSkipBootstrapInjection &&
     params.bootstrapContextMode !== "lightweight" &&

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts
@@ -24,8 +24,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       },
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
-      modelApi: "anthropic-messages",
-      isCacheTtlEligibleProvider: () => true,
+      cacheTtlProviderEligible: true,
       now: 123,
     });
 
@@ -55,8 +54,7 @@ describe("runEmbeddedAttempt cache-ttl tracking after compaction", () => {
       },
       provider: "anthropic",
       modelId: "claude-sonnet-4-20250514",
-      modelApi: "anthropic-messages",
-      isCacheTtlEligibleProvider: () => true,
+      cacheTtlProviderEligible: true,
       now: 123,
     });
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -29,6 +29,7 @@ import {
 import {
   buildEmbeddedSubscriptionParams,
   cleanupEmbeddedAttemptResources,
+  resolveEmbeddedSubscriptionFinalTag,
 } from "./attempt.subscription-cleanup.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
 
@@ -135,6 +136,19 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     await cleanupTempPaths(tempPaths);
     clearMemoryPluginState();
     vi.restoreAllMocks();
+  });
+
+  it("does not materialize coding tools when the model cannot use tools", async () => {
+    hoisted.supportsModelToolsMock.mockReturnValue(false);
+
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+    });
+
+    expect(hoisted.supportsModelToolsMock).toHaveBeenCalled();
+    expect(hoisted.createOpenClawCodingToolsMock).not.toHaveBeenCalled();
   });
 
   it("sends transcriptPrompt visibly and queues runtime context as hidden custom context", async () => {
@@ -843,6 +857,22 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
     expect(params.silentExpected).toBe(true);
     expect(params.sessionKey).toBe(sessionKey);
+  });
+
+  it("resolves final-tag enforcement from prepared runtime hints", () => {
+    expect(
+      resolveEmbeddedSubscriptionFinalTag({
+        enforceFinalTag: undefined,
+        reasoningTagHint: true,
+      }),
+    ).toBe(true);
+    expect(
+      resolveEmbeddedSubscriptionFinalTag({
+        enforceFinalTag: true,
+        reasoningTagHint: false,
+        skipProviderRuntimeHints: true,
+      }),
+    ).toBe(false);
   });
 
   it("skips maintenance when afterTurn fails", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -157,6 +157,36 @@ describe("embedded attempt context injection", () => {
     expect(resolveBootstrapContextForRun).toHaveBeenCalledTimes(1);
   });
 
+  it("skips lightweight default bootstrap context without resolving workspace files", async () => {
+    const { result, hasCompletedBootstrapTurn, resolveBootstrapContextForRun } =
+      await resolveBootstrapContext({
+        contextInjectionMode: "always",
+        bootstrapContextMode: "lightweight",
+        bootstrapContextRunKind: "default",
+      });
+
+    expect(result.bootstrapFiles).toEqual([]);
+    expect(result.contextFiles).toEqual([]);
+    expect(result.shouldRecordCompletedBootstrapTurn).toBe(false);
+    expect(hasCompletedBootstrapTurn).not.toHaveBeenCalled();
+    expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
+  });
+
+  it("skips lightweight cron bootstrap context without resolving workspace files", async () => {
+    const { result, hasCompletedBootstrapTurn, resolveBootstrapContextForRun } =
+      await resolveBootstrapContext({
+        contextInjectionMode: "always",
+        bootstrapContextMode: "lightweight",
+        bootstrapContextRunKind: "cron",
+      });
+
+    expect(result.bootstrapFiles).toEqual([]);
+    expect(result.contextFiles).toEqual([]);
+    expect(result.shouldRecordCompletedBootstrapTurn).toBe(false);
+    expect(hasCompletedBootstrapTurn).not.toHaveBeenCalled();
+    expect(resolveBootstrapContextForRun).not.toHaveBeenCalled();
+  });
+
   it("runs full bootstrap injection after a successful non-heartbeat turn", async () => {
     const resolver = vi.fn(async () => ({
       bootstrapFiles: [{ name: "AGENTS.md", content: "bootstrap context" }],

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../shared/string-coerce.js";
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.types.js";
+import { buildAgentRuntimePlan } from "../../runtime-plan/build.js";
 import type { WorkspaceBootstrapFile } from "../../workspace.js";
 
 type SubscribeEmbeddedPiSessionFn =
@@ -62,7 +63,6 @@ type AttemptSpawnWorkspaceHoisted = {
   ensureGlobalUndiciEnvProxyDispatcherMock: UnknownMock;
   ensureGlobalUndiciStreamTimeoutsMock: UnknownMock;
   buildEmbeddedMessageActionDiscoveryInputMock: UnknownMock;
-  createOpenClawCodingToolsMock: UnknownMock;
   subscribeEmbeddedPiSessionMock: Mock<SubscribeEmbeddedPiSessionFn>;
   acquireSessionWriteLockMock: Mock<AcquireSessionWriteLockFn>;
   installToolResultContextGuardMock: UnknownMock;
@@ -74,6 +74,18 @@ type AttemptSpawnWorkspaceHoisted = {
   resolveContextInjectionModeMock: Mock<() => "always" | "continuation-skip">;
   hasCompletedBootstrapTurnMock: Mock<() => Promise<boolean>>;
   supportsModelToolsMock: Mock<(model?: unknown) => boolean>;
+  createOpenClawCodingToolsMock: Mock<
+    (options?: { workspaceDir?: string; spawnWorkspaceDir?: string }) => Array<{
+      name: string;
+      execute: (
+        callId: string,
+        input: { task?: string },
+        session?: unknown,
+        abortSignal?: unknown,
+        ctx?: unknown,
+      ) => Promise<unknown>;
+    }>
+  >;
   getGlobalHookRunnerMock: Mock<() => unknown>;
   initializeGlobalHookRunnerMock: UnknownMock;
   runContextEngineMaintenanceMock: AsyncContextEngineMaintenanceMock;
@@ -124,7 +136,6 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const ensureGlobalUndiciEnvProxyDispatcherMock = vi.fn();
   const ensureGlobalUndiciStreamTimeoutsMock = vi.fn();
   const buildEmbeddedMessageActionDiscoveryInputMock = vi.fn((params: unknown) => params);
-  const createOpenClawCodingToolsMock = vi.fn(() => []);
   const installToolResultContextGuardMock = vi.fn(() => () => {});
   const installContextEngineLoopHookMock = vi.fn(() => () => {});
   const flushPendingToolResultsAfterIdleMock = vi.fn(async () => {});
@@ -147,6 +158,28 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   );
   const hasCompletedBootstrapTurnMock = vi.fn<() => Promise<boolean>>(async () => false);
   const supportsModelToolsMock = vi.fn<(model?: unknown) => boolean>(() => true);
+  const createOpenClawCodingToolsMock = vi.fn(
+    (options?: { workspaceDir?: string; spawnWorkspaceDir?: string }) => [
+      {
+        name: "sessions_spawn",
+        execute: async (
+          _callId: string,
+          input: { task?: string },
+          _session?: unknown,
+          _abortSignal?: unknown,
+          _ctx?: unknown,
+        ) =>
+          await spawnSubagentDirectMock(
+            {
+              task: input.task ?? "",
+            },
+            {
+              workspaceDir: options?.spawnWorkspaceDir ?? options?.workspaceDir,
+            },
+          ),
+      },
+    ],
+  );
   const getGlobalHookRunnerMock = vi.fn<() => unknown>(() => undefined);
   const initializeGlobalHookRunnerMock = vi.fn();
   const runContextEngineMaintenanceMock = vi.fn(async (_params?: unknown) => undefined);
@@ -181,7 +214,6 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     ensureGlobalUndiciEnvProxyDispatcherMock,
     ensureGlobalUndiciStreamTimeoutsMock,
     buildEmbeddedMessageActionDiscoveryInputMock,
-    createOpenClawCodingToolsMock,
     subscribeEmbeddedPiSessionMock,
     acquireSessionWriteLockMock,
     installToolResultContextGuardMock,
@@ -193,6 +225,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     resolveContextInjectionModeMock,
     hasCompletedBootstrapTurnMock,
     supportsModelToolsMock,
+    createOpenClawCodingToolsMock,
     getGlobalHookRunnerMock,
     initializeGlobalHookRunnerMock,
     runContextEngineMaintenanceMock,
@@ -211,17 +244,39 @@ export function getHoisted(): AttemptSpawnWorkspaceHoisted {
 
 vi.mock("@mariozechner/pi-coding-agent", () => {
   function AuthStorage() {}
-  class DefaultResourceLoader {
-    async reload() {}
-  }
   function ModelRegistry() {}
+  const createExtensionRuntime = () => ({
+    flagValues: new Map(),
+    pendingProviderRegistrations: [],
+    refreshTools: vi.fn(),
+    sendMessage: vi.fn(),
+    sendUserMessage: vi.fn(),
+    appendEntry: vi.fn(),
+    setSessionName: vi.fn(),
+    getSessionName: vi.fn(),
+    setLabel: vi.fn(),
+    getActiveTools: vi.fn(() => []),
+    getAllTools: vi.fn(() => []),
+    setActiveTools: vi.fn(),
+    getCommands: vi.fn(() => []),
+    setModel: vi.fn(async () => true),
+    getThinkingLevel: vi.fn(() => "medium"),
+    setThinkingLevel: vi.fn(),
+    registerProvider: vi.fn(),
+    unregisterProvider: vi.fn(),
+  });
   const estimateTokens = (value: unknown) =>
     Math.max(1, Math.ceil(JSON.stringify(value ?? "").length / 4));
 
   return {
     AuthStorage,
     createAgentSession: (...args: unknown[]) => hoisted.createAgentSessionMock(...args),
-    DefaultResourceLoader,
+    createEventBus: vi.fn(() => ({})),
+    createExtensionRuntime,
+    createSyntheticSourceInfo: vi.fn((path: string, info: Record<string, unknown>) => ({
+      path,
+      ...info,
+    })),
     estimateTokens,
     generateSummary: async () => "",
     ModelRegistry,
@@ -498,10 +553,6 @@ vi.mock("../../anthropic-vertex-stream.js", () => ({
 
 vi.mock("../../custom-api-registry.js", () => ({
   ensureCustomApiRegistered: () => {},
-}));
-
-vi.mock("../../model-auth.js", () => ({
-  resolveModelAuthMode: () => undefined,
 }));
 
 vi.mock("../../model-tool-support.js", () => ({
@@ -825,6 +876,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.resolveContextInjectionModeMock.mockReset().mockReturnValue("always");
   hoisted.hasCompletedBootstrapTurnMock.mockReset().mockResolvedValue(false);
   hoisted.supportsModelToolsMock.mockReset().mockReturnValue(true);
+  hoisted.createOpenClawCodingToolsMock.mockClear();
   hoisted.getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
   hoisted.runContextEngineMaintenanceMock.mockReset().mockResolvedValue(undefined);
   hoisted.getHistoryLimitFromSessionKeyMock.mockReset().mockReturnValue(undefined);
@@ -1054,6 +1106,16 @@ export async function createContextEngineAttemptRunner(params: {
     authStorage: testAuthStorage as never,
     authProfileStore: { version: 1, profiles: {} },
     modelRegistry: {} as never,
+    runtimePlan: buildAgentRuntimePlan({
+      provider: "openai",
+      modelId: "gpt-test",
+      model: testModel,
+      modelApi: "openai-completions",
+      config: {},
+      workspaceDir,
+      agentDir,
+      providerRuntimeHandle: { provider: "openai" },
+    }),
     thinkLevel: "off",
     senderIsOwner: true,
     disableMessageTool: true,

--- a/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.subscription-cleanup.ts
@@ -14,6 +14,16 @@ export function buildEmbeddedSubscriptionParams(
   return params;
 }
 
+export function resolveEmbeddedSubscriptionFinalTag(params: {
+  enforceFinalTag?: boolean;
+  reasoningTagHint: boolean;
+  skipProviderRuntimeHints?: boolean;
+}): boolean {
+  return params.skipProviderRuntimeHints === true
+    ? false
+    : params.enforceFinalTag || params.reasoningTagHint;
+}
+
 export async function cleanupEmbeddedAttemptResources(params: {
   removeToolResultContextGuard?: () => void;
   flushPendingToolResultsAfterIdle: (params: {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -21,6 +21,7 @@ import {
   resolveAttemptFsWorkspaceOnly,
   resolveEmbeddedAgentStreamFn,
   resolveUnknownToolGuardThreshold,
+  shouldCreateBundleLspRuntimeForAttempt,
   shouldCreateBundleMcpRuntimeForAttempt,
   shouldBuildCoreCodingToolsForAllowlist,
   resolveAttemptToolPolicyMessageProvider,
@@ -171,37 +172,31 @@ describe("normalizeMessagesForLlmBoundary", () => {
   });
 });
 
-describe("shouldCreateBundleMcpRuntimeForAttempt", () => {
-  it("skips bundle MCP when tools are disabled or unavailable", () => {
-    expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: false })).toBe(false);
-    expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true, disableTools: true })).toBe(
-      false,
-    );
+describe.each([
+  ["bundle MCP", shouldCreateBundleMcpRuntimeForAttempt, ["bundle-mcp", "strict__strict_probe"]],
+  [
+    "bundle LSP",
+    shouldCreateBundleLspRuntimeForAttempt,
+    ["bundle-lsp", "lsp_hover_typescript", "LSP_*"],
+  ],
+] as const)("%s runtime planning", (_label, shouldCreateRuntime, allowedTools) => {
+  it("skips runtime creation when tools are disabled or unavailable", () => {
+    expect(shouldCreateRuntime({ toolsEnabled: false })).toBe(false);
+    expect(shouldCreateRuntime({ toolsEnabled: true, disableTools: true })).toBe(false);
   });
 
-  it("creates bundle MCP only when the allowlist can reach bundle MCP tool names", () => {
-    expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true })).toBe(true);
-    expect(shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true, toolsAllow: [] })).toBe(
-      true,
-    );
+  it("creates the runtime only when the allowlist can reach its tool names", () => {
+    expect(shouldCreateRuntime({ toolsEnabled: true })).toBe(true);
+    expect(shouldCreateRuntime({ toolsEnabled: true, toolsAllow: [] })).toBe(true);
     expect(
-      shouldCreateBundleMcpRuntimeForAttempt({
+      shouldCreateRuntime({
         toolsEnabled: true,
         toolsAllow: ["memory_search", "memory_get"],
       }),
     ).toBe(false);
-    expect(
-      shouldCreateBundleMcpRuntimeForAttempt({
-        toolsEnabled: true,
-        toolsAllow: ["bundle-mcp"],
-      }),
-    ).toBe(true);
-    expect(
-      shouldCreateBundleMcpRuntimeForAttempt({
-        toolsEnabled: true,
-        toolsAllow: ["strict__strict_probe"],
-      }),
-    ).toBe(true);
+    for (const toolName of allowedTools) {
+      expect(shouldCreateRuntime({ toolsEnabled: true, toolsAllow: [toolName] })).toBe(true);
+    }
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
@@ -82,17 +82,14 @@ function shouldAppendAttemptCacheTtl(params: {
   timedOutDuringCompaction: boolean;
   compactionOccurredThisAttempt: boolean;
   config?: OpenClawConfig;
-  provider: string;
-  modelId: string;
-  modelApi?: string;
-  isCacheTtlEligibleProvider: (provider: string, modelId: string, modelApi?: string) => boolean;
+  cacheTtlProviderEligible: boolean;
 }): boolean {
   if (params.timedOutDuringCompaction || params.compactionOccurredThisAttempt) {
     return false;
   }
   return (
     params.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl" &&
-    params.isCacheTtlEligibleProvider(params.provider, params.modelId, params.modelApi)
+    params.cacheTtlProviderEligible
   );
 }
 
@@ -105,8 +102,7 @@ export function appendAttemptCacheTtlIfNeeded(params: {
   config?: OpenClawConfig;
   provider: string;
   modelId: string;
-  modelApi?: string;
-  isCacheTtlEligibleProvider: (provider: string, modelId: string, modelApi?: string) => boolean;
+  cacheTtlProviderEligible: boolean;
   now?: number;
 }): boolean {
   if (!shouldAppendAttemptCacheTtl(params)) {

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
-import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
+import {
+  resolveAttemptTranscriptPolicy,
+  shouldPersistStrictTurnSessionRepair,
+} from "./attempt.transcript-policy.js";
 
 const resolveProviderRuntimePluginMock = vi.hoisted(() => vi.fn());
 
@@ -89,5 +92,28 @@ describe("resolveAttemptTranscriptPolicy", () => {
       workspaceDir: "/tmp/openclaw-transcript-policy",
       env,
     });
+  });
+});
+
+describe("shouldPersistStrictTurnSessionRepair", () => {
+  it("only trims persisted assistant prefill for strict turn policies", () => {
+    expect(
+      shouldPersistStrictTurnSessionRepair({
+        validateAnthropicTurns: false,
+        validateGeminiTurns: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPersistStrictTurnSessionRepair({
+        validateAnthropicTurns: true,
+        validateGeminiTurns: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPersistStrictTurnSessionRepair({
+        validateAnthropicTurns: false,
+        validateGeminiTurns: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.transcript-policy.ts
@@ -34,3 +34,9 @@ export function resolveAttemptTranscriptPolicy(params: {
     })
   );
 }
+
+export function shouldPersistStrictTurnSessionRepair(
+  policy: Pick<TranscriptPolicy, "validateAnthropicTurns" | "validateGeminiTurns">,
+): boolean {
+  return policy.validateAnthropicTurns || policy.validateGeminiTurns;
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2,11 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import {
-  createAgentSession,
-  DefaultResourceLoader,
-  SessionManager,
-} from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager } from "@mariozechner/pi-coding-agent";
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
 import { getRuntimeConfig } from "../../../config/config.js";
@@ -29,11 +25,6 @@ import {
   extractModelCompat,
   resolveToolCallArgumentsEncoding,
 } from "../../../plugins/provider-model-compat.js";
-import {
-  resolveProviderSystemPromptContribution,
-  resolveProviderTextTransforms,
-  transformProviderSystemPrompt,
-} from "../../../plugins/provider-runtime.js";
 import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../../sessions/input-provenance.js";
@@ -81,7 +72,6 @@ import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-pr
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { stripRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
 import { buildModelAliasLines } from "../../model-alias-lines.js";
-import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
 import { releaseWsSession } from "../../openai-ws-stream.js";
@@ -104,11 +94,7 @@ import {
 import { countActiveToolExecutions } from "../../pi-embedded-subscribe.handlers.tools.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
-import {
-  applyPiAutoCompactionGuard,
-  applyPiCompactionSettingsFromConfig,
-  isSilentOverflowProneModel,
-} from "../../pi-settings.js";
+import { applyPiAutoCompactionGuard, isSilentOverflowProneModel } from "../../pi-settings.js";
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,
@@ -195,6 +181,7 @@ import {
   validateReplayTurns,
 } from "../replay-history.js";
 import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
+import { createEmbeddedPiResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
@@ -234,17 +221,14 @@ import { flushPendingToolResultsAfterIdle } from "../wait-for-idle-before-flush.
 import { abortable as abortableWithSignal } from "./abortable.js";
 import { createEmbeddedAgentSessionWithResourceLoader } from "./attempt-session.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
+import { createStageTracker, emitStageSummary } from "../../../infra/stage-timing.js";
 import {
   rotateTranscriptAfterCompaction,
   shouldRotateCompactionTranscript,
 } from "../compaction-successor-transcript.js";
 import { resolveAttemptWorkspaceBootstrapRouting } from "./attempt-bootstrap-routing.js";
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
-import {
-  createEmbeddedRunStageTracker,
-  formatEmbeddedRunStageSummary,
-  shouldWarnEmbeddedRunStageSummary,
-} from "./attempt-stage-timing.js";
+import { EmbeddedRunStageName } from "./attempt-stage-timing.js";
 import { buildAttemptSystemPrompt } from "./attempt-system-prompt.js";
 import {
   assembleAttemptContextEngine,
@@ -283,6 +267,7 @@ import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-rec
 import {
   buildEmbeddedSubscriptionParams,
   cleanupEmbeddedAttemptResources,
+  resolveEmbeddedSubscriptionFinalTag,
 } from "./attempt.subscription-cleanup.js";
 import {
   appendAttemptCacheTtlIfNeeded,
@@ -302,7 +287,10 @@ import {
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.tool-call-normalization.js";
 import { buildEmbeddedAttemptToolRunContext } from "./attempt.tool-run-context.js";
-import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
+import {
+  resolveAttemptTranscriptPolicy,
+  shouldPersistStrictTurnSessionRepair,
+} from "./attempt.transcript-policy.js";
 import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
 import {
   resolveRunTimeoutDuringCompaction,
@@ -603,14 +591,39 @@ export function shouldCreateBundleMcpRuntimeForAttempt(params: {
   disableTools?: boolean;
   toolsAllow?: string[];
 }): boolean {
+  return shouldCreateBundledCapabilityRuntimeForAttempt({
+    ...params,
+    matchesAllowedToolName: (toolName) =>
+      toolName === "bundle-mcp" || toolName.includes(TOOL_NAME_SEPARATOR),
+  });
+}
+
+export function shouldCreateBundleLspRuntimeForAttempt(params: {
+  toolsEnabled: boolean;
+  disableTools?: boolean;
+  toolsAllow?: string[];
+}): boolean {
+  return shouldCreateBundledCapabilityRuntimeForAttempt({
+    ...params,
+    matchesAllowedToolName: (toolName) =>
+      toolName === "bundle-lsp" || toolName === "lsp" || toolName.startsWith("lsp_"),
+  });
+}
+
+function shouldCreateBundledCapabilityRuntimeForAttempt(params: {
+  toolsEnabled: boolean;
+  disableTools?: boolean;
+  toolsAllow?: string[];
+  matchesAllowedToolName: (normalizedToolName: string) => boolean;
+}): boolean {
   if (!params.toolsEnabled || params.disableTools === true) {
     return false;
   }
   if (!params.toolsAllow || params.toolsAllow.length === 0) {
     return true;
   }
-  return params.toolsAllow.some(
-    (toolName) => toolName === "bundle-mcp" || toolName.includes(TOOL_NAME_SEPARATOR),
+  return params.toolsAllow.some((toolName) =>
+    params.matchesAllowedToolName(normalizeToolName(toolName)),
   );
 }
 
@@ -704,22 +717,14 @@ export async function runEmbeddedAttempt(
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
   );
-  const prepStages = createEmbeddedRunStageTracker();
+  const prepStages = createStageTracker();
+  let prepStageSummaryCompleted = false;
   const emitPrepStageSummary = (phase: string) => {
-    const summary = prepStages.snapshot();
-    const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary);
-    if (!shouldWarn && !log.isEnabled("trace")) {
-      return;
-    }
-    const message = formatEmbeddedRunStageSummary(
-      `[trace:embedded-run] prep stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
-      summary,
-    );
-    if (shouldWarn) {
-      log.warn(message);
-    } else {
-      log.trace(message);
-    }
+    emitStageSummary({
+      logger: log,
+      prefix: `[timing:embedded-run] prep stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
+      summary: prepStages.snapshot(),
+    });
   };
   const emitCorePluginToolStageSummary = (
     phase: string,
@@ -728,22 +733,14 @@ export async function runEmbeddedAttempt(
     if (summary.stages.length === 0) {
       return;
     }
-    const shouldWarn = shouldWarnEmbeddedRunStageSummary(summary, {
+    emitStageSummary({
+      logger: log,
+      prefix: `[trace:embedded-run] core-plugin-tool stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
+      summary,
+      normalLevel: "trace",
       totalThresholdMs: 5_000,
       stageThresholdMs: 2_000,
     });
-    if (!shouldWarn && !log.isEnabled("trace")) {
-      return;
-    }
-    const message = formatEmbeddedRunStageSummary(
-      `[trace:embedded-run] core-plugin-tool stages: runId=${params.runId} sessionId=${params.sessionId} phase=${phase}`,
-      summary,
-    );
-    if (shouldWarn) {
-      log.warn(message);
-    } else {
-      log.trace(message);
-    }
   };
 
   await fs.mkdir(resolvedWorkspace, { recursive: true });
@@ -770,7 +767,7 @@ export async function runEmbeddedAttempt(
     config: params.config,
     sessionAgentId,
   });
-  prepStages.mark("workspace-sandbox");
+  prepStages.mark(EmbeddedRunStageName.workspaceSessionPrep);
 
   let restoreSkillEnv: (() => void) | undefined;
   let aborted = Boolean(params.abortSignal?.aborted);
@@ -807,7 +804,7 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
       agentId: sessionAgentId,
     });
-    prepStages.mark("skills");
+    prepStages.mark(EmbeddedRunStageName.skillPrep);
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const contextInjectionMode = resolveContextInjectionMode(params.config);
@@ -856,9 +853,10 @@ export async function runEmbeddedAttempt(
         ...(err ? { errorCategory: diagnosticErrorCategory(err) } : {}),
       });
     };
-    const corePluginToolStages = createEmbeddedRunStageTracker();
+    const corePluginToolStages = createStageTracker();
+    const toolsEnabled = supportsModelTools(params.model);
     const toolsRaw =
-      params.disableTools || isRawModelRun
+      params.disableTools || isRawModelRun || !toolsEnabled
         ? []
         : (() => {
             const allTools = createOpenClawCodingTools({
@@ -910,9 +908,6 @@ export async function runEmbeddedAttempt(
               modelCompat: extractModelCompat(params.model),
               modelApi: params.model.api,
               modelContextWindowTokens: params.model.contextWindow,
-              modelAuthMode: resolveModelAuthMode(params.model.provider, params.config, undefined, {
-                workspaceDir: effectiveWorkspace,
-              }),
               currentChannelId: params.currentChannelId,
               currentThreadTs: params.currentThreadTs,
               currentMessageId: params.currentMessageId,
@@ -927,6 +922,7 @@ export async function runEmbeddedAttempt(
               enableHeartbeatTool: params.enableHeartbeatTool,
               forceHeartbeatTool: params.forceHeartbeatTool,
               authProfileStore: params.authProfileStore,
+              preparedToolPlanning: params.runtimePlan.tools.preparedPlanning,
               recordToolPrepStage: (name) => corePluginToolStages.mark(name),
               onYield: (message) => {
                 yieldDetected = true;
@@ -941,9 +937,9 @@ export async function runEmbeddedAttempt(
             corePluginToolStages.mark("attempt:tools-allow");
             return filteredTools;
           })();
-    prepStages.mark("core-plugin-tools");
+    prepStages.mark(EmbeddedRunStageName.toolPlanning);
+    prepStages.mark(EmbeddedRunStageName.toolMaterialization);
     emitCorePluginToolStageSummary("core-plugin-tools", corePluginToolStages.snapshot());
-    const toolsEnabled = supportsModelTools(params.model);
     const bootstrapHasFileAccess = toolsEnabled && toolsRaw.some((tool) => tool.name === "read");
     const bootstrapRouting = await resolveAttemptWorkspaceBootstrapRouting({
       isWorkspaceBootstrapPending,
@@ -985,7 +981,7 @@ export async function runEmbeddedAttempt(
           runKind: params.bootstrapContextRunKind,
         }),
     });
-    prepStages.mark("bootstrap-context");
+    prepStages.mark(EmbeddedRunStageName.bootstrapContext);
     const remappedContextFiles = remapInjectedContextFilesToWorkspace({
       files: resolvedContextFiles,
       sourceWorkspaceDir: resolvedWorkspace,
@@ -1079,18 +1075,22 @@ export async function runEmbeddedAttempt(
           ],
         })
       : undefined;
-    const bundleLspRuntime =
-      toolsEnabled && !isRawModelRun
-        ? await createBundleLspToolRuntime({
-            workspaceDir: effectiveWorkspace,
-            cfg: params.config,
-            reservedToolNames: [
-              ...tools.map((tool) => tool.name),
-              ...(clientTools?.map((tool) => tool.function.name) ?? []),
-              ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
-            ],
-          })
-        : undefined;
+    const bundleLspEnabled = shouldCreateBundleLspRuntimeForAttempt({
+      toolsEnabled,
+      disableTools: params.disableTools || isRawModelRun,
+      toolsAllow: params.toolsAllow,
+    });
+    const bundleLspRuntime = bundleLspEnabled
+      ? await createBundleLspToolRuntime({
+          workspaceDir: effectiveWorkspace,
+          cfg: params.config,
+          reservedToolNames: [
+            ...tools.map((tool) => tool.name),
+            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
+          ],
+        })
+      : undefined;
     const filteredBundledTools = applyFinalEffectiveToolPolicy({
       bundledTools: [...(bundleMcpRuntime?.tools ?? []), ...(bundleLspRuntime?.tools ?? [])],
       config: params.config,
@@ -1114,7 +1114,7 @@ export async function runEmbeddedAttempt(
       warn: (message) => log.warn(message),
     });
     const effectiveTools = [...tools, ...filteredBundledTools];
-    prepStages.mark("bundle-tools");
+    prepStages.mark(EmbeddedRunStageName.pluginCapabilityLoading);
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,
@@ -1177,9 +1177,15 @@ export async function runEmbeddedAttempt(
       config: params.config,
       workspaceDir: effectiveWorkspace,
       env: process.env,
+      runtimeHandle: params.runtimePlan.providerRuntimeHandle,
       modelId: params.modelId,
       modelApi: params.model.api,
       model: params.model,
+    });
+    const enforceFinalTag = resolveEmbeddedSubscriptionFinalTag({
+      enforceFinalTag: params.enforceFinalTag,
+      reasoningTagHint,
+      skipProviderRuntimeHints: params.skipProviderRuntimeHints,
     });
     // Resolve channel-specific message actions for system prompt
     const channelActions = runtimeChannel
@@ -1274,13 +1280,7 @@ export async function runEmbeddedAttempt(
       trigger: params.trigger,
     };
     const promptContribution =
-      params.runtimePlan?.prompt.resolveSystemPromptContribution(promptContributionContext) ??
-      resolveProviderSystemPromptContribution({
-        provider: params.provider,
-        config: params.config,
-        workspaceDir: effectiveWorkspace,
-        context: promptContributionContext,
-      });
+      params.runtimePlan.prompt.resolveSystemPromptContribution(promptContributionContext);
 
     const bootstrapTruncationNotice = buildBootstrapPromptWarningNotice(
       bootstrapPromptWarning.lines,
@@ -1292,7 +1292,8 @@ export async function runEmbeddedAttempt(
     const attemptSystemPrompt = buildAttemptSystemPrompt({
       isRawModelRun,
       systemPromptOverrideText,
-      transformProviderSystemPrompt,
+      transformProviderSystemPrompt: ({ context }) =>
+        params.runtimePlan.prompt.transformSystemPrompt(context),
       embeddedSystemPrompt: {
         workspaceDir: effectiveWorkspace,
         defaultThinkLevel: params.thinkLevel,
@@ -1380,7 +1381,7 @@ export async function runEmbeddedAttempt(
     });
     const systemPromptOverride = attemptSystemPrompt.systemPromptOverride;
     let systemPromptText = systemPromptOverride();
-    prepStages.mark("system-prompt");
+    prepStages.mark(EmbeddedRunStageName.systemPrompt);
 
     // Keep the session lock scoped to transcript/session mutations. Cold plugin
     // and tool setup can be slow, and holding the lock there blocks CLI fallback
@@ -1395,6 +1396,7 @@ export async function runEmbeddedAttempt(
         }),
       }),
     });
+    prepStages.mark(EmbeddedRunStageName.sessionWriteLock);
 
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
@@ -1402,16 +1404,6 @@ export async function runEmbeddedAttempt(
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
     let trajectoryEndRecorded = false;
     try {
-      await repairSessionFileIfNeeded({
-        sessionFile: params.sessionFile,
-        debug: (message) => log.debug(message),
-        warn: (message) => log.warn(message),
-      });
-      const hadSessionFile = await fs
-        .stat(params.sessionFile)
-        .then(() => true)
-        .catch(() => false);
-
       const transcriptPolicy = resolveAttemptTranscriptPolicy({
         runtimePlan: params.runtimePlan,
         runtimePlanModelContext,
@@ -1420,6 +1412,17 @@ export async function runEmbeddedAttempt(
         config: params.config,
         env: process.env,
       });
+      await repairSessionFileIfNeeded({
+        sessionFile: params.sessionFile,
+        debug: (message) => log.debug(message),
+        trimTrailingAssistantMessages: shouldPersistStrictTurnSessionRepair(transcriptPolicy),
+        warn: (message) => log.warn(message),
+      });
+      prepStages.mark(EmbeddedRunStageName.sessionTranscriptRepair);
+      const hadSessionFile = await fs
+        .stat(params.sessionFile)
+        .then(() => true)
+        .catch(() => false);
 
       await prewarmSessionFile(params.sessionFile);
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
@@ -1442,6 +1445,7 @@ export async function runEmbeddedAttempt(
         },
       });
       trackSessionManagerAccess(params.sessionFile);
+      prepStages.mark(EmbeddedRunStageName.sessionManagerOpen);
 
       await runAttemptContextEngineBootstrap({
         hadSessionFile,
@@ -1469,6 +1473,7 @@ export async function runEmbeddedAttempt(
           }),
         warn: (message) => log.warn(message),
       });
+      prepStages.mark(EmbeddedRunStageName.contextEngineBootstrap);
 
       await prepareSessionManagerForRun({
         sessionManager,
@@ -1477,6 +1482,7 @@ export async function runEmbeddedAttempt(
         sessionId: params.sessionId,
         cwd: effectiveWorkspace,
       });
+      prepStages.mark(EmbeddedRunStageName.sessionManagerPrepare);
 
       const settingsManager = createPreparedEmbeddedPiSettingsManager({
         cwd: effectiveWorkspace,
@@ -1494,34 +1500,37 @@ export async function runEmbeddedAttempt(
         }),
       };
       applyPiAutoCompactionGuard(piAutoCompactionGuardArgs);
+      prepStages.mark(EmbeddedRunStageName.piSettings);
 
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
+      const cacheTtlProviderEligible =
+        params.config?.agents?.defaults?.contextPruning?.mode === "cache-ttl"
+          ? isCacheTtlEligibleProvider(params.provider, params.modelId, params.model.api, {
+              config: params.config,
+              workspaceDir: effectiveWorkspace,
+              env: process.env,
+              runtimeHandle: params.runtimePlan.providerRuntimeHandle,
+            })
+          : false;
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        workspaceDir: effectiveWorkspace,
+        env: process.env,
+        providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
+        cacheTtlProviderEligible,
       });
-      const resourceLoader = new DefaultResourceLoader({
-        cwd: resolvedWorkspace,
-        agentDir,
-        settingsManager,
+      prepStages.mark(EmbeddedRunStageName.extensionFactoryBuild);
+      const resourceLoader = createEmbeddedPiResourceLoader({
         extensionFactories,
       });
+      prepStages.mark(EmbeddedRunStageName.resourceLoaderCreate);
       await resourceLoader.reload();
-      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
-      // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply
-      // both guards.
-      applyPiCompactionSettingsFromConfig({
-        settingsManager,
-        cfg: params.config,
-        contextTokenBudget: params.contextTokenBudget,
-      });
-      applyPiAutoCompactionGuard(piAutoCompactionGuardArgs);
-      prepStages.mark("session-resource-loader");
+      prepStages.mark(EmbeddedRunStageName.sessionResourceLoader);
 
       // Get hook runner early so it's available when creating tools
       const hookRunner = getGlobalHookRunner();
@@ -1663,7 +1672,7 @@ export async function runEmbeddedAttempt(
       }
       session.setActiveToolsByName(sessionToolAllowlist);
       const activeSession = session;
-      prepStages.mark("agent-session");
+      prepStages.mark(EmbeddedRunStageName.agentSession);
       if (isRawModelRun) {
         // Raw model probes should measure exactly the requested prompt against
         // the selected provider/model. Reset clears restored transcript state
@@ -1881,6 +1890,7 @@ export async function runEmbeddedAttempt(
         cfg: params.config,
         agentDir,
         workspaceDir: effectiveWorkspace,
+        providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
       });
       const shouldUseWebSocketTransport = shouldUseOpenAIWebSocketTransportForAttempt({
         provider: params.provider,
@@ -1919,17 +1929,13 @@ export async function runEmbeddedAttempt(
         model: params.model,
         resolvedApiKey: params.resolvedApiKey,
         authStorage: params.authStorage,
+        providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
       });
-      const providerTextTransforms = resolveProviderTextTransforms({
-        provider: params.provider,
-        config: params.config,
-        workspaceDir: effectiveWorkspace,
-      });
-      if (providerTextTransforms) {
+      if (params.runtimePlan.prompt.textTransforms) {
         activeSession.agent.streamFn = wrapStreamFnTextTransforms({
           streamFn: activeSession.agent.streamFn,
-          input: providerTextTransforms.input,
-          output: providerTextTransforms.output,
+          input: params.runtimePlan.prompt.textTransforms.input,
+          output: params.runtimePlan.prompt.textTransforms.output,
           transformSystemPrompt: false,
         });
       }
@@ -1946,7 +1952,10 @@ export async function runEmbeddedAttempt(
         params.model,
         agentDir,
         resolvedTransport,
-        { preparedExtraParams: effectiveExtraParams },
+        {
+          preparedExtraParams: effectiveExtraParams,
+          providerRuntimeHandle: params.runtimePlan.providerRuntimeHandle,
+        },
       );
       const effectivePromptCacheRetention = resolveCacheRetention(
         effectiveExtraParams,
@@ -1966,7 +1975,7 @@ export async function runEmbeddedAttempt(
             `(${params.provider}/${params.modelId})`,
         );
       }
-      prepStages.mark("stream-setup");
+      prepStages.mark(EmbeddedRunStageName.streamSetup);
       emitPrepStageSummary("stream-ready");
 
       const cacheObservabilityEnabled = Boolean(cacheTrace) || log.isEnabled("debug");
@@ -1983,6 +1992,7 @@ export async function runEmbeddedAttempt(
         });
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
+      prepStages.mark(EmbeddedRunStageName.promptCacheTraceSetup);
 
       // Anthropic Claude endpoints can reject replayed `thinking` blocks
       // (e.g. thinkingSignature:"reasoning_text") on any follow-up provider
@@ -2172,6 +2182,7 @@ export async function runEmbeddedAttempt(
           nextCallId: () => `${params.runId}:model:${(diagnosticModelCallSeq += 1)}`,
         },
       );
+      prepStages.mark(EmbeddedRunStageName.streamWrapperSetup);
 
       try {
         if (isRawModelRun) {
@@ -2196,6 +2207,7 @@ export async function runEmbeddedAttempt(
             sessionManager,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            runtimeHandle: params.runtimePlan.providerRuntimeHandle,
           });
           cacheTrace?.recordStage("session:sanitized", { messages: prior });
           const validated = await validateReplayTurns({
@@ -2209,6 +2221,7 @@ export async function runEmbeddedAttempt(
             model: params.model,
             sessionId: params.sessionId,
             policy: transcriptPolicy,
+            runtimeHandle: params.runtimePlan.providerRuntimeHandle,
           });
           const heartbeatSummary =
             params.config && sessionAgentId
@@ -2292,6 +2305,7 @@ export async function runEmbeddedAttempt(
         activeSession.dispose();
         throw err;
       }
+      prepStages.mark(EmbeddedRunStageName.sessionHistoryPrepare);
 
       let yieldAborted = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
@@ -2343,7 +2357,7 @@ export async function runEmbeddedAttempt(
           session: activeSession,
           runId: params.runId,
           initialReplayState: params.initialReplayState,
-          hookRunner: getGlobalHookRunner() ?? undefined,
+          hookRunner: hookRunner ?? undefined,
           verboseLevel: params.verboseLevel,
           reasoningMode: params.reasoningLevel ?? "off",
           thinkingLevel: params.thinkLevel,
@@ -2365,7 +2379,7 @@ export async function runEmbeddedAttempt(
             // post-completion cleanup does not observe a logically finished run as active.
             clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
           },
-          enforceFinalTag: params.enforceFinalTag,
+          enforceFinalTag,
           silentExpected: params.silentExpected,
           config: params.config,
           sessionKey: sandboxSessionKey,
@@ -2375,6 +2389,7 @@ export async function runEmbeddedAttempt(
           internalEvents: params.internalEvents,
         }),
       );
+      prepStages.mark(EmbeddedRunStageName.subscriptionSetup);
 
       const {
         assistantTexts,
@@ -2426,6 +2441,7 @@ export async function runEmbeddedAttempt(
         params.replyOperation.attachBackend(queueHandle);
       }
       setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+      prepStages.mark(EmbeddedRunStageName.activeRunRegistration);
 
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
@@ -3035,8 +3051,30 @@ export async function runEmbeddedAttempt(
               messages: btwSnapshotMessages,
               inFlightPrompt: promptForModel,
             });
+            let modelRequestPrepared = false;
+            const markModelRequestPrep = () => {
+              if (!modelRequestPrepared) {
+                prepStages.mark(EmbeddedRunStageName.modelRequestPrep);
+                modelRequestPrepared = true;
+              }
+            };
+            const submitPromptToModel = async (
+              promptText: string,
+              options?: Parameters<typeof activeSession.prompt>[1],
+            ) => {
+              try {
+                const promptPromise =
+                  options === undefined
+                    ? activeSession.prompt(promptText)
+                    : activeSession.prompt(promptText, options);
+                markModelRequestPrep();
+                await abortable(promptPromise);
+              } finally {
+                prepStages.mark(EmbeddedRunStageName.modelExecution);
+              }
+            };
             if (promptSubmission.runtimeOnly) {
-              await abortable(activeSession.prompt(promptForModel));
+              await submitPromptToModel(promptForModel);
             } else {
               const runtimeContext = promptSubmission.runtimeContext?.trim();
               const runtimeSystemPrompt = runtimeContext
@@ -3057,11 +3095,11 @@ export async function runEmbeddedAttempt(
                 // Only pass images option if there are actually images to pass
                 // This avoids potential issues with models that don't expect the images parameter
                 if (imageResult.images.length > 0) {
-                  await abortable(
-                    activeSession.prompt(promptForModel, { images: imageResult.images }),
-                  );
+                  await submitPromptToModel(promptForModel, {
+                    images: imageResult.images,
+                  });
                 } else {
-                  await abortable(activeSession.prompt(promptForModel));
+                  await submitPromptToModel(promptForModel);
                 }
               } finally {
                 if (runtimeSystemPrompt) {
@@ -3098,6 +3136,7 @@ export async function runEmbeddedAttempt(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );
         }
+        prepStages.mark(EmbeddedRunStageName.promptFinalization);
 
         if (pendingMidTurnPrecheckRequest) {
           const request = pendingMidTurnPrecheckRequest;
@@ -3167,6 +3206,7 @@ export async function runEmbeddedAttempt(
             throw err;
           }
         }
+        prepStages.mark(EmbeddedRunStageName.compactionRetryWait);
 
         // Check if ANY compaction occurred during the entire attempt (prompt + retry).
         // Using a cumulative count (> 0) instead of a delta check avoids missing
@@ -3188,8 +3228,7 @@ export async function runEmbeddedAttempt(
           config: params.config,
           provider: params.provider,
           modelId: params.modelId,
-          modelApi: params.model.api,
-          isCacheTtlEligibleProvider,
+          cacheTtlProviderEligible,
         });
 
         // If timeout occurred during compaction, use pre-compaction snapshot when available
@@ -3258,6 +3297,7 @@ export async function runEmbeddedAttempt(
             fallbackLastCacheTouchAt,
           }),
         });
+        prepStages.mark(EmbeddedRunStageName.attemptStateCapture);
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {
@@ -3400,6 +3440,7 @@ export async function runEmbeddedAttempt(
               log.warn(`agent_end hook failed: ${err}`);
             });
         }
+        prepStages.mark(EmbeddedRunStageName.contextEngineFinalize);
       } finally {
         clearTimeout(abortTimer);
         if (abortWarnTimer) {
@@ -3426,6 +3467,7 @@ export async function runEmbeddedAttempt(
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
+      prepStages.mark(EmbeddedRunStageName.subscriptionCleanup);
 
       const toolMetasNormalized = toolMetas
         .filter(
@@ -3482,10 +3524,8 @@ export async function runEmbeddedAttempt(
               sessionId: params.sessionId,
               provider: params.provider,
               model: params.modelId,
-              resolvedRef:
-                params.runtimePlan?.observability.resolvedRef ??
-                `${params.provider}/${params.modelId}`,
-              ...(params.runtimePlan?.observability.harnessId
+              resolvedRef: params.runtimePlan.observability.resolvedRef,
+              ...(params.runtimePlan.observability.harnessId
                 ? { harnessId: params.runtimePlan.observability.harnessId }
                 : {}),
               assistantTexts,
@@ -3573,6 +3613,9 @@ export async function runEmbeddedAttempt(
         promptError: promptError ? formatErrorMessage(promptError) : undefined,
       });
       trajectoryEndRecorded = true;
+      prepStages.mark(EmbeddedRunStageName.attemptResultBuild);
+      emitPrepStageSummary("attempt-complete");
+      prepStageSummaryCompleted = true;
 
       const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
         slot.completed && slot.params
@@ -3633,6 +3676,10 @@ export async function runEmbeddedAttempt(
         yieldDetected: yieldDetected || undefined,
       };
     } finally {
+      if (!prepStageSummaryCompleted) {
+        emitPrepStageSummary("cleanup");
+        prepStageSummaryCompleted = true;
+      }
       if (trajectoryRecorder && !trajectoryEndRecorded) {
         trajectoryRecorder.recordEvent("session.ended", {
           status: promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup",
@@ -3693,6 +3740,10 @@ export async function runEmbeddedAttempt(
       }
     }
   } finally {
+    if (!prepStageSummaryCompleted) {
+      emitPrepStageSummary("cleanup");
+      prepStageSummaryCompleted = true;
+    }
     emitDiagnosticRunCompleted?.(
       aborted ? "aborted" : "error",
       promptError ?? new Error("run exited before diagnostic completion"),

--- a/src/agents/pi-embedded-runner/run/auth-controller.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.test.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { ProviderRuntimePluginHandle } from "../../../plugins/provider-hook-runtime.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { RuntimeAuthState } from "./helpers.js";
 
@@ -87,6 +88,7 @@ function createMutableAuthControllerHarness(): MutableAuthControllerHarness {
 function createMutableEmbeddedRunAuthController(params: {
   harness: MutableAuthControllerHarness;
   setRuntimeApiKey: RuntimeApiKeySetter;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
   profileCandidates?: string[];
   warn?: (message: string) => void;
 }) {
@@ -99,6 +101,7 @@ function createMutableEmbeddedRunAuthController(params: {
       profiles: {},
     } as AuthProfileStore,
     authStorage: { setRuntimeApiKey: params.setRuntimeApiKey },
+    providerRuntimeHandle: params.providerRuntimeHandle,
     profileCandidates: params.profileCandidates ?? ["default"],
     initialThinkLevel: "medium",
     attemptedThinking: new Set(),
@@ -150,6 +153,7 @@ describe("createEmbeddedRunAuthController", () => {
   it("applies runtime request overrides on the first auth exchange", async () => {
     const harness = createMutableAuthControllerHarness();
     const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+    const providerRuntimeHandle: ProviderRuntimePluginHandle = { provider: "custom-openai" };
 
     mocks.getApiKeyForModel.mockResolvedValue({
       apiKey: "source-api-key",
@@ -172,6 +176,7 @@ describe("createEmbeddedRunAuthController", () => {
     const controller = createMutableEmbeddedRunAuthController({
       harness,
       setRuntimeApiKey,
+      providerRuntimeHandle,
     });
 
     await controller.initializeAuthProfile();
@@ -180,6 +185,11 @@ describe("createEmbeddedRunAuthController", () => {
       expect.objectContaining({
         agentDir: "/tmp/agent",
         workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expect(mocks.prepareProviderRuntimeAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeHandle: providerRuntimeHandle,
       }),
     );
     expect(harness.runtimeModel.baseUrl).toBe("https://runtime.example.com/v1");

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
+import type { ProviderRuntimePluginHandle } from "../../../plugins/provider-hook-runtime.js";
 import { prepareProviderRuntimeAuth } from "../../../plugins/provider-runtime.js";
 import {
   type AuthProfileStore,
@@ -46,6 +47,7 @@ export function createEmbeddedRunAuthController(params: {
   workspaceDir: string;
   authStore: AuthProfileStore;
   authStorage: RuntimeApiKeySink;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
   profileCandidates: Array<string | undefined>;
   lockedProfileId?: string;
   initialThinkLevel: ThinkLevel;
@@ -126,6 +128,7 @@ export function createEmbeddedRunAuthController(params: {
       config: params.config,
       workspaceDir: params.workspaceDir,
       env: process.env,
+      runtimeHandle: params.providerRuntimeHandle,
       context: {
         config: params.config,
         agentDir: params.agentDir,

--- a/src/agents/pi-embedded-runner/run/auth-selection.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-selection.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderRuntimePluginHandle } from "../../../plugins/provider-hook-runtime.js";
+import { resolveProviderAuthProfileId } from "../../../plugins/provider-runtime.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import { resolveAuthProfileOrder } from "../../model-auth.js";
+import { prepareEmbeddedRunAuthSelection } from "./auth-selection.js";
+
+const modelAuthMocks = vi.hoisted(() => ({
+  resolveAuthProfileOrder: vi.fn(),
+}));
+
+vi.mock("../../model-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../model-auth.js")>();
+  return {
+    ...actual,
+    resolveAuthProfileOrder: modelAuthMocks.resolveAuthProfileOrder,
+  };
+});
+
+vi.mock("../../../plugins/provider-runtime.js", () => ({
+  resolveProviderAuthProfileId: vi.fn(),
+}));
+
+const demoAuthStore: AuthProfileStore = {
+  version: 1,
+  profiles: {
+    "demo:a": { type: "api_key", provider: "demo", key: "a" },
+    "demo:b": { type: "api_key", provider: "demo", key: "b" },
+  },
+};
+
+function selectAuth(
+  overrides: Partial<Parameters<typeof prepareEmbeddedRunAuthSelection>[0]> = {},
+) {
+  return prepareEmbeddedRunAuthSelection({
+    agentDir: "/tmp/agent",
+    workspaceDir: "/tmp/workspace",
+    provider: "demo",
+    modelId: "demo-model",
+    authStore: demoAuthStore,
+    harnessId: "pi",
+    pluginHarnessOwnsTransport: false,
+    ...overrides,
+  });
+}
+
+describe("prepareEmbeddedRunAuthSelection", () => {
+  beforeEach(() => {
+    vi.mocked(resolveProviderAuthProfileId).mockReset();
+    vi.mocked(resolveAuthProfileOrder).mockReset();
+  });
+
+  it("reuses the resolved provider runtime handle for provider auth profile hooks", () => {
+    const runtimeHandle = {
+      provider: "demo",
+      plugin: {
+        id: "demo",
+        label: "Demo",
+        auth: [],
+      },
+    } as ProviderRuntimePluginHandle;
+    vi.mocked(resolveAuthProfileOrder).mockReturnValue(["demo:a", "demo:b"]);
+    vi.mocked(resolveProviderAuthProfileId).mockReturnValue("demo:b");
+
+    const selection = selectAuth({
+      providerRuntimeHandle: runtimeHandle,
+    });
+
+    expect(resolveProviderAuthProfileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "demo",
+        runtimeHandle,
+      }),
+    );
+    expect(selection.profileCandidates).toEqual(["demo:b", "demo:a"]);
+  });
+
+  it("reuses prepared auth profile order instead of resolving it again", () => {
+    vi.mocked(resolveAuthProfileOrder).mockReturnValue(["demo:a"]);
+
+    const selection = selectAuth({
+      authProfileOrder: ["demo:b", "demo:a"],
+    });
+
+    expect(resolveAuthProfileOrder).not.toHaveBeenCalled();
+    expect(selection.profileCandidates).toEqual(["demo:b", "demo:a"]);
+    expect(resolveProviderAuthProfileId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          profileOrder: ["demo:b", "demo:a"],
+        }),
+      }),
+    );
+  });
+
+  it("keeps the requested prepared auth profile first", () => {
+    const selection = selectAuth({
+      authProfileId: "demo:a",
+      authProfileOrder: ["demo:b", "demo:a"],
+    });
+
+    expect(resolveAuthProfileOrder).not.toHaveBeenCalled();
+    expect(selection.profileCandidates).toEqual(["demo:a", "demo:b"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/auth-selection.ts
+++ b/src/agents/pi-embedded-runner/run/auth-selection.ts
@@ -1,0 +1,186 @@
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../../../plugins/provider-hook-runtime.js";
+import { resolveProviderAuthProfileId } from "../../../plugins/provider-runtime.js";
+import {
+  type AuthProfileStore,
+  preferAuthProfileFirst,
+  resolveAuthProfileEligibility,
+} from "../../auth-profiles.js";
+import { externalCliDiscoveryForProviderAuth } from "../../auth-profiles/external-cli-discovery.js";
+import {
+  ensureAuthProfileStore,
+  resolveAuthProfileOrder,
+  shouldPreferExplicitConfigApiKeyAuth,
+} from "../../model-auth.js";
+import { resolveProviderIdForAuth } from "../../provider-auth-aliases.js";
+import { buildAgentRuntimeAuthPlan } from "../../runtime-plan/auth.js";
+
+export function prepareEmbeddedRunAuthSelection(params: {
+  config?: OpenClawConfig;
+  agentDir: string;
+  workspaceDir: string;
+  provider: string;
+  modelId: string;
+  authProfileId?: string;
+  authProfileIdSource?: "auto" | "user";
+  authProfileOrder?: readonly string[];
+  authStore?: AuthProfileStore;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
+  harnessId: string;
+  pluginHarnessOwnsTransport: boolean;
+}): {
+  authStore: AuthProfileStore;
+  lockedProfileId?: string;
+  preferredProfileId?: string;
+  forwardedPluginHarnessProfileId?: string;
+  profileCandidates: Array<string | undefined>;
+} {
+  const authStore: AuthProfileStore = params.pluginHarnessOwnsTransport
+    ? { version: 1, profiles: {} }
+    : (params.authStore ??
+      ensureAuthProfileStore(params.agentDir, {
+        externalCli: externalCliDiscoveryForProviderAuth({
+          cfg: params.config,
+          provider: params.provider,
+          preferredProfile: params.authProfileId,
+        }),
+      }));
+  const requestedProfileId = params.authProfileId?.trim();
+  const buildPluginHarnessAuthPlan = (profileId?: string) =>
+    buildAgentRuntimeAuthPlan({
+      provider: params.provider,
+      ...(profileId
+        ? {
+            authProfileProvider: profileId.split(":", 1)[0],
+            sessionAuthProfileId: profileId,
+          }
+        : {}),
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      harnessId: params.harnessId,
+      harnessRuntime: params.harnessId,
+      allowHarnessAuthProfileForwarding: true,
+    });
+  const resolvePluginHarnessPreferredProfileId = (): string | undefined => {
+    if (requestedProfileId || !params.pluginHarnessOwnsTransport) {
+      return requestedProfileId;
+    }
+    const runtimeAuthPlan = buildPluginHarnessAuthPlan();
+    const harnessAuthProvider = runtimeAuthPlan.harnessAuthProvider;
+    if (!harnessAuthProvider) {
+      return undefined;
+    }
+    const harnessAuthStore = ensureAuthProfileStore(params.agentDir, {
+      allowKeychainPrompt: false,
+    });
+    return resolveAuthProfileOrder({
+      cfg: params.config,
+      store: harnessAuthStore,
+      provider: harnessAuthProvider,
+    })[0]?.trim();
+  };
+  const preferredProfileId = params.pluginHarnessOwnsTransport
+    ? resolvePluginHarnessPreferredProfileId()
+    : requestedProfileId;
+  let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+  const canForwardPluginHarnessAuthProfile = (
+    profileId: string | undefined,
+  ): profileId is string => {
+    if (!params.pluginHarnessOwnsTransport || !profileId) {
+      return false;
+    }
+    const runtimeAuthPlan = buildPluginHarnessAuthPlan(profileId);
+    return runtimeAuthPlan.forwardedAuthProfileId === profileId;
+  };
+  if (lockedProfileId) {
+    if (params.pluginHarnessOwnsTransport) {
+      if (!canForwardPluginHarnessAuthProfile(lockedProfileId)) {
+        lockedProfileId = undefined;
+      }
+    } else {
+      const lockedProfile = authStore.profiles[lockedProfileId];
+      const lockedProfileProvider = lockedProfile
+        ? resolveProviderIdForAuth(lockedProfile.provider, {
+            config: params.config,
+            workspaceDir: params.workspaceDir,
+          })
+        : undefined;
+      const runProvider = resolveProviderIdForAuth(params.provider, {
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+      });
+      if (!lockedProfile || !lockedProfileProvider || lockedProfileProvider !== runProvider) {
+        lockedProfileId = undefined;
+      }
+    }
+  }
+  const forwardedPluginHarnessProfileId =
+    params.pluginHarnessOwnsTransport &&
+    !lockedProfileId &&
+    canForwardPluginHarnessAuthProfile(preferredProfileId)
+      ? preferredProfileId
+      : undefined;
+  if (lockedProfileId && !params.pluginHarnessOwnsTransport) {
+    const eligibility = resolveAuthProfileEligibility({
+      cfg: params.config,
+      store: authStore,
+      provider: params.provider,
+      profileId: lockedProfileId,
+    });
+    if (!eligibility.eligible) {
+      throw new Error(
+        `Auth profile "${lockedProfileId}" is not configured for ${params.provider}.`,
+      );
+    }
+  }
+  const profileOrder = (() => {
+    if (shouldPreferExplicitConfigApiKeyAuth(params.config, params.provider)) {
+      return [];
+    }
+    const preparedOrder = params.pluginHarnessOwnsTransport
+      ? undefined
+      : params.authProfileOrder?.filter((profileId) => Boolean(profileId.trim()));
+    if (preparedOrder) {
+      return preferAuthProfileFirst(preferredProfileId, preparedOrder);
+    }
+    return resolveAuthProfileOrder({
+      cfg: params.config,
+      store: authStore,
+      provider: params.provider,
+      preferredProfile: preferredProfileId,
+    });
+  })();
+  const providerPreferredProfileId = lockedProfileId
+    ? undefined
+    : resolveProviderAuthProfileId({
+        provider: params.provider,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        runtimeHandle: params.providerRuntimeHandle,
+        context: {
+          config: params.config,
+          agentDir: params.agentDir,
+          workspaceDir: params.workspaceDir,
+          provider: params.provider,
+          modelId: params.modelId,
+          preferredProfileId,
+          lockedProfileId,
+          profileOrder,
+          authStore,
+        },
+      });
+  const providerOrderedProfiles = preferAuthProfileFirst(providerPreferredProfileId, profileOrder);
+  const profileCandidates = lockedProfileId
+    ? [lockedProfileId]
+    : providerOrderedProfiles.length > 0
+      ? providerOrderedProfiles
+      : [undefined];
+
+  return {
+    authStore,
+    lockedProfileId,
+    preferredProfileId,
+    forwardedPluginHarnessProfileId,
+    profileCandidates,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { CommandQueueEnqueueFn } from "../../../process/command-queue.types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.exec-types.js";
 import type { AgentStreamParams, ClientToolDefinition } from "../../command/shared-types.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
@@ -125,6 +126,8 @@ export type RunEmbeddedPiAgentParams = {
   agentHarnessId?: string;
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
+  authProfileOrder?: string[];
+  authProfileStore?: AuthProfileStore;
   thinkLevel?: ThinkLevel;
   fastMode?: boolean;
   verboseLevel?: VerboseLevel;
@@ -179,6 +182,7 @@ export type RunEmbeddedPiAgentParams = {
   streamParams?: AgentStreamParams;
   ownerNumbers?: string[];
   enforceFinalTag?: boolean;
+  skipProviderRuntimeHints?: boolean;
   silentExpected?: boolean;
   /**
    * Treat a clean empty assistant stop as an intentional silent reply.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -39,7 +39,7 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   /** Session-pinned embedded harness id. Prevents runtime hot-switching. */
   agentHarnessId?: string;
   /** OpenClaw-owned runtime policy prepared by the orchestrator for this attempt. */
-  runtimePlan?: AgentRuntimePlan;
+  runtimePlan: AgentRuntimePlan;
   model: Model<Api>;
   authStorage: AuthStorage;
   /** Auth profile store already resolved during startup for this attempt. */

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -18,7 +18,7 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     loadWorkspaceSkillEntriesSpy.mockReturnValue([]);
   });
 
-  it("loads skill entries with config when no resolved snapshot skills exist", () => {
+  it("loads skill entries with config when no prepared snapshot exists", () => {
     const config: OpenClawConfig = {
       plugins: {
         entries: {
@@ -30,10 +30,6 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     const result = resolveEmbeddedRunSkillEntries({
       workspaceDir: "/tmp/workspace",
       config,
-      skillsSnapshot: {
-        prompt: "skills prompt",
-        skills: [],
-      },
     });
 
     expect(result.shouldLoadSkillEntries).toBe(true);
@@ -46,10 +42,6 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       workspaceDir: "/tmp/workspace",
       config: {},
       agentId: "writer",
-      skillsSnapshot: {
-        prompt: "skills prompt",
-        skills: [],
-      },
     });
 
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/tmp/workspace", {
@@ -86,10 +78,6 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     resolveEmbeddedRunSkillEntries({
       workspaceDir: "/tmp/workspace",
       config: sourceConfig,
-      skillsSnapshot: {
-        prompt: "skills prompt",
-        skills: [],
-      },
     });
 
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/tmp/workspace", {
@@ -126,15 +114,28 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     resolveEmbeddedRunSkillEntries({
       workspaceDir: "/tmp/workspace",
       config: callerConfig,
-      skillsSnapshot: {
-        prompt: "skills prompt",
-        skills: [],
-      },
     });
 
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/tmp/workspace", {
       config: callerConfig,
     });
+  });
+
+  it("skips skill entry loading when a prompt snapshot is present", () => {
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+      skillsSnapshot: {
+        prompt: "skills prompt",
+        skills: [{ name: "diffs" }],
+      },
+    });
+
+    expect(result).toEqual({
+      shouldLoadSkillEntries: false,
+      skillEntries: [],
+    });
+    expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
   });
 
   it("skips skill entry loading when resolved snapshot skills are present", () => {

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -11,7 +11,10 @@ export function resolveEmbeddedRunSkillEntries(params: {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
 } {
-  const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+  const hasPreparedSnapshot = Boolean(
+    params.skillsSnapshot?.resolvedSkills || params.skillsSnapshot?.prompt?.trim(),
+  );
+  const shouldLoadSkillEntries = !hasPreparedSnapshot;
   const config = resolveSkillRuntimeConfig(params.config);
   return {
     shouldLoadSkillEntries,

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
@@ -71,6 +72,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 }): StreamFn {
   if (params.providerStreamFn) {
     return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
@@ -105,7 +107,9 @@ export function resolveEmbeddedAgentStreamFn(params: {
   }
 
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
-    const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
+    const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model, {
+      providerRuntimeHandle: params.providerRuntimeHandle,
+    });
     if (boundaryAwareStreamFn) {
       // Boundary-aware transports read credentials from options.apiKey just
       // like provider-owned streams, but the embedded run layer never gets to

--- a/src/agents/pi-embedded-runner/tool-schema-runtime.ts
+++ b/src/agents/pi-embedded-runner/tool-schema-runtime.ts
@@ -1,6 +1,7 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   inspectProviderToolSchemasWithPlugin,
@@ -19,6 +20,7 @@ type ProviderToolSchemaParams<TSchemaType extends TSchema = TSchema, TResult = u
   modelId?: string;
   modelApi?: string | null;
   model?: ProviderRuntimeModel;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 };
 
 function buildProviderToolSchemaContext<TSchemaType extends TSchema = TSchema, TResult = unknown>(
@@ -51,6 +53,7 @@ export function normalizeProviderToolSchemas<
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    runtimeHandle: params.runtimeHandle,
     context: buildProviderToolSchemaContext(params, provider),
   });
   return Array.isArray(pluginNormalized)
@@ -68,6 +71,7 @@ export function logProviderToolSchemaDiagnostics(params: ProviderToolSchemaParam
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    runtimeHandle: params.runtimeHandle,
     context: buildProviderToolSchemaContext(params, provider),
   });
   if (!Array.isArray(diagnostics)) {

--- a/src/agents/pi-project-settings-snapshot.ts
+++ b/src/agents/pi-project-settings-snapshot.ts
@@ -10,6 +10,11 @@ import {
   normalizePluginsConfigWithResolver,
   resolveEffectivePluginActivationState,
 } from "../plugins/config-policy.js";
+import {
+  createPluginCacheKey,
+  resolveConfigScopedRuntimeCacheValue,
+  type ConfigScopedRuntimeCache,
+} from "../plugins/plugin-cache-primitives.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
@@ -18,6 +23,7 @@ const log = createSubsystemLogger("embedded-pi-settings");
 
 export const DEFAULT_EMBEDDED_PI_PROJECT_SETTINGS_POLICY = "sanitize";
 const SANITIZED_PROJECT_PI_KEYS = ["shellPath", "shellCommandPrefix"] as const;
+const bundlePiSettingsSnapshotCache: ConfigScopedRuntimeCache<PiSettingsSnapshot> = new WeakMap();
 
 export type EmbeddedPiProjectSettingsPolicy = "trusted" | "sanitize" | "ignore";
 
@@ -36,6 +42,10 @@ function sanitizePiSettingsSnapshot(settings: PiSettingsSnapshot): PiSettingsSna
 
 function sanitizeProjectSettings(settings: PiSettingsSnapshot): PiSettingsSnapshot {
   return sanitizePiSettingsSnapshot(settings);
+}
+
+function clonePiSettingsSnapshot(settings: PiSettingsSnapshot): PiSettingsSnapshot {
+  return structuredClone(settings) as PiSettingsSnapshot;
 }
 
 function loadBundleSettingsFile(params: {
@@ -68,7 +78,7 @@ function loadBundleSettingsFile(params: {
   }
 }
 
-export function loadEnabledBundlePiSettingsSnapshot(params: {
+function loadEnabledBundlePiSettingsSnapshotUncached(params: {
   cwd: string;
   cfg?: OpenClawConfig;
 }): PiSettingsSnapshot {
@@ -132,6 +142,36 @@ export function loadEnabledBundlePiSettingsSnapshot(params: {
   }
 
   return snapshot;
+}
+
+export function loadEnabledBundlePiSettingsSnapshot(params: {
+  cwd: string;
+  cfg?: OpenClawConfig;
+}): PiSettingsSnapshot {
+  const workspaceDir = params.cwd.trim();
+  if (!workspaceDir) {
+    return {};
+  }
+  const load = () =>
+    loadEnabledBundlePiSettingsSnapshotUncached({
+      cwd: workspaceDir,
+      cfg: params.cfg,
+    });
+  if (!params.cfg) {
+    return load();
+  }
+  const cached = resolveConfigScopedRuntimeCacheValue({
+    cache: bundlePiSettingsSnapshotCache,
+    config: params.cfg,
+    key: createPluginCacheKey([
+      "enabled-bundle-pi-settings",
+      workspaceDir,
+      params.cfg.plugins,
+      params.cfg.mcp,
+    ]),
+    load,
+  });
+  return clonePiSettingsSnapshot(cached);
 }
 
 export function resolveEmbeddedPiProjectSettingsPolicy(

--- a/src/agents/pi-project-settings.bundle.test.ts
+++ b/src/agents/pi-project-settings.bundle.test.ts
@@ -292,4 +292,44 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
 
     expect(snapshot).toEqual({});
   });
+
+  it("reuses bundle settings for the same config snapshot but reloads a new config snapshot", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workspace-");
+    const pluginRoot = await createWorkspaceBundle({ workspaceDir });
+    const settingsPath = path.join(pluginRoot, "settings.json");
+    const cfg = {
+      plugins: {
+        entries: {
+          "claude-bundle": { enabled: true },
+        },
+      },
+    };
+    await fs.writeFile(settingsPath, JSON.stringify({ hideThinkingBlock: true }), "utf-8");
+
+    const first = loadEnabledBundlePiSettingsSnapshot({
+      cwd: workspaceDir,
+      cfg,
+    });
+    await fs.writeFile(settingsPath, JSON.stringify({ hideThinkingBlock: false }), "utf-8");
+    first.hideThinkingBlock = false;
+
+    expect(
+      loadEnabledBundlePiSettingsSnapshot({
+        cwd: workspaceDir,
+        cfg,
+      }).hideThinkingBlock,
+    ).toBe(true);
+    expect(
+      loadEnabledBundlePiSettingsSnapshot({
+        cwd: workspaceDir,
+        cfg: {
+          plugins: {
+            entries: {
+              "claude-bundle": { enabled: true },
+            },
+          },
+        },
+      }).hideThinkingBlock,
+    ).toBe(false);
+  });
 });

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -7,41 +7,6 @@ import {
 } from "./pi-project-settings-snapshot.js";
 import { applyPiCompactionSettingsFromConfig } from "./pi-settings.js";
 
-function createEmbeddedPiSettingsManager(params: {
-  cwd: string;
-  agentDir: string;
-  cfg?: OpenClawConfig;
-}): SettingsManager {
-  const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
-  const policy = resolveEmbeddedPiProjectSettingsPolicy(params.cfg);
-  const pluginSettings = loadEnabledBundlePiSettingsSnapshot({
-    cwd: params.cwd,
-    cfg: params.cfg,
-  });
-  const hasPluginSettings = Object.keys(pluginSettings).length > 0;
-  if (policy === "trusted" && !hasPluginSettings) {
-    return fileSettingsManager;
-  }
-  const settings = buildEmbeddedPiSettingsSnapshot({
-    globalSettings: fileSettingsManager.getGlobalSettings(),
-    pluginSettings,
-    projectSettings: fileSettingsManager.getProjectSettings(),
-    policy,
-  });
-  return SettingsManager.inMemory(settings);
-}
-
-function createRuntimeEmbeddedPiSettingsManager(settingsManager: SettingsManager): SettingsManager {
-  return SettingsManager.inMemory(
-    buildEmbeddedPiSettingsSnapshot({
-      globalSettings: settingsManager.getGlobalSettings(),
-      pluginSettings: {},
-      projectSettings: settingsManager.getProjectSettings(),
-      policy: "trusted",
-    }),
-  );
-}
-
 export function createPreparedEmbeddedPiSettingsManager(params: {
   cwd: string;
   agentDir: string;
@@ -49,8 +14,17 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   /** Resolved context window budget so reserve-token floor can be capped for small models. */
   contextTokenBudget?: number;
 }): SettingsManager {
-  const settingsManager = createRuntimeEmbeddedPiSettingsManager(
-    createEmbeddedPiSettingsManager(params),
+  const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
+  const settingsManager = SettingsManager.inMemory(
+    buildEmbeddedPiSettingsSnapshot({
+      globalSettings: fileSettingsManager.getGlobalSettings(),
+      pluginSettings: loadEnabledBundlePiSettingsSnapshot({
+        cwd: params.cwd,
+        cfg: params.cfg,
+      }),
+      projectSettings: fileSettingsManager.getProjectSettings(),
+      policy: resolveEmbeddedPiProjectSettingsPolicy(params.cfg),
+    }),
   );
   applyPiCompactionSettingsFromConfig({
     settingsManager,

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -244,6 +244,35 @@ describe("createOpenClawCodingTools", () => {
     expect(stages.indexOf("schema-normalization")).toBeLessThan(stages.indexOf("tool-hooks"));
   });
 
+  it("skips extended tool surface materialization for local-only runtime toolsAllow", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    const tools = createOpenClawCodingTools({
+      config: testConfig,
+      runtimeToolAllowlist: ["exec", "read", "group:fs", "bash", "apply-patch"],
+    });
+
+    expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+    expect(tools.map((tool) => tool.name)).not.toEqual(expect.arrayContaining(["message"]));
+    expect(applyRuntimeToolsAllow(tools, ["exec", "read"]).map((tool) => tool.name)).toEqual([
+      "read",
+      "exec",
+    ]);
+  });
+
+  it("keeps extended tool planning for non-local runtime toolsAllow entries", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      config: testConfig,
+      runtimeToolAllowlist: ["group:runtime"],
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalled();
+  });
+
   it("preserves action enums in normalized schemas", () => {
     const defaultTools = createOpenClawCodingTools({ config: testConfig, senderIsOwner: true });
     const toolNames = ["canvas", "nodes", "cron", "gateway", "message"];
@@ -333,7 +362,6 @@ describe("createOpenClawCodingTools", () => {
     const oauthTools = createOpenClawCodingTools({
       config: testConfig,
       modelProvider: "anthropic",
-      modelAuthMode: "oauth",
     });
     const names = new Set(oauthTools.map((tool) => tool.name));
     expect(names.has("exec")).toBe(true);

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -23,7 +23,6 @@ import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
-import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
@@ -52,6 +51,7 @@ import {
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
+import type { PreparedOpenClawToolPlanning } from "./runtime-plan/types.js";
 import type { SandboxContext } from "./sandbox.js";
 import {
   isSubagentEnvelopeSession,
@@ -70,6 +70,7 @@ import {
   applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
   collectExplicitDenylist,
+  expandToolGroups,
   mergeAlsoAllowPolicy,
   normalizeToolName,
   resolveToolProfilePolicy,
@@ -82,6 +83,14 @@ function isOpenAIProvider(provider?: string) {
 }
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
+const LOCAL_CODING_TOOL_NAMES = new Set([
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+]);
 
 type BashToolsModule = typeof import("./bash-tools.js");
 
@@ -91,6 +100,21 @@ const bashToolsModuleLoader = createLazyImportLoader<BashToolsModule>(
 
 function loadBashToolsModule(): Promise<BashToolsModule> {
   return bashToolsModuleLoader.load();
+}
+
+function shouldPlanExtendedToolSurface(runtimeToolAllowlist?: readonly string[]): boolean {
+  if (!runtimeToolAllowlist || runtimeToolAllowlist.length === 0) {
+    return true;
+  }
+
+  return runtimeToolAllowlist.some((entry) => {
+    const normalized = normalizeToolName(entry);
+    if (!normalized) {
+      return false;
+    }
+    const expanded = expandToolGroups([normalized]);
+    return expanded.some((toolName) => !LOCAL_CODING_TOOL_NAMES.has(toolName));
+  });
 }
 
 function createLazyExecTool(defaults?: ExecToolDefaults): AnyAgentTool {
@@ -318,11 +342,6 @@ export function createOpenClawCodingTools(options?: {
   modelCompat?: ModelCompatConfig;
   /** If false, keep OpenClaw web_search even when a provider-native search tool is active. */
   suppressManagedWebSearch?: boolean;
-  /**
-   * Auth mode for the current provider. We only need this for Anthropic OAuth
-   * tool-name blocking quirks.
-   */
-  modelAuthMode?: ModelAuthMode;
   /** Current channel ID for auto-threading (Slack). */
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading (Slack). */
@@ -374,6 +393,8 @@ export function createOpenClawCodingTools(options?: {
   ownerOnlyToolAllowlist?: string[];
   /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
   authProfileStore?: AuthProfileStore;
+  /** Request-scoped plugin metadata prepared by the runtime plan. */
+  preparedToolPlanning?: PreparedOpenClawToolPlanning;
   /** Callback invoked when sessions_yield tool is called. */
   onYield?: (message: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
@@ -505,6 +526,19 @@ export function createOpenClawCodingTools(options?: {
   }
   const imageSanitization = resolveImageSanitizationLimits(options?.config);
   options?.recordToolPrepStage?.("workspace-policy");
+  const explicitToolAllowlist = collectExplicitAllowlist([
+    profilePolicyWithAlsoAllow,
+    providerProfilePolicyWithAlsoAllow,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    sandboxToolPolicy,
+    subagentPolicy,
+    options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
+  ]);
+  const planExtendedToolSurface = shouldPlanExtendedToolSurface(options?.runtimeToolAllowlist);
 
   const base = includeCoreTools
     ? (createCodingTools(workspaceRoot) as unknown as AnyAgentTool[]).flatMap((tool) => {
@@ -635,37 +669,59 @@ export function createOpenClawCodingTools(options?: {
     sandboxToolPolicy,
     subagentPolicy,
   ]);
+  const agentChannel = resolveGatewayMessageChannel(options?.messageProvider);
+  const openClawToolOptions = {
+    sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
+    allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
+    agentSessionKey: options?.sessionKey,
+    agentChannel,
+    agentAccountId: options?.agentAccountId,
+    agentTo: options?.messageTo,
+    agentThreadId: options?.messageThreadId,
+    agentGroupId: options?.groupId ?? null,
+    agentGroupChannel: options?.groupChannel ?? null,
+    agentGroupSpace: options?.groupSpace ?? null,
+    agentMemberRoleIds: options?.memberRoleIds,
+    agentDir: options?.agentDir,
+    sandboxRoot,
+    sandboxContainerWorkdir: sandbox?.containerWorkdir,
+    sandboxFsBridge,
+    fsPolicy,
+    workspaceDir: workspaceRoot,
+    spawnWorkspaceDir: options?.spawnWorkspaceDir
+      ? resolveWorkspaceRoot(options.spawnWorkspaceDir)
+      : undefined,
+    sandboxed: !!sandbox,
+    config: options?.config,
+    coreToolAllowlist: explicitToolAllowlist,
+    pluginToolAllowlist,
+    pluginToolDenylist,
+    currentChannelId: options?.currentChannelId,
+    currentThreadTs: options?.currentThreadTs,
+    currentMessageId: options?.currentMessageId,
+    modelProvider: options?.modelProvider,
+    modelId: options?.modelId,
+    replyToMode: options?.replyToMode,
+    hasRepliedRef: options?.hasRepliedRef,
+    modelHasVision: options?.modelHasVision,
+    requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
+    disableMessageTool: options?.disableMessageTool,
+    enableHeartbeatTool,
+    ...(cronSelfRemoveOnlyJobId ? { cronSelfRemoveOnlyJobId } : {}),
+    requesterAgentIdOverride: agentId,
+    requesterSenderId: options?.senderId,
+    authProfileStore: options?.authProfileStore,
+    preparedToolPlanning: options?.preparedToolPlanning,
+    senderIsOwner: options?.senderIsOwner,
+    sessionId: options?.sessionId,
+    onYield: options?.onYield,
+    allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
+    recordToolPrepStage: options?.recordToolPrepStage,
+  };
   const pluginToolsOnly = includeCoreTools
     ? []
     : resolveOpenClawPluginToolsForOptions({
-        options: {
-          agentSessionKey: options?.sessionKey,
-          agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
-          agentAccountId: options?.agentAccountId,
-          agentTo: options?.messageTo,
-          agentThreadId: options?.messageThreadId,
-          agentDir: options?.agentDir,
-          workspaceDir: workspaceRoot,
-          config: options?.config,
-          fsPolicy,
-          requesterSenderId: options?.senderId,
-          senderIsOwner: options?.senderIsOwner,
-          sessionId: options?.sessionId,
-          sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
-          allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
-          sandboxed: !!sandbox,
-          pluginToolAllowlist,
-          pluginToolDenylist,
-          currentChannelId: options?.currentChannelId,
-          currentThreadTs: options?.currentThreadTs,
-          currentMessageId: options?.currentMessageId,
-          modelProvider: options?.modelProvider,
-          modelHasVision: options?.modelHasVision,
-          requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
-          disableMessageTool: options?.disableMessageTool,
-          requesterAgentIdOverride: agentId,
-          allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
-        },
+        options: openClawToolOptions,
         resolvedConfig: options?.config,
       });
   const tools: AnyAgentTool[] = [
@@ -698,55 +754,13 @@ export function createOpenClawCodingTools(options?: {
     ...(execTool ? [execTool as unknown as AnyAgentTool] : []),
     ...(processTool ? [processTool as unknown as AnyAgentTool] : []),
     // Channel docking: include channel-defined agent tools (login, etc.).
-    ...(includeCoreTools ? listChannelAgentTools({ cfg: options?.config }) : []),
+    ...(includeCoreTools && planExtendedToolSurface
+      ? listChannelAgentTools({ cfg: options?.config })
+      : []),
     ...(includeCoreTools
-      ? createOpenClawTools({
-          sandboxBrowserBridgeUrl: sandbox?.browser?.bridgeUrl,
-          allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
-          agentSessionKey: options?.sessionKey,
-          runSessionKey: options?.runSessionKey,
-          agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
-          agentAccountId: options?.agentAccountId,
-          agentTo: options?.messageTo,
-          agentThreadId: options?.messageThreadId,
-          agentGroupId: options?.groupId ?? null,
-          agentGroupChannel: options?.groupChannel ?? null,
-          agentGroupSpace: options?.groupSpace ?? null,
-          agentMemberRoleIds: options?.memberRoleIds,
-          agentDir: options?.agentDir,
-          sandboxRoot,
-          sandboxContainerWorkdir: sandbox?.containerWorkdir,
-          sandboxFsBridge,
-          fsPolicy,
-          workspaceDir: workspaceRoot,
-          spawnWorkspaceDir: options?.spawnWorkspaceDir
-            ? resolveWorkspaceRoot(options.spawnWorkspaceDir)
-            : undefined,
-          sandboxed: !!sandbox,
-          config: options?.config,
-          pluginToolAllowlist,
-          pluginToolDenylist,
-          currentChannelId: options?.currentChannelId,
-          currentThreadTs: options?.currentThreadTs,
-          currentMessageId: options?.currentMessageId,
-          modelProvider: options?.modelProvider,
-          modelId: options?.modelId,
-          replyToMode: options?.replyToMode,
-          hasRepliedRef: options?.hasRepliedRef,
-          modelHasVision: options?.modelHasVision,
-          requireExplicitMessageTarget: options?.requireExplicitMessageTarget,
-          disableMessageTool: options?.disableMessageTool,
-          enableHeartbeatTool,
-          ...(cronSelfRemoveOnlyJobId ? { cronSelfRemoveOnlyJobId } : {}),
-          requesterAgentIdOverride: agentId,
-          requesterSenderId: options?.senderId,
-          authProfileStore: options?.authProfileStore,
-          senderIsOwner: options?.senderIsOwner,
-          sessionId: options?.sessionId,
-          onYield: options?.onYield,
-          allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
-          recordToolPrepStage: options?.recordToolPrepStage,
-        })
+      ? planExtendedToolSurface
+        ? createOpenClawTools(openClawToolOptions)
+        : []
       : pluginToolsOnly),
   ];
   options?.recordToolPrepStage?.("openclaw-tools");

--- a/src/agents/provider-model-normalization.runtime.ts
+++ b/src/agents/provider-model-normalization.runtime.ts
@@ -4,14 +4,20 @@ type ProviderRuntimeModule = Pick<
   typeof import("../plugins/provider-runtime.js"),
   "normalizeProviderModelIdWithPlugin"
 >;
+type PluginRuntimeStateModule = Pick<
+  typeof import("../plugins/runtime.js"),
+  "getActivePluginGatewayRuntimeRegistryVersion" | "getActivePluginRegistryVersion"
+>;
 
 const require = createRequire(import.meta.url);
 const PROVIDER_RUNTIME_CANDIDATES = [
   "../plugins/provider-runtime.js",
   "../plugins/provider-runtime.ts",
 ] as const;
+const PLUGIN_RUNTIME_STATE_CANDIDATES = ["../plugins/runtime.js", "../plugins/runtime.ts"] as const;
 
 let providerRuntimeModule: ProviderRuntimeModule | undefined;
+let pluginRuntimeStateModule: PluginRuntimeStateModule | undefined;
 
 function loadProviderRuntime(): ProviderRuntimeModule | null {
   if (providerRuntimeModule) {
@@ -26,6 +32,31 @@ function loadProviderRuntime(): ProviderRuntimeModule | null {
     }
   }
   return null;
+}
+
+function loadPluginRuntimeState(): PluginRuntimeStateModule | null {
+  if (pluginRuntimeStateModule) {
+    return pluginRuntimeStateModule;
+  }
+  for (const candidate of PLUGIN_RUNTIME_STATE_CANDIDATES) {
+    try {
+      pluginRuntimeStateModule = require(candidate) as PluginRuntimeStateModule;
+      return pluginRuntimeStateModule;
+    } catch {
+      // Try source/runtime candidates in order.
+    }
+  }
+  return null;
+}
+
+export function getProviderModelNormalizationRuntimeCacheKey(): string {
+  const runtime = loadPluginRuntimeState();
+  const gatewayVersion = runtime?.getActivePluginGatewayRuntimeRegistryVersion?.();
+  if (typeof gatewayVersion === "number") {
+    return `gateway:${gatewayVersion}`;
+  }
+  const activeVersion = runtime?.getActivePluginRegistryVersion?.();
+  return typeof activeVersion === "number" ? `active:${activeVersion}` : "none";
 }
 
 export function normalizeProviderModelIdWithRuntime(params: {

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,0 +1,85 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Model } from "@mariozechner/pi-ai";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
+
+const createTransportAwareStreamFnForModel = vi.fn();
+const ensureCustomApiRegistered = vi.fn();
+const resolveProviderStreamFn = vi.fn();
+
+vi.mock("./custom-api-registry.js", () => ({
+  ensureCustomApiRegistered,
+}));
+
+vi.mock("./provider-transport-stream.js", () => ({
+  createTransportAwareStreamFnForModel,
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderStreamFn,
+}));
+
+let registerProviderStreamForModel: typeof import("./provider-stream.js").registerProviderStreamForModel;
+
+function buildModel(): Model<"openai-responses"> {
+  return {
+    id: "demo-model",
+    name: "Demo Model",
+    api: "openai-responses",
+    provider: "demo",
+    baseUrl: "https://api.example.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+  };
+}
+
+describe("registerProviderStreamForModel", () => {
+  beforeAll(async () => {
+    ({ registerProviderStreamForModel } = await import("./provider-stream.js"));
+  });
+
+  beforeEach(() => {
+    createTransportAwareStreamFnForModel.mockReset();
+    ensureCustomApiRegistered.mockReset();
+    resolveProviderStreamFn.mockReset();
+  });
+
+  it("passes prepared provider runtime handles to stream hook resolution", () => {
+    const model = buildModel();
+    const streamFn = vi.fn() as unknown as StreamFn;
+    const providerRuntimeHandle = {
+      provider: "demo",
+      plugin: {
+        id: "demo",
+        label: "Demo",
+        auth: [],
+      },
+    } as ProviderRuntimePluginHandle;
+    resolveProviderStreamFn.mockReturnValue(streamFn);
+
+    expect(
+      registerProviderStreamForModel({
+        model,
+        providerRuntimeHandle,
+        workspaceDir: "/workspace",
+      }),
+    ).toBe(streamFn);
+
+    expect(resolveProviderStreamFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "demo",
+        workspaceDir: "/workspace",
+        runtimeHandle: providerRuntimeHandle,
+        context: expect.objectContaining({
+          provider: "demo",
+          modelId: "demo-model",
+          model,
+        }),
+      }),
+    );
+    expect(ensureCustomApiRegistered).toHaveBeenCalledWith("openai-responses", streamFn);
+  });
+});

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
@@ -11,6 +12,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 }): StreamFn | undefined {
   const streamFn =
     resolveProviderStreamFn({
@@ -18,6 +20,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      runtimeHandle: params.providerRuntimeHandle,
       context: {
         config: params.cfg,
         agentDir: params.agentDir,
@@ -32,6 +35,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      providerRuntimeHandle: params.providerRuntimeHandle,
     });
   if (!streamFn) {
     return undefined;

--- a/src/agents/provider-transport-stream.ts
+++ b/src/agents/provider-transport-stream.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
 import {
@@ -33,6 +34,7 @@ type ProviderTransportStreamContext = {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 };
 
 function createProviderOwnedGoogleTransportStreamFn(
@@ -45,6 +47,7 @@ function createProviderOwnedGoogleTransportStreamFn(
       config: ctx?.cfg,
       workspaceDir: ctx?.workspaceDir,
       env: ctx?.env,
+      runtimeHandle: ctx?.providerRuntimeHandle,
       context: {
         config: ctx?.cfg,
         agentDir: ctx?.agentDir,

--- a/src/agents/runtime-plan/build.test.ts
+++ b/src/agents/runtime-plan/build.test.ts
@@ -1,20 +1,74 @@
 import { createParameterFreeTool } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../../config/config.js";
+import { prepareProviderExtraParams } from "../../plugins/provider-hook-runtime.js";
 import { buildAgentRuntimePlan } from "./build.js";
+
+const manifestMocks = vi.hoisted(() => ({
+  loadManifestMetadataSnapshot: vi.fn(() => ({}) as never),
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: manifestMocks.loadManifestMetadataSnapshot,
+}));
 
 vi.mock("../../plugins/provider-hook-runtime.js", () => ({
   __testing: {},
+  ensureProviderRuntimePluginHandle: vi.fn(
+    (params) => params.runtimeHandle ?? { provider: "openai" },
+  ),
   prepareProviderExtraParams: vi.fn(() => undefined),
   resolveProviderAuthProfileId: vi.fn(() => undefined),
   resolveProviderExtraParamsForTransport: vi.fn(() => undefined),
   resolveProviderFollowupFallbackRoute: vi.fn(() => undefined),
-  resolveProviderHookPlugin: vi.fn(() => undefined),
   resolveProviderPluginsForHooks: vi.fn(() => []),
   resolveProviderRuntimePlugin: vi.fn(() => undefined),
+  resolveProviderRuntimePluginHandle: vi.fn(() => ({ provider: "openai" })),
   wrapProviderStreamFn: vi.fn(() => undefined),
 }));
 
+const gpt54Model = {
+  id: "gpt-5.4",
+  name: "GPT-5.4",
+  api: "openai-responses",
+  provider: "openai",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8_192,
+} as const;
+
 describe("AgentRuntimePlan", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+    manifestMocks.loadManifestMetadataSnapshot.mockClear();
+  });
+
+  it("defers default transport extra params until they are read", () => {
+    const prepareProviderExtraParamsMock = vi.mocked(prepareProviderExtraParams);
+    prepareProviderExtraParamsMock.mockClear();
+
+    const plan = buildAgentRuntimePlan({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
+      config: {},
+      workspaceDir: "/tmp/openclaw-runtime-plan",
+      model: gpt54Model,
+    });
+
+    expect(prepareProviderExtraParamsMock).not.toHaveBeenCalled();
+    expect(plan.transport.extraParams).toMatchObject({
+      parallel_tool_calls: true,
+      text_verbosity: "low",
+      openaiWsWarmup: false,
+    });
+    expect(prepareProviderExtraParamsMock).toHaveBeenCalledTimes(1);
+    void plan.transport.extraParams;
+    expect(prepareProviderExtraParamsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("records resolved model, auth, transport, tool, delivery, and observability policy", () => {
     const plan = buildAgentRuntimePlan({
       provider: "openai",
@@ -27,16 +81,8 @@ describe("AgentRuntimePlan", () => {
       config: {},
       workspaceDir: "/tmp/openclaw-runtime-plan",
       model: {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        api: "openai-responses",
-        provider: "openai",
+        ...gpt54Model,
         baseUrl: "https://api.openai.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200_000,
-        maxTokens: 8_192,
       },
     });
 
@@ -95,16 +141,8 @@ describe("AgentRuntimePlan", () => {
       config: {},
       workspaceDir: "/tmp/openclaw-runtime-plan",
       model: {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        api: "openai-responses",
-        provider: "openai",
+        ...gpt54Model,
         baseUrl: "https://api.openai.com/v1",
-        reasoning: true,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200_000,
-        maxTokens: 8_192,
       },
     });
 
@@ -113,5 +151,31 @@ describe("AgentRuntimePlan", () => {
     expect(normalized).toHaveLength(1);
     expect(normalized[0]?.name).toBe("ping");
     expect(normalized[0]?.parameters).toBeTypeOf("object");
+  });
+
+  it("plans tool metadata against the runtime source snapshot lazily", () => {
+    const sourceConfig = { channels: { telegram: { botToken: "token" } } };
+    const runtimeConfig = {
+      ...sourceConfig,
+      plugins: { allow: ["telegram"] },
+    };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const plan = buildAgentRuntimePlan({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      config: runtimeConfig,
+      workspaceDir: "/tmp/openclaw-runtime-plan",
+    });
+
+    expect(manifestMocks.loadManifestMetadataSnapshot).not.toHaveBeenCalled();
+
+    plan.tools.preparedPlanning?.loadMetadataSnapshot?.();
+
+    expect(manifestMocks.loadManifestMetadataSnapshot).toHaveBeenCalledWith({
+      config: sourceConfig,
+      workspaceDir: "/tmp/openclaw-runtime-plan",
+      env: process.env,
+    });
   });
 });

--- a/src/agents/runtime-plan/build.ts
+++ b/src/agents/runtime-plan/build.ts
@@ -3,11 +3,17 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import type { TSchema } from "typebox";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolveProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
   resolveProviderFollowupFallbackRoute,
   resolveProviderSystemPromptContribution,
+  resolveProviderTextTransforms,
+  transformProviderSystemPrompt,
 } from "../../plugins/provider-runtime.js";
 import { resolvePreparedExtraParams } from "../pi-embedded-runner/extra-params.js";
 import { classifyEmbeddedPiRunResultForModelFallback } from "../pi-embedded-runner/result-fallback-classifier.js";
@@ -53,6 +59,7 @@ export function buildAgentRuntimeDeliveryPlan(
   params: BuildAgentRuntimeDeliveryPlanParams,
 ): AgentRuntimeDeliveryPlan {
   const config = asOpenClawConfig(params.config);
+  const providerRuntimeHandle = params.providerRuntimeHandle;
   return {
     isSilentPayload(payload): boolean {
       return isSilentReplyPayloadText(payload.text, SILENT_REPLY_TOKEN) && !hasMedia(payload);
@@ -62,6 +69,7 @@ export function buildAgentRuntimeDeliveryPlan(
         provider: params.provider,
         config,
         workspaceDir: params.workspaceDir,
+        runtimeHandle: providerRuntimeHandle,
         context: {
           config,
           agentDir: params.agentDir,
@@ -90,6 +98,24 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
   const model = asProviderRuntimeModel(params.model);
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
   const transport = params.resolvedTransport;
+  const toolPlanningConfig = config ? projectConfigOntoRuntimeSourceSnapshot(config) : undefined;
+  let toolPlanningMetadataSnapshot: PluginMetadataSnapshot | undefined;
+  const loadToolPlanningMetadataSnapshot = () => {
+    toolPlanningMetadataSnapshot ??= loadManifestMetadataSnapshot({
+      config: toolPlanningConfig,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      env: process.env,
+    });
+    return toolPlanningMetadataSnapshot;
+  };
+  const providerRuntimeHandle =
+    params.providerRuntimeHandle ??
+    resolveProviderRuntimePluginHandle({
+      provider: params.provider,
+      config,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+    });
   const auth = buildAgentRuntimeAuthPlan({
     provider: params.provider,
     authProfileProvider: params.authProfileProvider,
@@ -112,6 +138,7 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
     config,
     workspaceDir: params.workspaceDir,
     env: process.env,
+    runtimeHandle: providerRuntimeHandle,
     modelId: params.modelId,
     modelApi,
     model,
@@ -137,6 +164,7 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
       config,
       workspaceDir: overrides?.workspaceDir ?? params.workspaceDir,
       env: process.env,
+      runtimeHandle: providerRuntimeHandle,
       modelApi: overrides?.modelApi ?? modelApi,
       model: asProviderRuntimeModel(overrides?.model) ?? model,
     });
@@ -154,19 +182,52 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
       agentId: overrides.agentId ?? params.agentId,
       model: asProviderRuntimeModel(overrides.model) ?? model,
       resolvedTransport: overrides.resolvedTransport ?? transport,
+      providerRuntimeHandle,
     });
+  let memoizedTranscriptPolicy: ReturnType<typeof resolveTranscriptRuntimePolicy> | undefined;
+  let memoizedTransportExtraParams: ReturnType<typeof resolveTransportExtraParams> | undefined;
+  const resolveDefaultTranscriptPolicy = () => {
+    memoizedTranscriptPolicy ??= resolveTranscriptRuntimePolicy();
+    return memoizedTranscriptPolicy;
+  };
+  const resolveDefaultTransportExtraParams = () => {
+    memoizedTransportExtraParams ??= resolveTransportExtraParams();
+    return memoizedTransportExtraParams;
+  };
+  const providerTextTransforms = resolveProviderTextTransforms({
+    provider: params.provider,
+    config,
+    workspaceDir: params.workspaceDir,
+    env: process.env,
+    runtimeHandle: providerRuntimeHandle,
+  });
 
   return {
     resolvedRef,
+    providerRuntimeHandle,
     auth,
     prompt: {
       provider: params.provider,
       modelId: params.modelId,
+      textTransforms: providerTextTransforms,
       resolveSystemPromptContribution(context) {
         return resolveProviderSystemPromptContribution({
           provider: params.provider,
           config,
           workspaceDir: context.workspaceDir ?? params.workspaceDir,
+          runtimeHandle: providerRuntimeHandle,
+          context: {
+            ...context,
+            config: asOpenClawConfig(context.config),
+          },
+        });
+      },
+      transformSystemPrompt(context) {
+        return transformProviderSystemPrompt({
+          provider: params.provider,
+          config,
+          workspaceDir: context.workspaceDir ?? params.workspaceDir,
+          runtimeHandle: providerRuntimeHandle,
           context: {
             ...context,
             config: asOpenClawConfig(context.config),
@@ -175,6 +236,9 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
       },
     },
     tools: {
+      preparedPlanning: {
+        loadMetadataSnapshot: loadToolPlanningMetadataSnapshot,
+      },
       normalize<TSchemaType extends TSchema = TSchema, TResult = unknown>(
         tools: AgentTool<TSchemaType, TResult>[],
         overrides?: {
@@ -203,13 +267,17 @@ export function buildAgentRuntimePlan(params: BuildAgentRuntimePlanParams): Agen
       },
     },
     transcript: {
-      policy: resolveTranscriptRuntimePolicy(),
+      get policy() {
+        return resolveDefaultTranscriptPolicy();
+      },
       resolvePolicy: resolveTranscriptRuntimePolicy,
     },
     delivery: buildAgentRuntimeDeliveryPlan(params),
     outcome: buildAgentRuntimeOutcomePlan(),
     transport: {
-      extraParams: resolveTransportExtraParams(),
+      get extraParams() {
+        return resolveDefaultTransportExtraParams();
+      },
       resolveExtraParams: resolveTransportExtraParams,
     },
     observability: {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -1,5 +1,8 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { TSchema } from "typebox";
+import type { PluginTextTransforms } from "../../plugins/cli-backend.types.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 
 export type AgentRuntimeTransport = "sse" | "websocket" | "auto";
 
@@ -251,12 +254,24 @@ export type AgentRuntimeAuthPlan = {
 export type AgentRuntimePromptPlan = {
   provider: string;
   modelId: string;
+  textTransforms?: PluginTextTransforms;
   resolveSystemPromptContribution(
     context: AgentRuntimeSystemPromptContributionContext,
   ): AgentRuntimeSystemPromptContribution | undefined;
+  transformSystemPrompt(
+    context: AgentRuntimeSystemPromptContributionContext & {
+      systemPrompt: string;
+    },
+  ): string;
+};
+
+export type PreparedOpenClawToolPlanning = {
+  metadataSnapshot?: PluginMetadataSnapshot;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
 };
 
 export type AgentRuntimeToolPlan = {
+  preparedPlanning?: PreparedOpenClawToolPlanning;
   normalize<TSchemaType extends TSchema = TSchema, TResult = unknown>(
     tools: AgentTool<TSchemaType, TResult>[],
     params?: {
@@ -306,6 +321,7 @@ export type AgentRuntimeTransportPlan = {
 
 export type AgentRuntimePlan = {
   resolvedRef: AgentRuntimeResolvedRef;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
   auth: AgentRuntimeAuthPlan;
   prompt: AgentRuntimePromptPlan;
   tools: AgentRuntimeToolPlan;
@@ -337,6 +353,7 @@ export type BuildAgentRuntimeDeliveryPlanParams = {
   agentDir?: string;
   provider: string;
   modelId: string;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 };
 
 export type BuildAgentRuntimePlanParams = {
@@ -356,4 +373,5 @@ export type BuildAgentRuntimePlanParams = {
   thinkingLevel?: AgentRuntimeThinkLevel;
   extraParamsOverride?: Record<string, unknown>;
   resolvedTransport?: AgentRuntimeTransport;
+  providerRuntimeHandle?: ProviderRuntimePluginHandle;
 };

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -2,14 +2,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   getCurrentPluginMetadataSnapshot: vi.fn(),
+  resolveGatewayStartupPluginIds: vi.fn(),
   ensureStandaloneRuntimePluginRegistryLoaded: vi.fn(),
   getActivePluginRuntimeSubagentMode: vi.fn<() => "default" | "explicit" | "gateway-bindable">(
     () => "default",
   ),
+  getActivePluginGatewayRuntimeRegistry: vi.fn<() => unknown | null>(() => null),
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir: vi.fn<() => string | undefined>(
+    () => undefined,
+  ),
+  getActivePluginGatewayRuntimeSubagentMode: vi.fn<
+    () => "default" | "explicit" | "gateway-bindable"
+  >(() => "default"),
 }));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../plugins/gateway-startup-plugin-ids.js", () => ({
+  resolveGatewayStartupPluginIds: hoisted.resolveGatewayStartupPluginIds,
 }));
 
 vi.mock("../plugins/runtime/standalone-runtime-registry-loader.js", () => ({
@@ -18,6 +30,10 @@ vi.mock("../plugins/runtime/standalone-runtime-registry-loader.js", () => ({
 
 vi.mock("../plugins/runtime.js", () => ({
   getActivePluginRuntimeSubagentMode: hoisted.getActivePluginRuntimeSubagentMode,
+  getActivePluginGatewayRuntimeRegistry: hoisted.getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir:
+    hoisted.getActivePluginGatewayRuntimeRegistryWorkspaceDir,
+  getActivePluginGatewayRuntimeSubagentMode: hoisted.getActivePluginGatewayRuntimeSubagentMode,
 }));
 
 describe("ensureRuntimePluginsLoaded", () => {
@@ -26,10 +42,18 @@ describe("ensureRuntimePluginsLoaded", () => {
   beforeEach(async () => {
     hoisted.getCurrentPluginMetadataSnapshot.mockReset();
     hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(undefined);
+    hoisted.resolveGatewayStartupPluginIds.mockReset();
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue([]);
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReset();
     hoisted.ensureStandaloneRuntimePluginRegistryLoaded.mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset();
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("default");
+    hoisted.getActivePluginGatewayRuntimeRegistry.mockReset();
+    hoisted.getActivePluginGatewayRuntimeRegistry.mockReturnValue(null);
+    hoisted.getActivePluginGatewayRuntimeRegistryWorkspaceDir.mockReset();
+    hoisted.getActivePluginGatewayRuntimeRegistryWorkspaceDir.mockReturnValue(undefined);
+    hoisted.getActivePluginGatewayRuntimeSubagentMode.mockReset();
+    hoisted.getActivePluginGatewayRuntimeSubagentMode.mockReturnValue("default");
     vi.resetModules();
     ({ ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js"));
   });
@@ -46,18 +70,27 @@ describe("ensureRuntimePluginsLoaded", () => {
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves runtime plugins through the shared runtime helper", async () => {
+  it("falls back to the gateway startup plan when no prepared snapshot is pinned", async () => {
+    const config = {} as never;
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["whatsapp", "openai"]);
+
     ensureRuntimePluginsLoaded({
-      config: {} as never,
+      config,
       workspaceDir: "/tmp/workspace",
       allowGatewaySubagentBinding: true,
     });
 
+    expect(hoisted.resolveGatewayStartupPluginIds).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["whatsapp", "openai"],
       loadOptions: {
-        config: {} as never,
+        config,
         workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["whatsapp", "openai"],
         runtimeOptions: {
           allowGatewaySubagentBinding: true,
         },
@@ -160,16 +193,19 @@ describe("ensureRuntimePluginsLoaded", () => {
   });
 
   it("does not enable gateway subagent binding for normal runtime loads", async () => {
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["telegram"]);
+
     ensureRuntimePluginsLoaded({
       config: {} as never,
       workspaceDir: "/tmp/workspace",
     });
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["telegram"],
       loadOptions: {
         config: {} as never,
         workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["telegram"],
         runtimeOptions: undefined,
       },
     });
@@ -177,6 +213,7 @@ describe("ensureRuntimePluginsLoaded", () => {
 
   it("inherits gateway-bindable mode from an active gateway registry", async () => {
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["telegram"]);
 
     ensureRuntimePluginsLoaded({
       config: {} as never,
@@ -184,9 +221,49 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
 
     expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
-      requiredPluginIds: undefined,
+      requiredPluginIds: ["telegram"],
       loadOptions: {
         config: {} as never,
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["telegram"],
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      },
+    });
+  });
+
+  it("reuses the prepared gateway runtime for gateway-bindable reply attempts", async () => {
+    hoisted.getActivePluginGatewayRuntimeRegistry.mockReturnValue({ plugins: [] });
+    hoisted.getActivePluginGatewayRuntimeRegistryWorkspaceDir.mockReturnValue("/tmp/workspace");
+    hoisted.getActivePluginGatewayRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+      allowGatewaySubagentBinding: true,
+    });
+
+    expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).not.toHaveBeenCalled();
+  });
+
+  it("loads plugins when the prepared gateway runtime belongs to another workspace", async () => {
+    hoisted.getActivePluginGatewayRuntimeRegistry.mockReturnValue({ plugins: [] });
+    hoisted.getActivePluginGatewayRuntimeRegistryWorkspaceDir.mockReturnValue("/tmp/other");
+    hoisted.getActivePluginGatewayRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.resolveGatewayStartupPluginIds.mockReturnValue(["telegram"]);
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+      allowGatewaySubagentBinding: true,
+    });
+
+    expect(hoisted.ensureStandaloneRuntimePluginRegistryLoaded).toHaveBeenCalledWith({
+      requiredPluginIds: ["telegram"],
+      loadOptions: {
+        config: {} as never,
+        onlyPluginIds: ["telegram"],
         workspaceDir: "/tmp/workspace",
         runtimeOptions: {
           allowGatewaySubagentBinding: true,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,6 +1,12 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
-import { getActivePluginRuntimeSubagentMode } from "../plugins/runtime.js";
+import { resolveGatewayStartupPluginIds } from "../plugins/gateway-startup-plugin-ids.js";
+import {
+  getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir,
+  getActivePluginGatewayRuntimeSubagentMode,
+  getActivePluginRuntimeSubagentMode,
+} from "../plugins/runtime.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "../plugins/runtime/standalone-runtime-registry-loader.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -27,6 +33,43 @@ function resolveStartupPluginIdsFromCurrentSnapshot(params: {
   return pluginIds.filter((pluginId): pluginId is string => typeof pluginId === "string");
 }
 
+function resolveStartupPluginIds(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+}): string[] | undefined {
+  const snapshotPluginIds = resolveStartupPluginIdsFromCurrentSnapshot(params);
+  if (snapshotPluginIds !== undefined) {
+    return snapshotPluginIds;
+  }
+  if (!params.config) {
+    return undefined;
+  }
+  return resolveGatewayStartupPluginIds({
+    config: params.config,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    env: process.env,
+  });
+}
+
+function hasPreparedGatewayRuntime(params: {
+  workspaceDir?: string;
+  allowGatewaySubagentBinding: boolean;
+}): boolean {
+  if (!params.allowGatewaySubagentBinding) {
+    return false;
+  }
+  if (!getActivePluginGatewayRuntimeRegistry()) {
+    return false;
+  }
+  if (getActivePluginGatewayRuntimeSubagentMode() !== "gateway-bindable") {
+    return false;
+  }
+  const preparedWorkspaceDir = getActivePluginGatewayRuntimeRegistryWorkspaceDir();
+  return (
+    !params.workspaceDir || !preparedWorkspaceDir || preparedWorkspaceDir === params.workspaceDir
+  );
+}
+
 export function ensureRuntimePluginsLoaded(params: {
   config?: OpenClawConfig;
   workspaceDir?: string | null;
@@ -36,13 +79,21 @@ export function ensureRuntimePluginsLoaded(params: {
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)
       : undefined;
-  const startupPluginIds = resolveStartupPluginIdsFromCurrentSnapshot({
+  const startupPluginIds = resolveStartupPluginIds({
     config: params.config,
     workspaceDir,
   });
   const allowGatewaySubagentBinding =
     params.allowGatewaySubagentBinding === true ||
     getActivePluginRuntimeSubagentMode() === "gateway-bindable";
+  if (
+    hasPreparedGatewayRuntime({
+      workspaceDir,
+      allowGatewaySubagentBinding,
+    })
+  ) {
+    return;
+  }
   ensureStandaloneRuntimePluginRegistryLoaded({
     requiredPluginIds: startupPluginIds,
     loadOptions: {

--- a/src/agents/session-file-repair.test.ts
+++ b/src/agents/session-file-repair.test.ts
@@ -312,7 +312,7 @@ describe("repairSessionFileIfNeeded", () => {
     expect(after).toBe(original);
   });
 
-  it("preserves delivered trailing assistant messages in the session file", async () => {
+  it("trims trailing assistant messages from the session file", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
     const assistantEntry = {
@@ -329,15 +329,46 @@ describe("repairSessionFileIfNeeded", () => {
     const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantEntry)}\n`;
     await fs.writeFile(file, original, "utf-8");
 
-    const result = await repairSessionFileIfNeeded({ sessionFile: file });
+    const debug = vi.fn();
+    const result = await repairSessionFileIfNeeded({ sessionFile: file, debug });
 
-    expect(result.repaired).toBe(false);
+    expect(result.repaired).toBe(true);
+    expect(result.trimmedTrailingAssistantMessages).toBe(1);
+    expect(debug.mock.calls[0]?.[0]).toContain("trimmed 1 trailing assistant message(s)");
 
-    const after = await fs.readFile(file, "utf-8");
-    expect(after).toBe(original);
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedLines = repaired.trim().split("\n");
+    expect(repairedLines).toHaveLength(2);
   });
 
-  it("preserves multiple consecutive delivered trailing assistant messages", async () => {
+  it("preserves trailing assistant messages when strict turn repair is disabled", async () => {
+    const { file } = await createTempSessionPath();
+    const { header, message } = buildSessionHeaderAndMessage();
+    const assistantEntry = {
+      type: "message",
+      id: "msg-asst",
+      parentId: null,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "valid prior answer" }],
+        stopReason: "stop",
+      },
+    };
+    const original = `${JSON.stringify(header)}\n${JSON.stringify(message)}\n${JSON.stringify(assistantEntry)}\n`;
+    await fs.writeFile(file, original, "utf-8");
+
+    const result = await repairSessionFileIfNeeded({
+      sessionFile: file,
+      trimTrailingAssistantMessages: false,
+    });
+
+    expect(result.repaired).toBe(false);
+    expect(result.trimmedTrailingAssistantMessages ?? 0).toBe(0);
+    await expect(fs.readFile(file, "utf-8")).resolves.toBe(original);
+  });
+
+  it("trims multiple consecutive trailing assistant messages", async () => {
     const { file } = await createTempSessionPath();
     const { header, message } = buildSessionHeaderAndMessage();
     const assistantEntry1 = {
@@ -367,10 +398,12 @@ describe("repairSessionFileIfNeeded", () => {
 
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
 
-    expect(result.repaired).toBe(false);
+    expect(result.repaired).toBe(true);
+    expect(result.trimmedTrailingAssistantMessages).toBe(2);
 
-    const after = await fs.readFile(file, "utf-8");
-    expect(after).toBe(original);
+    const repaired = await fs.readFile(file, "utf-8");
+    const repairedLines = repaired.trim().split("\n");
+    expect(repairedLines).toHaveLength(2);
   });
 
   it("does not trim non-trailing assistant messages", async () => {
@@ -400,6 +433,7 @@ describe("repairSessionFileIfNeeded", () => {
     const result = await repairSessionFileIfNeeded({ sessionFile: file });
 
     expect(result.repaired).toBe(false);
+    expect(result.trimmedTrailingAssistantMessages ?? 0).toBe(0);
   });
 
   it("preserves trailing assistant messages that contain tool calls", async () => {

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -12,6 +12,7 @@ type RepairReport = {
   rewrittenAssistantMessages?: number;
   droppedBlankUserMessages?: number;
   rewrittenUserMessages?: number;
+  trimmedTrailingAssistantMessages?: number;
   backupPath?: string;
   reason?: string;
 };
@@ -135,11 +136,56 @@ function repairUserEntryWithBlankTextContent(entry: SessionMessageEntry): UserEn
   };
 }
 
+function isToolCallBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const type = (block as { type?: unknown }).type;
+  return type === "toolCall" || type === "toolUse" || type === "functionCall";
+}
+
+function isAssistantMessageEntry(entry: unknown): entry is SessionMessageEntry {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { type?: unknown; message?: unknown };
+  if (record.type !== "message" || !record.message || typeof record.message !== "object") {
+    return false;
+  }
+  const message = record.message as { role?: unknown; content?: unknown };
+  return message.role === "assistant";
+}
+
+function assistantEntryHasToolCall(entry: SessionMessageEntry): boolean {
+  const content = entry.message.content;
+  return Array.isArray(content) && content.some(isToolCallBlock);
+}
+
+function countTrimmableTrailingAssistantEntries(entries: unknown[]): number {
+  let count = 0;
+  for (let index = entries.length - 1; index > 0; index -= 1) {
+    const entry = entries[index];
+    if (!isAssistantMessageEntry(entry)) {
+      break;
+    }
+    if (assistantEntryHasToolCall(entry)) {
+      return 0;
+    }
+    count += 1;
+  }
+  const suffixStartIndex = entries.length - count;
+  if (count === 0 || suffixStartIndex <= 1) {
+    return 0;
+  }
+  return count;
+}
+
 function buildRepairSummaryParts(params: {
   droppedLines: number;
   rewrittenAssistantMessages: number;
   droppedBlankUserMessages: number;
   rewrittenUserMessages: number;
+  trimmedTrailingAssistantMessages: number;
 }): string {
   const parts: string[] = [];
   if (params.droppedLines > 0) {
@@ -154,12 +200,16 @@ function buildRepairSummaryParts(params: {
   if (params.rewrittenUserMessages > 0) {
     parts.push(`rewrote ${params.rewrittenUserMessages} user message(s)`);
   }
+  if (params.trimmedTrailingAssistantMessages > 0) {
+    parts.push(`trimmed ${params.trimmedTrailingAssistantMessages} trailing assistant message(s)`);
+  }
   return parts.length > 0 ? parts.join(", ") : "no changes";
 }
 
 export async function repairSessionFileIfNeeded(params: {
   sessionFile: string;
   debug?: (message: string) => void;
+  trimTrailingAssistantMessages?: boolean;
   warn?: (message: string) => void;
 }): Promise<RepairReport> {
   const sessionFile = params.sessionFile.trim();
@@ -233,11 +283,24 @@ export async function repairSessionFileIfNeeded(params: {
     return { repaired: false, droppedLines, reason: "invalid session header" };
   }
 
+  // Sessions ending on role=assistant cause Anthropic prefill 400s when
+  // thinking is enabled. The outbound path strips per-request, but leaving
+  // the file corrupted causes repeated reject cycles across restarts.
+  let trimmedTrailingAssistantMessages = 0;
+  if (params.trimTrailingAssistantMessages !== false) {
+    const trimCount = countTrimmableTrailingAssistantEntries(entries);
+    while (trimmedTrailingAssistantMessages < trimCount) {
+      entries.pop();
+      trimmedTrailingAssistantMessages += 1;
+    }
+  }
+
   if (
     droppedLines === 0 &&
     rewrittenAssistantMessages === 0 &&
     droppedBlankUserMessages === 0 &&
-    rewrittenUserMessages === 0
+    rewrittenUserMessages === 0 &&
+    trimmedTrailingAssistantMessages === 0
   ) {
     return { repaired: false, droppedLines: 0 };
   }
@@ -272,6 +335,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      trimmedTrailingAssistantMessages,
       reason: `repair failed: ${err instanceof Error ? err.message : "unknown error"}`,
     };
   }
@@ -282,6 +346,7 @@ export async function repairSessionFileIfNeeded(params: {
       rewrittenAssistantMessages,
       droppedBlankUserMessages,
       rewrittenUserMessages,
+      trimmedTrailingAssistantMessages,
     })} (${path.basename(sessionFile)})`,
   );
   return {
@@ -290,6 +355,7 @@ export async function repairSessionFileIfNeeded(params: {
     rewrittenAssistantMessages,
     droppedBlankUserMessages,
     rewrittenUserMessages,
+    trimmedTrailingAssistantMessages,
     backupPath,
   };
 }

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { withPathResolutionEnv } from "../test-utils/env.js";
 import { createFixtureSuite } from "../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
@@ -10,10 +10,22 @@ import {
   setMockSkillsHomeEnv,
   type SkillsHomeEnvSnapshot,
 } from "./skills/home-env.test-support.js";
-import { buildWorkspaceSkillSnapshot, buildWorkspaceSkillsPrompt } from "./skills/workspace.js";
+import {
+  bumpSkillsSnapshotVersion,
+  resetSkillsRefreshStateForTest,
+} from "./skills/refresh-state.js";
+import {
+  buildWorkspaceSkillSnapshot,
+  buildWorkspaceSkillsPrompt,
+  resetWorkspaceSkillDiscoveryCacheForTest,
+} from "./skills/workspace.js";
+
+const pluginSkillsMocks = vi.hoisted(() => ({
+  resolvePluginSkillDirs: vi.fn(() => []),
+}));
 
 vi.mock("./skills/plugin-skills.js", () => ({
-  resolvePluginSkillDirs: () => [],
+  resolvePluginSkillDirs: pluginSkillsMocks.resolvePluginSkillDirs,
 }));
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-snapshot-suite-");
@@ -59,6 +71,12 @@ afterAll(async () => {
     tempHome = null;
   }
   await fixtureSuite.cleanup();
+});
+
+afterEach(() => {
+  resetWorkspaceSkillDiscoveryCacheForTest();
+  resetSkillsRefreshStateForTest();
+  pluginSkillsMocks.resolvePluginSkillDirs.mockClear();
 });
 
 function withWorkspaceHome<T>(workspaceDir: string, cb: () => T): T {
@@ -173,6 +191,82 @@ describe("buildWorkspaceSkillSnapshot", () => {
     );
 
     expect(snapshot.prompt).toBe(prompt);
+  });
+
+  it("reuses discovery only for versioned skill snapshots", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha",
+    });
+
+    const first = buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "beta"),
+      name: "beta",
+      description: "Beta",
+    });
+    const sameVersion = buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+    const nextVersion = bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
+    const refreshed = buildSnapshot(workspaceDir, { snapshotVersion: nextVersion });
+
+    expectSnapshotNamesAndPrompt(first, { contains: ["alpha"], omits: ["beta"] });
+    expectSnapshotNamesAndPrompt(sameVersion, { contains: ["alpha"], omits: ["beta"] });
+    expectSnapshotNamesAndPrompt(refreshed, { contains: ["alpha", "beta"] });
+  });
+
+  it("reuses plugin skill directory discovery for versioned snapshots", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha",
+    });
+
+    buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+    buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+
+    const nextVersion = bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
+    buildSnapshot(workspaceDir, { snapshotVersion: nextVersion });
+
+    expect(pluginSkillsMocks.resolvePluginSkillDirs).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps resolved skills isolated when reusing versioned discovery", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha",
+    });
+
+    const first = buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+    first.resolvedSkills![0]!.description = "mutated";
+
+    const second = buildSnapshot(workspaceDir, { snapshotVersion: 1 });
+
+    expect(second.resolvedSkills![0]!.description).toBe("Alpha");
+  });
+
+  it("keeps unversioned skill snapshots fresh", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha",
+    });
+
+    const first = buildSnapshot(workspaceDir);
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "beta"),
+      name: "beta",
+      description: "Beta",
+    });
+    const fresh = buildSnapshot(workspaceDir);
+
+    expectSnapshotNamesAndPrompt(first, { contains: ["alpha"], omits: ["beta"] });
+    expectSnapshotNamesAndPrompt(fresh, { contains: ["alpha", "beta"] });
   });
 
   it("truncates the skills prompt when it exceeds the configured char budget", async () => {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -142,6 +142,20 @@ type LoadedSkillRecord = {
   frontmatter?: ParsedSkillFrontmatter;
 };
 
+type WorkspaceSkillEntriesCacheKey = {
+  key: string;
+  snapshotVersion: number;
+};
+
+type WorkspaceSkillEntriesCacheRecord = {
+  snapshotVersion: number;
+  entries: SkillEntry[];
+};
+
+const workspaceSkillEntriesCache = new Map<string, WorkspaceSkillEntriesCacheRecord>();
+let pluginSkillDirsCacheByConfig = new WeakMap<OpenClawConfig, Map<string, string[]>>();
+let pluginSkillDirsCacheWithoutConfig = new Map<string, string[]>();
+
 type CandidateSkillDir = {
   skillDir: string;
   name: string;
@@ -233,6 +247,121 @@ function resolveRawEntryScanLimit(maxCandidateDirs: number | undefined): number 
     DEFAULT_MAX_RAW_ENTRIES_PER_DIRECTORY_SCAN,
     Math.max(DEFAULT_MIN_RAW_ENTRIES_PER_DIRECTORY_SCAN, normalized * 10),
   );
+}
+
+function cloneSkillEntries(entries: SkillEntry[]): SkillEntry[] {
+  return structuredClone(entries);
+}
+
+function resolveWorkspaceSkillEntriesCacheKey(params: {
+  workspaceDir: string;
+  snapshotVersion?: number;
+  managedSkillsDir: string;
+  bundledSkillsDir?: string;
+  extraDirs: string[];
+  pluginSkillDirs: string[];
+  limits: ResolvedSkillsLimits;
+}): WorkspaceSkillEntriesCacheKey | undefined {
+  if (params.snapshotVersion === undefined) {
+    return undefined;
+  }
+  return {
+    snapshotVersion: params.snapshotVersion,
+    key: JSON.stringify({
+      workspaceDir: path.resolve(params.workspaceDir),
+      managedSkillsDir: path.resolve(params.managedSkillsDir),
+      bundledSkillsDir: params.bundledSkillsDir ? path.resolve(params.bundledSkillsDir) : "",
+      extraDirs: params.extraDirs.map((dir) => path.resolve(dir)),
+      pluginSkillDirs: params.pluginSkillDirs.map((dir) => path.resolve(dir)),
+      limits: {
+        maxCandidatesPerRoot: params.limits.maxCandidatesPerRoot,
+        maxSkillsLoadedPerSource: params.limits.maxSkillsLoadedPerSource,
+        maxSkillFileBytes: params.limits.maxSkillFileBytes,
+      },
+    }),
+  };
+}
+
+function readCachedWorkspaceSkillEntries(
+  cacheKey: WorkspaceSkillEntriesCacheKey | undefined,
+  opts?: { clone?: boolean },
+): SkillEntry[] | undefined {
+  if (!cacheKey) {
+    return undefined;
+  }
+  const cached = workspaceSkillEntriesCache.get(cacheKey.key);
+  if (!cached || cached.snapshotVersion !== cacheKey.snapshotVersion) {
+    return undefined;
+  }
+  return opts?.clone === false ? cached.entries : cloneSkillEntries(cached.entries);
+}
+
+function rememberWorkspaceSkillEntries(params: {
+  cacheKey: WorkspaceSkillEntriesCacheKey | undefined;
+  entries: SkillEntry[];
+}): SkillEntry[] {
+  if (!params.cacheKey) {
+    return params.entries;
+  }
+  workspaceSkillEntriesCache.set(params.cacheKey.key, {
+    snapshotVersion: params.cacheKey.snapshotVersion,
+    entries: cloneSkillEntries(params.entries),
+  });
+  return params.entries;
+}
+
+function resolvePluginSkillDirsCacheKey(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  snapshotVersion?: number;
+}): string | undefined {
+  if (params.snapshotVersion === undefined) {
+    return undefined;
+  }
+  return JSON.stringify({
+    workspaceDir: path.resolve(params.workspaceDir),
+    snapshotVersion: params.snapshotVersion,
+    plugins: params.config?.plugins ?? null,
+    acp: params.config?.acp ?? null,
+  });
+}
+
+function resolveVersionedPluginSkillDirs(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  snapshotVersion?: number;
+}): string[] {
+  const cacheKey = resolvePluginSkillDirsCacheKey(params);
+  if (!cacheKey) {
+    return resolvePluginSkillDirs({
+      workspaceDir: params.workspaceDir,
+      config: params.config,
+    });
+  }
+  const cache = params.config
+    ? (pluginSkillDirsCacheByConfig.get(params.config) ??
+      (() => {
+        const next = new Map<string, string[]>();
+        pluginSkillDirsCacheByConfig.set(params.config!, next);
+        return next;
+      })())
+    : pluginSkillDirsCacheWithoutConfig;
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached.slice();
+  }
+  const resolved = resolvePluginSkillDirs({
+    workspaceDir: params.workspaceDir,
+    config: params.config,
+  });
+  cache.set(cacheKey, resolved.slice());
+  return resolved;
+}
+
+export function resetWorkspaceSkillDiscoveryCacheForTest(): void {
+  workspaceSkillEntriesCache.clear();
+  pluginSkillDirsCacheByConfig = new WeakMap();
+  pluginSkillDirsCacheWithoutConfig = new Map();
 }
 
 function tryRealpath(filePath: string): string | null {
@@ -412,6 +541,8 @@ function loadSkillEntries(
     agentId?: string;
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
+    snapshotVersion?: number;
+    cloneCachedEntries?: boolean;
   },
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config, opts?.agentId);
@@ -632,12 +763,31 @@ function loadSkillEntries(
   const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
   const bundledSkillsDir = opts?.bundledSkillsDir ?? resolveBundledSkillsDir();
   const extraDirsRaw = opts?.config?.skills?.load?.extraDirs ?? [];
-  const extraDirs = extraDirsRaw.map((d) => normalizeOptionalString(d) ?? "").filter(Boolean);
-  const pluginSkillDirs = resolvePluginSkillDirs({
+  const extraDirs = extraDirsRaw
+    .map((d) => normalizeOptionalString(d) ?? "")
+    .filter(Boolean)
+    .map((dir) => resolveUserPath(dir));
+  const pluginSkillDirs = resolveVersionedPluginSkillDirs({
     workspaceDir,
     config: opts?.config,
+    snapshotVersion: opts?.snapshotVersion,
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
+  const cacheKey = resolveWorkspaceSkillEntriesCacheKey({
+    workspaceDir,
+    snapshotVersion: opts?.snapshotVersion,
+    managedSkillsDir,
+    bundledSkillsDir,
+    extraDirs,
+    pluginSkillDirs,
+    limits,
+  });
+  const cachedEntries = readCachedWorkspaceSkillEntries(cacheKey, {
+    clone: opts?.cloneCachedEntries !== false,
+  });
+  if (cachedEntries) {
+    return cachedEntries;
+  }
 
   const bundledSkills = bundledSkillsDir
     ? loadSkills({
@@ -646,9 +796,8 @@ function loadSkillEntries(
       })
     : [];
   const extraSkills = mergedExtraDirs.flatMap((dir) => {
-    const resolved = resolveUserPath(dir);
     return loadSkills({
-      dir: resolved,
+      dir,
       source: "openclaw-extra",
     });
   });
@@ -723,7 +872,7 @@ function loadSkillEntries(
         },
       };
     });
-  return skillEntries;
+  return rememberWorkspaceSkillEntries({ cacheKey, entries: skillEntries });
 }
 
 function escapeXml(str: string): string {
@@ -816,7 +965,7 @@ function applySkillsPromptLimits(params: {
 
 export function buildWorkspaceSkillSnapshot(
   workspaceDir: string,
-  opts?: WorkspaceSkillBuildOptions & { snapshotVersion?: number },
+  opts?: WorkspaceSkillBuildOptions,
 ): SkillSnapshot {
   const { eligible, prompt, resolvedSkills } = resolveWorkspaceSkillPromptState(workspaceDir, opts);
   const skillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
@@ -846,6 +995,7 @@ type WorkspaceSkillBuildOptions = {
   bundledSkillsDir?: string;
   entries?: SkillEntry[];
   agentId?: string;
+  snapshotVersion?: number;
   /** If provided, only include skills with these names */
   skillFilter?: string[];
   eligibility?: SkillEligibilityContext;
@@ -871,7 +1021,12 @@ function resolveWorkspaceSkillPromptState(
   prompt: string;
   resolvedSkills: Skill[];
 } {
-  const skillEntries = opts?.entries ?? loadSkillEntries(workspaceDir, opts);
+  const skillEntries =
+    opts?.entries ??
+    loadSkillEntries(workspaceDir, {
+      ...opts,
+      cloneCachedEntries: false,
+    });
   const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(opts);
   const eligible = filterSkillEntries(
     skillEntries,
@@ -881,7 +1036,7 @@ function resolveWorkspaceSkillPromptState(
   );
   const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
-  const resolvedSkills = promptEntries.map((entry) => entry.skill);
+  const resolvedSkills = promptEntries.map((entry) => cloneSkillForSnapshot(entry.skill));
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.
   // Budget checks and final render both use this same representation so the
   // tier decision is based on the exact strings that end up in the prompt.
@@ -907,6 +1062,13 @@ function resolveWorkspaceSkillPromptState(
     .filter(Boolean)
     .join("\n");
   return { eligible, prompt, resolvedSkills };
+}
+
+function cloneSkillForSnapshot(skill: Skill): Skill {
+  return {
+    ...skill,
+    sourceInfo: skill.sourceInfo ? { ...skill.sourceInfo } : skill.sourceInfo,
+  };
 }
 
 export function resolveSkillsPromptForRun(params: {
@@ -939,6 +1101,7 @@ export function loadWorkspaceSkillEntries(
     bundledSkillsDir?: string;
     skillFilter?: string[];
     agentId?: string;
+    snapshotVersion?: number;
     eligibility?: SkillEligibilityContext;
   },
 ): SkillEntry[] {

--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -2,7 +2,12 @@ import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
 
-function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
+export type ToolPolicyMatcher = (name: string) => boolean;
+
+export function createToolPolicyMatcher(policy?: SandboxToolPolicy): ToolPolicyMatcher {
+  if (!policy) {
+    return () => true;
+  }
   const deny = compileGlobPatterns({
     raw: expandToolGroups(policy.deny ?? []),
     normalize: normalizeToolName,
@@ -30,10 +35,7 @@ function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
 }
 
 export function isToolAllowedByPolicyName(name: string, policy?: SandboxToolPolicy): boolean {
-  if (!policy) {
-    return true;
-  }
-  return makeToolPolicyMatcher(policy)(name);
+  return createToolPolicyMatcher(policy)(name);
 }
 
 export function isToolAllowedByPolicies(

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -578,6 +578,7 @@ export function createImageGenerateTool(options?: {
   workspaceDir?: string;
   sandbox?: ImageGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
+  precomputedAvailability?: boolean;
 }): AnyAgentTool | null {
   const cfg = options?.config ?? getRuntimeConfig();
   if (
@@ -588,6 +589,7 @@ export function createImageGenerateTool(options?: {
       authStore: options?.authProfileStore,
       modelConfig: cfg.agents?.defaults?.imageGenerationModel,
       providerKey: "imageGenerationProviders",
+      precomputedAvailability: options?.precomputedAvailability,
     })
   ) {
     return null;

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -618,13 +618,27 @@ describe("image tool implicit imageModel config", () => {
     __testing.setProviderDepsForTest();
   });
 
-  it("stays disabled without auth when no pairing is possible", async () => {
+  it("defers unavailable image model reporting until execution", async () => {
     await withTempAgentDir(async (agentDir) => {
       const cfg: OpenClawConfig = {
         agents: { defaults: { model: { primary: "openai/gpt-5.4" } } },
       };
       expect(resolveImageModelConfigForTool({ cfg, agentDir })).toBeNull();
-      expect(createImageTool({ config: cfg, agentDir })).toBeNull();
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await expect(
+        tool.execute("t1", {
+          prompt: "Describe it.",
+          image: "missing.png",
+        }),
+      ).resolves.toMatchObject({
+        content: [
+          {
+            type: "text",
+            text: "Image analysis is unavailable because no image-capable model is configured with usable auth.",
+          },
+        ],
+        details: { error: "image_model_unavailable" },
+      });
     });
   });
 

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -107,6 +107,22 @@ function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requested
   return Math.min(requestedMaxTokens, modelMaxTokens);
 }
 
+function collectProviderIdsFromModelRefs(refs: Array<string | undefined>): string[] {
+  const providers = new Set<string>();
+  for (const ref of refs) {
+    const trimmed = ref?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const slash = trimmed.indexOf("/");
+    if (slash <= 0) {
+      continue;
+    }
+    providers.add(trimmed.slice(0, slash).trim().toLowerCase());
+  }
+  return [...providers].filter(Boolean);
+}
+
 /**
  * Resolve the effective image model config for the `image` tool.
  *
@@ -277,7 +293,14 @@ async function runImagePrompt(params: {
 }> {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.imageModelConfig);
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
-  const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
+  const providerIds = collectProviderIdsFromModelRefs([
+    params.modelOverride,
+    params.imageModelConfig.primary,
+    ...(params.imageModelConfig.fallbacks ?? []),
+  ]);
+  const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg, {
+    providerIds,
+  });
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
@@ -409,9 +432,6 @@ export function createImageTool(options?: {
         authStore: options?.authProfileStore,
       })
     : explicitImageModelConfig;
-  if (!resolvedImageModelConfig && !options?.deferAutoModelResolution) {
-    return null;
-  }
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   // If model has native vision, images in the prompt are auto-injected
@@ -489,6 +509,26 @@ export function createImageTool(options?: {
         record,
         DEFAULT_PROMPT,
       );
+      const imageModelConfig =
+        resolvedImageModelConfig ??
+        resolveImageModelConfigForTool({
+          cfg: options?.config,
+          agentDir,
+          workspaceDir: options?.workspaceDir,
+          authStore: options?.authProfileStore,
+        }) ??
+        (modelOverride?.trim() ? { primary: modelOverride.trim() } : null);
+      if (!imageModelConfig) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Image analysis is unavailable because no image-capable model is configured with usable auth.",
+            },
+          ],
+          details: { error: "image_model_unavailable" },
+        };
+      }
       const maxBytesMb = typeof record.maxBytesMb === "number" ? record.maxBytesMb : undefined;
       const maxBytes = pickMaxBytes(options?.config, maxBytesMb);
 
@@ -620,19 +660,6 @@ export function createImageTool(options?: {
       }
 
       // MARK: - Run image prompt with all loaded images
-      const imageModelConfig =
-        resolvedImageModelConfig ??
-        resolveImageModelConfigForTool({
-          cfg: options?.config,
-          agentDir,
-          workspaceDir: options?.workspaceDir,
-          authStore: options?.authProfileStore,
-        });
-      if (!imageModelConfig) {
-        throw new Error(
-          "No image model is configured. Set agents.defaults.imageModel or configure an image-capable provider.",
-        );
-      }
       const result = await runImagePrompt({
         cfg: options?.config,
         agentDir,

--- a/src/agents/tools/manifest-capability-availability.ts
+++ b/src/agents/tools/manifest-capability-availability.ts
@@ -1,9 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
-import {
-  isManifestPluginAvailableForControlPlane,
-  loadManifestContractSnapshot,
-} from "../../plugins/manifest-contract-eligibility.js";
+import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import {
   hasNonEmptyManifestEnvCandidate,
@@ -70,24 +67,6 @@ export function getCurrentCapabilityMetadataSnapshot(params: {
     config: params.config,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
-}
-
-export function loadCapabilityMetadataSnapshot(params: {
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): Pick<PluginMetadataSnapshot, "index" | "plugins"> {
-  return (
-    getCurrentPluginMetadataSnapshot({
-      config: params.config,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    }) ??
-    loadManifestContractSnapshot({
-      config: params.config,
-      env: params.env,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    })
-  );
 }
 
 export function hasSnapshotCapabilityAvailability(params: {

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -147,6 +147,19 @@ describe("hasGenerationToolAvailability", () => {
     expect(loadProviders).not.toHaveBeenCalled();
   });
 
+  it("uses precomputed availability without reloading providers", () => {
+    const loadProviders = vi.fn(() => []);
+
+    expect(
+      hasGenerationToolAvailability({
+        providerKey: "imageGenerationProviders",
+        providers: loadProviders,
+        precomputedAvailability: true,
+      }),
+    ).toBe(true);
+    expect(loadProviders).not.toHaveBeenCalled();
+  });
+
   it("checks configured runtime providers against the supplied auth store", () => {
     expect(
       hasGenerationToolAvailability({

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -314,7 +314,11 @@ export function hasGenerationToolAvailability(params: {
   modelConfig?: AgentModelConfig;
   providers?: CapabilityProvider[] | (() => CapabilityProvider[]);
   providerKey: GenerationCapabilityProviderKey;
+  precomputedAvailability?: boolean;
 }): boolean {
+  if (params.precomputedAvailability !== undefined) {
+    return params.precomputedAvailability;
+  }
   if (params.cfg?.plugins?.enabled === false) {
     return false;
   }

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -558,6 +558,7 @@ export function createMusicGenerateTool(options?: {
   sandbox?: MusicGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
   scheduleBackgroundWork?: MusicGenerateBackgroundScheduler;
+  precomputedAvailability?: boolean;
 }): AnyAgentTool | null {
   const cfg: OpenClawConfig = options?.config ?? getRuntimeConfig();
   if (
@@ -568,6 +569,7 @@ export function createMusicGenerateTool(options?: {
       authStore: options?.authProfileStore,
       modelConfig: cfg.agents?.defaults?.musicGenerationModel,
       providerKey: "musicGenerationProviders",
+      precomputedAvailability: options?.precomputedAvailability,
     })
   ) {
     return null;

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -6,9 +6,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as webMedia from "../../media/web-media.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import * as modelAuth from "../model-auth.js";
-import * as modelsConfig from "../models-config.js";
-import * as modelDiscovery from "../pi-model-discovery.js";
+import * as simpleCompletionRuntime from "../simple-completion-runtime.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 import * as pdfModelConfigModule from "./pdf-tool.model-config.js";
 import { resetPdfToolAuthEnv, withTempPdfAgentDir } from "./pdf-tool.test-support.js";
@@ -93,27 +91,22 @@ async function stubPdfToolInfra(
     loadSpy.mockResolvedValue(FAKE_PDF_MEDIA as never);
   }
 
-  vi.spyOn(modelDiscovery, "discoverAuthStorage").mockReturnValue({
-    setRuntimeApiKey: vi.fn(),
-  } as never);
-  const find =
+  vi.spyOn(simpleCompletionRuntime, "prepareSimpleCompletionModel").mockResolvedValue(
     params?.modelFound === false
-      ? () => null
-      : () =>
-          ({
+      ? ({ error: "Unknown model: test" } as never)
+      : ({
+          model: {
             provider: params?.provider ?? "anthropic",
+            id: params?.provider === "openai" ? "gpt-5.4-mini" : "claude-opus-4-6",
             maxTokens: 8192,
             input: params?.input ?? ["text", "document"],
-          }) as never;
-  vi.spyOn(modelDiscovery, "discoverModels").mockReturnValue({ find } as never);
-
-  vi.spyOn(modelsConfig, "ensureOpenClawModelsJson").mockResolvedValue({
-    agentDir,
-    wrote: false,
-  });
-
-  vi.spyOn(modelAuth, "getApiKeyForModel").mockResolvedValue({ apiKey: "test-key" } as never);
-  vi.spyOn(modelAuth, "requireApiKey").mockReturnValue("test-key");
+          },
+          auth: {
+            apiKey: "test-key",
+            mode: "api-key",
+          },
+        } as never),
+  );
 
   return { loadSpy };
 }

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -13,14 +13,13 @@ import {
 } from "../../shared/string-coerce.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { prepareSimpleCompletionModel } from "../simple-completion-runtime.js";
 import { ToolInputError } from "./common.js";
 import { coerceImageModelConfig, type ImageModelConfig } from "./image-tool.helpers.js";
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
-  resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
-  resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
   resolveRemoteMediaSsrfPolicy,
 } from "./media-tool-shared.js";
@@ -37,9 +36,6 @@ import {
 import { resolvePdfModelConfigForTool } from "./pdf-tool.model-config.js";
 import {
   createSandboxBridgeReadFile,
-  discoverAuthStorage,
-  discoverModels,
-  ensureOpenClawModelsJson,
   resolveSandboxedBridgeMediaPath,
   runWithImageModelFallback,
   type AnyAgentTool,
@@ -142,10 +138,6 @@ async function runPdfPrompt(params: {
 }> {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.pdfModelConfig);
 
-  await ensureOpenClawModelsJson(effectiveCfg, params.agentDir);
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir);
-
   let extractionCache: PdfExtractedContent[] | null = null;
   const getExtractions = async (): Promise<PdfExtractedContent[]> => {
     if (!extractionCache) {
@@ -158,13 +150,21 @@ async function runPdfPrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
-      const apiKey = await resolveModelRuntimeApiKey({
-        model,
+      const prepared = await prepareSimpleCompletionModel({
         cfg: effectiveCfg,
+        provider,
+        modelId,
         agentDir: params.agentDir,
-        authStorage,
+        skipPiDiscovery: true,
       });
+      if ("error" in prepared) {
+        throw new Error(prepared.error);
+      }
+      const { model } = prepared;
+      const apiKey = prepared.auth.apiKey?.trim();
+      if (!apiKey) {
+        throw new Error(`No API key resolved for provider "${model.provider}".`);
+      }
 
       if (providerSupportsNativePdf(provider)) {
         if (params.pageNumbers && params.pageNumbers.length > 0) {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -27,6 +27,7 @@ import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js"
 import type { BuildStatusTextParams } from "../../status/status-text.types.js";
 import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { formatTaskStatusDetail, formatTaskStatusTitle } from "../../tasks/task-status.js";
+import { resolveModelCatalogScope } from "../model-catalog-scope.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
   buildAllowedModelSet,
@@ -243,7 +244,24 @@ async function resolveModelOverride(params: {
     cfg: params.cfg,
     defaultProvider: currentProvider,
   });
-  const catalog = await loadModelCatalog({ config: params.cfg });
+  const resolved = resolveModelRefFromString({
+    cfg: params.cfg,
+    raw,
+    defaultProvider: currentProvider,
+    aliasIndex,
+  });
+  if (!resolved) {
+    throw new Error(`Unrecognized model "${raw}".`);
+  }
+
+  const catalog = await loadModelCatalog({
+    config: params.cfg,
+    ...resolveModelCatalogScope({
+      cfg: params.cfg,
+      provider: resolved.ref.provider,
+      model: resolved.ref.model,
+    }),
+  });
   const allowed = buildAllowedModelSet({
     cfg: params.cfg,
     catalog,
@@ -252,14 +270,6 @@ async function resolveModelOverride(params: {
     agentId: params.agentId,
   });
 
-  const resolved = resolveModelRefFromString({
-    raw,
-    defaultProvider: currentProvider,
-    aliasIndex,
-  });
-  if (!resolved) {
-    throw new Error(`Unrecognized model "${raw}".`);
-  }
   const key = modelKey(resolved.ref.provider, resolved.ref.model);
   if (allowed.allowedKeys.size > 0 && !allowed.allowedKeys.has(key)) {
     throw new Error(`Model "${key}" is not allowed.`);
@@ -656,7 +666,14 @@ export function createSessionStatusTool(opts?: {
             !configuredSelectedEntry ||
             configuredSelectedEntry.reasoning === undefined;
           const runtimeCatalog = shouldHydrateRuntimeCatalog
-            ? await loadModelCatalog({ config: cfg })
+            ? await loadModelCatalog({
+                config: cfg,
+                ...resolveModelCatalogScope({
+                  cfg,
+                  provider: providerForCard,
+                  model: defaultModelForCard,
+                }),
+              })
             : undefined;
           const runtimeSelectedEntry = runtimeCatalog?.find(
             (entry) => entry.provider === providerForCard && entry.id === defaultModelForCard,

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -815,6 +815,7 @@ export function createVideoGenerateTool(options?: {
   sandbox?: VideoGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
   scheduleBackgroundWork?: VideoGenerateBackgroundScheduler;
+  precomputedAvailability?: boolean;
 }): AnyAgentTool | null {
   const cfg: OpenClawConfig = options?.config ?? getRuntimeConfig();
   if (
@@ -825,6 +826,7 @@ export function createVideoGenerateTool(options?: {
       authStore: options?.authProfileStore,
       modelConfig: cfg.agents?.defaults?.videoGenerationModel,
       providerKey: "videoGenerationProviders",
+      precomputedAvailability: options?.precomputedAvailability,
     })
   ) {
     return null;

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
+import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import { resolveProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
 import { shouldPreserveThinkingBlocks } from "../plugins/provider-replay-helpers.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
@@ -219,6 +220,7 @@ export function resolveTranscriptPolicy(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   model?: ProviderRuntimeModel;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
   const cacheConfig = canCacheTranscriptPolicy(params) ? params.config : undefined;
@@ -231,14 +233,16 @@ export function resolveTranscriptPolicy(params: {
       return cached;
     }
   }
-  const runtimePlugin = provider
-    ? resolveProviderRuntimePlugin({
-        provider,
-        config: params.config,
-        workspaceDir: params.workspaceDir,
-        env: params.env,
-      })
-    : undefined;
+  const runtimePlugin =
+    params.runtimeHandle?.plugin ??
+    (provider
+      ? resolveProviderRuntimePlugin({
+          provider,
+          config: params.config,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        })
+      : undefined);
   const context = {
     config: params.config,
     workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -83,6 +83,11 @@ import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
 import { createReplyMediaContext } from "./reply-media-paths.runtime.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import {
+  emitReplyStageSummary,
+  ReplyStageName,
+  type ReplyStageTracker,
+} from "./reply-stage-timing.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 // Maximum number of LiveSessionModelSwitchError retries before surfacing a
@@ -901,6 +906,7 @@ export async function runAgentTurnWithFallback(params: {
   resolvedVerboseLevel: VerboseLevel;
   toolProgressDetail?: "explain" | "raw";
   replyMediaContext?: ReplyMediaContext;
+  replyStageTracker?: ReplyStageTracker;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -915,6 +921,7 @@ export async function runAgentTurnWithFallback(params: {
           ...params.followupRun.run,
           config: runtimeConfig,
         };
+  params.replyStageTracker?.mark(ReplyStageName.queuedRuntimeConfig);
 
   const runId = params.opts?.runId ?? crypto.randomUUID();
   const replyMediaContext =
@@ -933,6 +940,7 @@ export async function runAgentTurnWithFallback(params: {
       requesterSenderUsername: params.followupRun.run.senderUsername,
       requesterSenderE164: params.followupRun.run.senderE164,
     });
+  params.replyStageTracker?.mark(ReplyStageName.replyMediaContext);
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {
     if (didNotifyAgentRunStart) {
@@ -1006,6 +1014,7 @@ export async function runAgentTurnWithFallback(params: {
       isControlUiVisible: shouldSurfaceToControlUi,
     });
   }
+  params.replyStageTracker?.mark(ReplyStageName.agentRunContext);
   let runResult: Awaited<ReturnType<typeof runEmbeddedPiAgent>>;
   let fallbackProvider = params.followupRun.run.provider;
   let fallbackModel = params.followupRun.run.model;
@@ -1214,9 +1223,11 @@ export async function runAgentTurnWithFallback(params: {
         : undefined;
       const onToolResult = params.opts?.onToolResult;
       const outcomePlan = buildAgentRuntimeOutcomePlan();
+      params.replyStageTracker?.mark(ReplyStageName.fallbackSetup);
       const runLane = CommandLane.Main;
+      const modelFallbackOptions = resolveModelFallbackOptions(effectiveRun, runtimeConfig);
       const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
-        ...resolveModelFallbackOptions(effectiveRun, runtimeConfig),
+        ...modelFallbackOptions,
         runId,
         sessionId: params.followupRun.run.sessionId,
         lane: runLane,
@@ -1261,6 +1272,7 @@ export async function runAgentTurnWithFallback(params: {
               `failed to persist fallback candidate selection (non-fatal): ${String(error)}`,
             );
           }
+          params.replyStageTracker?.mark(ReplyStageName.fallbackCandidateSelection);
 
           const agentRuntimeOverride = normalizeOptionalString(
             params.getActiveSessionEntry()?.agentRuntimeOverride,
@@ -1272,6 +1284,7 @@ export async function runAgentTurnWithFallback(params: {
               agentId: params.followupRun.run.agentId,
               runtimeOverride: agentRuntimeOverride,
             }) ?? provider;
+          params.replyStageTracker?.mark(ReplyStageName.runtimeSelection);
 
           if (isCliProvider(cliExecutionProvider, runtimeConfig)) {
             const startedAt = Date.now();
@@ -1295,6 +1308,7 @@ export async function runAgentTurnWithFallback(params: {
                 config: runtimeConfig,
               },
             );
+            params.replyStageTracker?.mark(ReplyStageName.authProfile);
             const hookMessageProvider = resolveOriginMessageProvider({
               originatingChannel: params.followupRun.originatingChannel,
               provider: params.sessionCtx.Provider,
@@ -1421,8 +1435,10 @@ export async function runAgentTurnWithFallback(params: {
               runId,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
               model,
+              modelFallbacksOverride: modelFallbackOptions.fallbacksOverride,
             },
           );
+          params.replyStageTracker?.mark(ReplyStageName.embeddedRunParams);
           return (async () => {
             let attemptCompactionCount = 0;
             const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
@@ -1430,6 +1446,15 @@ export async function runAgentTurnWithFallback(params: {
               sessionKey: params.sessionKey,
             });
             try {
+              params.replyStageTracker?.mark(ReplyStageName.embeddedRunDispatch);
+              if (params.replyStageTracker) {
+                emitReplyStageSummary({
+                  runId,
+                  sessionId: params.followupRun.run.sessionId,
+                  phase: "before-embedded-dispatch",
+                  tracker: params.replyStageTracker,
+                });
+              }
               const result = await runEmbeddedPiAgent({
                 ...embeddedContext,
                 allowGatewaySubagentBinding: true,

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -2,30 +2,6 @@ import { resolveEffectiveModelFallbacks } from "../../agents/agent-scope.js";
 import type { resolveProviderScopedAuthProfile } from "./agent-runner-auth-profile.js";
 import type { FollowupRun } from "./queue.js";
 
-export type ReasoningTagProviderResolver = (
-  provider: string,
-  options: {
-    config: FollowupRun["run"]["config"];
-    workspaceDir: string;
-    modelId: string;
-  },
-) => boolean;
-
-export const resolveEnforceFinalTagWithResolver = (
-  run: FollowupRun["run"],
-  provider: string,
-  model = run.model,
-  isReasoningTagProvider?: ReasoningTagProviderResolver,
-) =>
-  (run.skipProviderRuntimeHints ? false : undefined) ??
-  (run.enforceFinalTag ||
-    isReasoningTagProvider?.(provider, {
-      config: run.config,
-      workspaceDir: run.workspaceDir,
-      modelId: model,
-    }) ||
-    false);
-
 export function resolveModelFallbackOptions(
   run: FollowupRun["run"],
   configOverride: FollowupRun["run"]["config"] = run.config,
@@ -36,6 +12,8 @@ export function resolveModelFallbackOptions(
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
+    authStore: run.authProfileStore,
+    preflightAuthCooldown: false,
     fallbacksOverride: resolveEffectiveModelFallbacks({
       cfg: config,
       agentId: run.agentId,
@@ -52,16 +30,19 @@ export function buildEmbeddedRunBaseParams(params: {
   runId: string;
   authProfile: ReturnType<typeof resolveProviderScopedAuthProfile>;
   allowTransientCooldownProbe?: boolean;
-  isReasoningTagProvider?: ReasoningTagProviderResolver;
+  modelFallbacksOverride?: ReturnType<typeof resolveEffectiveModelFallbacks>;
 }) {
   const config = params.run.config;
-  const modelFallbacksOverride = resolveEffectiveModelFallbacks({
-    cfg: config,
-    agentId: params.run.agentId,
-    hasSessionModelOverride: params.run.hasSessionModelOverride === true,
-    modelOverrideSource: params.run.modelOverrideSource,
-  });
+  const modelFallbacksOverride =
+    params.modelFallbacksOverride ??
+    resolveEffectiveModelFallbacks({
+      cfg: config,
+      agentId: params.run.agentId,
+      hasSessionModelOverride: params.run.hasSessionModelOverride === true,
+      modelOverrideSource: params.run.modelOverrideSource,
+    });
   return {
+    sessionId: params.run.sessionId,
     sessionFile: params.run.sessionFile,
     workspaceDir: params.run.workspaceDir,
     agentDir: params.run.agentDir,
@@ -70,12 +51,8 @@ export function buildEmbeddedRunBaseParams(params: {
     ownerNumbers: params.run.ownerNumbers,
     inputProvenance: params.run.inputProvenance,
     senderIsOwner: params.run.senderIsOwner,
-    enforceFinalTag: resolveEnforceFinalTagWithResolver(
-      params.run,
-      params.provider,
-      params.model,
-      params.isReasoningTagProvider,
-    ),
+    enforceFinalTag: params.run.skipProviderRuntimeHints ? false : params.run.enforceFinalTag,
+    skipProviderRuntimeHints: params.run.skipProviderRuntimeHints,
     silentExpected: params.run.silentExpected,
     allowEmptyAssistantReplyAsSilent: params.run.allowEmptyAssistantReplyAsSilent,
     silentReplyPromptMode: params.run.silentReplyPromptMode,
@@ -84,6 +61,8 @@ export function buildEmbeddedRunBaseParams(params: {
     model: params.model,
     modelFallbacksOverride,
     ...params.authProfile,
+    authProfileStore: params.run.authProfileStore,
+    authProfileOrder: params.run.authProfileOrder,
     thinkLevel: params.run.thinkLevel,
     verboseLevel: params.run.verboseLevel,
     reasoningLevel: params.run.reasoningLevel,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -26,7 +26,6 @@ const {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
-  resolveEnforceFinalTag,
   resolveProviderScopedAuthProfile,
 } = await import("./agent-runner-utils.js");
 
@@ -79,6 +78,8 @@ describe("agent-runner-utils", () => {
       provider: run.provider,
       model: run.model,
       agentDir: run.agentDir,
+      authStore: run.authProfileStore,
+      preflightAuthCooldown: false,
       fallbacksOverride: ["fallback-model"],
     });
   });
@@ -99,7 +100,7 @@ describe("agent-runner-utils", () => {
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {
-    const run = makeRun({ enforceFinalTag: true });
+    const run = makeRun({ enforceFinalTag: true, authProfileOrder: ["profile-openai"] });
     const authProfile = resolveProviderScopedAuthProfile({
       provider: "openai",
       primaryProvider: "openai",
@@ -116,6 +117,7 @@ describe("agent-runner-utils", () => {
     });
 
     expect(resolved).toMatchObject({
+      sessionId: run.sessionId,
       sessionFile: run.sessionFile,
       workspaceDir: run.workspaceDir,
       agentDir: run.agentDir,
@@ -127,6 +129,7 @@ describe("agent-runner-utils", () => {
       model: "gpt-4.1-mini",
       authProfileId: "profile-openai",
       authProfileIdSource: "user",
+      authProfileOrder: ["profile-openai"],
       thinkLevel: run.thinkLevel,
       verboseLevel: run.verboseLevel,
       reasoningLevel: run.reasoningLevel,
@@ -135,17 +138,27 @@ describe("agent-runner-utils", () => {
       timeoutMs: run.timeoutMs,
       runId: "run-1",
     });
+    expect(hoisted.isReasoningTagProviderMock).not.toHaveBeenCalled();
   });
 
-  it("does not force final-tag enforcement for minimax providers", () => {
-    const run = makeRun();
-
-    expect(resolveEnforceFinalTag(run, "minimax", "MiniMax-M2.7")).toBe(false);
-    expect(hoisted.isReasoningTagProviderMock).toHaveBeenCalledWith("minimax", {
-      config: run.config,
-      workspaceDir: run.workspaceDir,
-      modelId: "MiniMax-M2.7",
+  it("carries skipProviderRuntimeHints without resolving provider runtime hints", () => {
+    const run = makeRun({ enforceFinalTag: true, skipProviderRuntimeHints: true });
+    const authProfile = resolveProviderScopedAuthProfile({
+      provider: "openai",
+      primaryProvider: "openai",
     });
+
+    const resolved = buildEmbeddedRunBaseParams({
+      run,
+      provider: "minimax",
+      model: "MiniMax-M2.7",
+      runId: "run-1",
+      authProfile,
+    });
+
+    expect(resolved.enforceFinalTag).toBe(false);
+    expect(resolved.skipProviderRuntimeHints).toBe(true);
+    expect(hoisted.isReasoningTagProviderMock).not.toHaveBeenCalled();
   });
 
   it("builds embedded contexts and scopes auth profile by provider", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -20,7 +20,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
-import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import type { TemplateContext } from "../templating.js";
 import {
   resolveProviderScopedAuthProfile,
@@ -28,11 +27,13 @@ import {
 } from "./agent-runner-auth-profile.js";
 export { resolveProviderScopedAuthProfile, resolveRunAuthProfile };
 import {
-  buildEmbeddedRunBaseParams as buildEmbeddedRunBaseParamsCore,
+  buildEmbeddedRunBaseParams,
   resolveModelFallbackOptions,
-  resolveEnforceFinalTagWithResolver,
 } from "./agent-runner-run-params.js";
-export { resolveModelFallbackOptions } from "./agent-runner-run-params.js";
+export {
+  buildEmbeddedRunBaseParams,
+  resolveModelFallbackOptions,
+} from "./agent-runner-run-params.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import type { FollowupRun } from "./queue.js";
 
@@ -174,21 +175,6 @@ export const formatBunFetchSocketError = (message: string) => {
   ].join("\n");
 };
 
-export const resolveEnforceFinalTag = (
-  run: FollowupRun["run"],
-  provider: string,
-  model = run.model,
-) => resolveEnforceFinalTagWithResolver(run, provider, model, isReasoningTagProvider);
-
-export function buildEmbeddedRunBaseParams(
-  params: Parameters<typeof buildEmbeddedRunBaseParamsCore>[0],
-) {
-  return buildEmbeddedRunBaseParamsCore({
-    ...params,
-    isReasoningTagProvider,
-  });
-}
-
 function buildEmbeddedContextFromTemplate(params: {
   run: FollowupRun["run"];
   sessionCtx: TemplateContext;
@@ -263,6 +249,7 @@ export function buildEmbeddedRunExecutionParams(params: {
   model: string;
   runId: string;
   allowTransientCooldownProbe?: boolean;
+  modelFallbacksOverride?: ReturnType<typeof resolveModelFallbackOptions>["fallbacksOverride"];
 }) {
   const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts(params);
   const runBaseParams = buildEmbeddedRunBaseParams({
@@ -272,6 +259,7 @@ export function buildEmbeddedRunExecutionParams(params: {
     runId: params.runId,
     authProfile,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    modelFallbacksOverride: params.modelFallbacksOverride,
   });
   return {
     embeddedContext,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import { hasConfiguredModelFallbacks, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded-runner/runs.js";
 import { deriveContextPromptTokens, hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
@@ -80,9 +79,10 @@ import {
   replyRunRegistry,
   type ReplyOperation,
 } from "./reply-run-registry.js";
+import { createReplyStageTracker, ReplyStageName } from "./reply-stage-timing.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
-import { createTypingSignaler } from "./typing-mode.js";
+import { createTypingSignaler, type TypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
@@ -919,6 +919,7 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
+  typingSignals?: TypingSignaler;
   resetTriggered?: boolean;
   replyThreadingOverride?: TemplateContext["ReplyThreading"];
   replyOperation?: ReplyOperation;
@@ -952,6 +953,7 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    typingSignals: providedTypingSignals,
     resetTriggered,
     replyThreadingOverride,
     replyOperation: providedReplyOperation,
@@ -966,11 +968,13 @@ export async function runReplyAgent(params: {
   const effectiveShouldFollowup = !effectiveResetTriggered && shouldFollowup;
 
   const isHeartbeat = opts?.isHeartbeat === true;
-  const typingSignals = createTypingSignaler({
-    typing,
-    mode: typingMode,
-    isHeartbeat,
-  });
+  const typingSignals =
+    providedTypingSignals ??
+    createTypingSignaler({
+      typing,
+      mode: typingMode,
+      isHeartbeat,
+    });
 
   const shouldEmitToolResult = createShouldEmitToolResult({
     sessionKey,
@@ -1140,9 +1144,11 @@ export async function runReplyAgent(params: {
   let runFollowupTurn = queuedRunFollowupTurn;
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
+  const replyStageTracker = createReplyStageTracker();
 
   try {
     await typingSignals.signalRunStart();
+    replyStageTracker.mark(ReplyStageName.typingRunStart);
 
     activeSessionEntry = await runPreflightCompactionIfNeeded({
       cfg,
@@ -1158,6 +1164,7 @@ export async function runReplyAgent(params: {
       isHeartbeat,
       replyOperation,
     });
+    replyStageTracker.mark(ReplyStageName.preflightCompaction);
     preflightCompactionApplied =
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
@@ -1178,6 +1185,7 @@ export async function runReplyAgent(params: {
       isHeartbeat,
       replyOperation,
     });
+    replyStageTracker.mark(ReplyStageName.memoryFlush);
 
     runFollowupTurn = createFollowupRunner({
       opts,
@@ -1190,6 +1198,7 @@ export async function runReplyAgent(params: {
       defaultModel,
       agentCfgContextTokens,
     });
+    replyStageTracker.mark(ReplyStageName.followupRunner);
 
     let responseUsageLine: string | undefined;
     type SessionResetOptions = {
@@ -1238,6 +1247,7 @@ export async function runReplyAgent(params: {
       });
 
     replyOperation.setPhase("running");
+    replyStageTracker.mark(ReplyStageName.replyOperationStart);
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
@@ -1267,6 +1277,7 @@ export async function runReplyAgent(params: {
       resolvedVerboseLevel,
       toolProgressDetail,
       replyMediaContext,
+      replyStageTracker,
     });
 
     if (runOutcome.kind === "final") {
@@ -1531,11 +1542,9 @@ export async function runReplyAgent(params: {
       activeSessionEntry?.responseUsage ??
       (sessionKey ? activeSessionStore?.[sessionKey]?.responseUsage : undefined);
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
+    const runAuthMode = normalizeOptionalString(runResult.meta?.requestShaping?.authMode);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
-      const authMode = resolveModelAuthMode(providerUsed, cfg, undefined, {
-        workspaceDir: followupRun.run.workspaceDir,
-      });
-      const showCost = authMode === "api-key";
+      const showCost = runAuthMode === "api-key";
       const costConfig = showCost
         ? resolveModelCostConfig({
             provider: providerUsed,
@@ -1694,13 +1703,7 @@ export async function runReplyAgent(params: {
       runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
     });
     const requestShaping = {
-      authMode:
-        runResult.meta?.requestShaping?.authMode ??
-        (cfg?.models?.providers && providerUsed in cfg.models.providers
-          ? (resolveModelAuthMode(providerUsed, cfg, undefined, {
-              workspaceDir: followupRun.run.workspaceDir,
-            }) ?? undefined)
-          : undefined),
+      authMode: runAuthMode,
       thinking:
         runResult.meta?.requestShaping?.thinking ??
         normalizeOptionalString(followupRun.run.thinkLevel),

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -176,7 +176,8 @@ function buildParams(
 
 describe("handleModelsCommand", () => {
   it("shows a simple providers menu on text surfaces", async () => {
-    const result = await handleModelsCommand(buildParams("/models"), true);
+    const params = buildParams("/models");
+    const result = await handleModelsCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("Providers:");
@@ -186,6 +187,10 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain("Use: /models <provider>");
     expect(result?.reply?.text).toContain("Switch: /model <provider/model>");
     expect(result?.reply?.text).not.toContain("Add: /models add");
+    expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledWith({
+      config: params.cfg,
+      readOnly: true,
+    });
     expect(modelProviderAuthMocks.createProviderAuthChecker).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceDir: "/tmp" }),
     );

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -75,7 +75,7 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelCatalog({ config: cfg });
+  const catalog = await loadModelCatalog({ config: cfg, readOnly: true });
   const visibleCatalog = resolveVisibleModelCatalog({
     cfg,
     catalog,

--- a/src/auto-reply/reply/commands-tts.test.ts
+++ b/src/auto-reply/reply/commands-tts.test.ts
@@ -33,7 +33,7 @@ vi.mock("../../globals.js", () => ({
 vi.mock("../../tts/provider-registry.js", () => ({
   canonicalizeSpeechProviderId: vi.fn((provider: string) => provider),
   getSpeechProvider: vi.fn(() => null),
-  listSpeechProviders: vi.fn(() => []),
+  listLoadedSpeechProviders: vi.fn(() => []),
 }));
 
 vi.mock("../../tts/tts.js", () => ttsMocks);

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -8,7 +8,7 @@ import {
 import {
   canonicalizeSpeechProviderId,
   getSpeechProvider,
-  listSpeechProviders,
+  listLoadedSpeechProviders,
 } from "../../tts/provider-registry.js";
 import {
   getResolvedSpeechProviderConfig,
@@ -325,7 +325,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
   if (action === "provider") {
     const currentProvider = getTtsProvider(config, prefsPath);
     if (!args.trim()) {
-      const providers = listSpeechProviders(params.cfg);
+      const providers = listLoadedSpeechProviders(params.cfg);
       return {
         shouldContinue: false,
         reply: {

--- a/src/auto-reply/reply/conversation-label-generator.test.ts
+++ b/src/auto-reply/reply/conversation-label-generator.test.ts
@@ -77,6 +77,7 @@ describe("generateConversationLabel", () => {
       "gpt-test",
       "/tmp/agents/billing/agent",
       {},
+      { skipPiDiscovery: true },
     );
     expect(getRuntimeAuthForModel).toHaveBeenCalledWith({
       model: { provider: "openai" },

--- a/src/auto-reply/reply/conversation-label-generator.ts
+++ b/src/auto-reply/reply/conversation-label-generator.ts
@@ -34,7 +34,9 @@ export async function generateConversationLabel(
       ? Math.floor(params.maxLength)
       : DEFAULT_MAX_LABEL_LENGTH;
   const modelRef = resolveDefaultModelForAgent({ cfg, agentId });
-  const resolved = await resolveModelAsync(modelRef.provider, modelRef.model, agentDir, cfg);
+  const resolved = await resolveModelAsync(modelRef.provider, modelRef.model, agentDir, cfg, {
+    skipPiDiscovery: true,
+  });
   if (!resolved.model) {
     logVerbose(
       `conversation-label-generator: failed to resolve model ${modelRef.provider}/${modelRef.model}`,

--- a/src/auto-reply/reply/directive-handling.fast-lane.ts
+++ b/src/auto-reply/reply/directive-handling.fast-lane.ts
@@ -78,7 +78,9 @@ export async function applyInlineDirectivesFastLane(
     aliasIndex,
     allowedModelKeys,
     allowedModelCatalog,
-    thinkingCatalog: await modelState.resolveThinkingCatalog(),
+    thinkingCatalog: await modelState.resolveThinkingCatalog({
+      hydrateRuntimeCatalog: directives.hasThinkDirective,
+    }),
     resetModelOverride,
     provider,
     model,

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -6,6 +6,10 @@ import type { MsgContext } from "../templating.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./directives.js";
 
+type ThinkingCatalogOptions = {
+  hydrateRuntimeCatalog?: boolean;
+};
+
 export type HandleDirectiveOnlyCoreParams = {
   cfg: OpenClawConfig;
   directives: InlineDirectives;
@@ -56,7 +60,9 @@ export type ApplyInlineDirectivesFastLaneParams = HandleDirectiveOnlyCoreParams 
   agentCfg?: NonNullable<OpenClawConfig["agents"]>["defaults"];
   modelState: {
     resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
-    resolveThinkingCatalog: () => Promise<ModelCatalogEntry[] | undefined>;
+    resolveThinkingCatalog: (
+      options?: ThinkingCatalogOptions,
+    ) => Promise<ModelCatalogEntry[] | undefined>;
     allowedModelKeys: Set<string>;
     allowedModelCatalog: Awaited<
       ReturnType<typeof import("../../agents/model-catalog.js").loadModelCatalog>

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -13,7 +13,6 @@ import {
   internalHookMocks,
   mocks,
   resetPluginTtsAndThreadMocks,
-  runtimePluginMocks,
   sessionBindingMocks,
   sessionStoreMocks,
   setDiscordTestRegistry,
@@ -85,7 +84,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     diagnosticMocks.logMessageProcessed.mockReset();
     diagnosticMocks.logSessionStateChange.mockReset();
     diagnosticMocks.markDiagnosticSessionProgress.mockReset();
-    runtimePluginMocks.ensureRuntimePluginsLoaded.mockReset();
     resetPluginTtsAndThreadMocks();
   });
 
@@ -105,10 +103,6 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       replyResolver: async () => ({ text: "model reply" }),
     });
 
-    expect(runtimePluginMocks.ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
-      config: emptyConfig,
-      workspaceDir: expect.any(String),
-    });
     expect(hookMocks.runner.runReplyDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: "agent:test:session",

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -113,9 +113,6 @@ const replyMediaPathMocks = vi.hoisted(() => ({
     (_params?: unknown) => async (payload: ReplyPayload) => payload,
   ),
 }));
-const runtimePluginMocks = vi.hoisted(() => ({
-  ensureRuntimePluginsLoaded: vi.fn(),
-}));
 const threadInfoMocks = vi.hoisted(() => ({
   parseSessionThreadInfo: vi.fn<
     (sessionKey: string | undefined) => {
@@ -135,7 +132,6 @@ export {
   mocks,
   sessionBindingMocks,
   sessionStoreMocks,
-  runtimePluginMocks,
 };
 
 function parseGenericThreadSessionInfo(sessionKey: string | undefined) {
@@ -229,9 +225,6 @@ vi.mock("../../infra/outbound/session-binding-service.js", () => ({
 vi.mock("../../infra/agent-events.js", () => ({
   emitAgentEvent: (params: unknown) => agentEventMocks.emitAgentEvent(params),
   onAgentEvent: (listener: unknown) => agentEventMocks.onAgentEvent(listener),
-}));
-vi.mock("./runtime-plugins.runtime.js", () => ({
-  ensureRuntimePluginsLoaded: runtimePluginMocks.ensureRuntimePluginsLoaded,
 }));
 vi.mock("./conversation-binding-input.js", () => {
   const normalize = (value: unknown) =>

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -156,9 +156,6 @@ const replyMediaPathMocks = vi.hoisted(() => ({
     (_params?: unknown) => async (payload: ReplyPayload) => payload,
   ),
 }));
-const runtimePluginMocks = vi.hoisted(() => ({
-  ensureRuntimePluginsLoaded: vi.fn(),
-}));
 const conversationBindingMocks = vi.hoisted(() => {
   type BindingMsgContext = {
     OriginatingChannel?: string | null;
@@ -452,9 +449,6 @@ vi.mock("../../tts/tts.runtime.js", () => ({
 vi.mock("./reply-media-paths.runtime.js", () => ({
   createReplyMediaPathNormalizer: (params: unknown) =>
     replyMediaPathMocks.createReplyMediaPathNormalizer(params),
-}));
-vi.mock("./runtime-plugins.runtime.js", () => ({
-  ensureRuntimePluginsLoaded: runtimePluginMocks.ensureRuntimePluginsLoaded,
 }));
 vi.mock("./conversation-binding-input.js", () => ({
   resolveConversationBindingAccountIdFromMessage:
@@ -811,10 +805,9 @@ describe("dispatchReplyFromConfig", () => {
     replyMediaPathMocks.createReplyMediaPathNormalizer.mockReturnValue(
       async (payload: ReplyPayload) => payload,
     );
-    runtimePluginMocks.ensureRuntimePluginsLoaded.mockClear();
   });
 
-  it("loads runtime plugins before reading inbound hook state", async () => {
+  it("reads prepared inbound hook state without loading plugins", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
@@ -826,13 +819,7 @@ describe("dispatchReplyFromConfig", () => {
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(runtimePluginMocks.ensureRuntimePluginsLoaded).toHaveBeenCalledWith({
-      config: cfg,
-      workspaceDir: expect.any(String),
-    });
-    expect(runtimePluginMocks.ensureRuntimePluginsLoaded.mock.invocationCallOrder[0]).toBeLessThan(
-      hookMocks.runner.hasHooks.mock.invocationCallOrder[0],
-    );
+    expect(hookMocks.runner.hasHooks).toHaveBeenCalled();
   });
 
   it("does not route when Provider matches OriginatingChannel (even if Surface is missing)", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -103,7 +103,6 @@ const getReplyFromConfigRuntimeLoader = createLazyImportLoader(
 );
 const abortRuntimeLoader = createLazyImportLoader(() => import("./abort.runtime.js"));
 const ttsRuntimeLoader = createLazyImportLoader(() => import("../../tts/tts.runtime.js"));
-const runtimePluginsLoader = createLazyImportLoader(() => import("./runtime-plugins.runtime.js"));
 const replyMediaPathsRuntimeLoader = createLazyImportLoader(
   () => import("./reply-media-paths.runtime.js"),
 );
@@ -122,10 +121,6 @@ function loadAbortRuntime() {
 
 function loadTtsRuntime() {
   return ttsRuntimeLoader.load();
-}
-
-function loadRuntimePlugins() {
-  return runtimePluginsLoader.load();
 }
 
 function loadReplyMediaPathsRuntime() {
@@ -443,8 +438,6 @@ export async function dispatchReplyFromConfig(
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, sessionAgentId);
-  const { ensureRuntimePluginsLoaded } = await loadRuntimePlugins();
-  ensureRuntimePluginsLoaded({ config: cfg, workspaceDir });
   const hookRunner = getGlobalHookRunner();
 
   // Extract message context for hooks (plugin and internal)

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -23,6 +23,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
 import {
+  buildEmbeddedRunBaseParams,
   resolveQueuedReplyExecutionConfig,
   resolveQueuedReplyRuntimeConfig,
   resolveModelFallbackOptions,
@@ -261,22 +262,30 @@ export function createFollowupRunner(params: {
       replyOperation.setPhase("running");
       try {
         const outcomePlan = buildAgentRuntimeOutcomePlan();
+        const modelFallbackOptions = resolveModelFallbackOptions(run, runtimeConfig);
         const fallbackResult = await runWithModelFallback<EmbeddedAgentRunResult>({
-          ...resolveModelFallbackOptions(run, runtimeConfig),
+          ...modelFallbackOptions,
           cfg: runtimeConfig,
           runId,
           classifyResult: ({ result, provider, model }) =>
             outcomePlan.classifyRunResult({ result, provider, model }),
           run: async (provider, model, runOptions) => {
             const authProfile = resolveRunAuthProfile(run, provider, { config: runtimeConfig });
+            const runBaseParams = buildEmbeddedRunBaseParams({
+              run: { ...run, config: runtimeConfig },
+              provider,
+              model,
+              runId,
+              authProfile,
+              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              modelFallbacksOverride: modelFallbackOptions.fallbacksOverride,
+            });
             let attemptCompactionCount = 0;
             try {
               const result = await runEmbeddedPiAgent({
                 allowGatewaySubagentBinding: true,
                 replyOperation,
-                sessionId: run.sessionId,
-                sessionKey: run.sessionKey,
-                agentId: run.agentId,
+                ...runBaseParams,
                 trigger: "user",
                 messageChannel: queued.originatingChannel ?? undefined,
                 messageProvider: run.messageProvider,
@@ -295,36 +304,14 @@ export function createFollowupRunner(params: {
                 senderName: run.senderName,
                 senderUsername: run.senderUsername,
                 senderE164: run.senderE164,
-                senderIsOwner: run.senderIsOwner,
-                sessionFile: run.sessionFile,
-                agentDir: run.agentDir,
-                workspaceDir: run.workspaceDir,
-                config: runtimeConfig,
-                skillsSnapshot: run.skillsSnapshot,
                 prompt: queued.prompt,
                 transcriptPrompt: queued.transcriptPrompt,
                 currentTurnContext: queued.currentTurnContext,
                 extraSystemPrompt: run.extraSystemPrompt,
-                silentReplyPromptMode: run.silentReplyPromptMode,
-                sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,
                 forceMessageTool: run.sourceReplyDeliveryMode === "message_tool_only",
-                ownerNumbers: run.ownerNumbers,
-                enforceFinalTag: run.enforceFinalTag,
-                allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
-                provider,
-                model,
-                ...authProfile,
-                thinkLevel: run.thinkLevel,
-                verboseLevel: run.verboseLevel,
-                reasoningLevel: run.reasoningLevel,
                 suppressToolErrorWarnings: opts?.suppressToolErrorWarnings,
-                execOverrides: run.execOverrides,
-                bashElevated: run.bashElevated,
-                timeoutMs: run.timeoutMs,
-                runId,
                 images: queuedImages,
                 imageOrder: queuedImageOrder,
-                allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
                 blockReplyBreak: run.blockReplyBreak,
                 bootstrapPromptWarningSignaturesSeen,
                 bootstrapPromptWarningSignature:

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -327,7 +327,9 @@ export async function applyInlineDirectiveOverrides(params: {
       resolveDefaultThinkingLevel: () => modelState.resolveDefaultThinkingLevel(),
     });
     const currentThinkLevel = resolvedDefaultThinkLevel;
-    const thinkingCatalog = await modelState.resolveThinkingCatalog();
+    const thinkingCatalog = await modelState.resolveThinkingCatalog({
+      hydrateRuntimeCatalog: directives.hasThinkDirective,
+    });
     const directiveReply = await (
       await loadDirectiveImpl()
     ).handleDirectiveOnly({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -7,9 +7,15 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import { createReplyOperation } from "./reply-run-registry.js";
 
-vi.mock("../../agents/auth-profiles/session-override.js", () => ({
-  resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("../../agents/auth-profiles/session-override.js", () => {
+  const resolveSessionAuthProfileOverride = vi.fn().mockResolvedValue(undefined);
+  return {
+    resolveSessionAuthProfileOverride,
+    resolveSessionAuthProfileOverrideState: vi.fn(async (params: unknown) => ({
+      authProfileId: await resolveSessionAuthProfileOverride(params),
+    })),
+  };
+});
 
 vi.mock("../../agents/pi-embedded.runtime.js", () => ({
   abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
@@ -56,10 +62,6 @@ vi.mock(import("../../routing/session-key.js"), async (importOriginal) => {
     normalizeAgentId: (id: string | undefined | null) => id ?? "default",
   };
 });
-
-vi.mock("../../utils/provider-utils.js", () => ({
-  isReasoningTagProvider: vi.fn().mockReturnValue(false),
-}));
 
 vi.mock("../command-detection.js", () => ({
   hasControlCommand: vi.fn().mockReturnValue(false),
@@ -122,6 +124,28 @@ vi.mock("./session-system-events.js", () => ({
 }));
 
 vi.mock("./typing-mode.js", () => ({
+  createTypingSignaler: vi.fn(
+    (params: {
+      typing: { startTypingLoop: () => Promise<void> };
+      mode: string;
+      isHeartbeat: boolean;
+    }) => ({
+      mode: params.mode,
+      shouldStartImmediately: params.mode === "instant",
+      shouldStartOnMessageStart: params.mode === "message",
+      shouldStartOnText: params.mode === "message" || params.mode === "instant",
+      shouldStartOnReasoning: params.mode === "thinking",
+      signalRunStart: vi.fn(async () => {
+        if (!params.isHeartbeat && params.mode === "instant") {
+          await params.typing.startTypingLoop();
+        }
+      }),
+      signalMessageStart: vi.fn(async () => {}),
+      signalTextDelta: vi.fn(async () => {}),
+      signalReasoningDelta: vi.fn(async () => {}),
+      signalToolStart: vi.fn(async () => {}),
+    }),
+  ),
   resolveTypingMode: vi.fn().mockReturnValue("off"),
 }));
 
@@ -129,6 +153,7 @@ let runPreparedReply: typeof import("./get-reply-run.js").runPreparedReply;
 let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
 let routeReply: typeof import("./route-reply.runtime.js").routeReply;
 let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
+let ensureSkillSnapshot: typeof import("./session-updates.runtime.js").ensureSkillSnapshot;
 let resolveTypingMode: typeof import("./typing-mode.js").resolveTypingMode;
 let buildDirectChatContext: typeof import("./groups.js").buildDirectChatContext;
 let buildGroupChatContext: typeof import("./groups.js").buildGroupChatContext;
@@ -212,6 +237,12 @@ function baseParams(
     model: "claude-opus-4-1",
     typing: {
       onReplyStart: vi.fn().mockResolvedValue(undefined),
+      startTypingLoop: vi.fn().mockResolvedValue(undefined),
+      startTypingOnText: vi.fn().mockResolvedValue(undefined),
+      refreshTypingTtl: vi.fn(),
+      isActive: vi.fn(() => false),
+      markRunComplete: vi.fn(),
+      markDispatchIdle: vi.fn(),
       cleanup: vi.fn(),
     } as never,
     defaultProvider: "anthropic",
@@ -242,6 +273,7 @@ describe("runPreparedReply media-only handling", () => {
     ({ runReplyAgent } = await import("./agent-runner.runtime.js"));
     ({ routeReply } = await import("./route-reply.runtime.js"));
     ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
+    ({ ensureSkillSnapshot } = await import("./session-updates.runtime.js"));
     ({ resolveTypingMode } = await import("./typing-mode.js"));
     ({ buildDirectChatContext, buildGroupChatContext } = await import("./groups.js"));
     ({ buildInboundUserContextPrefix } = await import("./inbound-meta.js"));
@@ -1441,6 +1473,50 @@ describe("runPreparedReply media-only handling", () => {
       | { suppressTyping?: boolean }
       | undefined;
     expect(call?.suppressTyping).toBe(true);
+  });
+
+  it("starts instant typing before skill snapshot prep", async () => {
+    const order: string[] = [];
+    const previousFastEnv = process.env.OPENCLAW_TEST_FAST;
+    process.env.OPENCLAW_TEST_FAST = "0";
+    vi.mocked(resolveTypingMode).mockReturnValueOnce("instant");
+    vi.mocked(ensureSkillSnapshot).mockImplementationOnce(async ({ sessionEntry, systemSent }) => {
+      order.push("skills");
+      return {
+        sessionEntry,
+        systemSent,
+        skillsSnapshot: undefined,
+      };
+    });
+    const typing = {
+      onReplyStart: vi.fn().mockResolvedValue(undefined),
+      startTypingLoop: vi.fn(async () => {
+        order.push("typing");
+      }),
+      startTypingOnText: vi.fn().mockResolvedValue(undefined),
+      refreshTypingTtl: vi.fn(),
+      isActive: vi.fn(() => false),
+      markRunComplete: vi.fn(),
+      markDispatchIdle: vi.fn(),
+      cleanup: vi.fn(),
+    };
+
+    try {
+      await runPreparedReply(
+        baseParams({
+          typing: typing as never,
+        }),
+      );
+
+      expect(typing.startTypingLoop).toHaveBeenCalledOnce();
+      expect(order.slice(0, 2)).toEqual(["typing", "skills"]);
+    } finally {
+      if (previousFastEnv === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousFastEnv;
+      }
+    }
   });
 
   it("routes queued system events into user prompt text, not system prompt context", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,5 +1,8 @@
 import crypto from "node:crypto";
-import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+import {
+  resolveSessionAuthProfileOverrideState,
+  type ResolvedSessionAuthProfileOverride,
+} from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import type { CurrentTurnPromptContext } from "../../agents/pi-embedded-runner/run/params.js";
@@ -27,7 +30,6 @@ import {
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { resolveEnvelopeFormatOptions } from "../envelope.js";
 import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../heartbeat.js";
@@ -64,12 +66,17 @@ import { buildReplyPromptBodies } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
 import { isSteeringQueueMode } from "./queue/steering.js";
+import {
+  createReplyStageTracker,
+  emitReplyStageSummary,
+  ReplyStageName,
+} from "./reply-stage-timing.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import { resolveBareSessionResetPromptState } from "./session-reset-prompt.js";
 import { resolveBareResetBootstrapFileAccess } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
 import { buildSessionStartupContextPrelude, shouldApplyStartupContext } from "./startup-context.js";
-import { resolveTypingMode } from "./typing-mode.js";
+import { createTypingSignaler, resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
 
@@ -416,6 +423,7 @@ export async function runPreparedReply(
     execOverrides,
     abortedLastRun,
   } = params;
+  const preparedStageTracker = createReplyStageTracker();
   const isHeartbeat = opts?.isHeartbeat === true;
   const promptSessionCtx = resolvePromptSessionContextForSystemEvent({
     sessionCtx,
@@ -466,6 +474,12 @@ export async function runPreparedReply(
     suppressTyping,
     sourceReplyDeliveryMode: opts?.sourceReplyDeliveryMode,
   });
+  const typingSignals = createTypingSignaler({
+    typing,
+    mode: typingMode,
+    isHeartbeat,
+  });
+  preparedStageTracker.mark(ReplyStageName.preparedContext);
   const shouldInjectGroupIntro = Boolean(
     isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),
   );
@@ -605,6 +619,7 @@ export async function runPreparedReply(
           cfg,
         })
       : null;
+  preparedStageTracker.mark(ReplyStageName.bareResetPrep);
   const baseBodyFinal = isBareSessionReset
     ? (bareResetPromptState?.prompt ?? "")
     : stripPromptThinkingDirectives(baseBody);
@@ -654,6 +669,7 @@ export async function runPreparedReply(
   const effectiveBaseBody = hasUserBody
     ? baseBodyForPrompt
     : [inboundUserContext, "[User sent media without caption]"].filter(Boolean).join("\n\n");
+  await typingSignals.signalRunStart();
   const transcriptBodyBase = isHeartbeat
     ? HEARTBEAT_TRANSCRIPT_PROMPT
     : isBareSessionReset
@@ -678,7 +694,9 @@ export async function runPreparedReply(
   if (!resolvedThinkLevel && prefixedBodyBase) {
     const parts = prefixedBodyBase.split(/\s+/);
     const maybeLevel = normalizeThinkLevel(parts[0]);
-    const thinkingCatalog = maybeLevel ? await modelState.resolveThinkingCatalog() : undefined;
+    const thinkingCatalog = maybeLevel
+      ? await modelState.resolveThinkingCatalog({ hydrateRuntimeCatalog: true })
+      : undefined;
     if (
       maybeLevel &&
       isThinkingLevelSupported({ provider, model, level: maybeLevel, catalog: thinkingCatalog })
@@ -695,6 +713,7 @@ export async function runPreparedReply(
     : !isNewSession && threadStarterBody
       ? `[Thread starter - for context]\n${threadStarterBody}`
       : undefined;
+  preparedStageTracker.mark(ReplyStageName.userPromptPrep);
   const drainedSystemEventBlocks: string[] = [];
   let forceSenderIsOwnerFalseFromSystemEvents = false;
   const rebuildPromptBodies = async (): Promise<{
@@ -750,12 +769,17 @@ export async function runPreparedReply(
   sessionEntry = skillResult.sessionEntry ?? sessionEntry;
   currentSystemSent = skillResult.systemSent;
   const skillsSnapshot = skillResult.skillsSnapshot;
+  preparedStageTracker.mark(ReplyStageName.skillSnapshot);
   let { prefixedCommandBody, queuedBody, transcriptCommandBody } = await rebuildPromptBodies();
+  preparedStageTracker.mark(ReplyStageName.promptBodies);
   const currentTurnContext = resolveCurrentTurnPromptContext(sessionCtx);
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
   }
-  const thinkingCatalog = await modelState.resolveThinkingCatalog();
+  const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
+  const thinkingCatalog = await modelState.resolveThinkingCatalog({
+    hydrateRuntimeCatalog: explicitThink,
+  });
   if (
     !isThinkingLevelSupported({
       provider,
@@ -764,7 +788,6 @@ export async function runPreparedReply(
       catalog: thinkingCatalog,
     })
   ) {
-    const explicitThink = directives.hasThinkDirective && directives.thinkLevel !== undefined;
     if (explicitThink) {
       typing.cleanup();
       return {
@@ -798,6 +821,7 @@ export async function runPreparedReply(
       }
     }
   }
+  preparedStageTracker.mark(ReplyStageName.thinkingCatalog);
   const sessionIdFinal = sessionId ?? crypto.randomUUID();
   const sessionFilePathOptions = resolveSessionFilePathOptions({ agentId, storePath });
   const resolvePreparedSessionState = (): {
@@ -824,6 +848,7 @@ export async function runPreparedReply(
     };
   };
   let preparedSessionState = resolvePreparedSessionState();
+  preparedStageTracker.mark(ReplyStageName.sessionState);
   const resolvedQueue = useFastReplyRuntime
     ? {
         mode: "collect" as const,
@@ -856,19 +881,24 @@ export async function runPreparedReply(
     );
     logVerbose(`Interrupting ${sessionLaneKey} (cleared ${cleared}, aborted=${aborted})`);
   }
-  let authProfileId = useFastReplyRuntime
-    ? preparedSessionState.sessionEntry?.authProfileOverride
-    : await resolveSessionAuthProfileOverride({
-        cfg,
-        provider,
-        agentDir,
-        sessionEntry: preparedSessionState.sessionEntry,
-        sessionStore,
-        sessionKey,
-        storePath,
-        isNewSession,
-      });
+  preparedStageTracker.mark(ReplyStageName.queueRuntime);
+  const resolvePreparedAuthProfileState = async (): Promise<ResolvedSessionAuthProfileOverride> =>
+    useFastReplyRuntime
+      ? { authProfileId: preparedSessionState.sessionEntry?.authProfileOverride }
+      : await resolveSessionAuthProfileOverrideState({
+          cfg,
+          provider,
+          agentDir,
+          sessionEntry: preparedSessionState.sessionEntry,
+          sessionStore,
+          sessionKey,
+          storePath,
+          isNewSession,
+        });
+  let authProfileState = await resolvePreparedAuthProfileState();
+  let authProfileId = authProfileState.authProfileId;
   const { runReplyAgent } = await loadAgentRunnerRuntime();
+  preparedStageTracker.mark(ReplyStageName.authProfile);
   const queueKey = sessionKey ?? sessionIdFinal;
   preparedSessionState = resolvePreparedSessionState();
   const resolveActiveQueueSessionId = () =>
@@ -911,18 +941,8 @@ export async function runPreparedReply(
         piRuntime?.waitForEmbeddedPiRunEnd(activeRunSessionId) ?? Promise.resolve(undefined),
       refreshPreparedState: async () => {
         preparedSessionState = resolvePreparedSessionState();
-        authProfileId = useFastReplyRuntime
-          ? preparedSessionState.sessionEntry?.authProfileOverride
-          : await resolveSessionAuthProfileOverride({
-              cfg,
-              provider,
-              agentDir,
-              sessionEntry: preparedSessionState.sessionEntry,
-              sessionStore,
-              sessionKey,
-              storePath,
-              isNewSession,
-            });
+        authProfileState = await resolvePreparedAuthProfileState();
+        authProfileId = authProfileState.authProfileId;
         preparedSessionState = resolvePreparedSessionState();
         ({ prefixedCommandBody, queuedBody, transcriptCommandBody } = await rebuildPromptBodies());
       },
@@ -934,6 +954,7 @@ export async function runPreparedReply(
     }
     ({ activeSessionId, isActive, isStreaming } = queueState.busyState);
   }
+  preparedStageTracker.mark(ReplyStageName.activeQueue);
   const authProfileIdSource = preparedSessionState.sessionEntry?.authProfileOverrideSource;
   const runHasSessionModelOverride = Boolean(
     normalizeOptionalString(preparedSessionState.sessionEntry?.modelOverride) ||
@@ -993,6 +1014,8 @@ export async function runPreparedReply(
         : undefined,
       authProfileId,
       authProfileIdSource,
+      authProfileStore: authProfileState.authStore,
+      authProfileOrder: authProfileState.authProfileOrder,
       thinkLevel: resolvedThinkLevel,
       fastMode: useFastReplyRuntime
         ? false
@@ -1026,14 +1049,6 @@ export async function runPreparedReply(
       extraSystemPromptStatic: extraSystemPromptStaticParts.join("\n\n"),
       skipProviderRuntimeHints: useFastReplyRuntime,
       allowEmptyAssistantReplyAsSilent,
-      ...(!useFastReplyRuntime &&
-      isReasoningTagProvider(provider, {
-        config: cfg,
-        workspaceDir,
-        modelId: model,
-      })
-        ? { enforceFinalTag: true }
-        : {}),
     },
   };
 
@@ -1044,6 +1059,13 @@ export async function runPreparedReply(
           implicitCurrentMessage: "deny" as const,
         }
       : undefined;
+  preparedStageTracker.mark(ReplyStageName.followupRun);
+  emitReplyStageSummary({
+    runId: opts?.runId ?? "pending",
+    sessionId: preparedSessionState.sessionId,
+    phase: "prepared-reply",
+    tracker: preparedStageTracker,
+  });
 
   return runReplyAgent({
     commandBody: prefixedCommandBody,
@@ -1081,6 +1103,7 @@ export async function runPreparedReply(
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
+    typingSignals,
     resetTriggered: effectiveResetTriggered,
     replyThreadingOverride,
   });

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -109,7 +109,7 @@ describe("createModelSelectionState catalog loading", () => {
     expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
-  it("hydrates runtime catalog metadata when the configured allowlist entry lacks reasoning", async () => {
+  it("does not hydrate runtime catalog metadata for ordinary thinking defaults", async () => {
     vi.mocked(loadModelCatalog).mockClear();
     vi.mocked(loadModelCatalog).mockResolvedValueOnce([
       { provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4", reasoning: true },
@@ -142,7 +142,51 @@ describe("createModelSelectionState catalog loading", () => {
       hasModelDirective: false,
     });
 
-    await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("medium");
+    await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("off");
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+  });
+
+  it("hydrates runtime catalog metadata only when explicit thinking handling asks for it", async () => {
+    vi.mocked(loadModelCatalog).mockClear();
+    vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+      { provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4", reasoning: true },
+    ]);
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://api.openai.com/v1",
+            models: [makeConfiguredModel({ reasoning: undefined })],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      hasModelDirective: false,
+    });
+
+    await expect(
+      state.resolveThinkingCatalog({ hydrateRuntimeCatalog: false }),
+    ).resolves.toHaveLength(1);
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+
+    await expect(
+      state.resolveThinkingCatalog({ hydrateRuntimeCatalog: true }),
+    ).resolves.toHaveLength(1);
     expect(loadModelCatalog).toHaveBeenCalledOnce();
   });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,14 +1,13 @@
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
-import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { resolveModelCatalogScope } from "../../agents/model-catalog-scope.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
   buildConfiguredModelCatalog,
   buildAllowedModelSet,
   modelKey,
   normalizeModelRef,
-  normalizeProviderId,
   resolvePersistedOverrideModelRef,
   resolveReasoningDefault,
   resolveThinkingDefault,
@@ -25,6 +24,9 @@ export {
 import { resolveStoredModelOverride } from "./stored-model-override.js";
 
 type ModelCatalog = ModelCatalogEntry[];
+type ThinkingCatalogOptions = {
+  hydrateRuntimeCatalog?: boolean;
+};
 
 type ModelSelectionState = {
   provider: string;
@@ -33,7 +35,7 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resetModelOverrideRef?: string;
-  resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
+  resolveThinkingCatalog: (options?: ThinkingCatalogOptions) => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
   resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
@@ -78,8 +80,28 @@ function loadSessionStoreRuntime() {
   return sessionStoreRuntimeLoader.load();
 }
 
+async function loadScopedModelCatalogForSelection(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+  provider: string;
+  model: string;
+}): Promise<ModelCatalog> {
+  const scope = resolveModelCatalogScope({
+    cfg: params.cfg,
+    provider: params.provider,
+    model: params.model,
+  });
+  return (await loadModelCatalogRuntime()).loadModelCatalog({
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    providerRefs: scope.providerRefs,
+    modelRefs: scope.modelRefs,
+  });
+}
+
 export async function createModelSelectionState(params: {
   cfg: OpenClawConfig;
+  workspaceDir?: string;
   agentId?: string;
   agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
   sessionEntry?: SessionEntry;
@@ -139,7 +161,12 @@ export async function createModelSelectionState(params: {
   });
 
   if (needsModelCatalog) {
-    modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
+    modelCatalog = await loadScopedModelCatalogForSelection({
+      cfg,
+      workspaceDir: params.workspaceDir,
+      provider,
+      model,
+    });
     logStage("catalog-loaded", `entries=${modelCatalog.length}`);
     const allowed = buildAllowedModelSet({
       cfg,
@@ -224,27 +251,11 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  if (sessionEntry && sessionStore && sessionKey && sessionEntry.authProfileOverride) {
-    const { ensureAuthProfileStore } = await import("../../agents/auth-profiles.runtime.js");
-    const store = ensureAuthProfileStore(undefined, {
-      allowKeychainPrompt: false,
-    });
-    logStage("auth-profile-store-loaded", `profiles=${Object.keys(store.profiles).length}`);
-    const profile = store.profiles[sessionEntry.authProfileOverride];
-    const providerKey = normalizeProviderId(provider);
-    if (!profile || normalizeProviderId(profile.provider) !== providerKey) {
-      await clearSessionAuthProfileOverride({
-        sessionEntry,
-        sessionStore,
-        sessionKey,
-        storePath,
-      });
-    }
-  }
-
   let thinkingCatalog: ModelCatalog | undefined;
-  const resolveThinkingCatalog = async () => {
-    if (thinkingCatalog) {
+  let thinkingCatalogHydrated = modelCatalog !== null;
+  const resolveThinkingCatalog = async (options?: ThinkingCatalogOptions) => {
+    const hydrateRuntimeCatalog = options?.hydrateRuntimeCatalog === true;
+    if (thinkingCatalog && (!hydrateRuntimeCatalog || thinkingCatalogHydrated)) {
       return thinkingCatalog;
     }
     let catalogForThinking =
@@ -253,9 +264,16 @@ export async function createModelSelectionState(params: {
       (entry) => entry.provider === provider && entry.id === model,
     );
     const shouldHydrateRuntimeCatalog =
-      !modelCatalog && (!selectedCatalogEntry || selectedCatalogEntry.reasoning === undefined);
+      hydrateRuntimeCatalog &&
+      !modelCatalog &&
+      (!selectedCatalogEntry || selectedCatalogEntry.reasoning === undefined);
     if (shouldHydrateRuntimeCatalog) {
-      modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
+      modelCatalog = await loadScopedModelCatalogForSelection({
+        cfg,
+        workspaceDir: params.workspaceDir,
+        provider,
+        model,
+      });
       logStage("catalog-loaded-for-thinking", `entries=${modelCatalog.length}`);
       const runtimeSelectedEntry = modelCatalog.find(
         (entry) => entry.provider === provider && entry.id === model,
@@ -266,6 +284,7 @@ export async function createModelSelectionState(params: {
             ? modelCatalog
             : allowedModelCatalog
           : allowedModelCatalog;
+      thinkingCatalogHydrated = true;
     }
     thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;
     return thinkingCatalog;
@@ -297,7 +316,12 @@ export async function createModelSelectionState(params: {
   const resolveDefaultReasoningLevel = async (): Promise<"on" | "off"> => {
     let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
     if (!catalogForReasoning || catalogForReasoning.length === 0) {
-      modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
+      modelCatalog = await loadScopedModelCatalogForSelection({
+        cfg,
+        workspaceDir: params.workspaceDir,
+        provider,
+        model,
+      });
       logStage("catalog-loaded-for-reasoning", `entries=${modelCatalog.length}`);
       catalogForReasoning = modelCatalog;
     }

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -1,3 +1,4 @@
+import type { AuthProfileStore } from "../../../agents/auth-profiles.js";
 import type { ExecToolDefaults } from "../../../agents/bash-tools.js";
 import type { CurrentTurnPromptContext } from "../../../agents/pi-embedded-runner/run/params.js";
 import type { SkillSnapshot } from "../../../agents/skills.js";
@@ -79,6 +80,8 @@ export type FollowupRun = {
     modelOverrideSource?: "auto" | "user";
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
+    authProfileOrder?: string[];
+    authProfileStore?: AuthProfileStore;
     thinkLevel?: ThinkLevel;
     verboseLevel?: VerboseLevel;
     reasoningLevel?: ReasoningLevel;

--- a/src/auto-reply/reply/reply-stage-timing.ts
+++ b/src/auto-reply/reply/reply-stage-timing.ts
@@ -1,0 +1,62 @@
+import {
+  createStageTracker,
+  emitStageSummary,
+  type StageSummary,
+  type StageTracker,
+} from "../../infra/stage-timing.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+export type ReplyStageTracker = StageTracker;
+export type ReplyStageSummary = StageSummary;
+
+export const ReplyStageName = {
+  preparedContext: "prepared-context",
+  bareResetPrep: "bare-reset-prep",
+  userPromptPrep: "user-prompt-prep",
+  skillSnapshot: "skill-snapshot",
+  promptBodies: "prompt-bodies",
+  thinkingCatalog: "thinking-catalog",
+  sessionState: "session-state",
+  queueRuntime: "queue-runtime",
+  authProfile: "auth-profile",
+  activeQueue: "active-queue",
+  followupRun: "followup-run",
+  typingRunStart: "typing-run-start",
+  preflightCompaction: "preflight-compaction",
+  memoryFlush: "memory-flush",
+  followupRunner: "followup-runner",
+  replyOperationStart: "reply-operation-start",
+  queuedRuntimeConfig: "queued-runtime-config",
+  replyMediaContext: "reply-media-context",
+  agentRunContext: "agent-run-context",
+  fallbackSetup: "fallback-setup",
+  fallbackCandidateSelection: "fallback-candidate-selection",
+  runtimeSelection: "runtime-selection",
+  embeddedRunParams: "embedded-run-params",
+  embeddedRunDispatch: "embedded-run-dispatch",
+} as const;
+
+const log = createSubsystemLogger("reply-path");
+const REPLY_STAGE_WARN_TOTAL_MS = 5_000;
+const REPLY_STAGE_WARN_STAGE_MS = 2_000;
+
+export function createReplyStageTracker(options?: { now?: () => number }): ReplyStageTracker {
+  return createStageTracker(options);
+}
+
+export function emitReplyStageSummary(params: {
+  runId: string;
+  sessionId: string;
+  phase: string;
+  tracker: ReplyStageTracker;
+  normalLevel?: "debug" | "trace";
+}): boolean {
+  return emitStageSummary({
+    logger: log,
+    prefix: `[timing:reply-run] pre-dispatch stages: runId=${params.runId} sessionId=${params.sessionId} phase=${params.phase}`,
+    summary: params.tracker.snapshot(),
+    normalLevel: params.normalLevel,
+    totalThresholdMs: REPLY_STAGE_WARN_TOTAL_MS,
+    stageThresholdMs: REPLY_STAGE_WARN_STAGE_MS,
+  });
+}

--- a/src/auto-reply/reply/runtime-plugins.runtime.ts
+++ b/src/auto-reply/reply/runtime-plugins.runtime.ts
@@ -1,1 +1,0 @@
-export { ensureRuntimePluginsLoaded } from "../../agents/runtime-plugins.js";

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { ModelAliasIndex } from "./model-selection-directive.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
+
+const loadModelCatalog = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog,
+}));
 
 const modelCatalog: ModelCatalogEntry[] = [
   { provider: "minimax", id: "m2.7", name: "M2.7" },
@@ -51,6 +57,33 @@ async function applyResetFixture(params: {
 }
 
 describe("applyResetModelOverride", () => {
+  it("scopes model catalog loading to the reset model hint", async () => {
+    loadModelCatalog.mockResolvedValueOnce(modelCatalog);
+    const fixture = createResetFixture();
+
+    await applyResetModelOverride({
+      cfg: fixture.cfg,
+      resetTriggered: true,
+      bodyStripped: "minimax summarize",
+      sessionCtx: fixture.sessionCtx,
+      ctx: fixture.ctx,
+      sessionEntry: fixture.sessionEntry,
+      sessionStore: fixture.sessionStore,
+      sessionKey: "agent:main:dm:1",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      aliasIndex: fixture.aliasIndex,
+    });
+
+    expect(loadModelCatalog).toHaveBeenCalledWith({
+      config: fixture.cfg,
+      providerRefs: ["minimax", "openai"],
+      modelRefs: ["openai/minimax", "minimax"],
+    });
+    expect(fixture.sessionEntry.providerOverride).toBe("minimax");
+    expect(fixture.sessionEntry.modelOverride).toBe("m2.7");
+  });
+
   it("selects a model hint and strips it from the body", async () => {
     const { sessionEntry, sessionCtx } = await applyResetFixture({
       resetTriggered: true,

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -29,9 +29,50 @@ function splitBody(body: string) {
   };
 }
 
-async function loadResetModelCatalog(cfg: OpenClawConfig): Promise<ModelCatalogEntry[]> {
+function resolveResetModelCatalogScope(params: {
+  raw: string;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): { providerRefs: string[]; modelRefs: string[] } | undefined {
+  const providerRefs = new Set<string>();
+  const modelRefs = new Set<string>();
+  const firstTokenProvider = normalizeProviderId(params.raw);
+  if (firstTokenProvider) {
+    providerRefs.add(firstTokenProvider);
+  }
+
+  const resolved = resolveModelRefFromDirectiveString({
+    raw: params.raw,
+    defaultProvider: params.defaultProvider,
+    aliasIndex: params.aliasIndex,
+  });
+  if (!resolved) {
+    return providerRefs.size > 0 ? { providerRefs: [...providerRefs], modelRefs: [] } : undefined;
+  }
+
+  providerRefs.add(resolved.ref.provider);
+  modelRefs.add(modelKey(resolved.ref.provider, resolved.ref.model));
+  modelRefs.add(resolved.ref.model);
+
+  return {
+    providerRefs: [...providerRefs],
+    modelRefs: [...modelRefs],
+  };
+}
+
+async function loadResetModelCatalog(params: {
+  cfg: OpenClawConfig;
+  raw: string;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): Promise<ModelCatalogEntry[]> {
   const { loadModelCatalog } = await import("../../agents/model-catalog.js");
-  return loadModelCatalog({ config: cfg });
+  const scope = resolveResetModelCatalogScope(params);
+  return loadModelCatalog({
+    config: params.cfg,
+    providerRefs: scope?.providerRefs,
+    modelRefs: scope?.modelRefs,
+  });
 }
 
 async function resolveResetFallbackModels(params: {
@@ -163,7 +204,14 @@ export async function applyResetModelOverride(params: {
     return {};
   }
 
-  const catalog = params.modelCatalog ?? (await loadResetModelCatalog(params.cfg));
+  const catalog =
+    params.modelCatalog ??
+    (await loadResetModelCatalog({
+      cfg: params.cfg,
+      raw: first,
+      defaultProvider: params.defaultProvider,
+      aliasIndex: params.aliasIndex,
+    }));
   const allowedModelKeys = await buildResetAllowedModelKeys({
     cfg: params.cfg,
     catalog,

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -105,4 +105,27 @@ describe("ensureSkillSnapshot", () => {
     );
     expect(resolveAgentIdFromSessionKeyMock).not.toHaveBeenCalled();
   });
+
+  it("reuses persisted prompt snapshots without hydrating resolved skills", async () => {
+    const skillsSnapshot = {
+      prompt: "persisted skills prompt",
+      skills: [{ name: "diagnose" }],
+      version: 0,
+    };
+
+    const result = await ensureSkillSnapshot({
+      sessionKey: "main",
+      isFirstTurnInSession: false,
+      workspaceDir: "/tmp/workspace",
+      cfg: {},
+      sessionEntry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        skillsSnapshot,
+      },
+    });
+
+    expect(result.skillsSnapshot).toBe(skillsSnapshot);
+    expect(buildWorkspaceSkillSnapshotMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -10,7 +10,6 @@ import {
   shouldRefreshSnapshotForVersion,
 } from "../../agents/skills/refresh-state.js";
 import { ensureSkillsWatcher } from "../../agents/skills/refresh.js";
-import { hydrateResolvedSkills } from "../../agents/skills/snapshot-hydration.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -27,11 +26,10 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./session-hooks.js";
 export { drainFormattedSystemEvents } from "./session-system-events.js";
 
-// nextEntry.skillsSnapshot may carry resolvedSkills (full Skill[] with
-// SKILL.md bodies) for in-turn use. The persistence layer in
-// src/config/sessions/store-load.ts strips resolvedSkills before serializing,
-// so the on-disk sessions.json stays small. The in-memory params.sessionStore
-// reference still carries the runtime cache for the rest of this turn.
+// Persisted snapshots are the prompt contract for normal replies. Full
+// resolvedSkills hydration is owned by adapters that need skill files, such as
+// Claude CLI plugin materialization; the reply prep path should not rebuild
+// skill catalogs just to rehydrate that adapter-only cache.
 async function persistSessionEntryUpdate(params: {
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -176,9 +174,7 @@ export async function ensureSkillSnapshot(params: {
         updatedAt: Date.now(),
       };
     const skillSnapshot =
-      !current.skillsSnapshot || shouldRefreshSnapshot
-        ? buildSnapshot()
-        : hydrateResolvedSkills(current.skillsSnapshot, buildSnapshot);
+      !current.skillsSnapshot || shouldRefreshSnapshot ? buildSnapshot() : current.skillsSnapshot;
     nextEntry = {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
@@ -195,10 +191,10 @@ export async function ensureSkillSnapshot(params: {
     (nextEntry?.skillsSnapshot !== existingSnapshot || !shouldRefreshSnapshot);
   const skillsSnapshot =
     hasFreshSnapshotInEntry && nextEntry?.skillsSnapshot
-      ? hydrateResolvedSkills(nextEntry.skillsSnapshot, buildSnapshot)
+      ? nextEntry.skillsSnapshot
       : shouldRefreshSnapshot || !nextEntry?.skillsSnapshot
         ? buildSnapshot()
-        : hydrateResolvedSkills(nextEntry.skillsSnapshot, buildSnapshot);
+        : nextEntry.skillsSnapshot;
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/channels/plugins/bundled-ids.ts
+++ b/src/channels/plugins/bundled-ids.ts
@@ -1,13 +1,21 @@
 import { listChannelCatalogEntries } from "../../plugins/channel-catalog-registry.js";
 import { resolveBundledChannelRootScope } from "./bundled-root.js";
 
+const bundledChannelPluginIdsByRoot = new Map<string, readonly string[]>();
+
 export function listBundledChannelPluginIdsForRoot(
-  _packageRoot: string,
+  packageRoot: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  return listChannelCatalogEntries({ origin: "bundled", env })
+  const cached = bundledChannelPluginIdsByRoot.get(packageRoot);
+  if (cached) {
+    return [...cached];
+  }
+  const pluginIds = listChannelCatalogEntries({ origin: "bundled", env })
     .map((entry) => entry.pluginId)
     .toSorted((left, right) => left.localeCompare(right));
+  bundledChannelPluginIdsByRoot.set(packageRoot, pluginIds);
+  return [...pluginIds];
 }
 
 export function listBundledChannelPluginIds(env: NodeJS.ProcessEnv = process.env): string[] {

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -57,10 +57,12 @@ describe("bundled root-aware plugin lookups", () => {
   it("reads bundled channel ids from the active bundled root without re-importing", async () => {
     const rootA = makeBundledRoot("openclaw-bundled-ids-a-");
     const rootB = makeBundledRoot("openclaw-bundled-ids-b-");
+    const catalogReadsByRoot = new Map<string | undefined, number>();
 
     vi.doMock("../../plugins/channel-catalog-registry.js", () => ({
       listChannelCatalogEntries: (params?: { env?: NodeJS.ProcessEnv }) => {
         const activeRoot = params?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        catalogReadsByRoot.set(activeRoot, (catalogReadsByRoot.get(activeRoot) ?? 0) + 1);
         if (activeRoot === rootA.pluginsDir) {
           return [{ pluginId: "alpha" }];
         }
@@ -78,9 +80,12 @@ describe("bundled root-aware plugin lookups", () => {
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootA.pluginsDir;
     expect(bundledIds.listBundledChannelPluginIds()).toEqual(["alpha"]);
+    expect(bundledIds.listBundledChannelPluginIds()).toEqual(["alpha"]);
+    expect(catalogReadsByRoot.get(rootA.pluginsDir)).toBe(1);
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootB.pluginsDir;
     expect(bundledIds.listBundledChannelPluginIds()).toEqual(["beta"]);
+    expect(catalogReadsByRoot.get(rootB.pluginsDir)).toBe(1);
   });
 
   it("reads bootstrap plugins from the active bundled root without re-importing", async () => {

--- a/src/commands/models/list.configured.test.ts
+++ b/src/commands/models/list.configured.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
+  getProviderModelNormalizationRuntimeCacheKey: vi.fn(() => "test-runtime"),
   normalizeProviderModelIdWithRuntime: vi.fn(() => {
     throw new Error("runtime model normalization should not load for models list entries");
   }),

--- a/src/config/model-refs.ts
+++ b/src/config/model-refs.ts
@@ -1,0 +1,69 @@
+import { normalizeProviderId } from "../agents/provider-id.js";
+import { isRecord } from "../utils.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+export function collectConfiguredModelRefs(cfg: OpenClawConfig): string[] {
+  const refs: string[] = [];
+  const pushModelRef = (value: unknown) => {
+    if (typeof value === "string" && value.trim()) {
+      refs.push(value.trim());
+    }
+  };
+  const collectModelConfig = (value: unknown) => {
+    if (typeof value === "string") {
+      pushModelRef(value);
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    pushModelRef(value.primary);
+    const fallbacks = value.fallbacks;
+    if (Array.isArray(fallbacks)) {
+      for (const entry of fallbacks) {
+        pushModelRef(entry);
+      }
+    }
+  };
+  const collectFromAgent = (agent: Record<string, unknown> | null | undefined) => {
+    if (!agent) {
+      return;
+    }
+    for (const key of [
+      "model",
+      "imageModel",
+      "pdfModel",
+      "imageGenerationModel",
+      "videoGenerationModel",
+      "musicGenerationModel",
+    ]) {
+      collectModelConfig(agent[key]);
+    }
+    const models = agent.models;
+    if (isRecord(models)) {
+      for (const key of Object.keys(models)) {
+        pushModelRef(key);
+      }
+    }
+  };
+
+  collectFromAgent(cfg.agents?.defaults as Record<string, unknown> | undefined);
+  const list = cfg.agents?.list;
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      if (isRecord(entry)) {
+        collectFromAgent(entry);
+      }
+    }
+  }
+  return refs;
+}
+
+export function extractProviderFromModelRef(value: string): string | null {
+  const trimmed = value.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0) {
+    return null;
+  }
+  return normalizeProviderId(trimmed.slice(0, slash));
+}

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -15,6 +15,7 @@ import { resolvePluginSetupAutoEnableReasons } from "../plugins/setup-registry.j
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { isRecord } from "../utils.js";
 import { isChannelConfigured } from "./channel-configured.js";
+import { collectConfiguredModelRefs, extractProviderFromModelRef } from "./model-refs.js";
 import { shouldSkipPreferredPluginAutoEnable } from "./plugin-auto-enable.prefer-over.js";
 import type {
   PluginAutoEnableCandidate,
@@ -45,70 +46,6 @@ function resolveAutoEnableProviderPluginIds(
     }
   }
   return Object.fromEntries(entries);
-}
-
-function collectModelRefs(cfg: OpenClawConfig): string[] {
-  const refs: string[] = [];
-  const pushModelRef = (value: unknown) => {
-    if (typeof value === "string" && value.trim()) {
-      refs.push(value.trim());
-    }
-  };
-  const collectModelConfig = (value: unknown) => {
-    if (typeof value === "string") {
-      pushModelRef(value);
-      return;
-    }
-    if (!isRecord(value)) {
-      return;
-    }
-    pushModelRef(value.primary);
-    const fallbacks = value.fallbacks;
-    if (Array.isArray(fallbacks)) {
-      for (const entry of fallbacks) {
-        pushModelRef(entry);
-      }
-    }
-  };
-  const collectFromAgent = (agent: Record<string, unknown> | null | undefined) => {
-    if (!agent) {
-      return;
-    }
-    for (const key of [
-      "model",
-      "imageGenerationModel",
-      "videoGenerationModel",
-      "musicGenerationModel",
-    ]) {
-      collectModelConfig(agent[key]);
-    }
-    const models = agent.models;
-    if (isRecord(models)) {
-      for (const key of Object.keys(models)) {
-        pushModelRef(key);
-      }
-    }
-  };
-
-  collectFromAgent(cfg.agents?.defaults as Record<string, unknown> | undefined);
-  const list = cfg.agents?.list;
-  if (Array.isArray(list)) {
-    for (const entry of list) {
-      if (isRecord(entry)) {
-        collectFromAgent(entry);
-      }
-    }
-  }
-  return refs;
-}
-
-function extractProviderFromModelRef(value: string): string | null {
-  const trimmed = value.trim();
-  const slash = trimmed.indexOf("/");
-  if (slash <= 0) {
-    return null;
-  }
-  return normalizeProviderId(trimmed.slice(0, slash));
 }
 
 function hasConfiguredEmbeddedHarnessRuntime(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
@@ -157,7 +94,7 @@ function isProviderConfigured(cfg: OpenClawConfig, providerId: string): boolean 
     }
   }
 
-  for (const ref of collectModelRefs(cfg)) {
+  for (const ref of collectConfiguredModelRefs(cfg)) {
     const provider = extractProviderFromModelRef(ref);
     if (provider && provider === normalized) {
       return true;
@@ -493,7 +430,7 @@ function hasConfiguredProviderModelOrHarness(cfg: OpenClawConfig, env: NodeJS.Pr
   if (cfg.models?.providers && Object.keys(cfg.models.providers).length > 0) {
     return true;
   }
-  if (collectModelRefs(cfg).length > 0) {
+  if (collectConfiguredModelRefs(cfg).length > 0) {
     return true;
   }
   return hasConfiguredEmbeddedHarnessRuntime(cfg, env);
@@ -618,7 +555,7 @@ export function resolveConfiguredPluginAutoEnableCandidates(params: {
     }
   }
 
-  for (const modelRef of collectModelRefs(params.config)) {
+  for (const modelRef of collectConfiguredModelRefs(params.config)) {
     const owningPluginIds = resolveOwningPluginIdsForModelRef({
       model: modelRef,
       config: params.config,

--- a/src/config/sessions/store.skills-stripping.test.ts
+++ b/src/config/sessions/store.skills-stripping.test.ts
@@ -177,8 +177,8 @@ describe("session store strips resolvedSkills from persistence", () => {
   });
 });
 
-describe("embedded runner falls back to disk when resolvedSkills is absent", () => {
-  it("signals shouldLoadSkillEntries when the persisted snapshot has no resolvedSkills", () => {
+describe("embedded runner reuses persisted skill prompt snapshots", () => {
+  it("signals shouldLoadSkillEntries when the stripped snapshot has no prompt contract", () => {
     const result = resolveEmbeddedRunSkillEntries({
       workspaceDir: "/nonexistent-workspace-for-test",
       skillsSnapshot: {
@@ -190,6 +190,20 @@ describe("embedded runner falls back to disk when resolvedSkills is absent", () 
     });
 
     expect(result.shouldLoadSkillEntries).toBe(true);
+  });
+
+  it("skips loading when a persisted prompt snapshot is present", () => {
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/nonexistent-workspace-for-test",
+      skillsSnapshot: {
+        prompt: "persisted prompt",
+        skills: [{ name: "x" }],
+        version: 1,
+      },
+    });
+
+    expect(result.shouldLoadSkillEntries).toBe(false);
+    expect(result.skillEntries).toEqual([]);
   });
 
   it("skips loading when resolvedSkills is present (in-turn cache hot path)", () => {

--- a/src/cron/isolated-agent.model-formatting.test.ts
+++ b/src/cron/isolated-agent.model-formatting.test.ts
@@ -4,13 +4,19 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 const {
   loadModelCatalogMock,
   getModelRefStatusMock,
+  inferUniqueProviderFromConfiguredModelsMock,
   normalizeModelSelectionMock,
+  resolveModelCatalogScopeMock,
+  resolveModelRefFromStringMock,
   resolveAllowedModelRefMock,
+  buildModelAliasIndexMock,
   resolveConfiguredModelRefMock,
   resolveHooksGmailModelMock,
 } = vi.hoisted(() => ({
   loadModelCatalogMock: vi.fn(),
   getModelRefStatusMock: vi.fn(),
+  inferUniqueProviderFromConfiguredModelsMock: vi.fn(() => undefined),
+  buildModelAliasIndexMock: vi.fn(() => ({ byAlias: new Map(), byKey: new Map() })),
   normalizeModelSelectionMock: vi.fn((value: unknown) => {
     if (typeof value === "string" && value.trim()) {
       return value.trim();
@@ -25,6 +31,18 @@ const {
     }
     return undefined;
   }),
+  resolveModelCatalogScopeMock: vi.fn(
+    ({ provider, model }: { provider: string; model: string }) => ({
+      providerRefs: [provider],
+      modelRefs: [`${provider}/${model}`, model],
+    }),
+  ),
+  resolveModelRefFromStringMock: vi.fn(
+    ({ raw, defaultProvider }: { raw: string; defaultProvider: string }) => {
+      const parsed = parseModelRefForMock(raw, defaultProvider);
+      return "error" in parsed ? null : { ref: parsed };
+    },
+  ),
   resolveAllowedModelRefMock: vi.fn(),
   resolveConfiguredModelRefMock: vi.fn(),
   resolveHooksGmailModelMock: vi.fn(),
@@ -33,9 +51,13 @@ const {
 vi.mock("./isolated-agent/run-model-selection.runtime.js", () => ({
   DEFAULT_MODEL: "claude-opus-4-6",
   DEFAULT_PROVIDER: "anthropic",
+  buildModelAliasIndex: buildModelAliasIndexMock,
   getModelRefStatus: getModelRefStatusMock,
+  inferUniqueProviderFromConfiguredModels: inferUniqueProviderFromConfiguredModelsMock,
   loadModelCatalog: loadModelCatalogMock,
   normalizeModelSelection: normalizeModelSelectionMock,
+  resolveModelCatalogScope: resolveModelCatalogScopeMock,
+  resolveModelRefFromString: resolveModelRefFromStringMock,
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
@@ -69,7 +91,17 @@ type SelectModelOptions = {
 };
 
 function parseModelRef(raw: string): { provider: string; model: string } | { error: string } {
+  return parseModelRefForMock(raw);
+}
+
+function parseModelRefForMock(
+  raw: string,
+  defaultProvider?: string,
+): { provider: string; model: string } | { error: string } {
   const trimmed = raw.trim();
+  if (!trimmed.includes("/") && defaultProvider) {
+    return { provider: defaultProvider, model: trimmed };
+  }
   const slash = trimmed.indexOf("/");
   if (slash <= 0 || slash === trimmed.length - 1) {
     return { error: "invalid model" };
@@ -148,6 +180,20 @@ describe("cron model formatting and precedence edge cases", () => {
     vi.clearAllMocks();
     loadModelCatalogMock.mockResolvedValue([]);
     getModelRefStatusMock.mockReturnValue({ allowed: false });
+    inferUniqueProviderFromConfiguredModelsMock.mockReturnValue(undefined);
+    buildModelAliasIndexMock.mockReturnValue({ byAlias: new Map(), byKey: new Map() });
+    resolveModelCatalogScopeMock.mockImplementation(
+      ({ provider, model }: { provider: string; model: string }) => ({
+        providerRefs: [provider],
+        modelRefs: [`${provider}/${model}`, model],
+      }),
+    );
+    resolveModelRefFromStringMock.mockImplementation(
+      ({ raw, defaultProvider }: { raw: string; defaultProvider: string }) => {
+        const parsed = parseModelRefForMock(raw, defaultProvider);
+        return "error" in parsed ? null : { ref: parsed };
+      },
+    );
     resolveHooksGmailModelMock.mockReturnValue(null);
     resolveConfiguredModelRefMock.mockImplementation(({ cfg }: { cfg?: Record<string, unknown> }) =>
       resolveConfiguredModelForTest(cfg ?? {}),
@@ -166,6 +212,11 @@ describe("cron model formatting and precedence edge cases", () => {
         },
         { provider: "openai", model: "gpt-4.1-mini" },
       );
+      expect(loadModelCatalogMock).toHaveBeenCalledWith({
+        config: {},
+        providerRefs: ["openai"],
+        modelRefs: ["openai/gpt-4.1-mini", "gpt-4.1-mini"],
+      });
     });
 
     it("handles leading/trailing whitespace in model string", async () => {

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -3,12 +3,16 @@ import type { CronJob } from "../types.js";
 import {
   DEFAULT_MODEL,
   DEFAULT_PROVIDER,
+  buildModelAliasIndex,
   getModelRefStatus,
+  inferUniqueProviderFromConfiguredModels,
   loadModelCatalog,
   normalizeModelSelection,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelCatalogScope,
+  resolveModelRefFromString,
 } from "./run-model-selection.runtime.js";
 
 type CronSessionModelOverrides = {
@@ -61,12 +65,76 @@ export async function resolveCronModelSelection(
   let provider = resolvedDefault.provider;
   let model = resolvedDefault.model;
 
-  let catalog: Awaited<ReturnType<typeof loadModelCatalog>> | undefined;
-  const loadCatalogOnce = async () => {
-    if (!catalog) {
-      catalog = await loadModelCatalog({ config: params.cfgWithAgentDefaults });
+  let catalog: Awaited<ReturnType<typeof loadModelCatalog>> = [];
+  let loadedFullCatalog = false;
+  const loadedCatalogScopeKeys = new Set<string>();
+  const appendCatalog = (entries: Awaited<ReturnType<typeof loadModelCatalog>>) => {
+    const seen = new Set(catalog.map((entry) => `${entry.provider}/${entry.id}`));
+    for (const entry of entries) {
+      const key = `${entry.provider}/${entry.id}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      catalog.push(entry);
+    }
+  };
+  const loadCatalogOnce = async (scope?: { providerRefs: string[]; modelRefs: string[] }) => {
+    if (loadedFullCatalog) {
+      return catalog;
+    }
+    if (!scope) {
+      catalog = await loadModelCatalog({
+        config: params.cfgWithAgentDefaults,
+      });
+      loadedFullCatalog = true;
+      return catalog;
+    }
+    const scopeKey = JSON.stringify({
+      providerRefs: scope.providerRefs,
+      modelRefs: scope.modelRefs,
+    });
+    if (!loadedCatalogScopeKeys.has(scopeKey)) {
+      loadedCatalogScopeKeys.add(scopeKey);
+      appendCatalog(
+        await loadModelCatalog({
+          config: params.cfgWithAgentDefaults,
+          providerRefs: scope.providerRefs,
+          modelRefs: scope.modelRefs,
+        }),
+      );
     }
     return catalog;
+  };
+  const resolveRawCatalogScope = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const defaultProvider = !trimmed.includes("/")
+      ? (inferUniqueProviderFromConfiguredModels({
+          cfg: params.cfgWithAgentDefaults,
+          model: trimmed,
+        }) ?? resolvedDefault.provider)
+      : resolvedDefault.provider;
+    const aliasIndex = buildModelAliasIndex({
+      cfg: params.cfgWithAgentDefaults,
+      defaultProvider,
+    });
+    const resolved = resolveModelRefFromString({
+      cfg: params.cfgWithAgentDefaults,
+      raw: trimmed,
+      defaultProvider,
+      aliasIndex,
+    });
+    if (!resolved) {
+      return undefined;
+    }
+    return resolveModelCatalogScope({
+      cfg: params.cfgWithAgentDefaults,
+      provider: resolved.ref.provider,
+      model: resolved.ref.model,
+    });
   };
 
   const subagentModelRaw =
@@ -76,7 +144,7 @@ export async function resolveCronModelSelection(
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
-      catalog: await loadCatalogOnce(),
+      catalog: await loadCatalogOnce(resolveRawCatalogScope(subagentModelRaw)),
       raw: subagentModelRaw,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
@@ -97,7 +165,13 @@ export async function resolveCronModelSelection(
   if (hooksGmailModelRef) {
     const status = getModelRefStatus({
       cfg: params.cfg,
-      catalog: await loadCatalogOnce(),
+      catalog: await loadCatalogOnce(
+        resolveModelCatalogScope({
+          cfg: params.cfgWithAgentDefaults,
+          provider: hooksGmailModelRef.provider,
+          model: hooksGmailModelRef.model,
+        }),
+      ),
       ref: hooksGmailModelRef,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
@@ -114,7 +188,7 @@ export async function resolveCronModelSelection(
   if (modelOverride !== undefined && modelOverride.length > 0) {
     const resolvedOverride = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
-      catalog: await loadCatalogOnce(),
+      catalog: await loadCatalogOnce(resolveRawCatalogScope(modelOverride)),
       raw: modelOverride,
       defaultProvider: resolvedDefault.provider,
       defaultModel: resolvedDefault.model,
@@ -136,7 +210,13 @@ export async function resolveCronModelSelection(
         params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: params.cfgWithAgentDefaults,
-        catalog: await loadCatalogOnce(),
+        catalog: await loadCatalogOnce(
+          resolveModelCatalogScope({
+            cfg: params.cfgWithAgentDefaults,
+            provider: sessionProviderOverride,
+            model: sessionModelOverride,
+          }),
+        ),
         raw: `${sessionProviderOverride}/${sessionModelOverride}`,
         defaultProvider: resolvedDefault.provider,
         defaultModel: resolvedDefault.model,

--- a/src/cron/isolated-agent/run-model-selection.runtime.ts
+++ b/src/cron/isolated-agent/run-model-selection.runtime.ts
@@ -1,9 +1,13 @@
 export { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+export { resolveModelCatalogScope } from "../../agents/model-catalog-scope.js";
 export { loadModelCatalog } from "../../agents/model-catalog.js";
 export {
+  buildModelAliasIndex,
   getModelRefStatus,
+  inferUniqueProviderFromConfiguredModels,
   normalizeModelSelection,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelRefFromString,
 } from "../../agents/model-selection-resolve.js";

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -38,6 +38,39 @@ function normalizeModelSelectionForTest(value: unknown): string | undefined {
   return normalizeOptionalString((value as { primary?: unknown }).primary);
 }
 
+function resolveModelRefFromStringForTest(params: {
+  raw: string;
+  defaultProvider: string;
+}): { ref: { provider: string; model: string } } | null {
+  const trimmed = params.raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const slash = trimmed.indexOf("/");
+  if (slash < 0) {
+    return { ref: { provider: params.defaultProvider, model: trimmed } };
+  }
+  if (slash === 0 || slash === trimmed.length - 1) {
+    return null;
+  }
+  return {
+    ref: {
+      provider: trimmed.slice(0, slash).trim().toLowerCase(),
+      model: trimmed.slice(slash + 1).trim(),
+    },
+  };
+}
+
+function resolveModelCatalogScopeForTest(params: { provider: string; model: string }): {
+  providerRefs: string[];
+  modelRefs: string[];
+} {
+  return {
+    providerRefs: [params.provider],
+    modelRefs: [`${params.provider}/${params.model}`, params.model],
+  };
+}
+
 export const buildWorkspaceSkillSnapshotMock = createMock();
 export const resolveAgentConfigMock = createMock();
 export const resolveEffectiveModelFallbacksMock = createMock();
@@ -48,6 +81,10 @@ export const isCliProviderMock = createMock();
 export const resolveAllowedModelRefMock = createMock();
 export const resolveConfiguredModelRefMock = createMock();
 export const resolveHooksGmailModelMock = createMock();
+export const buildModelAliasIndexMock = createMock();
+export const inferUniqueProviderFromConfiguredModelsMock = createMock();
+export const resolveModelCatalogScopeMock = createMock();
+export const resolveModelRefFromStringMock = createMock();
 export const resolveThinkingDefaultMock = createMock();
 export const runWithModelFallbackMock = createMock();
 export const runEmbeddedPiAgentMock = createMock();
@@ -152,9 +189,17 @@ vi.mock("./skills-snapshot.runtime.js", () => ({
 vi.mock("./run-model-selection.runtime.js", () => ({
   DEFAULT_MODEL: "gpt-5.4",
   DEFAULT_PROVIDER: "openai",
+  buildModelAliasIndex: (...args: unknown[]) =>
+    buildModelAliasIndexMock(...args) ?? { byAlias: new Map(), byKey: new Map() },
+  inferUniqueProviderFromConfiguredModels: (...args: unknown[]) =>
+    inferUniqueProviderFromConfiguredModelsMock(...args),
   loadModelCatalog: loadModelCatalogMock,
   getModelRefStatus: getModelRefStatusMock,
   normalizeModelSelection: normalizeModelSelectionForTest,
+  resolveModelCatalogScope: (...args: [{ provider: string; model: string }]) =>
+    resolveModelCatalogScopeMock(...args) ?? resolveModelCatalogScopeForTest(args[0]),
+  resolveModelRefFromString: (...args: [{ raw: string; defaultProvider: string }]) =>
+    resolveModelRefFromStringMock(...args) ?? resolveModelRefFromStringForTest(args[0]),
   resolveAllowedModelRef: resolveAllowedModelRefMock,
   resolveConfiguredModelRef: resolveConfiguredModelRefMock,
   resolveHooksGmailModel: resolveHooksGmailModelMock,
@@ -317,6 +362,10 @@ function resetRunConfigMocks(): void {
   resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.4" });
   resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-5.4" } });
   resolveHooksGmailModelMock.mockReturnValue(null);
+  buildModelAliasIndexMock.mockReturnValue({ byAlias: new Map(), byKey: new Map() });
+  inferUniqueProviderFromConfiguredModelsMock.mockReturnValue(undefined);
+  resolveModelCatalogScopeMock.mockImplementation(resolveModelCatalogScopeForTest);
+  resolveModelRefFromStringMock.mockImplementation(resolveModelRefFromStringForTest);
   resolveThinkingDefaultMock.mockReturnValue("off");
   getModelRefStatusMock.mockReturnValue({ allowed: false });
   resolveCronStyleNowMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,4 +1,5 @@
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
+import { resolveModelCatalogScope } from "../../agents/model-catalog-scope.js";
 import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.types.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
@@ -486,10 +487,17 @@ async function prepareCronRunContext(params: {
   let catalog: Awaited<ReturnType<CronModelCatalogRuntime["loadModelCatalog"]>> | undefined;
   const loadCatalog = async () => {
     if (!catalog) {
+      const scope = resolveModelCatalogScope({
+        cfg: cfgWithAgentDefaults,
+        provider,
+        model,
+      });
       catalog = await (
         await loadCronModelCatalogRuntime()
       ).loadModelCatalog({
         config: cfgWithAgentDefaults,
+        providerRefs: scope.providerRefs,
+        modelRefs: scope.modelRefs,
       });
     }
     return catalog;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -392,6 +392,7 @@ async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise<void> 
   }
   const { DEFAULT_MODEL, DEFAULT_PROVIDER } = await import("../agents/defaults.js");
   const { loadModelCatalog } = await import("../agents/model-catalog.js");
+  const { resolveModelCatalogScope } = await import("../agents/model-catalog-scope.js");
   const { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel } =
     await import("../agents/model-selection.js");
   const { note } = await import("../terminal/note.js");
@@ -408,7 +409,14 @@ async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise<void> 
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const catalog = await loadModelCatalog({ config: ctx.cfg });
+  const catalog = await loadModelCatalog({
+    config: ctx.cfg,
+    ...resolveModelCatalogScope({
+      cfg: ctx.cfg,
+      provider: hooksModelRef.provider,
+      model: hooksModelRef.model,
+    }),
+  });
   const status = getModelRefStatus({
     cfg: ctx.cfg,
     catalog,

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -17,7 +17,10 @@ const pluginManifestRegistryMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../agents/provider-model-normalization.runtime.js", () => {
-  return { normalizeProviderModelIdWithRuntime: normalizeProviderModelIdWithRuntimeMock };
+  return {
+    getProviderModelNormalizationRuntimeCacheKey: () => "test-runtime",
+    normalizeProviderModelIdWithRuntime: normalizeProviderModelIdWithRuntimeMock,
+  };
 });
 
 vi.mock("../plugins/manifest-registry-installed.js", async (importOriginal) => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -231,6 +231,30 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toBe("channel exited without an error");
   });
 
+  it("keeps channel exit handling robust when a channel logger is missing", async () => {
+    const log = createSubsystemLogger("gateway/server-channels-test");
+    const startAccount = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createChannelManager({
+      getRuntimeConfig: () => ({}),
+      channelLogs: {} as Record<ChannelId, SubsystemLogger>,
+      channelRuntimeEnvs: { discord: runtimeForLogger(log) } as unknown as Record<
+        ChannelId,
+        RuntimeEnv
+      >,
+    });
+
+    await manager.startChannels();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(false);
+    expect(account?.lastError).toBe("boom");
+  });
+
   it("does not record a clean-exit error for manual abort stops", async () => {
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -3,6 +3,10 @@ import { ErrorCodes } from "../protocol/index.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  listLoadedSpeechProviders: vi.fn(() => []),
+  listSpeechProviders: vi.fn(() => {
+    throw new Error("broad speech provider registry should not be used by Gateway TTS RPCs");
+  }),
   resolveExplicitTtsOverrides: vi.fn(() => ({})),
   textToSpeech: vi.fn(async () => ({
     success: true,
@@ -21,7 +25,10 @@ vi.mock("../../config/config.js", () => ({
 vi.mock("../../tts/provider-registry.js", () => ({
   canonicalizeSpeechProviderId: vi.fn(),
   getSpeechProvider: vi.fn(),
-  listSpeechProviders: vi.fn(() => []),
+  listLoadedSpeechProviders:
+    mocks.listLoadedSpeechProviders as typeof import("../../tts/provider-registry.js").listLoadedSpeechProviders,
+  listSpeechProviders:
+    mocks.listSpeechProviders as typeof import("../../tts/provider-registry.js").listSpeechProviders,
 }));
 
 vi.mock("../../tts/tts.js", () => ({
@@ -47,6 +54,9 @@ describe("ttsHandlers", () => {
   beforeEach(() => {
     mocks.getRuntimeConfig.mockReset();
     mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.listLoadedSpeechProviders.mockReset();
+    mocks.listLoadedSpeechProviders.mockReturnValue([]);
+    mocks.listSpeechProviders.mockClear();
     mocks.resolveExplicitTtsOverrides.mockReset();
     mocks.resolveExplicitTtsOverrides.mockReturnValue({});
     mocks.textToSpeech.mockReset();
@@ -85,5 +95,47 @@ describe("ttsHandlers", () => {
       }),
     );
     expect(mocks.textToSpeech).not.toHaveBeenCalled();
+  });
+
+  it("uses loaded providers for status/provider listing RPCs", async () => {
+    const provider = {
+      id: "openai",
+      label: "OpenAI",
+      isConfigured: vi.fn(() => true),
+      synthesize: vi.fn(),
+      models: ["tts-1"],
+      voices: ["alloy"],
+    };
+    mocks.listLoadedSpeechProviders.mockReturnValue([provider]);
+
+    const { ttsHandlers } = await import("./tts.js");
+    const statusRespond = vi.fn();
+    const providersRespond = vi.fn();
+
+    await ttsHandlers["tts.status"]({
+      params: {},
+      respond: statusRespond,
+      context: { getRuntimeConfig: mocks.getRuntimeConfig },
+    } as never);
+    await ttsHandlers["tts.providers"]({
+      params: {},
+      respond: providersRespond,
+      context: { getRuntimeConfig: mocks.getRuntimeConfig },
+    } as never);
+
+    expect(mocks.listLoadedSpeechProviders).toHaveBeenCalledTimes(2);
+    expect(mocks.listSpeechProviders).not.toHaveBeenCalled();
+    expect(statusRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        providerStates: [expect.objectContaining({ id: "openai", configured: true })],
+      }),
+    );
+    expect(providersRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        providers: [expect.objectContaining({ id: "openai", configured: true })],
+      }),
+    );
   });
 });

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -2,7 +2,7 @@ import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   canonicalizeSpeechProviderId,
   getSpeechProvider,
-  listSpeechProviders,
+  listLoadedSpeechProviders,
 } from "../../tts/provider-registry.js";
 import {
   getResolvedSpeechProviderConfig,
@@ -37,7 +37,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const fallbackProviders = resolveTtsProviderOrder(provider, cfg)
         .slice(1)
         .filter((candidate) => isTtsProviderConfigured(config, candidate, cfg));
-      const providerStates = listSpeechProviders(cfg).map((candidate) => ({
+      const providerStates = listLoadedSpeechProviders(cfg).map((candidate) => ({
         id: candidate.id,
         label: candidate.label,
         configured: candidate.isConfigured({
@@ -225,7 +225,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const config = resolveTtsConfig(cfg);
       const prefsPath = resolveTtsPrefsPath(config);
       respond(true, {
-        providers: listSpeechProviders(cfg).map((provider) => ({
+        providers: listLoadedSpeechProviders(cfg).map((provider) => ({
           id: provider.id,
           name: provider.label,
           configured: provider.isConfigured({

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -3,7 +3,10 @@ import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginLookUpTable } from "../plugins/plugin-lookup-table.js";
 import type { PluginRegistry } from "../plugins/registry.js";
-import { pinActivePluginChannelRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
+} from "../plugins/runtime.js";
 import {
   setGatewayNodesRuntime,
   setGatewaySubagentRuntime,
@@ -73,6 +76,11 @@ function logGatewayPluginDiagnostics(params: {
   }
 }
 
+function pinGatewayStartupRegistries(pluginRegistry: PluginRegistry): void {
+  pinActivePluginChannelRegistry(pluginRegistry);
+  pinActivePluginGatewayRuntimeRegistry(pluginRegistry);
+}
+
 export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   const activationSourceConfig = params.activationSourceConfig ?? params.cfg;
   const autoEnabled = applyPluginAutoEnable({
@@ -125,7 +133,7 @@ export function loadGatewayStartupPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayStartupRegistries,
   });
 }
 
@@ -137,6 +145,6 @@ export function reloadDeferredGatewayPlugins(
 ) {
   return prepareGatewayPluginLoad({
     ...params,
-    beforePrimeRegistry: pinActivePluginChannelRegistry,
+    beforePrimeRegistry: pinGatewayStartupRegistries,
   });
 }

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -43,6 +43,8 @@ const hoisted = vi.hoisted(() => {
   }));
   const resolveEmbeddedAgentRuntime = vi.fn(() => "pi");
   const ensureOpenClawModelsJson = vi.fn(async () => undefined);
+  const resolveModelAsync = vi.fn(async () => ({}));
+  const prewarmTtsRuntimeFacade = vi.fn(() => undefined);
   return {
     startPluginServices,
     startGmailWatcherWithLogs,
@@ -69,6 +71,8 @@ const hoisted = vi.hoisted(() => {
     resolveConfiguredModelRef,
     resolveEmbeddedAgentRuntime,
     ensureOpenClawModelsJson,
+    resolveModelAsync,
+    prewarmTtsRuntimeFacade,
   };
 });
 
@@ -181,6 +185,14 @@ vi.mock("../agents/models-config.js", () => ({
   ensureOpenClawModelsJson: hoisted.ensureOpenClawModelsJson,
 }));
 
+vi.mock("../agents/pi-embedded-runner/model.js", () => ({
+  resolveModelAsync: hoisted.resolveModelAsync,
+}));
+
+vi.mock("../tts/tts.js", () => ({
+  prewarmTtsRuntimeFacade: hoisted.prewarmTtsRuntimeFacade,
+}));
+
 vi.mock("./server-tailscale.js", () => ({
   startGatewayTailscaleExposure: hoisted.startGatewayTailscaleExposure,
 }));
@@ -226,6 +238,10 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.resolveEmbeddedAgentRuntime.mockReturnValue("pi");
     hoisted.ensureOpenClawModelsJson.mockReset();
     hoisted.ensureOpenClawModelsJson.mockResolvedValue(undefined);
+    hoisted.resolveModelAsync.mockReset();
+    hoisted.resolveModelAsync.mockResolvedValue({});
+    hoisted.prewarmTtsRuntimeFacade.mockReset();
+    hoisted.prewarmTtsRuntimeFacade.mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -576,18 +592,22 @@ describe("startGatewayPostAttachRuntime", () => {
     }
   });
 
-  it("starts channels without waiting for primary model prewarm completion", async () => {
+  it("starts channels after bounded primary model prewarm completion", async () => {
     await withEnvAsync(
       { OPENCLAW_SKIP_CHANNELS: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
       async () => {
+        const events: string[] = [];
         let resolvePrewarm!: () => void;
-        const prewarmPrimaryModel = vi.fn(
-          async () =>
-            await new Promise<undefined>((resolve) => {
-              resolvePrewarm = () => resolve(undefined);
-            }),
-        );
-        const startChannels = vi.fn(async () => undefined);
+        const prewarmPrimaryModel = vi.fn(async () => {
+          events.push("prewarm-start");
+          await new Promise<undefined>((resolve) => {
+            resolvePrewarm = () => resolve(undefined);
+          });
+          events.push("prewarm-done");
+        });
+        const startChannels = vi.fn(async () => {
+          events.push("channels");
+        });
 
         const sidecarsPromise = startGatewaySidecars({
           cfg: {
@@ -611,24 +631,119 @@ describe("startGatewayPostAttachRuntime", () => {
           },
         });
 
-        await vi.waitFor(
-          () => {
-            expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
-            expect(prewarmPrimaryModel).toHaveBeenCalledWith(
-              expect.objectContaining({
-                workspaceDir: "/tmp/openclaw-workspace",
-              }),
-            );
-            expect(startChannels).toHaveBeenCalledTimes(1);
-          },
-          { timeout: 2_000 },
-        );
-        await sidecarsPromise;
+        await vi.waitFor(() => {
+          expect(hoisted.prewarmTtsRuntimeFacade).toHaveBeenCalledTimes(1);
+          expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
+          expect(prewarmPrimaryModel).toHaveBeenCalledWith(
+            expect.objectContaining({
+              workspaceDir: "/tmp/openclaw-workspace",
+            }),
+          );
+        });
+        expect(startChannels).not.toHaveBeenCalled();
 
         resolvePrewarm();
-        await Promise.resolve();
+        await sidecarsPromise;
+
+        expect(startChannels).toHaveBeenCalledTimes(1);
+        expect(events).toEqual(["prewarm-start", "prewarm-done", "channels"]);
       },
     );
+  });
+
+  it("prewarms the TTS runtime facade before channel startup", async () => {
+    const events: string[] = [];
+    hoisted.prewarmTtsRuntimeFacade.mockImplementationOnce(() => {
+      events.push("tts-runtime");
+    });
+    const startChannels = vi.fn(async () => {
+      events.push("channels");
+    });
+
+    await withEnvAsync(
+      {
+        OPENCLAW_SKIP_CHANNELS: undefined,
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: "1",
+      },
+      async () => {
+        await startGatewaySidecars({
+          cfg: {
+            hooks: { internal: { enabled: false } },
+          } as never,
+          pluginRegistry: createPostAttachParams().pluginRegistry,
+          defaultWorkspaceDir: "/tmp/openclaw-workspace",
+          deps: {} as never,
+          startChannels,
+          log: { warn: vi.fn() },
+          logHooks: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+          logChannels: {
+            info: vi.fn(),
+            error: vi.fn(),
+          },
+        });
+      },
+    );
+
+    expect(startChannels).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["tts-runtime", "channels"]);
+  });
+
+  it("starts channels after primary model prewarm timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      await withEnvAsync(
+        { OPENCLAW_SKIP_CHANNELS: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
+        async () => {
+          const prewarmPrimaryModel = vi.fn(async () => {
+            await new Promise(() => undefined);
+          });
+          const startChannels = vi.fn(async () => undefined);
+          const log = { warn: vi.fn() };
+
+          const sidecarsPromise = startGatewaySidecars({
+            cfg: {
+              hooks: { internal: { enabled: false } },
+              agents: { defaults: { model: "openai/gpt-5.4" } },
+            } as never,
+            pluginRegistry: createPostAttachParams().pluginRegistry,
+            defaultWorkspaceDir: "/tmp/openclaw-workspace",
+            deps: {} as never,
+            startChannels,
+            prewarmPrimaryModel: prewarmPrimaryModel as never,
+            log,
+            logHooks: {
+              info: vi.fn(),
+              warn: vi.fn(),
+              error: vi.fn(),
+            },
+            logChannels: {
+              info: vi.fn(),
+              error: vi.fn(),
+            },
+          });
+
+          await vi.waitFor(() => {
+            expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
+          });
+          expect(startChannels).not.toHaveBeenCalled();
+
+          await vi.advanceTimersByTimeAsync(5_000);
+          await sidecarsPromise;
+
+          expect(startChannels).toHaveBeenCalledTimes(1);
+          expect(log.warn).toHaveBeenCalledWith(
+            "startup model warmup timed out after 5000ms; continuing without waiting",
+          );
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps startup-gated methods unavailable while sidecars are still resuming", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -295,18 +295,19 @@ async function prewarmConfiguredPrimaryModel(params: {
   if (runtime !== "auto" && runtime !== "pi") {
     return;
   }
-  // Keep startup prewarm metadata-only; resolving models can import provider runtimes and block readiness.
-  const { ensureOpenClawModelsJson } = await import("../agents/models-config.js");
+  const [{ preparePreparedRuntimeModelAsync, resolvePreparedRuntimeModelAsync }] =
+    await Promise.all([import("../agents/pi-embedded-runner/model.js")]);
   const agentDir = resolveOpenClawAgentDir();
   const workspaceDir =
     params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg));
   try {
-    await ensureOpenClawModelsJson(params.cfg, agentDir, {
+    await preparePreparedRuntimeModelAsync(provider, agentDir, params.cfg, {
       workspaceDir,
       providerDiscoveryProviderIds: [provider],
       providerDiscoveryTimeoutMs: STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS,
       providerDiscoveryEntriesOnly: true,
     });
+    await resolvePreparedRuntimeModelAsync(provider, model, agentDir, params.cfg);
   } catch (err) {
     params.log.warn(`startup model warmup failed for ${provider}/${model}: ${String(err)}`);
   }
@@ -341,7 +342,7 @@ async function prewarmConfiguredPrimaryModelWithTimeout(
   await Promise.race([warmup, timeout]);
 }
 
-function schedulePrimaryModelPrewarm(
+async function prewarmPrimaryModelBeforeChannelStart(
   params: {
     cfg: OpenClawConfig;
     workspaceDir?: string;
@@ -349,11 +350,11 @@ function schedulePrimaryModelPrewarm(
     startupTrace?: GatewayStartupTrace;
   },
   prewarm: typeof prewarmConfiguredPrimaryModel = prewarmConfiguredPrimaryModel,
-): void {
+): Promise<void> {
   if (shouldSkipStartupModelPrewarm()) {
     return;
   }
-  void measureStartup(params.startupTrace, "sidecars.model-prewarm", () =>
+  await measureStartup(params.startupTrace, "sidecars.model-prewarm", () =>
     prewarmConfiguredPrimaryModelWithTimeout(
       {
         cfg: params.cfg,
@@ -362,8 +363,20 @@ function schedulePrimaryModelPrewarm(
       },
       prewarm,
     ),
-  ).catch((err) => {
-    params.log.warn(`startup model warmup failed: ${String(err)}`);
+  );
+}
+
+async function prewarmTtsRuntimeBeforeChannelStart(params: {
+  startupTrace?: GatewayStartupTrace;
+  log: { warn: (msg: string) => void };
+}): Promise<void> {
+  await measureStartup(params.startupTrace, "sidecars.tts-runtime-prewarm", async () => {
+    try {
+      const { prewarmTtsRuntimeFacade } = await import("../tts/tts.js");
+      prewarmTtsRuntimeFacade();
+    } catch (err) {
+      params.log.warn(`startup TTS runtime warmup failed: ${String(err)}`);
+    }
   });
 }
 
@@ -397,7 +410,7 @@ export async function startGatewaySidecars(params: {
     if (params.cfg.hooks?.gmail?.model) {
       const [
         { DEFAULT_MODEL, DEFAULT_PROVIDER },
-        { loadModelCatalog },
+        { resolveModelCatalogScope, loadModelCatalog },
         { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel },
       ] = await Promise.all([
         import("../agents/defaults.js"),
@@ -415,7 +428,14 @@ export async function startGatewaySidecars(params: {
             defaultProvider: DEFAULT_PROVIDER,
             defaultModel: DEFAULT_MODEL,
           });
-        const catalog = await loadModelCatalog({ config: params.cfg });
+        const catalog = await loadModelCatalog({
+          config: params.cfg,
+          ...resolveModelCatalogScope({
+            cfg: params.cfg,
+            provider: hooksModelRef.provider,
+            model: hooksModelRef.model,
+          }),
+        });
         const status = getModelRefStatus({
           cfg: params.cfg,
           catalog,
@@ -464,7 +484,11 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {
-        schedulePrimaryModelPrewarm(
+        await prewarmTtsRuntimeBeforeChannelStart({
+          log: params.log,
+          startupTrace: params.startupTrace,
+        });
+        await prewarmPrimaryModelBeforeChannelStart(
           {
             cfg: params.cfg,
             workspaceDir: params.defaultWorkspaceDir,
@@ -870,7 +894,8 @@ export const __testing = {
   prewarmConfiguredPrimaryModel,
   prewarmConfiguredPrimaryModelWithTimeout,
   refreshLatestUpdateRestartSentinelIfPresent,
+  prewarmPrimaryModelBeforeChannelStart,
+  prewarmTtsRuntimeBeforeChannelStart,
   resolveGatewayMemoryStartupPolicy,
-  schedulePrimaryModelPrewarm,
   shouldSkipStartupModelPrewarm,
 };

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -9,6 +9,7 @@ const ensureOpenClawModelsJsonMock = vi.fn<
   ) => Promise<{ agentDir: string; wrote: boolean }>
 >(async () => ({ agentDir: "/tmp/agent", wrote: false }));
 const piModelModuleLoadedMock = vi.fn();
+const resolveModelAsyncMock = vi.fn(async () => ({}));
 const resolveEmbeddedAgentRuntimeMock = vi.fn(() => "auto");
 
 vi.mock("../agents/agent-paths.js", () => ({
@@ -28,7 +29,7 @@ vi.mock("../agents/models-config.js", () => ({
 vi.mock("../agents/pi-embedded-runner/model.js", () => {
   piModelModuleLoadedMock();
   return {
-    resolveModel: () => ({}),
+    resolveModelAsync: (...args: unknown[]) => resolveModelAsyncMock(...args),
   };
 });
 
@@ -49,11 +50,12 @@ describe("gateway startup primary model warmup", () => {
   beforeEach(() => {
     ensureOpenClawModelsJsonMock.mockClear();
     piModelModuleLoadedMock.mockClear();
+    resolveModelAsyncMock.mockClear();
     resolveEmbeddedAgentRuntimeMock.mockClear();
     resolveEmbeddedAgentRuntimeMock.mockReturnValue("auto");
   });
 
-  it("prewarms an explicit configured primary model", async () => {
+  it("prewarms an explicit configured primary runtime model", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -79,7 +81,13 @@ describe("gateway startup primary model warmup", () => {
         providerDiscoveryEntriesOnly: true,
       }),
     );
-    expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+      "openai-codex",
+      "gpt-5.4",
+      "/tmp/agent",
+      cfg,
+      { skipPiDiscovery: true },
+    );
   });
 
   it("skips warmup when no explicit primary model is configured", async () => {
@@ -90,6 +98,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).not.toHaveBeenCalled();
   });
 
   it("honors the startup model prewarm skip env", () => {
@@ -106,7 +115,7 @@ describe("gateway startup primary model warmup", () => {
     ).toBe(true);
   });
 
-  it("skips static warmup for configured CLI backends", async () => {
+  it("skips primary runtime model warmup for configured CLI backends", async () => {
     await prewarmConfiguredPrimaryModel({
       cfg: {
         agents: {
@@ -128,9 +137,10 @@ describe("gateway startup primary model warmup", () => {
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).not.toHaveBeenCalled();
   });
 
-  it("skips static warmup when a non-PI agent runtime is forced", async () => {
+  it("skips primary runtime model warmup when a non-PI agent runtime is forced", async () => {
     resolveEmbeddedAgentRuntimeMock.mockReturnValue("codex");
     await prewarmConfiguredPrimaryModel({
       cfg: {
@@ -147,9 +157,10 @@ describe("gateway startup primary model warmup", () => {
 
     expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).not.toHaveBeenCalled();
   });
 
-  it("keeps PI static warmup when the PI agent runtime is forced", async () => {
+  it("keeps PI primary runtime model warmup when the PI agent runtime is forced", async () => {
     resolveEmbeddedAgentRuntimeMock.mockReturnValue("pi");
     const cfg = {
       agents: {
@@ -176,7 +187,13 @@ describe("gateway startup primary model warmup", () => {
         providerDiscoveryEntriesOnly: true,
       }),
     );
-    expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+      "openai-codex",
+      "gpt-5.4",
+      "/tmp/agent",
+      cfg,
+      { skipPiDiscovery: true },
+    );
   });
 
   it("warns when scoped models.json preparation fails", async () => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -46,6 +46,7 @@ import {
 import type { PluginHookGatewayCronService } from "../plugins/hook-types.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
   pinActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -1094,6 +1095,7 @@ export async function startGatewayServer(
       attachedPluginGatewayHandlerKeys = new Set(Object.keys(pluginRegistry.gatewayHandlers));
       pinActivePluginHttpRouteRegistry(pluginRegistry);
       pinActivePluginChannelRegistry(pluginRegistry);
+      pinActivePluginGatewayRuntimeRegistry(pluginRegistry);
     };
     const refreshAttachedGatewayDiscovery = async (nextPluginRegistry: typeof pluginRegistry) => {
       if (minimalTestGateway) {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -85,6 +85,16 @@ export function resolveGatewayScopedTools(params: {
     params.cfg,
     agentId ?? resolveDefaultAgentId(params.cfg),
   );
+  const explicitToolAllowlist = collectExplicitAllowlist([
+    profilePolicyWithAlsoAllow,
+    providerProfilePolicyWithAlsoAllow,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    subagentPolicy,
+  ]);
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -98,6 +108,7 @@ export function resolveGatewayScopedTools(params: {
     senderIsOwner: params.senderIsOwner,
     config: params.cfg,
     workspaceDir,
+    coreToolAllowlist: explicitToolAllowlist,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,
       providerProfilePolicy,

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -3,9 +3,12 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 import type * as ProviderRegistry from "./provider-registry.js";
 
-const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
-  resolvePluginCapabilityProvidersMock: vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
-}));
+const { resolvePluginCapabilityProviderMock, resolvePluginCapabilityProvidersMock } = vi.hoisted(
+  () => ({
+    resolvePluginCapabilityProviderMock: vi.fn<() => ImageGenerationProviderPlugin | undefined>(),
+    resolvePluginCapabilityProvidersMock: vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
+  }),
+);
 
 let getImageGenerationProvider: typeof ProviderRegistry.getImageGenerationProvider;
 let listImageGenerationProviders: typeof ProviderRegistry.listImageGenerationProviders;
@@ -29,6 +32,7 @@ function createProvider(
 async function loadProviderRegistry() {
   vi.resetModules();
   vi.doMock("../plugins/capability-provider-runtime.js", () => ({
+    resolvePluginCapabilityProvider: resolvePluginCapabilityProviderMock,
     resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
   }));
   return await import("./provider-registry.js");
@@ -36,6 +40,8 @@ async function loadProviderRegistry() {
 
 describe("image-generation provider registry", () => {
   beforeEach(async () => {
+    resolvePluginCapabilityProviderMock.mockReset();
+    resolvePluginCapabilityProviderMock.mockReturnValue(undefined);
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
     ({ getImageGenerationProvider, listImageGenerationProviders } = await loadProviderRegistry());
@@ -52,13 +58,30 @@ describe("image-generation provider registry", () => {
   });
 
   it("uses active plugin providers without loading from disk", () => {
-    resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-image" })]);
+    resolvePluginCapabilityProviderMock.mockReturnValue(createProvider({ id: "custom-image" }));
 
     const provider = getImageGenerationProvider("custom-image");
 
     expect(provider?.id).toBe("custom-image");
-    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
       key: "imageGenerationProviders",
+      providerId: "custom-image",
+      cfg: undefined,
+    });
+    expect(resolvePluginCapabilityProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to alias maps when direct provider resolution misses", () => {
+    resolvePluginCapabilityProvidersMock.mockReturnValue([
+      createProvider({ id: "safe-image", aliases: ["safe-alias"] }),
+    ]);
+
+    const provider = getImageGenerationProvider("safe-alias");
+
+    expect(provider?.id).toBe("safe-image");
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
+      key: "imageGenerationProviders",
+      providerId: "safe-alias",
       cfg: undefined,
     });
   });

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -1,7 +1,10 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import {
+  resolvePluginCapabilityProvider,
+  resolvePluginCapabilityProviders,
+} from "../plugins/capability-provider-runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_IMAGE_GENERATION_PROVIDERS: readonly ImageGenerationProviderPlugin[] = [];
@@ -73,5 +76,10 @@ export function getImageGenerationProvider(
   if (!normalized) {
     return undefined;
   }
-  return buildProviderMaps(cfg).aliases.get(normalized);
+  const direct = resolvePluginCapabilityProvider({
+    key: "imageGenerationProviders",
+    providerId: normalized,
+    cfg,
+  });
+  return direct ?? buildProviderMaps(cfg).aliases.get(normalized);
 }

--- a/src/infra/stage-timing.test.ts
+++ b/src/infra/stage-timing.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStageTracker, emitStageSummary } from "./stage-timing.js";
+
+describe("stage timing", () => {
+  it("captures stage duration and elapsed time", () => {
+    let clock = 10;
+    const tracker = createStageTracker({ now: () => clock });
+
+    clock = 25;
+    tracker.mark("workspace");
+    clock = 40;
+    tracker.mark("tools");
+    clock = 45;
+
+    expect(tracker.snapshot()).toEqual({
+      totalMs: 35,
+      stages: [
+        { name: "workspace", durationMs: 15, elapsedMs: 15 },
+        { name: "tools", durationMs: 15, elapsedMs: 30 },
+      ],
+    });
+  });
+
+  it("emits normal summaries through the configured level", () => {
+    const logger = {
+      isEnabled: (level: "debug" | "trace") => level === "debug",
+      debug: vi.fn(),
+      trace: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    expect(
+      emitStageSummary({
+        logger,
+        prefix: "run stages: runId=r1",
+        summary: {
+          totalMs: 80,
+          stages: [{ name: "model-execution", durationMs: 55, elapsedMs: 80 }],
+        },
+      }),
+    ).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      "run stages: runId=r1 totalMs=80 stages=model-execution:55ms@80ms",
+    );
+    expect(logger.trace).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("emits slow summaries as warnings", () => {
+    const logger = {
+      isEnabled: vi.fn(() => false),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    expect(
+      emitStageSummary({
+        logger,
+        prefix: "run stages: runId=r1",
+        summary: {
+          totalMs: 10,
+          stages: [{ name: "auth", durationMs: 5_000, elapsedMs: 5_000 }],
+        },
+      }),
+    ).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "run stages: runId=r1 totalMs=10 stages=auth:5000ms@5000ms",
+    );
+    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.trace).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/stage-timing.ts
+++ b/src/infra/stage-timing.ts
@@ -1,0 +1,104 @@
+export type StageTiming = {
+  name: string;
+  durationMs: number;
+  elapsedMs: number;
+};
+
+export type StageSummary = {
+  totalMs: number;
+  stages: StageTiming[];
+};
+
+export type StageTracker = {
+  mark: (name: string) => void;
+  snapshot: () => StageSummary;
+};
+
+export type StageLogger = {
+  isEnabled: (level: "debug" | "trace") => boolean;
+  debug: (message: string) => void;
+  trace: (message: string) => void;
+  warn: (message: string) => void;
+};
+
+const DEFAULT_STAGE_WARN_TOTAL_MS = 10_000;
+const DEFAULT_STAGE_WARN_STAGE_MS = 5_000;
+
+export function createStageTracker(options?: { now?: () => number }): StageTracker {
+  const now = options?.now ?? Date.now;
+  const startedAt = now();
+  let previousAt = startedAt;
+  const stages: StageTiming[] = [];
+
+  const toMs = (value: number) => Math.max(0, Math.round(value));
+
+  return {
+    mark(name) {
+      const currentAt = now();
+      stages.push({
+        name,
+        durationMs: toMs(currentAt - previousAt),
+        elapsedMs: toMs(currentAt - startedAt),
+      });
+      previousAt = currentAt;
+    },
+    snapshot() {
+      return {
+        totalMs: toMs(now() - startedAt),
+        stages: stages.slice(),
+      };
+    },
+  };
+}
+
+function shouldWarnStageSummary(
+  summary: StageSummary,
+  options?: {
+    totalThresholdMs?: number;
+    stageThresholdMs?: number;
+  },
+): boolean {
+  const totalThresholdMs = options?.totalThresholdMs ?? DEFAULT_STAGE_WARN_TOTAL_MS;
+  const stageThresholdMs = options?.stageThresholdMs ?? DEFAULT_STAGE_WARN_STAGE_MS;
+  return (
+    summary.totalMs >= totalThresholdMs ||
+    summary.stages.some((stage) => stage.durationMs >= stageThresholdMs)
+  );
+}
+
+function formatStageSummary(prefix: string, summary: StageSummary): string {
+  const stages =
+    summary.stages.length > 0
+      ? summary.stages
+          .map((stage) => `${stage.name}:${stage.durationMs}ms@${stage.elapsedMs}ms`)
+          .join(",")
+      : "none";
+  return `${prefix} totalMs=${summary.totalMs} stages=${stages}`;
+}
+
+export function emitStageSummary(params: {
+  logger: StageLogger;
+  prefix: string;
+  summary: StageSummary;
+  normalLevel?: "debug" | "trace";
+  totalThresholdMs?: number;
+  stageThresholdMs?: number;
+}): boolean {
+  const shouldWarn = shouldWarnStageSummary(params.summary, {
+    totalThresholdMs: params.totalThresholdMs,
+    stageThresholdMs: params.stageThresholdMs,
+  });
+  const normalLevel = params.normalLevel ?? "debug";
+  if (!shouldWarn && !params.logger.isEnabled(normalLevel)) {
+    return false;
+  }
+  const message = formatStageSummary(params.prefix, params.summary);
+  if (shouldWarn) {
+    params.logger.warn(message);
+  } else if (normalLevel === "trace") {
+    params.logger.trace(message);
+  } else {
+    params.logger.debug(message);
+  }
+  return true;
+}

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -27,13 +27,20 @@ const hasAvailableAuthForProviderMock = vi.hoisted(() =>
 const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
 const runFfmpegMock = vi.hoisted(() => vi.fn());
 const runExecMock = vi.hoisted(() => vi.fn());
+const buildMediaUnderstandingRegistryMock = vi.hoisted(() => vi.fn());
+const extractFileContentFromSourceMock = vi.hoisted(() => vi.fn());
+const logVerboseMock = vi.hoisted(() => vi.fn());
+const shouldLogVerboseMock = vi.hoisted(() => vi.fn(() => true));
 
 let applyMediaUnderstanding: typeof import("./apply.js").applyMediaUnderstanding;
 let clearMediaUnderstandingBinaryCacheForTests: typeof import("./runner.js").clearMediaUnderstandingBinaryCacheForTests;
+let actualExtractFileContentFromSource: typeof import("../media/input-files.js").extractFileContentFromSource;
 const mockedResolveApiKey = resolveApiKeyForProviderMock;
 const mockedFetchRemoteMedia = fetchRemoteMediaMock;
 const mockedRunFfmpeg = runFfmpegMock;
 const mockedRunExec = runExecMock;
+const mockedBuildMediaUnderstandingRegistry = buildMediaUnderstandingRegistryMock;
+const mockedExtractFileContentFromSource = extractFileContentFromSourceMock;
 
 const TEMP_MEDIA_PREFIX = "openclaw-media-";
 let suiteTempMediaRootDir = "";
@@ -263,34 +270,45 @@ describe("applyMediaUnderstanding", () => {
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
+    vi.doMock("../globals.js", () => ({
+      logVerbose: logVerboseMock,
+      shouldLogVerbose: shouldLogVerboseMock,
+    }));
+    const inputFilesModule =
+      await vi.importActual<typeof import("../media/input-files.js")>("../media/input-files.js");
+    actualExtractFileContentFromSource = inputFilesModule.extractFileContentFromSource;
+    vi.doMock("../media/input-files.js", () => ({
+      ...inputFilesModule,
+      extractFileContentFromSource: extractFileContentFromSourceMock,
+    }));
     vi.doMock("./provider-registry.js", async () => {
       const actual =
         await vi.importActual<typeof import("./provider-registry.js")>("./provider-registry.js");
       const registryProviders = createRegistryMediaProviders();
       return {
         ...actual,
-        buildMediaUnderstandingRegistry: (
-          overrides?: Record<string, MediaUnderstandingProvider>,
-        ) => {
-          const registry = new Map<string, MediaUnderstandingProvider>(
-            Object.entries(registryProviders),
-          );
-          for (const [key, provider] of Object.entries(overrides ?? {})) {
-            const normalizedKey = actual.normalizeMediaProviderId(key);
-            const existing = registry.get(normalizedKey);
-            registry.set(
-              normalizedKey,
-              existing
-                ? {
-                    ...existing,
-                    ...provider,
-                    capabilities: provider.capabilities ?? existing.capabilities,
-                  }
-                : provider,
+        buildMediaUnderstandingRegistry: buildMediaUnderstandingRegistryMock.mockImplementation(
+          (overrides?: Record<string, MediaUnderstandingProvider>) => {
+            const registry = new Map<string, MediaUnderstandingProvider>(
+              Object.entries(registryProviders),
             );
-          }
-          return registry;
-        },
+            for (const [key, provider] of Object.entries(overrides ?? {})) {
+              const normalizedKey = actual.normalizeMediaProviderId(key);
+              const existing = registry.get(normalizedKey);
+              registry.set(
+                normalizedKey,
+                existing
+                  ? {
+                      ...existing,
+                      ...provider,
+                      capabilities: provider.capabilities ?? existing.capabilities,
+                    }
+                  : provider,
+              );
+            }
+            return registry;
+          },
+        ),
       };
     });
     ({ applyMediaUnderstanding } = await import("./apply.js"));
@@ -312,6 +330,12 @@ describe("applyMediaUnderstanding", () => {
     mockedFetchRemoteMedia.mockClear();
     mockedRunFfmpeg.mockReset();
     mockedRunExec.mockReset();
+    mockedBuildMediaUnderstandingRegistry.mockClear();
+    mockedExtractFileContentFromSource.mockReset();
+    logVerboseMock.mockClear();
+    shouldLogVerboseMock.mockReset();
+    shouldLogVerboseMock.mockReturnValue(true);
+    mockedExtractFileContentFromSource.mockImplementation(actualExtractFileContentFromSource);
     mockedFetchRemoteMedia.mockResolvedValue({
       buffer: createSafeAudioFixtureBuffer(2048),
       contentType: "audio/ogg",
@@ -1446,6 +1470,48 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expectFileNotApplied({ ctx, result, body: "<media:file>" });
+  });
+
+  it("does not build the media provider registry for document-only turns", async () => {
+    const filePath = await createTempMediaFile({
+      fileName: "notes.txt",
+      content: "plain text attachment",
+    });
+
+    const { result } = await applyWithDisabledMedia({
+      body: "<media:file>",
+      mediaPath: filePath,
+      mediaType: "text/plain",
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(mockedBuildMediaUnderstandingRegistry).not.toHaveBeenCalled();
+  });
+
+  it("keeps a PDF placeholder block when pre-extraction is unavailable", async () => {
+    mockedExtractFileContentFromSource.mockRejectedValueOnce(
+      new Error(
+        "PDF extraction disabled or unavailable: enable the document-extract plugin to process application/pdf files.",
+      ),
+    );
+    const filePath = await createTempMediaFile({
+      fileName: "paper.pdf",
+      content: Buffer.from("%PDF-1.7\n1 0 obj\n<< /Type /Catalog >>\nendobj\n", "utf8"),
+    });
+
+    const { ctx, result } = await applyWithDisabledMedia({
+      body: "<media:file>",
+      mediaPath: filePath,
+      mediaType: "application/pdf",
+    });
+
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("pre-extraction unavailable");
+    expect(ctx.Body).toContain('mime="application/pdf"');
+    expect(logVerboseMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("file attachment skipped (extract)"),
+    );
+    expect(logVerboseMock).not.toHaveBeenCalled();
   });
 
   it("respects configured allowedMimes for text-like attachments", async () => {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -47,6 +47,9 @@ export type ApplyMediaUnderstandingResult = {
   appliedFile: boolean;
 };
 
+const PDF_EXTRACTION_UNAVAILABLE_PLACEHOLDER =
+  "[PDF attachment available; pre-extraction unavailable. Use the PDF attachment reference in the media note above if you need to inspect it directly.]";
+
 const CAPABILITY_ORDER: MediaUnderstandingCapability[] = ["image", "audio", "video"];
 const EMPTY_VOICE_NOTE_PLACEHOLDER =
   "[Voice note could not be transcribed because the audio attachment was too small]";
@@ -493,6 +496,17 @@ async function extractFileBlocks(params: {
         config: cfg,
       });
     } catch (err) {
+      if (mimeType === "application/pdf") {
+        blocks.push(
+          renderFileContextBlock({
+            filename: bufferResult.fileName,
+            fallbackName: `file-${attachment.index + 1}`,
+            mimeType,
+            content: PDF_EXTRACTION_UNAVAILABLE_PLACEHOLDER,
+          }),
+        );
+        continue;
+      }
       if (shouldLogVerbose()) {
         logVerbose(`media: file attachment skipped (extract): ${String(err)}`);
       }
@@ -534,7 +548,13 @@ export async function applyMediaUnderstanding(params: {
       .find((value) => value && value.trim()) ?? undefined;
 
   const attachments = normalizeMediaAttachments(ctx);
-  const providerRegistry = buildProviderRegistry(params.providers, cfg);
+  let providerRegistry: Map<string, MediaUnderstandingProvider> | null = null;
+  const getProviderRegistry = () => {
+    providerRegistry ??= buildProviderRegistry(params.providers, cfg, {
+      providerIds: params.activeModel?.provider ? [params.activeModel.provider] : [],
+    });
+    return providerRegistry;
+  };
   const cache = createMediaAttachmentCache(attachments, {
     localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx }),
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
@@ -551,7 +571,7 @@ export async function applyMediaUnderstanding(params: {
         attachments: cache,
         media: attachments,
         agentDir: params.agentDir,
-        providerRegistry,
+        providerRegistry: getProviderRegistry,
         config,
         activeModel: params.activeModel,
       });

--- a/src/media-understanding/audio-transcription-runner.ts
+++ b/src/media-understanding/audio-transcription-runner.ts
@@ -23,7 +23,9 @@ export async function runAudioTranscription(params: {
     return { transcript: undefined, attachments };
   }
 
-  const providerRegistry = buildProviderRegistry(params.providers, params.cfg);
+  const providerRegistry = buildProviderRegistry(params.providers, params.cfg, {
+    providerIds: params.activeModel?.provider ? [params.activeModel.provider] : [],
+  });
   const cache = createMediaAttachmentCache(attachments, {
     ...(params.localPathRoots ? { localPathRoots: params.localPathRoots } : {}),
     ssrfPolicy: params.cfg.tools?.web?.fetch?.ssrfPolicy,

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -2,11 +2,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   completeMock: vi.fn(),
-  ensureOpenClawModelsJsonMock: vi.fn(async () => {}),
-  getApiKeyForModelMock: vi.fn(async () => ({
-    apiKey: "oauth-test", // pragma: allowlist secret
-    source: "test",
-    mode: "oauth",
+  prepareSimpleCompletionModelMock: vi.fn(async () => ({
+    model: {
+      provider: "minimax-portal",
+      id: "MiniMax-VL-01",
+      input: ["text", "image"],
+      baseUrl: "https://api.minimax.io/anthropic",
+    },
+    auth: {
+      apiKey: "oauth-test", // pragma: allowlist secret
+      source: "test",
+      mode: "oauth",
+    },
   })),
   resolveApiKeyForProviderMock: vi.fn(async () => ({
     apiKey: "oauth-test", // pragma: allowlist secret
@@ -14,32 +21,17 @@ const hoisted = vi.hoisted(() => ({
     mode: "oauth",
   })),
   requireApiKeyMock: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? ""),
-  setRuntimeApiKeyMock: vi.fn(),
-  discoverModelsMock: vi.fn(),
   fetchMock: vi.fn(),
   registerProviderStreamForModelMock: vi.fn(),
-  prepareProviderDynamicModelMock: vi.fn(async () => {}),
-  resolveModelWithRegistryMock: vi.fn(),
 }));
 const {
   completeMock,
-  ensureOpenClawModelsJsonMock,
-  getApiKeyForModelMock,
+  prepareSimpleCompletionModelMock,
   resolveApiKeyForProviderMock,
   requireApiKeyMock,
-  setRuntimeApiKeyMock,
-  discoverModelsMock,
   fetchMock,
   registerProviderStreamForModelMock,
-  prepareProviderDynamicModelMock,
-  resolveModelWithRegistryMock,
 } = hoisted;
-
-type ResolveModelWithRegistryTestParams = {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
-  provider: string;
-  modelId: string;
-};
 
 vi.mock("@mariozechner/pi-ai", async () => {
   const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
@@ -49,39 +41,17 @@ vi.mock("@mariozechner/pi-ai", async () => {
   };
 });
 
-vi.mock("../agents/models-config.js", async () => ({
-  ...(await vi.importActual<typeof import("../agents/models-config.js")>(
-    "../agents/models-config.js",
-  )),
-  ensureOpenClawModelsJson: ensureOpenClawModelsJsonMock,
-}));
-
 vi.mock("../agents/model-auth.js", () => ({
-  getApiKeyForModel: getApiKeyForModelMock,
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
   requireApiKey: requireApiKeyMock,
 }));
 
+vi.mock("../agents/simple-completion-runtime.js", () => ({
+  prepareSimpleCompletionModel: prepareSimpleCompletionModelMock,
+}));
+
 vi.mock("../agents/provider-stream.js", () => ({
   registerProviderStreamForModel: registerProviderStreamForModelMock,
-}));
-
-vi.mock("../agents/pi-model-discovery-runtime.js", () => ({
-  discoverAuthStorage: () => ({
-    setRuntimeApiKey: setRuntimeApiKeyMock,
-  }),
-  discoverModels: discoverModelsMock,
-}));
-
-vi.mock("../plugins/provider-runtime.js", async () => ({
-  ...(await vi.importActual<typeof import("../plugins/provider-runtime.js")>(
-    "../plugins/provider-runtime.js",
-  )),
-  prepareProviderDynamicModel: prepareProviderDynamicModelMock,
-}));
-
-vi.mock("../agents/pi-embedded-runner/model.js", () => ({
-  resolveModelWithRegistry: resolveModelWithRegistryMock,
 }));
 
 const { describeImageWithModel } = await import("./image.js");
@@ -107,20 +77,15 @@ describe("describeImageWithModel", () => {
       })),
       text: vi.fn(async () => ""),
     });
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValue({
+      model: {
         provider: "minimax-portal",
         id: "MiniMax-VL-01",
         input: ["text", "image"],
         baseUrl: "https://api.minimax.io/anthropic",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
-    resolveModelWithRegistryMock.mockImplementation(
-      // Delegate to modelRegistry.find so tests that override discoverModelsMock
-      // automatically get the right model through resolveModelWithRegistry.
-      ({ modelRegistry, provider, modelId }: ResolveModelWithRegistryTestParams) =>
-        modelRegistry.find(provider, modelId),
-    );
   });
 
   it("routes minimax-portal image models through the MiniMax VLM endpoint", async () => {
@@ -143,12 +108,18 @@ describe("describeImageWithModel", () => {
       text: "portal ok",
       model: "MiniMax-VL-01",
     });
-    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalled();
-    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
-      expect.objectContaining({ store: authStore }),
+    expect(prepareSimpleCompletionModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: {},
+        provider: "minimax-portal",
+        modelId: "MiniMax-VL-01",
+        agentDir: "/tmp/openclaw-agent",
+        profileId: undefined,
+        preferredProfile: undefined,
+        skipPiDiscovery: true,
+      }),
     );
     expect(requireApiKeyMock).toHaveBeenCalled();
-    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("minimax-portal", "oauth-test");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.minimax.io/v1/coding_plan/vlm",
       expect.objectContaining({
@@ -170,13 +141,14 @@ describe("describeImageWithModel", () => {
   });
 
   it("uses generic completion for non-canonical minimax-portal image models", async () => {
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
         provider: "minimax-portal",
         id: "custom-vision",
         input: ["text", "image"],
         baseUrl: "https://api.minimax.io/anthropic",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
     completeMock.mockResolvedValue({
       role: "assistant",
@@ -219,17 +191,16 @@ describe("describeImageWithModel", () => {
   });
 
   it("resolves configured image models when discovery has not registered the provider", async () => {
-    const registryFind = vi.fn(() => null);
-    discoverModelsMock.mockReturnValue({ find: registryFind });
-    resolveModelWithRegistryMock.mockImplementationOnce(
-      ({ provider, modelId }: ResolveModelWithRegistryTestParams) => ({
-        provider,
-        id: modelId,
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
+        provider: "lmstudio",
+        id: "google/gemma-4-e2b",
         api: "anthropic-messages",
         input: ["text", "image"],
         baseUrl: "http://127.0.0.1:1234",
-      }),
-    );
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
+    } as never);
     completeMock.mockResolvedValue({
       role: "assistant",
       api: "anthropic-messages",
@@ -276,8 +247,7 @@ describe("describeImageWithModel", () => {
       text: "local vision ok",
       model: "google/gemma-4-e2b",
     });
-    expect(registryFind).not.toHaveBeenCalled();
-    expect(resolveModelWithRegistryMock).toHaveBeenCalledWith(
+    expect(prepareSimpleCompletionModelMock).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "lmstudio",
         modelId: "google/gemma-4-e2b",
@@ -292,19 +262,19 @@ describe("describeImageWithModel", () => {
         }),
       }),
     );
-    expect(prepareProviderDynamicModelMock).not.toHaveBeenCalled();
     expect(completeMock).toHaveBeenCalledOnce();
   });
 
   it("reports the resolved model input when an image model is text-only", async () => {
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
         provider: "lmstudio",
         id: "text-only",
         api: "openai-completions",
         input: ["text"],
         baseUrl: "http://127.0.0.1:1234",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
 
     await expect(
@@ -326,13 +296,14 @@ describe("describeImageWithModel", () => {
   });
 
   it("passes image prompt as system instructions for codex image requests", async () => {
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
         provider: "openai-codex",
         id: "gpt-5.4",
         input: ["text", "image"],
         baseUrl: "https://chatgpt.com/backend-api",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
     completeMock.mockResolvedValue({
       role: "assistant",
@@ -387,14 +358,15 @@ describe("describeImageWithModel", () => {
   });
 
   it("places OpenRouter image prompts in user content before images", async () => {
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
         api: "openai-completions",
         provider: "openrouter",
         id: "google/gemini-2.5-flash",
         input: ["text", "image"],
         baseUrl: "https://openrouter.ai/api/v1",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
     completeMock.mockResolvedValue({
       role: "assistant",
@@ -490,8 +462,9 @@ describe("describeImageWithModel", () => {
   ])(
     "retries reasoning-only image responses with reasoning disabled for $name",
     async ({ provider, model, expectedRetryPayload }) => {
-      discoverModelsMock.mockReturnValue({
-        find: vi.fn(() => model),
+      prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+        model,
+        auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
       });
       completeMock
         .mockResolvedValueOnce({
@@ -552,14 +525,15 @@ describe("describeImageWithModel", () => {
 
   it("rejects when a generic image completion ignores the abort signal", async () => {
     vi.useFakeTimers();
-    discoverModelsMock.mockReturnValue({
-      find: vi.fn(() => ({
+    prepareSimpleCompletionModelMock.mockResolvedValueOnce({
+      model: {
         api: "openai-responses",
         provider: "openai",
         id: "gpt-5.4-mini",
         input: ["text", "image"],
         baseUrl: "https://api.openai.com/v1",
-      })),
+      },
+      auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
     });
     completeMock.mockImplementation(() => new Promise(() => {}));
 
@@ -585,7 +559,7 @@ describe("describeImageWithModel", () => {
 
   it("rejects when image runtime setup exceeds the request timeout", async () => {
     vi.useFakeTimers();
-    ensureOpenClawModelsJsonMock.mockImplementationOnce(() => new Promise(() => {}));
+    prepareSimpleCompletionModelMock.mockImplementationOnce(() => new Promise(() => {}));
 
     const result = describeImageWithModel({
       cfg: {},
@@ -606,17 +580,19 @@ describe("describeImageWithModel", () => {
   });
 
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
-    const findMock = vi.fn((provider: string, modelId: string) => {
-      expect(provider).toBe("google");
-      expect(modelId).toBe("gemini-3-flash-preview");
+    prepareSimpleCompletionModelMock.mockImplementationOnce(async (params) => {
+      expect(params.provider).toBe("google");
+      expect(params.modelId).toBe("gemini-3-flash-preview");
       return {
-        provider: "google",
-        id: "gemini-3-flash-preview",
-        input: ["text", "image"],
-        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        model: {
+          provider: "google",
+          id: "gemini-3-flash-preview",
+          input: ["text", "image"],
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        },
+        auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
       };
     });
-    discoverModelsMock.mockReturnValue({ find: findMock });
     completeMock.mockResolvedValue({
       role: "assistant",
       api: "google-generative-ai",
@@ -644,27 +620,29 @@ describe("describeImageWithModel", () => {
       text: "flash ok",
       model: "gemini-3-flash-preview",
     });
-    expect(findMock).toHaveBeenCalledOnce();
-    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+    expect(prepareSimpleCompletionModelMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        provider: "google",
+        modelId: "gemini-3-flash-preview",
         profileId: "google:default",
       }),
     );
-    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
 
   it("normalizes gemini 3.1 flash-lite ids before lookup and keeps profile auth selection", async () => {
-    const findMock = vi.fn((provider: string, modelId: string) => {
-      expect(provider).toBe("google");
-      expect(modelId).toBe("gemini-3.1-flash-lite-preview");
+    prepareSimpleCompletionModelMock.mockImplementationOnce(async (params) => {
+      expect(params.provider).toBe("google");
+      expect(params.modelId).toBe("gemini-3.1-flash-lite-preview");
       return {
-        provider: "google",
-        id: "gemini-3.1-flash-lite-preview",
-        input: ["text", "image"],
-        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        model: {
+          provider: "google",
+          id: "gemini-3.1-flash-lite-preview",
+          input: ["text", "image"],
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        },
+        auth: { apiKey: "oauth-test", source: "test", mode: "oauth" },
       };
     });
-    discoverModelsMock.mockReturnValue({ find: findMock });
     completeMock.mockResolvedValue({
       role: "assistant",
       api: "google-generative-ai",
@@ -692,12 +670,12 @@ describe("describeImageWithModel", () => {
       text: "flash lite ok",
       model: "gemini-3.1-flash-lite-preview",
     });
-    expect(findMock).toHaveBeenCalledOnce();
-    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+    expect(prepareSimpleCompletionModelMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        provider: "google",
+        modelId: "gemini-3.1-flash-lite-preview",
         profileId: "google:default",
       }),
     );
-    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -1,36 +1,21 @@
 import type { Api, Context, Model, ProviderStreamOptions } from "@mariozechner/pi-ai";
 import { complete } from "@mariozechner/pi-ai";
 import { isMinimaxVlmModel, minimaxUnderstandImage } from "../agents/minimax-vlm.js";
-import {
-  getApiKeyForModel,
-  requireApiKey,
-  resolveApiKeyForProvider,
-} from "../agents/model-auth.js";
-import { findNormalizedProviderValue, normalizeModelRef } from "../agents/model-selection.js";
-import { ensureOpenClawModelsJson } from "../agents/models-config.js";
-import { resolveModelWithRegistry } from "../agents/pi-embedded-runner/model.js";
+import { requireApiKey, resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { normalizeModelRef } from "../agents/model-selection.js";
 import { resolveProviderRequestCapabilities } from "../agents/provider-attribution.js";
 import { registerProviderStreamForModel } from "../agents/provider-stream.js";
+import { prepareSimpleCompletionModel } from "../agents/simple-completion-runtime.js";
 import {
   coerceImageAssistantText,
   hasImageReasoningOnlyResponse,
 } from "../agents/tools/image-tool.helpers.js";
-import { prepareProviderDynamicModel } from "../plugins/provider-runtime.js";
 import type {
   ImageDescriptionRequest,
   ImageDescriptionResult,
   ImagesDescriptionRequest,
   ImagesDescriptionResult,
 } from "./types.js";
-
-let piModelDiscoveryRuntimePromise: Promise<
-  typeof import("../agents/pi-model-discovery-runtime.js")
-> | null = null;
-
-function loadPiModelDiscoveryRuntime() {
-  piModelDiscoveryRuntimePromise ??= import("../agents/pi-model-discovery-runtime.js");
-  return piModelDiscoveryRuntimePromise;
-}
 
 function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requestedMaxTokens = 4096) {
   if (
@@ -142,57 +127,21 @@ async function resolveImageRuntime(params: {
   preferredProfile?: string;
   authStore?: ImageDescriptionRequest["authStore"];
 }): Promise<{ apiKey: string; model: Model<Api> }> {
-  await ensureOpenClawModelsJson(params.cfg, params.agentDir);
-  const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
-  const configuredProviders = params.cfg.models?.providers;
-  const providerConfig =
-    configuredProviders?.[resolvedRef.provider] ??
-    findNormalizedProviderValue(configuredProviders, resolvedRef.provider);
-  // Fast path: resolve without dynamic model preparation first.
-  // This avoids unnecessary prepare hooks (e.g. OpenRouter catalog fetch)
-  // for models that are already explicitly resolvable.
-  let model = resolveModelWithRegistry({
+  const prepared = await prepareSimpleCompletionModel({
+    cfg: params.cfg,
     provider: resolvedRef.provider,
     modelId: resolvedRef.model,
-    modelRegistry,
-    cfg: params.cfg,
     agentDir: params.agentDir,
-  }) as Model<Api> | null;
-
-  // If the model is not in the registry yet, prepare dynamic provider models
-  // and retry (needed for provider-runtime-backed dynamic models).
-  if (!model) {
-    await prepareProviderDynamicModel({
-      provider: resolvedRef.provider,
-      config: params.cfg,
-      context: {
-        config: params.cfg,
-        agentDir: params.agentDir,
-        provider: resolvedRef.provider,
-        modelId: resolvedRef.model,
-        modelRegistry,
-        providerConfig,
-      },
-    });
-    model = resolveModelWithRegistry({
-      provider: resolvedRef.provider,
-      modelId: resolvedRef.model,
-      modelRegistry,
-      cfg: params.cfg,
-      agentDir: params.agentDir,
-    }) as Model<Api> | null;
+    profileId: params.profile,
+    preferredProfile: params.preferredProfile,
+    skipPiDiscovery: true,
+  });
+  if ("error" in prepared) {
+    throw new Error(prepared.error);
   }
-  if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-  }
+  const { model, auth } = prepared;
   if (!model.input?.includes("image")) {
-    // resolveModelWithRegistry may synthesize a text-only fallback for configured
-    // providers, which would change "Unknown model" → "Model does not support images"
-    // and skip the MiniMax VLM recovery path. Throw Unknown model for MiniMax VLM
-    // models so the caller can attempt the fallback.
     if (isMinimaxVlmModel(resolvedRef.provider, resolvedRef.model)) {
       throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
     }
@@ -201,17 +150,10 @@ async function resolveImageRuntime(params: {
         `(resolved ${model.provider}/${model.id} input: ${formatModelInputCapabilities(model.input)})`,
     );
   }
-  const apiKeyInfo = await getApiKeyForModel({
+  return {
+    apiKey: requireApiKey(auth, model.provider),
     model,
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    profileId: params.profile,
-    preferredProfile: params.preferredProfile,
-    store: params.authStore,
-  });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
-  authStorage.setRuntimeApiKey(model.provider, apiKey);
-  return { apiKey, model };
+  };
 }
 
 function buildImageContext(

--- a/src/media-understanding/provider-capability-registry.ts
+++ b/src/media-understanding/provider-capability-registry.ts
@@ -17,12 +17,14 @@ function mergeProviderCapabilities(
 
 export function buildMediaUnderstandingCapabilityRegistry(
   cfg?: OpenClawConfig,
+  options?: { providerIds?: readonly string[] },
 ): MediaUnderstandingCapabilityRegistry {
   const registry: MediaUnderstandingCapabilityRegistry = new Map();
 
   for (const provider of resolvePluginCapabilityProviders({
     key: "mediaUnderstandingProviders",
     cfg,
+    ...(options?.providerIds ? { providerIds: options.providerIds } : {}),
   })) {
     mergeProviderCapabilities(registry, provider);
   }

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -30,11 +30,13 @@ export { normalizeMediaProviderId } from "./provider-id.js";
 export function buildMediaUnderstandingRegistry(
   overrides?: Record<string, MediaUnderstandingProvider>,
   cfg?: OpenClawConfig,
+  options?: { providerIds?: readonly string[] },
 ): Map<string, MediaUnderstandingProvider> {
   const registry = new Map<string, MediaUnderstandingProvider>();
   for (const provider of resolvePluginCapabilityProviders({
     key: "mediaUnderstandingProviders",
     cfg,
+    ...(options?.providerIds ? { providerIds: options.providerIds } : {}),
   })) {
     mergeProviderIntoRegistry(registry, provider);
   }

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -51,15 +51,21 @@ export { createMediaAttachmentCache, normalizeMediaAttachments } from "./runner.
 export type { ActiveMediaModel } from "./active-model.types.js";
 
 type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
+type ProviderRegistryInput = ProviderRegistry | (() => ProviderRegistry);
 type HasAvailableAuthForProvider =
   typeof import("../agents/model-auth.js").hasAvailableAuthForProvider;
 type ModelCatalogApi = typeof import("../agents/model-catalog.js");
 type ModelCatalog = Awaited<ReturnType<ModelCatalogApi["loadModelCatalog"]>>;
+type LoadModelCatalog = ModelCatalogApi["loadModelCatalog"];
 
 export type RunCapabilityResult = {
   outputs: MediaUnderstandingOutput[];
   decision: MediaUnderstandingDecision;
 };
+
+function resolveProviderRegistry(input: ProviderRegistryInput): ProviderRegistry {
+  return typeof input === "function" ? input() : input;
+}
 
 let cachedHasAvailableAuthForProvider: HasAvailableAuthForProvider | null = null;
 let cachedModelCatalogApi: ModelCatalogApi | null = null;
@@ -67,6 +73,20 @@ let cachedModelCatalogApi: ModelCatalogApi | null = null;
 async function loadModelCatalogApi(): Promise<ModelCatalogApi> {
   cachedModelCatalogApi ??= await import("../agents/model-catalog.js");
   return cachedModelCatalogApi;
+}
+
+function scopedModelCatalogParams(params: {
+  cfg: OpenClawConfig;
+  providerId: string;
+  model?: string;
+}): Parameters<LoadModelCatalog>[0] {
+  const providerId = params.providerId.trim();
+  const model = params.model?.trim();
+  return {
+    config: params.cfg,
+    providerRefs: providerId ? [providerId] : [],
+    modelRefs: providerId && model ? [`${providerId}/${model}`, model] : model ? [model] : [],
+  };
 }
 
 function resolveLiteralProviderApiKey(
@@ -92,16 +112,17 @@ async function hasProviderAuthAvailable(params: {
 
 function resolveConfiguredKeyProviderOrder(params: {
   cfg: OpenClawConfig;
-  providerRegistry: ProviderRegistry;
+  providerRegistry: ProviderRegistryInput;
   capability: MediaUnderstandingCapability;
   fallbackProviders: readonly string[];
 }): string[] {
+  const providerRegistry = resolveProviderRegistry(params.providerRegistry);
   const configuredProviders = Object.keys(params.cfg.models?.providers ?? {})
     .map((providerId) => normalizeMediaProviderId(providerId))
     .filter(Boolean)
     .filter((providerId, index, values) => values.indexOf(providerId) === index)
     .filter((providerId) =>
-      providerSupportsCapability(params.providerRegistry.get(providerId), params.capability),
+      providerSupportsCapability(providerRegistry.get(providerId), params.capability),
     );
 
   return [...new Set([...configuredProviders, ...params.fallbackProviders])];
@@ -204,7 +225,13 @@ async function explicitImageModelVisionStatus(params: {
     return "supported";
   }
   const { findModelInCatalog, loadModelCatalog, modelSupportsVision } = await loadModelCatalogApi();
-  const catalog = await loadModelCatalog({ config: params.cfg });
+  const catalog = await loadModelCatalog(
+    scopedModelCatalogParams({
+      cfg: params.cfg,
+      providerId: params.providerId,
+      model: params.model,
+    }),
+  );
   const entry = findModelInCatalog(catalog, params.providerId, params.model);
   if (!entry) {
     return "unknown";
@@ -251,7 +278,9 @@ async function resolveAutoImageModelId(params: {
     return bundledDefaultModel;
   }
   const { loadModelCatalog, modelSupportsVision } = await loadModelCatalogApi();
-  const catalog = await loadModelCatalog({ config: params.cfg });
+  const catalog = await loadModelCatalog(
+    scopedModelCatalogParams({ cfg: params.cfg, providerId: params.providerId }),
+  );
   return resolveCatalogImageModelId({
     providerId: params.providerId,
     catalog,
@@ -262,8 +291,9 @@ async function resolveAutoImageModelId(params: {
 export function buildProviderRegistry(
   overrides?: Record<string, MediaUnderstandingProvider>,
   cfg?: OpenClawConfig,
+  options?: { providerIds?: readonly string[] },
 ): ProviderRegistry {
-  return buildMediaUnderstandingRegistry(overrides, cfg);
+  return buildMediaUnderstandingRegistry(overrides, cfg, options);
 }
 
 export function resolveMediaAttachmentLocalRoots(params: {
@@ -674,7 +704,9 @@ export async function resolveAutoImageModel(params: {
   agentDir?: string;
   activeModel?: ActiveMediaModel;
 }): Promise<ActiveMediaModel | null> {
-  const providerRegistry = buildProviderRegistry(undefined, params.cfg);
+  const providerRegistry = buildProviderRegistry(undefined, params.cfg, {
+    providerIds: params.activeModel?.provider ? [params.activeModel.provider] : [],
+  });
   const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
     if (!entry || entry.type === "cli") {
       return null;
@@ -868,7 +900,7 @@ export async function runCapability(params: {
   attachments: MediaAttachmentCache;
   media: MediaAttachment[];
   agentDir?: string;
-  providerRegistry: ProviderRegistry;
+  providerRegistry: ProviderRegistryInput;
   config?: MediaUnderstandingConfig;
   activeModel?: ActiveMediaModel;
 }): Promise<RunCapabilityResult> {
@@ -919,7 +951,13 @@ export async function runCapability(params: {
   ) {
     const { findModelInCatalog, loadModelCatalog, modelSupportsVision } =
       await loadModelCatalogApi();
-    const catalog = await loadModelCatalog({ config: cfg });
+    const catalog = await loadModelCatalog(
+      scopedModelCatalogParams({
+        cfg,
+        providerId: activeProvider,
+        model: params.activeModel?.model,
+      }),
+    );
     const entry = findModelInCatalog(catalog, activeProvider, params.activeModel?.model ?? "");
     if (modelSupportsVision(entry)) {
       if (shouldLogVerbose()) {
@@ -951,18 +989,19 @@ export async function runCapability(params: {
     }
   }
 
+  const providerRegistry = resolveProviderRegistry(params.providerRegistry);
   const entries = resolveModelEntries({
     cfg,
     capability,
     config,
-    providerRegistry: params.providerRegistry,
+    providerRegistry,
   });
   let resolvedEntries = entries;
   if (resolvedEntries.length === 0) {
     resolvedEntries = await resolveAutoEntries({
       cfg,
       agentDir: params.agentDir,
-      providerRegistry: params.providerRegistry,
+      providerRegistry,
       capability,
       activeModel: params.activeModel,
     });
@@ -987,7 +1026,7 @@ export async function runCapability(params: {
       ctx,
       attachmentIndex: attachment.index,
       agentDir: params.agentDir,
-      providerRegistry: params.providerRegistry,
+      providerRegistry,
       cache: params.attachments,
       entries: resolvedEntries,
       config,

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -143,6 +143,12 @@ describe("runCapability image skip", () => {
       expect(result.decision.attachments[0]?.attempts[0]?.reason).toBe(
         "primary model supports vision natively",
       );
+      expect(loadModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerRefs: ["openai"],
+          modelRefs: ["openai/gpt-4.1", "gpt-4.1"],
+        }),
+      );
     } finally {
       await cache.cleanup();
     }
@@ -335,6 +341,12 @@ describe("runCapability image skip", () => {
         provider: "openrouter",
         model: "google/gemini-2.5-flash",
       });
+      expect(loadModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerRefs: ["openrouter"],
+          modelRefs: ["openrouter/google/gemini-2.5-flash", "google/gemini-2.5-flash"],
+        }),
+      );
     } finally {
       setActivePluginRegistry(createEmptyPluginRegistry());
       vi.unstubAllEnvs();

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -100,7 +100,9 @@ export async function runMediaUnderstandingFile(
     };
   }
 
-  const providerRegistry = buildProviderRegistry(undefined, cfg);
+  const providerRegistry = buildProviderRegistry(undefined, cfg, {
+    providerIds: params.activeModel?.provider ? [params.activeModel.provider] : [],
+  });
   const cache = createMediaAttachmentCache(attachments, {
     localPathRoots: [path.dirname(params.filePath)],
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
@@ -151,7 +153,9 @@ export async function describeImageFile(
 
 export async function describeImageFileWithModel(params: DescribeImageFileWithModelParams) {
   const timeoutMs = params.timeoutMs ?? 30_000;
-  const providerRegistry = buildProviderRegistry(undefined, params.cfg);
+  const providerRegistry = buildProviderRegistry(undefined, params.cfg, {
+    providerIds: [params.provider],
+  });
   const provider = providerRegistry.get(normalizeMediaProviderId(params.provider));
   if (!provider?.describeImage) {
     throw new Error(`Provider does not support image analysis: ${params.provider}`);

--- a/src/music-generation/provider-registry.test.ts
+++ b/src/music-generation/provider-registry.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MusicGenerationProviderPlugin } from "../plugins/types.js";
+
+const { resolvePluginCapabilityProviderMock, resolvePluginCapabilityProvidersMock } = vi.hoisted(
+  () => ({
+    resolvePluginCapabilityProviderMock: vi.fn<() => MusicGenerationProviderPlugin | undefined>(),
+    resolvePluginCapabilityProvidersMock: vi.fn<() => MusicGenerationProviderPlugin[]>(() => []),
+  }),
+);
+
+vi.mock("../plugins/capability-provider-runtime.js", () => ({
+  resolvePluginCapabilityProvider: resolvePluginCapabilityProviderMock,
+  resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
+}));
+
+function createProvider(
+  params: Pick<MusicGenerationProviderPlugin, "id"> & Partial<MusicGenerationProviderPlugin>,
+): MusicGenerationProviderPlugin {
+  return {
+    label: params.id,
+    capabilities: {},
+    generateMusic: async () => ({
+      tracks: [{ buffer: Buffer.from("track"), mimeType: "audio/mpeg" }],
+    }),
+    ...params,
+  };
+}
+
+async function loadProviderRegistry() {
+  vi.resetModules();
+  return await import("./provider-registry.js");
+}
+
+describe("music-generation provider registry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resolvePluginCapabilityProviderMock.mockReset();
+    resolvePluginCapabilityProviderMock.mockReturnValue(undefined);
+    resolvePluginCapabilityProvidersMock.mockReset();
+    resolvePluginCapabilityProvidersMock.mockReturnValue([]);
+  });
+
+  it("delegates provider listing to the capability provider boundary", async () => {
+    const { listMusicGenerationProviders } = await loadProviderRegistry();
+
+    expect(listMusicGenerationProviders()).toEqual([]);
+    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+      key: "musicGenerationProviders",
+      cfg: undefined,
+    });
+  });
+
+  it("uses direct provider resolution for explicit ids", async () => {
+    resolvePluginCapabilityProviderMock.mockReturnValue(createProvider({ id: "custom-music" }));
+    const { getMusicGenerationProvider } = await loadProviderRegistry();
+
+    const provider = getMusicGenerationProvider("custom-music");
+
+    expect(provider?.id).toBe("custom-music");
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
+      key: "musicGenerationProviders",
+      providerId: "custom-music",
+      cfg: undefined,
+    });
+    expect(resolvePluginCapabilityProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to alias maps when direct provider resolution misses", async () => {
+    resolvePluginCapabilityProvidersMock.mockReturnValue([
+      createProvider({ id: "safe-music", aliases: ["safe-alias"] }),
+    ]);
+    const { getMusicGenerationProvider } = await loadProviderRegistry();
+
+    const provider = getMusicGenerationProvider("safe-alias");
+
+    expect(provider?.id).toBe("safe-music");
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
+      key: "musicGenerationProviders",
+      providerId: "safe-alias",
+      cfg: undefined,
+    });
+  });
+});

--- a/src/music-generation/provider-registry.ts
+++ b/src/music-generation/provider-registry.ts
@@ -1,7 +1,10 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import {
+  resolvePluginCapabilityProvider,
+  resolvePluginCapabilityProviders,
+} from "../plugins/capability-provider-runtime.js";
 import type { MusicGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_MUSIC_GENERATION_PROVIDERS: readonly MusicGenerationProviderPlugin[] = [];
@@ -73,5 +76,10 @@ export function getMusicGenerationProvider(
   if (!normalized) {
     return undefined;
   }
-  return buildProviderMaps(cfg).aliases.get(normalized);
+  const direct = resolvePluginCapabilityProvider({
+    key: "musicGenerationProviders",
+    providerId: normalized,
+    cfg,
+  });
+  return direct ?? buildProviderMaps(cfg).aliases.get(normalized);
 }

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -10,6 +10,7 @@ export * from "../agents/identity.js";
 export * from "../agents/model-auth-markers.js";
 export * from "../agents/model-auth.js";
 export * from "../agents/model-catalog.js";
+export * from "../agents/model-catalog-scope.js";
 export * from "../agents/model-selection.js";
 export * from "../agents/simple-completion-runtime.js";
 export * from "../agents/pi-embedded-block-chunker.js";

--- a/src/plugin-sdk/speech-core.ts
+++ b/src/plugin-sdk/speech-core.ts
@@ -35,6 +35,7 @@ export { parseTtsDirectives } from "../tts/directives.js";
 export {
   canonicalizeSpeechProviderId,
   getSpeechProvider,
+  listLoadedSpeechProviders,
   listSpeechProviders,
   normalizeSpeechProviderId,
 } from "../tts/provider-registry.js";

--- a/src/plugin-sdk/tts-runtime.ts
+++ b/src/plugin-sdk/tts-runtime.ts
@@ -31,6 +31,10 @@ function loadFacadeModule(): FacadeModule {
   });
 }
 
+export function prewarmTtsRuntimeFacade(): void {
+  loadFacadeModule();
+}
+
 export const _test: FacadeModule["_test"] = createLazyFacadeObjectValue(
   () => loadFacadeModule()._test,
 );

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -1,13 +1,20 @@
 import { resolveCompatibleRuntimePluginRegistry, type PluginLoadOptions } from "./loader.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
+  getActivePluginChannelRegistryWorkspaceDir,
   getActivePluginChannelRegistry,
+  getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir,
   getActivePluginHttpRouteRegistry,
   getActivePluginRegistry,
   getActivePluginRegistryWorkspaceDir,
 } from "./runtime.js";
 
-export type ActiveRuntimePluginRegistrySurface = "active" | "channel" | "http-route";
+export type ActiveRuntimePluginRegistrySurface =
+  | "active"
+  | "channel"
+  | "gateway-runtime"
+  | "http-route";
 
 export function getActiveRuntimePluginRegistry(): PluginRegistry | null {
   return getActivePluginRegistry();
@@ -62,10 +69,27 @@ function resolveSurfaceRegistry(
       return getActivePluginRegistry();
     case "channel":
       return getActivePluginChannelRegistry();
+    case "gateway-runtime":
+      return getActivePluginGatewayRuntimeRegistry();
     case "http-route":
       return getActivePluginHttpRouteRegistry();
   }
   return null;
+}
+
+function resolveSurfaceWorkspaceDir(
+  surface: ActiveRuntimePluginRegistrySurface,
+): string | undefined {
+  switch (surface) {
+    case "active":
+    case "http-route":
+      return getActivePluginRegistryWorkspaceDir();
+    case "channel":
+      return getActivePluginChannelRegistryWorkspaceDir();
+    case "gateway-runtime":
+      return getActivePluginGatewayRuntimeRegistryWorkspaceDir();
+  }
+  return undefined;
 }
 
 export function getLoadedRuntimePluginRegistry(
@@ -89,7 +113,7 @@ export function getLoadedRuntimePluginRegistry(
     return compatible;
   }
 
-  const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
+  const activeWorkspaceDir = resolveSurfaceWorkspaceDir(surface);
   const requestedWorkspaceDir = params.workspaceDir ?? params.loadOptions?.workspaceDir;
   if (requestedWorkspaceDir !== undefined && activeWorkspaceDir !== requestedWorkspaceDir) {
     return undefined;

--- a/src/plugins/bundle-config-shared.ts
+++ b/src/plugins/bundle-config-shared.ts
@@ -6,6 +6,11 @@ import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/bou
 import { isRecord } from "../utils.js";
 import { normalizePluginsConfig, resolveEffectivePluginActivationState } from "./config-state.js";
 import type { PluginBundleFormat } from "./manifest-types.js";
+import {
+  createPluginCacheKey,
+  resolveConfigScopedRuntimeCacheValue,
+  type ConfigScopedRuntimeCache,
+} from "./plugin-cache-primitives.js";
 import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry.js";
 
 type ReadBundleJsonResult =
@@ -17,6 +22,11 @@ export type BundleServerRuntimeSupport = {
   supportedServerNames: string[];
   unsupportedServerNames: string[];
   diagnostics: string[];
+};
+
+export type EnabledBundleConfigResult<TConfig, TDiagnostic> = {
+  config: TConfig;
+  diagnostics: TDiagnostic[];
 };
 
 export function readBundleJsonObject(params: {
@@ -141,4 +151,43 @@ export function loadEnabledBundleConfig<TConfig, TDiagnostic>(params: {
   }
 
   return { config: merged, diagnostics };
+}
+
+function cloneEnabledBundleConfigResult<TConfig, TDiagnostic>(
+  result: EnabledBundleConfigResult<TConfig, TDiagnostic>,
+): EnabledBundleConfigResult<TConfig, TDiagnostic> {
+  return structuredClone(result) as EnabledBundleConfigResult<TConfig, TDiagnostic>;
+}
+
+export function loadCachedEnabledBundleConfig<TConfig, TDiagnostic>(params: {
+  cache: ConfigScopedRuntimeCache<EnabledBundleConfigResult<TConfig, TDiagnostic>>;
+  cacheKeyParts: readonly unknown[];
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  createEmptyConfig: () => TConfig;
+  loadBundleConfig: (params: {
+    pluginId: string;
+    rootDir: string;
+    bundleFormat: PluginBundleFormat;
+  }) => { config: TConfig; diagnostics: string[] };
+  createDiagnostic: (pluginId: string, message: string) => TDiagnostic;
+}): EnabledBundleConfigResult<TConfig, TDiagnostic> {
+  const load = () =>
+    loadEnabledBundleConfig({
+      workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
+      createEmptyConfig: params.createEmptyConfig,
+      loadBundleConfig: params.loadBundleConfig,
+      createDiagnostic: params.createDiagnostic,
+    });
+  if (!params.cfg) {
+    return cloneEnabledBundleConfigResult(load());
+  }
+  const cached = resolveConfigScopedRuntimeCacheValue({
+    cache: params.cache,
+    config: params.cfg,
+    key: createPluginCacheKey(params.cacheKeyParts),
+    load,
+  });
+  return cloneEnabledBundleConfigResult(cached);
 }

--- a/src/plugins/bundle-lsp.ts
+++ b/src/plugins/bundle-lsp.ts
@@ -6,8 +6,9 @@ import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import {
   inspectBundleServerRuntimeSupport,
-  loadEnabledBundleConfig,
+  loadCachedEnabledBundleConfig,
   readBundleJsonObject,
+  type EnabledBundleConfigResult,
 } from "./bundle-config-shared.js";
 import {
   CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
@@ -15,11 +16,22 @@ import {
   normalizeBundlePathList,
 } from "./bundle-manifest.js";
 import type { PluginBundleFormat } from "./manifest-types.js";
+import type { ConfigScopedRuntimeCache } from "./plugin-cache-primitives.js";
 
 export type BundleLspServerConfig = Record<string, unknown>;
 
 export type BundleLspConfig = {
   lspServers: Record<string, BundleLspServerConfig>;
+};
+
+export type BundleLspDiagnostic = {
+  pluginId: string;
+  message: string;
+};
+
+export type EnabledBundleLspConfigResult = {
+  config: BundleLspConfig;
+  diagnostics: BundleLspDiagnostic[];
 };
 
 export type BundleLspRuntimeSupport = {
@@ -32,6 +44,9 @@ export type BundleLspRuntimeSupport = {
 const MANIFEST_PATH_BY_FORMAT: Partial<Record<PluginBundleFormat, string>> = {
   claude: CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
 };
+const enabledBundleLspConfigCache: ConfigScopedRuntimeCache<
+  EnabledBundleConfigResult<BundleLspConfig, BundleLspDiagnostic>
+> = new WeakMap();
 
 function extractLspServerMap(raw: unknown): Record<string, BundleLspServerConfig> {
   if (!isRecord(raw)) {
@@ -142,8 +157,10 @@ export function inspectBundleLspRuntimeSupport(params: {
 export function loadEnabledBundleLspConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
-}): { config: BundleLspConfig; diagnostics: Array<{ pluginId: string; message: string }> } {
-  return loadEnabledBundleConfig({
+}): EnabledBundleLspConfigResult {
+  return loadCachedEnabledBundleConfig({
+    cache: enabledBundleLspConfigCache,
+    cacheKeyParts: ["enabled-bundle-lsp", params.workspaceDir, params.cfg?.plugins],
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
     createEmptyConfig: () => ({ lspServers: {} }),

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { isRecord } from "../utils.js";
+import { loadEnabledBundleLspConfig } from "./bundle-lsp.js";
 import { loadEnabledBundleMcpConfig } from "./bundle-mcp.js";
 import {
   createEnabledPluginEntries,
@@ -215,6 +216,64 @@ describe("loadEnabledBundleMcpConfig", () => {
             normalizePathForAssertion("local-probe.mjs")!,
           ],
         });
+      },
+    );
+  });
+
+  it("returns isolated cached bundle MCP and LSP config results", async () => {
+    await withBundleHomeEnv(
+      tempHarness,
+      "openclaw-bundle-config-cache",
+      async ({ homeDir, workspaceDir }) => {
+        const pluginRoot = await writeClaudeBundleManifest({
+          homeDir,
+          pluginId: "cached-bundle",
+          manifest: {
+            name: "cached-bundle",
+          },
+        });
+        await fs.writeFile(
+          path.join(pluginRoot, ".mcp.json"),
+          `${JSON.stringify(
+            {
+              mcpServers: {
+                cachedMcp: {
+                  command: "node",
+                },
+              },
+            },
+            null,
+            2,
+          )}\n`,
+          "utf-8",
+        );
+        await fs.writeFile(
+          path.join(pluginRoot, ".lsp.json"),
+          `${JSON.stringify(
+            {
+              lspServers: {
+                cachedLsp: {
+                  command: "node",
+                },
+              },
+            },
+            null,
+            2,
+          )}\n`,
+          "utf-8",
+        );
+        const cfg = createEnabledBundleConfig(["cached-bundle"]);
+
+        const firstMcp = loadEnabledBundleMcpConfig({ workspaceDir, cfg });
+        const firstLsp = loadEnabledBundleLspConfig({ workspaceDir, cfg });
+        firstMcp.config.mcpServers.cachedMcp = { command: "mutated" };
+        firstLsp.config.lspServers.cachedLsp = { command: "mutated" };
+
+        const secondMcp = loadEnabledBundleMcpConfig({ workspaceDir, cfg });
+        const secondLsp = loadEnabledBundleLspConfig({ workspaceDir, cfg });
+
+        expect(secondMcp.config.mcpServers.cachedMcp?.command).toBe("node");
+        expect(secondLsp.config.lspServers.cachedLsp?.command).toBe("node");
       },
     );
   });

--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -5,10 +5,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
 import {
+  loadCachedEnabledBundleConfig,
   inspectBundleServerRuntimeSupport,
-  loadEnabledBundleConfig,
   readBundleJsonObject,
   resolveBundleJsonOpenFailure,
+  type EnabledBundleConfigResult,
 } from "./bundle-config-shared.js";
 import {
   CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
@@ -18,6 +19,7 @@ import {
   normalizeBundlePathList,
 } from "./bundle-manifest.js";
 import type { PluginBundleFormat } from "./manifest-types.js";
+import type { ConfigScopedRuntimeCache } from "./plugin-cache-primitives.js";
 
 export type BundleMcpServerConfig = Record<string, unknown>;
 
@@ -47,6 +49,9 @@ const MANIFEST_PATH_BY_FORMAT: Record<PluginBundleFormat, string> = {
   cursor: CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
 };
 const CLAUDE_PLUGIN_ROOT_PLACEHOLDER = "${CLAUDE_PLUGIN_ROOT}";
+const enabledBundleMcpConfigCache: ConfigScopedRuntimeCache<
+  EnabledBundleConfigResult<BundleMcpConfig, BundleMcpDiagnostic>
+> = new WeakMap();
 
 function resolveBundleMcpConfigPaths(params: {
   raw: Record<string, unknown>;
@@ -285,7 +290,14 @@ export function loadEnabledBundleMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
 }): EnabledBundleMcpConfigResult {
-  return loadEnabledBundleConfig({
+  return loadCachedEnabledBundleConfig({
+    cache: enabledBundleMcpConfigCache,
+    cacheKeyParts: [
+      "enabled-bundle-mcp",
+      params.workspaceDir,
+      params.cfg?.plugins,
+      params.cfg?.mcp,
+    ],
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
     createEmptyConfig: () => ({ mcpServers: {} }),

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -702,6 +702,96 @@ describe("resolvePluginCapabilityProviders", () => {
     });
   });
 
+  it("does not treat every configured model provider as a requested speech provider", () => {
+    const active = createEmptyPluginRegistry();
+    active.speechProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: {
+        id: "openai",
+        label: "openai",
+        isConfigured: () => true,
+        synthesize: async () => ({
+          audioBuffer: Buffer.from("x"),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        }),
+      },
+    } as never);
+    const loaded = createEmptyPluginRegistry();
+    loaded.speechProviders.push(
+      {
+        pluginId: "microsoft",
+        pluginName: "microsoft",
+        source: "test",
+        provider: {
+          id: "microsoft",
+          label: "microsoft",
+          isConfigured: () => true,
+          synthesize: async () => ({
+            audioBuffer: Buffer.from("x"),
+            outputFormat: "mp3",
+            voiceCompatible: false,
+            fileExtension: ".mp3",
+          }),
+        },
+      } as never,
+      {
+        pluginId: "elevenlabs",
+        pluginName: "elevenlabs",
+        source: "test",
+        provider: {
+          id: "elevenlabs",
+          label: "elevenlabs",
+          isConfigured: () => true,
+          synthesize: async () => ({
+            audioBuffer: Buffer.from("x"),
+            outputFormat: "mp3",
+            voiceCompatible: false,
+            fileExtension: ".mp3",
+          }),
+        },
+      } as never,
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "microsoft",
+          origin: "bundled",
+          contracts: { speechProviders: ["microsoft"] },
+        },
+        {
+          id: "elevenlabs",
+          origin: "bundled",
+          contracts: { speechProviders: ["elevenlabs"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? active : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "speechProviders",
+      cfg: {
+        models: {
+          providers: {
+            microsoft: { apiKey: "model-key" },
+            elevenlabs: { apiKey: "model-key" },
+          },
+        },
+        messages: { tts: { provider: "openai" } },
+      } as OpenClawConfig,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["openai"]);
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
+    expect(collectActiveRegistryLookups()).toEqual([]);
+  });
+
   it("merges active and allowlisted bundled capability providers when cfg is passed", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -623,7 +623,7 @@ describe("resolvePluginCapabilityProviders", () => {
 
     expectResolvedCapabilityProviderIds(providers, ["openai", "deepgram"]);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
-    expectActiveRegistryLookup(["deepgram", "google"]);
+    expectActiveRegistryLookup(["deepgram"]);
   });
 
   it("keeps active speech providers when cfg requests an active provider alias", () => {
@@ -1167,6 +1167,146 @@ describe("resolvePluginCapabilityProviders", () => {
       }),
     );
     expectActiveRegistryLookup(["google"]);
+  });
+
+  it("narrows media capability loading to configured media providers", () => {
+    const cfg = {
+      tools: {
+        media: {
+          image: {
+            models: [{ provider: "google" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const loaded = createEmptyPluginRegistry();
+    loaded.mediaUnderstandingProviders.push({
+      pluginId: "google",
+      pluginName: "google",
+      source: "test",
+      provider: {
+        id: "google",
+        capabilities: ["image"],
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "google",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["google"] },
+        },
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["openai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      cfg,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["google"]);
+    expectActiveRegistryLookup(["google"]);
+  });
+
+  it("narrows media capability loading to the active model provider", () => {
+    const loaded = createEmptyPluginRegistry();
+    loaded.mediaUnderstandingProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: {
+        id: "openai",
+        capabilities: ["image"],
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "google",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["google"] },
+        },
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["openai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "mediaUnderstandingProviders",
+      providerIds: ["openai"],
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["openai"]);
+    expectActiveRegistryLookup(["openai"]);
+  });
+
+  it("narrows image-generation capability loading to configured model providers", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          imageGenerationModel: {
+            primary: "openai/gpt-image-1",
+            fallbacks: ["google/imagen-4"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const loaded = createEmptyPluginRegistry();
+    loaded.imageGenerationProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: {
+        id: "openai",
+      },
+    } as never);
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["openai"] },
+        },
+        {
+          id: "google",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["google"] },
+        },
+        {
+          id: "vydra",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["vydra"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
+      params === undefined ? undefined : loaded,
+    );
+
+    const providers = resolvePluginCapabilityProviders({
+      key: "imageGenerationProviders",
+      cfg,
+    });
+
+    expectResolvedCapabilityProviderIds(providers, ["openai"]);
+    expectActiveRegistryLookup(["google", "openai"]);
   });
 
   it("loads fallback snapshots without startup dependency repair", () => {

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -303,7 +303,6 @@ function collectRequestedSpeechProviderIds(cfg: OpenClawConfig | undefined): Set
       : undefined;
   addStringValue(requested, tts?.provider);
   addObjectKeys(requested, tts?.providers);
-  addObjectKeys(requested, cfg?.models?.providers);
   return requested;
 }
 

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -1,3 +1,7 @@
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { loadBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
@@ -316,25 +320,81 @@ function addMediaModelProviders(target: Set<string>, value: unknown): void {
 
 function collectRequestedMediaUnderstandingProviderIds(
   cfg: OpenClawConfig | undefined,
+  providerIds?: readonly string[],
 ): Set<string> {
   const requested = new Set<string>();
+  for (const providerId of providerIds ?? []) {
+    addStringValue(requested, providerId);
+  }
   const media = cfg?.tools?.media;
   addMediaModelProviders(requested, media?.models);
   addMediaModelProviders(requested, media?.image?.models);
   addMediaModelProviders(requested, media?.audio?.models);
   addMediaModelProviders(requested, media?.video?.models);
+  addConfiguredModelRefProviderIds(requested, cfg?.agents?.defaults?.imageModel);
+  addConfiguredModelRefProviderIds(requested, cfg?.agents?.defaults?.pdfModel);
+  return requested;
+}
+
+function addConfiguredModelRefProviderIds(target: Set<string>, value: unknown): void {
+  const addModelRefProvider = (raw: string | undefined) => {
+    if (typeof raw !== "string") {
+      return;
+    }
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return;
+    }
+    const slashIndex = trimmed.indexOf("/");
+    if (slashIndex <= 0) {
+      return;
+    }
+    const providerId = trimmed.slice(0, slashIndex).trim().toLowerCase();
+    if (providerId) {
+      target.add(providerId);
+    }
+  };
+
+  addModelRefProvider(resolveAgentModelPrimaryValue(value as never));
+  for (const fallback of resolveAgentModelFallbackValues(value as never)) {
+    addModelRefProvider(fallback);
+  }
+}
+
+function collectRequestedImageGenerationProviderIds(cfg: OpenClawConfig | undefined): Set<string> {
+  const requested = new Set<string>();
+  addConfiguredModelRefProviderIds(requested, cfg?.agents?.defaults?.imageGenerationModel);
+  return requested;
+}
+
+function collectRequestedVideoGenerationProviderIds(cfg: OpenClawConfig | undefined): Set<string> {
+  const requested = new Set<string>();
+  addConfiguredModelRefProviderIds(requested, cfg?.agents?.defaults?.videoGenerationModel);
+  return requested;
+}
+
+function collectRequestedMusicGenerationProviderIds(cfg: OpenClawConfig | undefined): Set<string> {
+  const requested = new Set<string>();
+  addConfiguredModelRefProviderIds(requested, cfg?.agents?.defaults?.musicGenerationModel);
   return requested;
 }
 
 function collectRequestedCapabilityProviderIds(params: {
   key: CapabilityProviderRegistryKey;
   cfg?: OpenClawConfig;
+  providerIds?: readonly string[];
 }): Set<string> | undefined {
   switch (params.key) {
     case "speechProviders":
       return collectRequestedSpeechProviderIds(params.cfg);
     case "mediaUnderstandingProviders":
-      return collectRequestedMediaUnderstandingProviderIds(params.cfg);
+      return collectRequestedMediaUnderstandingProviderIds(params.cfg, params.providerIds);
+    case "imageGenerationProviders":
+      return collectRequestedImageGenerationProviderIds(params.cfg);
+    case "videoGenerationProviders":
+      return collectRequestedVideoGenerationProviderIds(params.cfg);
+    case "musicGenerationProviders":
+      return collectRequestedMusicGenerationProviderIds(params.cfg);
     default:
       return undefined;
   }
@@ -386,7 +446,17 @@ function resolveRequestedCapabilityPluginIds(params: {
   cfg?: OpenClawConfig;
   requested?: Set<string>;
 }): CapabilityPluginResolution | undefined {
-  if (params.key !== "speechProviders" || !params.requested || params.requested.size === 0) {
+  if (
+    ![
+      "speechProviders",
+      "mediaUnderstandingProviders",
+      "imageGenerationProviders",
+      "videoGenerationProviders",
+      "musicGenerationProviders",
+    ].includes(params.key) ||
+    !params.requested ||
+    params.requested.size === 0
+  ) {
     return undefined;
   }
   const runtimePluginIds = new Set<string>();
@@ -436,7 +506,15 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
         ? loadedEntries
         : coldEntries;
   const missingRequested =
-    params.key === "speechProviders" && params.requested && params.requested.size > 0
+    [
+      "speechProviders",
+      "mediaUnderstandingProviders",
+      "imageGenerationProviders",
+      "videoGenerationProviders",
+      "musicGenerationProviders",
+    ].includes(params.key) &&
+    params.requested &&
+    params.requested.size > 0
       ? new Set(params.requested)
       : undefined;
   if (missingRequested) {
@@ -531,6 +609,7 @@ function resolveCachedCapabilityProviderEntries<K extends CapabilityProviderRegi
 export function resolvePluginCapabilityProviders<K extends CapabilityProviderRegistryKey>(params: {
   key: K;
   cfg?: OpenClawConfig;
+  providerIds?: readonly string[];
 }): CapabilityProviderForKey<K>[] {
   if (shouldSkipCapabilityResolution(params)) {
     return [];
@@ -540,7 +619,11 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
   const activeProviders = activeRegistry?.[params.key] ?? [];
   const missingRequestedProviders =
     activeProviders.length > 0
-      ? collectRequestedCapabilityProviderIds({ key: params.key, cfg: params.cfg })
+      ? collectRequestedCapabilityProviderIds({
+          key: params.key,
+          cfg: params.cfg,
+          providerIds: params.providerIds,
+        })
       : undefined;
   if (activeProviders.length > 0 && params.key !== "memoryEmbeddingProviders") {
     if (!missingRequestedProviders) {
@@ -551,17 +634,14 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
       return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
     }
   }
-  let requestedSpeechProviders: Set<string> | undefined;
-  if (params.key === "speechProviders") {
-    requestedSpeechProviders =
-      missingRequestedProviders ??
-      (activeProviders.length === 0 ? collectRequestedSpeechProviderIds(params.cfg) : undefined);
-  }
+  const requestedProviders =
+    missingRequestedProviders ??
+    (activeProviders.length === 0 ? collectRequestedCapabilityProviderIds(params) : undefined);
   const pluginIds =
     resolveRequestedCapabilityPluginIds({
       key: params.key,
       cfg: params.cfg,
-      requested: requestedSpeechProviders,
+      requested: requestedProviders,
     }) ??
     resolveCapabilityPluginIds({
       key: params.key,
@@ -581,7 +661,7 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
     cfg: params.cfg,
     bundledCompatPluginIds: pluginIds.bundledCompatPluginIds,
     loadOptions,
-    requested: requestedSpeechProviders,
+    requested: requestedProviders,
   });
   if (params.key !== "memoryEmbeddingProviders") {
     const mergeLoadedProviders =

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -164,6 +164,7 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         enabledByDefault: true,
         providers: ["openai", "openai-codex"],
         cliBackends: ["codex-cli"],
+        contracts: { speechProviders: ["openai"] },
       },
       {
         id: "google",
@@ -614,7 +615,7 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["voice-call"],
         modelId: "demo-cli/demo-model",
       }),
-      ["demo-channel", "browser", "voice-call", "memory-core"],
+      ["demo-channel", "browser", "demo-provider-plugin", "voice-call", "memory-core"],
     ],
     [
       "keeps bundled startup sidecars with enabledByDefault at idle startup",
@@ -627,6 +628,19 @@ describe("resolveGatewayStartupPluginIds", () => {
         providerIds: ["demo-provider"],
       }),
       ["demo-channel", "browser", "memory-core"],
+    ],
+    [
+      "includes configured image and PDF model owner plugins at startup",
+      {
+        channels: {},
+        agents: {
+          defaults: {
+            imageModel: { primary: "demo-cli/image-model" },
+            pdfModel: { primary: "demo-cli/pdf-model" },
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "demo-provider-plugin", "memory-core"],
     ],
     [
       "includes configured bundled speech providers at startup",
@@ -643,6 +657,18 @@ describe("resolveGatewayStartupPluginIds", () => {
         messages: { tts: { providers: { "tts-local-cli": { command: "say" } } } },
       } as OpenClawConfig,
       ["browser", "tts-local-cli", "memory-core"],
+    ],
+    [
+      "includes speech providers referenced through models.providers at startup",
+      {
+        channels: {},
+        models: {
+          providers: {
+            openai: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "openai", "memory-core"],
     ],
     [
       "maps legacy edge TTS selection to the Microsoft speech plugin",

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -3,6 +3,7 @@ import {
   listExplicitlyDisabledChannelIdsForConfig,
   listPotentialConfiguredChannelIds,
 } from "../channels/config-presence.js";
+import { collectConfiguredModelRefs } from "../config/model-refs.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   DEFAULT_MEMORY_DREAMING_PLUGIN_ID,
@@ -20,6 +21,10 @@ import {
   normalizeConfiguredSpeechProviderIdForStartup,
 } from "./gateway-startup-speech-providers.js";
 import type { InstalledPluginIndexRecord } from "./installed-plugin-index.js";
+import {
+  isActivatedManifestOwner,
+  passesManifestOwnerBasePolicy,
+} from "./manifest-owner-policy.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import {
   isPluginMetadataSnapshotCompatible,
@@ -31,6 +36,7 @@ import {
   normalizePluginsConfigWithRegistry,
 } from "./plugin-registry-contributions.js";
 import type { PluginRegistrySnapshot } from "./plugin-registry-snapshot.js";
+import { resolveOwningPluginIdsForModelRefs } from "./providers.js";
 
 export type GatewayStartupPluginPlan = {
   channelPluginIds: readonly string[];
@@ -52,6 +58,28 @@ function isConfigActivationValueEnabled(value: unknown): boolean {
     return false;
   }
   return true;
+}
+
+function isPluginBlockedByStartupConfig(params: {
+  pluginId: string;
+  pluginsConfig: NormalizedPluginsConfig;
+  activationSourcePlugins?: NormalizedPluginsConfig;
+  requireGlobalEnabled?: boolean;
+}): boolean {
+  const { pluginId, pluginsConfig, activationSourcePlugins } = params;
+  if (
+    params.requireGlobalEnabled === true &&
+    (!pluginsConfig.enabled || activationSourcePlugins?.enabled === false)
+  ) {
+    return true;
+  }
+  if (pluginsConfig.deny.includes(pluginId) || activationSourcePlugins?.deny.includes(pluginId)) {
+    return true;
+  }
+  return (
+    pluginsConfig.entries[pluginId]?.enabled === false ||
+    activationSourcePlugins?.entries[pluginId]?.enabled === false
+  );
 }
 
 function listPotentialEnabledChannelIds(config: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
@@ -124,6 +152,34 @@ function resolveContextEngineSlotStartupPluginId(params: {
     return undefined;
   }
   return normalized;
+}
+
+function canStartConfiguredModelOwnerPlugin(params: {
+  plugin: InstalledPluginIndexRecord;
+  pluginsConfig: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  const ownerPlugin = {
+    id: params.plugin.pluginId,
+    origin: params.plugin.origin,
+    enabledByDefault: params.plugin.enabledByDefault,
+  };
+  if (
+    !passesManifestOwnerBasePolicy({
+      plugin: ownerPlugin,
+      normalizedConfig: params.pluginsConfig,
+    })
+  ) {
+    return false;
+  }
+  if (params.plugin.origin !== "workspace") {
+    return true;
+  }
+  return isActivatedManifestOwner({
+    plugin: ownerPlugin,
+    normalizedConfig: params.pluginsConfig,
+    rootConfig: params.rootConfig,
+  });
 }
 
 function shouldConsiderForGatewayStartup(params: {
@@ -230,14 +286,11 @@ function canStartConfiguredSpeechProviderPlugin(params: {
     return false;
   }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSource.plugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSource.plugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSource.plugins,
+    })
   ) {
     return false;
   }
@@ -268,18 +321,13 @@ function canStartConfiguredRootPlugin(params: {
   if (!hasConfiguredActivationPath({ manifest: params.manifest, config: params.config })) {
     return false;
   }
-  if (!params.pluginsConfig.enabled || !params.activationSourcePlugins.enabled) {
-    return false;
-  }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSourcePlugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSourcePlugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSourcePlugins,
+      requireGlobalEnabled: true,
+    })
   ) {
     return false;
   }
@@ -334,18 +382,13 @@ function canStartExplicitHookPlugin(params: {
   ) {
     return false;
   }
-  if (!params.pluginsConfig.enabled || !params.activationSourcePlugins.enabled) {
-    return false;
-  }
   if (
-    params.pluginsConfig.deny.includes(params.plugin.pluginId) ||
-    params.activationSourcePlugins.deny.includes(params.plugin.pluginId)
-  ) {
-    return false;
-  }
-  if (
-    params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false ||
-    params.activationSourcePlugins.entries[params.plugin.pluginId]?.enabled === false
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      activationSourcePlugins: params.activationSourcePlugins,
+      requireGlobalEnabled: true,
+    })
   ) {
     return false;
   }
@@ -371,13 +414,13 @@ function canStartConfiguredChannelPlugin(params: {
   manifestLookup: ManifestRegistryLookup;
   platform?: NodeJS.Platform;
 }): boolean {
-  if (!params.pluginsConfig.enabled) {
-    return false;
-  }
-  if (params.pluginsConfig.deny.includes(params.plugin.pluginId)) {
-    return false;
-  }
-  if (params.pluginsConfig.entries[params.plugin.pluginId]?.enabled === false) {
+  if (
+    isPluginBlockedByStartupConfig({
+      pluginId: params.plugin.pluginId,
+      pluginsConfig: params.pluginsConfig,
+      requireGlobalEnabled: true,
+    })
+  ) {
     return false;
   }
   const explicitBundledChannelConfig =
@@ -525,6 +568,14 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
     activationSourcePlugins,
     normalizePluginId,
   });
+  const configuredModelOwnerPluginIds = new Set(
+    resolveOwningPluginIdsForModelRefs({
+      models: collectConfiguredModelRefs(activationSourceConfig),
+      config: activationSourceConfig,
+      env: params.env,
+      manifestRegistry: params.manifestRegistry,
+    }),
+  );
   const pluginIds = params.index.plugins
     .filter((plugin) => {
       const manifest = findManifestPlugin(manifestLookup, plugin.pluginId);
@@ -567,6 +618,13 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         })
       ) {
         return true;
+      }
+      if (configuredModelOwnerPluginIds.has(plugin.pluginId)) {
+        return canStartConfiguredModelOwnerPlugin({
+          plugin,
+          pluginsConfig,
+          rootConfig: params.config,
+        });
       }
       if (
         canStartConfiguredSpeechProviderPlugin({

--- a/src/plugins/gateway-startup-speech-providers.ts
+++ b/src/plugins/gateway-startup-speech-providers.ts
@@ -140,9 +140,21 @@ function addConfiguredTtsProviderIds(target: Set<string>, value: unknown): void 
   }
 }
 
+function addModelBackedSpeechProviderIds(target: Set<string>, value: unknown): void {
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const [providerId, providerConfig] of Object.entries(value)) {
+    if (isConfigActivationValueEnabled(providerConfig)) {
+      addProviderIfEnabled(target, value, providerId);
+    }
+  }
+}
+
 export function collectConfiguredSpeechProviderIds(config: OpenClawConfig): ReadonlySet<string> {
   const configured = new Set<string>();
   addConfiguredTtsProviderIds(configured, resolveEffectiveTtsConfig(config));
+  addModelBackedSpeechProviderIds(configured, config.models?.providers);
 
   const agents = config.agents;
   if (isRecord(agents) && Array.isArray(agents.list)) {

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
 import { buildAuthProfileId } from "../agents/auth-profiles/identity.js";
+import { preferAuthProfileFirst } from "../agents/auth-profiles/order.js";
 import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
 import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -173,22 +174,17 @@ export function applyAuthProfileConfig(
   const preferProfileFirst = params.preferProfileFirst ?? true;
   const reorderedProviderOrder =
     existingProviderOrder && preferProfileFirst
-      ? [
-          params.profileId,
-          ...existingProviderOrder.filter((profileId) => profileId !== params.profileId),
-        ]
+      ? preferAuthProfileFirst(params.profileId, [params.profileId, ...existingProviderOrder])
       : existingProviderOrder;
   const hasMixedConfiguredModes = configuredProviderProfiles.some(
     ({ profileId, mode }) => profileId !== params.profileId && mode !== params.mode,
   );
   const derivedProviderOrder =
     existingProviderOrder === undefined && preferProfileFirst && hasMixedConfiguredModes
-      ? [
+      ? preferAuthProfileFirst(params.profileId, [
           params.profileId,
-          ...configuredProviderProfiles
-            .map(({ profileId }) => profileId)
-            .filter((profileId) => profileId !== params.profileId),
-        ]
+          ...configuredProviderProfiles.map(({ profileId }) => profileId),
+        ])
       : undefined;
   const baseOrder =
     matchingProviderOrderEntries.length > 0

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -23,7 +23,7 @@ import type {
 
 const providerRuntimePluginCache: ConfigScopedRuntimeCache<ProviderPlugin | null> = new WeakMap();
 
-type ProviderRuntimePluginLookupParams = {
+export type ProviderRuntimePluginLookupParams = {
   provider: string;
   config?: OpenClawConfig;
   workspaceDir?: string;
@@ -31,6 +31,14 @@ type ProviderRuntimePluginLookupParams = {
   applyAutoEnable?: boolean;
   bundledProviderAllowlistCompat?: boolean;
   bundledProviderVitestCompat?: boolean;
+};
+
+export type ProviderRuntimePluginHandle = ProviderRuntimePluginLookupParams & {
+  plugin?: ProviderPlugin;
+};
+
+export type ProviderRuntimePluginHandleParams = ProviderRuntimePluginLookupParams & {
+  runtimeHandle?: ProviderRuntimePluginHandle;
 };
 
 function matchesProviderId(provider: ProviderPlugin, providerId: string): boolean {
@@ -100,7 +108,7 @@ export function resolveProviderPluginsForHooks(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: string[];
-  providerRefs?: string[];
+  providerRefs?: readonly string[];
   applyAutoEnable?: boolean;
   bundledProviderAllowlistCompat?: boolean;
   bundledProviderVitestCompat?: boolean;
@@ -180,20 +188,29 @@ export function resolveProviderRuntimePlugin(
   return plugin ?? undefined;
 }
 
-export function resolveProviderHookPlugin(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): ProviderPlugin | undefined {
-  return (
-    resolveProviderRuntimePlugin(params) ??
-    resolveProviderPluginsForHooks({
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    }).find((candidate) => matchesProviderId(candidate, params.provider))
-  );
+export function resolveProviderRuntimePluginHandle(
+  params: ProviderRuntimePluginLookupParams,
+): ProviderRuntimePluginHandle {
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  const env = params.env;
+  const runtimePlugin = resolveProviderRuntimePlugin({
+    ...params,
+    workspaceDir,
+    env,
+  });
+
+  return {
+    ...params,
+    workspaceDir,
+    env,
+    plugin: runtimePlugin,
+  };
+}
+
+export function ensureProviderRuntimePluginHandle(
+  params: ProviderRuntimePluginHandleParams,
+): ProviderRuntimePluginHandle {
+  return params.runtimeHandle ?? resolveProviderRuntimePluginHandle(params);
 }
 
 export function prepareProviderExtraParams(params: {
@@ -201,9 +218,13 @@ export function prepareProviderExtraParams(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderPrepareExtraParamsContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.prepareExtraParams?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.prepareExtraParams?.(params.context) ??
+    undefined
+  );
 }
 
 export function resolveProviderExtraParamsForTransport(params: {
@@ -211,10 +232,12 @@ export function resolveProviderExtraParamsForTransport(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderExtraParamsForTransportContext;
 }) {
   return (
-    resolveProviderRuntimePlugin(params)?.extraParamsForTransport?.(params.context) ?? undefined
+    ensureProviderRuntimePluginHandle(params).plugin?.extraParamsForTransport?.(params.context) ??
+    undefined
   );
 }
 
@@ -223,9 +246,12 @@ export function resolveProviderAuthProfileId(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderResolveAuthProfileIdContext;
 }): string | undefined {
-  const resolved = resolveProviderRuntimePlugin(params)?.resolveAuthProfileId?.(params.context);
+  const resolved = ensureProviderRuntimePluginHandle(params).plugin?.resolveAuthProfileId?.(
+    params.context,
+  );
   return typeof resolved === "string" && resolved.trim() ? resolved.trim() : undefined;
 }
 
@@ -234,9 +260,13 @@ export function resolveProviderFollowupFallbackRoute(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderFollowupFallbackRouteContext;
 }): ProviderFollowupFallbackRouteResult | undefined {
-  return resolveProviderHookPlugin(params)?.followupFallbackRoute?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.followupFallbackRoute?.(params.context) ??
+    undefined
+  );
 }
 
 export function wrapProviderStreamFn(params: {
@@ -244,7 +274,10 @@ export function wrapProviderStreamFn(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderWrapStreamFnContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.wrapStreamFn?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.wrapStreamFn?.(params.context) ?? undefined
+  );
 }

--- a/src/plugins/provider-runtime.synthetic-auth-discovery.test.ts
+++ b/src/plugins/provider-runtime.synthetic-auth-discovery.test.ts
@@ -108,4 +108,20 @@ describe("resolveProviderSyntheticAuthWithPlugin", () => {
       mode: "api-key",
     });
   });
+
+  it("does not fall back to unscoped discovery when no plugin owns the provider", () => {
+    resolvePluginDiscoveryProvidersRuntime.mockClear();
+
+    expect(
+      resolveProviderSyntheticAuthWithPlugin({
+        provider: "unowned-provider",
+        context: {
+          config: undefined,
+          provider: "unowned-provider",
+          providerConfig: undefined,
+        },
+      }),
+    ).toBeUndefined();
+    expect(resolvePluginDiscoveryProvidersRuntime).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -359,6 +359,30 @@ describe("provider-runtime", () => {
     });
   });
 
+  it("uses prepared provider runtime handles for stream hooks without rediscovery", () => {
+    const streamFn = vi.fn();
+    const createStreamFn = vi.fn(() => streamFn);
+
+    expect(
+      resolveProviderStreamFn({
+        provider: DEMO_PROVIDER_ID,
+        runtimeHandle: {
+          provider: DEMO_PROVIDER_ID,
+          plugin: {
+            id: DEMO_PROVIDER_ID,
+            label: "Demo",
+            auth: [],
+            createStreamFn,
+          } as ProviderPlugin,
+        },
+        context: createDemoResolvedModelContext({}),
+      }),
+    ).toBe(streamFn);
+
+    expect(createStreamFn).toHaveBeenCalledWith(createDemoResolvedModelContext({}));
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
   it("matches providers by hook alias for runtime hook lookup", () => {
     resolvePluginProvidersMock.mockReturnValue([
       {
@@ -807,6 +831,47 @@ describe("provider-runtime", () => {
       baseUrl: "https://runtime.example.com/v1",
       expiresAt: 123,
     });
+    expect(prepareRuntimeAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "raw-token",
+        modelId: MODEL.id,
+        provider: DEMO_PROVIDER_ID,
+      }),
+    );
+  });
+
+  it("uses an existing runtime handle for provider-prepared runtime auth", async () => {
+    const prepareRuntimeAuth = vi.fn(async () => ({
+      apiKey: "runtime-token",
+      baseUrl: "https://runtime.example.com/v1",
+    }));
+    const plugin = {
+      id: DEMO_PROVIDER_ID,
+      label: "Demo",
+      auth: [],
+      prepareRuntimeAuth,
+    } satisfies ProviderPlugin;
+
+    await expect(
+      prepareProviderRuntimeAuth({
+        provider: DEMO_PROVIDER_ID,
+        runtimeHandle: { provider: DEMO_PROVIDER_ID, plugin },
+        context: {
+          config: undefined,
+          workspaceDir: "/tmp/demo-workspace",
+          env: process.env,
+          provider: DEMO_PROVIDER_ID,
+          modelId: MODEL.id,
+          model: MODEL,
+          apiKey: "raw-token",
+          authMode: "token",
+        },
+      }),
+    ).resolves.toEqual({
+      apiKey: "runtime-token",
+      baseUrl: "https://runtime.example.com/v1",
+    });
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
     expect(prepareRuntimeAuth).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: "raw-token",
@@ -1266,6 +1331,32 @@ describe("provider-runtime", () => {
       }),
     ).toBeUndefined();
     expect(resolvePluginProvidersMock).toHaveBeenCalledOnce();
+  });
+
+  it("reuses provider runtime handles for reasoning output mode", () => {
+    const resolveReasoningOutputMode = vi.fn(() => "tagged" as const);
+
+    expect(
+      resolveProviderReasoningOutputModeWithPlugin({
+        provider: "mock-openai",
+        runtimeHandle: {
+          provider: "mock-openai",
+          plugin: {
+            id: "mock-openai",
+            label: "Mock OpenAI",
+            auth: [],
+            resolveReasoningOutputMode,
+          } satisfies ProviderPlugin,
+        },
+        context: createDemoResolvedModelContext({
+          provider: "mock-openai",
+          modelId: "gpt-5.5",
+        }),
+      }),
+    ).toBe("tagged");
+
+    expect(resolveReasoningOutputMode).toHaveBeenCalledOnce();
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not run broad provider-hook scans for auth profile selection", () => {
@@ -2170,6 +2261,30 @@ describe("provider-runtime", () => {
     );
     expect(resolveCatalogHookProviderPluginIdsMock).toHaveBeenCalledTimes(1);
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves scoped catalog hook refs instead of broad-loading providers", async () => {
+    resolveCatalogHookProviderPluginIdsMock.mockReturnValue([]);
+
+    await expect(
+      augmentModelCatalogWithProviderPlugins({
+        env: process.env,
+        providerRefs: ["openai-codex", "openai"],
+        modelRefs: ["openai-codex/gpt-5.5"],
+        context: {
+          env: process.env,
+          entries: [],
+        },
+      }),
+    ).resolves.toEqual([]);
+
+    expect(resolveCatalogHookProviderPluginIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerRefs: ["openai-codex", "openai"],
+        modelRefs: ["openai-codex/gpt-5.5"],
+      }),
+    );
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not stack-overflow when provider hook resolution reenters the same plugin load", () => {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -18,9 +18,10 @@ import {
   resolveProviderAuthProfileId,
   resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
-  resolveProviderHookPlugin,
+  ensureProviderRuntimePluginHandle,
   resolveProviderPluginsForHooks,
   resolveProviderRuntimePlugin,
+  type ProviderRuntimePluginHandle,
   wrapProviderStreamFn,
 } from "./provider-hook-runtime.js";
 import { resolveBundledProviderPolicySurface } from "./provider-public-artifacts.js";
@@ -153,6 +154,8 @@ export const __testing = {
 function resolveProviderPluginsForCatalogHooks(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
+  providerRefs?: readonly string[];
+  modelRefs?: readonly string[];
   env?: NodeJS.ProcessEnv;
 }): ProviderPlugin[] {
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
@@ -160,6 +163,8 @@ function resolveProviderPluginsForCatalogHooks(params: {
   const onlyPluginIds = resolveCatalogHookProviderPluginIds({
     config: params.config,
     workspaceDir,
+    providerRefs: params.providerRefs,
+    modelRefs: params.modelRefs,
     env,
   });
   if (onlyPluginIds.length === 0) {
@@ -188,9 +193,10 @@ export function resolveProviderSystemPromptContribution(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderSystemPromptContributionContext;
 }): ProviderSystemPromptContribution | undefined {
-  const plugin = resolveProviderRuntimePlugin(params);
+  const plugin = ensureProviderRuntimePluginHandle(params).plugin;
   const baseOverlay = resolveGpt5SystemPromptContribution({
     config: params.context.config ?? params.config,
     providerId: params.context.provider ?? params.provider,
@@ -240,9 +246,10 @@ export function transformProviderSystemPrompt(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderTransformSystemPromptContext;
 }): string {
-  const plugin = resolveProviderRuntimePlugin(params);
+  const plugin = ensureProviderRuntimePluginHandle(params).plugin;
   const textTransforms = mergePluginTextTransforms(
     resolveRuntimeTextTransforms(),
     plugin?.textTransforms,
@@ -257,10 +264,11 @@ export function resolveProviderTextTransforms(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
 }): PluginTextTransforms | undefined {
   return mergePluginTextTransforms(
     resolveRuntimeTextTransforms(),
-    resolveProviderRuntimePlugin(params)?.textTransforms,
+    ensureProviderRuntimePluginHandle(params).plugin?.textTransforms,
   );
 }
 
@@ -420,7 +428,7 @@ export function normalizeProviderModelIdWithPlugin(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderNormalizeModelIdContext;
 }): string | undefined {
-  const plugin = resolveProviderHookPlugin(params);
+  const plugin = resolveProviderRuntimePlugin(params);
   return (
     normalizeOptionalString(plugin?.normalizeModelId?.(params.context)) ??
     normalizeProviderModelIdWithManifest(params)
@@ -437,7 +445,7 @@ export function normalizeProviderTransportWithPlugin(params: {
   const hasTransportChange = (normalized: { api?: string | null; baseUrl?: string }) =>
     (normalized.api ?? params.context.api) !== params.context.api ||
     (normalized.baseUrl ?? params.context.baseUrl) !== params.context.baseUrl;
-  const matchedPlugin = resolveProviderHookPlugin(params);
+  const matchedPlugin = resolveProviderRuntimePlugin(params);
   const normalizedMatched = matchedPlugin?.normalizeTransport?.(params.context);
   if (normalizedMatched && hasTransportChange(normalizedMatched)) {
     return normalizedMatched;
@@ -524,9 +532,13 @@ export function resolveProviderReplayPolicyWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderReplayPolicyContext;
 }): ProviderReplayPolicy | undefined {
-  return resolveProviderRuntimePlugin(params)?.buildReplayPolicy?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.buildReplayPolicy?.(params.context) ??
+    undefined
+  );
 }
 
 export async function sanitizeProviderReplayHistoryWithPlugin(params: {
@@ -534,9 +546,12 @@ export async function sanitizeProviderReplayHistoryWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderSanitizeReplayHistoryContext;
 }) {
-  return await resolveProviderRuntimePlugin(params)?.sanitizeReplayHistory?.(params.context);
+  return await ensureProviderRuntimePluginHandle(params).plugin?.sanitizeReplayHistory?.(
+    params.context,
+  );
 }
 
 export async function validateProviderReplayTurnsWithPlugin(params: {
@@ -544,9 +559,12 @@ export async function validateProviderReplayTurnsWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderValidateReplayTurnsContext;
 }) {
-  return await resolveProviderRuntimePlugin(params)?.validateReplayTurns?.(params.context);
+  return await ensureProviderRuntimePluginHandle(params).plugin?.validateReplayTurns?.(
+    params.context,
+  );
 }
 
 export function normalizeProviderToolSchemasWithPlugin(params: {
@@ -554,9 +572,13 @@ export function normalizeProviderToolSchemasWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderNormalizeToolSchemasContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.normalizeToolSchemas?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.normalizeToolSchemas?.(params.context) ??
+    undefined
+  );
 }
 
 export function inspectProviderToolSchemasWithPlugin(params: {
@@ -564,9 +586,13 @@ export function inspectProviderToolSchemasWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderNormalizeToolSchemasContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.inspectToolSchemas?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.inspectToolSchemas?.(params.context) ??
+    undefined
+  );
 }
 
 export function resolveProviderReasoningOutputModeWithPlugin(params: {
@@ -574,9 +600,12 @@ export function resolveProviderReasoningOutputModeWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderReasoningOutputModeContext;
 }): ProviderReasoningOutputMode | undefined {
-  const mode = resolveProviderRuntimePlugin(params)?.resolveReasoningOutputMode?.(params.context);
+  const mode = ensureProviderRuntimePluginHandle(params).plugin?.resolveReasoningOutputMode?.(
+    params.context,
+  );
   return mode === "native" || mode === "tagged" ? mode : undefined;
 }
 
@@ -585,9 +614,12 @@ export function resolveProviderStreamFn(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderCreateStreamFnContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.createStreamFn?.(params.context) ?? undefined;
+  return (
+    ensureProviderRuntimePluginHandle(params).plugin?.createStreamFn?.(params.context) ?? undefined
+  );
 }
 
 export function resolveProviderTransportTurnStateWithPlugin(params: {
@@ -630,9 +662,12 @@ export async function prepareProviderRuntimeAuth(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderPrepareRuntimeAuthContext;
 }) {
-  return await resolveProviderRuntimePlugin(params)?.prepareRuntimeAuth?.(params.context);
+  return await ensureProviderRuntimePluginHandle(params).plugin?.prepareRuntimeAuth?.(
+    params.context,
+  );
 }
 
 export async function resolveProviderUsageAuthWithPlugin(params: {
@@ -663,7 +698,7 @@ export function matchesProviderContextOverflowWithPlugin(params: {
   context: ProviderFailoverErrorContext;
 }): boolean {
   const plugins = params.provider
-    ? [resolveProviderHookPlugin({ ...params, provider: params.provider })].filter(
+    ? [resolveProviderRuntimePlugin({ ...params, provider: params.provider })].filter(
         (plugin): plugin is ProviderPlugin => Boolean(plugin),
       )
     : resolveProviderPluginsForHooks(params);
@@ -683,7 +718,7 @@ export function classifyProviderFailoverReasonWithPlugin(params: {
   context: ProviderFailoverErrorContext;
 }) {
   const plugins = params.provider
-    ? [resolveProviderHookPlugin({ ...params, provider: params.provider })].filter(
+    ? [resolveProviderRuntimePlugin({ ...params, provider: params.provider })].filter(
         (plugin): plugin is ProviderPlugin => Boolean(plugin),
       )
     : resolveProviderPluginsForHooks(params);
@@ -731,9 +766,10 @@ export function resolveProviderCacheTtlEligibility(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   context: ProviderCacheTtlEligibilityContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.isCacheTtlEligible?.(params.context);
+  return ensureProviderRuntimePluginHandle(params).plugin?.isCacheTtlEligible?.(params.context);
 }
 
 export function resolveProviderBinaryThinking(params: {
@@ -881,15 +917,6 @@ export function resolveProviderSyntheticAuthWithPlugin(params: {
       return runtimeProviderResolved;
     }
   }
-  if (providerRefs.length === 1) {
-    return resolvePluginDiscoveryProvidersRuntime({
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    })
-      .find((provider) => matchesAnyProviderPluginRef(provider, providerRefs))
-      ?.resolveSyntheticAuth?.(params.context);
-  }
   return undefined;
 }
 
@@ -979,6 +1006,8 @@ export function shouldDeferProviderSyntheticProfileAuthWithPlugin(params: {
 export async function augmentModelCatalogWithProviderPlugins(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
+  providerRefs?: readonly string[];
+  modelRefs?: readonly string[];
   env?: NodeJS.ProcessEnv;
   context: ProviderAugmentModelCatalogContext;
 }) {

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -29,6 +29,7 @@ const applyPluginAutoEnableMock = vi.fn<ApplyPluginAutoEnable>();
 
 let resolveOwningPluginIdsForProvider: typeof import("./providers.js").resolveOwningPluginIdsForProvider;
 let resolveOwningPluginIdsForModelRef: typeof import("./providers.js").resolveOwningPluginIdsForModelRef;
+let resolveCatalogHookProviderPluginIds: typeof import("./providers.js").resolveCatalogHookProviderPluginIds;
 let resolveActivatableProviderOwnerPluginIds: typeof import("./providers.js").resolveActivatableProviderOwnerPluginIds;
 let resolveEnabledProviderPluginIds: typeof import("./providers.js").resolveEnabledProviderPluginIds;
 let resolveExternalAuthProfileCompatFallbackPluginIds: typeof import("./providers.js").resolveExternalAuthProfileCompatFallbackPluginIds;
@@ -414,6 +415,7 @@ describe("resolvePluginProviders", () => {
     });
     ({
       resolveActivatableProviderOwnerPluginIds,
+      resolveCatalogHookProviderPluginIds,
       resolveOwningPluginIdsForProvider,
       resolveOwningPluginIdsForModelRef,
       resolveEnabledProviderPluginIds,
@@ -450,6 +452,28 @@ describe("resolvePluginProviders", () => {
     ]);
 
     expectOwningPluginIds("dynamic-provider", ["second-owner"]);
+  });
+
+  it("scopes catalog hook plugin ids to requested provider and model refs", () => {
+    setOwningProviderManifestPlugins();
+
+    expect(
+      resolveCatalogHookProviderPluginIds({
+        providerRefs: ["openai-codex"],
+        modelRefs: ["claude-sonnet-4-6"],
+      }),
+    ).toEqual(["anthropic", "openai"]);
+  });
+
+  it("does not broaden scoped catalog hook loads when no owner matches", () => {
+    setOwningProviderManifestPlugins();
+
+    expect(
+      resolveCatalogHookProviderPluginIds({
+        providerRefs: ["missing-provider"],
+        modelRefs: ["missing-model"],
+      }),
+    ).toEqual([]);
   });
 
   beforeEach(() => {

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -610,7 +610,30 @@ export function resolveCatalogHookProviderPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  providerRefs?: readonly string[];
+  modelRefs?: readonly string[];
 }): string[] {
+  const scopedRefs = Boolean(params.providerRefs?.length || params.modelRefs?.length);
+  if (scopedRefs) {
+    return dedupeSortedPluginIds([
+      ...(params.providerRefs ?? []).flatMap(
+        (provider) =>
+          resolveOwningPluginIdsForProvider({
+            provider,
+            config: params.config,
+            workspaceDir: params.workspaceDir,
+            env: params.env,
+          }) ?? [],
+      ),
+      ...resolveOwningPluginIdsForModelRefs({
+        models: params.modelRefs ?? [],
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      }),
+    ]);
+  }
+
   const registry = loadProviderRegistrySnapshot(params);
   const providerSurfacePluginIds = resolveProviderSurfacePluginIdSet({ ...params, registry });
   const normalizedConfig = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -8,6 +8,9 @@ export type RegistrySurfaceState = {
   registry: RuntimeTrackedPluginRegistry | null;
   pinned: boolean;
   version: number;
+  key: string | null;
+  workspaceDir: string | null;
+  runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";
 };
 
 export type RegistryState = {
@@ -15,6 +18,7 @@ export type RegistryState = {
   activeVersion: number;
   httpRoute: RegistrySurfaceState;
   channel: RegistrySurfaceState;
+  gatewayRuntime: RegistrySurfaceState;
   key: string | null;
   workspaceDir: string | null;
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable";

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -4,9 +4,15 @@ import { getChannelPlugin } from "../channels/plugins/registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import {
   getActivePluginChannelRegistryVersion,
+  getActivePluginGatewayRuntimeRegistry,
+  getActivePluginGatewayRuntimeRegistryVersion,
+  getActivePluginGatewayRuntimeRegistryWorkspaceDir,
+  getActivePluginGatewayRuntimeSubagentMode,
   getActivePluginRegistryVersion,
   getActivePluginChannelRegistry,
+  pinActivePluginGatewayRuntimeRegistry,
   pinActivePluginChannelRegistry,
+  releasePinnedPluginGatewayRuntimeRegistry,
   releasePinnedPluginChannelRegistry,
   requireActivePluginChannelRegistry,
   resetPluginRuntimeStateForTest,
@@ -37,6 +43,12 @@ function createRegistrySet() {
 
 function expectActiveChannelRegistry(registry: ReturnType<typeof createEmptyPluginRegistry>) {
   expect(getActivePluginChannelRegistry()).toBe(registry);
+}
+
+function expectActiveGatewayRuntimeRegistry(
+  registry: ReturnType<typeof createEmptyPluginRegistry>,
+) {
+  expect(getActivePluginGatewayRuntimeRegistry()).toBe(registry);
 }
 
 function expectPinnedChannelRegistry(
@@ -195,5 +207,51 @@ describe("channel registry pinning", () => {
     // The outbound loader must still find the telegram adapter from the pinned registry.
     const adapter = await loadChannelOutboundAdapter("telegram");
     expect(adapter).toBe(outboundAdapter);
+  });
+});
+
+describe("gateway runtime registry pinning", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("preserves pinned gateway runtime registry across active registry churn", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+
+    setActivePluginRegistry(replacement, "replacement-key", "default", "/tmp/other");
+
+    expectActiveGatewayRuntimeRegistry(startup);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBe("/tmp/workspace");
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("gateway-bindable");
+  });
+
+  it("release restores live-tracking behavior", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+    setActivePluginRegistry(replacement, "replacement-key", "default", "/tmp/other");
+
+    const gatewayVersionBeforeRelease = getActivePluginGatewayRuntimeRegistryVersion();
+    releasePinnedPluginGatewayRuntimeRegistry(startup);
+
+    expect(getActivePluginGatewayRuntimeRegistryVersion()).toBe(gatewayVersionBeforeRelease + 1);
+    expectActiveGatewayRuntimeRegistry(replacement);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBe("/tmp/other");
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("default");
+  });
+
+  it("resetPluginRuntimeStateForTest clears gateway runtime pin", () => {
+    const { startup, replacement } = createRegistrySet();
+    setActivePluginRegistry(startup, "startup-key", "gateway-bindable", "/tmp/workspace");
+    pinActivePluginGatewayRuntimeRegistry(startup);
+
+    resetPluginRuntimeStateForTest();
+    setActivePluginRegistry(replacement);
+
+    expectActiveGatewayRuntimeRegistry(replacement);
+    expect(getActivePluginGatewayRuntimeRegistryWorkspaceDir()).toBeUndefined();
+    expect(getActivePluginGatewayRuntimeSubagentMode()).toBe("default");
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -31,11 +31,25 @@ const state: RegistryState = (() => {
         registry: null,
         pinned: false,
         version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
       },
       channel: {
         registry: null,
         pinned: false,
         version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
+      },
+      gatewayRuntime: {
+        registry: null,
+        pinned: false,
+        version: 0,
+        key: null,
+        workspaceDir: null,
+        runtimeSubagentMode: "default",
       },
       key: null,
       workspaceDir: null,
@@ -96,30 +110,58 @@ function installSurfaceRegistry(
   surface: RegistrySurfaceState,
   registry: RegistryState["activeRegistry"],
   pinned: boolean,
+  metadata?: {
+    key?: string | null;
+    workspaceDir?: string | null;
+    runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  },
 ) {
   if (surface.registry === registry && surface.pinned === pinned) {
-    return;
+    if (!metadata) {
+      return;
+    }
+    const nextKey = metadata.key ?? surface.key;
+    const nextWorkspaceDir = metadata.workspaceDir ?? surface.workspaceDir;
+    const nextRuntimeSubagentMode = metadata.runtimeSubagentMode ?? surface.runtimeSubagentMode;
+    if (
+      surface.key === nextKey &&
+      surface.workspaceDir === nextWorkspaceDir &&
+      surface.runtimeSubagentMode === nextRuntimeSubagentMode
+    ) {
+      return;
+    }
   }
   surface.registry = registry;
   surface.pinned = pinned;
+  surface.key = metadata?.key ?? null;
+  surface.workspaceDir = metadata?.workspaceDir ?? null;
+  surface.runtimeSubagentMode = metadata?.runtimeSubagentMode ?? "default";
   surface.version += 1;
 }
 
 function syncTrackedSurface(
   surface: RegistrySurfaceState,
   registry: RegistryState["activeRegistry"],
+  metadata: {
+    key?: string | null;
+    workspaceDir?: string | null;
+    runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  } = {},
   refreshVersion = false,
 ) {
   if (surface.pinned) {
     return;
   }
   if (surface.registry === registry && !surface.pinned) {
+    surface.key = metadata.key ?? null;
+    surface.workspaceDir = metadata.workspaceDir ?? null;
+    surface.runtimeSubagentMode = metadata.runtimeSubagentMode ?? "default";
     if (refreshVersion) {
       surface.version += 1;
     }
     return;
   }
-  installSurfaceRegistry(surface, registry, false);
+  installSurfaceRegistry(surface, registry, false, metadata);
 }
 
 export function setActivePluginRegistry(
@@ -129,10 +171,16 @@ export function setActivePluginRegistry(
   workspaceDir?: string,
 ) {
   const previousRegistry = asPluginRegistry(state.activeRegistry);
+  const metadata = {
+    key: cacheKey ?? null,
+    workspaceDir: workspaceDir ?? null,
+    runtimeSubagentMode,
+  };
   state.activeRegistry = registry;
   state.activeVersion += 1;
-  syncTrackedSurface(state.httpRoute, registry, true);
-  syncTrackedSurface(state.channel, registry, true);
+  syncTrackedSurface(state.httpRoute, registry, metadata, true);
+  syncTrackedSurface(state.channel, registry, metadata, true);
+  syncTrackedSurface(state.gatewayRuntime, registry, metadata, true);
   state.key = cacheKey ?? null;
   state.workspaceDir = workspaceDir ?? null;
   state.runtimeSubagentMode = runtimeSubagentMode;
@@ -171,14 +219,22 @@ export function requireActivePluginRegistry(): PluginRegistry {
 }
 
 export function pinActivePluginHttpRouteRegistry(registry: PluginRegistry) {
-  installSurfaceRegistry(state.httpRoute, registry, true);
+  installSurfaceRegistry(state.httpRoute, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function releasePinnedPluginHttpRouteRegistry(registry?: PluginRegistry) {
   if (registry && state.httpRoute.registry !== registry) {
     return;
   }
-  installSurfaceRegistry(state.httpRoute, state.activeRegistry, false);
+  installSurfaceRegistry(state.httpRoute, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function getActivePluginHttpRouteRegistry(): PluginRegistry | null {
@@ -220,14 +276,22 @@ export function resolveActivePluginHttpRouteRegistry(fallback: PluginRegistry): 
  *  gateway startup after the initial plugin load so that config-schema reads
  *  and other non-primary registry loads cannot evict channel plugins. */
 export function pinActivePluginChannelRegistry(registry: PluginRegistry) {
-  installSurfaceRegistry(state.channel, registry, true);
+  installSurfaceRegistry(state.channel, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 export function releasePinnedPluginChannelRegistry(registry?: PluginRegistry) {
   if (registry && state.channel.registry !== registry) {
     return;
   }
-  installSurfaceRegistry(state.channel, state.activeRegistry, false);
+  installSurfaceRegistry(state.channel, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
 }
 
 /** Return the registry that should be used for channel plugin resolution.
@@ -241,6 +305,10 @@ export function getActivePluginChannelRegistryVersion(): number {
   return state.channel.registry ? state.channel.version : state.activeVersion;
 }
 
+export function getActivePluginChannelRegistryWorkspaceDir(): string | undefined {
+  return state.channel.workspaceDir ?? undefined;
+}
+
 export function requireActivePluginChannelRegistry(): PluginRegistry {
   const existing = getActivePluginChannelRegistry();
   if (existing) {
@@ -249,6 +317,44 @@ export function requireActivePluginChannelRegistry(): PluginRegistry {
   const created = requireActivePluginRegistry();
   installSurfaceRegistry(state.channel, created, false);
   return created;
+}
+
+export function pinActivePluginGatewayRuntimeRegistry(registry: PluginRegistry) {
+  installSurfaceRegistry(state.gatewayRuntime, registry, true, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
+}
+
+export function releasePinnedPluginGatewayRuntimeRegistry(registry?: PluginRegistry) {
+  if (registry && state.gatewayRuntime.registry !== registry) {
+    return;
+  }
+  installSurfaceRegistry(state.gatewayRuntime, state.activeRegistry, false, {
+    key: state.key,
+    workspaceDir: state.workspaceDir,
+    runtimeSubagentMode: state.runtimeSubagentMode,
+  });
+}
+
+export function getActivePluginGatewayRuntimeRegistry(): PluginRegistry | null {
+  return asPluginRegistry(state.gatewayRuntime.registry ?? state.activeRegistry);
+}
+
+export function getActivePluginGatewayRuntimeRegistryVersion(): number {
+  return state.gatewayRuntime.registry ? state.gatewayRuntime.version : state.activeVersion;
+}
+
+export function getActivePluginGatewayRuntimeRegistryWorkspaceDir(): string | undefined {
+  return state.gatewayRuntime.workspaceDir ?? undefined;
+}
+
+export function getActivePluginGatewayRuntimeSubagentMode():
+  | "default"
+  | "explicit"
+  | "gateway-bindable" {
+  return state.gatewayRuntime.runtimeSubagentMode;
 }
 
 export function getActivePluginRegistryKey(): string | null {
@@ -293,6 +399,7 @@ export function listImportedRuntimePluginIds(): string[] {
   collectLoadedPluginIds(asPluginRegistry(state.activeRegistry), imported);
   collectLoadedPluginIds(asPluginRegistry(state.channel.registry), imported);
   collectLoadedPluginIds(asPluginRegistry(state.httpRoute.registry), imported);
+  collectLoadedPluginIds(asPluginRegistry(state.gatewayRuntime.registry), imported);
   return [...imported].toSorted((left, right) => left.localeCompare(right));
 }
 
@@ -301,6 +408,7 @@ export function resetPluginRuntimeStateForTest(): void {
   state.activeVersion += 1;
   installSurfaceRegistry(state.httpRoute, null, false);
   installSurfaceRegistry(state.channel, null, false);
+  installSurfaceRegistry(state.gatewayRuntime, null, false);
   state.key = null;
   state.workspaceDir = null;
   state.runtimeSubagentMode = "default";

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 
 type MockRegistryToolEntry = {
   pluginId: string;
@@ -36,6 +37,7 @@ let getPluginToolMeta: typeof import("./tools.js").getPluginToolMeta;
 let resetPluginToolFactoryCache: typeof import("./tools.js").resetPluginToolFactoryCache;
 let getActivePluginRegistry: typeof import("./runtime.js").getActivePluginRegistry;
 let pinActivePluginChannelRegistry: typeof import("./runtime.js").pinActivePluginChannelRegistry;
+let pinActivePluginGatewayRuntimeRegistry: typeof import("./runtime.js").pinActivePluginGatewayRuntimeRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
 let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
 let clearCurrentPluginMetadataSnapshot: typeof import("./current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
@@ -74,6 +76,7 @@ function createResolveToolsParams(params?: {
   env?: NodeJS.ProcessEnv;
   suppressNameConflicts?: boolean;
   allowGatewaySubagentBinding?: boolean;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
 }) {
   return {
     context: (params?.context ?? createContext()) as never,
@@ -83,6 +86,7 @@ function createResolveToolsParams(params?: {
     ...(params?.env ? { env: params.env } : {}),
     ...(params?.suppressNameConflicts ? { suppressNameConflicts: true } : {}),
     ...(params?.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+    ...(params?.loadMetadataSnapshot ? { loadMetadataSnapshot: params.loadMetadataSnapshot } : {}),
   };
 }
 
@@ -99,6 +103,52 @@ function createToolRegistry(entries: MockRegistryToolEntry[]) {
   };
 }
 
+function createToolManifest(params: {
+  id: string;
+  tools: string[];
+  origin?: string;
+  enabledByDefault?: boolean | undefined;
+  providers?: string[];
+  extra?: Record<string, unknown>;
+}) {
+  return {
+    id: params.id,
+    origin: params.origin ?? "bundled",
+    enabledByDefault: "enabledByDefault" in params ? params.enabledByDefault : true,
+    channels: [],
+    providers: params.providers ?? [],
+    contracts: { tools: params.tools },
+    ...params.extra,
+  };
+}
+
+const optionalDemoManifest = (overrides?: {
+  origin?: string;
+  enabledByDefault?: boolean | undefined;
+}) =>
+  createToolManifest({
+    id: "optional-demo",
+    tools: ["optional_tool"],
+    ...overrides,
+  });
+const memoryCoreTools = ["memory_get", "memory_search"] as const;
+const memoryCoreManifest = () =>
+  createToolManifest({
+    id: "memory-core",
+    tools: [...memoryCoreTools],
+    enabledByDefault: false,
+  });
+const createMemorySearchFactory = () =>
+  vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
+const createMemoryCoreToolEntry = (factory: ReturnType<typeof createMemorySearchFactory>) => ({
+  pluginId: "memory-core",
+  optional: false,
+  source: "/tmp/memory-core.js",
+  names: [...memoryCoreTools],
+  declaredNames: [...memoryCoreTools],
+  factory,
+});
+
 function setRegistry(entries: MockRegistryToolEntry[]) {
   const registry = createToolRegistry(entries);
   loadOpenClawPluginsMock.mockReturnValue(registry);
@@ -106,23 +156,21 @@ function setRegistry(entries: MockRegistryToolEntry[]) {
   installToolManifestSnapshots({
     config: createContext().config,
     plugins: entries
-      .map((entry) => ({
-        id: entry.pluginId,
-        origin: "bundled",
-        enabledByDefault: true,
-        channels: [],
-        providers: [],
-        contracts: {
+      .map((entry) =>
+        createToolManifest({
+          id: entry.pluginId,
           tools: entry.declaredNames ?? entry.names,
-        },
-        ...(entry.optional
-          ? {
-              toolMetadata: Object.fromEntries(
-                (entry.declaredNames ?? entry.names).map((name) => [name, { optional: true }]),
-              ),
-            }
-          : {}),
-      }))
+          ...(entry.optional
+            ? {
+                extra: {
+                  toolMetadata: Object.fromEntries(
+                    (entry.declaredNames ?? entry.names).map((name) => [name, { optional: true }]),
+                  ),
+                },
+              }
+            : {}),
+        }),
+      )
       .filter((plugin) => plugin.contracts.tools.length > 0),
   });
   return registry;
@@ -212,16 +260,7 @@ function resolveAutoEnabledOptionalDemoTools() {
   const { rawContext, autoEnabledConfig } = createAutoEnabledOptionalContext();
   installToolManifestSnapshot({
     config: autoEnabledConfig,
-    plugin: {
-      id: "optional-demo",
-      origin: "bundled",
-      enabledByDefault: true,
-      channels: [],
-      providers: [],
-      contracts: {
-        tools: ["optional_tool"],
-      },
-    },
+    plugin: optionalDemoManifest(),
   });
   applyPluginAutoEnableMock.mockReturnValue({ config: autoEnabledConfig, changes: [] });
 
@@ -239,16 +278,7 @@ function resolveAutoEnabledOptionalDemoTools() {
 function createOptionalDemoActiveRegistry() {
   installToolManifestSnapshot({
     config: createContext().config,
-    plugin: {
-      id: "optional-demo",
-      origin: "bundled",
-      enabledByDefault: true,
-      channels: [],
-      providers: [],
-      contracts: {
-        tools: ["optional_tool"],
-      },
-    },
+    plugin: optionalDemoManifest(),
   });
   const registry = {
     plugins: [{ id: "optional-demo", status: "loaded" }],
@@ -275,76 +305,76 @@ function installToolManifestSnapshots(params: {
   config: ReturnType<typeof createContext>["config"];
   env?: NodeJS.ProcessEnv;
   plugins: Record<string, unknown>[];
-}) {
+}): PluginMetadataSnapshot {
   const plugins = params.plugins;
-  setCurrentPluginMetadataSnapshot(
-    {
-      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
-      workspaceDir: "/tmp",
-      index: {
-        version: 1,
-        hostContractVersion: "test",
-        compatRegistryVersion: "test",
-        migrationVersion: 1,
-        policyHash: "test",
-        generatedAtMs: 0,
-        installRecords: {},
-        plugins: plugins.map((plugin) => ({
-          pluginId: String(plugin.id),
-          origin: plugin.origin,
-          enabled: true,
-          enabledByDefault: plugin.enabledByDefault,
-          startup: {
-            sidecar: false,
-            memory: false,
-            deferConfiguredChannelFullLoadUntilAfterListen: false,
-            agentHarnesses: [],
-          },
-          compat: [],
-        })),
-        diagnostics: [],
-      },
-      registryDiagnostics: [],
-      manifestRegistry: { plugins, diagnostics: [] },
-      plugins,
+  const snapshot = {
+    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    workspaceDir: "/tmp",
+    index: {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "test",
+      generatedAtMs: 0,
+      installRecords: {},
+      plugins: plugins.map((plugin) => ({
+        pluginId: String(plugin.id),
+        origin: plugin.origin,
+        enabled: true,
+        enabledByDefault: plugin.enabledByDefault,
+        startup: {
+          sidecar: false,
+          memory: false,
+          deferConfiguredChannelFullLoadUntilAfterListen: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      })),
       diagnostics: [],
-      byPluginId: new Map(plugins.map((plugin) => [String(plugin.id), plugin])),
-      normalizePluginId: (id: string) => id,
-      owners: {
-        channels: new Map(),
-        channelConfigs: new Map(),
-        providers: new Map(),
-        modelCatalogProviders: new Map(),
-        cliBackends: new Map(),
-        setupProviders: new Map(),
-        commandAliases: new Map(),
-        contracts: new Map(),
-      },
-      metrics: {
-        registrySnapshotMs: 0,
-        manifestRegistryMs: 0,
-        ownerMapsMs: 0,
-        totalMs: 0,
-        indexPluginCount: plugins.length,
-        manifestPluginCount: plugins.length,
-      },
-    } as never,
-    { config: params.config, env: params.env ?? process.env, workspaceDir: "/tmp" },
-  );
+    },
+    registryDiagnostics: [],
+    manifestRegistry: { plugins, diagnostics: [] },
+    plugins,
+    diagnostics: [],
+    byPluginId: new Map(plugins.map((plugin) => [String(plugin.id), plugin])),
+    normalizePluginId: (id: string) => id,
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map(),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+    metrics: {
+      registrySnapshotMs: 0,
+      manifestRegistryMs: 0,
+      ownerMapsMs: 0,
+      totalMs: 0,
+      indexPluginCount: plugins.length,
+      manifestPluginCount: plugins.length,
+    },
+  } as unknown as PluginMetadataSnapshot;
+  setCurrentPluginMetadataSnapshot(snapshot, {
+    config: params.config,
+    env: params.env ?? process.env,
+    workspaceDir: "/tmp",
+  });
+  return snapshot;
 }
 
 function createXaiToolManifest() {
   return {
-    id: "xai",
-    origin: "bundled",
-    enabledByDefault: true,
-    channels: [],
-    providers: ["xai"],
+    ...createToolManifest({
+      id: "xai",
+      tools: ["x_search"],
+      providers: ["xai"],
+    }),
     providerAuthEnvVars: {
       xai: ["XAI_API_KEY"],
-    },
-    contracts: {
-      tools: ["x_search"],
     },
     toolMetadata: {
       x_search: {
@@ -418,6 +448,7 @@ describe("resolvePluginTools optional tools", () => {
     ({
       getActivePluginRegistry,
       pinActivePluginChannelRegistry,
+      pinActivePluginGatewayRuntimeRegistry,
       resetPluginRuntimeStateForTest,
       setActivePluginRegistry,
     } = await import("./runtime.js"));
@@ -496,16 +527,7 @@ describe("resolvePluginTools optional tools", () => {
     loadOpenClawPluginsMock.mockReturnValue(registry);
     installToolManifestSnapshot({
       config,
-      plugin: {
-        id: "optional-demo",
-        origin: "bundled",
-        enabledByDefault: true,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["optional_tool"],
-        },
-      },
+      plugin: optionalDemoManifest(),
     });
 
     ensureStandalonePluginToolRegistryLoaded({
@@ -540,16 +562,7 @@ describe("resolvePluginTools optional tools", () => {
     loadOpenClawPluginsMock.mockReturnValue(registry);
     installToolManifestSnapshot({
       config,
-      plugin: {
-        id: "optional-demo",
-        origin: "config",
-        enabledByDefault: undefined,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["optional_tool"],
-        },
-      },
+      plugin: optionalDemoManifest({ origin: "config", enabledByDefault: undefined }),
     });
 
     // No ensureStandalonePluginToolRegistryLoaded pre-call and no pinned channel registry —
@@ -638,6 +651,26 @@ describe("resolvePluginTools optional tools", () => {
     );
   });
 
+  it("reuses the current manifest registry for plugin auto-enable", () => {
+    const config = createContext().config;
+    const plugin = optionalDemoManifest();
+    installToolManifestSnapshot({ config, plugin });
+
+    resolvePluginTools(
+      createResolveToolsParams({
+        toolAllowlist: ["optional_tool"],
+      }),
+    );
+
+    expect(applyPluginAutoEnableMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manifestRegistry: expect.objectContaining({
+          plugins: expect.arrayContaining([expect.objectContaining({ id: "optional-demo" })]),
+        }),
+      }),
+    );
+  });
+
   it("warns when cold registry load still does not provide the selected plugin tools", () => {
     const context = {
       ...createContext(),
@@ -656,16 +689,7 @@ describe("resolvePluginTools optional tools", () => {
     loadOpenClawPluginsMock.mockReturnValue(registry);
     installToolManifestSnapshot({
       config,
-      plugin: {
-        id: "optional-demo",
-        origin: "config",
-        enabledByDefault: undefined,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["optional_tool"],
-        },
-      },
+      plugin: optionalDemoManifest({ origin: "config", enabledByDefault: undefined }),
     });
 
     const tools = resolvePluginTools(
@@ -696,28 +720,7 @@ describe("resolvePluginTools optional tools", () => {
     const optionalEntry = createOptionalDemoEntry();
     installToolManifestSnapshots({
       config,
-      plugins: [
-        {
-          id: "multi",
-          origin: "bundled",
-          enabledByDefault: true,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["other_tool"],
-          },
-        },
-        {
-          id: "optional-demo",
-          origin: "bundled",
-          enabledByDefault: true,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["optional_tool"],
-          },
-        },
-      ],
+      plugins: [createToolManifest({ id: "multi", tools: ["other_tool"] }), optionalDemoManifest()],
     });
     const staleRegistry = createToolRegistry([multiEntry]);
     staleRegistry.plugins.push({ id: "optional-demo", status: "loaded" });
@@ -900,6 +903,28 @@ describe("resolvePluginTools optional tools", () => {
     const tools = resolveOptionalDemoTools();
 
     expect(tools).toHaveLength(0);
+  });
+
+  it("uses a caller-owned metadata snapshot loader for plugin tool planning", () => {
+    setOptionalDemoRegistry();
+    const context = createContext();
+    const snapshot = installToolManifestSnapshots({
+      config: context.config,
+      plugins: [optionalDemoManifest()],
+    });
+    clearCurrentPluginMetadataSnapshot();
+    const loadMetadataSnapshot = vi.fn(() => snapshot);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context,
+        toolAllowlist: ["optional_tool"],
+        loadMetadataSnapshot,
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(loadMetadataSnapshot).toHaveBeenCalledTimes(1);
   });
 
   it("does not invoke named optional tool factories without a matching allowlist", () => {
@@ -1452,16 +1477,7 @@ describe("resolvePluginTools optional tools", () => {
       installToolManifestSnapshot({
         config: createContext().config,
         env: params.env,
-        plugin: {
-          id: "optional-demo",
-          origin: "bundled",
-          enabledByDefault: true,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["optional_tool"],
-          },
-        },
+        plugin: optionalDemoManifest(),
       });
     }
 
@@ -1825,16 +1841,7 @@ describe("resolvePluginTools optional tools", () => {
   it("does not widen active registry reuse to non-matching plugin tool owners", () => {
     installToolManifestSnapshot({
       config: createContext().config,
-      plugin: {
-        id: "optional-demo",
-        origin: "bundled",
-        enabledByDefault: true,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["optional_tool"],
-        },
-      },
+      plugin: optionalDemoManifest(),
     });
     const heavyFactory = vi.fn(() => makeTool("heavy_tool"));
     const activeRegistry = {
@@ -1886,44 +1893,21 @@ describe("resolvePluginTools optional tools", () => {
     installToolManifestSnapshots({
       config,
       plugins: [
-        {
-          id: "memory-core",
-          origin: "bundled",
-          enabledByDefault: false,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["memory_get", "memory_search"],
-          },
-        },
-        {
+        memoryCoreManifest(),
+        createToolManifest({
           id: "memory-lancedb",
-          origin: "bundled",
+          tools: ["memory_recall"],
           enabledByDefault: false,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["memory_recall"],
-          },
-        },
+        }),
       ],
     });
-    const memorySearchFactory = vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
+    const memorySearchFactory = createMemorySearchFactory();
     const activeRegistry = {
       plugins: [
         { id: "memory-core", status: "loaded" },
         { id: "memory-lancedb", status: "disabled" },
       ],
-      tools: [
-        {
-          pluginId: "memory-core",
-          optional: false,
-          source: "/tmp/memory-core.js",
-          names: ["memory_search", "memory_get"],
-          declaredNames: ["memory_search", "memory_get"],
-          factory: memorySearchFactory,
-        },
-      ],
+      tools: [createMemoryCoreToolEntry(memorySearchFactory)],
       diagnostics: [],
     };
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
@@ -1957,30 +1941,12 @@ describe("resolvePluginTools optional tools", () => {
     };
     installToolManifestSnapshot({
       config,
-      plugin: {
-        id: "memory-core",
-        origin: "bundled",
-        enabledByDefault: false,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["memory_get", "memory_search"],
-        },
-      },
+      plugin: memoryCoreManifest(),
     });
-    const memorySearchFactory = vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
+    const memorySearchFactory = createMemorySearchFactory();
     const activeRegistry = {
       plugins: [{ id: "memory-core", status: "loaded" }],
-      tools: [
-        {
-          pluginId: "memory-core",
-          optional: false,
-          source: "/tmp/memory-core.js",
-          names: ["memory_search", "memory_get"],
-          declaredNames: ["memory_search", "memory_get"],
-          factory: memorySearchFactory,
-        },
-      ],
+      tools: [createMemoryCoreToolEntry(memorySearchFactory)],
       diagnostics: [],
     };
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
@@ -2018,30 +1984,12 @@ describe("resolvePluginTools optional tools", () => {
     };
     installToolManifestSnapshot({
       config,
-      plugin: {
-        id: "memory-core",
-        origin: "bundled",
-        enabledByDefault: false,
-        channels: [],
-        providers: [],
-        contracts: {
-          tools: ["memory_get", "memory_search"],
-        },
-      },
+      plugin: memoryCoreManifest(),
     });
-    const memorySearchFactory = vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
+    const memorySearchFactory = createMemorySearchFactory();
     const loadedRegistry = {
       plugins: [{ id: "memory-core", status: "loaded" }],
-      tools: [
-        {
-          pluginId: "memory-core",
-          optional: false,
-          source: "/tmp/memory-core.js",
-          names: ["memory_search", "memory_get"],
-          declaredNames: ["memory_search", "memory_get"],
-          factory: memorySearchFactory,
-        },
-      ],
+      tools: [createMemoryCoreToolEntry(memorySearchFactory)],
       diagnostics: [],
     };
     setActivePluginRegistry(
@@ -2097,26 +2045,12 @@ describe("resolvePluginTools optional tools", () => {
     installToolManifestSnapshots({
       config,
       plugins: [
-        {
-          id: "optional-demo",
-          origin: "bundled",
-          enabledByDefault: true,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["optional_tool"],
-          },
-        },
-        {
+        optionalDemoManifest(),
+        createToolManifest({
           id: "tavily",
-          origin: "bundled",
+          tools: ["tavily_search"],
           enabledByDefault: false,
-          channels: [],
-          providers: [],
-          contracts: {
-            tools: ["tavily_search"],
-          },
-        },
+        }),
       ],
     });
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
@@ -2202,6 +2136,39 @@ describe("resolvePluginTools optional tools", () => {
     const tools = resolvePluginTools(
       createResolveToolsParams({
         toolAllowlist: ["optional_tool"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["optional_tool"]);
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses the pinned gateway runtime registry after provider runtime loads replace active registry", () => {
+    const gatewayRegistry = createOptionalDemoActiveRegistry();
+    setActivePluginRegistry(
+      gatewayRegistry as never,
+      "gateway-startup",
+      "gateway-bindable",
+      "/tmp",
+    );
+    pinActivePluginGatewayRuntimeRegistry(gatewayRegistry as never);
+    setActivePluginRegistry(
+      {
+        plugins: [],
+        tools: [],
+        diagnostics: [],
+      } as never,
+      "provider-runtime",
+      "default",
+      "/tmp",
+    );
+    resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        toolAllowlist: ["optional_tool"],
+        allowGatewaySubagentBinding: true,
       }),
     );
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -6,13 +6,18 @@ import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import {
-  isManifestPluginAvailableForControlPlane,
   loadManifestContractSnapshot,
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
 } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
-import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
+import type {
+  PluginMetadataManifestView,
+  PluginMetadataSnapshot,
+} from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
+import { getActivePluginGatewayRuntimeRegistry } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptions,
   resolvePluginRuntimeLoadContext,
@@ -433,6 +438,19 @@ function resolvePluginToolRuntimePluginIds(params: {
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const denylist = normalizeDenylist(params.toolDenylist);
   const normalizedPlugins = normalizePluginsConfig(params.config?.plugins);
+  for (const entry of getActivePluginGatewayRuntimeRegistry()?.tools ?? []) {
+    const names = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
+    if (
+      pluginToolNamesMatchAllowlist({
+        names,
+        pluginId: entry.pluginId,
+        optional: entry.optional,
+        allowlist,
+      })
+    ) {
+      pluginIds.add(entry.pluginId);
+    }
+  }
   const snapshot =
     params.snapshot ??
     loadManifestContractSnapshot({
@@ -743,6 +761,16 @@ function resolvePluginToolRegistry(params: {
     workspaceDir: params.loadOptions.workspaceDir,
     requiredPluginIds: params.onlyPluginIds,
   };
+  const gatewayRuntimeRegistry = getLoadedRuntimePluginRegistry({
+    env: lookup.env,
+    workspaceDir: lookup.workspaceDir,
+    requiredPluginIds: lookup.requiredPluginIds,
+    surface: "gateway-runtime",
+  });
+  if (registryHasScopedPluginTools(gatewayRuntimeRegistry, params.onlyPluginIds)) {
+    return gatewayRuntimeRegistry;
+  }
+
   const channelRegistry = getLoadedRuntimePluginRegistry({
     ...lookup,
     surface: "channel",
@@ -772,7 +800,7 @@ function resolvePluginToolRegistry(params: {
   if (registryHasScopedPluginTools(standaloneRegistry, params.onlyPluginIds)) {
     return standaloneRegistry;
   }
-  return standaloneRegistry ?? channelRegistry ?? activeRegistry;
+  return standaloneRegistry ?? gatewayRuntimeRegistry ?? channelRegistry ?? activeRegistry;
 }
 
 function registryHasScopedPluginTools(
@@ -799,6 +827,8 @@ function resolvePluginToolLoadState(params: {
   toolDenylist?: string[];
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
+  metadataSnapshot?: PluginMetadataSnapshot;
   env?: NodeJS.ProcessEnv;
 }):
   | {
@@ -812,10 +842,19 @@ function resolvePluginToolLoadState(params: {
   | undefined {
   const env = params.env ?? process.env;
   const baseConfig = applyTestPluginDefaults(params.context.config ?? {}, env);
+  const metadataSnapshot =
+    params.metadataSnapshot ??
+    params.loadMetadataSnapshot?.() ??
+    loadManifestMetadataSnapshot({
+      config: baseConfig,
+      workspaceDir: params.context.workspaceDir,
+      env,
+    });
   const context = resolvePluginRuntimeLoadContext({
     config: baseConfig,
     env,
     workspaceDir: params.context.workspaceDir,
+    manifestRegistry: metadataSnapshot.manifestRegistry,
   });
   const normalized = normalizePluginsConfig(context.config.plugins);
   if (!normalized.enabled) {
@@ -825,11 +864,7 @@ function resolvePluginToolLoadState(params: {
   const runtimeOptions = params.allowGatewaySubagentBinding
     ? { allowGatewaySubagentBinding: true as const }
     : undefined;
-  const snapshot = loadManifestContractSnapshot({
-    config: context.config,
-    workspaceDir: context.workspaceDir,
-    env,
-  });
+  const snapshot: PluginMetadataManifestView = metadataSnapshot;
   const onlyPluginIds = resolvePluginToolRuntimePluginIds({
     config: context.config,
     availabilityConfig: params.context.runtimeConfig ?? context.config,
@@ -840,6 +875,9 @@ function resolvePluginToolLoadState(params: {
     hasAuthForProvider: params.hasAuthForProvider,
     snapshot,
   });
+  if (onlyPluginIds.length === 0) {
+    return undefined;
+  }
   const loadOptions = buildPluginRuntimeLoadOptions(context, {
     activate: false,
     toolDiscovery: true,
@@ -855,6 +893,8 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
   toolDenylist?: string[];
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
+  metadataSnapshot?: PluginMetadataSnapshot;
   env?: NodeJS.ProcessEnv;
 }): void {
   const loadState = resolvePluginToolLoadState(params);
@@ -876,6 +916,8 @@ export function resolvePluginTools(params: {
   suppressNameConflicts?: boolean;
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
+  loadMetadataSnapshot?: () => PluginMetadataSnapshot;
+  metadataSnapshot?: PluginMetadataSnapshot;
   env?: NodeJS.ProcessEnv;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -145,7 +145,7 @@ export function loadBundledWebSearchProviderEntriesFromDir(params: {
   });
 }
 
-function loadBundledRuntimeWebSearchProviderEntriesFromDir(params: {
+export function loadBundledRuntimeWebSearchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebSearchProviderEntry[] | null {

--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -6,7 +6,9 @@ import type { PluginWebFetchProviderEntry, PluginWebSearchProviderEntry } from "
 import { resolveBundledWebFetchResolutionConfig } from "./web-fetch-providers.shared.js";
 import {
   loadBundledWebFetchProviderEntriesFromDir,
+  loadBundledRuntimeWebSearchProviderEntriesFromDir,
   loadBundledWebSearchProviderEntriesFromDir,
+  resolveBundledExplicitRuntimeWebSearchProvidersFromPublicArtifacts,
   resolveBundledExplicitWebFetchProvidersFromPublicArtifacts,
   resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
 } from "./web-provider-public-artifacts.explicit.js";
@@ -83,12 +85,20 @@ function resolveBundledManifestRecordsByPluginId(params: {
   );
 }
 
-export function resolveBundledWebSearchProvidersFromPublicArtifacts(
-  params: BundledWebProviderPublicArtifactParams,
-): PluginWebSearchProviderEntry[] | null {
+function resolveBundledProvidersFromPublicArtifacts<TProvider>(params: {
+  contract: "webSearchProviders" | "webFetchProviders";
+  configKey: "webSearch" | "webFetch";
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  bundledAllowlistCompat?: boolean;
+  onlyPluginIds?: readonly string[];
+  resolveExplicitProviders: (params: { onlyPluginIds: readonly string[] }) => TProvider[] | null;
+  loadProvidersFromDir: (params: { dirName: string; pluginId: string }) => TProvider[] | null;
+}): TProvider[] | null {
   const pluginIds = resolveBundledCandidatePluginIds({
-    contract: "webSearchProviders",
-    configKey: "webSearch",
+    contract: params.contract,
+    configKey: params.configKey,
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
@@ -98,7 +108,7 @@ export function resolveBundledWebSearchProvidersFromPublicArtifacts(
   if (pluginIds.pluginIds.length === 0) {
     return [];
   }
-  const directProviders = resolveBundledExplicitWebSearchProvidersFromPublicArtifacts({
+  const directProviders = params.resolveExplicitProviders({
     onlyPluginIds: pluginIds.pluginIds,
   });
   if (directProviders) {
@@ -111,13 +121,13 @@ export function resolveBundledWebSearchProvidersFromPublicArtifacts(
     onlyPluginIds: pluginIds.pluginIds,
     manifestRecords: pluginIds.manifestRecords,
   });
-  const providers: PluginWebSearchProviderEntry[] = [];
+  const providers: TProvider[] = [];
   for (const pluginId of pluginIds.pluginIds) {
     const record = recordsByPluginId.get(pluginId);
     if (!record) {
       return null;
     }
-    const loadedProviders = loadBundledWebSearchProviderEntriesFromDir({
+    const loadedProviders = params.loadProvidersFromDir({
       dirName: path.basename(record.rootDir),
       pluginId,
     });
@@ -129,48 +139,38 @@ export function resolveBundledWebSearchProvidersFromPublicArtifacts(
   return providers;
 }
 
+export function resolveBundledWebSearchProvidersFromPublicArtifacts(
+  params: BundledWebProviderPublicArtifactParams,
+): PluginWebSearchProviderEntry[] | null {
+  return resolveBundledProvidersFromPublicArtifacts({
+    contract: "webSearchProviders",
+    configKey: "webSearch",
+    ...params,
+    resolveExplicitProviders: resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
+    loadProvidersFromDir: loadBundledWebSearchProviderEntriesFromDir,
+  });
+}
+
+export function resolveBundledRuntimeWebSearchProvidersFromPublicArtifacts(
+  params: BundledWebProviderPublicArtifactParams,
+): PluginWebSearchProviderEntry[] | null {
+  return resolveBundledProvidersFromPublicArtifacts({
+    contract: "webSearchProviders",
+    configKey: "webSearch",
+    ...params,
+    resolveExplicitProviders: resolveBundledExplicitRuntimeWebSearchProvidersFromPublicArtifacts,
+    loadProvidersFromDir: loadBundledRuntimeWebSearchProviderEntriesFromDir,
+  });
+}
+
 export function resolveBundledWebFetchProvidersFromPublicArtifacts(
   params: BundledWebProviderPublicArtifactParams,
 ): PluginWebFetchProviderEntry[] | null {
-  const pluginIds = resolveBundledCandidatePluginIds({
+  return resolveBundledProvidersFromPublicArtifacts({
     contract: "webFetchProviders",
     configKey: "webFetch",
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    bundledAllowlistCompat: params.bundledAllowlistCompat,
-    onlyPluginIds: params.onlyPluginIds,
+    ...params,
+    resolveExplicitProviders: resolveBundledExplicitWebFetchProvidersFromPublicArtifacts,
+    loadProvidersFromDir: loadBundledWebFetchProviderEntriesFromDir,
   });
-  if (pluginIds.pluginIds.length === 0) {
-    return [];
-  }
-  const directProviders = resolveBundledExplicitWebFetchProvidersFromPublicArtifacts({
-    onlyPluginIds: pluginIds.pluginIds,
-  });
-  if (directProviders) {
-    return directProviders;
-  }
-  const recordsByPluginId = resolveBundledManifestRecordsByPluginId({
-    config: params.config,
-    workspaceDir: params.workspaceDir,
-    env: params.env,
-    onlyPluginIds: pluginIds.pluginIds,
-    manifestRecords: pluginIds.manifestRecords,
-  });
-  const providers: PluginWebFetchProviderEntry[] = [];
-  for (const pluginId of pluginIds.pluginIds) {
-    const record = recordsByPluginId.get(pluginId);
-    if (!record) {
-      return null;
-    }
-    const loadedProviders = loadBundledWebFetchProviderEntriesFromDir({
-      dirName: path.basename(record.rootDir),
-      pluginId,
-    });
-    if (!loadedProviders) {
-      return null;
-    }
-    providers.push(...loadedProviders);
-  }
-  return providers;
 }

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -141,6 +141,36 @@ describe("web-provider-runtime-shared", () => {
     );
   });
 
+  it("does not fall back to plugin loading during runtime web provider resolution", () => {
+    const mapRegistryProviders = vi.fn(() => ["mapped"]);
+    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(undefined);
+
+    const providers = resolveRuntimeWebProviders(
+      {
+        config: {},
+        onlyPluginIds: ["alpha"],
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => ["alpha"],
+        mapRegistryProviders,
+      },
+    );
+
+    expect(providers).toEqual([]);
+    expect(mocks.getLoadedRuntimePluginRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredPluginIds: ["alpha"],
+      }),
+    );
+    expect(mapRegistryProviders).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
   it("preserves explicit scopes when config is omitted in direct runtime resolution", () => {
     const mapRegistryProviders = vi.fn(() => []);
     mocks.getLoadedRuntimePluginRegistry.mockReturnValue({} as never);
@@ -271,6 +301,34 @@ describe("web-provider-runtime-shared", () => {
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
+  it("uses bundled runtime web provider public artifacts before full plugin loads", () => {
+    const bundledRuntimeProviders = ["provider"];
+
+    const providers = resolveRuntimeWebProviders(
+      {
+        config: {},
+        onlyPluginIds: ["brave"],
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => ["brave"],
+        mapRegistryProviders: vi.fn(() => {
+          throw new Error(
+            "runtime registry should stay unused when bundled public artifacts resolve",
+          );
+        }),
+        resolveBundledRuntimePublicArtifactProviders: () => bundledRuntimeProviders,
+      },
+    );
+
+    expect(providers).toEqual(bundledRuntimeProviders);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
   it("ignores runtime web provider cache opt-outs after startup loading", () => {
     const loadedRegistry = { source: "loaded" };
     const mapRegistryProviders = vi.fn(() => ["provider"]);
@@ -386,7 +444,7 @@ describe("web-provider-runtime-shared", () => {
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
-  it("falls back when the direct runtime registry has no web providers", () => {
+  it("keeps direct runtime resolution off plugin loading when no runtime web providers exist", () => {
     const activeRegistry = { source: "active" };
     const fallbackRegistry = { source: "fallback" };
     const mapRegistryProviders = vi.fn(({ registry }) =>
@@ -417,8 +475,8 @@ describe("web-provider-runtime-shared", () => {
       },
     );
 
-    expect(result).toEqual(["brave"]);
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("does not fall back when direct runtime registry returns empty under an explicit empty scope", () => {

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -1,11 +1,15 @@
 import { withActivatedPluginIds } from "./activation-context.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
-import { isPluginRegistryLoadInFlight, loadOpenClawPlugins } from "./loader.js";
+import {
+  isPluginRegistryLoadInFlight,
+  loadOpenClawPlugins,
+  resolveCompatibleRuntimePluginRegistry,
+} from "./loader.js";
 import type { PluginLoadOptions } from "./loader.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasExplicitPluginIdScope, normalizePluginIdScope } from "./plugin-scope.js";
 import type { PluginRegistry } from "./registry.js";
-import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
   createPluginRuntimeLoaderLogger,
@@ -46,6 +50,13 @@ type ResolveWebProviderRuntimeDeps<TEntry> = {
     onlyPluginIds?: readonly string[];
   }) => TEntry[];
   resolveBundledPublicArtifactProviders?: (params: {
+    config?: PluginLoadOptions["config"];
+    workspaceDir?: string;
+    env?: PluginLoadOptions["env"];
+    bundledAllowlistCompat?: boolean;
+    onlyPluginIds?: readonly string[];
+  }) => TEntry[] | null;
+  resolveBundledRuntimePublicArtifactProviders?: (params: {
     config?: PluginLoadOptions["config"];
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
@@ -229,10 +240,17 @@ export function resolvePluginWebProviders<TEntry>(
     // through to a scoped provider load below so first-class assistant tools
     // still see the configured provider.
   }
-  if (isPluginRegistryLoadInFlight(loadOptions)) {
-    return [];
+  const activeRuntimeRegistry = resolveCompatibleRuntimePluginRegistry(loadOptions);
+  if (activeRuntimeRegistry) {
+    return deps.mapRegistryProviders({
+      registry: activeRuntimeRegistry,
+      onlyPluginIds: context.onlyPluginIds,
+    });
   }
   if (hasExplicitEmptyScope) {
+    return [];
+  }
+  if (isPluginRegistryLoadInFlight(loadOptions)) {
     return [];
   }
   const registry = loadOpenClawPlugins(loadOptions);
@@ -246,21 +264,64 @@ export function resolveRuntimeWebProviders<TEntry>(
   params: Omit<ResolvePluginWebProvidersParams, "activate" | "cache" | "mode">,
   deps: ResolveWebProviderRuntimeDeps<TEntry>,
 ): TEntry[] {
-  const runtimeRegistry = getLoadedRuntimePluginRegistry({
-    env: params.env,
-    workspaceDir: params.workspaceDir,
-    requiredPluginIds: params.onlyPluginIds,
+  const runtimeParams = { ...params, cache: true };
+  const context = resolveWebProviderRuntimeContext(runtimeParams, deps);
+  const loadOptions = resolveWebProviderLoadOptions(context, runtimeParams);
+  const explicitCompatibilityInputs =
+    params.config !== undefined ||
+    params.workspaceDir !== undefined ||
+    params.env !== undefined ||
+    params.origin !== undefined ||
+    params.bundledAllowlistCompat === true ||
+    params.onlyPluginIds !== undefined;
+  if (!explicitCompatibilityInputs) {
+    const activeRegistry = getActivePluginRegistry();
+    if (activeRegistry) {
+      return deps.mapRegistryProviders({
+        registry: activeRegistry,
+        onlyPluginIds: context.onlyPluginIds,
+      });
+    }
+  }
+  const compatible = getLoadedRuntimePluginRegistry({
+    env: context.env,
+    loadOptions,
+    workspaceDir: context.workspaceDir,
+    requiredPluginIds: context.loadPluginIds,
   });
   const hasExplicitEmptyScope =
-    params.onlyPluginIds !== undefined && params.onlyPluginIds.length === 0;
+    context.onlyPluginIds !== undefined && context.onlyPluginIds.length === 0;
   const runtimeProviders = resolveRuntimeRegistryWebProviders({
     hasExplicitEmptyScope,
     mapRegistryProviders: deps.mapRegistryProviders,
-    onlyPluginIds: params.onlyPluginIds,
-    registry: runtimeRegistry,
+    onlyPluginIds: context.onlyPluginIds,
+    registry: compatible,
   });
   if (runtimeProviders?.shouldReturn) {
     return runtimeProviders.providers;
   }
-  return resolvePluginWebProviders(params, deps);
+  const activeRuntimeRegistry = resolveCompatibleRuntimePluginRegistry(
+    explicitCompatibilityInputs ? loadOptions : undefined,
+  );
+  const activeRuntimeProviders = resolveRuntimeRegistryWebProviders({
+    hasExplicitEmptyScope,
+    mapRegistryProviders: deps.mapRegistryProviders,
+    onlyPluginIds: context.onlyPluginIds,
+    registry: activeRuntimeRegistry,
+  });
+  if (activeRuntimeProviders?.shouldReturn) {
+    return activeRuntimeProviders.providers;
+  }
+  const scopedPluginIds = context.onlyPluginIds;
+  if (scopedPluginIds !== undefined && scopedPluginIds.length === 0) {
+    return [];
+  }
+  const bundledRuntimeArtifactProviders = deps.resolveBundledRuntimePublicArtifactProviders?.({
+    config: context.config,
+    workspaceDir: context.workspaceDir,
+    env: context.env,
+    bundledAllowlistCompat: params.bundledAllowlistCompat,
+    onlyPluginIds: context.loadPluginIds,
+  });
+  return bundledRuntimeArtifactProviders ?? [];
 }

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -2,7 +2,10 @@ import { loadOpenClawPlugins } from "./loader.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { type PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
-import { resolveBundledWebSearchProvidersFromPublicArtifacts } from "./web-provider-public-artifacts.js";
+import {
+  resolveBundledRuntimeWebSearchProvidersFromPublicArtifacts,
+  resolveBundledWebSearchProvidersFromPublicArtifacts,
+} from "./web-provider-public-artifacts.js";
 import {
   mapRegistryProviders,
   resolveManifestDeclaredWebProviderCandidatePluginIds,
@@ -61,6 +64,8 @@ export function resolvePluginWebSearchProviders(params: {
     resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebSearchProviders,
     resolveBundledPublicArtifactProviders: resolveBundledWebSearchProvidersFromPublicArtifacts,
+    resolveBundledRuntimePublicArtifactProviders:
+      resolveBundledRuntimeWebSearchProvidersFromPublicArtifacts,
   });
 }
 
@@ -76,5 +81,7 @@ export function resolveRuntimeWebSearchProviders(params: {
     resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
     resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebSearchProviders,
+    resolveBundledRuntimePublicArtifactProviders:
+      resolveBundledRuntimeWebSearchProvidersFromPublicArtifacts,
   });
 }

--- a/src/secrets/runtime-web-tools-fallback.runtime.ts
+++ b/src/secrets/runtime-web-tools-fallback.runtime.ts
@@ -1,7 +1,7 @@
-import { resolvePluginWebFetchProviders } from "../plugins/web-fetch-providers.runtime.js";
-import { resolvePluginWebSearchProviders } from "../plugins/web-search-providers.runtime.js";
+import { resolveRuntimeWebFetchProviders } from "../plugins/web-fetch-providers.runtime.js";
+import { resolveRuntimeWebSearchProviders } from "../plugins/web-search-providers.runtime.js";
 
 export const runtimeWebToolsFallbackProviders = {
-  resolvePluginWebFetchProviders,
-  resolvePluginWebSearchProviders,
+  resolveRuntimeWebFetchProviders,
+  resolveRuntimeWebSearchProviders,
 };

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -7,12 +7,12 @@ import type {
 
 type ProviderUnderTest = "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "duckduckgo";
 
-const { resolvePluginWebSearchProvidersMock } = vi.hoisted(() => ({
-  resolvePluginWebSearchProvidersMock: vi.fn(() => buildTestWebSearchProviders()),
+const { resolveRuntimeWebSearchProvidersMock } = vi.hoisted(() => ({
+  resolveRuntimeWebSearchProvidersMock: vi.fn(() => buildTestWebSearchProviders()),
 }));
 
-const { resolvePluginWebFetchProvidersMock } = vi.hoisted(() => ({
-  resolvePluginWebFetchProvidersMock: vi.fn(() => buildTestWebFetchProviders()),
+const { resolveRuntimeWebFetchProvidersMock } = vi.hoisted(() => ({
+  resolveRuntimeWebFetchProvidersMock: vi.fn(() => buildTestWebFetchProviders()),
 }));
 const {
   resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock,
@@ -78,8 +78,8 @@ vi.mock("./runtime-web-tools-fallback.runtime.js", async () => {
     ...actual,
     runtimeWebToolsFallbackProviders: {
       ...actual.runtimeWebToolsFallbackProviders,
-      resolvePluginWebSearchProviders: resolvePluginWebSearchProvidersMock,
-      resolvePluginWebFetchProviders: resolvePluginWebFetchProvidersMock,
+      resolveRuntimeWebSearchProviders: resolveRuntimeWebSearchProvidersMock,
+      resolveRuntimeWebFetchProviders: resolveRuntimeWebFetchProvidersMock,
     },
   };
 });
@@ -320,8 +320,8 @@ describe("runtime web tools resolution", () => {
   });
 
   beforeEach(() => {
-    resolvePluginWebSearchProvidersMock.mockClear();
-    resolvePluginWebFetchProvidersMock.mockClear();
+    resolveRuntimeWebSearchProvidersMock.mockClear();
+    resolveRuntimeWebFetchProvidersMock.mockClear();
     resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock.mockClear();
     resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock.mockClear();
     resolveBundledWebSearchProvidersFromPublicArtifactsMock.mockClear();
@@ -371,7 +371,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.selectedProviderKeySource).toBe("env");
     expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("keeps web fetch inactive when only web search is configured", async () => {
@@ -407,7 +407,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.providerSource).toBe("none");
     expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("skips fetch provider discovery when web fetch only configures runtime limits", async () => {
@@ -437,7 +437,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.selectedProvider).toBeUndefined();
     expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("skips fetch provider discovery when web fetch is explicitly disabled", async () => {
@@ -472,7 +472,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.fetch.selectedProvider).toBeUndefined();
     expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("keeps active fetch provider SecretRefs on the discovery path", async () => {
@@ -988,7 +988,7 @@ describe("runtime web tools resolution", () => {
     });
     expect(resolveManifestContractOwnerPluginIdMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("uses exact plugin-id hints for configured bundled provider entries without manifest owner lookup", async () => {
@@ -1035,7 +1035,7 @@ describe("runtime web tools resolution", () => {
     });
     expect(resolveManifestContractOwnerPluginIdMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("uses single plugin-scoped web search config as a bundled provider hint", async () => {
@@ -1065,7 +1065,7 @@ describe("runtime web tools resolution", () => {
     });
     expect(resolveManifestContractOwnerPluginIdMock).not.toHaveBeenCalled();
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not auto-detect from legacy top-level web search apiKey", async () => {
@@ -1087,7 +1087,7 @@ describe("runtime web tools resolution", () => {
     expect(metadata.search.selectedProvider).toBe("duckduckgo");
     expect(resolveManifestContractPluginIdsByCompatibilityRuntimePathMock).not.toHaveBeenCalled();
     expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not resolve web fetch provider SecretRef when web fetch is inactive", async () => {
@@ -1123,7 +1123,7 @@ describe("runtime web tools resolution", () => {
     expect(context.warnings).toEqual([]);
     expect(resolveBundledExplicitWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("keeps configured provider metadata and inactive warnings when search is disabled", async () => {
@@ -1219,8 +1219,8 @@ describe("runtime web tools resolution", () => {
 
     expect(metadata.search.providerSource).toBe("none");
     expect(metadata.fetch.providerSource).toBe("none");
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("uses bundled public artifacts for bundled web search provider discovery", async () => {
@@ -1240,7 +1240,7 @@ describe("runtime web tools resolution", () => {
     });
 
     expect(metadata.search.selectedProvider).toBe("brave");
-    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("uses runtime web search discovery when the managed plugin index install records is populated", async () => {
@@ -1268,7 +1268,7 @@ describe("runtime web tools resolution", () => {
 
     expect(metadata.search.selectedProvider).toBe("brave");
     expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebSearchProvidersMock).toHaveBeenCalledWith(
+    expect(resolveRuntimeWebSearchProvidersMock).toHaveBeenCalledWith(
       expect.objectContaining({
         bundledAllowlistCompat: true,
       }),
@@ -1292,7 +1292,7 @@ describe("runtime web tools resolution", () => {
     });
 
     expect(metadata.fetch.selectedProvider).toBe("firecrawl");
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 
   it("uses runtime web fetch discovery when the managed plugin index install records is populated", async () => {
@@ -1321,7 +1321,7 @@ describe("runtime web tools resolution", () => {
 
     expect(metadata.fetch.selectedProvider).toBe("firecrawl");
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledWith(
+    expect(resolveRuntimeWebFetchProvidersMock).toHaveBeenCalledWith(
       expect.objectContaining({
         bundledAllowlistCompat: true,
       }),
@@ -1562,6 +1562,6 @@ describe("runtime web tools resolution", () => {
       onlyPluginIds: ["firecrawl"],
     });
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
-    expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
+    expect(resolveRuntimeWebFetchProvidersMock).not.toHaveBeenCalled();
   });
 });

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -387,8 +387,8 @@ async function resolveBundledWebSearchProviders(params: {
     if (bundled && bundled.length > 0) {
       return bundled;
     }
-    const { resolvePluginWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
-    return resolvePluginWebSearchProviders({
+    const { resolveRuntimeWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
+    return resolveRuntimeWebSearchProviders({
       config: params.sourceConfig,
       env,
       bundledAllowlistCompat: true,
@@ -407,16 +407,16 @@ async function resolveBundledWebSearchProviders(params: {
     if (bundled && bundled.length > 0) {
       return bundled;
     }
-    const { resolvePluginWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
-    return resolvePluginWebSearchProviders({
+    const { resolveRuntimeWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
+    return resolveRuntimeWebSearchProviders({
       config: params.sourceConfig,
       env,
       bundledAllowlistCompat: true,
       origin: "bundled",
     });
   }
-  const { resolvePluginWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
-  return resolvePluginWebSearchProviders({
+  const { resolveRuntimeWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
+  return resolveRuntimeWebSearchProviders({
     config: params.sourceConfig,
     env,
     bundledAllowlistCompat: true,
@@ -437,8 +437,8 @@ async function resolveBundledWebFetchProviders(params: {
     if (bundled && bundled.length > 0) {
       return bundled;
     }
-    const { resolvePluginWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
-    return resolvePluginWebFetchProviders({
+    const { resolveRuntimeWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
+    return resolveRuntimeWebFetchProviders({
       config: params.sourceConfig,
       env,
       bundledAllowlistCompat: true,
@@ -457,16 +457,16 @@ async function resolveBundledWebFetchProviders(params: {
     if (bundled && bundled.length > 0) {
       return bundled;
     }
-    const { resolvePluginWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
-    return resolvePluginWebFetchProviders({
+    const { resolveRuntimeWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
+    return resolveRuntimeWebFetchProviders({
       config: params.sourceConfig,
       env,
       bundledAllowlistCompat: true,
       origin: "bundled",
     });
   }
-  const { resolvePluginWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
-  return resolvePluginWebFetchProviders({
+  const { resolveRuntimeWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
+  return resolveRuntimeWebFetchProviders({
     config: params.sourceConfig,
     env,
     bundledAllowlistCompat: true,

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { createTtsDirectiveTextStreamCleaner, parseTtsDirectives } from "./directives.js";
 import type {
@@ -6,6 +6,16 @@ import type {
   SpeechDirectiveTokenParseResult,
   SpeechModelOverridePolicy,
 } from "./provider-types.js";
+
+const { getSpeechProviderMock, listLoadedSpeechProvidersMock } = vi.hoisted(() => ({
+  getSpeechProviderMock: vi.fn(),
+  listLoadedSpeechProvidersMock: vi.fn(),
+}));
+
+vi.mock("./provider-registry.js", () => ({
+  getSpeechProvider: getSpeechProviderMock,
+  listLoadedSpeechProviders: listLoadedSpeechProvidersMock,
+}));
 
 function makeProvider(
   id: string,
@@ -58,6 +68,12 @@ const fullPolicy: SpeechModelOverridePolicy = {
 };
 
 describe("parseTtsDirectives provider-aware routing", () => {
+  beforeEach(() => {
+    getSpeechProviderMock.mockReset();
+    listLoadedSpeechProvidersMock.mockReset();
+    listLoadedSpeechProvidersMock.mockReturnValue([]);
+  });
+
   it("does not resolve providers when text has no directives", () => {
     const failProvider = {
       get id() {
@@ -123,6 +139,44 @@ describe("parseTtsDirectives provider-aware routing", () => {
     expect(result.overrides.provider).toBeUndefined();
     expect(result.overrides.providerOverrides?.elevenlabs).toEqual({ speed: 1.5 });
     expect(result.overrides.providerOverrides?.minimax).toBeUndefined();
+  });
+
+  it("uses the preferred provider directly without listing the full registry", () => {
+    getSpeechProviderMock.mockReturnValue(minimax);
+    const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
+      cfg: {} as never,
+      preferredProviderId: "minimax",
+    });
+
+    expect(result.overrides.providerOverrides?.minimax).toEqual({ speed: 1.5 });
+    expect(listLoadedSpeechProvidersMock).not.toHaveBeenCalled();
+    expect(getSpeechProviderMock).toHaveBeenCalledWith("minimax", expect.anything());
+  });
+
+  it("single-loads an explicit provider before falling back to loaded providers", () => {
+    const edgeProvider = makeProvider(
+      "microsoft",
+      10,
+      ({ key, value }) =>
+        key === "voice" ? { handled: true, overrides: { voice: value } } : undefined,
+      { aliases: ["edge"] },
+    );
+    getSpeechProviderMock.mockReturnValue(edgeProvider);
+
+    const result = parseTtsDirectives(
+      "[[tts:provider=edge voice=en-US-MichelleNeural]]",
+      fullPolicy,
+      {
+        cfg: {} as never,
+      },
+    );
+
+    expect(result.overrides.provider).toBe("edge");
+    expect(result.overrides.providerOverrides?.microsoft).toEqual({
+      voice: "en-US-MichelleNeural",
+    });
+    expect(getSpeechProviderMock).toHaveBeenCalledWith("edge", expect.anything());
+    expect(listLoadedSpeechProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not fall through when the explicit provider does not handle the key", () => {

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/types.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { listSpeechProviders } from "./provider-registry.js";
+import { getSpeechProvider, listLoadedSpeechProviders } from "./provider-registry.js";
 import type {
   SpeechModelOverridePolicy,
   SpeechProviderConfig,
@@ -40,7 +40,14 @@ function resolveDirectiveProviders(options?: ParseTtsDirectiveOptions): SpeechPr
   if (options?.providers) {
     return [...options.providers].toSorted(buildProviderOrder);
   }
-  return listSpeechProviders(options?.cfg).toSorted(buildProviderOrder);
+  const preferredProviderId = normalizeLowercaseStringOrEmpty(options?.preferredProviderId);
+  if (preferredProviderId && options?.cfg) {
+    const preferredProvider = getSpeechProvider(preferredProviderId, options.cfg);
+    if (preferredProvider) {
+      return [preferredProvider];
+    }
+  }
+  return listLoadedSpeechProviders(options?.cfg).toSorted(buildProviderOrder);
 }
 
 function resolveDirectiveProviderConfig(
@@ -276,7 +283,9 @@ export function parseTtsDirectives(
         return directiveProviders;
       }
       if (declaredProviderId) {
-        const declaredProvider = resolveDirectiveProvider(getProviders(), declaredProviderId);
+        const declaredProvider =
+          (options?.cfg ? getSpeechProvider(declaredProviderId, options.cfg) : undefined) ??
+          resolveDirectiveProvider(getProviders(), declaredProviderId);
         if (!declaredProvider) {
           warnings.push(`unknown provider "${declaredProviderId}"`);
           directiveProviders = [];

--- a/src/tts/provider-registry.ts
+++ b/src/tts/provider-registry.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.js";
+import { getLoadedRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import {
   resolvePluginCapabilityProvider,
   resolvePluginCapabilityProviders,
@@ -17,6 +18,10 @@ function resolveSpeechProviderPluginEntries(cfg?: OpenClawConfig): SpeechProvide
   });
 }
 
+function resolveLoadedSpeechProviderPluginEntries(): SpeechProviderPlugin[] {
+  return (getLoadedRuntimePluginRegistry()?.speechProviders ?? []).map((entry) => entry.provider);
+}
+
 const defaultSpeechProviderRegistryResolver: SpeechProviderRegistryResolver = {
   getProvider: (providerId, cfg) =>
     resolvePluginCapabilityProvider({
@@ -31,7 +36,19 @@ const defaultSpeechProviderRegistry = createSpeechProviderRegistry(
   defaultSpeechProviderRegistryResolver,
 );
 
+const loadedSpeechProviderRegistry = createSpeechProviderRegistry({
+  getProvider: (providerId) =>
+    resolveLoadedSpeechProviderPluginEntries().find((provider) => {
+      if (provider.id === providerId) {
+        return true;
+      }
+      return provider.aliases?.includes(providerId) ?? false;
+    }),
+  listProviders: () => resolveLoadedSpeechProviderPluginEntries(),
+});
+
 export const listSpeechProviders = defaultSpeechProviderRegistry.listSpeechProviders;
+export const listLoadedSpeechProviders = loadedSpeechProviderRegistry.listSpeechProviders;
 export const getSpeechProvider = defaultSpeechProviderRegistry.getSpeechProvider;
 export const canonicalizeSpeechProviderId =
   defaultSpeechProviderRegistry.canonicalizeSpeechProviderId;

--- a/src/tts/tts-core.test.ts
+++ b/src/tts/tts-core.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { summarizeText } from "./tts-core.js";
+
+describe("summarizeText", () => {
+  it("resolves summary models through the lean skipPiDiscovery path", async () => {
+    const resolveModelAsync = vi.fn(async () => ({
+      model: { provider: "openai", model: "gpt-5.4", api: "openai-responses" },
+    }));
+    const prepareModelForSimpleCompletion = vi.fn(({ model }) => model);
+    const getApiKeyForModel = vi.fn(async () => ({ apiKey: "test-key" }));
+    const requireApiKey = vi.fn(() => "test-key");
+    const completeSimple = vi.fn(async () => ({
+      content: [{ type: "text", text: "short summary" }],
+    }));
+
+    await summarizeText(
+      {
+        text: "a".repeat(400),
+        targetLength: 120,
+        cfg: {
+          agents: {
+            defaults: {
+              model: "openai/gpt-5.4",
+            },
+          },
+        },
+        config: {
+          enabled: true,
+          auto: "always",
+          provider: "openai",
+          providerSource: "default",
+          providerConfigs: {},
+          personas: {},
+          modelOverrides: {
+            enabled: true,
+            allowText: true,
+            allowProvider: false,
+            allowVoice: true,
+            allowModelId: true,
+            allowVoiceSettings: true,
+            allowNormalization: true,
+            allowSeed: true,
+          },
+          maxTextLength: 1000,
+          timeoutMs: 1000,
+        },
+        timeoutMs: 1000,
+      },
+      {
+        completeSimple,
+        getApiKeyForModel,
+        prepareModelForSimpleCompletion,
+        requireApiKey,
+        resolveModelAsync,
+      },
+    );
+
+    expect(resolveModelAsync).toHaveBeenCalledWith(
+      "openai",
+      "gpt-5.4",
+      undefined,
+      expect.anything(),
+      {
+        skipPiDiscovery: true,
+      },
+    );
+  });
+});

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -92,7 +92,9 @@ export async function summarizeText(
 
   const startTime = Date.now();
   const { ref } = resolveSummaryModelRef(cfg, config);
-  const resolved = await deps.resolveModelAsync(ref.provider, ref.model, undefined, cfg);
+  const resolved = await deps.resolveModelAsync(ref.provider, ref.model, undefined, cfg, {
+    skipPiDiscovery: true,
+  });
   if (!resolved.model) {
     throw new Error(resolved.error ?? `Unknown summary model: ${ref.provider}/${ref.model}`);
   }

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -13,6 +13,7 @@ describe("tts runtime facade", () => {
     expect(publicFacadeSource).toContain('} from "../plugin-sdk/tts-runtime.js";');
     expect(publicFacadeSource).not.toContain("speech-core");
     expect(runtimeFacadeSource).toContain("function loadFacadeModule()");
+    expect(runtimeFacadeSource).toContain("function prewarmTtsRuntimeFacade()");
     expect(runtimeFacadeSource).toContain('dirName: "speech-core"');
     expect(runtimeFacadeSource).toContain(
       'createLazyFacadeRuntimeValue(loadFacadeModule, "buildTtsSystemPromptHint")',

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -12,6 +12,7 @@ export {
   listSpeechVoices,
   listTtsPersonas,
   maybeApplyTtsToPayload,
+  prewarmTtsRuntimeFacade,
   resolveExplicitTtsOverrides,
   resolveTtsAutoMode,
   resolveTtsConfig,

--- a/src/utils/provider-utils.test.ts
+++ b/src/utils/provider-utils.test.ts
@@ -50,14 +50,26 @@ describe("resolveReasoningOutputMode", () => {
   it("falls back to provider hooks for unknown providers", () => {
     resolveProviderReasoningOutputModeWithPluginMock.mockReturnValue("tagged");
 
+    const runtimeHandle = {
+      provider: "custom-provider",
+      plugin: {
+        id: "custom-provider",
+        label: "Custom",
+        auth: [],
+      },
+    };
+
     expect(
       resolveReasoningOutputMode({
         provider: "custom-provider",
         workspaceDir: process.cwd(),
+        runtimeHandle,
         modelId: "custom/model",
       }),
     ).toBe("tagged");
-    expect(resolveProviderReasoningOutputModeWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(resolveProviderReasoningOutputModeWithPluginMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeHandle }),
+    );
   });
 
   it("returns native when hooks do not provide an override", () => {

--- a/src/utils/provider-utils.ts
+++ b/src/utils/provider-utils.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderReasoningOutputModeWithPlugin } from "../plugins/provider-runtime.js";
 import {
@@ -19,6 +20,7 @@ export function resolveReasoningOutputMode(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
   modelId?: string;
   modelApi?: string | null;
   model?: ProviderRuntimeModel;
@@ -34,6 +36,7 @@ export function resolveReasoningOutputMode(params: {
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    runtimeHandle: params.runtimeHandle,
     context: {
       config: params.config,
       workspaceDir: params.workspaceDir,
@@ -69,6 +72,7 @@ export function isReasoningTagProvider(
     config?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    runtimeHandle?: ProviderRuntimePluginHandle;
     modelId?: string;
     modelApi?: string | null;
     model?: ProviderRuntimeModel;
@@ -80,6 +84,7 @@ export function isReasoningTagProvider(
       config: options?.config,
       workspaceDir: options?.workspaceDir,
       env: options?.env,
+      runtimeHandle: options?.runtimeHandle,
       modelId: options?.modelId,
       modelApi: options?.modelApi,
       model: options?.model,

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -2,9 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 import type * as ProviderRegistry from "./provider-registry.js";
 
-const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
-  resolvePluginCapabilityProvidersMock: vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
-}));
+const { resolvePluginCapabilityProviderMock, resolvePluginCapabilityProvidersMock } = vi.hoisted(
+  () => ({
+    resolvePluginCapabilityProviderMock: vi.fn<() => VideoGenerationProviderPlugin | undefined>(),
+    resolvePluginCapabilityProvidersMock: vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
+  }),
+);
 
 let getVideoGenerationProvider: typeof ProviderRegistry.getVideoGenerationProvider;
 let listVideoGenerationProviders: typeof ProviderRegistry.listVideoGenerationProviders;
@@ -25,6 +28,7 @@ function createProvider(
 async function loadProviderRegistry() {
   vi.resetModules();
   vi.doMock("../plugins/capability-provider-runtime.js", () => ({
+    resolvePluginCapabilityProvider: resolvePluginCapabilityProviderMock,
     resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
   }));
   return await import("./provider-registry.js");
@@ -32,6 +36,8 @@ async function loadProviderRegistry() {
 
 describe("video-generation provider registry", () => {
   beforeEach(async () => {
+    resolvePluginCapabilityProviderMock.mockReset();
+    resolvePluginCapabilityProviderMock.mockReturnValue(undefined);
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
     ({ getVideoGenerationProvider, listVideoGenerationProviders } = await loadProviderRegistry());
@@ -46,13 +52,31 @@ describe("video-generation provider registry", () => {
   });
 
   it("uses active plugin providers without loading from disk", () => {
-    resolvePluginCapabilityProvidersMock.mockReturnValue([createProvider({ id: "custom-video" })]);
+    resolvePluginCapabilityProviderMock.mockReturnValue(createProvider({ id: "custom-video" }));
 
     const provider = getVideoGenerationProvider("custom-video");
 
     expect(provider?.id).toBe("custom-video");
-    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
       key: "videoGenerationProviders",
+      providerId: "custom-video",
+      cfg: undefined,
+    });
+    expect(resolvePluginCapabilityProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to alias maps when direct provider resolution misses", async () => {
+    resolvePluginCapabilityProvidersMock.mockReturnValue([
+      createProvider({ id: "safe-video", aliases: ["safe-alias"] }),
+    ]);
+    const { getVideoGenerationProvider } = await loadProviderRegistry();
+
+    const provider = getVideoGenerationProvider("safe-alias");
+
+    expect(provider?.id).toBe("safe-video");
+    expect(resolvePluginCapabilityProviderMock).toHaveBeenCalledWith({
+      key: "videoGenerationProviders",
+      providerId: "safe-alias",
       cfg: undefined,
     });
   });

--- a/src/video-generation/provider-registry.ts
+++ b/src/video-generation/provider-registry.ts
@@ -1,7 +1,10 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
-import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
+import {
+  resolvePluginCapabilityProvider,
+  resolvePluginCapabilityProviders,
+} from "../plugins/capability-provider-runtime.js";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_VIDEO_GENERATION_PROVIDERS: readonly VideoGenerationProviderPlugin[] = [];
@@ -73,5 +76,10 @@ export function getVideoGenerationProvider(
   if (!normalized) {
     return undefined;
   }
-  return buildProviderMaps(cfg).aliases.get(normalized);
+  const direct = resolvePluginCapabilityProvider({
+    key: "videoGenerationProviders",
+    providerId: normalized,
+    cfg,
+  });
+  return direct ?? buildProviderMaps(cfg).aliases.get(normalized);
 }


### PR DESCRIPTION
## Summary

This PR makes the reply path reuse prepared runtime surfaces instead of rediscovering auth, model, provider, plugin, and tool state during each reply. Rather than adding cache layers around each expensive helper, it carries prepared request facts through runtime interfaces: selected provider/model refs, auth state, provider runtime handles, tool planning state, metadata snapshot loaders, and Gateway runtime registries. That gives reply dispatch, embedded agent startup, tool planning, provider runtime lookup, media handling, TTS selection, Gateway startup ownership, and outbound send paths one scoped view of the runtime while keeping reuse local to the request or prepared Gateway surface and reducing broad rediscovery plus stale-cache risk.

## What Changed

- Prepares model/auth/provider runtime state before reply dispatch and passes it into embedded runs.
- Reuses scoped plugin capability/runtime catalogs for media, tools, provider lookups, and speech generation.
- Lazily materializes prepared tool surfaces while preserving requested plugin tools and existing allowlist behavior.
- Keeps configured image/PDF model owner plugins in startup/runtime ownership discovery.
- Keeps OAuth provider token formatting hooks reachable when no prepared formatter is pinned.
- Preserves non-Gateway automatic TTS provider discovery when callers have not loaded a scoped provider set yet.
- Documents the prepared runtime path in AGENTS.md so new reply-path work does not reintroduce broad discovery machinery.
- Adds stage timing around reply and embedded startup so slow discovery paths remain visible in logs.

## Live Benchmark

A simple live reply test was run against latest main and this branch from clean Gateway restarts. The first main attempt hit a provider overload and was discarded; the table below uses successful reply deliveries only.

| Ref | Message processed | Final text delivery |
| --- | ---: | ---: |
| Latest main `a90be47` | 57.651s | ~58.25s |
| This branch `019f068` | 13.520s | ~14.03s |

## Verification

- `pnpm test extensions/speech-core/src/tts.test.ts src/image-generation/provider-registry.test.ts src/video-generation/provider-registry.test.ts`
- `pnpm test src/agents/openclaw-tools.media-factory-plan.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts src/agents/tools/web-search.late-bind.test.ts src/agents/tools/web-tool-runtime-context.test.ts src/plugins/web-provider-runtime-shared.test.ts src/plugins/capability-provider-runtime.test.ts extensions/speech-core/src/tts.test.ts src/image-generation/provider-registry.test.ts src/video-generation/provider-registry.test.ts`
- `pnpm build`
- `git diff --check origin/main...HEAD`
- Conflict-marker scan over tracked source files
