### PR TITLE
fix(plugins): honor archive dependency lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
 - Doctor/plugins: install configured missing official plugins such as Discord and Brave during doctor/update repair, auto-enable repaired provider plugins, preserve config when a download fails, and stop auto-enable from inventing plugin entries when no manifest declares a configured channel. Fixes #76872. Thanks @jack-stormentswe.
+- Plugins/install: honor archive plugin package-lock files while installing runtime dependencies, preventing verified archives from resolving a different dependency graph. (#76921) Thanks @Lucenx9.
 
 ## 2026.5.2
 

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -438,8 +438,8 @@ describe("installPackageDir", () => {
         env: expect.objectContaining({
           npm_config_global: "false",
           npm_config_location: "project",
-          npm_config_package_lock: "false",
-          npm_config_save: "false",
+          npm_config_package_lock: "true",
+          npm_config_save: "true",
         }),
       }),
     );

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -265,7 +265,7 @@ export async function installPackageDir(params: {
             {
               timeoutMs: Math.max(params.timeoutMs, 300_000),
               cwd: stageDir,
-              env: createSafeNpmInstallEnv(process.env),
+              env: createSafeNpmInstallEnv(process.env, { packageLock: true }),
             },
           );
         } finally {


### PR DESCRIPTION
## Summary

- Problem: archive-backed plugin dependency installs ran `npm install` with package-lock use disabled.
- Why it matters: verified plugin archives could still resolve runtime dependency code outside the archive-provided lockfile.
- What changed: archive dependency installs now create the safe npm environment with `packageLock: true`, and the existing install-package-dir test locks that behavior.
- What did NOT change (scope boundary): npm scripts remain disabled; this does not change npm-spec plugin installs or dependency denylist scanning.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the archive dependency install path used `createSafeNpmInstallEnv(process.env)` without opting into lockfile usage.
- Missing detection / guardrail: the existing install-package-dir test asserted project-local npm config hygiene but did not require package-lock usage.
- Contributing context (if known): `createSafeNpmInstallEnv` defaults `npm_config_package_lock` to `false` unless callers explicitly pass `packageLock: true`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/install-package-dir.test.ts`
- Scenario the test should lock in: dependency installs for copied package directories preserve project-local npm config while enabling package-lock usage.
- Why this is the smallest reliable guardrail: this is the shared installer seam where archive plugin dependency installs invoke npm.
- Existing test that already covers this (if any): `forces dependency installs to stay project-local when npm global config leaks in`
- If no new test is added, why not: the existing test already inspected the exact npm environment; this PR updates its expected security invariant.

## User-visible / Behavior Changes

Archive-backed plugin installs with runtime dependencies now honor package-lock files in the verified archive when npm installs dependencies.

## Diagram (if applicable)

```text
Before:
archive plugin -> verified archive -> npm install package-lock=false -> dependency graph can drift

After:
archive plugin -> verified archive -> npm install package-lock=true -> archive lockfile is honored
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: the npm install command surface is unchanged, but dependency resolution now honors package-lock integrity for archive plugin installs, reducing dependency-substitution risk. Install scripts remain disabled.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24.15.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Inspect archive dependency install path in `src/infra/install-package-dir.ts`.
2. Run the targeted installer test.

### Expected

- The npm install environment sets `npm_config_package_lock` to `true` for package-dir dependency installs.

### Actual

- Before this PR, the test expected `npm_config_package_lock: "false"`; after this PR, it expects and verifies `"true"`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm format:check src/infra/install-package-dir.ts src/infra/install-package-dir.test.ts`
  - `pnpm test src/infra/install-package-dir.test.ts`
- Edge cases checked: project-local npm config overrides still remain asserted in the existing test.
- What you did **not** verify: full `pnpm check` or full test suite, to avoid unnecessary load on the local machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: archive plugins without lockfiles may generate or update a package-lock during dependency install.
  - Mitigation: dependency installs already happen in an isolated staged copy; npm scripts remain disabled, and this behavior matches the existing `packageLock: true` usage in other install paths.
