### PR TITLE
docs: add steer command guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -84,6 +84,10 @@
     "target": "Steering queue"
   },
   {
+    "source": "Steer",
+    "target": "Steer"
+  },
+  {
     "source": "Models",
     "target": "Models"
   },

--- a/docs/concepts/queue-steering.md
+++ b/docs/concepts/queue-steering.md
@@ -40,6 +40,9 @@ Codex review and manual compaction turns reject same-turn steering. When a
 runtime cannot accept steering, OpenClaw falls back to the followup queue where
 that mode allows it.
 
+This page explains queue-mode steering for normal inbound messages. For the
+explicit `/steer <message>` command, see [Steer](/tools/steer).
+
 ## Modes
 
 | Mode            | Active-run behavior                                                                                                          | Later followup behavior                                                             |
@@ -86,5 +89,6 @@ sending the batched `turn/steer`.
 ## Related
 
 - [Command queue](/concepts/queue)
+- [Steer](/tools/steer)
 - [Messages](/concepts/messages)
 - [Agent loop](/concepts/agent-loop)

--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -51,7 +51,8 @@ streaming surfaces can look like duplicates. Prefer `collect`/`steer` if you wan
 one response per inbound message.
 
 For runtime-specific timing and dependency behavior, see
-[Steering queue](/concepts/queue-steering).
+[Steering queue](/concepts/queue-steering). For the explicit `/steer <message>`
+command, see [Steer](/tools/steer).
 
 Configure globally or per channel via `messages.queue`:
 
@@ -121,4 +122,5 @@ keys.
 
 - [Session management](/concepts/session)
 - [Steering queue](/concepts/queue-steering)
+- [Steer](/tools/steer)
 - [Retry policy](/concepts/retry)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1309,6 +1309,7 @@
                 "group": "Agent coordination",
                 "pages": [
                   "tools/agent-send",
+                  "tools/steer",
                   "tools/subagents",
                   "tools/acp-agents",
                   "tools/acp-agents-setup",

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -145,7 +145,7 @@ Current source-of-truth:
     - `/model [name|#|status]` shows or sets the model.
     - `/models [provider] [page] [limit=<n>|size=<n>|all]` lists configured/auth-available providers or models for a provider; add `all` to browse that provider's full catalog.
     - `/queue <mode>` manages queue behavior (`steer`, legacy `queue`, `followup`, `collect`, `steer-backlog`, `interrupt`) plus options like `debounce:0.5s cap:25 drop:summarize`; `/queue default` or `/queue reset` clears the session override. See [Command queue](/concepts/queue) and [Steering queue](/concepts/queue-steering).
-    - `/steer <message>` injects guidance into the active run for the current session, independent of `/queue` mode. It does not start a new run when the session is idle. Alias: `/tell`.
+    - `/steer <message>` injects guidance into the active run for the current session, independent of `/queue` mode. It does not start a new run when the session is idle. Alias: `/tell`. See [Steer](/tools/steer).
 
   </Accordion>
   <Accordion title="Discovery and status">
@@ -175,7 +175,7 @@ Current source-of-truth:
     - `/unfocus` removes the current binding.
     - `/agents` lists thread-bound agents for the current session.
     - `/kill <id|#|all>` aborts one or all running sub-agents.
-    - `/subagents steer <id|#> <message>` sends steering to a running sub-agent.
+    - `/subagents steer <id|#> <message>` sends steering to a running sub-agent. See [Steer](/tools/steer).
 
   </Accordion>
   <Accordion title="Owner-only writes and admin">

--- a/docs/tools/steer.md
+++ b/docs/tools/steer.md
@@ -1,0 +1,78 @@
+---
+summary: "Steer an active run without changing queue mode"
+read_when:
+  - Using /steer or /tell while an agent is already running
+  - Comparing /steer with /queue steer
+  - Deciding whether to steer the current run, a sub-agent, or an ACP session
+title: "Steer"
+sidebarTitle: "Steer"
+---
+
+`/steer` sends guidance to an already-active run. It is for "adjust this
+run while it is still working" moments, not for starting a new turn.
+
+## Current session
+
+Use top-level `/steer` to target the active run for the current session:
+
+```text
+/steer prefer the smaller patch and keep the tests focused
+/tell summarize before making the next tool call
+```
+
+Behavior:
+
+- Targets only the current session's active run.
+- Works independently of the session's `/queue` mode.
+- Does not start a new run when the session is idle.
+- Replies with a warning when there is no active run to steer.
+- Uses the active runtime's steering path, so the model sees the guidance at
+  the next supported runtime boundary.
+
+## Steer vs queue
+
+`/queue steer` changes how normal inbound messages behave when they arrive
+while a run is active. `/steer <message>` is an explicit command that tries to
+inject that command's message into the active run at the next supported runtime
+boundary, regardless of the stored `/queue` setting.
+
+Use:
+
+- `/steer <message>` when you want to guide the active run right now.
+- `/queue steer` when you want future normal messages to steer active runs by
+  default.
+- `/queue collect` or `/queue followup` when new messages should wait for a
+  later turn instead of steering the active run.
+
+For queue modes and fallback behavior, see [Command queue](/concepts/queue) and
+[Steering queue](/concepts/queue-steering).
+
+## Sub-agents
+
+Use `/subagents steer` when the target is a child run:
+
+```text
+/subagents steer 2 focus only on the API surface
+```
+
+Top-level `/steer` does not select a sub-agent by id or list index. It always
+targets the current session's active run. See [Sub-agents](/tools/subagents) for
+sub-agent ids, labels, and control commands.
+
+## ACP sessions
+
+Use `/acp steer` when the target is an ACP harness session:
+
+```text
+/acp steer --session agent:main:acp:codex tighten the repro
+```
+
+See [ACP agents](/tools/acp-agents) for ACP session selection and runtime
+behavior.
+
+## Related
+
+- [Slash commands](/tools/slash-commands)
+- [Command queue](/concepts/queue)
+- [Steering queue](/concepts/queue-steering)
+- [Sub-agents](/tools/subagents)

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -47,7 +47,7 @@ session**:
 /subagents spawn <agentId> <task> [--model <model>] [--thinking <level>]
 ```
 
-Use top-level `/steer <message>` to steer the current requester session's active run. Use `/subagents steer <id|#> <message>` when the target is a child run.
+Use top-level [`/steer <message>`](/tools/steer) to steer the current requester session's active run. Use `/subagents steer <id|#> <message>` when the target is a child run.
 
 `/subagents info` shows run metadata (status, timestamps, session id,
 transcript path, cleanup). Use `sessions_history` for a bounded,


### PR DESCRIPTION
Summary
- Add a dedicated `tools/steer` docs page for top-level `/steer`, `/tell`, subagent steering, and ACP steering.
- Cross-link the steer guide from slash commands, subagents, command queue, and steering queue docs.
- Add the page to docs navigation and the zh-CN glossary label list.

Verification
- `pnpm check:docs`
- `git diff --check`