### PR TITLE
fix(messaging): stop short commentary from being suppressed after message tool delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/messaging: stop assistant commentary from being silently dropped after a `message` tool delivery when the commentary text is shorter than ~50% of the sent payload — short closing remarks such as "V2EX hot topics sent 😂" were falsely matched as substrings of the longer tool content and suppressed before reaching the channel. Fixes #76915. Thanks @hclsys.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  isMessagingToolDuplicate,
+  isMessagingToolDuplicateNormalized,
+  normalizeTextForComparison,
+} from "./messaging-dedupe.js";
+
+describe("normalizeTextForComparison", () => {
+  it("lowercases text", () => {
+    expect(normalizeTextForComparison("Hello World")).toBe("hello world");
+  });
+
+  it("strips emoji", () => {
+    expect(normalizeTextForComparison("sent! 🎵")).toBe("sent!");
+    expect(normalizeTextForComparison("done 😂")).toBe("done");
+  });
+
+  it("collapses whitespace", () => {
+    expect(normalizeTextForComparison("  hello   world  ")).toBe("hello world");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeTextForComparison("")).toBe("");
+  });
+});
+
+describe("isMessagingToolDuplicateNormalized", () => {
+  it("returns false when sentTexts is empty", () => {
+    expect(isMessagingToolDuplicateNormalized("hello world example", [])).toBe(false);
+  });
+
+  it("returns false when candidate is shorter than MIN_DUPLICATE_TEXT_LENGTH", () => {
+    expect(isMessagingToolDuplicateNormalized("hi", ["hi, how are you doing today"])).toBe(false);
+  });
+
+  it("returns true when candidate contains sent text (assistant re-narrates)", () => {
+    const sent = "v2ex ranked list of hot topics for today";
+    const candidate = `here is the v2ex ranked list of hot topics for today that was delivered`;
+    expect(isMessagingToolDuplicateNormalized(candidate, [sent])).toBe(true);
+  });
+
+  it("returns true when sent contains candidate and candidate is substantial (>=50% length)", () => {
+    const sent = "hello world this is a duplicate message sent via tool";
+    const candidate = "hello world this is a duplicate message sent"; // ~83% of sent length
+    expect(isMessagingToolDuplicateNormalized(candidate, [sent])).toBe(true);
+  });
+
+  it("returns false when candidate is a short commentary that appears in long sent text (#76915)", () => {
+    // Reproduces the bug: assistant says "delivered to telegram" as commentary,
+    // but the long sent text (a ranked list) happens to contain that phrase.
+    const longSentText =
+      "1. some article title\n2. another title\nv2ex hot topics delivered to telegram\n3. yet another";
+    const normalizedSent = normalizeTextForComparison(longSentText);
+    const shortCommentary = "v2ex hot topics delivered to telegram";
+    const normalizedCommentary = normalizeTextForComparison(shortCommentary);
+    // Commentary is ~30% of sent length — must not be suppressed
+    expect(isMessagingToolDuplicateNormalized(normalizedCommentary, [normalizedSent])).toBe(false);
+  });
+
+  it("returns false when candidate is short music commentary vs long file metadata", () => {
+    const longSentText =
+      "flac audio file: 梁静茹 宁夏 — bitrate: 1411kbps, duration: 4:23, size: 44mb, track: 1/12, album: 宁夏, year: 2004";
+    const normalizedSent = normalizeTextForComparison(longSentText);
+    const commentary = "小鸡出品，梁静茹《宁夏》，flac 无损直接发你了";
+    const normalizedCommentary = normalizeTextForComparison(commentary);
+    expect(isMessagingToolDuplicateNormalized(normalizedCommentary, [normalizedSent])).toBe(false);
+  });
+
+  it("returns true when sent text is identical to candidate", () => {
+    const text = "this is the message that was already delivered via tool";
+    const normalized = normalizeTextForComparison(text);
+    expect(isMessagingToolDuplicateNormalized(normalized, [normalized])).toBe(true);
+  });
+});
+
+describe("isMessagingToolDuplicate", () => {
+  it("returns false for empty sentTexts", () => {
+    expect(isMessagingToolDuplicate("hello world delivered", [])).toBe(false);
+  });
+
+  it("suppresses exact duplicate", () => {
+    const sent = "here is your report summary for today";
+    expect(isMessagingToolDuplicate(sent, [sent])).toBe(true);
+  });
+
+  it("does not suppress short commentary after long tool delivery (#76915)", () => {
+    const longDelivered =
+      "1. article one title\n2. article two title\n3. article three title\nhot topics sent to telegram — enjoy the weekend";
+    const commentary = "hot topics sent to telegram 😂";
+    expect(isMessagingToolDuplicate(commentary, [longDelivered])).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -2,6 +2,12 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 
 const MIN_DUPLICATE_TEXT_LENGTH = 10;
 
+// Minimum length ratio for the "sent text contains candidate" direction of dedup.
+// A candidate shorter than this fraction of the sent text is not suppressed as a
+// substring match — it is short commentary that incidentally appears within a long
+// message-tool payload and should still be delivered.
+const MIN_SUBSTRING_SUPPRESSION_RATIO = 0.5;
+
 /**
  * Normalize text for duplicate comparison.
  * - Trims whitespace
@@ -30,7 +36,21 @@ export function isMessagingToolDuplicateNormalized(
     if (!normalizedSent || normalizedSent.length < MIN_DUPLICATE_TEXT_LENGTH) {
       return false;
     }
-    return normalized.includes(normalizedSent) || normalizedSent.includes(normalized);
+    // The candidate contains the sent text — the assistant is re-narrating it.
+    if (normalized.includes(normalizedSent)) {
+      return true;
+    }
+    // The sent text contains the candidate — but only suppress when the candidate
+    // is substantial relative to the sent text. Short commentary (e.g. "delivered
+    // your file!") must not be suppressed because it accidentally appears as a
+    // substring inside a long message-tool payload (#76915).
+    if (
+      normalizedSent.includes(normalized) &&
+      normalized.length >= normalizedSent.length * MIN_SUBSTRING_SUPPRESSION_RATIO
+    ) {
+      return true;
+    }
+    return false;
   });
 }
 


### PR DESCRIPTION
## Problem

When an assistant sends a short closing remark after a `message` tool delivery — e.g.:

> "V2EX hot topics sent 😂"

…the assistant commentary was silently dropped before reaching the channel.

**Root cause:** `isMessagingToolDuplicateNormalized` performs a bidirectional substring check. The `normalizedSent.includes(normalized)` direction fires false positives when short commentary (~20–40 chars) accidentally appears as a substring inside a long tool payload (~100+ chars).

Example from the issue:
```
longSentText = "1. some article\n2. another\nv2ex hot topics delivered to telegram\n3. yet another"
commentary   = "v2ex hot topics delivered to telegram"   // 37 chars — ~30% of sent length
```
The commentary is a substring of `longSentText`, so the old code incorrectly returned `true` → message suppressed.

## Fix

Split the two substring directions with a proportionality guard:

```ts
const MIN_SUBSTRING_SUPPRESSION_RATIO = 0.5;

// candidate contains sent → assistant is re-narrating; suppress
if (normalized.includes(normalizedSent)) return true;

// sent contains candidate → only suppress when candidate is substantial
// (≥ 50% of sent length). Short incidental substrings pass through.
if (
  normalizedSent.includes(normalized) &&
  normalized.length >= normalizedSent.length * MIN_SUBSTRING_SUPPRESSION_RATIO
) {
  return true;
}
```

A candidate shorter than 50% of the sent text is never suppressed via the reverse-inclusion direction.

## Tests

Added `messaging-dedupe.test.ts` (14 tests) — previously no test file existed for this module. Includes:
- Regression test for the exact pattern from #76915 (commentary ~30% of sent length → not suppressed)
- Regression test for short music commentary vs long file metadata
- Existing correct-suppression cases still pass

```
✓ src/agents/pi-embedded-helpers/messaging-dedupe.test.ts (14)
Test Files  1 passed (1)
Tests       14 passed (14)
```

Fixes #76915. Thanks @hclsys.