### PR TITLE
fix(googlechat): restore verification certificate retrieval after headers regression (#76742)

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -339,6 +339,47 @@ describe("googlechat google auth runtime", () => {
     }
   });
 
+  it("normalizes Google auth request headers before upstream interceptors run", async () => {
+    const config = {
+      headers: { "x-test": "1" },
+      url: new URL("https://www.googleapis.com/oauth2/v1/certs"),
+    };
+
+    const normalized = __testing.normalizeGoogleAuthPreparedRequestHeaders(config);
+
+    expect(normalized.headers).toBeInstanceOf(Headers);
+    expect(normalized.headers.has("x-test")).toBe(true);
+    expect(normalized.headers.get("x-test")).toBe("1");
+  });
+
+  it("normalizes plain-object response headers to a Headers instance", () => {
+    const response = {
+      headers: { "cache-control": "max-age=3600", "content-type": "application/json" },
+      config: {},
+      data: {},
+    };
+
+    const normalized = __testing.normalizeGoogleAuthResponseHeaders(response);
+
+    expect(normalized.headers).toBeInstanceOf(Headers);
+    expect((normalized.headers as Headers).get("cache-control")).toBe("max-age=3600");
+    expect((normalized.headers as Headers).get("content-type")).toBe("application/json");
+  });
+
+  it("leaves native Headers on response untouched", () => {
+    const nativeHeaders = new Headers({ "cache-control": "no-cache" });
+    const response = {
+      headers: nativeHeaders,
+      config: {},
+      data: {},
+    };
+
+    const normalized = __testing.normalizeGoogleAuthResponseHeaders(response);
+
+    expect(normalized.headers).toBe(nativeHeaders);
+    expect((normalized.headers as Headers).get("cache-control")).toBe("no-cache");
+  });
+
   it("rejects service-account credentials that override Google auth endpoints", async () => {
     await expect(
       resolveValidatedGoogleChatCredentials({

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -8,8 +8,9 @@ const mocks = vi.hoisted(() => ({
     hostnameAllowlist: hosts,
   })),
   fetchWithSsrFGuard: vi.fn(),
-  gaxiosCtor: vi.fn(function MockGaxios(this: { defaults: Record<string, unknown> }, defaults) {
+  gaxiosCtor: vi.fn(function MockGaxios(this: { defaults: Record<string, unknown>; interceptors: { request: Set<unknown>; response: Set<unknown> } }, defaults) {
     this.defaults = defaults as Record<string, unknown>;
+    this.interceptors = { request: new Set(), response: new Set() };
   }),
 }));
 
@@ -434,6 +435,43 @@ describe("googlechat google auth runtime", () => {
     } finally {
       await fs.rm(tempDir, { force: true, recursive: true });
     }
+  });
+
+  it("registers a request interceptor that normalizes plain-object headers to Headers instances (#76742)", async () => {
+    const transport = await getGoogleAuthTransport();
+    const interceptors = (transport as unknown as { interceptors: { request: Set<{ resolved: (config: unknown) => Promise<unknown> }> } }).interceptors.request;
+    expect(interceptors.size).toBeGreaterThanOrEqual(1);
+
+    // Simulate what gaxios `extend(true, {}, config)` can produce when the
+    // bundled deep-clone downgrades a `Headers` instance to a plain object.
+    const plainObjectHeaders = { "x-goog-api-client": "gl-node/24.14.1" };
+    const config = { headers: plainObjectHeaders, url: "https://example.com" };
+
+    // Run through all registered interceptors in order.
+    let processed: Record<string, unknown> = config;
+    for (const interceptor of interceptors) {
+      processed = (await interceptor.resolved(processed)) as Record<string, unknown>;
+    }
+
+    expect(processed.headers).toBeInstanceOf(Headers);
+    expect((processed.headers as Headers).has("x-goog-api-client")).toBe(true);
+    expect((processed.headers as Headers).get("x-goog-api-client")).toBe("gl-node/24.14.1");
+  });
+
+  it("headers interceptor leaves proper Headers instances untouched (#76742)", async () => {
+    const transport = await getGoogleAuthTransport();
+    const interceptors = (transport as unknown as { interceptors: { request: Set<{ resolved: (config: unknown) => Promise<unknown> }> } }).interceptors.request;
+
+    const nativeHeaders = new Headers({ accept: "application/json" });
+    const config = { headers: nativeHeaders, url: "https://example.com" };
+
+    let processed: Record<string, unknown> = config;
+    for (const interceptor of interceptors) {
+      processed = (await interceptor.resolved(processed)) as Record<string, unknown>;
+    }
+
+    // Should be the exact same instance — no unnecessary re-wrapping.
+    expect(processed.headers).toBe(nativeHeaders);
   });
 
   it("does not disclose raw credential paths or OS errors when file reads fail", async () => {

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -20,6 +20,9 @@ type GoogleAuthRuntime = {
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
 type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
+type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
+  headers?: unknown;
+};
 type GuardedGoogleAuthRequestInit = RequestInit & {
   agent?: unknown;
   cert?: unknown;
@@ -66,6 +69,47 @@ const MAX_GOOGLE_CHAT_SERVICE_ACCOUNT_FILE_BYTES = 64 * 1024;
 
 let googleAuthRuntimePromise: Promise<GoogleAuthRuntime> | null = null;
 let googleAuthTransportPromise: Promise<GoogleAuthTransport> | null = null;
+
+function normalizeGoogleAuthPreparedRequestHeaders<T extends GoogleAuthRequestWithUnknownHeaders>(
+  config: T,
+): T & { headers: Headers } {
+  if (!(config.headers instanceof Headers)) {
+    config.headers = new Headers(config.headers as HeadersInit | undefined);
+  }
+  return config as T & { headers: Headers };
+}
+
+/**
+ * Ensure response headers support the `.get()` method expected by
+ * `google-auth-library` (e.g. `getFederatedSignonCertsAsync` reads
+ * `res?.headers.get('cache-control')`).
+ *
+ * When the bundled build's deep-clone utility (`extend`) from gaxios
+ * serialises a `GaxiosResponse`, the native `Headers` instance can be
+ * downgraded to a plain `Record<string, string>` whose `.get()` method is
+ * lost.  This helper converts such objects back to a proper `Headers`.
+ */
+function normalizeGoogleAuthResponseHeaders<
+  T extends { headers?: unknown; config?: unknown; data?: unknown },
+>(response: T): T {
+  const h = response.headers;
+  if (h && typeof h === "object" && !(h instanceof Headers) && typeof (h as Headers).get !== "function") {
+    (response as Record<string, unknown>).headers = new Headers(h as Record<string, string>);
+  }
+  return response;
+}
+
+function installGoogleAuthHeaderCompatibilityInterceptor(
+  transport: GoogleAuthTransport,
+): GoogleAuthTransport {
+  transport.interceptors.request.add({
+    resolved: async (config) => normalizeGoogleAuthPreparedRequestHeaders(config),
+  });
+  transport.interceptors.response.add({
+    resolved: async (response) => normalizeGoogleAuthResponseHeaders(response),
+  });
+  return transport;
+}
 
 function asNullableObjectRecord(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : null;
@@ -507,23 +551,7 @@ export async function getGoogleAuthTransport(): Promise<GoogleAuthTransport> {
         const transport = new Gaxios({
           fetchImplementation: createGoogleAuthFetch(),
         });
-        // google-auth-library's AuthClient registers a request interceptor
-        // that calls `config.headers.has()` / `.set()` expecting a native
-        // `Headers` instance.  When the bundled build's deep-clone utility
-        // (`extend`) copies the prepared config, `Headers` can be downgraded
-        // to a plain object whose prototype methods are lost.  Normalizing
-        // headers here — before the AuthClient interceptor fires — prevents
-        // the "config.headers.has is not a function" regression (#76742).
-        transport.interceptors.request.add({
-          resolved: async (config) => {
-            if (config.headers != null && !(config.headers instanceof Headers)) {
-              config.headers = new Headers(
-                config.headers as unknown as HeadersInit,
-              );
-            }
-            return config;
-          },
-        });
+        installGoogleAuthHeaderCompatibilityInterceptor(transport);
         return transport;
       } catch (error) {
         googleAuthTransportPromise = null;
@@ -552,6 +580,8 @@ export const __testing = {
     googleAuthRuntimePromise = null;
     googleAuthTransportPromise = null;
   },
+  normalizeGoogleAuthPreparedRequestHeaders,
+  normalizeGoogleAuthResponseHeaders,
   resolveGoogleAuthEnvProxyUrl,
   validateGoogleChatServiceAccountCredentials,
 };

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -504,9 +504,27 @@ export async function getGoogleAuthTransport(): Promise<GoogleAuthTransport> {
     googleAuthTransportPromise = (async () => {
       try {
         const { Gaxios } = await loadGoogleAuthRuntime();
-        return new Gaxios({
+        const transport = new Gaxios({
           fetchImplementation: createGoogleAuthFetch(),
         });
+        // google-auth-library's AuthClient registers a request interceptor
+        // that calls `config.headers.has()` / `.set()` expecting a native
+        // `Headers` instance.  When the bundled build's deep-clone utility
+        // (`extend`) copies the prepared config, `Headers` can be downgraded
+        // to a plain object whose prototype methods are lost.  Normalizing
+        // headers here — before the AuthClient interceptor fires — prevents
+        // the "config.headers.has is not a function" regression (#76742).
+        transport.interceptors.request.add({
+          resolved: async (config) => {
+            if (config.headers != null && !(config.headers instanceof Headers)) {
+              config.headers = new Headers(
+                config.headers as unknown as HeadersInit,
+              );
+            }
+            return config;
+          },
+        });
+        return transport;
       } catch (error) {
         googleAuthTransportPromise = null;
         throw error;


### PR DESCRIPTION
Fixes #76742

## Root Cause

`google-auth-library`'s `AuthClient` registers a `DEFAULT_REQUEST_INTERCEPTOR` that calls `config.headers.has('x-goog-api-client')`, expecting `config.headers` to be a native `Headers` instance.

After the `stageRuntimeDependencies` removal in ed8f50f24, the bundled build's deep-clone utility (`extend`) used by gaxios's `#prepareRequest` can downgrade a `Headers` instance to a plain object whose prototype methods (`.has()`, `.set()`, etc.) are lost. This causes:

```
Google Chat webhook auth rejected: Failed to retrieve verification certificates: config.headers.has is not a function
```

when `OAuth2Client.verifyIdToken()` → `getFederatedSignonCertsAsync()` fetches federated sign-on certificates through the shared Gaxios transport.

## Fix

Add a headers-normalizing request interceptor to the shared Gaxios transport in `getGoogleAuthTransport()`. This interceptor runs **before** the AuthClient interceptor and converts any plain-object headers back to a proper `Headers` instance. If headers are already a `Headers` instance, they are left untouched.

## Tests

- Added test verifying plain-object headers are normalized to `Headers` instances
- Added test verifying native `Headers` instances are passed through unchanged