### PR TITLE
feat(acpx): add args support for agent command overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/ACPX: accept an optional `args` array in `agents.<name>` config so paths and arguments containing spaces are preserved correctly when spawning ACP agent processes. Thanks @codex.
 - Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
 - Plugins/CLI: include package dependency install state in `openclaw plugins list --json` so scripts can spot missing plugin dependencies without runtime-loading plugins.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -85,6 +85,10 @@
             "command": {
               "type": "string",
               "minLength": 1
+            },
+            "args": {
+              "type": "array",
+              "items": { "type": "string" }
             }
           },
           "required": ["command"]

--- a/extensions/acpx/src/config-schema.ts
+++ b/extensions/acpx/src/config-schema.ts
@@ -33,7 +33,7 @@ export type AcpxPluginConfig = {
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
   mcpServers?: Record<string, McpServerConfig>;
-  agents?: Record<string, { command: string }>;
+  agents?: Record<string, { command: string; args?: string[] }>;
 };
 
 export type ResolvedAcpxPluginConfig = {
@@ -111,6 +111,7 @@ export const AcpxPluginConfigSchema = z.strictObject({
       z.string(),
       z.strictObject({
         command: nonEmptyTrimmedString("agents.<id>.command must be a non-empty string"),
+        args: z.array(z.string({ error: "args must be an array of strings" })).optional(),
       }),
     )
     .optional(),

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -58,6 +58,38 @@ describe("embedded acpx plugin config", () => {
     });
   });
 
+  it("combines agent command with args array", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          claude: { command: "node", args: ["/path/to/adapter.mjs", "--verbose"] },
+          codex: { command: "codex-acp", args: ["--model", "gpt-5"] },
+        },
+      },
+      workspaceDir: "/tmp/openclaw-acpx",
+    });
+
+    expect(resolved.agents).toEqual({
+      claude: "node /path/to/adapter.mjs --verbose",
+      codex: "codex-acp --model gpt-5",
+    });
+  });
+
+  it("handles agent command without args (backward compat)", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        agents: {
+          simple: { command: "simple-acp" },
+        },
+      },
+      workspaceDir: "/tmp/openclaw-acpx",
+    });
+
+    expect(resolved.agents).toEqual({
+      simple: "simple-acp",
+    });
+  });
+
   it("leaves probeAgent undefined by default so the runtime picks its built-in probe agent", () => {
     const resolved = resolveAcpxPluginConfig({
       rawConfig: undefined,

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -238,10 +238,12 @@ export function resolveAcpxPluginConfig(params: {
     moduleUrl: params.moduleUrl,
   });
   const agents = Object.fromEntries(
-    Object.entries(normalized.agents ?? {}).map(([name, entry]) => [
-      normalizeLowercaseStringOrEmpty(name),
-      entry.command.trim(),
-    ]),
+    Object.entries(normalized.agents ?? {}).map(([name, entry]) => {
+      const cmd = entry.command.trim();
+      const cmdArgs = entry.args ?? [];
+      const fullCommand = cmdArgs.length > 0 ? `${cmd} ${cmdArgs.join(" ")}` : cmd;
+      return [normalizeLowercaseStringOrEmpty(name), fullCommand];
+    }),
   );
 
   // Lowercase probeAgent so lookups match the registry keys built above, which

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -139,6 +139,17 @@ function resolveTsxImportSpecifier(): string {
   }
 }
 
+// Shell-quote a single argument so it survives command-line parsing as one token.
+// Wraps in single quotes and escapes embedded single quotes by ending the quoted
+// segment, inserting an escaped quote, and resuming the quoted segment.
+function shellQuote(arg: string): string {
+  if (!/[\s'"\\$|&;<>{}()*?\[\]~`]/.test(arg)) {
+    return arg;
+  }
+  const escaped = arg.replace(/'/g, "'\"'\"'");
+  return `'${escaped}'`;
+}
+
 function resolvePluginToolsMcpServerConfig(moduleUrl: string = import.meta.url): McpServerConfig {
   const pluginRoot = resolveAcpxPluginRoot(moduleUrl);
   const openClawRoot = resolveOpenClawRoot(pluginRoot);
@@ -241,7 +252,7 @@ export function resolveAcpxPluginConfig(params: {
     Object.entries(normalized.agents ?? {}).map(([name, entry]) => {
       const cmd = entry.command.trim();
       const cmdArgs = entry.args ?? [];
-      const fullCommand = cmdArgs.length > 0 ? `${cmd} ${cmdArgs.join(" ")}` : cmd;
+      const fullCommand = cmdArgs.length > 0 ? `${cmd} ${cmdArgs.map(shellQuote).join(" ")}` : cmd;
       return [normalizeLowercaseStringOrEmpty(name), fullCommand];
     }),
   );


### PR DESCRIPTION
## Summary
- Add optional `args` field to acpx agents config (`agents.<id>.args: string[]`)
- When `args` is provided, command and args are joined into a single command string for the acpx agent registry
- Backward compatible: omitting `args` works as before

## Context
The acpx agent config only accepted `command` as a flat string. This made it impossible to configure agent overrides with separate arguments in the structured config format (e.g., `openclaw.json`). Users had to embed args into the command string with careful quoting.

With `args` support:
```json
"agents": {
  "claude": {
    "command": "node",
    "args": ["/path/to/adapter.mjs", "--verbose"]
  }
}
```
is equivalent to `"command": "node /path/to/adapter.mjs --verbose"`.

## Test plan
- [x] Unit tests for args merging and backward compatibility in `config.test.ts`
- [x] All 12 existing acpx config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)