### PR TITLE
feat(gateway/transcript): add silent option to assistant transcript append helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 - Diagnostics: handle missing session-tail files in cron recovery context without tripping extension test typecheck. Thanks @vincentkoc.
 - QA/Slack: update the Slack dispatch preview fallback test SDK mock for structured progress draft helpers, so the rich progress draft regression suite covers the new imports instead of failing before assertions run. Thanks @vincentkoc.
+- Gateway/transcript inject: add a `silent` option to `appendInjectedAssistantMessageToTranscript` so callers that already have the assistant message visible on screen (e.g. WebChat streaming finalization) can persist to the JSONL without firing a `session.message` event that would trigger a downstream `chat.history` reload. Refs #76804. Thanks @jack-stormentswe.
 - Plugins/loader: keep bundled plugin package `test-api.js` aliases behind private QA mode, so source transforms do not expose test-only public surfaces during normal plugin loading. Thanks @vincentkoc.
 - Gateway/startup: start cron and record the post-ready memory trace even when deferred maintenance timers fail after readiness, so a non-fatal timer setup issue does not silently leave scheduled jobs idle. Thanks @vincentkoc.
 - Exec approvals: unwrap BSD/macOS `env -P <path>` carrier commands before approval-command and strict inline-eval checks, so `/approve` shell execution and inline interpreter payloads are still blocked behind that env form.

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -53,6 +53,14 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   abortMeta?: GatewayInjectedAbortMeta;
   now?: number;
   config?: SessionWriteLockAcquireTimeoutConfig;
+  /**
+   * When true, the JSONL transcript is updated but no `session.message`
+   * transcript-events listener is notified. Callers that already have the
+   * message visible on screen (e.g. WebChat streaming) can avoid triggering
+   * a downstream `chat.history` reload that would replace the rendered
+   * messages with the persisted snapshot. (#76804)
+   */
+  silent?: boolean;
 }): Promise<GatewayInjectedTranscriptAppendResult> {
   const now = params.now ?? Date.now();
   const usage = {
@@ -110,11 +118,13 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
       useRawWhenLinear: true,
       config: params.config,
     });
-    emitSessionTranscriptUpdate({
-      sessionFile: params.transcriptPath,
-      message: messageBody,
-      messageId,
-    });
+    if (!params.silent) {
+      emitSessionTranscriptUpdate({
+        sessionFile: params.transcriptPath,
+        message: messageBody,
+        messageId,
+      });
+    }
     return { ok: true, messageId, message: messageBody };
   } catch (err) {
     return { ok: false, error: formatErrorMessage(err) };

--- a/src/gateway/server-methods/chat.inject.parentid.test.ts
+++ b/src/gateway/server-methods/chat.inject.parentid.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as transcriptEvents from "../../sessions/transcript-events.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
 import { createTranscriptFixtureSync } from "./chat.test-helpers.js";
 
@@ -31,6 +32,54 @@ describe("gateway chat.inject transcript writes", () => {
       expect(last).toHaveProperty("id");
       expect(last).toHaveProperty("message");
     } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits a session transcript update by default (#76804)", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-chat-inject-emit-",
+      sessionId: "sess-emit",
+    });
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      const appended = await appendInjectedAssistantMessageToTranscript({
+        transcriptPath,
+        message: "hello",
+      });
+      expect(appended.ok).toBe(true);
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy.mock.calls[0]?.[0]).toMatchObject({
+        sessionFile: transcriptPath,
+        messageId: appended.messageId,
+      });
+    } finally {
+      emitSpy.mockRestore();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips the session transcript update emit when silent is set (#76804)", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-chat-inject-silent-",
+      sessionId: "sess-silent",
+    });
+    const emitSpy = vi.spyOn(transcriptEvents, "emitSessionTranscriptUpdate");
+    try {
+      const appended = await appendInjectedAssistantMessageToTranscript({
+        transcriptPath,
+        message: "hello",
+        silent: true,
+      });
+      expect(appended.ok).toBe(true);
+      expect(appended.messageId).toBeTruthy();
+      expect(emitSpy).not.toHaveBeenCalled();
+      const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/).filter(Boolean);
+      const last = JSON.parse(lines.at(-1) as string) as Record<string, unknown>;
+      expect(last).toHaveProperty("id", appended.messageId);
+      expect(last).toHaveProperty("message");
+    } finally {
+      emitSpy.mockRestore();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
Refs #76804.

The Gateway helper `appendInjectedAssistantMessageToTranscript` always emits a `session.message` event on the transcript-events bus after writing. WebChat clients listen for that event and call `chat.history`, which replaces visible chat messages from the persisted snapshot. Callers that already have the assistant message on screen via streaming have no way to persist a JSONL record without triggering that reload.

Add a `silent` option that skips the post-write `emitSessionTranscriptUpdate` call. The JSONL write is unchanged; only the WS broadcast is suppressed. The default stays opt-in (emit on by default) so existing callers are not affected.

The maintainer's main-branch fix for #76804 (skip chat.history reload during active sends) addresses the visible disappearing-message symptom; this option gives future and out-of-band transcript writers a safe way to keep the JSONL in sync without re-firing the reload path.

- `pnpm test src/gateway/server-methods/chat.inject.parentid.test.ts` -> 4/4 PASS (2 new cases: default emit + silent skip).
- `pnpm exec oxfmt --check` clean.