### PR TITLE
fix(doctor): preserve pinned plugin repair failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
 - Doctor/plugins: install configured missing official plugins such as Discord and Brave during doctor/update repair, auto-enable repaired provider plugins, preserve config when a download fails, and stop auto-enable from inventing plugin entries when no manifest declares a configured channel. Fixes #76872. Thanks @jack-stormentswe.
+- Doctor/plugins: keep pinned install-record repair errors from falling back to weaker catalog reinstalls in the same doctor run. (#76961) Thanks @Lucenx9.
 
 ## 2026.5.2
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1287,6 +1287,84 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     ]);
   });
 
+  it("does not fall back to catalog reinstall after a persisted record repair error", async () => {
+    const records = {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@1.2.3",
+        installPath: "/tmp/openclaw-missing-discord-install-record",
+        integrity: "sha512-pinned-good-integrity",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          channels: ["discord"],
+        },
+      ],
+      diagnostics: [],
+    });
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+        trustedSourceLinkedOfficialInstall: true,
+      },
+    ]);
+    mocks.updateNpmInstalledPlugins.mockResolvedValue({
+      changed: false,
+      config: {
+        plugins: {
+          installs: records,
+        },
+      },
+      outcomes: [
+        {
+          pluginId: "discord",
+          status: "error",
+          message: "Integrity drift for discord.",
+        },
+      ],
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pluginIds: ["discord"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({ installs: records }),
+        }),
+      }),
+    );
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      changes: [],
+      warnings: ["Integrity drift for discord."],
+    });
+  });
+
   it("updates a known configured plugin when its installed manifest path still exists", async () => {
     const records = {
       discord: {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -545,6 +545,7 @@ async function repairMissingPluginInstalls(params: {
   const changes: string[] = [];
   const warnings: string[] = [];
   const deferredPluginIds = new Set<string>();
+  const failedRecordedRepairPluginIds = new Set<string>();
   let nextRecords = records;
 
   for (const [pluginId, record] of Object.entries(records)) {
@@ -616,6 +617,7 @@ async function repairMissingPluginInstalls(params: {
       if (outcome.status === "updated" || outcome.status === "unchanged") {
         changes.push(`Repaired missing configured plugin "${outcome.pluginId}".`);
       } else if (outcome.status === "error") {
+        failedRecordedRepairPluginIds.add(outcome.pluginId);
         warnings.push(outcome.message);
       }
     }
@@ -627,6 +629,9 @@ async function repairMissingPluginInstalls(params: {
       if (deferredPluginIds.has(pluginId)) {
         return false;
       }
+      if (failedRecordedRepairPluginIds.has(pluginId)) {
+        return false;
+      }
       const hasRecord = Object.hasOwn(nextRecords, pluginId);
       return (
         (!knownIds.has(pluginId) && !hasRecord && !bundledPluginsById.has(pluginId)) ||
@@ -636,16 +641,21 @@ async function repairMissingPluginInstalls(params: {
       );
     }),
   );
+  const fallbackBlockedPluginIds =
+    deferredPluginIds.size > 0 || failedRecordedRepairPluginIds.size > 0
+      ? new Set([
+          ...(params.blockedPluginIds ?? []),
+          ...deferredPluginIds,
+          ...failedRecordedRepairPluginIds,
+        ])
+      : params.blockedPluginIds;
   for (const candidate of collectDownloadableInstallCandidates({
     cfg: params.cfg,
     env,
     missingPluginIds,
     configuredPluginIds: params.pluginIds,
     configuredChannelIds: params.channelIds,
-    blockedPluginIds:
-      deferredPluginIds.size > 0
-        ? new Set([...(params.blockedPluginIds ?? []), ...deferredPluginIds])
-        : params.blockedPluginIds,
+    blockedPluginIds: fallbackBlockedPluginIds,
   })) {
     const hasUsableRecord =
       Object.hasOwn(nextRecords, candidate.pluginId) &&


### PR DESCRIPTION
## Summary

- Problem: `doctor --fix` could fall back to catalog reinstall after the persisted plugin-record repair/update path returned an error.
- Why it matters: an integrity drift failure from a pinned npm install record should not degrade into an unpinned catalog reinstall in the same repair run.
- What changed: failed recorded repair outcomes now block catalog fallback candidates for that plugin while preserving the warning for the operator.
- What did NOT change (scope boundary): skipped update outcomes can still use the existing catalog fallback behavior; successful recorded repairs are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: doctor repair treated update errors as warnings but still allowed the same missing plugin to be collected from catalog install candidates.
- Missing detection / guardrail: there was coverage for skipped update fallback and successful record repair, but not for error outcomes that preserve pinned integrity failures.
- Contributing context (if known): configured channels can select catalog candidates even when the plugin is removed from the explicit missing-plugin set.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor/shared/missing-configured-plugin-install.test.ts`
- Scenario the test should lock in: a missing persisted npm record with pinned integrity whose repair update returns `error` does not trigger catalog reinstall.
- Why this is the smallest reliable guardrail: the control-flow bug lives in the doctor repair helper and can be proven with mocked update/install dependencies.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When doctor repair cannot restore a missing configured plugin from its existing install record because the update path errors, it now reports that warning and does not silently reinstall the plugin from a weaker catalog candidate in the same run.

## Diagram (if applicable)

```text
Before:
missing install record -> protected update error -> catalog fallback reinstall

After:
missing install record -> protected update error -> warning, no catalog fallback for that plugin
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: this narrows the doctor repair install surface by keeping failed pinned-record repairs from falling back to catalog-based reinstalls without the prior record's integrity pin.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24.15.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure a missing persisted npm plugin install record with pinned integrity.
2. Mock the protected update repair path to return an `error` outcome.
3. Provide a catalog candidate for the same configured channel plugin.
4. Run doctor missing-plugin repair.

### Expected

- The update warning is returned and catalog reinstall is not attempted.

### Actual

- Before this PR, catalog reinstall could still run after the update error. After this PR, the regression test confirms it does not.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm format:check src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts`
  - `pnpm test src/commands/doctor/shared/missing-configured-plugin-install.test.ts`
- Edge cases checked: configured channel catalog fallback remains covered by the existing skipped-update test.
- What you did **not** verify: full `pnpm check` or full test suite, to avoid unnecessary load on the local machine.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a plugin with a repair error now requires a later explicit repair/retry instead of immediate catalog fallback.
  - Mitigation: this is intentional for integrity-sensitive failures; the existing warning remains visible to the operator.
