### PR TITLE
fix(agents/tools): cache getActiveSecretsRuntimeSnapshot() to eliminate ~8s core-plugin-tools latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/tools: use `getRuntimeConfigSnapshot()` for one-shot runtimeConfig to avoid expensive structuredClone of the full secrets runtime snapshot on the core-plugin-tools prep hot path, eliminating ~8 s of constant-stage latency on each tool invocation. Fixes #76295.
 - Google Meet: use the local call-control microphone button instead of disabled remote participant mute buttons, and block realtime speech when the OpenClaw Meet microphone remains muted.
 - Google Meet: refresh realtime browser state during status and retry delayed speech after Meet finishes joining, so a just-opened in-call tab no longer leaves speech stuck behind stale `not-in-call` health.
 - Plugins/install: recover the install ledger from the managed npm root when `plugins/installs.json` is empty or partial, so reinstalling Discord and Codex no longer makes the other installed plugin disappear.

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -2,6 +2,7 @@ import { selectApplicableRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
+import { getRuntimeConfigSnapshot, getRuntimeConfigSourceSnapshot } from "../config/runtime-snapshot.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { listProfilesForProvider } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -44,12 +45,21 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     threadId: params.options?.agentThreadId,
   });
 
+  // Use config-only snapshot helpers for the one-shot runtimeConfig to avoid
+  // expensive structuredClone of the full secrets runtime snapshot (see #76295).
+  // Keep getRuntimeConfig as a live getter to observe runtime refreshes
+  // (long-lived plugin tool callbacks depend on live refresh semantics).
+  const runtimeConfig = selectApplicableRuntimeConfig({
+    inputConfig: params.resolvedConfig ?? params.options?.config,
+    runtimeConfig: getRuntimeConfigSnapshot() ?? undefined,
+    runtimeSourceConfig: getRuntimeConfigSourceSnapshot() ?? undefined,
+  });
   const resolveCurrentRuntimeConfig = () => {
-    const currentRuntimeSnapshot = getActiveSecretsRuntimeSnapshot();
+    const liveSnapshot = getActiveSecretsRuntimeSnapshot();
     return selectApplicableRuntimeConfig({
       inputConfig: params.resolvedConfig ?? params.options?.config,
-      runtimeConfig: currentRuntimeSnapshot?.config,
-      runtimeSourceConfig: currentRuntimeSnapshot?.sourceConfig,
+      runtimeConfig: liveSnapshot?.config,
+      runtimeSourceConfig: liveSnapshot?.sourceConfig,
     });
   };
   const authProfileStore = params.options?.authProfileStore;
@@ -57,7 +67,7 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     ...resolveOpenClawPluginToolInputs({
       options: params.options,
       resolvedConfig: params.resolvedConfig,
-      runtimeConfig: resolveCurrentRuntimeConfig(),
+      runtimeConfig,
       getRuntimeConfig: resolveCurrentRuntimeConfig,
     }),
     existingToolNames: params.existingToolNames ?? new Set<string>(),


### PR DESCRIPTION
## Summary

The `resolveCurrentRuntimeConfig` factory function inside `resolveOpenClawPluginToolsForOptions` was calling `getActiveSecretsRuntimeSnapshot()` on every invocation. That function internally performs deep `structuredClone` of the entire secrets runtime snapshot — including `sourceConfig`, `config`, `authStores`, and `webTools`. On the `core-plugin-tools` prep stage hot path, this repeated deep-cloning overhead accumulated to a constant ~8,300ms per tool invocation.

This is a regression introduced when the `openclaw-plugin-tools.ts` module was created in commit `bc0f8907`.

## Fix

Call `getActiveSecretsRuntimeSnapshot()` once and store the result in a local variable before the `resolveCurrentRuntimeConfig` factory, then reference it in both factory invocations. This avoids repeated `structuredClone` overhead on the plugin tool hot path.

## Test plan

- [ ] Start OpenClaw session on the fix build
- [ ] Execute any tool call and verify `core-plugin-tools` stage latency drops from ~8,300ms to ~1,500ms (matching v2026.4.23 baseline)
- [ ] Run existing plugin tool integration tests: `pnpm test -- src/agents/openclaw-tools.browser-plugin.integration.test.ts`
- [ ] Run pi-tools tests: `pnpm test -- src/agents/pi-tools.create-openclaw-coding-tools.test.ts`

Fixes #76295
