### PR TITLE
fix(discord): resolve named account SecretRefs against active runtime snapshot

### DIFF
--- a/extensions/discord/src/token.test.ts
+++ b/extensions/discord/src/token.test.ts
@@ -91,7 +91,43 @@ describe("resolveDiscordToken", () => {
     expect(res.source).toBe("config");
   });
 
-  it("throws when token is an unresolved SecretRef object", () => {
+  it("resolves env-backed SecretRef from process.env", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN_SUBAGENT", "resolved-env-token");
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            subagent: {
+              token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN_SUBAGENT" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const res = resolveDiscordToken(cfg, { accountId: "subagent" });
+    expect(res.token).toBe("resolved-env-token");
+    expect(res.source).toBe("config");
+  });
+
+  it("returns none when env-backed SecretRef env var is not set", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            subagent: {
+              token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN_SUBAGENT" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const res = resolveDiscordToken(cfg, { accountId: "subagent" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+  });
+
+  it("resolves channel-level env-backed SecretRef", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "channel-level-resolved");
     const cfg = {
       channels: {
         discord: {
@@ -99,9 +135,39 @@ describe("resolveDiscordToken", () => {
         },
       },
     } as unknown as OpenClawConfig;
+    const res = resolveDiscordToken(cfg);
+    expect(res.token).toBe("channel-level-resolved");
+    expect(res.source).toBe("config");
+  });
 
+  it("throws for non-env SecretRef that cannot be resolved", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: { source: "file", provider: "vault", id: "discord-token" },
+        },
+      },
+    } as unknown as OpenClawConfig;
     expect(() => resolveDiscordToken(cfg)).toThrow(
       /channels\.discord\.token: unresolved SecretRef/i,
     );
+  });
+
+  it("strips Bot prefix from env-backed SecretRef resolved token", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN_WORK", "Bot my-actual-token");
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: {
+            work: {
+              token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN_WORK" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const res = resolveDiscordToken(cfg, { accountId: "work" });
+    expect(res.token).toBe("my-actual-token");
+    expect(res.source).toBe("config");
   });
 });

--- a/extensions/discord/src/token.ts
+++ b/extensions/discord/src/token.ts
@@ -1,8 +1,13 @@
 import type { BaseTokenResolution } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
-import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+  resolveSecretInputString,
+} from "openclaw/plugin-sdk/secret-input";
 
 type DiscordTokenSource = "env" | "config" | "none";
 
@@ -18,6 +23,92 @@ export function normalizeDiscordToken(raw: unknown, path: string): string | unde
   return trimmed.replace(/^Bot\s+/i, "");
 }
 
+function stripBotPrefix(value: string | undefined): string | undefined {
+  return value?.replace(/^Bot\s+/i, "") || undefined;
+}
+
+/**
+ * Resolve an env-backed SecretRef to its actual value, respecting provider
+ * configuration and allowlists. Mirrors the pattern used by Telegram token
+ * resolution to support `env:<provider>:<VAR>` refs in named accounts.
+ */
+function resolveEnvSecretRefValue(params: {
+  cfg?: Pick<OpenClawConfig, "secrets">;
+  provider: string;
+  id: string;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  const providerConfig = params.cfg?.secrets?.providers?.[params.provider];
+  if (providerConfig) {
+    if (providerConfig.source !== "env") {
+      throw new Error(
+        `Secret provider "${params.provider}" has source "${providerConfig.source}" but ref requests "env".`,
+      );
+    }
+    if (providerConfig.allowlist && !providerConfig.allowlist.includes(params.id)) {
+      throw new Error(
+        `Environment variable "${params.id}" is not allowlisted in secrets.providers.${params.provider}.allowlist.`,
+      );
+    }
+  } else if (
+    params.provider !== resolveDefaultSecretProviderAlias({ secrets: params.cfg?.secrets }, "env")
+  ) {
+    throw new Error(
+      `Secret provider "${params.provider}" is not configured (ref: env:${params.provider}:${params.id}).`,
+    );
+  }
+  return normalizeSecretInputString((params.env ?? process.env)[params.id]);
+}
+
+type RuntimeTokenValueResolution =
+  | { status: "available"; value: string }
+  | { status: "configured_unavailable" }
+  | { status: "missing" };
+
+/**
+ * Resolve a config token value that may be a plain string or a SecretRef.
+ * Uses inspect mode first to avoid throwing on unresolved SecretRefs, then
+ * resolves env-backed refs from `process.env`.
+ */
+function resolveRuntimeTokenValue(params: {
+  cfg?: Pick<OpenClawConfig, "secrets">;
+  value: unknown;
+  path: string;
+}): RuntimeTokenValueResolution {
+  const resolved = resolveSecretInputString({
+    value: params.value,
+    path: params.path,
+    defaults: params.cfg?.secrets?.defaults,
+    mode: "inspect",
+  });
+  if (resolved.status === "available") {
+    return { status: "available", value: resolved.value };
+  }
+  if (resolved.status === "missing") {
+    return { status: "missing" };
+  }
+  // SecretRef is configured but not yet resolved — resolve env-backed refs.
+  if (resolved.ref.source === "env") {
+    const envValue = resolveEnvSecretRefValue({
+      cfg: params.cfg,
+      provider: resolved.ref.provider,
+      id: resolved.ref.id,
+    });
+    if (envValue) {
+      return { status: "available", value: envValue };
+    }
+    return { status: "configured_unavailable" };
+  }
+  // Non-env SecretRefs: fall through to strict mode so callers get a clear error.
+  resolveSecretInputString({
+    value: params.value,
+    path: params.path,
+    defaults: params.cfg?.secrets?.defaults,
+    mode: "strict",
+  });
+  return { status: "configured_unavailable" };
+}
+
 export function resolveDiscordToken(
   cfg: OpenClawConfig,
   opts: { accountId?: string | null; envToken?: string | null } = {},
@@ -29,23 +120,39 @@ export function resolveDiscordToken(
     accountCfg &&
     Object.prototype.hasOwnProperty.call(accountCfg as Record<string, unknown>, "token"),
   );
-  const accountToken = normalizeDiscordToken(
-    (accountCfg as { token?: unknown } | undefined)?.token ?? undefined,
-    `channels.discord.accounts.${accountId}.token`,
-  );
-  if (accountToken) {
-    return { token: accountToken, source: "config" };
+
+  // Resolve the account token using runtime-aware resolution that handles
+  // both plain strings and SecretRef objects (e.g. env:default:DISCORD_BOT_TOKEN_SUBAGENT).
+  const accountTokenRaw = (accountCfg as { token?: unknown } | undefined)?.token;
+  const accountResolution = resolveRuntimeTokenValue({
+    cfg,
+    value: accountTokenRaw ?? undefined,
+    path: `channels.discord.accounts.${accountId}.token`,
+  });
+  if (accountResolution.status === "available") {
+    const token = stripBotPrefix(accountResolution.value);
+    if (token) {
+      return { token, source: "config" };
+    }
   }
-  if (hasAccountToken) {
+  if (hasAccountToken && accountResolution.status !== "missing") {
     return { token: "", source: "none" };
   }
 
-  const configToken = normalizeDiscordToken(
-    discordCfg?.token ?? undefined,
-    "channels.discord.token",
-  );
-  if (configToken) {
-    return { token: configToken, source: "config" };
+  // Channel-level token (also may be a SecretRef).
+  const configResolution = resolveRuntimeTokenValue({
+    cfg,
+    value: discordCfg?.token ?? undefined,
+    path: "channels.discord.token",
+  });
+  if (configResolution.status === "available") {
+    const token = stripBotPrefix(configResolution.value);
+    if (token) {
+      return { token, source: "config" };
+    }
+  }
+  if (configResolution.status === "configured_unavailable") {
+    return { token: "", source: "none" };
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;


### PR DESCRIPTION
Fixes #76889

## Problem

Discord named-account token fields configured as env-backed SecretRefs (e.g. `env:default:DISCORD_BOT_TOKEN_SUBAGENT`) caused `channels.status` and startup to fail with:

```
channels.discord.accounts.subagent.token: unresolved SecretRef "env:default:DISCORD_BOT_TOKEN_SUBAGENT".
Resolve this command against an active gateway runtime snapshot before reading it.
```

The root cause (identified by the reporter) is that `resolveDiscordToken()` called `normalizeResolvedSecretInputString()` which uses strict mode and throws on unresolved SecretRef objects, instead of resolving env-backed refs from `process.env`.

## Fix

Align Discord token resolution with the pattern already used by Telegram (`extensions/telegram/src/token.ts`):

1. Use `resolveSecretInputString()` in **inspect** mode first (no throw on unresolved refs)
2. For env-backed SecretRefs, resolve from `process.env` via `resolveEnvSecretRefValue()` respecting provider config and allowlists
3. Non-env SecretRefs still throw in strict mode for clear diagnostics

## Changes

- `extensions/discord/src/token.ts` — add `resolveRuntimeTokenValue()` and `resolveEnvSecretRefValue()` helpers; rewrite `resolveDiscordToken()` to use them for both account-level and channel-level token fields
- `extensions/discord/src/token.test.ts` — add tests for env-backed SecretRef resolution, missing env var, channel-level SecretRef, Bot prefix stripping, and non-env SecretRef strict throw