### PR TITLE
fix(tools): skip denied optional media factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use.
 - Gateway/performance: lazy-load early runtime discovery and shutdown-hook helpers, defer maintenance timers until after readiness, and trim duplicate plugin auto-enable work during Gateway startup.
 - QA/Mantis: add a `pnpm openclaw qa mantis discord-smoke` runner and manual GitHub workflow that verify the Mantis Discord bot can see the configured guild/channel, post a smoke message, add a reaction, and upload artifacts.
 - Gateway/performance: lazy-load the heavy cron runtime after the rest of Gateway startup, defer restart-sentinel refresh after readiness, and let the Gateway startup benchmark write per-run V8 CPU profiles with `--cpu-prof-dir`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use.
+- Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
 - Gateway/performance: lazy-load early runtime discovery and shutdown-hook helpers, defer maintenance timers until after readiness, and trim duplicate plugin auto-enable work during Gateway startup.
 - QA/Mantis: add a `pnpm openclaw qa mantis discord-smoke` runner and manual GitHub workflow that verify the Mantis Discord bot can see the configured guild/channel, post a smoke message, add a reaction, and upload artifacts.
 - Gateway/performance: lazy-load the heavy cron runtime after the rest of Gateway startup, defer restart-sentinel refresh after readiness, and let the Gateway startup benchmark write per-run V8 CPU profiles with `--cpu-prof-dir`.

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -247,6 +247,35 @@ describe("optional media tool factory planning", () => {
     });
   });
 
+  it("skips tools that the resolved denylist blocks", () => {
+    const config: OpenClawConfig = {};
+    installSnapshot(config, [
+      createPlugin({
+        id: "image-owner",
+        contracts: { imageGenerationProviders: ["image-owner"] },
+        setupProviders: [{ id: "image-owner", envVars: ["IMAGE_OWNER_API_KEY"] }],
+      }),
+      createPlugin({
+        id: "media-owner",
+        contracts: { mediaUnderstandingProviders: ["anthropic"] },
+        setupProviders: [{ id: "anthropic", envVars: ["ANTHROPIC_API_KEY"] }],
+      }),
+    ]);
+
+    expect(
+      __testing.resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(["image-owner", "anthropic"]),
+        toolDenylist: ["image_generate", "pdf"],
+      }),
+    ).toEqual({
+      imageGenerate: false,
+      videoGenerate: false,
+      musicGenerate: false,
+      pdf: false,
+    });
+  });
+
   it("keeps auth-backed providers on the factory path", () => {
     const config: OpenClawConfig = {};
     installSnapshot(config, [

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -276,6 +276,45 @@ describe("optional media tool factory planning", () => {
     });
   });
 
+  it("applies wildcard deny patterns to optional factory planning", () => {
+    const config: OpenClawConfig = {};
+    installSnapshot(config, [
+      createPlugin({
+        id: "image-owner",
+        contracts: { imageGenerationProviders: ["image-owner"] },
+        setupProviders: [{ id: "image-owner", envVars: ["IMAGE_OWNER_API_KEY"] }],
+      }),
+      createPlugin({
+        id: "video-owner",
+        contracts: { videoGenerationProviders: ["video-owner"] },
+        setupProviders: [{ id: "video-owner", envVars: ["VIDEO_OWNER_API_KEY"] }],
+      }),
+      createPlugin({
+        id: "music-owner",
+        contracts: { musicGenerationProviders: ["music-owner"] },
+        setupProviders: [{ id: "music-owner", envVars: ["MUSIC_OWNER_API_KEY"] }],
+      }),
+      createPlugin({
+        id: "media-owner",
+        contracts: { mediaUnderstandingProviders: ["anthropic"] },
+        setupProviders: [{ id: "anthropic", envVars: ["ANTHROPIC_API_KEY"] }],
+      }),
+    ]);
+
+    expect(
+      __testing.resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(["image-owner", "video-owner", "music-owner", "anthropic"]),
+        toolDenylist: ["*_generate", "p*"],
+      }),
+    ).toEqual({
+      imageGenerate: false,
+      videoGenerate: false,
+      musicGenerate: false,
+      pdf: false,
+    });
+  });
+
   it("keeps auth-backed providers on the factory path", () => {
     const config: OpenClawConfig = {};
     installSnapshot(config, [

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -22,7 +22,7 @@ import {
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
-import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -83,31 +83,15 @@ function hasExplicitImageModelConfig(config: OpenClawConfig | undefined): boolea
   return hasToolModelConfig(coerceImageModelConfig(config));
 }
 
-function isToolAllowedByFactoryAllowlist(toolName: string, allowlist?: string[]): boolean {
-  if (!allowlist || allowlist.length === 0) {
-    return true;
-  }
-  const expanded = new Set(expandToolGroups(allowlist));
-  return expanded.has("*") || expanded.has(normalizeToolName(toolName));
-}
-
-function isToolDeniedByFactoryDenylist(toolName: string, denylist?: string[]): boolean {
-  if (!denylist || denylist.length === 0) {
-    return false;
-  }
-  const expanded = new Set(expandToolGroups(denylist));
-  return expanded.has("*") || expanded.has(normalizeToolName(toolName));
-}
-
 function isToolAllowedByFactoryPolicy(params: {
   toolName: string;
   allowlist?: string[];
   denylist?: string[];
 }): boolean {
-  if (isToolDeniedByFactoryDenylist(params.toolName, params.denylist)) {
-    return false;
-  }
-  return isToolAllowedByFactoryAllowlist(params.toolName, params.allowlist);
+  return isToolAllowedByPolicyName(params.toolName, {
+    allow: params.allowlist,
+    deny: params.denylist,
+  });
 }
 
 function resolveImageToolFactoryAvailable(params: {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -91,6 +91,25 @@ function isToolAllowedByFactoryAllowlist(toolName: string, allowlist?: string[])
   return expanded.has("*") || expanded.has(normalizeToolName(toolName));
 }
 
+function isToolDeniedByFactoryDenylist(toolName: string, denylist?: string[]): boolean {
+  if (!denylist || denylist.length === 0) {
+    return false;
+  }
+  const expanded = new Set(expandToolGroups(denylist));
+  return expanded.has("*") || expanded.has(normalizeToolName(toolName));
+}
+
+function isToolAllowedByFactoryPolicy(params: {
+  toolName: string;
+  allowlist?: string[];
+  denylist?: string[];
+}): boolean {
+  if (isToolDeniedByFactoryDenylist(params.toolName, params.denylist)) {
+    return false;
+  }
+  return isToolAllowedByFactoryAllowlist(params.toolName, params.allowlist);
+}
+
 function resolveImageToolFactoryAvailable(params: {
   config?: OpenClawConfig;
   agentDir?: string;
@@ -159,21 +178,29 @@ function resolveOptionalMediaToolFactoryPlan(params: {
   workspaceDir?: string;
   authStore?: AuthProfileStore;
   toolAllowlist?: string[];
+  toolDenylist?: string[];
 }): OptionalMediaToolFactoryPlan {
   const defaults = params.config?.agents?.defaults;
-  const allowImageGenerate = isToolAllowedByFactoryAllowlist(
-    "image_generate",
-    params.toolAllowlist,
-  );
-  const allowVideoGenerate = isToolAllowedByFactoryAllowlist(
-    "video_generate",
-    params.toolAllowlist,
-  );
-  const allowMusicGenerate = isToolAllowedByFactoryAllowlist(
-    "music_generate",
-    params.toolAllowlist,
-  );
-  const allowPdf = isToolAllowedByFactoryAllowlist("pdf", params.toolAllowlist);
+  const allowImageGenerate = isToolAllowedByFactoryPolicy({
+    toolName: "image_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowVideoGenerate = isToolAllowedByFactoryPolicy({
+    toolName: "video_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowMusicGenerate = isToolAllowedByFactoryPolicy({
+    toolName: "music_generate",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
+  const allowPdf = isToolAllowedByFactoryPolicy({
+    toolName: "pdf",
+    allowlist: params.toolAllowlist,
+    denylist: params.toolDenylist,
+  });
   const explicitImageGeneration = hasExplicitToolModelConfig(defaults?.imageGenerationModel);
   const explicitVideoGeneration = hasExplicitToolModelConfig(defaults?.videoGenerationModel);
   const explicitMusicGeneration = hasExplicitToolModelConfig(defaults?.musicGenerationModel);
@@ -256,6 +283,7 @@ export function createOpenClawTools(
     sandboxed?: boolean;
     config?: OpenClawConfig;
     pluginToolAllowlist?: string[];
+    pluginToolDenylist?: string[];
     /** Current channel ID for auto-threading. */
     currentChannelId?: string;
     /** Current thread timestamp for auto-threading. */
@@ -348,6 +376,7 @@ export function createOpenClawTools(
     workspaceDir,
     authStore: options?.authProfileStore,
     toolAllowlist: options?.pluginToolAllowlist,
+    toolDenylist: options?.pluginToolDenylist,
   });
   const imageToolAgentDir = options?.agentDir;
   const imageTool = resolveImageToolFactoryAvailable({

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -180,6 +180,21 @@ describe("createOpenClawCodingTools", () => {
     );
   });
 
+  it("passes explicit denylist entries to OpenClaw tool factory planning", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+
+    createOpenClawCodingTools({
+      config: { tools: { deny: ["pdf"] } },
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginToolDenylist: expect.arrayContaining(["pdf"]),
+      }),
+    );
+  });
+
   it("records core tool-prep stages for hot-path diagnostics", () => {
     const stages: string[] = [];
 

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -69,6 +69,7 @@ import {
 import {
   applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
+  collectExplicitDenylist,
   mergeAlsoAllowPolicy,
   normalizeToolName,
   resolveToolProfilePolicy,
@@ -617,6 +618,17 @@ export function createOpenClawCodingTools(options?: {
     subagentPolicy,
     options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
   ]);
+  const pluginToolDenylist = collectExplicitDenylist([
+    profilePolicy,
+    providerProfilePolicy,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    sandboxToolPolicy,
+    subagentPolicy,
+  ]);
   const pluginToolsOnly = includeCoreTools
     ? []
     : resolveOpenClawPluginToolsForOptions({
@@ -705,6 +717,7 @@ export function createOpenClawCodingTools(options?: {
           sandboxed: !!sandbox,
           config: options?.config,
           pluginToolAllowlist,
+          pluginToolDenylist,
           currentChannelId: options?.currentChannelId,
           currentThreadTs: options?.currentThreadTs,
           currentMessageId: options?.currentMessageId,

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -112,6 +112,25 @@ export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefi
   return entries;
 }
 
+export function collectExplicitDenylist(policies: Array<ToolPolicyLike | undefined>): string[] {
+  const entries: string[] = [];
+  for (const policy of policies) {
+    if (!policy?.deny) {
+      continue;
+    }
+    for (const value of policy.deny) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      const trimmed = value.trim();
+      if (trimmed) {
+        entries.push(trimmed);
+      }
+    }
+  }
+  return entries;
+}
+
 export function buildPluginToolGroups<T extends { name: string }>(params: {
   tools: T[];
   toolMeta: (tool: T) => { pluginId: string } | undefined;


### PR DESCRIPTION
## Summary

- Pass explicit tool denylist entries into OpenClaw tool factory planning.
- Skip optional image, video, music, and PDF factories when the effective policy already denies those tools.
- Add regression coverage for denylist-aware factory planning and the pi-tools handoff.

## Why

I hit this on my VPS while investigating gateway latency. A cron and agent turn spent about 5.1 s in `openclaw-tools:pdf-tool` during `core-plugin-tools` prep, even though the tool was not needed for that run.

Current `main` already avoids optional media and PDF factories when an explicit allowlist cannot expose them. This PR adds the matching denylist side, so tools that will be filtered out later are not built on the hot path.

This is intentionally narrower than #73039 and complementary to #76728. It does not memoize factory output.

Helps #76606 and #76500.

## Tests

- `pnpm test src/agents/openclaw-tools.media-factory-plan.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/openclaw-tools.ts src/agents/pi-tools.ts src/agents/tool-policy.ts src/agents/openclaw-tools.media-factory-plan.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts`
- `git diff --check`
- `pnpm tsgo:core:test`
- `pnpm check:changed`

## Real-world validation

On my OpenClaw VPS, adding an explicit tools allowlist for the cron-heavy agent removed the unwanted `pdf-tool` prep path. After hot reload, an 8 minute observation window had no new prep stages, no `pdf-tool` prep logs, and no Slack disconnect or DNS error logs.

## AI-assisted

Yes. I used Codex, reviewed the diff, and ran the tests above.
