### PR TITLE
docs: clarify IRC managed proxy coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
+- Docs: clarify that IRC uses raw TCP/TLS sockets and is not proxied by managed HTTP proxy mode, so direct IRC egress should be explicitly approved before enabling IRC in managed-proxy deployments. Thanks @jesse-merhi.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
 - Discord/status: let explicit reaction tool calls opt into tracking subsequent tool progress on the reacted message with `trackToolCalls: true`, and use the shared tool display emoji table for status reactions.
 - Gateway/config: stop Gateway startup and hot reload from auto-restoring invalid config; invalid config now fails closed and `openclaw doctor --fix` owns last-known-good repair.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/commands: add `/steer <message>` for queue-independent steering of the active current-session run without starting a new turn when the session is idle. (#76934)
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Doctor/config: `doctor --fix` now commits safe legacy migrations even when unrelated validation issues (e.g. a missing plugin) prevent full validation from passing, so `agents.defaults.llm` and other known-legacy keys are always cleaned up by `doctor --fix` regardless of other config problems. Fixes #76798. (#76800) Thanks @hclsys.
-- Docs: clarify that IRC uses raw TCP/TLS sockets and is not proxied by managed HTTP proxy mode, so direct IRC egress should be explicitly approved before enabling IRC in managed-proxy deployments. Thanks @jesse-merhi.
+- Docs: clarify that IRC uses raw TCP/TLS sockets outside operator-managed forward proxy routing, so direct IRC egress should be explicitly approved before enabling IRC. Thanks @jesse-merhi.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
 - Discord/status: let explicit reaction tool calls opt into tracking subsequent tool progress on the reacted message with `trackToolCalls: true`, and use the shared tool display emoji table for status reactions.
 - Gateway/config: stop Gateway startup and hot reload from auto-restoring invalid config; invalid config now fails closed and `openclaw doctor --fix` owns last-known-good repair.

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -39,6 +39,7 @@ openclaw gateway run
 
 ## Security defaults
 
+- IRC uses raw TCP/TLS sockets. OpenClaw managed HTTP proxy mode does not proxy IRC traffic; disable IRC in managed-proxy deployments unless direct IRC egress is explicitly approved.
 - `channels.irc.dmPolicy` defaults to `"pairing"`.
 - `channels.irc.groupPolicy` defaults to `"allowlist"`.
 - With `groupPolicy="allowlist"`, set `channels.irc.groups` to define allowed channels.

--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -39,7 +39,7 @@ openclaw gateway run
 
 ## Security defaults
 
-- IRC uses raw TCP/TLS sockets. OpenClaw managed HTTP proxy mode does not proxy IRC traffic; disable IRC in managed-proxy deployments unless direct IRC egress is explicitly approved.
+- IRC uses raw TCP/TLS sockets outside OpenClaw operator-managed forward proxy routing. In deployments that require all egress through that forward proxy, set `channels.irc.enabled=false` unless direct IRC egress is explicitly approved.
 - `channels.irc.dmPolicy` defaults to `"pairing"`.
 - `channels.irc.groupPolicy` defaults to `"allowlist"`.
 - With `groupPolicy="allowlist"`, set `channels.irc.groups` to define allowed channels.

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -193,7 +193,7 @@ proxy:
 
 - The proxy improves coverage for process-local JavaScript HTTP and WebSocket clients, but it is not an OS-level network sandbox.
 - Raw `net`, `tls`, and `http2` sockets, native addons, and child processes may bypass Node-level proxy routing unless they inherit and respect proxy environment variables.
-- IRC is a raw TCP/TLS channel and is not proxied by managed HTTP proxy mode. Disable IRC in managed-proxy deployments unless direct IRC egress is explicitly approved.
+- IRC is a raw TCP/TLS channel outside operator-managed forward proxy routing. In deployments that require all egress through that forward proxy, set `channels.irc.enabled=false` unless direct IRC egress is explicitly approved.
 - User local WebUIs and local model servers should be allowlisted in the operator proxy policy when needed; OpenClaw does not expose a general local-network bypass for them.
 - Gateway control-plane proxy bypass is intentionally limited to `localhost` and literal loopback IP URLs. Use `ws://127.0.0.1:18789`, `ws://[::1]:18789`, or `ws://localhost:18789` for local direct Gateway control-plane connections; other hostnames route like ordinary hostname-based traffic.
 - OpenClaw does not inspect, test, or certify your proxy policy.

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -193,6 +193,7 @@ proxy:
 
 - The proxy improves coverage for process-local JavaScript HTTP and WebSocket clients, but it is not an OS-level network sandbox.
 - Raw `net`, `tls`, and `http2` sockets, native addons, and child processes may bypass Node-level proxy routing unless they inherit and respect proxy environment variables.
+- IRC is a raw TCP/TLS channel and is not proxied by managed HTTP proxy mode. Disable IRC in managed-proxy deployments unless direct IRC egress is explicitly approved.
 - User local WebUIs and local model servers should be allowlisted in the operator proxy policy when needed; OpenClaw does not expose a general local-network bypass for them.
 - Gateway control-plane proxy bypass is intentionally limited to `localhost` and literal loopback IP URLs. Use `ws://127.0.0.1:18789`, `ws://[::1]:18789`, or `ws://localhost:18789` for local direct Gateway control-plane connections; other hostnames route like ordinary hostname-based traffic.
 - OpenClaw does not inspect, test, or certify your proxy policy.


### PR DESCRIPTION
## Summary
- clarify that IRC uses raw TCP/TLS sockets and is not carried by OpenClaw managed HTTP proxy mode
- mention the IRC limitation in both IRC channel docs and managed network proxy docs
- advise managed-proxy deployments to disable IRC unless direct IRC egress is explicitly approved
- keep runtime behavior unchanged; no SOCKS5/HTTP CONNECT implementation is added because IRC usage is niche and proxy support would require IRC-specific infrastructure

## Test Plan
- [x] `pnpm format:check CHANGELOG.md docs/channels/irc.md docs/security/network-proxy.md`
- [x] `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed`