### PR TITLE
fix(googlechat): normalize response headers in webhook verifier (#76880)

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -369,6 +369,34 @@ describe("googlechat google auth runtime", () => {
     expect(normalized.headers.get("x-test")).toBe("1");
   });
 
+  it("normalizes plain-object response headers to a Headers instance", () => {
+    const response = {
+      headers: { "cache-control": "max-age=3600", "content-type": "application/json" },
+      config: {},
+      data: {},
+    };
+
+    const normalized = __testing.normalizeGoogleAuthResponseHeaders(response);
+
+    expect(normalized.headers).toBeInstanceOf(Headers);
+    expect((normalized.headers as Headers).get("cache-control")).toBe("max-age=3600");
+    expect((normalized.headers as Headers).get("content-type")).toBe("application/json");
+  });
+
+  it("leaves native Headers on response untouched", () => {
+    const nativeHeaders = new Headers({ "cache-control": "no-cache" });
+    const response = {
+      headers: nativeHeaders,
+      config: {},
+      data: {},
+    };
+
+    const normalized = __testing.normalizeGoogleAuthResponseHeaders(response);
+
+    expect(normalized.headers).toBe(nativeHeaders);
+    expect((normalized.headers as Headers).get("cache-control")).toBe("no-cache");
+  });
+
   it("rejects service-account credentials that override Google auth endpoints", async () => {
     await expect(
       resolveValidatedGoogleChatCredentials({

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -79,11 +79,34 @@ function normalizeGoogleAuthPreparedRequestHeaders<T extends GoogleAuthRequestWi
   return config as T & { headers: Headers };
 }
 
+/**
+ * Ensure response headers support the `.get()` method expected by
+ * `google-auth-library` (e.g. `getFederatedSignonCertsAsync` reads
+ * `res?.headers.get('cache-control')`).
+ *
+ * When the bundled build's deep-clone utility (`extend`) from gaxios
+ * serialises a `GaxiosResponse`, the native `Headers` instance can be
+ * downgraded to a plain `Record<string, string>` whose `.get()` method is
+ * lost.  This helper converts such objects back to a proper `Headers`.
+ */
+function normalizeGoogleAuthResponseHeaders<
+  T extends { headers?: unknown; config?: unknown; data?: unknown },
+>(response: T): T {
+  const h = response.headers;
+  if (h && typeof h === "object" && !(h instanceof Headers) && typeof (h as Headers).get !== "function") {
+    (response as Record<string, unknown>).headers = new Headers(h as Record<string, string>);
+  }
+  return response;
+}
+
 function installGoogleAuthHeaderCompatibilityInterceptor(
   transport: GoogleAuthTransport,
 ): GoogleAuthTransport {
   transport.interceptors.request.add({
     resolved: async (config) => normalizeGoogleAuthPreparedRequestHeaders(config),
+  });
+  transport.interceptors.response.add({
+    resolved: async (response) => normalizeGoogleAuthResponseHeaders(response),
   });
   return transport;
 }
@@ -558,6 +581,7 @@ export const __testing = {
     googleAuthTransportPromise = null;
   },
   normalizeGoogleAuthPreparedRequestHeaders,
+  normalizeGoogleAuthResponseHeaders,
   resolveGoogleAuthEnvProxyUrl,
   validateGoogleChatServiceAccountCredentials,
 };


### PR DESCRIPTION
Fixes #76880
References #76742

## Root Cause

`google-auth-library`'s `getFederatedSignonCertsAsync` reads the cache-control header via `res?.headers.get('cache-control')` (line 613 in `oauth2client.js`). When the bundled build's deep-clone utility (`extend`) from gaxios serialises a `GaxiosResponse`, the native `Headers` instance can be downgraded to a plain `Record<string, string>` whose `.get()` method is lost, causing:

```
Google Chat webhook auth rejected: res?.headers.get is not a function
```

The previous fix (01e2755dc) added a **request** interceptor to normalize request headers (`config.headers.has`), but didn't address the same issue on the **response** side.

## Fix

Add a response interceptor to the shared Gaxios transport in `getGoogleAuthTransport()`, mirroring the existing request interceptor. This interceptor converts any plain-object response headers back to a proper `Headers` instance before `google-auth-library` accesses them. Native `Headers` instances are left untouched.

## Tests

- Added test verifying plain-object response headers are normalized to `Headers` instances with correct values
- Added test verifying native `Headers` instances on responses are passed through unchanged (identity check)