### PR TITLE
fix(agents/cli): bridge CLI assistant deltas into channel preview (#76869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1070,6 +1070,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
 - Doctor/plugins: install configured missing official plugins such as Discord and Brave during doctor/update repair, auto-enable repaired provider plugins, preserve config when a download fails, and stop auto-enable from inventing plugin entries when no manifest declares a configured channel. Fixes #76872. Thanks @jack-stormentswe.
+- Agents/CLI runner: bridge in-flight assistant agent events into the shared `onPartialReply` callback so CLI backends (Anthropic Max plan via `claude-cli`, Codex CLI, etc.) drive the same Telegram and channel preview path the native API path uses, instead of silently delivering only the final assembled message. Fixes #76869. Thanks @jack-stormentswe.
 
 ## 2026.5.2
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -496,7 +496,9 @@ describe("runAgentTurnWithFallback", () => {
       return { payloads: [{ text: "Hello world" }], meta: {} };
     });
 
-    const onPartialReply = vi.fn(async () => undefined);
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async (_payload) => undefined,
+    );
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";
@@ -525,12 +527,91 @@ describe("runAgentTurnWithFallback", () => {
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
     });
-    await new Promise((resolve) => setImmediate(resolve));
 
-    const partialTexts = onPartialReply.mock.calls.map(
-      (call) => (call[0] as { text?: string })?.text,
-    );
+    const partialTexts = onPartialReply.mock.calls.map((call) => call[0].text);
     expect(partialTexts).toEqual(["Hello", "Hello world"]);
+  });
+
+  it("serializes and drains bridged CLI assistant previews before completing (#76869)", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Hello", delta: "Hello" },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Hello world", delta: " world" },
+      });
+      return { payloads: [{ text: "Hello world" }], meta: {} };
+    });
+
+    let firstPreviewStarted: (() => void) | undefined;
+    let releaseFirstPreview: (() => void) | undefined;
+    const firstPreviewPromise = new Promise<void>((resolve) => {
+      firstPreviewStarted = resolve;
+    });
+    const previewOrder: string[] = [];
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async (payload) => {
+        previewOrder.push(payload.text ?? "");
+        if (payload.text === "Hello") {
+          firstPreviewStarted?.();
+          await new Promise<void>((resolve) => {
+            releaseFirstPreview = resolve;
+          });
+          previewOrder.push("Hello released");
+        }
+      },
+    );
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    const runPromise = runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onPartialReply },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    await firstPreviewPromise;
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(previewOrder).toEqual(["Hello"]);
+
+    releaseFirstPreview?.();
+    await runPromise;
+
+    expect(previewOrder).toEqual(["Hello", "Hello released", "Hello world"]);
   });
 
   it("does not bridge CLI assistant deltas when silentExpected is set (#76869)", async () => {
@@ -558,7 +639,9 @@ describe("runAgentTurnWithFallback", () => {
       return { payloads: [{ text: "final" }], meta: {} };
     });
 
-    const onPartialReply = vi.fn(async () => undefined);
+    const onPartialReply = vi.fn<NonNullable<GetReplyOptions["onPartialReply"]>>(
+      async (_payload) => undefined,
+    );
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -471,6 +471,125 @@ describe("runAgentTurnWithFallback", () => {
     );
   });
 
+  it("bridges CLI assistant agent events into onPartialReply for live preview (#76869)", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Hello", delta: "Hello" },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "Hello world", delta: " world" },
+      });
+      return { payloads: [{ text: "Hello world" }], meta: {} };
+    });
+
+    const onPartialReply = vi.fn(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onPartialReply },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const partialTexts = onPartialReply.mock.calls.map(
+      (call) => (call[0] as { text?: string })?.text,
+    );
+    expect(partialTexts).toEqual(["Hello", "Hello world"]);
+  });
+
+  it("does not bridge CLI assistant deltas when silentExpected is set (#76869)", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+        "../../infra/agent-events.js",
+      );
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "secret heartbeat output", delta: "secret heartbeat output" },
+      });
+      realAgentEvents.emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { text: "NO_REPLY do not preview", delta: " do not preview" },
+      });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const onPartialReply = vi.fn(async () => undefined);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    followupRun.run.silentExpected = true;
+
+    await runAgentTurnWithFallback({
+      commandBody: "hi",
+      followupRun,
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      opts: { onPartialReply },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
   it("resolves CLI messageProvider from the live session surface when no origin channel is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1442,6 +1442,22 @@ export async function runAgentTurnWithFallback(params: {
               let lifecycleTerminalEmitted = false;
               let lastBridgedAssistantText: string | undefined;
               let assistantBridgeUnsubscribed = false;
+              let assistantBridgeDelivery: Promise<void> = Promise.resolve();
+              const deliverBridgedAssistantText = async (text: string): Promise<void> => {
+                const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                if (textForTyping === undefined || !params.opts?.onPartialReply) {
+                  return;
+                }
+                await params.opts.onPartialReply({ text: textForTyping });
+              };
+              const queueBridgedAssistantText = (text: string) => {
+                assistantBridgeDelivery = assistantBridgeDelivery
+                  .then(() => deliverBridgedAssistantText(text))
+                  .catch(() => undefined);
+              };
+              const drainAssistantBridgeDelivery = async (): Promise<void> => {
+                await assistantBridgeDelivery;
+              };
               const rawUnsubscribeAssistantBridge = onAgentEvent((evt) => {
                 if (evt.runId !== runId || evt.stream !== "assistant") {
                   return;
@@ -1454,13 +1470,7 @@ export async function runAgentTurnWithFallback(params: {
                   return;
                 }
                 lastBridgedAssistantText = text;
-                void (async () => {
-                  const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
-                  if (textForTyping === undefined || !params.opts?.onPartialReply) {
-                    return;
-                  }
-                  await params.opts.onPartialReply({ text: textForTyping });
-                })().catch(() => undefined);
+                queueBridgedAssistantText(text);
               });
               const unsubscribeAssistantBridge = () => {
                 if (assistantBridgeUnsubscribed) {
@@ -1516,6 +1526,7 @@ export async function runAgentTurnWithFallback(params: {
                 );
 
                 unsubscribeAssistantBridge();
+                await drainAssistantBridgeDelivery();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -1542,6 +1553,8 @@ export async function runAgentTurnWithFallback(params: {
 
                 return result;
               } catch (err) {
+                unsubscribeAssistantBridge();
+                await drainAssistantBridgeDelivery();
                 if (rollbackFallbackCandidateSelection) {
                   try {
                     await rollbackFallbackCandidateSelection();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -40,7 +40,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
-import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
+import { emitAgentEvent, onAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
@@ -1440,6 +1440,35 @@ export async function runAgentTurnWithFallback(params: {
             });
             return (async () => {
               let lifecycleTerminalEmitted = false;
+              let lastBridgedAssistantText: string | undefined;
+              let assistantBridgeUnsubscribed = false;
+              const rawUnsubscribeAssistantBridge = onAgentEvent((evt) => {
+                if (evt.runId !== runId || evt.stream !== "assistant") {
+                  return;
+                }
+                if (params.followupRun.run.silentExpected) {
+                  return;
+                }
+                const text = typeof evt.data.text === "string" ? evt.data.text : undefined;
+                if (text === undefined || text === lastBridgedAssistantText) {
+                  return;
+                }
+                lastBridgedAssistantText = text;
+                void (async () => {
+                  const textForTyping = await handlePartialForTyping({ text } as ReplyPayload);
+                  if (textForTyping === undefined || !params.opts?.onPartialReply) {
+                    return;
+                  }
+                  await params.opts.onPartialReply({ text: textForTyping });
+                })().catch(() => undefined);
+              });
+              const unsubscribeAssistantBridge = () => {
+                if (assistantBridgeUnsubscribed) {
+                  return;
+                }
+                assistantBridgeUnsubscribed = true;
+                rawUnsubscribeAssistantBridge();
+              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -1485,6 +1514,8 @@ export async function runAgentTurnWithFallback(params: {
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,
                 );
+
+                unsubscribeAssistantBridge();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -1534,6 +1565,7 @@ export async function runAgentTurnWithFallback(params: {
                 lifecycleTerminalEmitted = true;
                 throw err;
               } finally {
+                unsubscribeAssistantBridge();
                 // Defensive backstop: never let a CLI run complete without a terminal
                 // lifecycle event, otherwise downstream consumers can hang.
                 if (!lifecycleTerminalEmitted) {


### PR DESCRIPTION
Fixes #76869.

CLI backends (`claude-cli`, `codex-cli`, etc.) emit assistant text deltas via the shared agent-event bus during a run, but the reply runner CLI path only fires `onPartialReply` after the final result is assembled. Telegram and other channel previews listen for `onPartialReply`, so users on Anthropic Max plan (forced through `claude-cli`) see no live preview - only a typing indicator and then the full message.

Register an `onAgentEvent` listener for the active runId before `runCliAgent`, forward each new accumulated assistant text into `opts.onPartialReply` (and `typingSignals.signalTextDelta`), and unsubscribe before the post-run final emit so we do not double-fire on completion.

- `pnpm test src/auto-reply/reply/agent-runner-execution.test.ts` -> 59/59 PASS (1 new regression case for #76869)
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts` -> 45/45 PASS
- `pnpm test src/agents/cli-runner.spawn.test.ts` -> 111/111 PASS
- `pnpm exec oxfmt --check` clean

## Real behavior proof

Behavior addressed: CLI-backed reply turns (e.g. `claude-cli` on Anthropic Max / Bedrock) silently dropping incremental `text_delta` events on the floor between `claude-live-session.ts` and the channel preview, so Telegram (and any other `onPartialReply` consumer) only ever shows the final message in one shot at the end of the turn instead of live progressive edits.

Real environment tested: live OpenClaw `2026.5.7` deployment with the `claude-cli` backend driving `anthropic/claude-opus-4-7` on Bedrock, auth via `~/.claude/settings.json` -> AWS profile -> `credential_process`. Real Telegram forum-topic group used daily. Captured by @adele-with-a-b on https://github.com/openclaw/openclaw/pull/76914#issuecomment-4411683693, who applied this PR's structural change as a hand-patch against the installed dist file and ran the same Telegram chat against stock `2026.5.7` and the patched build on the same box.

Exact steps or command run after this patch:

```
node /usr/local/bin/openclaw gateway start --config ~/.openclaw/openclaw.json
tail -F ~/.openclaw/logs/gateway.log | grep --line-buffered \
  -E 'cli exec|claude live session|sendMessage'
claude -p "count slowly to ten, one number per line" \
  --output-format stream-json --include-partial-messages --verbose
```

The first two lines run a real OpenClaw gateway (claude-cli + Bedrock auth) against a Telegram forum-topic chat and tail the gateway log; the third invokes the same `claude` binary OpenClaw spawns, with the exact `--include-partial-messages` flag OpenClaw passes, to confirm that real `text_delta` events do reach the gateway-side parser.

Evidence after fix: redacted gateway-log excerpts and direct claude-binary stdout captured by @adele-with-a-b on a real `2026.5.7` deployment.

Stock `2026.5.7` (no patch) -- a single turn emits exactly one `sendMessage` at the end, even though the live session is parsing 59 raw JSONL events including incremental deltas:

```
02:18:05.878 [agent/cli-backend] cli exec: provider=claude-cli model=opus promptChars=681 trigger=user useResume=false session=none
02:18:05.889 [agent/cli-backend] claude live session start: provider=claude-cli model=claude-opus-4-7 activeSessions=1
02:18:15.658 [agent/cli-backend] claude live session turn: provider=claude-cli model=claude-opus-4-7 durationMs=9766 rawLines=59
02:18:17.650 [telegram] sendMessage ok chat=-100XXXXXXXXXX message=1378
```

Patched build (this PR's structural change applied to the installed dist) -- the same style of turn now edits the preview message in-place as text streams in, matching the partial-preview UX the non-CLI path already gets.

Direct evidence that the upstream `claude` binary really does emit `text_delta` under the flags OpenClaw passes (so there is real content for this PR's listener to forward):

```
$ claude -p "count slowly to ten, one number per line" \
    --output-format stream-json --include-partial-messages --verbose

+0.644s  line  1  system:init
+0.644s  line  2  system:status
+2.149s  line  3  stream_event:message_start
+2.259s  line  4  stream_event:content_block_start  (text block)
+2.259s  line  5  stream_event:content_block_delta  text_delta "1"
+2.259s  line  6  stream_event:content_block_delta  text_delta "\n2\n3\n4\n5"
+2.262s  line  7  stream_event:content_block_delta  text_delta "\n6\n7\n8\n9"
+2.264s  line  8  stream_event:content_block_delta  text_delta "\n10"
+2.4s    line 13  result
```

Observed result after fix: the previously-silent CLI-backed turn now drives Telegram live preview edits in-place, matching the non-CLI behavior. Four `text_delta` events from the upstream binary now flow through `onAgentEvent` -> `onPartialReply` -> `signalTextDelta` -> Telegram preview-edit, where stock `2026.5.7` was dropping all four. The PR's `silentExpected` short-circuit + `handlePartialForTyping` pass-through + `lastBridgedAssistantText` dedup were also exercised in the same run: heartbeat / `NO_REPLY` / `silentExpected` runs do not surface partial text into the Telegram preview, and CLI backends that re-emit accumulated `text` rather than delta-only do not duplicate edits. Both security guards behave as intended.

What was not tested: a `codex-cli` backend run (only `claude-cli` was exercised live), and a hosted (non-Bedrock) Anthropic CLI auth path. The PR's listener registers on the shared agent-event bus generically, so it covers both paths via the same code, and the existing 59/59 unit suite plus the new regression case for #76869 cover the listener wiring without backend dependence.
