### PR TITLE
resolve telegram topic bottleneck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -906,6 +906,7 @@ Docs: https://docs.openclaw.ai
 - QA/Matrix: steer the live tool-progress preview check away from `HEARTBEAT.md` and report final preview candidates when the live marker reply misses the exact token. Thanks @vincentkoc.
 - QA/Matrix: let the live tool-progress preview check verify progress replacement events without depending on the preview saying `Working`. Thanks @vincentkoc.
 - Tlon: expose `groupInviteAllowlist` in the channel config schema and clarify that group invite auto-accept fails closed without an invite allowlist. Thanks @vincentkoc.
+- Telegram: let forum-topic messages that omit `chat.is_forum` use per-topic processing lanes when Telegram still marks them as topic messages, and coalesce duplicate group typing cues so cosmetic Telegram API calls do not pile up ahead of real replies during topic bursts.
 - Control UI/WebChat: collapse duplicate in-flight internal text sends onto the active Gateway run so rapid repeat submits do not start fresh `agent:main:main` dispatches. Fixes #75737. Thanks @dsdsddd1 and @BunsDev.
 - Mattermost: accept the documented `channels.mattermost.streaming` config and honor `streaming: "off"` by disabling draft preview posts. Thanks @vincentkoc.
 - Mattermost: expose streaming progress config labels and help text in generated channel config metadata so Control UI/docs can explain the new `channels.mattermost.streaming.progress.*` fields. Thanks @vincentkoc.

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -59,6 +59,7 @@ const DEFAULT_TELEGRAM_BOT_RUNTIME: TelegramBotRuntime = {
   sequentialize,
   apiThrottler,
 };
+const TELEGRAM_TYPING_COALESCE_MS = 4_000;
 
 let telegramBotRuntimeForTest: TelegramBotRuntime | undefined;
 
@@ -562,6 +563,7 @@ export function createTelegramBotCore(
     sendChatActionFn: (chatId, action, threadParams) =>
       bot.api.sendChatAction(chatId, action, threadParams),
     logger: (message) => logVerbose(`telegram: ${message}`),
+    minIntervalMs: TELEGRAM_TYPING_COALESCE_MS,
   });
 
   const processMessage = createTelegramMessageProcessor({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -415,6 +415,71 @@ describe("createTelegramBot", () => {
     expect(events).toEqual(["busy:start", "status", "busy:end"]);
   });
 
+  it("lets Telegram topic messages without chat forum metadata use separate lanes", async () => {
+    installPerKeySequentializer();
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    const events: string[] = [];
+    let releaseFirstTopic!: () => void;
+    const firstTopicGate = new Promise<void>((resolve) => {
+      releaseFirstTopic = resolve;
+    });
+
+    createTelegramBot({ token: "tok" });
+    const sequentializer = sequentializeSpy.mock.results[0]?.value as
+      | TelegramMiddleware
+      | undefined;
+    expect(sequentializer).toBeDefined();
+    if (!sequentializer) {
+      return;
+    }
+
+    const topicCtx = (threadId: number, updateId: number) => {
+      const base = makeForumGroupMessageCtx({ threadId, text: `topic ${threadId}` });
+      return {
+        ...base,
+        message: {
+          ...base.message,
+          message_id: updateId,
+          is_topic_message: true,
+          chat: {
+            id: -1001234567890,
+            type: "supergroup",
+            title: "Forum Group",
+          },
+        },
+        update: { update_id: updateId },
+      };
+    };
+
+    const firstPromise = sequentializer(topicCtx(10, 301), async () => {
+      events.push("first:start");
+      await firstTopicGate;
+      events.push("first:end");
+    });
+
+    await flushTelegramTestMicrotasks();
+    expect(events).toEqual(["first:start"]);
+
+    await sequentializer(topicCtx(20, 302), async () => {
+      events.push("second");
+    });
+
+    expect(events).toEqual(["first:start", "second"]);
+
+    releaseFirstTopic();
+    await firstPromise;
+    expect(events).toEqual(["first:start", "second", "first:end"]);
+  });
+
   it("keeps ordinary Telegram messages serialized within the same topic", async () => {
     installPerKeySequentializer();
     loadConfig.mockReturnValue({

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -33,6 +33,53 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(handler.isSuspended()).toBe(false);
   });
 
+  it("coalesces duplicate chat actions while one for the chat is pending", async () => {
+    let resolveSend: ((value: true) => void) | undefined;
+    const send = new Promise<true>((resolve) => {
+      resolveSend = resolve;
+    });
+    const fn = vi.fn(() => send);
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      minIntervalMs: 4000,
+    });
+
+    const first = handler.sendChatAction(-100, "typing", { message_thread_id: 1 });
+    await handler.sendChatAction(-100, "typing", { message_thread_id: 2 });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(-100, "typing", { message_thread_id: 1 });
+
+    resolveSend?.(true);
+    await first;
+  });
+
+  it("coalesces recent same-chat actions after the pending send resolves", async () => {
+    let now = 1000;
+    const fn = vi.fn().mockResolvedValue(true);
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      minIntervalMs: 4000,
+      now: () => now,
+    });
+
+    await handler.sendChatAction(-100, "typing");
+    now = 4999;
+    await handler.sendChatAction(-100, "typing");
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await handler.sendChatAction(-100, "upload_photo");
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    now = 5000;
+    await handler.sendChatAction(-100, "typing");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
   it("applies exponential backoff on consecutive 401 errors", async () => {
     const fn = vi.fn().mockRejectedValue(make401Error());
     const logger = vi.fn();

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -47,10 +47,6 @@ export type CreateTelegramSendChatActionHandlerParams = {
   sendChatActionFn: SendChatActionFn;
   logger: TelegramSendChatActionLogger;
   maxConsecutive401?: number;
-  /**
-   * Best-effort per-chat/action coalescing window. Kept opt-in so tests and
-   * non-typing callers can preserve exact sendChatAction semantics.
-   */
   minIntervalMs?: number;
   now?: () => number;
 };
@@ -90,21 +86,13 @@ export function createTelegramSendChatActionHandler({
 }: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
   let consecutive401Failures = 0;
   let suspended = false;
-  const pendingKeys = new Set<string>();
-  const lastAttemptAtByKey = new Map<string, number>();
+  const blockedUntilByKey = new Map<string, number>();
 
   const reset = () => {
     consecutive401Failures = 0;
     suspended = false;
-    pendingKeys.clear();
-    lastAttemptAtByKey.clear();
+    blockedUntilByKey.clear();
   };
-
-  const coalesceKey = (chatId: number | string, action: ChatAction) =>
-    // The Telegram API throttler keys group traffic by chat_id, not thread ID.
-    // Coalescing at the same level keeps topic typing cues from filling the
-    // shared outbound lane ahead of real replies.
-    `${String(chatId)}:${action}`;
 
   const sendChatAction = async (
     chatId: number | string,
@@ -115,19 +103,14 @@ export function createTelegramSendChatActionHandler({
       return;
     }
 
-    const shouldCoalesce = Number.isFinite(minIntervalMs) && minIntervalMs > 0;
-    const key = shouldCoalesce ? coalesceKey(chatId, action) : undefined;
+    const key = minIntervalMs > 0 ? `${String(chatId)}:${action}` : undefined;
+    const attemptedAt = key ? now() : 0;
     if (key) {
-      if (pendingKeys.has(key)) {
+      const blockedUntil = blockedUntilByKey.get(key);
+      if (blockedUntil !== undefined && attemptedAt < blockedUntil) {
         return;
       }
-      const currentTime = now();
-      const lastAttemptAt = lastAttemptAtByKey.get(key);
-      if (lastAttemptAt !== undefined && currentTime - lastAttemptAt < minIntervalMs) {
-        return;
-      }
-      pendingKeys.add(key);
-      lastAttemptAtByKey.set(key, currentTime);
+      blockedUntilByKey.set(key, Number.POSITIVE_INFINITY);
     }
 
     if (consecutive401Failures > 0) {
@@ -167,7 +150,7 @@ export function createTelegramSendChatActionHandler({
       throw error;
     } finally {
       if (key) {
-        pendingKeys.delete(key);
+        blockedUntilByKey.set(key, attemptedAt + minIntervalMs);
       }
     }
   };

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -47,6 +47,12 @@ export type CreateTelegramSendChatActionHandlerParams = {
   sendChatActionFn: SendChatActionFn;
   logger: TelegramSendChatActionLogger;
   maxConsecutive401?: number;
+  /**
+   * Best-effort per-chat/action coalescing window. Kept opt-in so tests and
+   * non-typing callers can preserve exact sendChatAction semantics.
+   */
+  minIntervalMs?: number;
+  now?: () => number;
 };
 
 const BACKOFF_POLICY: BackoffPolicy = {
@@ -79,14 +85,26 @@ export function createTelegramSendChatActionHandler({
   sendChatActionFn,
   logger,
   maxConsecutive401 = 10,
+  minIntervalMs = 0,
+  now = () => Date.now(),
 }: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
   let consecutive401Failures = 0;
   let suspended = false;
+  const pendingKeys = new Set<string>();
+  const lastAttemptAtByKey = new Map<string, number>();
 
   const reset = () => {
     consecutive401Failures = 0;
     suspended = false;
+    pendingKeys.clear();
+    lastAttemptAtByKey.clear();
   };
+
+  const coalesceKey = (chatId: number | string, action: ChatAction) =>
+    // The Telegram API throttler keys group traffic by chat_id, not thread ID.
+    // Coalescing at the same level keeps topic typing cues from filling the
+    // shared outbound lane ahead of real replies.
+    `${String(chatId)}:${action}`;
 
   const sendChatAction = async (
     chatId: number | string,
@@ -95,6 +113,21 @@ export function createTelegramSendChatActionHandler({
   ): Promise<void> => {
     if (suspended) {
       return;
+    }
+
+    const shouldCoalesce = Number.isFinite(minIntervalMs) && minIntervalMs > 0;
+    const key = shouldCoalesce ? coalesceKey(chatId, action) : undefined;
+    if (key) {
+      if (pendingKeys.has(key)) {
+        return;
+      }
+      const currentTime = now();
+      const lastAttemptAt = lastAttemptAtByKey.get(key);
+      if (lastAttemptAt !== undefined && currentTime - lastAttemptAt < minIntervalMs) {
+        return;
+      }
+      pendingKeys.add(key);
+      lastAttemptAtByKey.set(key, currentTime);
     }
 
     if (consecutive401Failures > 0) {
@@ -132,6 +165,10 @@ export function createTelegramSendChatActionHandler({
         }
       }
       throw error;
+    } finally {
+      if (key) {
+        pendingKeys.delete(key);
+      }
     }
   };
 

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -35,6 +35,25 @@ describe("getTelegramSequentialKey", () => {
     [
       {
         message: mockMessage({
+          chat: mockChat({ id: 123, type: "supergroup" }),
+          message_thread_id: 9,
+          is_topic_message: true,
+        }),
+      },
+      "telegram:123:topic:9",
+    ],
+    [
+      {
+        message: mockMessage({
+          chat: mockChat({ id: 123, type: "supergroup" }),
+          is_topic_message: true,
+        }),
+      },
+      "telegram:123:topic:1",
+    ],
+    [
+      {
+        message: mockMessage({
           chat: mockChat({ id: 123, type: "supergroup", is_forum: true }),
         }),
       },

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -97,8 +97,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;
   const isForum =
-    msg?.chat?.is_forum ??
-    (msg?.chat?.type === "supergroup" && msg.is_topic_message === true ? true : undefined);
+    msg?.chat?.is_forum ?? (msg?.chat?.type === "supergroup" && msg?.is_topic_message === true);
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -96,7 +96,9 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   }
   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";
   const messageThreadId = msg?.message_thread_id;
-  const isForum = msg?.chat?.is_forum;
+  const isForum =
+    msg?.chat?.is_forum ??
+    (msg?.chat?.type === "supergroup" && msg.is_topic_message === true ? true : undefined);
   const threadId = isGroup
     ? resolveTelegramForumThreadId({ isForum, messageThreadId })
     : messageThreadId;


### PR DESCRIPTION
## Summary

- Split Telegram sequentializer lanes by topic when Telegram omits `chat.is_forum` but still marks the update as `is_topic_message`.
- Preserve the existing conservative behavior for regular supergroup reply threads that only include `message_thread_id`.
- Coalesce duplicate Telegram `sendChatAction` typing cues per chat/action so topic bursts do not let cosmetic typing calls pile up in the same per-chat Telegram API throttle lane ahead of real replies.
- Add regression coverage for the key resolver, middleware-level per-topic lane behavior, and typing cue coalescing.

## Root Cause
Telegram topic updates can include `is_topic_message: true` and `message_thread_id` even when `chat.is_forum` is omitted. The sequentializer chooses its lane before later message normalization can recover forum metadata, so those updates were serialized on the chat-wide lane. Repeated typing cues could also queue in the same Telegram API lane ahead of real replies.

## Real behavior proof
- Behavior or issue addressed: Telegram topic messages with `is_topic_message` should get per-topic sequentializer lanes even when `chat.is_forum` is missing, ordinary supergroup reply threads should remain chat-wide, and duplicate same-chat/action typing cues should coalesce while a cue is pending.
- Real environment tested: isolated local worktree for PR #76951 at `cc6d22bf`; temporary `OPENCLAW_HOME` and `OPENCLAW_CONFIG_PATH`; no existing Gateway service, Telegram account, bot session, or user session store was touched.
- Exact steps or command run after this patch: Ran a temp-home `node --import tsx --input-type=module` probe using redacted synthetic Telegram update shapes and the real `getTelegramSequentialKey` / `createTelegramSendChatActionHandler` implementations.
- Evidence after fix:

```text
isolated_home=[redacted-temp-home]
topic_key=telegram:[redacted-chat]:topic:[redacted-thread]
ordinary_supergroup_key=telegram:[redacted-chat]
coalesced_send_count=1
coalesced_first_thread=[redacted-thread]
```

- Observed result after fix: A topic update without `chat.is_forum` still resolves to `telegram:<chat>:topic:<thread>`, an ordinary supergroup reply thread without `is_topic_message` remains on the chat-wide key, and two pending duplicate typing cues result in one Telegram API call.
- What was not tested: A live Telegram bot/account run, because no Telegram token was present in the environment/profile on the proof host. The exercised path uses the same key resolver and typing handler that the live bot runtime calls.
- Before evidence: Current `main` only used `chat.is_forum` for group topic lane selection, so the same synthetic topic update would fall back to the chat-wide `telegram:<chat>` key; current `sendChatAction` awaited each cue directly.

## Verification

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/telegram/src/bot-core.ts extensions/telegram/src/sendchataction-401-backoff.ts extensions/telegram/src/sendchataction-401-backoff.test.ts extensions/telegram/src/sequential-key.ts extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `pnpm test extensions/telegram/src/sendchataction-401-backoff.test.ts extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts -- --reporter=verbose` — 3 files, 114 tests passed.
- `git diff --check`