### PR TITLE
fix: recover macOS Gateway LaunchAgent after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/update: recover an installed-but-unloaded macOS LaunchAgent after package updates, rerun Gateway health/version/channel readiness checks, and print restart, reinstall, and rollback guidance before reporting update failure. (#76790) Thanks @jonathanlindsay.
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.
 - Memory/status: split builtin sqlite-vec store readiness from embedding-provider readiness in `memory status --deep` and `openclaw status`, so local vector-store failures no longer look like provider failures and provider failures no longer hide a healthy local vector store.
 - Memory/status: keep plain `openclaw memory status` and `openclaw memory status --json` on the cheap read-only path by reserving vector and embedding provider probes for `--deep` or `--index`. Fixes #76769. Thanks @daruire.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -103,10 +103,17 @@ explicit `openclaw completion --write-state` runs.
 When a local managed Gateway service is installed and restart is enabled,
 package-manager updates stop the running service before replacing the package
 tree, then refresh the service metadata from the updated install, restart the
-service, and verify the restarted Gateway reports the expected version. With
-`--no-restart`, package replacement still runs but the managed service is not
-stopped or restarted, so the running Gateway may keep old code until you restart
-it manually.
+service, and verify the restarted Gateway reports the expected version before
+reporting success. On macOS, the post-update check also verifies the LaunchAgent
+is loaded/running for the active profile and the configured loopback port is
+healthy. If the plist is installed but launchd is not supervising it, OpenClaw
+re-bootstraps and kickstarts the LaunchAgent automatically, then reruns the
+health/version/channel readiness checks. If the Gateway still does not become
+healthy, the command exits non-zero and prints the restart log path plus explicit
+restart, reinstall, and package rollback instructions. With `--no-restart`,
+package replacement still runs but the managed service is not stopped or
+restarted, so the running Gateway may keep old code until you restart it
+manually.
 
 ## Git checkout flow
 

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -1,13 +1,15 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildGatewayInstallEntrypointCandidates as resolveGatewayInstallEntrypointCandidates,
   resolveGatewayInstallEntrypoint,
 } from "../../daemon/gateway-entrypoint.js";
 import {
   collectMissingPluginInstallPayloads,
+  recoverInstalledLaunchAgentAfterUpdate,
+  recoverLaunchAgentAndRecheckGatewayHealth,
   resolvePostInstallDoctorEnv,
   shouldPrepareUpdatedInstallRestart,
   resolveUpdatedGatewayRestartPort,
@@ -232,5 +234,204 @@ describe("shouldUseLegacyProcessRestartAfterUpdate", () => {
   it("keeps the in-process restart path for non-package updates", () => {
     expect(shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "git" })).toBe(true);
     expect(shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "unknown" })).toBe(true);
+  });
+});
+describe("recoverInstalledLaunchAgentAfterUpdate", () => {
+  it("re-bootstraps an installed-but-not-loaded macOS LaunchAgent after update", async () => {
+    const service = {} as never;
+    const serviceEnv = { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv;
+    const recoveredEnv = { ...serviceEnv, OPENCLAW_PORT: "18790" } as NodeJS.ProcessEnv;
+    const readState = vi.fn(async () => ({
+      installed: true,
+      loaded: false,
+      running: false,
+      env: recoveredEnv,
+      command: null,
+      runtime: { status: "unknown", missingSupervision: true },
+    }));
+    const recover = vi.fn(async () => ({
+      result: "restarted" as const,
+      loaded: true as const,
+      message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+    }));
+
+    await expect(
+      recoverInstalledLaunchAgentAfterUpdate({
+        service,
+        env: serviceEnv,
+        deps: {
+          platform: "darwin",
+          readState: readState as never,
+          recover: recover as never,
+        },
+      }),
+    ).resolves.toEqual({
+      attempted: true,
+      recovered: true,
+      message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+    });
+
+    expect(readState).toHaveBeenCalledWith(service, { env: serviceEnv });
+    expect(recover).toHaveBeenCalledWith({ result: "restarted", env: recoveredEnv });
+  });
+
+  it("does not touch non-macOS service managers", async () => {
+    const readState = vi.fn();
+    const recover = vi.fn();
+
+    await expect(
+      recoverInstalledLaunchAgentAfterUpdate({
+        service: {} as never,
+        deps: {
+          platform: "linux",
+          readState: readState as never,
+          recover: recover as never,
+        },
+      }),
+    ).resolves.toEqual({ attempted: false, recovered: false });
+
+    expect(readState).not.toHaveBeenCalled();
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("does not recover a loaded LaunchAgent", async () => {
+    const readState = vi.fn(async () => ({
+      installed: true,
+      loaded: true,
+      running: true,
+      env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
+      command: null,
+      runtime: { status: "running" },
+    }));
+    const recover = vi.fn();
+
+    await expect(
+      recoverInstalledLaunchAgentAfterUpdate({
+        service: {} as never,
+        deps: {
+          platform: "darwin",
+          readState: readState as never,
+          recover: recover as never,
+        },
+      }),
+    ).resolves.toEqual({ attempted: false, recovered: false });
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("returns an explicit failed recovery state when bootstrap repair fails", async () => {
+    const readState = vi.fn(async () => ({
+      installed: true,
+      loaded: false,
+      running: false,
+      env: { OPENCLAW_PROFILE: "stomme" } as NodeJS.ProcessEnv,
+      command: null,
+      runtime: { status: "unknown", missingSupervision: true },
+    }));
+    const recover = vi.fn(async () => null);
+
+    await expect(
+      recoverInstalledLaunchAgentAfterUpdate({
+        service: {} as never,
+        deps: {
+          platform: "darwin",
+          readState: readState as never,
+          recover: recover as never,
+        },
+      }),
+    ).resolves.toEqual({
+      attempted: true,
+      recovered: false,
+      detail:
+        "LaunchAgent was installed but not loaded; automatic bootstrap/kickstart recovery failed.",
+    });
+  });
+});
+
+describe("recoverLaunchAgentAndRecheckGatewayHealth", () => {
+  it("does not report recovered update health until the gateway passes the post-recovery wait", async () => {
+    const service = {} as never;
+    const unhealthy = {
+      runtime: { status: "stopped" },
+      portUsage: { port: 18790, status: "free", listeners: [], hints: [] },
+      healthy: false,
+      staleGatewayPids: [],
+      waitOutcome: "stopped-free",
+    } as never;
+    const healthy = {
+      runtime: { status: "running", pid: 4242 },
+      portUsage: { port: 18790, status: "busy", listeners: [{ pid: 4242 }], hints: [] },
+      healthy: true,
+      staleGatewayPids: [],
+      gatewayVersion: "2026.5.3",
+      waitOutcome: "healthy",
+    } as never;
+    const recoverLaunchAgent = vi.fn(async () => ({
+      attempted: true as const,
+      recovered: true as const,
+      message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+    }));
+    const waitForHealthy = vi.fn(async () => healthy);
+
+    await expect(
+      recoverLaunchAgentAndRecheckGatewayHealth({
+        health: unhealthy,
+        service,
+        port: 18790,
+        expectedVersion: "2026.5.3",
+        env: { OPENCLAW_PROFILE: "stomme", OPENCLAW_PORT: "18790" },
+        deps: { recoverLaunchAgent, waitForHealthy },
+      }),
+    ).resolves.toEqual({
+      health: healthy,
+      launchAgentRecovery: {
+        attempted: true,
+        recovered: true,
+        message:
+          "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+      },
+    });
+
+    expect(waitForHealthy).toHaveBeenCalledWith({
+      service,
+      port: 18790,
+      expectedVersion: "2026.5.3",
+      env: { OPENCLAW_PROFILE: "stomme", OPENCLAW_PORT: "18790" },
+    });
+  });
+
+  it("keeps the update unhealthy when LaunchAgent repair succeeds but health does not recover", async () => {
+    const service = {} as never;
+    const unhealthySnapshot = {
+      runtime: { status: "stopped" },
+      portUsage: { port: 18790, status: "free", listeners: [], hints: [] },
+      healthy: false,
+      staleGatewayPids: [],
+      waitOutcome: "stopped-free",
+    };
+    const unhealthy = unhealthySnapshot as never;
+    const stillUnhealthy = {
+      ...unhealthySnapshot,
+      waitOutcome: "timeout",
+    } as never;
+    const recoverLaunchAgent = vi.fn(async () => ({
+      attempted: true as const,
+      recovered: true as const,
+      message: "Gateway LaunchAgent was installed but not loaded; re-bootstrapped launchd service.",
+    }));
+    const waitForHealthy = vi.fn(async () => stillUnhealthy);
+
+    await expect(
+      recoverLaunchAgentAndRecheckGatewayHealth({
+        health: unhealthy,
+        service,
+        port: 18790,
+        expectedVersion: "2026.5.3",
+        deps: { recoverLaunchAgent, waitForHealthy },
+      }),
+    ).resolves.toMatchObject({
+      health: { healthy: false, waitOutcome: "timeout" },
+      launchAgentRecovery: { attempted: true, recovered: true },
+    });
   });
 });

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -21,7 +21,11 @@ import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/constants.js";
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
-import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import {
+  readGatewayServiceState,
+  resolveGatewayService,
+  type GatewayService,
+} from "../../daemon/service.js";
 import { createLowDiskSpaceWarning } from "../../infra/disk-space.js";
 import { runGlobalPackageUpdateSteps } from "../../infra/package-update-steps.js";
 import { getSelfAndAncestorPidsSync } from "../../infra/restart-stale-pids.js";
@@ -68,10 +72,12 @@ import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-runtime.js";
 import { runDaemonInstall, runDaemonRestart } from "../daemon-cli.js";
+import { recoverInstalledLaunchAgent } from "../daemon-cli/launchd-recovery.js";
 import {
   renderRestartDiagnostics,
   terminateStaleGatewayPids,
   waitForGatewayHealthyRestart,
+  type GatewayRestartSnapshot,
 } from "../daemon-cli/restart-health.js";
 import { commitPluginInstallRecordsWithConfig } from "../plugins-install-record-commit.js";
 import { listPersistedBundledPluginLocationBridges } from "../plugins-location-bridges.js";
@@ -230,6 +236,110 @@ export function shouldUseLegacyProcessRestartAfterUpdate(params: {
   updateMode: UpdateRunResult["mode"];
 }): boolean {
   return !isPackageManagerUpdateMode(params.updateMode);
+}
+
+type PostUpdateLaunchAgentRecoveryResult =
+  | { attempted: false; recovered: false }
+  | { attempted: true; recovered: true; message: string }
+  | { attempted: true; recovered: false; detail: string };
+
+type PostUpdateLaunchAgentRecoveryDeps = {
+  platform?: NodeJS.Platform;
+  readState?: typeof readGatewayServiceState;
+  recover?: typeof recoverInstalledLaunchAgent;
+};
+
+export async function recoverInstalledLaunchAgentAfterUpdate(params: {
+  service?: GatewayService;
+  env?: NodeJS.ProcessEnv;
+  deps?: PostUpdateLaunchAgentRecoveryDeps;
+}): Promise<PostUpdateLaunchAgentRecoveryResult> {
+  const platform = params.deps?.platform ?? process.platform;
+  if (platform !== "darwin") {
+    return { attempted: false, recovered: false };
+  }
+
+  const service = params.service ?? resolveGatewayService();
+  const readState = params.deps?.readState ?? readGatewayServiceState;
+  const recover = params.deps?.recover ?? recoverInstalledLaunchAgent;
+  const state = await readState(service, { env: params.env }).catch(() => null);
+  if (state?.loaded) {
+    return { attempted: false, recovered: false };
+  }
+  if (state && !state.installed && !state.runtime?.missingSupervision) {
+    return { attempted: false, recovered: false };
+  }
+
+  const recovered = await recover({ result: "restarted", env: state?.env ?? params.env }).catch(
+    () => null,
+  );
+  if (!recovered) {
+    return {
+      attempted: true,
+      recovered: false,
+      detail:
+        "LaunchAgent was installed but not loaded; automatic bootstrap/kickstart recovery failed.",
+    };
+  }
+
+  return {
+    attempted: true,
+    recovered: true,
+    message: recovered.message,
+  };
+}
+
+type PostUpdateGatewayHealthRecoveryDeps = {
+  recoverLaunchAgent?: typeof recoverInstalledLaunchAgentAfterUpdate;
+  waitForHealthy?: typeof waitForGatewayHealthyRestart;
+};
+
+export async function recoverLaunchAgentAndRecheckGatewayHealth(params: {
+  health: GatewayRestartSnapshot;
+  service: GatewayService;
+  port: number;
+  expectedVersion?: string;
+  env?: NodeJS.ProcessEnv;
+  deps?: PostUpdateGatewayHealthRecoveryDeps;
+}): Promise<{
+  health: GatewayRestartSnapshot;
+  launchAgentRecovery: PostUpdateLaunchAgentRecoveryResult | null;
+}> {
+  if (params.health.healthy) {
+    return { health: params.health, launchAgentRecovery: null };
+  }
+
+  const recoverLaunchAgent =
+    params.deps?.recoverLaunchAgent ?? recoverInstalledLaunchAgentAfterUpdate;
+  const launchAgentRecovery = await recoverLaunchAgent({
+    service: params.service,
+    env: params.env,
+  });
+  if (!launchAgentRecovery.recovered) {
+    return { health: params.health, launchAgentRecovery };
+  }
+
+  const waitForHealthy = params.deps?.waitForHealthy ?? waitForGatewayHealthyRestart;
+  const health = await waitForHealthy({
+    service: params.service,
+    port: params.port,
+    expectedVersion: params.expectedVersion,
+    env: params.env,
+  });
+  return { health, launchAgentRecovery };
+}
+
+function formatPostUpdateGatewayRecoveryInstructions(result: UpdateRunResult): string[] {
+  const lines = [
+    `Recovery: run \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`; if macOS reports the LaunchAgent is installed but not loaded, run \`${replaceCliName(formatCliCommand("openclaw gateway install --force"), CLI_NAME)}\` from the logged-in user session, then rerun \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\`.`,
+  ];
+  const beforeVersion = normalizeOptionalString(result.before?.version);
+  if (isPackageManagerUpdateMode(result.mode) && beforeVersion) {
+    lines.push(
+      `Rollback: reinstall OpenClaw ${beforeVersion} with the same package manager, then rerun \`${replaceCliName(formatCliCommand("openclaw gateway install --force"), CLI_NAME)}\`.`,
+    );
+  }
+  return lines;
 }
 
 type PrePackageServiceStop = {
@@ -1184,6 +1294,7 @@ async function maybeRestartService(params: {
       service,
       port: params.gatewayPort,
       expectedVersion: expectedGatewayVersion,
+      env: params.serviceEnv,
     });
     if (!health.healthy && health.staleGatewayPids.length > 0) {
       if (!params.opts.json) {
@@ -1199,7 +1310,31 @@ async function maybeRestartService(params: {
         service,
         port: params.gatewayPort,
         expectedVersion: expectedGatewayVersion,
+        env: params.serviceEnv,
       });
+    }
+
+    const recoveryVerification = await recoverLaunchAgentAndRecheckGatewayHealth({
+      health,
+      service,
+      port: params.gatewayPort,
+      expectedVersion: expectedGatewayVersion,
+      env: params.serviceEnv,
+    });
+    health = recoveryVerification.health;
+    const launchAgentRecovery = recoveryVerification.launchAgentRecovery;
+    if (launchAgentRecovery?.attempted) {
+      if (!params.opts.json) {
+        defaultRuntime.log(
+          launchAgentRecovery.recovered
+            ? theme.warn(launchAgentRecovery.message)
+            : theme.warn(launchAgentRecovery.detail),
+        );
+      } else {
+        defaultRuntime.error(
+          launchAgentRecovery.recovered ? launchAgentRecovery.message : launchAgentRecovery.detail,
+        );
+      }
     }
 
     if (health.healthy) {
@@ -1209,8 +1344,16 @@ async function maybeRestartService(params: {
     const diagnosticLines = [
       "Gateway did not become healthy after restart.",
       ...renderRestartDiagnostics(health),
+      ...(launchAgentRecovery?.attempted
+        ? [
+            launchAgentRecovery.recovered
+              ? `LaunchAgent recovery: ${launchAgentRecovery.message}`
+              : `LaunchAgent recovery failed: ${launchAgentRecovery.detail}`,
+          ]
+        : []),
       `Restart log: ${resolveGatewayRestartLogPath(params.serviceEnv ?? process.env)}`,
       `Run \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\` for details.`,
+      ...formatPostUpdateGatewayRecoveryInstructions(params.result),
     ];
     if (params.opts.json) {
       defaultRuntime.error(diagnosticLines.join("\n"));


### PR DESCRIPTION
## Summary
- Add a macOS-only post-update fail-safe that detects an installed-but-not-loaded Gateway LaunchAgent and reuses the existing launchd bootstrap/kickstart repair path.
- Re-run Gateway health/version/channel readiness checks after recovery so package-manager updates do not report success until the restarted Gateway is actually healthy.
- Add explicit operator recovery and package rollback guidance when post-update health still fails.
- Document the post-update LaunchAgent recovery behavior in the CLI update docs.

## Root cause / audit
Package-manager updates already restart the managed Gateway and wait for the expected Gateway version, but the final failure path did not make a second-chance macOS LaunchAgent repair attempt when launchd had a plist installed but was not supervising it. In that state the service can appear installed yet remain unloaded, leaving customers with a completed package update but no running Gateway until an operator manually bootstraps/kickstarts launchd.

## Tests
- `corepack pnpm exec oxfmt --check --threads=1 src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts docs/cli/update.md`
- `node scripts/test-projects.mjs src/cli/update-cli/update-command.test.ts src/cli/update-cli/restart-helper.test.ts src/cli/daemon-cli/launchd-recovery.test.ts` (49 tests)
- `corepack pnpm tsgo:core`
- `corepack pnpm tsgo:core:test`
- `node scripts/check-docs-mdx.mjs docs/cli/update.md`
- `corepack pnpm build`

## Stomme-only local verification
No Atlas/PolyTrader profile or port 18789 checks were used.

- `OPENCLAW_PROFILE=stomme OPENCLAW_PORT=18790 openclaw --version` → `OpenClaw 2026.5.2 (8b2a6e5)`
- `launchctl print gui/$(id -u)/ai.openclaw.stomme` → loaded/running, pid observed
- `OPENCLAW_PROFILE=stomme OPENCLAW_PORT=18790 openclaw gateway status --json --url ws://127.0.0.1:18790 --timeout 150000 --require-rpc` → service loaded=true, runtime=running, gateway port=18790, rpc.ok=true, port status=busy
- `GET http://127.0.0.1:18790/health` → 200 / live
- `GET http://127.0.0.1:18790/ready` → 200
- `OPENCLAW_PROFILE=stomme OPENCLAW_PORT=18790 openclaw channels status --json --probe --timeout 150000` → Telegram configured, probe ok (non-secret fields only inspected)
