### PR TITLE
docs(tools): scope loop detection recommendation to smaller models

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -78,7 +78,7 @@ When a run id is available, recent tool-call history is evaluated only within th
 
 ## Recommended setup
 
-- Start with `enabled: true`, defaults unchanged.
+- For smaller models, start with `enabled: true`, defaults unchanged. Flagship models rarely need loop detection and can leave it disabled.
 - Keep thresholds ordered as `warningThreshold < criticalThreshold < globalCircuitBreakerThreshold`.
 - If false positives occur:
   - raise `warningThreshold` and/or `criticalThreshold`


### PR DESCRIPTION
## Summary
- Update the recommended setup in `docs/tools/loop-detection.md` so `enabled: true` is suggested only for smaller models. Flagship models rarely loop and can leave loop detection disabled.

## Test plan
- [ ] Visual review of the rendered docs page