### PR TITLE
fix(cron): keep isolated CLI runs non-owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: require an observed Telegram send, edit, or fallback before treating a forum-topic final as delivered, so final replies generated in transcript no longer disappear from Telegram topics. Fixes #76554. (#76764) Thanks @bubucilo and @obviyus.
 - Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
+- Cron/CLI runtimes: keep CLI-backed isolated cron runs on non-owner loopback authorization while preserving the scoped cron self-removal grant. (#76902) Thanks @Lucenx9.
 
 ## 2026.5.2
 

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -411,6 +411,7 @@ export function buildRunClaudeCliAgentParams(params: RunClaudeCliAgentParams): R
     messageChannel: params.messageChannel,
     messageProvider: params.messageProvider,
     senderIsOwner: params.senderIsOwner,
+    ownerOnlyToolAllowlist: params.ownerOnlyToolAllowlist,
   };
 }
 

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -667,6 +667,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         timeoutMs: 1_000,
         runId: "run-test-scoped-loopback-token",
         config: createCliBackendConfig(),
+        trigger: "cron",
+        jobId: "job-current",
         senderIsOwner: false,
         ownerOnlyToolAllowlist: ["cron"],
       });
@@ -674,6 +676,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(createMcpLoopbackScopedBearerToken).toHaveBeenCalledWith(runtime, {
         senderIsOwner: false,
         ownerOnlyToolAllowlist: ["cron"],
+        trigger: "cron",
+        jobId: "job-current",
       });
       expect(context.preparedBackend.env?.OPENCLAW_MCP_TOKEN).toBe("scoped-non-owner-token");
 

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -158,6 +158,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       getActiveMcpLoopbackRuntime: vi.fn(() => undefined),
       ensureMcpLoopbackServer: vi.fn(createTestMcpLoopbackServer),
       createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      createMcpLoopbackScopedBearerToken: vi.fn((runtime, params) =>
+        params.senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken,
+      ),
+      releaseMcpLoopbackScopedBearerToken: vi.fn(),
       resolveOpenClawReferencePaths: vi.fn(async () => ({ docsPath: null, sourcePath: null })),
     });
     mockGetGlobalHookRunner.mockReturnValue(null);
@@ -609,6 +613,72 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.preparedBackend.mcpConfigHash).toBeUndefined();
       expect(context.preparedBackend.env).toBeUndefined();
       expect(context.preparedBackend.backend.args).toEqual(["--print"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses scoped loopback bearer tokens for non-owner CLI owner-only grants", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      const runtime = {
+        port: 31783,
+        ownerToken: "owner-token",
+        nonOwnerToken: "non-owner-token",
+      };
+      const getActiveMcpLoopbackRuntime = vi.fn(() => runtime);
+      const createMcpLoopbackScopedBearerToken = vi.fn(() => "scoped-non-owner-token");
+      const releaseMcpLoopbackScopedBearerToken = vi.fn();
+      setCliRunnerPrepareTestDeps({
+        getActiveMcpLoopbackRuntime,
+        createMcpLoopbackScopedBearerToken,
+        releaseMcpLoopbackScopedBearerToken,
+        createMcpLoopbackServerConfig: vi.fn(createTestMcpLoopbackServerConfig),
+      });
+      cliBackendsTesting.setDepsForTest({
+        resolvePluginSetupCliBackend: () => undefined,
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "scoped-cli",
+            pluginId: "scoped-plugin",
+            bundleMcp: true,
+            bundleMcpMode: "claude-config-file",
+            config: {
+              command: "scoped-cli",
+              args: ["--print"],
+              systemPromptArg: "--system-prompt",
+              systemPromptWhen: "first",
+              sessionMode: "existing",
+              output: "text",
+              input: "arg",
+            },
+          },
+        ],
+      });
+
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "scoped-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-scoped-loopback-token",
+        config: createCliBackendConfig(),
+        senderIsOwner: false,
+        ownerOnlyToolAllowlist: ["cron"],
+      });
+
+      expect(createMcpLoopbackScopedBearerToken).toHaveBeenCalledWith(runtime, {
+        senderIsOwner: false,
+        ownerOnlyToolAllowlist: ["cron"],
+      });
+      expect(context.preparedBackend.env?.OPENCLAW_MCP_TOKEN).toBe("scoped-non-owner-token");
+
+      await context.preparedBackend.cleanup?.();
+      expect(releaseMcpLoopbackScopedBearerToken).toHaveBeenCalledWith("scoped-non-owner-token");
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -193,6 +193,8 @@ export async function prepareCliRunContext(
     ? prepareDeps.createMcpLoopbackScopedBearerToken(mcpLoopbackRuntime, {
         senderIsOwner: params.senderIsOwner === true,
         ownerOnlyToolAllowlist: params.ownerOnlyToolAllowlist,
+        trigger: params.trigger,
+        jobId: params.jobId,
       })
     : undefined;
   const preparedBackend = await prepareCliBundleMcpConfig({

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -2,7 +2,9 @@ import { getRuntimeConfig } from "../../config/config.js";
 import { ensureMcpLoopbackServer } from "../../gateway/mcp-http.js";
 import {
   createMcpLoopbackServerConfig,
+  createMcpLoopbackScopedBearerToken,
   getActiveMcpLoopbackRuntime,
+  releaseMcpLoopbackScopedBearerToken,
 } from "../../gateway/mcp-http.loopback-runtime.js";
 import type {
   CliBackendAuthEpochMode,
@@ -59,6 +61,8 @@ const prepareDeps = {
   getActiveMcpLoopbackRuntime,
   ensureMcpLoopbackServer,
   createMcpLoopbackServerConfig,
+  createMcpLoopbackScopedBearerToken,
+  releaseMcpLoopbackScopedBearerToken,
   resolveOpenClawReferencePaths: async (
     params: Parameters<typeof import("../docs-path.js").resolveOpenClawReferencePaths>[0],
   ) => (await import("../docs-path.js")).resolveOpenClawReferencePaths(params),
@@ -185,6 +189,12 @@ export async function prepareCliRunContext(
     }
     mcpLoopbackRuntime = prepareDeps.getActiveMcpLoopbackRuntime();
   }
+  const mcpBearerToken = mcpLoopbackRuntime
+    ? prepareDeps.createMcpLoopbackScopedBearerToken(mcpLoopbackRuntime, {
+        senderIsOwner: params.senderIsOwner === true,
+        ownerOnlyToolAllowlist: params.ownerOnlyToolAllowlist,
+      })
+    : undefined;
   const preparedBackend = await prepareCliBundleMcpConfig({
     enabled: bundleMcpEnabled,
     mode: backendResolved.bundleMcpMode,
@@ -196,10 +206,7 @@ export async function prepareCliRunContext(
       : undefined,
     env: mcpLoopbackRuntime
       ? {
-          OPENCLAW_MCP_TOKEN:
-            params.senderIsOwner === true
-              ? mcpLoopbackRuntime.ownerToken
-              : mcpLoopbackRuntime.nonOwnerToken,
+          OPENCLAW_MCP_TOKEN: mcpBearerToken ?? mcpLoopbackRuntime.nonOwnerToken,
           OPENCLAW_MCP_AGENT_ID: sessionAgentId ?? "",
           OPENCLAW_MCP_ACCOUNT_ID: params.agentAccountId ?? "",
           OPENCLAW_MCP_SESSION_KEY: params.sessionKey ?? "",
@@ -231,13 +238,20 @@ export async function prepareCliRunContext(
     preparedExecution?.env && Object.keys(preparedExecution.env).length > 0
       ? { ...preparedBackend.env, ...preparedExecution.env }
       : preparedBackend.env;
+  const releaseMcpBearerToken = mcpBearerToken
+    ? () => prepareDeps.releaseMcpLoopbackScopedBearerToken(mcpBearerToken)
+    : undefined;
   const preparedBackendCleanup =
-    preparedBackend.cleanup || preparedExecution?.cleanup
+    preparedBackend.cleanup || preparedExecution?.cleanup || releaseMcpBearerToken
       ? async () => {
           try {
             await preparedExecution?.cleanup?.();
           } finally {
-            await preparedBackend.cleanup?.();
+            try {
+              await preparedBackend.cleanup?.();
+            } finally {
+              releaseMcpBearerToken?.();
+            }
           }
         }
       : undefined;

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -50,6 +50,7 @@ export type RunCliAgentParams = {
   messageProvider?: string;
   agentAccountId?: string;
   senderIsOwner?: boolean;
+  ownerOnlyToolAllowlist?: string[];
   disableTools?: boolean;
   abortSignal?: AbortSignal;
   onExecutionStarted?: () => void;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -172,6 +172,9 @@ export function createCronPromptExecutor(params: {
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
             senderIsOwner: false,
+            ownerOnlyToolAllowlist: resolveCronOwnerOnlyToolAllowlist(
+              params.agentPayload?.toolsAllow,
+            ),
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -171,7 +171,7 @@ export function createCronPromptExecutor(params: {
             onExecutionStarted: params.onExecutionStarted,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
-            senderIsOwner: true,
+            senderIsOwner: false,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,

--- a/src/cron/isolated-agent/run.owner-auth.test.ts
+++ b/src/cron/isolated-agent/run.owner-auth.test.ts
@@ -48,7 +48,7 @@ function makeParamsWithToolsAllow(toolsAllow: string[]) {
   };
 }
 
-function makeCliRuntimeParams() {
+function makeCliRuntimeParams(toolsAllow?: string[]) {
   const params = makeParams();
   const job = params.job as Record<string, unknown>;
   return {
@@ -68,6 +68,7 @@ function makeCliRuntimeParams() {
         message: "check owner tools",
         allowUnsafeExternalContent: true,
         externalContentSource: "webhook",
+        ...(toolsAllow ? { toolsAllow } : {}),
       },
     } as never,
   };
@@ -127,7 +128,7 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
         meta: { agentMeta: { usage: { input: 10, output: 20 } } },
       });
 
-      await runCronIsolatedAgentTurn(makeCliRuntimeParams());
+      await runCronIsolatedAgentTurn(makeCliRuntimeParams([" CRON "]));
 
       expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
       expect(runCliAgentMock).toHaveBeenCalledTimes(1);
@@ -136,6 +137,7 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
         model: "claude-opus-4-6",
         trigger: "cron",
         senderIsOwner: false,
+        ownerOnlyToolAllowlist: ["cron"],
       });
     },
   );

--- a/src/cron/isolated-agent/run.owner-auth.test.ts
+++ b/src/cron/isolated-agent/run.owner-auth.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../agents/test-helpers/fast-coding-tools.js";
 import {
+  isCliProviderMock,
   loadRunCronIsolatedAgentTurn,
   resetRunCronIsolatedAgentTurnHarness,
+  resolveConfiguredModelRefMock,
   resolveDeliveryTargetMock,
+  runCliAgentMock,
   runEmbeddedPiAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
@@ -40,6 +43,31 @@ function makeParamsWithToolsAllow(toolsAllow: string[]) {
         kind: "agentTurn",
         message: "check owner tools",
         toolsAllow,
+      },
+    } as never,
+  };
+}
+
+function makeCliRuntimeParams() {
+  const params = makeParams();
+  const job = params.job as Record<string, unknown>;
+  return {
+    ...params,
+    cfg: {
+      agents: {
+        defaults: {
+          agentRuntime: { id: "claude-cli" },
+          model: "anthropic/claude-opus-4-6",
+        },
+      },
+    },
+    job: {
+      ...job,
+      payload: {
+        kind: "agentTurn",
+        message: "check owner tools",
+        allowUnsafeExternalContent: true,
+        externalContentSource: "webhook",
       },
     } as never,
   };
@@ -82,6 +110,33 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
       expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
       const senderIsOwner = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.senderIsOwner;
       expect(senderIsOwner).toBe(false);
+    },
+  );
+
+  it(
+    "passes senderIsOwner=false to isolated cron CLI runs",
+    { timeout: RUN_OWNER_AUTH_TIMEOUT_MS },
+    async () => {
+      isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+      resolveConfiguredModelRefMock.mockReturnValue({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+      runCliAgentMock.mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      });
+
+      await runCronIsolatedAgentTurn(makeCliRuntimeParams());
+
+      expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+      expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+      expect(runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+        trigger: "cron",
+        senderIsOwner: false,
+      });
     },
   );
 

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -9,10 +9,14 @@ type McpLoopbackRuntime = {
 export type McpLoopbackBearerContext = {
   senderIsOwner: boolean;
   ownerOnlyToolAllowlist?: string[];
+  cronSelfRemoveOnlyJobId?: string;
 };
 
 let activeRuntime: McpLoopbackRuntime | undefined;
-const scopedNonOwnerTokens = new Map<string, { ownerOnlyToolAllowlist: string[] }>();
+const scopedNonOwnerTokens = new Map<
+  string,
+  { ownerOnlyToolAllowlist: string[]; cronSelfRemoveOnlyJobId?: string }
+>();
 
 function normalizeOwnerOnlyToolAllowlist(value: string[] | undefined): string[] | undefined {
   const normalized = Array.from(
@@ -40,17 +44,34 @@ export function resolveMcpLoopbackBearerToken(
 
 export function createMcpLoopbackScopedBearerToken(
   runtime: McpLoopbackRuntime,
-  params: { senderIsOwner: boolean; ownerOnlyToolAllowlist?: string[] },
+  params: {
+    senderIsOwner: boolean;
+    ownerOnlyToolAllowlist?: string[];
+    trigger?: string;
+    jobId?: string;
+  },
 ): string {
   if (params.senderIsOwner) {
     return runtime.ownerToken;
   }
-  const ownerOnlyToolAllowlist = normalizeOwnerOnlyToolAllowlist(params.ownerOnlyToolAllowlist);
+  const normalizedAllowlist = normalizeOwnerOnlyToolAllowlist(params.ownerOnlyToolAllowlist);
+  const cronSelfRemoveOnlyJobId =
+    normalizedAllowlist?.includes("cron") && params.trigger === "cron" && params.jobId?.trim()
+      ? params.jobId.trim()
+      : undefined;
+  const scopedAllowlist = normalizedAllowlist?.filter(
+    (toolName) => toolName !== "cron" || Boolean(cronSelfRemoveOnlyJobId),
+  );
+  const ownerOnlyToolAllowlist =
+    scopedAllowlist && scopedAllowlist.length > 0 ? scopedAllowlist : undefined;
   if (!ownerOnlyToolAllowlist) {
     return runtime.nonOwnerToken;
   }
   const token = crypto.randomBytes(32).toString("hex");
-  scopedNonOwnerTokens.set(token, { ownerOnlyToolAllowlist });
+  scopedNonOwnerTokens.set(token, {
+    ownerOnlyToolAllowlist,
+    ...(cronSelfRemoveOnlyJobId ? { cronSelfRemoveOnlyJobId } : {}),
+  });
   return token;
 }
 
@@ -65,7 +86,13 @@ export function resolveMcpLoopbackScopedBearerContext(
   if (!grant) {
     return undefined;
   }
-  return { senderIsOwner: false, ownerOnlyToolAllowlist: grant.ownerOnlyToolAllowlist };
+  return {
+    senderIsOwner: false,
+    ownerOnlyToolAllowlist: grant.ownerOnlyToolAllowlist,
+    ...(grant.cronSelfRemoveOnlyJobId
+      ? { cronSelfRemoveOnlyJobId: grant.cronSelfRemoveOnlyJobId }
+      : {}),
+  };
 }
 
 export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): void {

--- a/src/gateway/mcp-http.loopback-runtime.ts
+++ b/src/gateway/mcp-http.loopback-runtime.ts
@@ -1,10 +1,27 @@
+import crypto from "node:crypto";
+
 type McpLoopbackRuntime = {
   port: number;
   ownerToken: string;
   nonOwnerToken: string;
 };
 
+export type McpLoopbackBearerContext = {
+  senderIsOwner: boolean;
+  ownerOnlyToolAllowlist?: string[];
+};
+
 let activeRuntime: McpLoopbackRuntime | undefined;
+const scopedNonOwnerTokens = new Map<string, { ownerOnlyToolAllowlist: string[] }>();
+
+function normalizeOwnerOnlyToolAllowlist(value: string[] | undefined): string[] | undefined {
+  const normalized = Array.from(
+    new Set(
+      value?.map((entry) => entry.trim().toLowerCase()).filter((entry) => entry.length > 0) ?? [],
+    ),
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 export function getActiveMcpLoopbackRuntime(): McpLoopbackRuntime | undefined {
   return activeRuntime ? { ...activeRuntime } : undefined;
@@ -21,9 +38,40 @@ export function resolveMcpLoopbackBearerToken(
   return senderIsOwner ? runtime.ownerToken : runtime.nonOwnerToken;
 }
 
+export function createMcpLoopbackScopedBearerToken(
+  runtime: McpLoopbackRuntime,
+  params: { senderIsOwner: boolean; ownerOnlyToolAllowlist?: string[] },
+): string {
+  if (params.senderIsOwner) {
+    return runtime.ownerToken;
+  }
+  const ownerOnlyToolAllowlist = normalizeOwnerOnlyToolAllowlist(params.ownerOnlyToolAllowlist);
+  if (!ownerOnlyToolAllowlist) {
+    return runtime.nonOwnerToken;
+  }
+  const token = crypto.randomBytes(32).toString("hex");
+  scopedNonOwnerTokens.set(token, { ownerOnlyToolAllowlist });
+  return token;
+}
+
+export function releaseMcpLoopbackScopedBearerToken(token: string): void {
+  scopedNonOwnerTokens.delete(token);
+}
+
+export function resolveMcpLoopbackScopedBearerContext(
+  token: string,
+): McpLoopbackBearerContext | undefined {
+  const grant = scopedNonOwnerTokens.get(token);
+  if (!grant) {
+    return undefined;
+  }
+  return { senderIsOwner: false, ownerOnlyToolAllowlist: grant.ownerOnlyToolAllowlist };
+}
+
 export function clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken: string): void {
   if (activeRuntime?.ownerToken === ownerToken) {
     activeRuntime = undefined;
+    scopedNonOwnerTokens.clear();
   }
 }
 

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -178,7 +178,7 @@ export async function readMcpHttpBody(req: IncomingMessage): Promise<string> {
 export function resolveMcpRequestContext(
   req: IncomingMessage,
   cfg: OpenClawConfig,
-  auth: { senderIsOwner: boolean },
+  auth: McpLoopbackBearerContext,
 ): McpRequestContext {
   return {
     sessionKey: resolveScopedSessionKey(cfg, getHeader(req, "x-session-key")),

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -6,6 +6,10 @@ import { safeEqualSecret } from "../security/secret-equal.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-utils.js";
+import {
+  type McpLoopbackBearerContext,
+  resolveMcpLoopbackScopedBearerContext,
+} from "./mcp-http.loopback-runtime.js";
 import { isLoopbackAddress } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
 
@@ -30,6 +34,7 @@ type McpRequestContext = {
   messageProvider: string | undefined;
   accountId: string | undefined;
   senderIsOwner: boolean;
+  ownerOnlyToolAllowlist: string[] | undefined;
 };
 
 function resolveScopedSessionKey(cfg: OpenClawConfig, rawSessionKey: string | undefined): string {
@@ -65,7 +70,7 @@ export function validateMcpLoopbackRequest(params: {
   res: ServerResponse;
   ownerToken: string;
   nonOwnerToken: string;
-}): { senderIsOwner: boolean } | null {
+}): McpLoopbackBearerContext | null {
   let url: URL;
   try {
     url = new URL(params.req.url ?? "/", `http://${params.req.headers.host ?? "localhost"}`);
@@ -118,8 +123,15 @@ export function validateMcpLoopbackRequest(params: {
   const authHeader = getHeader(params.req, "authorization") ?? "";
   const ownerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.ownerToken}`);
   const nonOwnerTokenMatched = safeEqualSecret(authHeader, `Bearer ${params.nonOwnerToken}`);
-  const senderIsOwner = ownerTokenMatched ? true : nonOwnerTokenMatched ? false : null;
-  if (senderIsOwner === null) {
+  const scopedToken = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : "";
+  const scopedContext = scopedToken
+    ? resolveMcpLoopbackScopedBearerContext(scopedToken)
+    : undefined;
+  const bearerContext =
+    ownerTokenMatched || nonOwnerTokenMatched
+      ? { senderIsOwner: ownerTokenMatched }
+      : scopedContext;
+  if (!bearerContext) {
     logMcpLoopbackHttp("reject", {
       reason: "unauthorized",
       method: params.req.method ?? "",
@@ -142,7 +154,7 @@ export function validateMcpLoopbackRequest(params: {
     return null;
   }
 
-  return { senderIsOwner };
+  return bearerContext;
 }
 
 export async function readMcpHttpBody(req: IncomingMessage): Promise<string> {
@@ -174,5 +186,6 @@ export function resolveMcpRequestContext(
       normalizeMessageChannel(getHeader(req, "x-openclaw-message-channel")) ?? undefined,
     accountId: normalizeOptionalString(getHeader(req, "x-openclaw-account-id")),
     senderIsOwner: auth.senderIsOwner,
+    ownerOnlyToolAllowlist: auth.ownerOnlyToolAllowlist,
   };
 }

--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -35,6 +35,7 @@ type McpRequestContext = {
   accountId: string | undefined;
   senderIsOwner: boolean;
   ownerOnlyToolAllowlist: string[] | undefined;
+  cronSelfRemoveOnlyJobId: string | undefined;
 };
 
 function resolveScopedSessionKey(cfg: OpenClawConfig, rawSessionKey: string | undefined): string {
@@ -187,5 +188,6 @@ export function resolveMcpRequestContext(
     accountId: normalizeOptionalString(getHeader(req, "x-openclaw-account-id")),
     senderIsOwner: auth.senderIsOwner,
     ownerOnlyToolAllowlist: auth.ownerOnlyToolAllowlist,
+    cronSelfRemoveOnlyJobId: auth.cronSelfRemoveOnlyJobId,
   };
 }

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -28,6 +28,7 @@ export class McpLoopbackToolCache {
     accountId: string | undefined;
     senderIsOwner: boolean | undefined;
     ownerOnlyToolAllowlist: string[] | undefined;
+    cronSelfRemoveOnlyJobId: string | undefined;
   }): CachedScopedTools {
     const cacheKey = [
       params.sessionKey,
@@ -35,6 +36,7 @@ export class McpLoopbackToolCache {
       params.accountId ?? "",
       params.senderIsOwner === true ? "owner" : "non-owner",
       params.ownerOnlyToolAllowlist?.join(",") ?? "",
+      params.cronSelfRemoveOnlyJobId ?? "",
     ].join("\u0000");
     const now = Date.now();
     const cached = this.#entries.get(cacheKey);
@@ -50,6 +52,7 @@ export class McpLoopbackToolCache {
       senderIsOwner: params.senderIsOwner,
       surface: "loopback",
       excludeToolNames: NATIVE_TOOL_EXCLUDE,
+      cronSelfRemoveOnlyJobId: params.cronSelfRemoveOnlyJobId,
     });
     const tools = applyOwnerOnlyToolPolicy(
       next.tools,

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -27,12 +27,14 @@ export class McpLoopbackToolCache {
     messageProvider: string | undefined;
     accountId: string | undefined;
     senderIsOwner: boolean | undefined;
+    ownerOnlyToolAllowlist: string[] | undefined;
   }): CachedScopedTools {
     const cacheKey = [
       params.sessionKey,
       params.messageProvider ?? "",
       params.accountId ?? "",
       params.senderIsOwner === true ? "owner" : "non-owner",
+      params.ownerOnlyToolAllowlist?.join(",") ?? "",
     ].join("\u0000");
     const now = Date.now();
     const cached = this.#entries.get(cacheKey);
@@ -49,7 +51,11 @@ export class McpLoopbackToolCache {
       surface: "loopback",
       excludeToolNames: NATIVE_TOOL_EXCLUDE,
     });
-    const tools = applyOwnerOnlyToolPolicy(next.tools, params.senderIsOwner === true);
+    const tools = applyOwnerOnlyToolPolicy(
+      next.tools,
+      params.senderIsOwner === true,
+      params.ownerOnlyToolAllowlist,
+    );
     const nextEntry: CachedScopedTools = {
       agentId: next.agentId,
       tools,

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -352,6 +352,8 @@ describe("mcp loopback server", () => {
         ? createMcpLoopbackScopedBearerToken(runtime, {
             senderIsOwner: false,
             ownerOnlyToolAllowlist: ["cron"],
+            trigger: "cron",
+            jobId: "job-current",
           })
         : undefined,
       headers: {
@@ -366,9 +368,136 @@ describe("mcp loopback server", () => {
     const names = (payload.result?.tools ?? []).map((tool) => tool.name);
 
     expect(response.status).toBe(200);
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronSelfRemoveOnlyJobId: "job-current",
+      }),
+    );
     expect(names).toContain("message");
     expect(names).toContain("cron");
     expect(names).not.toContain("owner_probe");
+  });
+
+  it("keeps scoped non-owner cron grants limited to current-job removal", async () => {
+    const cronExecute = vi.fn(
+      async (
+        _toolCallId: string,
+        args: unknown,
+      ): Promise<{ content: Array<{ type: string; text: string }> }> => {
+        const input = (args ?? {}) as Record<string, unknown>;
+        if (input.action !== "remove" || input.jobId !== "job-current") {
+          throw new Error("Cron tool is restricted to removing the current cron job.");
+        }
+        return { content: [{ type: "text", text: "removed" }] };
+      },
+    );
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        {
+          name: "cron",
+          description: "manage schedules",
+          parameters: { type: "object", properties: {} },
+          execute: cronExecute,
+        },
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime
+        ? createMcpLoopbackScopedBearerToken(runtime, {
+            senderIsOwner: false,
+            ownerOnlyToolAllowlist: ["cron"],
+            trigger: "cron",
+            jobId: "job-current",
+          })
+        : undefined,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "cron", arguments: { action: "list" } },
+      }),
+    });
+    const payload = (await response.json()) as {
+      result?: { content?: Array<{ text?: string }>; isError?: boolean };
+    };
+
+    expect(response.status).toBe(200);
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronSelfRemoveOnlyJobId: "job-current",
+      }),
+    );
+    expect(cronExecute).toHaveBeenCalledOnce();
+    expect(payload.result?.isError).toBe(true);
+    expect(payload.result?.content?.[0]?.text).toBe(
+      "Cron tool is restricted to removing the current cron job.",
+    );
+  });
+
+  it("does not mint scoped cron grants without an active cron job id", async () => {
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        {
+          name: "message",
+          description: "send a message",
+          parameters: { type: "object", properties: {} },
+          execute: async () => ({
+            content: [{ type: "text", text: "ok" }],
+          }),
+        },
+        {
+          name: "cron",
+          description: "manage schedules",
+          parameters: { type: "object", properties: {} },
+          execute: async () => ({
+            content: [{ type: "text", text: "cron" }],
+          }),
+        },
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const token = runtime
+      ? createMcpLoopbackScopedBearerToken(runtime, {
+          senderIsOwner: false,
+          ownerOnlyToolAllowlist: ["cron"],
+          trigger: "cron",
+        })
+      : undefined;
+    const response = await sendRaw({
+      port: server.port,
+      token,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    const payload = (await response.json()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    const names = (payload.result?.tools ?? []).map((tool) => tool.name);
+
+    expect(token).toBe(runtime?.nonOwnerToken);
+    expect(response.status).toBe(200);
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronSelfRemoveOnlyJobId: undefined,
+      }),
+    );
+    expect(names).toContain("message");
+    expect(names).not.toContain("cron");
   });
 
   it("keeps owner-only tools available to owner loopback callers", async () => {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -63,6 +63,7 @@ vi.mock("./tool-resolution.js", () => ({
 
 import {
   createMcpLoopbackServerConfig,
+  createMcpLoopbackScopedBearerToken,
   closeMcpLoopbackServer,
   getActiveMcpLoopbackRuntime,
   resolveMcpLoopbackBearerToken,
@@ -308,6 +309,65 @@ describe("mcp loopback server", () => {
     expect(response.status).toBe(200);
     expect(names).toContain("message");
     expect(names).not.toContain("cron");
+    expect(names).not.toContain("owner_probe");
+  });
+
+  it("keeps allowlisted owner-only tools for scoped non-owner loopback callers", async () => {
+    resolveGatewayScopedToolsMock.mockReturnValue({
+      agentId: "main",
+      tools: [
+        {
+          name: "message",
+          description: "send a message",
+          parameters: { type: "object", properties: {} },
+          execute: async () => ({
+            content: [{ type: "text", text: "ok" }],
+          }),
+        },
+        {
+          name: "cron",
+          description: "manage schedules",
+          parameters: { type: "object", properties: {} },
+          execute: async () => ({
+            content: [{ type: "text", text: "cron" }],
+          }),
+        },
+        {
+          name: "owner_probe",
+          description: "owner-only by flag",
+          parameters: { type: "object", properties: {} },
+          ownerOnly: true,
+          execute: async () => ({
+            content: [{ type: "text", text: "owner" }],
+          }),
+        },
+      ],
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime
+        ? createMcpLoopbackScopedBearerToken(runtime, {
+            senderIsOwner: false,
+            ownerOnlyToolAllowlist: ["cron"],
+          })
+        : undefined,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:main",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    const payload = (await response.json()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    const names = (payload.result?.tools ?? []).map((tool) => tool.name);
+
+    expect(response.status).toBe(200);
+    expect(names).toContain("message");
+    expect(names).toContain("cron");
     expect(names).not.toContain("owner_probe");
   });
 

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -116,6 +116,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           accountId: requestContext.accountId,
           senderIsOwner: requestContext.senderIsOwner,
           ownerOnlyToolAllowlist: requestContext.ownerOnlyToolAllowlist,
+          cronSelfRemoveOnlyJobId: requestContext.cronSelfRemoveOnlyJobId,
         });
 
         const messages = Array.isArray(parsed) ? parsed : [parsed];

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -25,7 +25,9 @@ import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
 
 export {
   createMcpLoopbackServerConfig,
+  createMcpLoopbackScopedBearerToken,
   getActiveMcpLoopbackRuntime,
+  releaseMcpLoopbackScopedBearerToken,
   resolveMcpLoopbackBearerToken,
 } from "./mcp-http.loopback-runtime.js";
 
@@ -113,6 +115,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           messageProvider: requestContext.messageProvider,
           accountId: requestContext.accountId,
           senderIsOwner: requestContext.senderIsOwner,
+          ownerOnlyToolAllowlist: requestContext.ownerOnlyToolAllowlist,
         });
 
         const messages = Array.isArray(parsed) ? parsed : [parsed];

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -40,6 +40,7 @@ export function resolveGatewayScopedTools(params: {
   disablePluginTools?: boolean;
   senderIsOwner?: boolean;
   gatewayRequestedTools?: string[];
+  cronSelfRemoveOnlyJobId?: string;
 }) {
   const {
     agentId,
@@ -95,6 +96,7 @@ export function resolveGatewayScopedTools(params: {
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
     disablePluginTools: params.disablePluginTools,
     senderIsOwner: params.senderIsOwner,
+    cronSelfRemoveOnlyJobId: params.cronSelfRemoveOnlyJobId,
     config: params.cfg,
     workspaceDir,
     pluginToolAllowlist: collectExplicitAllowlist([


### PR DESCRIPTION
## Summary

- Problem: isolated cron runs that execute through a CLI runtime did not use the same non-owner authorization context as the embedded isolated path.
- Why it matters: isolated cron execution should keep a consistent tool-authorization boundary regardless of runtime backend.
- What changed: pass `senderIsOwner: false` to CLI-backed isolated cron runs and add a regression test for the CLI runtime mapping path.
- What did NOT change (scope boundary): no cron scheduling, delivery, model fallback, or CLI session behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the CLI cron execution branch used owner authorization while the embedded isolated branch already used non-owner authorization.
- Missing detection / guardrail: existing owner-auth coverage only asserted the embedded isolated path.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/run.owner-auth.test.ts`
- Scenario the test should lock in: isolated cron execution routed through a compatible CLI runtime still passes `senderIsOwner: false`.
- Why this is the smallest reliable guardrail: it exercises the existing cron runner harness at the runtime dispatch boundary.
- Existing test that already covers this (if any): embedded isolated owner-auth tests covered only the non-CLI path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: CLI-backed isolated cron runs now use the narrower non-owner authorization context that already applies to embedded isolated cron runs.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 via repo test runner
- Model/provider: mocked cron runner harness
- Integration/channel (if any): N/A
- Relevant config (redacted): CLI runtime mapping test config

### Steps

1. Run the isolated cron owner-auth test file.
2. Run targeted formatting check for the touched files.

### Expected

- CLI-backed isolated cron dispatch uses `senderIsOwner: false`.
- Existing embedded isolated cron owner-auth behavior stays unchanged.

### Actual

- Matches expected after this change.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm format:check src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.owner-auth.test.ts`
  - `pnpm test src/cron/isolated-agent/run.owner-auth.test.ts`
- Edge cases checked: embedded isolated cron owner-auth tests still pass in the same file.
- What you did **not** verify: full `pnpm check` / full test suite was intentionally not run locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: CLI-backed isolated cron runs may see fewer owner-scoped tools than before.
  - Mitigation: this matches the existing embedded isolated cron authorization boundary.
