### PR TITLE
fix(exec-approvals): lazy-load command explainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec approvals: keep `exec.approval.list` on the lightweight policy-summary path so listing pending approvals no longer loads the rich tree-sitter command explainer. (#76943) Thanks @rubencu.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.
 - Ollama: keep DeepSeek V4 cloud models thinking-capable even when Ollama Cloud `/api/show` omits the `thinking` capability, so `/think high` no longer rejects `ollama/deepseek-v4-*:cloud`.

--- a/src/infra/command-analysis/explain.lazy.test.ts
+++ b/src/infra/command-analysis/explain.lazy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../command-explainer/extract.js", () => {
+  throw new Error("command explainer should not load for lightweight summaries");
+});
+
+describe("command-analysis lazy command explainer", () => {
+  it("does not load tree-sitter parser dependencies for policy summaries", async () => {
+    const { resolveCommandAnalysisSummaryForDisplay } = await import("./explain.js");
+
+    expect(
+      resolveCommandAnalysisSummaryForDisplay({
+        host: "gateway",
+        commandText: "python3 -c 'print(1)'",
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        commandCount: 1,
+        riskKinds: ["inline-eval"],
+        warningLines: ["Contains inline-eval: python3 -c"],
+      }),
+    );
+  });
+});

--- a/src/infra/command-analysis/explain.test.ts
+++ b/src/infra/command-analysis/explain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { explainShellCommand } from "../command-explainer/index.js";
 import {
+  explainCommandForDisplay,
   resolveCommandAnalysisSummaryForDisplay,
   summarizeCommandExplanation,
   summarizeCommandSegmentsForDisplay,
@@ -16,6 +17,17 @@ describe("command-analysis explanation summary", () => {
     expect(summary.riskKinds).toContain("inline-eval");
     expect(summary.warningLines).toEqual(
       expect.arrayContaining([expect.stringContaining("inline-eval")]),
+    );
+  });
+
+  it("loads the rich command explainer for rich display summaries", async () => {
+    const result = await explainCommandForDisplay(`bash -lc 'python3 -c "print(1)"'`);
+
+    expect(result?.summary).toEqual(
+      expect.objectContaining({
+        commandCount: 1,
+        riskKinds: expect.arrayContaining(["shell-wrapper", "inline-eval"]),
+      }),
     );
   });
 

--- a/src/infra/command-analysis/explain.ts
+++ b/src/infra/command-analysis/explain.ts
@@ -1,4 +1,3 @@
-import { explainShellCommand } from "../command-explainer/extract.js";
 import type { CommandExplanation, CommandRisk } from "../command-explainer/types.js";
 import type { ExecCommandSegment } from "../exec-approvals-analysis.js";
 import { analyzeCommandForPolicy } from "./policy.js";
@@ -122,6 +121,7 @@ export async function explainCommandForDisplay(
   command: string,
 ): Promise<{ explanation: CommandExplanation; summary: CommandExplanationSummary } | null> {
   try {
+    const { explainShellCommand } = await import("../command-explainer/extract.js");
     const explanation = await explainShellCommand(command);
     return { explanation, summary: summarizeCommandExplanation(explanation) };
   } catch {


### PR DESCRIPTION
## Summary
- Lazily loads the rich tree-sitter command explainer only when code asks for a rich command display summary.
- Keeps exec approval list and lightweight approval summary handling on the policy-analysis path that does not need tree-sitter.
- Adds regression coverage for both sides of the boundary: lightweight approval summaries must not load the rich explainer, while rich display summaries still do.
- No new config, protocol, or approval-policy surface.

## Problem
`exec.approval.list` is a lightweight Gateway RPC for listing pending exec approval records. It should be able to run without constructing the rich command explanation stack, because that stack is only needed when a UI asks for a human-readable command display summary.

Before this patch, `src/infra/command-analysis/explain.ts` statically imported `../command-explainer/extract.js` at module load. Loading the exec approval handler group pulls in the lightweight summary helper, which therefore pulled in the rich tree-sitter explainer and its `web-tree-sitter` dependency even for `exec.approval.list`.

## Fix
- Remove the static rich-explainer import from `src/infra/command-analysis/explain.ts` module load.
- Dynamically import `../command-explainer/extract.js` inside `explainCommandForDisplay`, the rich-display path that actually needs it.
- Leave `resolveCommandAnalysisSummaryForDisplay` on the existing lightweight policy-analysis implementation.

## Behavior impact
- `exec.approval.list` can return pending approvals without loading tree-sitter command parsing.
- Rich command display summaries still use the rich explainer.
- Approval record shape, Gateway protocol methods, and approval-policy decisions are unchanged.

## Real behavior proof
- Behavior or issue addressed: `exec.approval.list` should not load or fail on the rich tree-sitter command explainer dependency. Before this patch, that lightweight Gateway call fails if `web-tree-sitter` or `command-explainer/extract.js` cannot be imported.
- Real environment tested: local OpenClaw Gateway built from source on macOS, loopback WebSocket token auth, `OPENCLAW_DISABLE_CRON=1`, `OPENCLAW_SKIP_CHANNELS=1`, `OPENCLAW_CANVAS_DISABLED=1`, `--allow-unconfigured`, and `NODE_OPTIONS='--loader /tmp/openclaw-rich-explainer-block-loader.mjs'`. The diagnostic loader throws if `web-tree-sitter` or `command-explainer/extract.js` is imported.
- Exact steps or command run after this patch: built the PR head with `pnpm build`, started the PR-head Gateway with `node openclaw.mjs gateway run --auth token --bind loopback --ws-log compact --allow-unconfigured`, then ran `node openclaw.mjs gateway call exec.approval.list --json` against the local loopback Gateway under the same diagnostic loader.
- Evidence after fix: copied live terminal output and runtime log excerpt from PR head `d96e498855db66be19c8e4b38ad720164815c9e2`:

```text
HEAD_SHA=d96e498855db
READY=1
CALL_STATUS=0
CALL_OUTPUT_BEGIN
[]
CALL_OUTPUT_END
GATEWAY_LOG_PROOF_BEGIN
2026-05-09T19:27:09.682-04:00 [gateway] ready
2026-05-09T19:27:10.618-04:00 [ws] res success exec.approval.list 178ms conn=[redacted] id=[redacted]
GATEWAY_LOG_PROOF_END
```

- Observed result after fix: `exec.approval.list` returned `[]` with exit status `0`, and the Gateway log showed a successful `exec.approval.list` response. The diagnostic loader did not log any blocked rich-explainer import on the PR head.
- What was not tested: full provider/model execution was not exercised in this live proof because this patch only changes the exec approval import boundary; broad PR CI covers the wider suite.
- Before evidence optional: copied live terminal output and runtime log excerpt from the unpatched base `58692b9b559715339be088d7487350716f7e5536` using the same diagnostic loader:

```text
MAIN_SHA=58692b9b5597
READY=1
CALL_STATUS=1
CALL_OUTPUT_BEGIN
Gateway call failed: GatewayClientRequestError: Error: blocked-rich-explainer-import:web-tree-sitter
CALL_OUTPUT_END
GATEWAY_LOG_PROOF_BEGIN
2026-05-09T19:26:41.970-04:00 [gateway] request handler failed: Error: blocked-rich-explainer-import:web-tree-sitter
2026-05-09T19:26:41.974-04:00 [ws] res failed exec.approval.list 319ms errorCode=UNAVAILABLE errorMessage=Error: blocked-rich-explainer-import:web-tree-sitter conn=[redacted] id=[redacted]
[openclaw-pr76943-probe] blocked rich explainer import: web-tree-sitter
GATEWAY_LOG_PROOF_END
```

## Verification
- PR diff contains only `src/infra/command-analysis/explain.ts`, `src/infra/command-analysis/explain.test.ts`, and `src/infra/command-analysis/explain.lazy.test.ts`; no `CHANGELOG.md` change.
- `pnpm test src/infra/command-analysis/explain.test.ts src/infra/command-analysis/explain.lazy.test.ts` passed: 2 Vitest shards, 6 tests.
- `pnpm exec oxfmt --check --threads=1 src/infra/command-analysis/explain.ts src/infra/command-analysis/explain.test.ts src/infra/command-analysis/explain.lazy.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- `pnpm build` passed on the PR head.
- Live Gateway before/after proof above passed against base `58692b9b559715339be088d7487350716f7e5536` and head `d96e498855db66be19c8e4b38ad720164815c9e2`.
- `codex review --base origin/main` passed with no actionable findings after the final rebase.
- Broad validation: GitHub PR CI on the exact head.
