### PR TITLE
ci: summarize Mantis bug proof comments

### DIFF
--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -14,7 +14,7 @@ on:
         default: main
         type: string
       pr_number:
-        description: Optional PR number to receive the QA evidence comment
+        description: Optional bug or fix PR number to receive the QA evidence comment
         required: false
         type: string
 
@@ -333,6 +333,8 @@ jobs:
           cat > "$comment_file" <<EOF
           <!-- mantis-discord-status-reactions -->
           ## Mantis Discord Status Reactions QA
+
+          Summary: Mantis reran Discord status reactions against the known queued-only baseline and the candidate ref. The baseline reproduced the bug, while the candidate showed the expected queued -> thinking -> done reaction sequence.
 
           - Scenario: \`discord-status-reactions-tool-only\`
           - Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -346,15 +346,20 @@ after the new secret has been stored.
 ## GitHub Artifacts And PR Comments
 
 Mantis workflows should upload the full evidence bundle as a short-lived Actions
-artifact. When the workflow is run for a PR, it should also publish the redacted
-PNG screenshots to the `qa-artifacts` branch and upsert a PR comment with inline
-before/after screenshots. Raw logs, observed messages, and other bulky evidence
-stay in the Actions artifact.
+artifact. When the workflow is run for a bug report or fix PR, it should also
+publish the redacted PNG screenshots to the `qa-artifacts` branch and upsert a
+comment on that bug or fix PR with inline before/after screenshots. Do not post
+the primary proof only on a generic QA automation PR. Raw logs, observed
+messages, and other bulky evidence stay in the Actions artifact.
 
 The PR comment should be short and visual:
 
 ```md
 Mantis Discord Status Reactions QA
+
+Summary: Mantis reran the reported Discord status-reaction bug against the known
+bad baseline and the candidate fix. The baseline reproduced the bug, while the
+candidate showed the expected queued -> thinking -> done sequence.
 
 - Scenario: `discord-status-reactions-tool-only`
 - Run: <workflow run link>


### PR DESCRIPTION
## Summary
- clarify that Mantis screenshot comments target the bug/fix PR, not a generic QA PR
- add a top summary to the inline screenshot comment template
- update Mantis docs with the target-PR evidence convention

## Verification
- actionlint .github/workflows/mantis-discord-status-reactions.yml
- pnpm exec oxfmt --check --threads=1 .github/workflows/mantis-discord-status-reactions.yml docs/concepts/mantis.md
- git diff --check

Also updated the existing QA comment on #76747 in place.