### PR TITLE
[codex] Fix model auth profile ids and LanceDB peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/models: add `--profile-id` to `openclaw models auth login` so OAuth-only providers such as OpenAI Codex can store multiple accounts without overwriting `provider:default`. Fixes #40402. Thanks @aureliadawne-pixel.
+- Memory/LanceDB: declare `apache-arrow` as a direct `@openclaw/memory-lancedb` runtime dependency so packaged CLI memory commands do not hang or fail when LanceDB's peer dependency is absent. Fixes #76910. Thanks @afiqfiles-max.
 - Gateway/usage: serve `usage.cost` and `sessions.usage` from a durable transcript aggregate cache with lock-safe background refreshes and localized stale-cache status, so large usage views avoid repeated full scans. (#76650) Thanks @Marvinthebored.
 - Plugins/hooks: let `plugins.entries.<id>.hooks.timeoutMs` and `plugins.entries.<id>.hooks.timeouts` bound plugin typed hooks from operator config, so slow hooks can be tuned without patching installed plugin code. Fixes #76778. Thanks @vincentkoc.
 - Telegram: add `channels.telegram.mediaGroupFlushMs` at the top level and per account so operators can tune album buffering instead of being stuck with the hard-coded 500ms media-group flush window. Fixes #76149. Thanks @vincentkoc.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0dd4f5abaf72f0d6b3fe5777cbf16c7a8c8052eece17436dc0ac2809b0ea27de  plugin-sdk-api-baseline.json
-2c2170cf2f1193f7dbecdef3ccd1b601992407e3d99863d1aa13cb1817c238fd  plugin-sdk-api-baseline.jsonl
+879219b8e7d7e879cf5dd3114b0dd1d5890e68d7c331922ed2dace9af2e3a7ed  plugin-sdk-api-baseline.json
+3edb65552ed3b40ab0515dd35fab29bb392b11f175f6db309f8b22bc780866d2  plugin-sdk-api-baseline.jsonl

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -173,6 +173,8 @@ provider you choose.
 
 `models auth login` runs a provider plugin’s auth flow (OAuth/API key). Use
 `openclaw plugins list` to see which providers are installed.
+Pass `--profile-id <id>` when you need the OAuth result written to a stable
+profile key, for example `openai-codex:account2`.
 Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a
 specific configured agent store. The parent `--agent` flag is honored by
 `add`, `login`, `setup-token`, `paste-token`, and `login-github-copilot`.

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -174,6 +174,11 @@ API key auth, and dynamic model resolution.
     `openclaw onboard --acme-ai-api-key <key>` and select
     `acme-ai/acme-large` as their model.
 
+    Interactive provider auth methods receive `ctx.profileId` when the caller
+    passes `openclaw models auth login --profile-id <id>`. OAuth providers that
+    cannot derive a stable account-specific profile id from upstream identity
+    data should pass that value through to their auth result.
+
     If the upstream provider uses different control tokens than OpenClaw, add a
     small bidirectional text transform instead of replacing the stream path:
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { Buffer } from "node:buffer";
+import { readFile } from "node:fs/promises";
 import { describe, test, expect, vi } from "vitest";
 import memoryPlugin, {
   detectCategory,
@@ -81,6 +82,16 @@ describe("memory plugin e2e", () => {
       ...overrides,
     }) as MemoryPluginTestConfig | undefined;
   }
+
+  test("declares LanceDB's apache-arrow peer as a package runtime dependency", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("./package.json", import.meta.url), "utf8"),
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies?.["apache-arrow"]).toBe("18.1.0");
+  });
 
   test("config schema parses valid config", async () => {
     const config = parseConfig({

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "dependencies": {
     "@lancedb/lancedb": "^0.27.2",
+    "apache-arrow": "18.1.0",
     "openai": "^6.35.0",
     "typebox": "1.1.37"
   },

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -1,10 +1,15 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const refreshOpenAICodexTokenMock = vi.hoisted(() => vi.fn());
+const loginOpenAICodexOAuthMock = vi.hoisted(() => vi.fn());
 const loginOpenAICodexDeviceCodeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./openai-codex-provider.runtime.js", () => ({
   refreshOpenAICodexToken: refreshOpenAICodexTokenMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-login", () => ({
+  loginOpenAICodexOAuth: loginOpenAICodexOAuthMock,
 }));
 
 vi.mock("./openai-codex-device-code.js", () => ({
@@ -52,6 +57,7 @@ describe("openai codex provider", () => {
 
   beforeEach(() => {
     refreshOpenAICodexTokenMock.mockReset();
+    loginOpenAICodexOAuthMock.mockReset();
     loginOpenAICodexDeviceCodeMock.mockReset();
   });
 
@@ -177,6 +183,37 @@ describe("openai codex provider", () => {
         choiceLabel: "OpenAI Codex Device Pairing",
         assistantPriority: -10,
       },
+    });
+  });
+
+  it("honors an explicit profile id for browser OAuth login", async () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const oauthMethod = provider.auth?.find((method) => method.id === "oauth");
+    loginOpenAICodexOAuthMock.mockResolvedValueOnce({
+      access:
+        "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9hY2NvdW50X2lkIjoiYWNjdC1icm93c2VyLTEyMyJ9fQ.signature",
+      refresh: "browser-refresh-token",
+      expires: Date.now() + 60_000,
+    });
+
+    const result = await oauthMethod?.run({
+      config: {},
+      env: process.env,
+      profileId: "openai-codex:account2",
+      prompter: { note: vi.fn(async () => {}) } as never,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as never,
+      isRemote: false,
+      openUrl: async () => {},
+      oauth: { createVpsAwareHandlers: (() => ({})) as never },
+    });
+
+    expect(loginOpenAICodexOAuthMock).toHaveBeenCalledOnce();
+    expect(result?.profiles[0]?.profileId).toBe("openai-codex:account2");
+    expect(result?.profiles[0]?.credential).toMatchObject({
+      type: "oauth",
+      provider: "openai-codex",
+      refresh: "browser-refresh-token",
+      accountId: "acct-browser-123",
     });
   });
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -363,6 +363,7 @@ async function runOpenAICodexOAuth(ctx: ProviderAuthContext) {
   return buildOauthProviderAuthResult({
     providerId: PROVIDER_ID,
     defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
+    profileId: ctx.profileId,
     access: creds.access,
     refresh: creds.refresh,
     expires: creds.expires,
@@ -413,6 +414,7 @@ async function runOpenAICodexDeviceCode(ctx: ProviderAuthContext) {
     return buildOauthProviderAuthResult({
       providerId: PROVIDER_ID,
       defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
+      profileId: ctx.profileId,
       access: creds.access,
       refresh: creds.refresh,
       expires: creds.expires,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -940,6 +940,9 @@ importers:
       '@lancedb/lancedb':
         specifier: ^0.27.2
         version: 0.27.2(apache-arrow@18.1.0)
+      apache-arrow:
+        specifier: 18.1.0
+        version: 18.1.0
       openai:
         specifier: ^6.35.0
         version: 6.35.0(ws@8.20.0)(zod@4.4.1)

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1679,10 +1679,17 @@ export function registerCapabilityCli(program: Command) {
     .command("login")
     .description("Run provider auth login")
     .requiredOption("--provider <id>", "Provider id")
+    .option("--profile-id <id>", "Auth profile id to write")
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
-        await modelsAuthLoginCommand({ provider: String(opts.provider) }, defaultRuntime);
+        await modelsAuthLoginCommand(
+          {
+            provider: String(opts.provider),
+            profileId: opts.profileId as string | undefined,
+          },
+          defaultRuntime,
+        );
       });
     });
 

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -168,6 +168,26 @@ describe("models cli", () => {
     expect(command).toHaveBeenCalledWith(expect.objectContaining(expected), expect.any(Object));
   });
 
+  it("passes --profile-id to models auth login", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "login",
+      "--provider",
+      "openai-codex",
+      "--profile-id",
+      "openai-codex:account2",
+    ]);
+
+    expect(modelsAuthLoginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai-codex",
+        profileId: "openai-codex:account2",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it.each([
     {
       label: "set",

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -319,6 +319,7 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option("--profile-id <id>", "Auth profile id to write")
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts, command) => {
       const agent = resolveOptionFromCommand<string>(command, "agent");
@@ -328,6 +329,7 @@ export function registerModelsCli(program: Command) {
           {
             provider: opts.provider as string | undefined,
             method: opts.method as string | undefined,
+            profileId: opts.profileId as string | undefined,
             setDefault: Boolean(opts.setDefault),
             agent,
           },

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -445,6 +445,49 @@ describe("modelsAuthLoginCommand", () => {
     );
   });
 
+  it("passes an explicit profile id through provider auth login", async () => {
+    const runtime = createRuntime();
+    runProviderAuth.mockImplementation(async (ctx) => ({
+      profiles: [
+        {
+          profileId: ctx.profileId,
+          credential: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      ],
+      defaultModel: "openai-codex/gpt-5.5",
+    }));
+
+    await modelsAuthLoginCommand(
+      { provider: "openai-codex", profileId: "openai-codex:account2" },
+      runtime,
+    );
+
+    expect(runProviderAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ profileId: "openai-codex:account2" }),
+    );
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "openai-codex:account2",
+      credential: expect.objectContaining({
+        type: "oauth",
+        provider: "openai-codex",
+      }),
+      agentDir: "/tmp/openclaw/agents/main",
+    });
+    expect(lastUpdatedConfig?.auth?.profiles?.["openai-codex:account2"]).toMatchObject({
+      provider: "openai-codex",
+      mode: "oauth",
+    });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Auth profile: openai-codex:account2 (openai-codex/oauth)",
+    );
+  });
+
   it("loads the owning plugin for an explicit provider even in a clean config", async () => {
     const runtime = createRuntime();
     const runClaudeCliMigration = vi.fn().mockResolvedValue({

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -291,6 +291,7 @@ async function runProviderAuthMethod(params: {
   config: OpenClawConfig;
   agentDir: string;
   workspaceDir: string;
+  profileId?: string;
   provider: ProviderPlugin;
   method: ProviderAuthMethod;
   runtime: RuntimeEnv;
@@ -304,6 +305,7 @@ async function runProviderAuthMethod(params: {
     env: process.env,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
+    profileId: params.profileId,
     prompter: params.prompter,
     runtime: params.runtime,
     allowSecretRefPrompt: false,
@@ -547,6 +549,7 @@ export async function modelsAuthAddCommand(opts: { agent?: string }, runtime: Ru
 type LoginOptions = {
   provider?: string;
   method?: string;
+  profileId?: string;
   setDefault?: boolean;
   yes?: boolean;
   agent?: string;
@@ -649,6 +652,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
     method: chosenMethod,
     runtime,
     prompter,
+    profileId: normalizeOptionalString(opts.profileId),
     setDefault: opts.setDefault,
   });
   maybeLogOpenAICodexNativeSearchTip(runtime, selectedProvider.id);

--- a/src/plugin-sdk/provider-auth-result.ts
+++ b/src/plugin-sdk/provider-auth-result.ts
@@ -7,6 +7,7 @@ import type { ProviderAuthResult } from "../plugins/types.js";
 export function buildOauthProviderAuthResult(params: {
   providerId: string;
   defaultModel: string;
+  profileId?: string | null;
   access: string;
   refresh?: string | null;
   expires?: number | null;
@@ -25,6 +26,7 @@ export function buildOauthProviderAuthResult(params: {
     profilePrefix: params.profilePrefix,
     profileName: params.profileName ?? email,
   });
+  const requestedProfileId = params.profileId?.trim();
 
   const credential: AuthProfileCredential = {
     type: "oauth",
@@ -38,7 +40,7 @@ export function buildOauthProviderAuthResult(params: {
   } as AuthProfileCredential;
 
   return {
-    profiles: [{ profileId, credential }],
+    profiles: [{ profileId: requestedProfileId || profileId, credential }],
     configPatch:
       params.configPatch ??
       ({

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -320,6 +320,13 @@ export type ProviderAuthContext = {
   env?: NodeJS.ProcessEnv;
   agentDir?: string;
   workspaceDir?: string;
+  /**
+   * Optional caller-requested auth profile id for interactive login flows.
+   *
+   * Provider methods may honor this when the provider cannot derive a stable
+   * account-specific id from the upstream OAuth/token response.
+   */
+  profileId?: string;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   /**


### PR DESCRIPTION
## Summary

- Add `--profile-id` to `openclaw models auth login` and pass it through provider auth context so OpenAI Codex OAuth/device-code logins can write to a caller-selected auth profile.
- Declare `apache-arrow` as a direct `@openclaw/memory-lancedb` runtime dependency so packaged LanceDB memory installs include LanceDB's required peer dependency.
- Update docs, changelog, targeted tests, and the plugin SDK API baseline for the new auth context field.

## Root Cause

OpenAI Codex OAuth login always let the provider helper derive the profile id, so repeated OAuth-only logins could overwrite the default profile instead of allowing a stable alternate profile such as `openai-codex:account2`.

The memory-lancedb extension relied on `@lancedb/lancedb`'s `apache-arrow` peer dependency being present transitively. That peer was present in the monorepo lockfile but was not declared by the packaged extension itself.

Fixes #40402.
Fixes #76910.

## Validation

- `corepack pnpm test src/commands/models/auth.test.ts src/cli/models-cli.test.ts extensions/openai/openai-codex-provider.test.ts extensions/memory-lancedb/index.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/cli/models.md docs/plugins/sdk-provider-plugins.md extensions/memory-lancedb/index.test.ts extensions/memory-lancedb/package.json extensions/openai/openai-codex-provider.test.ts extensions/openai/openai-codex-provider.ts src/cli/capability-cli.ts src/cli/models-cli.test.ts src/cli/models-cli.ts src/commands/models/auth.test.ts src/commands/models/auth.ts src/plugin-sdk/provider-auth-result.ts src/plugins/types.ts`
- `corepack pnpm plugin-sdk:check-exports`
- `corepack pnpm deps:root-ownership:check`
- `corepack pnpm plugin-sdk:api:check`
- `git diff --check`
- diff scan for common private key/token patterns