### PR TITLE
fix(agents): sanitize sender display name at OpenAI transport boundary [AI-assisted]

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4226,3 +4226,62 @@ describe("openai transport stream", () => {
     ).rejects.toThrow("Exceeded tool-call argument buffer limit");
   });
 });
+
+describe("sanitizeCompletionsUserMessageNames", () => {
+  const { sanitizeCompletionsUserMessageNames } = __testing;
+
+  it("sanitizes non-conforming name on user message", () => {
+    const messages = [{ role: "user", content: "hello", name: "José García" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect((messages[0] as Record<string, unknown>).name).toBe("Jos_Garc_a");
+  });
+
+  it("removes name when all characters are non-conforming", () => {
+    const messages = [{ role: "user", content: "hi", name: "张三" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect("name" in (messages[0] as Record<string, unknown>)).toBe(false);
+  });
+
+  it("preserves clean ASCII names", () => {
+    const messages = [{ role: "user", content: "hello", name: "Alice" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect((messages[0] as Record<string, unknown>).name).toBe("Alice");
+  });
+
+  it("truncates names exceeding 64 characters", () => {
+    const longName = "A".repeat(100);
+    const messages = [{ role: "user", content: "hello", name: longName }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect((messages[0] as Record<string, unknown>).name).toBe("A".repeat(64));
+  });
+
+  it("does not add name to user messages without one", () => {
+    const messages = [{ role: "user", content: "hello" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect("name" in (messages[0] as Record<string, unknown>)).toBe(false);
+  });
+
+  it("does not modify non-user messages", () => {
+    const messages = [{ role: "assistant", content: "hi", name: "bot 🤖" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect((messages[0] as Record<string, unknown>).name).toBe("bot 🤖");
+  });
+
+  it("replaces spaces with underscores", () => {
+    const messages = [{ role: "user", content: "hello", name: "John Doe" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect((messages[0] as Record<string, unknown>).name).toBe("John_Doe");
+  });
+
+  it("removes non-string name values", () => {
+    const messages = [{ role: "user", content: "hello", name: 42 }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect("name" in (messages[0] as Record<string, unknown>)).toBe(false);
+  });
+
+  it("handles emoji-only names by removing the field", () => {
+    const messages = [{ role: "user", content: "hello", name: "🚀🎉" }];
+    sanitizeCompletionsUserMessageNames(messages);
+    expect("name" in (messages[0] as Record<string, unknown>)).toBe(false);
+  });
+});

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -23,6 +23,7 @@ import type { ModelCompatConfig } from "../config/types.models.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
+import { sanitizeSenderNameForModel } from "../shared/string-coerce.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
 import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
 import { flattenCompletionMessagesToStringContent } from "./openai-completions-string-content.js";
@@ -55,6 +56,40 @@ import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transpor
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
 const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const log = createSubsystemLogger("openai-transport");
+
+/**
+ * Sanitize `name` fields on user-role messages in an OpenAI completions payload.
+ *
+ * The OpenAI Chat Completions API restricts the optional `name` field on user
+ * messages to `[a-zA-Z0-9_-]` with a maximum length of 64 characters. Channel
+ * display names (Telegram, Discord, etc.) routinely contain spaces, accents,
+ * CJK characters, and emoji which cause a 400 rejection when sent unsanitized.
+ *
+ * This runs at the transport boundary — after `convertMessages` builds the
+ * completions payload and before it is sent to the provider — so upstream
+ * callers retain the raw name for group policy matching and display purposes.
+ */
+function sanitizeCompletionsUserMessageNames(messages: unknown[]): void {
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    if (record.role !== "user" || !("name" in record)) {
+      continue;
+    }
+    if (typeof record.name !== "string") {
+      delete record.name;
+      continue;
+    }
+    const sanitized = sanitizeSenderNameForModel(record.name);
+    if (sanitized) {
+      record.name = sanitized;
+    } else {
+      delete record.name;
+    }
+  }
+}
 
 type BaseStreamOptions = {
   temperature?: number;
@@ -1848,6 +1883,7 @@ export function buildOpenAICompletionsParams(
       }
     : context;
   const messages = convertMessages(model as never, completionsContext, compat as never);
+  sanitizeCompletionsUserMessageNames(messages);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const params: Record<string, unknown> = {
@@ -1973,4 +2009,5 @@ export const __testing = {
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
+  sanitizeCompletionsUserMessageNames,
 };

--- a/src/shared/string-coerce.sanitize-sender-name.test.ts
+++ b/src/shared/string-coerce.sanitize-sender-name.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeSenderNameForModel } from "./string-coerce.js";
+
+describe("sanitizeSenderNameForModel", () => {
+  it("passes through clean ASCII names unchanged", () => {
+    expect(sanitizeSenderNameForModel("Alice")).toBe("Alice");
+    expect(sanitizeSenderNameForModel("bob-42")).toBe("bob-42");
+    expect(sanitizeSenderNameForModel("user_name")).toBe("user_name");
+  });
+
+  it("replaces spaces with underscores", () => {
+    expect(sanitizeSenderNameForModel("John Doe")).toBe("John_Doe");
+  });
+
+  it("replaces accented and CJK characters", () => {
+    expect(sanitizeSenderNameForModel("José García")).toBe("Jos_Garc_a");
+    expect(sanitizeSenderNameForModel("张三")).toBe(undefined);
+    expect(sanitizeSenderNameForModel("田中太郎")).toBe(undefined);
+  });
+
+  it("handles mixed ASCII and non-ASCII", () => {
+    expect(sanitizeSenderNameForModel("Alice 张三")).toBe("Alice");
+  });
+
+  it("replaces emoji", () => {
+    expect(sanitizeSenderNameForModel("Bob 🚀")).toBe("Bob");
+  });
+
+  it("collapses consecutive underscores", () => {
+    expect(sanitizeSenderNameForModel("a   b")).toBe("a_b");
+    expect(sanitizeSenderNameForModel("a!!!b")).toBe("a_b");
+  });
+
+  it("trims leading and trailing underscores", () => {
+    expect(sanitizeSenderNameForModel(" Alice ")).toBe("Alice");
+    expect(sanitizeSenderNameForModel("!!!Alice!!!")).toBe("Alice");
+  });
+
+  it("truncates to 64 characters", () => {
+    const long = "A".repeat(100);
+    const result = sanitizeSenderNameForModel(long);
+    expect(result).toBe("A".repeat(64));
+  });
+
+  it("returns undefined for null, undefined, and empty string", () => {
+    expect(sanitizeSenderNameForModel(null)).toBeUndefined();
+    expect(sanitizeSenderNameForModel(undefined)).toBeUndefined();
+    expect(sanitizeSenderNameForModel("")).toBeUndefined();
+  });
+
+  it("returns undefined when all characters are non-conforming", () => {
+    expect(sanitizeSenderNameForModel("🎉🎊🎈")).toBeUndefined();
+    expect(sanitizeSenderNameForModel("   ")).toBeUndefined();
+  });
+});

--- a/src/shared/string-coerce.ts
+++ b/src/shared/string-coerce.ts
@@ -82,3 +82,24 @@ export function normalizeOptionalStringifiedId(value: unknown): string | undefin
 export function hasNonEmptyString(value: unknown): value is string {
   return normalizeOptionalString(value) !== undefined;
 }
+
+/**
+ * Sanitize a sender display name for use as the `name` field in model API
+ * messages. The OpenAI API (and compatible providers) restrict this field to
+ * characters matching `[a-zA-Z0-9_-]` with a maximum length of 64 characters.
+ *
+ * Telegram (and other channel) display names routinely contain spaces, accents,
+ * CJK characters, and emoji which cause a 400 rejection when sent unsanitized.
+ *
+ * Returns `undefined` when the result would be empty after sanitization so the
+ * caller can omit the field entirely.
+ */
+export function sanitizeSenderNameForModel(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const sanitized = value.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  // Collapse consecutive underscores and trim leading/trailing underscores
+  const collapsed = sanitized.replace(/_+/g, "_").replace(/^_|_$/g, "");
+  return collapsed || undefined;
+}


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary

- Problem: Telegram and other channel display names containing spaces, accents, CJK characters, or emoji cause the OpenAI Chat Completions API to reject requests with HTTP 400, because the message `name` field only accepts `[a-zA-Z0-9_-]` (max 64 chars). This puts the entire provider into cooldown, blocking all models on that provider.
- Why it matters: Any multilingual Telegram group with non-ASCII display names is completely broken — the bot becomes unresponsive for the duration of the provider cooldown.
- What changed: Added `sanitizeSenderNameForModel()` utility that replaces non-conforming characters with underscores, collapses runs, and truncates to 64 chars. Applied at the OpenAI transport boundary in `buildOpenAICompletionsParams()` — after `convertMessages` builds the payload and before it hits the API — so upstream callers retain raw names for group policy matching and display.
- What did NOT change (scope boundary): Runner entry points (`get-reply-run.ts`, `agent-runner-utils.ts`) still pass raw `senderName` through `normalizeOptionalString`, preserving group policy name matching. No changes to Telegram channel code or any other channel plugin.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #61192
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The OpenAI Chat Completions API enforces `[a-zA-Z0-9_-]` on the optional `name` field of user messages, but channel display names (Telegram, Discord, etc.) are passed through unsanitized. When a user with a non-ASCII name sends a message in a group/forum topic, the entire API request is rejected with 400.
- Missing detection / guardrail: No sanitization layer existed between the raw channel display name and the model API payload boundary.
- Contributing context: The `name` field restriction is documented in the OpenAI API spec but not enforced at the application layer. Prior PR #62441 attempted a fix at the runner entry points but was closed — that approach would have broken group policy name matching that relies on raw names.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/openai-transport-stream.test.ts`, `src/shared/string-coerce.sanitize-sender-name.test.ts`
- Scenario the test should lock in: User messages with non-ASCII `name` fields (spaces, accents, CJK, emoji, >64 chars) are sanitized before reaching the API; clean names pass through unchanged; names that sanitize to empty are removed entirely.
- Why this is the smallest reliable guardrail: Transport-boundary sanitization catches all channel sources without requiring per-channel fixes.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A — 19 new test cases added.

## User-visible / Behavior Changes

- Users with non-ASCII display names in Telegram groups/forum topics will no longer trigger 400 errors and provider cooldowns.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 22+
- Model/provider: OpenAI Chat Completions API
- Integration/channel (if any): Telegram (forum topics with non-ASCII display names)
- Relevant config (redacted): Default Telegram channel config with historyLimit > 0

### Steps

1. Configure a Telegram supergroup with forum topics enabled
2. Have participants with non-ASCII names (spaces, accents, CJK, emoji) post in a topic
3. Send a message to the bot in that topic

### Expected

- The bot responds normally regardless of sender display name characters.

### Actual

- OpenAI API rejects with HTTP 400 due to invalid `name` field, triggering provider-wide cooldown.

## Evidence

- [x] Failing test/log before + passing after
- 19 new unit tests covering: clean ASCII names, spaces, accents, CJK characters, emoji, >64 char names, all-non-conforming names, non-string name values, and no-name-present cases

## Human Verification (required)

- Verified scenarios: All 19 new unit tests pass; existing 108 openai-transport-stream tests still pass; oxfmt format check passes
- Edge cases checked: Pure emoji names (removed entirely), CJK-only names (removed), mixed ASCII+non-ASCII (preserved ASCII portion), 100-char names (truncated to 64), non-string name values (removed)
- What you did **not** verify: Live Telegram group with actual non-ASCII usernames (no test environment available); non-OpenAI providers that may have different name field restrictions

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Sanitized names may cause collisions (e.g., "Alice!" and "Alice?" both become "Alice")
  - Mitigation: The `name` field is optional metadata for model context, not a security-critical identifier. Collisions only affect model awareness of who said what in group history, not routing or policy.
