### PR TITLE
[codex] Fix message CLI plugin preload failure exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/tools: stop treating `tools.deny: ["write"]` as an implicit `apply_patch` deny; operators who want to block patch writes should deny `apply_patch` or `group:fs` explicitly. Fixes #76749. (#76795) Thanks @Nek-12 and @hclsys.
 - Plugins/release: verify published plugin npm tarballs expose compiled runtime entries after publish, catching TS-only package artifacts before release closeout. Thanks @vincentkoc.
+- CLI/message: exit cleanly with a nonzero status when message-command plugin registry loading fails before dispatch, preventing `openclaw-message` children from staying alive after plugin load errors. Fixes #76168.
 - Gateway/update: recover an installed-but-unloaded macOS LaunchAgent after package updates, rerun Gateway health/version/channel readiness checks, and print restart, reinstall, and rollback guidance before reporting update failure. (#76790) Thanks @jonathanlindsay.
 - CLI/plugins: explain when a missing plugin command alias belongs to a bundled plugin that is disabled by default, including the `openclaw plugins enable <plugin>` repair command. (#76835)
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -136,6 +136,20 @@ describe("runMessageAction", () => {
     });
   });
 
+  it("exits with failure when plugin registry loading fails before dispatch", async () => {
+    vi.mocked(ensurePluginRegistryLoaded).mockImplementationOnce(() => {
+      throw new Error("plugin load failed");
+    });
+
+    await runSendAction();
+
+    expect(messageCommandMock).not.toHaveBeenCalled();
+    expect(errorMock).toHaveBeenCalledWith("Error: plugin load failed");
+    expect(exitMock).toHaveBeenCalledOnce();
+    expect(exitMock).toHaveBeenCalledWith(1);
+    expect(exitMock).not.toHaveBeenCalledWith(0);
+  });
+
   it("runs gateway_stop hooks before exit when registered", async () => {
     hasHooksMock.mockReturnValueOnce(true);
     await runSendAction();

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -82,12 +82,12 @@ export function createMessageCliHelpers(
 
   const runMessageAction = async (action: string, opts: Record<string, unknown>) => {
     setVerbose(Boolean(opts.verbose));
-    ensurePluginRegistryLoaded(resolveMessagePluginLoadOptions(opts));
-    const deps = createDefaultDeps();
     let failed = false;
     await runCommandWithRuntime(
       defaultRuntime,
       async () => {
+        ensurePluginRegistryLoaded(resolveMessagePluginLoadOptions(opts));
+        const deps = createDefaultDeps();
         await messageCommand(
           {
             ...normalizeMessageOptions(opts),


### PR DESCRIPTION
## Summary

- Move message CLI configured-channel plugin registry preload inside `runCommandWithRuntime` so preload failures use the message CLI error/exit path.
- Add regression coverage for plugin registry load failure before message dispatch.
- Add a changelog fix entry for #76168.

## Root Cause

`openclaw message` opts out of the command-catalog plugin bootstrap, then preloaded configured channel plugins directly in the message helper before `runCommandWithRuntime`. If that preload threw, the message CLI never reached its forced `defaultRuntime.exit(1)` path, which could leave message child processes alive when plugin loading failed.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/cli/program/message/helpers.ts src/cli/program/message/helpers.test.ts CHANGELOG.md`
- `pnpm test src/cli/program/message/helpers.test.ts`
- Testbox: `pnpm check:changed` (`tbx_01kqqdskjgmehrqs2jzjhvpkb5`, exit 0)
- `git diff --check`
- Live isolated CLI fixture: failing configured channel plugin setup entry, `timeout 10s pnpm openclaw message send --channel brokenlive ...` exited 1 in 7s with `PluginLoadFailureError`, and `pgrep` found no `openclaw-message` or message `run-node` leftovers afterward.

Fixes #76168.
