### PR TITLE
fix(telegram): suppress stale replies when dispatch is superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory/status: keep plain `openclaw memory status` and `openclaw memory status --json` on the cheap read-only path by reserving vector and embedding provider probes for `--deep` or `--index`. Fixes #76769. Thanks @daruire.
+- Telegram: suppress stale same-session replies when a newer accepted message arrives before an older in-flight Telegram dispatch finalizes. Fixes #76642. Thanks @chinar-amrutkar.
 - Control UI/Sessions: avoid full `sessions.list` reloads for chat-turn `sessions.changed` payloads, so large session stores no longer add multi-second delays while chat responses are being delivered. (#76676) Thanks @VACInc.
 - Gateway/watch: run `doctor --fix --non-interactive` once and retry when the dev Gateway child exits during startup, so stale local plugin install/config state does not leave the tmux watch session disappearing without a repair attempt.
 - Doctor/Telegram: warn when selected Telegram quote replies can suppress `streaming.preview.toolProgress`, and document the `replyToMode` trade-off without changing runtime delivery. Fixes #73487. Thanks @GodsBoy.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -129,8 +129,8 @@ vi.mock("./sticker-cache.js", () => ({
 }));
 
 let dispatchTelegramMessage: typeof import("./bot-message-dispatch.js").dispatchTelegramMessage;
-let getTelegramAbortFenceSizeForTests: typeof import("./bot-message-dispatch.js").getTelegramAbortFenceSizeForTests;
-let resetTelegramAbortFenceForTests: typeof import("./bot-message-dispatch.js").resetTelegramAbortFenceForTests;
+let getTelegramReplyFenceSizeForTests: typeof import("./bot-message-dispatch.js").getTelegramReplyFenceSizeForTests;
+let resetTelegramReplyFenceForTests: typeof import("./bot-message-dispatch.js").resetTelegramReplyFenceForTests;
 
 const telegramDepsForTest: TelegramBotDeps = {
   getRuntimeConfig: loadConfig as TelegramBotDeps["getRuntimeConfig"],
@@ -163,13 +163,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
   beforeAll(async () => {
     ({
       dispatchTelegramMessage,
-      getTelegramAbortFenceSizeForTests,
-      resetTelegramAbortFenceForTests,
+      getTelegramReplyFenceSizeForTests,
+      resetTelegramReplyFenceForTests,
     } = await import("./bot-message-dispatch.js"));
   });
 
   beforeEach(() => {
-    resetTelegramAbortFenceForTests();
+    resetTelegramReplyFenceForTests();
     createTelegramDraftStream.mockReset();
     dispatchReplyWithBufferedBlockDispatcher.mockReset();
     deliverReplies.mockReset();
@@ -3707,7 +3707,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     ).rejects.toThrow("sticker setup failed");
 
-    expect(getTelegramAbortFenceSizeForTests()).toBe(0);
+    expect(getTelegramReplyFenceSizeForTests()).toBe(0);
   });
 
   it("keeps older answer finalization when abort targets a different session", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3468,6 +3468,84 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(firstAnswerDraft.clear).not.toHaveBeenCalled();
   });
 
+  it("ignores stale answer finalization after a newer message supersedes the same session", async () => {
+    let releaseFirstFinal!: () => void;
+    const firstFinalGate = new Promise<void>((resolve) => {
+      releaseFirstFinal = resolve;
+    });
+    let resolvePreviewVisible!: () => void;
+    const previewVisible = new Promise<void>((resolve) => {
+      resolvePreviewVisible = resolve;
+    });
+
+    const firstAnswerDraft = createTestDraftStream({
+      messageId: 1001,
+      onUpdate: (text) => {
+        if (text === "Old reply partial") {
+          resolvePreviewVisible();
+        }
+      },
+    });
+    const firstReasoningDraft = createDraftStream();
+    const secondAnswerDraft = createDraftStream();
+    const secondReasoningDraft = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => firstAnswerDraft)
+      .mockImplementationOnce(() => firstReasoningDraft)
+      .mockImplementationOnce(() => secondAnswerDraft)
+      .mockImplementationOnce(() => secondReasoningDraft);
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Old reply partial" });
+        await firstFinalGate;
+        await dispatcherOptions.deliver({ text: "Old reply final" }, { kind: "final" });
+        return { queuedFinal: true };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "New reply final" }, { kind: "final" });
+        return { queuedFinal: true };
+      });
+    const newReplyDelivered = observeDeliveredReply("New reply final");
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
+
+    const firstPromise = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          Body: "earlier request",
+          RawBody: "earlier request",
+          MessageSid: "msg-1",
+        } as never,
+      }),
+    });
+
+    await previewVisible;
+
+    const secondPromise = dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          Body: "newer request",
+          RawBody: "newer request",
+          MessageSid: "msg-2",
+        } as never,
+      }),
+    });
+
+    await newReplyDelivered;
+
+    releaseFirstFinal();
+    await Promise.all([firstPromise, secondPromise]);
+
+    expect(editMessageTelegram).not.toHaveBeenCalledWith(
+      123,
+      1001,
+      "Old reply final",
+      expect.any(Object),
+    );
+    expect(firstAnswerDraft.clear).not.toHaveBeenCalled();
+  });
+
   it("discards hidden short partials instead of flushing a stale preview after abort", async () => {
     let releaseFirstCleanup!: () => void;
     const firstCleanupGate = new Promise<void>((resolve) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -907,7 +907,7 @@ export const dispatchTelegramMessage = async ({
                     const _hasMedia = reply.hasMedia;
 
                     const flushBufferedFinalAnswer = async () => {
-                      const buffered = reasoningStepState.takeBufferedFinalAnswer();
+                      const buffered = reasoningStepState.takeBufferedFinalAnswer(abortFenceGeneration);
                       if (!buffered) {
                         return;
                       }
@@ -935,6 +935,7 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.bufferFinalAnswer({
                           payload,
                           text: segment.text,
+                          bufferedGeneration: abortFenceGeneration,
                         });
                         continue;
                       }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -128,7 +128,7 @@ type TelegramAbortFenceState = {
   activeDispatches: number;
 };
 
-// Abort can arrive on Telegram's control lane ahead of older same-session reply work.
+// Newer accepted turns and authorized aborts can arrive ahead of older same-session reply work.
 const telegramAbortFenceByKey = new Map<string, TelegramAbortFenceState>();
 
 function normalizeTelegramFenceKey(value: unknown): string | undefined {
@@ -607,9 +607,9 @@ export const dispatchTelegramMessage = async ({
           : undefined;
 
   const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
-  const shouldSupersedeAbortFence =
-    ctxPayload.CommandAuthorized &&
-    isAbortRequestText(ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "");
+  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
+  const isAbortRequest = isAbortRequestText(dispatchText);
+  const shouldSupersedeAbortFence = isAbortRequest ? ctxPayload.CommandAuthorized : true;
 
   abortFenceGeneration = beginTelegramAbortFence({
     key: dispatchFenceKey,
@@ -907,7 +907,8 @@ export const dispatchTelegramMessage = async ({
                     const _hasMedia = reply.hasMedia;
 
                     const flushBufferedFinalAnswer = async () => {
-                      const buffered = reasoningStepState.takeBufferedFinalAnswer(abortFenceGeneration);
+                      const buffered =
+                        reasoningStepState.takeBufferedFinalAnswer(abortFenceGeneration);
                       if (!buffered) {
                         return;
                       }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -123,13 +123,13 @@ type DispatchTelegramMessageParams = {
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
 
-type TelegramAbortFenceState = {
+type TelegramReplyFenceState = {
   generation: number;
   activeDispatches: number;
 };
 
 // Newer accepted turns and authorized aborts can arrive ahead of older same-session reply work.
-const telegramAbortFenceByKey = new Map<string, TelegramAbortFenceState>();
+const telegramReplyFenceByKey = new Map<string, TelegramReplyFenceState>();
 
 function normalizeTelegramFenceKey(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -139,7 +139,7 @@ function normalizeTelegramFenceKey(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function resolveTelegramAbortFenceKey(params: {
+function resolveTelegramReplyFenceKey(params: {
   ctxPayload: { SessionKey?: string; CommandTargetSessionKey?: string };
   chatId: number | string;
   threadSpec: { id?: number | string | null; scope?: string };
@@ -151,9 +151,9 @@ function resolveTelegramAbortFenceKey(params: {
   );
 }
 
-function beginTelegramAbortFence(params: { key: string; supersede: boolean }): number {
-  const existing = telegramAbortFenceByKey.get(params.key);
-  const state: TelegramAbortFenceState = existing ?? {
+function beginTelegramReplyFence(params: { key: string; supersede: boolean }): number {
+  const existing = telegramReplyFenceByKey.get(params.key);
+  const state: TelegramReplyFenceState = existing ?? {
     generation: 0,
     activeDispatches: 0,
   };
@@ -161,31 +161,41 @@ function beginTelegramAbortFence(params: { key: string; supersede: boolean }): n
     state.generation += 1;
   }
   state.activeDispatches += 1;
-  telegramAbortFenceByKey.set(params.key, state);
+  telegramReplyFenceByKey.set(params.key, state);
   return state.generation;
 }
 
-function isTelegramAbortFenceSuperseded(params: { key: string; generation: number }): boolean {
-  return (telegramAbortFenceByKey.get(params.key)?.generation ?? 0) !== params.generation;
+function isTelegramReplyFenceSuperseded(params: { key: string; generation: number }): boolean {
+  return (telegramReplyFenceByKey.get(params.key)?.generation ?? 0) !== params.generation;
 }
 
-function endTelegramAbortFence(key: string): void {
-  const state = telegramAbortFenceByKey.get(key);
+function endTelegramReplyFence(key: string): void {
+  const state = telegramReplyFenceByKey.get(key);
   if (!state) {
     return;
   }
   state.activeDispatches -= 1;
   if (state.activeDispatches <= 0) {
-    telegramAbortFenceByKey.delete(key);
+    telegramReplyFenceByKey.delete(key);
   }
 }
 
-export function getTelegramAbortFenceSizeForTests(): number {
-  return telegramAbortFenceByKey.size;
+function shouldSupersedeTelegramReplyFence(ctxPayload: {
+  Body?: string;
+  RawBody?: string;
+  CommandBody?: string;
+  CommandAuthorized: boolean;
+}): boolean {
+  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
+  return !isAbortRequestText(dispatchText) || ctxPayload.CommandAuthorized;
 }
 
-export function resetTelegramAbortFenceForTests(): void {
-  telegramAbortFenceByKey.clear();
+export function getTelegramReplyFenceSizeForTests(): number {
+  return telegramReplyFenceByKey.size;
+}
+
+export function resetTelegramReplyFenceForTests(): void {
+  telegramReplyFenceByKey.clear();
 }
 
 function resolveTelegramReasoningLevel(params: {
@@ -305,25 +315,25 @@ export const dispatchTelegramMessage = async ({
     }
     await statusReactionController.restoreInitial();
   };
-  const dispatchFenceKey = resolveTelegramAbortFenceKey({
+  const replyFenceKey = resolveTelegramReplyFenceKey({
     ctxPayload,
     chatId,
     threadSpec,
   });
-  let abortFenceGeneration: number | undefined;
+  let replyFenceGeneration: number | undefined;
   let dispatchWasSuperseded = false;
   const isDispatchSuperseded = () =>
-    abortFenceGeneration !== undefined &&
-    isTelegramAbortFenceSuperseded({
-      key: dispatchFenceKey,
-      generation: abortFenceGeneration,
+    replyFenceGeneration !== undefined &&
+    isTelegramReplyFenceSuperseded({
+      key: replyFenceKey,
+      generation: replyFenceGeneration,
     });
-  const releaseAbortFence = () => {
-    if (abortFenceGeneration === undefined) {
+  const releaseReplyFence = () => {
+    if (replyFenceGeneration === undefined) {
       return;
     }
-    endTelegramAbortFence(dispatchFenceKey);
-    abortFenceGeneration = undefined;
+    endTelegramReplyFence(replyFenceKey);
+    replyFenceGeneration = undefined;
   };
   const draftMaxChars = Math.min(textLimit, 4096);
   const tableMode = resolveMarkdownTableMode({
@@ -607,13 +617,10 @@ export const dispatchTelegramMessage = async ({
           : undefined;
 
   const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
-  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
-  const isAbortRequest = isAbortRequestText(dispatchText);
-  const shouldSupersedeAbortFence = isAbortRequest ? ctxPayload.CommandAuthorized : true;
 
-  abortFenceGeneration = beginTelegramAbortFence({
-    key: dispatchFenceKey,
-    supersede: shouldSupersedeAbortFence,
+  replyFenceGeneration = beginTelegramReplyFence({
+    key: replyFenceKey,
+    supersede: shouldSupersedeTelegramReplyFence(ctxPayload),
   });
 
   const implicitQuoteReplyTargetId =
@@ -908,7 +915,7 @@ export const dispatchTelegramMessage = async ({
 
                     const flushBufferedFinalAnswer = async () => {
                       const buffered =
-                        reasoningStepState.takeBufferedFinalAnswer(abortFenceGeneration);
+                        reasoningStepState.takeBufferedFinalAnswer(replyFenceGeneration);
                       if (!buffered) {
                         return;
                       }
@@ -936,7 +943,7 @@ export const dispatchTelegramMessage = async ({
                         reasoningStepState.bufferFinalAnswer({
                           payload,
                           text: segment.text,
-                          bufferedGeneration: abortFenceGeneration,
+                          bufferedGeneration: replyFenceGeneration,
                         });
                         continue;
                       }
@@ -1254,7 +1261,7 @@ export const dispatchTelegramMessage = async ({
     }
   } finally {
     dispatchWasSuperseded = isDispatchSuperseded();
-    releaseAbortFence();
+    releaseReplyFence();
   }
   if (dispatchWasSuperseded) {
     if (statusReactionController) {

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -93,6 +93,7 @@ export function splitTelegramReasoningText(text?: string): TelegramReasoningSpli
 type BufferedFinalAnswer = {
   payload: ReplyPayload;
   text: string;
+  bufferedGeneration?: number;
 };
 
 export function createTelegramReasoningStepState() {
@@ -117,7 +118,16 @@ export function createTelegramReasoningStepState() {
     bufferedFinalAnswer = value;
   };
 
-  const takeBufferedFinalAnswer = (): BufferedFinalAnswer | undefined => {
+  const takeBufferedFinalAnswer = (
+    currentGeneration?: number,
+  ): BufferedFinalAnswer | undefined => {
+    if (
+      currentGeneration !== undefined &&
+      bufferedFinalAnswer?.bufferedGeneration !== undefined &&
+      bufferedFinalAnswer.bufferedGeneration !== currentGeneration
+    ) {
+      return undefined;
+    }
     const value = bufferedFinalAnswer;
     bufferedFinalAnswer = undefined;
     return value;

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -118,9 +118,7 @@ export function createTelegramReasoningStepState() {
     bufferedFinalAnswer = value;
   };
 
-  const takeBufferedFinalAnswer = (
-    currentGeneration?: number,
-  ): BufferedFinalAnswer | undefined => {
+  const takeBufferedFinalAnswer = (currentGeneration?: number): BufferedFinalAnswer | undefined => {
     if (
       currentGeneration !== undefined &&
       bufferedFinalAnswer?.bufferedGeneration !== undefined &&


### PR DESCRIPTION
## Summary

When a newer Telegram user message arrives while an older dispatch is still processing, buffered final answers from the old dispatch could be delivered into the new message's thread, causing stale/out-of-context replies.

## Root Cause

The `reasoningStepState.bufferFinalAnswer()` had no way to know if the dispatch that buffered the answer was still current. When message N+1 arrived while message N's dispatch was still in-flight, the buffered answer from message N could be flushed into message N+1's thread.

## Fix

- Add `bufferedGeneration?: number` to `BufferedFinalAnswer` type
- `bufferFinalAnswer()` now captures the current `abortFenceGeneration`
- `takeBufferedFinalAnswer(currentGeneration)` rejects buffered answers whose generation doesn't match the current dispatch's generation

Fixes #76642