### PR TITLE
fix(openai-codex): retry on IPv4 when IPv6 egress fails

### DIFF
--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -62,7 +62,7 @@ function createDispatcherWithPinnedOverride(lookup: PinnedHostname["lookup"]) {
 }
 
 describe("createPinnedDispatcher", () => {
-  it("uses pinned lookup without overriding global family policy", () => {
+  it("uses pinned lookup and inherits system autoSelectFamily", () => {
     const lookup = vi.fn() as unknown as PinnedHostname["lookup"];
     const pinned: PinnedHostname = {
       hostname: "api.telegram.org",
@@ -73,16 +73,13 @@ describe("createPinnedDispatcher", () => {
     const dispatcher = createPinnedDispatcher(pinned);
 
     expect(dispatcher).toBeDefined();
-    expect(agentCtor).toHaveBeenCalledWith({
-      connect: {
-        lookup,
-      },
-      allowH2: false,
-    });
     const firstCallArg = agentCtor.mock.calls[0]?.[0] as
       | { connect?: Record<string, unknown> }
       | undefined;
-    expect(firstCallArg?.connect?.autoSelectFamily).toBeUndefined();
+    expect(firstCallArg?.connect?.lookup).toBe(lookup);
+    // Per-request dispatchers now inherit the system autoSelectFamily setting
+    // (Happy Eyeballs) so IPv4-only hosts can fall back when DNS returns AAAA.
+    expect(firstCallArg?.connect?.autoSelectFamily).toBeDefined();
   });
 
   it("preserves caller transport hints while overriding lookup", () => {

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -1,3 +1,4 @@
+import * as net from "node:net";
 import { createRequire } from "node:module";
 
 export const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
@@ -22,6 +23,30 @@ type UndiciProxyAgentOptions = ConstructorParameters<UndiciRuntimeDeps["ProxyAge
 const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
   allowH2: false as const,
 });
+
+// Happy Eyeballs (RFC 8305): try IPv6 and IPv4 in parallel so hosts reachable
+// only on one family succeed without waiting for a full TCP timeout on the
+// other.  The per-request pinned dispatchers previously lacked this, causing
+// "fetch failed" on IPv4-only machines whose DNS still returned AAAA records
+// (see openclaw#76857).
+const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 300;
+
+function resolveAutoSelectFamilyConnectOptions(): {
+  autoSelectFamily: boolean;
+  autoSelectFamilyAttemptTimeout: number;
+} | undefined {
+  if (typeof net.getDefaultAutoSelectFamily !== "function") {
+    return undefined;
+  }
+  try {
+    return {
+      autoSelectFamily: net.getDefaultAutoSelectFamily(),
+      autoSelectFamilyAttemptTimeout: AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -65,9 +90,18 @@ function withHttp1OnlyDispatcherOptions<T extends object | undefined>(
   }
   // Enforce HTTP/1.1-only — must come after options to prevent accidental override
   Object.assign(base, HTTP1_ONLY_DISPATCHER_OPTIONS);
+  const baseRecord = base as Record<string, unknown>;
+  // Always propagate Happy Eyeballs to per-request dispatchers so they can
+  // fall back from IPv6→IPv4 (or vice-versa) without a full TCP timeout.
+  const autoSelectConnect = resolveAutoSelectFamilyConnectOptions();
+  if (autoSelectConnect && typeof baseRecord.connect !== "function") {
+    baseRecord.connect = {
+      ...(isObjectRecord(baseRecord.connect) ? baseRecord.connect : {}),
+      ...autoSelectConnect,
+    };
+  }
   if (timeoutMs !== undefined && Number.isFinite(timeoutMs) && timeoutMs > 0) {
     const normalizedTimeoutMs = Math.floor(timeoutMs);
-    const baseRecord = base as Record<string, unknown>;
     baseRecord.bodyTimeout = normalizedTimeoutMs;
     baseRecord.headersTimeout = normalizedTimeoutMs;
     if (typeof baseRecord.connect !== "function") {


### PR DESCRIPTION
Fixes #76857

## Problem

On IPv4-only Linux hosts where DNS still returns AAAA records (but there is no IPv6 route), OpenAI Codex Responses requests fail with `fetch failed` after a full TCP timeout. The workaround is pinning `chatgpt.com` to an IPv4 address in `/etc/hosts`.

Regression window: v2026.4.26 → v2026.5.2.

Same root-cause family as #76852 (telegram probe IPv4 fallback).

## Root Cause

Per-request pinned dispatchers created by `fetchWithSsrFGuard` (used by all LLM provider transports) did **not** inherit the system `autoSelectFamily` (Happy Eyeballs / RFC 8305) setting from the global dispatcher. Without Happy Eyeballs, undici attempts a single address-family connection; when the kernel prefers IPv6 and there is no IPv6 route, the connection hangs until TCP timeout.

The global dispatcher (`undici-global-dispatcher.ts`) already sets `autoSelectFamily`, but the per-request `Agent` instances created via `createHttp1Agent` → `withHttp1OnlyDispatcherOptions` never propagated it to their `connect` options.

## Fix

Propagate the system `net.getDefaultAutoSelectFamily()` setting into `withHttp1OnlyDispatcherOptions` so every per-request `Agent` / `EnvHttpProxyAgent` / `ProxyAgent` gets `autoSelectFamily` in its connect options. This lets undici race IPv6 and IPv4 connections with a 300ms head-start, falling back immediately when one family is unreachable.

The fix is in the generic transport layer (`src/infra/net/undici-runtime.ts`) rather than a single provider, so it benefits all providers hitting dual-stack endpoints on single-stack hosts.

## Testing

- Updated existing dispatcher test to verify `autoSelectFamily` is now present on pinned dispatchers