### PR TITLE
feat(bluebubbles): opt-in textFormatting passthrough (companion to BB Server PR #766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/bluebubbles: add opt-in `channels.bluebubbles.textFormatting.enabled` (default `false`) that translates inline markdown (`**bold**`, `*italic*`, `~~strike~~`, plus the `__bold__` alias and nested `**_bold italic_**`) into BlueBubbles `textFormatting` ranges on outbound `/api/v1/message/text` payloads. Gated on Private API + a new `isMacOS15OrHigher` probe; block-level markdown bails to plain stripping to avoid index drift. Stock pre-PR-766 BB servers ignore the unknown payload field, so the flag is safe to flip on hosts that are not yet upgraded. Companion to [BlueBubblesApp/bluebubbles-server#766](https://github.com/BlueBubblesApp/bluebubbles-server/pull/766) and [BlueBubblesApp/bluebubbles-helper#50](https://github.com/BlueBubblesApp/bluebubbles-helper/pull/50). Thanks @omarshahine.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.
 - Discord/status: let explicit reaction tool calls opt into tracking subsequent tool progress on the reacted message with `trackToolCalls: true`, and use the shared tool display emoji table for status reactions.

--- a/extensions/bluebubbles/src/account-resolve.ts
+++ b/extensions/bluebubbles/src/account-resolve.ts
@@ -26,6 +26,11 @@ export function resolveBlueBubblesServerAccount(params: BlueBubblesAccountResolv
    * (#67486)
    */
   sendTimeoutMs?: number;
+  /**
+   * Resolved value of `channels.bluebubbles.textFormatting.enabled` (or the
+   * matching per-account override). Default `false` — opt-in only.
+   */
+  textFormattingEnabled: boolean;
 } {
   const account = resolveBlueBubblesAccount({
     cfg: params.cfg ?? {},
@@ -73,5 +78,6 @@ export function resolveBlueBubblesServerAccount(params: BlueBubblesAccountResolv
     }),
     allowPrivateNetworkConfig: resolveBlueBubblesPrivateNetworkConfigValue(account.config),
     sendTimeoutMs,
+    textFormattingEnabled: account.config.textFormatting?.enabled === true,
   };
 }

--- a/extensions/bluebubbles/src/config-schema.ts
+++ b/extensions/bluebubbles/src/config-schema.ts
@@ -110,6 +110,17 @@ const bluebubblesAccountSchema = z
     replyContextApiFallback: z.boolean().optional(),
     groups: z.object({}).catchall(bluebubblesGroupConfigSchema).optional(),
     coalesceSameSenderDms: z.boolean().optional(),
+    textFormatting: z
+      .object({
+        /**
+         * Translate inline markdown into BlueBubbles `textFormatting`
+         * ranges on outbound sends. Requires BlueBubbles Server PR #766
+         * and macOS Sequoia (15) or newer. Default: false.
+         */
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .superRefine((value, ctx) => {
     const serverUrl = value.serverUrl?.trim() ?? "";

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -133,6 +133,22 @@ export function isMacOS26OrHigher(accountId?: string): boolean {
   return major !== null && major >= 26;
 }
 
+/**
+ * Check if the cached server info indicates macOS Sequoia (15) or higher.
+ * Used by the optional textFormatting send path: BlueBubbles Server PR #766
+ * returns a 400 when textFormatting is sent against a pre-Sequoia host.
+ * Returns false on no cached info (fail closed: skip the optional payload
+ * rather than risk a hard send failure).
+ */
+export function isMacOS15OrHigher(accountId?: string): boolean {
+  const info = getCachedBlueBubblesServerInfo(accountId);
+  if (!info?.os_version) {
+    return false;
+  }
+  const major = parseMacOSMajorVersion(info.os_version);
+  return major !== null && major >= 15;
+}
+
 export async function probeBlueBubbles(params: {
   baseUrl?: string | null;
   password?: string | null;

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -11,12 +11,14 @@ import {
   fetchBlueBubblesServerInfo,
   getCachedBlueBubblesPrivateApiStatus,
   isBlueBubblesPrivateApiStatusEnabled,
+  isMacOS15OrHigher,
   isMacOS26OrHigher,
 } from "./probe.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { warnBlueBubbles } from "./runtime.js";
 import { extractBlueBubblesMessageId, resolveBlueBubblesSendTarget } from "./send-helpers.js";
 import { extractHandleFromChatGuid, normalizeBlueBubblesHandle } from "./targets.js";
+import { extractTextFormatting } from "./text-formatting.js";
 import { DEFAULT_SEND_TIMEOUT_MS, type BlueBubblesSendTarget } from "./types.js";
 
 export type BlueBubblesSendOpts = {
@@ -497,13 +499,19 @@ export async function sendMessageBlueBubbles(
     throw new Error("BlueBubbles send requires text (message was empty after markdown removal)");
   }
 
-  const { baseUrl, password, accountId, allowPrivateNetwork, sendTimeoutMs } =
-    resolveBlueBubblesServerAccount({
-      cfg: opts.cfg ?? {},
-      accountId: opts.accountId,
-      serverUrl: opts.serverUrl,
-      password: opts.password,
-    });
+  const {
+    baseUrl,
+    password,
+    accountId,
+    allowPrivateNetwork,
+    sendTimeoutMs,
+    textFormattingEnabled,
+  } = resolveBlueBubblesServerAccount({
+    cfg: opts.cfg ?? {},
+    accountId: opts.accountId,
+    serverUrl: opts.serverUrl,
+    password: opts.password,
+  });
   // Send-path timeout: explicit caller override > per-account config > 30s default.
   // Kept separate from the default 10s client timeout so chat lookups, probes,
   // and health checks stay snappy while actual sends can ride out macOS 26
@@ -576,6 +584,26 @@ export async function sendMessageBlueBubbles(
   if (privateApiDecision.warningMessage) {
     warnBlueBubbles(privateApiDecision.warningMessage);
   }
+  // Optional text-formatting payload (BlueBubbles Server PR #766). Only
+  // attempted when (a) the operator opted in, (b) Private API is in play
+  // (PR #766's validator forces method=private-api when textFormatting is
+  // present, and rejects the combination on AppleScript), and (c) the BB
+  // host reports macOS Sequoia (15) or higher (PR #766 returns 400 on
+  // pre-Sequoia). Stock pre-PR servers silently drop the unknown field.
+  let messageBody = strippedText;
+  let textFormatting: ReturnType<typeof extractTextFormatting>["formatting"] | undefined;
+  if (
+    textFormattingEnabled &&
+    privateApiDecision.canUsePrivateApi &&
+    isMacOS15OrHigher(accountId)
+  ) {
+    const extracted = extractTextFormatting(trimmedText);
+    if (extracted.plain.trim() && extracted.formatting.length > 0) {
+      messageBody = extracted.plain;
+      textFormatting = extracted.formatting;
+    }
+  }
+
   // Always set `method` explicitly. BB Server's behavior on an omitted
   // `method` is version-dependent and silently drops on some setups (e.g.
   // macOS without Private API — message lands in Messages.app locally but
@@ -583,7 +611,7 @@ export async function sendMessageBlueBubbles(
   const payload: Record<string, unknown> = {
     chatGuid,
     tempGuid: crypto.randomUUID(),
-    message: strippedText,
+    message: messageBody,
     method: privateApiDecision.canUsePrivateApi ? "private-api" : "apple-script",
   };
 
@@ -596,6 +624,10 @@ export async function sendMessageBlueBubbles(
   // Add message effects support
   if (effectId && privateApiDecision.canUsePrivateApi) {
     payload.effectId = effectId;
+  }
+
+  if (textFormatting) {
+    payload.textFormatting = textFormatting;
   }
 
   const client = createBlueBubblesClient({

--- a/extensions/bluebubbles/src/text-formatting.test.ts
+++ b/extensions/bluebubbles/src/text-formatting.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { extractTextFormatting } from "./text-formatting.js";
+
+describe("extractTextFormatting", () => {
+  it("handles empty input", () => {
+    expect(extractTextFormatting("")).toEqual({ plain: "", formatting: [] });
+  });
+
+  it("returns plain text when no markers are present", () => {
+    expect(extractTextFormatting("hello world")).toEqual({
+      plain: "hello world",
+      formatting: [],
+    });
+  });
+
+  it("extracts a single bold range", () => {
+    const out = extractTextFormatting("hello **world**");
+    expect(out.plain).toBe("hello world");
+    expect(out.formatting).toEqual([{ start: 6, length: 5, styles: ["bold"] }]);
+  });
+
+  it("treats __X__ as bold", () => {
+    const out = extractTextFormatting("__loud__");
+    expect(out.plain).toBe("loud");
+    expect(out.formatting).toEqual([{ start: 0, length: 4, styles: ["bold"] }]);
+  });
+
+  it("extracts italic with single asterisks", () => {
+    const out = extractTextFormatting("*soft* spoken");
+    expect(out.plain).toBe("soft spoken");
+    expect(out.formatting).toEqual([{ start: 0, length: 4, styles: ["italic"] }]);
+  });
+
+  it("does not treat underscores inside identifiers as italic", () => {
+    const out = extractTextFormatting("snake_case_name");
+    expect(out.plain).toBe("snake_case_name");
+    expect(out.formatting).toEqual([]);
+  });
+
+  it("extracts strikethrough", () => {
+    const out = extractTextFormatting("price: ~~10~~ 5");
+    expect(out.plain).toBe("price: 10 5");
+    expect(out.formatting).toEqual([{ start: 7, length: 2, styles: ["strikethrough"] }]);
+  });
+
+  it("merges nested bold + italic into a single multi-style range", () => {
+    const out = extractTextFormatting("**_both_**");
+    expect(out.plain).toBe("both");
+    expect(out.formatting).toEqual([{ start: 0, length: 4, styles: ["italic", "bold"] }]);
+  });
+
+  it("handles mixed sequential markers", () => {
+    const out = extractTextFormatting("**a** then *b*");
+    expect(out.plain).toBe("a then b");
+    expect(out.formatting).toEqual([
+      { start: 0, length: 1, styles: ["bold"] },
+      { start: 7, length: 1, styles: ["italic"] },
+    ]);
+  });
+
+  it("falls back to literal when markers are unbalanced", () => {
+    const out = extractTextFormatting("hello **world");
+    expect(out.plain).toBe("hello **world");
+    expect(out.formatting).toEqual([]);
+  });
+
+  it("bails out when block-level markdown is present", () => {
+    const out = extractTextFormatting("# heading\n**bold**");
+    expect(out.plain).toBe("# heading\n**bold**");
+    expect(out.formatting).toEqual([]);
+  });
+
+  it("ranges align to the stripped message body", () => {
+    const out = extractTextFormatting("the **quick** brown ~~fox~~");
+    expect(out.plain).toBe("the quick brown fox");
+    for (const r of out.formatting) {
+      expect(r.start).toBeGreaterThanOrEqual(0);
+      expect(r.start + r.length).toBeLessThanOrEqual(out.plain.length);
+    }
+  });
+});

--- a/extensions/bluebubbles/src/text-formatting.ts
+++ b/extensions/bluebubbles/src/text-formatting.ts
@@ -1,0 +1,206 @@
+/**
+ * Markdown -> BlueBubbles textFormatting ranges.
+ *
+ * BlueBubbles Server PR #766 added an optional `textFormatting` field to
+ * `/api/v1/message/text` that the macOS 15+ Private API renders as bold /
+ * italic / underline / strikethrough runs. This helper translates inline
+ * markdown into the wire format that PR expects: an array of
+ * `{ start, length, styles[] }` ranges over the *stripped* message body.
+ *
+ * Stays intentionally minimal:
+ *   - Inline marks only: `**bold**`, `__bold__`, `*italic*`, `_italic_`,
+ *     `~~strike~~`. Nesting supported (e.g. `**_bold italic_**`).
+ *   - Block markdown (headings, blockquotes, code spans, hr, code fences)
+ *     is delegated to `stripMarkdown` from the plugin SDK; if the input
+ *     contains any of those, we abandon the formatting ranges and fall
+ *     back to plain stripping. Avoids subtle index drift between the
+ *     ranges and the message body BB validates against. The flag is opt-in
+ *     so this conservative path is safe.
+ *
+ * Backward compatibility: stock BB Server (no PR #766) silently drops the
+ * `textFormatting` payload key (validatorjs ignores unknown fields and
+ * the validator doesn't destructure it). On macOS <15, PR #766 returns a
+ * 400 — callers must gate on macOS version, not just feature config.
+ */
+
+export type TextFormattingStyle = "bold" | "italic" | "underline" | "strikethrough";
+
+export type TextFormattingRange = {
+  start: number;
+  length: number;
+  styles: TextFormattingStyle[];
+};
+
+export type ExtractedFormatting = {
+  plain: string;
+  formatting: TextFormattingRange[];
+};
+
+const BLOCK_MARKDOWN_PATTERN = /(^\s{0,3}#{1,6}\s)|(^\s{0,3}>\s?)|(^[-*_]{3,}\s*$)|(`)|(```)/m;
+
+type Token = { kind: "text"; value: string } | { kind: "open" | "close"; marker: Marker };
+
+type Marker = {
+  /** Wire-format style emitted for this marker. */
+  style: TextFormattingStyle;
+  /** Marker bytes in source (e.g. `**`, `*`, `~~`). */
+  open: string;
+  close: string;
+  /**
+   * If the marker can be matched by either of two source patterns (e.g.
+   * `**bold**` or `__bold__` both produce `bold`), list both. The first
+   * entry is the canonical form used for matching pairs.
+   */
+};
+
+const MARKERS: Marker[] = [
+  { style: "bold", open: "**", close: "**" },
+  { style: "bold", open: "__", close: "__" },
+  { style: "strikethrough", open: "~~", close: "~~" },
+  { style: "italic", open: "*", close: "*" },
+  { style: "italic", open: "_", close: "_" },
+];
+
+const WORD_CHAR = /[\p{L}\p{N}]/u;
+
+function tryReadMarker(input: string, i: number): Marker | null {
+  for (const m of MARKERS) {
+    if (input.startsWith(m.open, i)) {
+      // Single-char `*` / `_` markers must not be adjacent to `*` / `_`
+      // (those are double-mark openers handled above) or, for `_`, to a
+      // word character (matches stripMarkdown's word-boundary heuristic
+      // so `snake_case_names` are not mangled).
+      if (m.open === "*") {
+        const prev = input[i - 1];
+        const next = input[i + 1];
+        if (prev === "*" || next === "*") continue;
+      }
+      if (m.open === "_") {
+        const prev = input[i - 1];
+        const next = input[i + 1];
+        if (prev === "_" || next === "_") continue;
+        if (prev && WORD_CHAR.test(prev)) continue;
+      }
+      return m;
+    }
+  }
+  return null;
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  const stack: Marker[] = [];
+  let buf = "";
+  let i = 0;
+  const flush = () => {
+    if (buf.length > 0) {
+      tokens.push({ kind: "text", value: buf });
+      buf = "";
+    }
+  };
+  while (i < input.length) {
+    const top = stack[stack.length - 1];
+    // Prefer closing the active marker over re-opening it.
+    if (top && input.startsWith(top.close, i)) {
+      flush();
+      tokens.push({ kind: "close", marker: top });
+      stack.pop();
+      i += top.close.length;
+      continue;
+    }
+    const m = tryReadMarker(input, i);
+    if (m) {
+      // Look ahead for a matching close *somewhere* before EOL/EOI; if
+      // missing, treat the marker bytes as literal text.
+      const closeIdx = input.indexOf(m.close, i + m.open.length);
+      if (closeIdx === -1) {
+        buf += input[i];
+        i += 1;
+        continue;
+      }
+      flush();
+      tokens.push({ kind: "open", marker: m });
+      stack.push(m);
+      i += m.open.length;
+      continue;
+    }
+    buf += input[i];
+    i += 1;
+  }
+  flush();
+  // Any unclosed markers fall through as literal text — recover by
+  // converting trailing `open` tokens back into text. Simpler than a
+  // backtracking parser and matches user intent (unbalanced markup is
+  // probably literal in iMessage context).
+  return collapseUnclosed(tokens);
+}
+
+function collapseUnclosed(tokens: Token[]): Token[] {
+  const open = new Map<Marker, number>();
+  for (const t of tokens) {
+    if (t.kind === "open") open.set(t.marker, (open.get(t.marker) ?? 0) + 1);
+    else if (t.kind === "close") {
+      const n = open.get(t.marker);
+      if (n) open.set(t.marker, n - 1);
+    }
+  }
+  const unclosedMarkers = new Set<Marker>();
+  for (const [m, n] of open) if (n > 0) unclosedMarkers.add(m);
+  if (unclosedMarkers.size === 0) return tokens;
+  const out: Token[] = [];
+  for (const t of tokens) {
+    if (t.kind === "open" && unclosedMarkers.has(t.marker)) {
+      out.push({ kind: "text", value: t.marker.open });
+    } else {
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+export function extractTextFormatting(raw: string): ExtractedFormatting {
+  if (!raw) return { plain: "", formatting: [] };
+  if (BLOCK_MARKDOWN_PATTERN.test(raw)) {
+    return { plain: raw, formatting: [] };
+  }
+  const tokens = tokenize(raw);
+  let plain = "";
+  const stack: { marker: Marker; start: number }[] = [];
+  const ranges: TextFormattingRange[] = [];
+  for (const t of tokens) {
+    if (t.kind === "text") {
+      plain += t.value;
+    } else if (t.kind === "open") {
+      stack.push({ marker: t.marker, start: plain.length });
+    } else {
+      const top = stack.pop();
+      if (!top || top.marker !== t.marker) continue;
+      const length = plain.length - top.start;
+      if (length > 0) {
+        ranges.push({ start: top.start, length, styles: [top.marker.style] });
+      }
+    }
+  }
+  return { plain, formatting: mergeRanges(ranges) };
+}
+
+/**
+ * Merge ranges that share `{start, length}` into a single multi-style
+ * range. Keeps the wire payload compact and makes nested markers like
+ * `**_x_**` produce one range with `["bold","italic"]` instead of two
+ * overlapping ones (which the BB Server validator accepts but renders
+ * less predictably).
+ */
+function mergeRanges(ranges: TextFormattingRange[]): TextFormattingRange[] {
+  const byKey = new Map<string, TextFormattingRange>();
+  for (const r of ranges) {
+    const key = `${r.start}:${r.length}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      for (const s of r.styles) if (!existing.styles.includes(s)) existing.styles.push(s);
+    } else {
+      byKey.set(key, { start: r.start, length: r.length, styles: [...r.styles] });
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.start - b.start || a.length - b.length);
+}

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -121,6 +121,16 @@ export type BlueBubblesAccountConfig = {
    * `associatedMessageGuid`. Default: false.
    */
   coalesceSameSenderDms?: boolean;
+  /**
+   * Translate inline markdown (`**bold**`, `*italic*`, `~~strike~~`, etc.)
+   * into BlueBubbles `textFormatting` ranges on outbound sends. Requires
+   * BlueBubbles Server with PR #766 and macOS Sequoia (15) or newer; a
+   * runtime probe gates on the BB host's reported `os_version`, and stock
+   * servers silently ignore the unknown payload field. Default: false.
+   */
+  textFormatting?: {
+    enabled?: boolean;
+  };
 };
 
 export type BlueBubblesSendTarget =

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -324,6 +324,15 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         coalesceSameSenderDms: {
           type: "boolean",
         },
+        textFormatting: {
+          type: "object",
+          properties: {
+            enabled: {
+              type: "boolean",
+            },
+          },
+          additionalProperties: false,
+        },
         accounts: {
           type: "object",
           properties: {},
@@ -643,6 +652,15 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               coalesceSameSenderDms: {
                 type: "boolean",
+              },
+              textFormatting: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                },
+                additionalProperties: false,
               },
             },
             required: ["enrichGroupParticipantsFromContacts"],


### PR DESCRIPTION
## Summary

Adds an **opt-in** plugin counterpart to the still-open
[BlueBubblesApp/bluebubbles-server#766](https://github.com/BlueBubblesApp/bluebubbles-server/pull/766)
(server-side `textFormatting` plumbing) and
[BlueBubblesApp/bluebubbles-helper#50](https://github.com/BlueBubblesApp/bluebubbles-helper/pull/50)
(helper-side render). When all three are present, OpenClaw's BlueBubbles
plugin parses inline markdown in outbound text and emits the
`textFormatting` ranges that PR #766 forwards to PR #50, which paints
`__kIMTextBold/Italic/Underline/StrikethroughAttributeName` runs onto the
outgoing iMessage. Recipient sees native rich-text formatting.

The flag is **default off**. With it off, this PR is a no-op on the wire
— the plugin's outbound payload is byte-identical to today.

Companion to:
- BB Server: https://github.com/BlueBubblesApp/bluebubbles-server/pull/766
- BB Helper: https://github.com/BlueBubblesApp/bluebubbles-helper/pull/50

Drafting because both upstream PRs are still open. Will mark
ready-for-review once the BB server side is merged and a release with
the regenerated bundled helper dylib is cut. (Verified end-to-end on
macOS 26.4.1 with locally-built versions of all three.)

## What this changes

| File | Change |
|---|---|
| `extensions/bluebubbles/src/text-formatting.ts` (new, 206 LOC) | Markdown→ranges parser. Handles `**bold**` / `__bold__`, `*italic*` / `_italic_` (with stripMarkdown's word-boundary heuristic so `snake_case` is preserved), `~~strike~~`, and nested `**_bold italic_**`. Bails to plain stripping when block-level markdown (headings/blockquotes/code/hr) appears, to avoid offset drift between ranges and the message body PR #766's validator checks. |
| `extensions/bluebubbles/src/text-formatting.test.ts` (new) | 12 unit tests covering empty input, plain text, single styles, nested combos, identifier preservation, unbalanced markers, block-level bailout, and range-bounds invariants. |
| `extensions/bluebubbles/src/probe.ts` | Adds `isMacOS15OrHigher(accountId)` reusing the existing `getCachedBlueBubblesServerInfo` cache — same pattern as `isMacOS26OrHigher`. Fail-closed when no cached info (skip the optional payload rather than risk a 400 from PR #766's macOS-15 gate). |
| `extensions/bluebubbles/src/types.ts`, `config-schema.ts` | Adds `textFormatting?: { enabled?: boolean }` on the per-account schema. Multi-account catchall propagates the field to channel-level config. |
| `extensions/bluebubbles/src/account-resolve.ts` | Surfaces resolved `textFormattingEnabled: boolean` on the account-resolve return shape. |
| `extensions/bluebubbles/src/send.ts` | When the flag is on, the cached Private API status allows it, and `isMacOS15OrHigher` returns true: replaces `stripMarkdown(text)` with `extractTextFormatting(text)` (same plain output, plus ranges) and attaches `textFormatting` to the `/api/v1/message/text` payload only when ranges are non-empty. All other paths unchanged. |
| `src/config/bundled-channel-config-metadata.generated.ts` | Regenerated by `pnpm config:channels:gen`. |
| `CHANGELOG.md` | Unreleased > Changes entry. |

## Backward-compatibility properties

| Plugin flag | BB Server | BB Helper | macOS | Result |
|---|---|---|---|---|
| off | any | any | any | identical to today (no payload change) |
| on | stock | any | any | `textFormatting` silently dropped by validatorjs (unknown key); plain text sent — no breakage |
| on | PR #766 | PR #50 | 15+ | **formatted iMessage rendered** |
| on | PR #766 | PR #50 | <15 | plugin's macOS probe skips the field; plain text sent (avoids the 400 PR #766 returns on pre-Sequoia) |
| on | PR #766 | stock | any | server accepts and forwards, helper drops the unknown payload key, recipient sees plain text. The `attributedBody.runs` curl recipe in PR #766's discussion catches this. |

## Test plan

- [x] `pnpm test:extension bluebubbles` — 597/597 (was 585; +12 new in `text-formatting.test.ts`).
- [x] `pnpm tsgo:extensions` clean for the bluebubbles extension (only pre-existing errors elsewhere in the monorepo).
- [x] `pnpm config:channels:gen` regenerates the metadata cleanly.
- [x] End-to-end on macOS 26.4.1 (Apple Silicon) with locally-built BB Server PR #766 + BB Helper PR #50: recipient iPhone renders bold/italic/strike on `**bold**`, `*italic*`, `~~strike~~`, and the nested `**_combo_**`.
- [x] Stock BB Server (no PR #766) with the flag on: send returns 200, message arrives plain, no errors logged. Validator path verified by reading `packages/server/src/server/api/http/api/v1/validators/index.ts` — `validatorjs` ignores keys that aren't in the rule list, and `messageValidator.validateText` doesn't destructure unknown keys, so the field is dropped silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)