### PR TITLE
fix(plugins): keep npm bridge updates scanned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
 - Channels/Telegram: force a fresh final message when a visible non-preview bubble (tool/block/error) was delivered after the active answer preview, so multi-step assistant replies no longer end up with the final answer above intermediate output. Fixes #76529. Thanks @jack-stormentswe.
 - Channels/Telegram: require an observed Telegram send, edit, or fallback before treating a forum-topic final as delivered, so final replies generated in transcript no longer disappear from Telegram topics. Fixes #76554. (#76764) Thanks @bubucilo and @obviyus.
-- Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. Thanks @Lucenx9.
+- Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 
 ## 2026.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ Docs: https://docs.openclaw.ai
 - Agents/fallback: suppress duplicate current-turn user-message transcript writes after embedded fallback retries while still sending the retry prompt to the model. (#63696) Thanks @dashhuang.
 - Channels/Telegram: force a fresh final message when a visible non-preview bubble (tool/block/error) was delivered after the active answer preview, so multi-step assistant replies no longer end up with the final answer above intermediate output. Fixes #76529. Thanks @jack-stormentswe.
 - Channels/Telegram: require an observed Telegram send, edit, or fallback before treating a forum-topic final as delivered, so final replies generated in transcript no longer disappear from Telegram topics. Fixes #76554. (#76764) Thanks @bubucilo and @obviyus.
+- Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. Thanks @Lucenx9.
 
 ## 2026.5.2
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2004,6 +2004,10 @@ describe("syncPluginsForUpdateChannel", () => {
         spec: "@openclaw/legacy-chat",
         mode: "update",
         expectedPluginId: "legacy-chat",
+      }),
+    );
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
         trustedSourceLinkedOfficialInstall: true,
       }),
     );
@@ -2150,6 +2154,10 @@ describe("syncPluginsForUpdateChannel", () => {
         spec: "@openclaw/legacy-chat",
         mode: "update",
         expectedPluginId: "legacy-chat",
+      }),
+    );
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
         trustedSourceLinkedOfficialInstall: true,
       }),
     );

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1435,7 +1435,6 @@ export async function syncPluginsForUpdateChannel(params: {
             spec: npmSpec,
             mode: "update",
             expectedPluginId: targetPluginId,
-            trustedSourceLinkedOfficialInstall: true,
             logger,
           });
         }
@@ -1444,7 +1443,6 @@ export async function syncPluginsForUpdateChannel(params: {
           spec: npmSpec,
           mode: "update",
           expectedPluginId: targetPluginId,
-          trustedSourceLinkedOfficialInstall: true,
           logger,
         });
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: externalized bundled-plugin npm bridge updates marked network-fetched npm packages as `trustedSourceLinkedOfficialInstall` without carrying artifact integrity or provenance into that update path.
- Why it matters: that flag is consumed by the install security scanner as an override for critical built-in findings, so a poisoned bridge npm package could skip the normal scanner block during update.
- What changed: bridge-to-npm installs and ClawHub-to-npm bridge fallbacks now use the normal npm plugin install scanner path; tests assert the trust override is not passed.
- What did NOT change (scope boundary): catalog-matched official npm update behavior outside the externalized bundled bridge path is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the externalized bundled plugin bridge path treated an npm install spec as source-linked official without proving the fetched artifact matched reviewed official provenance.
- Missing detection / guardrail: update tests asserted the trust flag was present, but no test asserted that bridge npm installs remain on the scanner-blocking path when provenance is absent.
- Contributing context (if known): source-linked official trust is valid only when the caller has a stronger artifact/provenance signal than the bridge path currently carries.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/update.test.ts`
- Scenario the test should lock in: externalized bundled npm bridge installs, including ClawHub fallback to npm, must not pass `trustedSourceLinkedOfficialInstall: true`.
- Why this is the smallest reliable guardrail: the regression is introduced at the update-to-installer call boundary, so the update test can assert the exact installer options.
- Existing test that already covers this (if any): existing externalized bundled plugin tests covered the path but expected the unsafe trust flag; this PR flips that assertion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Externalized bundled npm bridge updates can now fail closed if the fetched npm package contains scanner-critical launch-code patterns and lacks a trusted provenance path.

## Diagram (if applicable)

```text
Before:
externalized bridge update -> npm install with trustedSourceLinkedOfficialInstall -> critical scanner findings warn only

After:
externalized bridge update -> npm install on normal scanner path -> critical scanner findings block
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the install/update execution surface is narrowed by keeping bridge npm updates subject to the normal critical security-scan block. The compatibility risk is false positives for packages that need launch-code patterns; mitigation is to require a real provenance/integrity path before granting official trust.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): plugin update bridge
- Relevant config (redacted): N/A

### Steps

1. Inspect `src/plugins/update.ts` bridge npm install calls.
2. Observe that both direct npm bridge updates and ClawHub fallback bridge updates pass `trustedSourceLinkedOfficialInstall: true`.
3. Run the externalized bundled plugin update tests after removing that trust override.

### Expected

- Externalized bundled npm bridge installs preserve `spec`, `mode`, and `expectedPluginId`, but do not pass `trustedSourceLinkedOfficialInstall: true`.

### Actual

- Before this PR, the update tests expected `trustedSourceLinkedOfficialInstall: true` on bridge npm installs.
- After this PR, the targeted tests pass with negative assertions for that flag.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/plugins/update.test.ts -t "externalized bundled plugin"`; `pnpm format:check CHANGELOG.md src/plugins/update.ts src/plugins/update.test.ts`
- Edge cases checked: direct npm bridge migration and ClawHub missing-package fallback to npm.
- What you did **not** verify: full `pnpm check`, full `pnpm test`, and a live external npm registry compromise/fetch scenario.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an externalized official package with legitimate scanner-critical launch-code patterns may fail update through the bridge npm fallback.
  - Mitigation: that package should use a provenance/integrity-backed trusted path before receiving official install trust; without that proof, fail-closed behavior is the safer default.
