### PR TITLE
fix(anthropic): expose resolveThinkingProfile from bundled policy artifact

### DIFF
--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -1,6 +1,10 @@
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
-import { applyConfigDefaults, normalizeConfig } from "./provider-policy-api.js";
+import {
+  applyConfigDefaults,
+  normalizeConfig,
+  resolveThinkingProfile,
+} from "./provider-policy-api.js";
 
 function createModel(id: string, name: string): ModelDefinitionConfig {
   return {
@@ -61,6 +65,31 @@ describe("anthropic provider policy public artifact", () => {
         providerConfig,
       }),
     ).toBe(providerConfig);
+  });
+
+  it("exposes Claude Opus 4.7 thinking levels without loading the full provider plugin", () => {
+    const profile = resolveThinkingProfile({
+      provider: "anthropic",
+      modelId: "claude-opus-4-7",
+    });
+
+    expect(profile).toMatchObject({
+      levels: expect.arrayContaining([{ id: "xhigh" }, { id: "adaptive" }, { id: "max" }]),
+      defaultLevel: "off",
+    });
+  });
+
+  it("keeps adaptive-only Claude profiles aligned with the runtime provider", () => {
+    const profile = resolveThinkingProfile({
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+
+    expect(profile).toMatchObject({
+      levels: expect.arrayContaining([{ id: "adaptive" }]),
+      defaultLevel: "adaptive",
+    });
+    expect(profile.levels.some((level) => level.id === "xhigh" || level.id === "max")).toBe(false);
   });
 
   it("applies Anthropic API-key defaults without loading the full provider plugin", () => {

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -1,3 +1,4 @@
+import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   applyAnthropicConfigDefaults,
@@ -10,4 +11,8 @@ export function normalizeConfig(params: { provider: string; providerConfig: Mode
 
 export function applyConfigDefaults(params: Parameters<typeof applyAnthropicConfigDefaults>[0]) {
   return applyAnthropicConfigDefaults(params);
+}
+
+export function resolveThinkingProfile(params: { provider?: string; modelId: string }) {
+  return resolveClaudeThinkingProfile(params.modelId);
 }


### PR DESCRIPTION
Closes #76779.

## What

Mirror the OpenAI / opencode bundled-policy pattern in `extensions/anthropic/provider-policy-api.ts` so non-runtime callers see the same Claude thinking profile that the in-process Anthropic plugin already builds.

## Why

`resolveProviderThinkingProfile` (in `src/plugins/provider-thinking.ts`) tries the active plugin registry first and then falls back to the bundled artifact's `resolveThinkingProfile`. The Anthropic artifact didn't export one, so the resolver fell through to BASE Claude levels for callers without the active runtime plugin loaded — most notably:

- Cron isolated agents (`isolated-agent-*.ts` → `Thinking level "max" is not supported for anthropic/claude-opus-4-7; downgrading to "high".`)
- Persisted directive remap on session/model switch (`directive-handling.persist.runtime-*.ts` → user-facing `Thinking level set to high (max not supported for anthropic/claude-opus-4-7).`)

…even though `docs/tools/thinking.md` advertises `xhigh`, `adaptive`, and `max` for Claude Opus 4.7, and `extensions/anthropic/register.runtime.ts` already wires the right profile via `resolveClaudeThinkingProfile(modelId)`.

## How

Re-export `resolveClaudeThinkingProfile` from the lightweight artifact, exactly the way `extensions/opencode/provider-policy-api.ts` does. No behavior change for callers that go through the active plugin runtime; bundled lookups now agree with `register.runtime.ts`.

```ts
import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";

export function resolveThinkingProfile(params: { provider?: string; modelId: string }) {
  return resolveClaudeThinkingProfile(params.modelId);
}
```

## Verification

User-facing repro before the fix (OpenClaw `2026.5.2`, Telegram chat command, `anthropic/claude-opus-4-7`):

```
/think max
Thinking level set to high (max not supported for anthropic/claude-opus-4-7).
```

After patching the locally installed bundled artifact with the equivalent JS, an isolated probe against the same module confirms the profile expands to match the runtime / docs:

```
anthropic/claude-opus-4-7:
  levels: off, minimal, low, medium, adaptive, high, xhigh, max
  default: off
  max ok: true · xhigh ok: true · adaptive ok: true
  resolveSupported(max): max
```

Other Claude families remain correct:

- `claude-opus-4-6`, `claude-sonnet-4-6` → `off, minimal, low, medium, adaptive, high` (default `adaptive`)
- `claude-haiku-4-5-20251001` → `off, minimal, low, medium, high` (no adaptive / xhigh / max)

## Tests

Added two cases to `extensions/anthropic/provider-policy-api.test.ts`, mirroring `extensions/opencode/provider-policy-api.test.ts`:

- Opus 4.7 surfaces `xhigh` + `adaptive` + `max` with `defaultLevel: "off"`.
- Opus 4.6 keeps the `adaptive`-only profile and never includes `xhigh` / `max`.

```
pnpm test extensions/anthropic/provider-policy-api.test.ts          → 6 passed
pnpm test src/plugin-sdk/provider-model-shared.test.ts              → 6 passed
pnpm test src/auto-reply/thinking.test.ts                           → 36 passed
pnpm check:changed                                                  → green
  - tsgo extensions / extensions:test
  - oxlint extensions
  - runtime sidecar loader guard
  - runtime import cycles
```

## Notes

- Pure re-export of an existing helper. No new public surface, no new config, no behavior change for the in-process plugin path.
- I'm not a maintainer; happy to follow the bot's review feedback on `#76779` (`@steipete` flagged as the most likely owner since the artifact and the shared helper were introduced together).
