### PR TITLE
fix(control-ui): filter archived sessions

### DIFF
--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:14:54.780Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:11.115Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:12:27.794Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:09.554Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:13:37.259Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:09.868Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:17:43.425Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:13.878Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:13:58.848Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:10.803Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:16:15.770Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:12.344Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:14:55.292Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:11.423Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:13:45.134Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:10.181Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:14:03.499Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:10.491Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:17:33.427Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:13.567Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:16:18.166Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:12.653Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:12:27.198Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:09.243Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:16:27.136Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:12.966Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:15:15.000Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:11.727Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:15:28.512Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:12.034Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:16:51.077Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:13.266Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:12:29.230Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:08.627Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,13 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-29T20:12:36.557Z",
+  "fallbackKeys": [
+    "sessionsView.showArchived"
+  ],
+  "generatedAt": "2026-05-02T18:33:08.944Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c7d0317c304e6a9d3505e9058a0a0aeb2a3a0eb1fc45d31d12b2602be4cbddcf",
-  "totalKeys": 986,
+  "sourceHash": "b548b0ebd6d8f107fa94830766d368d403292711e7df9959a34282a1fea44f74",
+  "totalKeys": 987,
   "translatedKeys": 986,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -161,6 +161,7 @@ export const ar: TranslationMap = {
     limit: "الحد",
     global: "عام",
     unknown: "غير معروف",
+    showArchived: "Show archived",
     minutesPlaceholder: "دقيقة",
     searchPlaceholder: "تصفية حسب المفتاح أو الوكيل أو التسمية أو النوع…",
     selected: "تم تحديد {count}",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -165,6 +165,7 @@ export const de: TranslationMap = {
     limit: "Limit",
     global: "Global",
     unknown: "Unbekannt",
+    showArchived: "Show archived",
     minutesPlaceholder: "Min.",
     searchPlaceholder: "Nach Schlüssel, Agent, Label, Art filtern…",
     selected: "{count} ausgewählt",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -160,6 +160,7 @@ export const en: TranslationMap = {
     limit: "Limit",
     global: "Global",
     unknown: "Unknown",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filter by key, agent, label, kind…",
     selected: "{count} selected",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -162,6 +162,7 @@ export const es: TranslationMap = {
     limit: "Límite",
     global: "Global",
     unknown: "Desconocido",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filtrar por clave, agente, etiqueta, tipo…",
     selected: "{count} seleccionados",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -163,6 +163,7 @@ export const fa: TranslationMap = {
     limit: "حد",
     global: "سراسری",
     unknown: "نامشخص",
+    showArchived: "Show archived",
     minutesPlaceholder: "دقیقه",
     searchPlaceholder: "فیلتر بر اساس کلید، عامل، برچسب، نوع…",
     selected: "{count} انتخاب‌شده",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -164,6 +164,7 @@ export const fr: TranslationMap = {
     limit: "Limite",
     global: "Global",
     unknown: "Inconnu",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filtrer par clé, agent, libellé, type…",
     selected: "{count} sélectionné(s)",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -162,6 +162,7 @@ export const id: TranslationMap = {
     limit: "Batas",
     global: "Global",
     unknown: "Tidak diketahui",
+    showArchived: "Show archived",
     minutesPlaceholder: "mnt",
     searchPlaceholder: "Filter menurut kunci, agen, label, jenis…",
     selected: "{count} dipilih",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -162,6 +162,7 @@ export const it: TranslationMap = {
     limit: "Limite",
     global: "Globale",
     unknown: "Sconosciuto",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filtra per chiave, agente, etichetta, tipo…",
     selected: "{count} selezionati",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -165,6 +165,7 @@ export const ja_JP: TranslationMap = {
     limit: "制限",
     global: "グローバル",
     unknown: "不明",
+    showArchived: "Show archived",
     minutesPlaceholder: "分",
     searchPlaceholder: "キー、エージェント、ラベル、種類で絞り込み…",
     selected: "{count} 件選択中",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -161,6 +161,7 @@ export const ko: TranslationMap = {
     limit: "제한",
     global: "전역",
     unknown: "알 수 없음",
+    showArchived: "Show archived",
     minutesPlaceholder: "분",
     searchPlaceholder: "키, 에이전트, 레이블, 종류로 필터링…",
     selected: "{count}개 선택됨",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -164,6 +164,7 @@ export const nl: TranslationMap = {
     limit: "Limiet",
     global: "Globaal",
     unknown: "Onbekend",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filter op sleutel, agent, label, type…",
     selected: "{count} geselecteerd",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -163,6 +163,7 @@ export const pl: TranslationMap = {
     limit: "Limit",
     global: "Globalne",
     unknown: "Nieznane",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filtruj według klucza, agenta, etykiety, rodzaju…",
     selected: "Wybrano: {count}",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -162,6 +162,7 @@ export const pt_BR: TranslationMap = {
     limit: "Limite",
     global: "Global",
     unknown: "Desconhecido",
+    showArchived: "Show archived",
     minutesPlaceholder: "min",
     searchPlaceholder: "Filtrar por chave, agente, rótulo, tipo…",
     selected: "{count} selecionado(s)",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -160,6 +160,7 @@ export const th: TranslationMap = {
     limit: "ขีดจำกัด",
     global: "ส่วนกลาง",
     unknown: "ไม่ทราบ",
+    showArchived: "Show archived",
     minutesPlaceholder: "นาที",
     searchPlaceholder: "กรองตามคีย์, agent, ป้ายกำกับ, ชนิด…",
     selected: "เลือกแล้ว {count} รายการ",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -164,6 +164,7 @@ export const tr: TranslationMap = {
     limit: "Sınır",
     global: "Genel",
     unknown: "Bilinmiyor",
+    showArchived: "Show archived",
     minutesPlaceholder: "dk",
     searchPlaceholder: "Anahtara, ajana, etikete, türe göre filtrele…",
     selected: "{count} seçildi",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -163,6 +163,7 @@ export const uk: TranslationMap = {
     limit: "Обмеження",
     global: "Глобально",
     unknown: "Невідомо",
+    showArchived: "Show archived",
     minutesPlaceholder: "хв",
     searchPlaceholder: "Фільтрувати за ключем, агентом, міткою, типом…",
     selected: "Вибрано: {count}",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -162,6 +162,7 @@ export const vi: TranslationMap = {
     limit: "Giới hạn",
     global: "Toàn cục",
     unknown: "Không rõ",
+    showArchived: "Show archived",
     minutesPlaceholder: "phút",
     searchPlaceholder: "Lọc theo khóa, agent, nhãn, loại…",
     selected: "Đã chọn {count}",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -160,6 +160,7 @@ export const zh_CN: TranslationMap = {
     limit: "限制",
     global: "全局",
     unknown: "未知",
+    showArchived: "Show archived",
     minutesPlaceholder: "分钟",
     searchPlaceholder: "按密钥、代理、标签、类型筛选…",
     selected: "已选择 {count} 项",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -160,6 +160,7 @@ export const zh_TW: TranslationMap = {
     limit: "限制",
     global: "全域",
     unknown: "未知",
+    showArchived: "Show archived",
     minutesPlaceholder: "分鐘",
     searchPlaceholder: "依金鑰、代理程式、標籤、類型篩選…",
     selected: "已選取 {count} 個",

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -190,9 +190,7 @@ img.chat-avatar {
   border-radius: var(--radius-lg);
   padding: 10px 14px;
   box-shadow: none;
-  transition:
-    background var(--duration-fast) ease-out,
-    border-color var(--duration-fast) ease-out;
+  transition: border-color var(--duration-fast) ease-out;
   width: auto;
   max-width: 100%;
   box-sizing: border-box;
@@ -320,7 +318,7 @@ img.chat-avatar {
 }
 
 .chat-bubble:hover {
-  background: var(--bg-hover);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
 }
 
 .chat-bubble--tool-shell:hover {
@@ -339,7 +337,7 @@ img.chat-avatar {
 }
 
 .chat-group.user .chat-bubble:hover {
-  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
 }
 
 /* Streaming animation */

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -132,6 +132,7 @@ function createChatSessionState(overrides: Partial<AppViewState> = {}) {
     client: { request: vi.fn() },
     sessionsLoading: false,
     sessionsError: null,
+    sessionsShowArchived: false,
     sessionsResult: {
       ts: 0,
       path: "",
@@ -488,12 +489,10 @@ describe("resolveSessionOptionGroups", () => {
     );
   });
 
-  it("keeps scoped fallbacks for active grouped sessions without useful row metadata", () => {
+  it("does not synthesize active grouped sessions without a listed row", () => {
     const sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
 
-    expect(labelsForSessionOptions({ sessionKey })).toContain(
-      "subagent:4f2146de-887b-4176-9abe-91140082959b",
-    );
+    expect(labelsForSessionOptions({ sessionKey })).toEqual([]);
     expect(
       labelsForSessionOptions({
         sessionKey,
@@ -577,6 +576,7 @@ describe("createChatSession", () => {
         limit: 0,
         includeGlobal: true,
         includeUnknown: true,
+        showArchived: false,
       },
     );
     expect(state.sessionKey).toBe("agent:ops:dashboard:new-chat");
@@ -765,6 +765,7 @@ describe("switchChatSession", () => {
       limit: 0,
       includeGlobal: true,
       includeUnknown: true,
+      showArchived: false,
     });
   });
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -636,6 +636,7 @@ export async function createChatSession(state: AppViewState) {
       limit: 0,
       includeGlobal: true,
       includeUnknown: true,
+      showArchived: state.sessionsShowArchived === true,
     },
   );
   if (
@@ -666,6 +667,7 @@ async function refreshSessionOptions(state: AppViewState) {
     limit: 0,
     includeGlobal: true,
     includeUnknown: true,
+    showArchived: state.sessionsShowArchived === true,
   });
 }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1677,6 +1677,7 @@ export function renderApp(state: AppViewState) {
                 limit: state.sessionsFilterLimit,
                 includeGlobal: state.sessionsIncludeGlobal,
                 includeUnknown: state.sessionsIncludeUnknown,
+                showArchived: state.sessionsShowArchived,
                 basePath: state.basePath,
                 searchQuery: state.sessionsSearchQuery,
                 agentIdentityById: state.agentIdentityById,
@@ -1695,6 +1696,16 @@ export function renderApp(state: AppViewState) {
                   state.sessionsFilterLimit = next.limit;
                   state.sessionsIncludeGlobal = next.includeGlobal;
                   state.sessionsIncludeUnknown = next.includeUnknown;
+                  state.sessionsShowArchived = next.showArchived;
+                  state.sessionsSelectedKeys = new Set();
+                  state.sessionsPage = 0;
+                  void loadSessions(state, {
+                    activeMinutes: Number(next.activeMinutes) || 0,
+                    limit: Number(next.limit) || 0,
+                    includeGlobal: next.includeGlobal,
+                    includeUnknown: next.includeUnknown,
+                    showArchived: next.showArchived,
+                  });
                 },
                 onSearchChange: (q) => {
                   state.sessionsSearchQuery = q;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -260,6 +260,7 @@ export type AppViewState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionsShowArchived: boolean;
   sessionsHideCron: boolean;
   sessionsSearchQuery: string;
   sessionsSortColumn: "key" | "kind" | "updated" | "tokens";

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -375,6 +375,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "50";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
+  @state() sessionsShowArchived = false;
   @state() sessionsHideCron = true;
   @state() sessionsSearchQuery = "";
   @state() sessionsSortColumn: "key" | "kind" | "updated" | "tokens" = "updated";

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -77,6 +77,7 @@ async function refreshSessionOptions(state: AppViewState) {
     limit: 0,
     includeGlobal: true,
     includeUnknown: true,
+    showArchived: state.sessionsShowArchived === true,
   });
 }
 
@@ -534,7 +535,9 @@ export function resolveSessionOptionGroups(
     }
     addOption(row.key);
   }
-  addOption(sessionKey);
+  if (byKey.has(sessionKey)) {
+    addOption(sessionKey);
+  }
 
   for (const group of groups.values()) {
     const counts = new Map<string, number>();

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -29,6 +29,7 @@ function createState(request: RequestFn, overrides: Partial<SessionsState> = {})
     sessionsFilterLimit: "0",
     sessionsIncludeGlobal: true,
     sessionsIncludeUnknown: true,
+    sessionsShowArchived: false,
     sessionsExpandedCheckpointKey: null,
     sessionsCheckpointItemsByKey: {},
     sessionsCheckpointLoadingKey: null,
@@ -249,6 +250,69 @@ describe("deleteSessionsAndRefresh", () => {
 });
 
 describe("loadSessions", () => {
+  it("hides archived terminal sessions by default", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      return {
+        ts: 1,
+        path: "(multiple)",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          { key: "agent:main:main", kind: "direct", updatedAt: 2 },
+          {
+            key: "agent:main:subagent:archived",
+            kind: "direct",
+            updatedAt: 1,
+            status: "done",
+          },
+        ],
+      };
+    });
+    const state = createState(request);
+
+    await loadSessions(state);
+
+    expect(state.sessionsResult?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:main",
+    ]);
+    expect(state.sessionsResult?.count).toBe(1);
+  });
+
+  it("includes archived terminal sessions when explicitly shown", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      return {
+        ts: 1,
+        path: "(multiple)",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          { key: "agent:main:main", kind: "direct", updatedAt: 2 },
+          {
+            key: "agent:main:subagent:archived",
+            kind: "direct",
+            updatedAt: 1,
+            status: "done",
+          },
+        ],
+      };
+    });
+    const state = createState(request, { sessionsShowArchived: true });
+
+    await loadSessions(state);
+
+    expect(state.sessionsResult?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:main",
+      "agent:main:subagent:archived",
+    ]);
+    expect(state.sessionsResult?.count).toBe(2);
+  });
+
   it("coalesces overlapping refreshes instead of dropping the latest request", async () => {
     let resolveFirst: () => void = () => undefined;
     const firstBlocker = new Promise<void>((resolve) => {
@@ -272,7 +336,7 @@ describe("loadSessions", () => {
         ts: 2,
         path: "(multiple)",
         count: 0,
-        defaults: {},
+        defaults: { modelProvider: null, model: null, contextTokens: null },
         sessions: [],
       };
     });
@@ -391,6 +455,76 @@ describe("loadSessions", () => {
 });
 
 describe("applySessionsChangedEvent", () => {
+  it("removes deleted sessions instead of keeping archived rows visible", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 2,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [
+          { key: "agent:main:main", kind: "direct", updatedAt: 1 },
+          { key: "agent:main:old", kind: "direct", updatedAt: 1 },
+        ],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:old",
+      reason: "delete",
+      ts: 2,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:main",
+    ]);
+    expect(state.sessionsResult?.count).toBe(1);
+  });
+
+  it("does not synthesize new sessions from partial events without a store-backed row", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 0,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:ephemeral",
+      reason: "message",
+      ts: 2,
+    });
+
+    expect(applied).toBe(false);
+    expect(state.sessionsResult?.sessions).toEqual([]);
+  });
+
+  it("drops rows that become archived while archived sessions are hidden", () => {
+    const state = createState(async () => undefined, {
+      sessionsResult: {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:subagent:done", kind: "direct", updatedAt: 1 }],
+      },
+    });
+
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:subagent:done",
+      sessionId: "sess-done",
+      status: "done",
+      ts: 2,
+    });
+
+    expect(applied).toBe(true);
+    expect(state.sessionsResult?.sessions).toEqual([]);
+  });
+
   it("updates fresh context usage from websocket event payloads", () => {
     const state = createState(async () => undefined, {
       sessionsResult: {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -23,6 +23,7 @@ export type SessionsState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
+  sessionsShowArchived: boolean;
   sessionsExpandedCheckpointKey: string | null;
   sessionsCheckpointItemsByKey: Record<string, SessionCompactionCheckpoint[]>;
   sessionsCheckpointLoadingKey: string | null;
@@ -35,6 +36,7 @@ type LoadSessionsOverrides = {
   limit?: number;
   includeGlobal?: boolean;
   includeUnknown?: boolean;
+  showArchived?: boolean;
 };
 
 type CreateSessionParams = {
@@ -79,6 +81,7 @@ const SESSION_EVENT_ROW_FIELDS = [
   "spawnedBy",
   "startedAt",
   "status",
+  "archived",
   "subject",
   "surface",
   "systemSent",
@@ -121,6 +124,34 @@ function normalizeSessionKind(value: unknown): GatewaySessionRow["kind"] | undef
   return value === "direct" || value === "group" || value === "global" || value === "unknown"
     ? value
     : undefined;
+}
+
+const TERMINAL_SESSION_STATUSES = new Set(["done", "failed", "killed", "timeout"]);
+
+export function isArchivedSessionRow(row: GatewaySessionRow): boolean {
+  if (row.archived === true) {
+    return true;
+  }
+  return typeof row.status === "string" && TERMINAL_SESSION_STATUSES.has(row.status);
+}
+
+function filterAvailableSessionRows(
+  rows: GatewaySessionRow[],
+  options: { showArchived: boolean },
+): GatewaySessionRow[] {
+  return rows.filter((row) => row.key && (options.showArchived || !isArchivedSessionRow(row)));
+}
+
+function projectSessionsResultForAvailability(
+  result: SessionsListResult,
+  options: { showArchived: boolean },
+): SessionsListResult {
+  const sessions = filterAvailableSessionRows(result.sessions, options);
+  return {
+    ...result,
+    count: sessions.length,
+    sessions,
+  };
 }
 
 function checkpointSummarySignature(
@@ -247,7 +278,23 @@ export function applySessionsChangedEvent(state: SessionsState, payload: unknown
 
   const previousRows = state.sessionsResult.sessions;
   const existingIndex = previousRows.findIndex((row) => row.key === key);
+  if (payload.reason === "delete") {
+    if (existingIndex < 0) {
+      return false;
+    }
+    state.sessionsResult = {
+      ...state.sessionsResult,
+      count: Math.max(0, state.sessionsResult.count - 1),
+      sessions: previousRows.filter((row) => row.key !== key),
+    };
+    invalidateCheckpointCacheForKey(state, key);
+    return true;
+  }
   const existing = existingIndex >= 0 ? previousRows[existingIndex] : undefined;
+  const hasReliableSource = eventSession !== null || typeof source.sessionId === "string";
+  if (!existing && !hasReliableSource) {
+    return false;
+  }
   const previousCheckpointSignature = checkpointSummarySignature(existing);
   const fallbackKind = normalizeSessionKind(source.kind) ?? existing?.kind ?? "unknown";
   const nextRow: GatewaySessionRow = {
@@ -269,6 +316,18 @@ export function applySessionsChangedEvent(state: SessionsState, payload: unknown
   }
   if (nextRow.totalTokensFresh === false && !hasOwn(source, "totalTokens")) {
     delete nextRow.totalTokens;
+  }
+  if (!state.sessionsShowArchived && isArchivedSessionRow(nextRow)) {
+    if (existingIndex < 0) {
+      return false;
+    }
+    state.sessionsResult = {
+      ...state.sessionsResult,
+      count: Math.max(0, state.sessionsResult.count - 1),
+      sessions: previousRows.filter((row) => row.key !== key),
+    };
+    invalidateCheckpointCacheForKey(state, key);
+    return true;
   }
 
   const sessions =
@@ -364,15 +423,16 @@ async function loadSessionsOnce(
     }
     const res = await client.request<SessionsListResult | undefined>("sessions.list", params);
     if (res) {
-      state.sessionsResult = res;
-      const nextKeys = new Set(res.sessions.map((row) => row.key));
+      const showArchived = overrides?.showArchived ?? state.sessionsShowArchived;
+      state.sessionsResult = projectSessionsResultForAvailability(res, { showArchived });
+      const nextKeys = new Set(state.sessionsResult.sessions.map((row) => row.key));
       for (const key of Object.keys(state.sessionsCheckpointItemsByKey)) {
         if (!nextKeys.has(key)) {
           invalidateCheckpointCacheForKey(state, key);
         }
       }
       let expandedNeedsRefetch = false;
-      for (const row of res.sessions) {
+      for (const row of state.sessionsResult.sessions) {
         const previous = previousRows.get(row.key);
         if (checkpointSummarySignature(previous) !== checkpointSummarySignature(row)) {
           invalidateCheckpointCacheForKey(state, row.key);

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -441,6 +441,7 @@ export type GatewaySessionRow = {
   totalTokens?: number;
   totalTokensFresh?: boolean;
   status?: SessionRunStatus;
+  archived?: boolean;
   hasActiveRun?: boolean;
   subagentRunState?: SubagentRunState;
   hasActiveSubagentRun?: boolean;

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -34,6 +34,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     limit: "120",
     includeGlobal: false,
     includeUnknown: false,
+    showArchived: false,
     basePath: "",
     searchQuery: "",
     agentIdentityById: {},
@@ -66,6 +67,35 @@ function buildProps(result: SessionsListResult): SessionsProps {
 }
 
 describe("sessions view", () => {
+  it("renders an explicit archived-session toggle", async () => {
+    const container = document.createElement("div");
+    const onFiltersChange = vi.fn();
+    render(
+      renderSessions({
+        ...buildProps(buildMultiResult([])),
+        onFiltersChange,
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const archivedToggle = container.querySelector(
+      ".session-archive-toggle input",
+    ) as HTMLInputElement | null;
+    expect(archivedToggle?.checked).toBe(false);
+
+    archivedToggle!.checked = true;
+    archivedToggle!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      activeMinutes: "",
+      limit: "120",
+      includeGlobal: false,
+      includeUnknown: false,
+      showArchived: true,
+    });
+  });
+
   it("renders and patches provider-owned thinking ids", async () => {
     const container = document.createElement("div");
     const onPatch = vi.fn();

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -22,6 +22,7 @@ export type SessionsProps = {
   limit: string;
   includeGlobal: boolean;
   includeUnknown: boolean;
+  showArchived: boolean;
   basePath: string;
   searchQuery: string;
   agentIdentityById: Record<string, AgentIdentityResult>;
@@ -40,6 +41,7 @@ export type SessionsProps = {
     limit: string;
     includeGlobal: boolean;
     includeUnknown: boolean;
+    showArchived: boolean;
   }) => void;
   onSearchChange: (query: string) => void;
   onSortChange: (column: "key" | "kind" | "updated" | "tokens", dir: "asc" | "desc") => void;
@@ -312,6 +314,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: props.includeUnknown,
+                showArchived: props.showArchived,
               })}
           />
         </label>
@@ -326,6 +329,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: (e.target as HTMLInputElement).value,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: props.includeUnknown,
+                showArchived: props.showArchived,
               })}
           />
         </label>
@@ -339,6 +343,7 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: (e.target as HTMLInputElement).checked,
                 includeUnknown: props.includeUnknown,
+                showArchived: props.showArchived,
               })}
           />
           <span>${t("sessionsView.global")}</span>
@@ -353,9 +358,25 @@ export function renderSessions(props: SessionsProps) {
                 limit: props.limit,
                 includeGlobal: props.includeGlobal,
                 includeUnknown: (e.target as HTMLInputElement).checked,
+                showArchived: props.showArchived,
               })}
           />
           <span>${t("sessionsView.unknown")}</span>
+        </label>
+        <label class="field-inline checkbox session-archive-toggle">
+          <input
+            type="checkbox"
+            .checked=${props.showArchived}
+            @change=${(e: Event) =>
+              props.onFiltersChange({
+                activeMinutes: props.activeMinutes,
+                limit: props.limit,
+                includeGlobal: props.includeGlobal,
+                includeUnknown: props.includeUnknown,
+                showArchived: (e.target as HTMLInputElement).checked,
+              })}
+          />
+          <span>${t("sessionsView.showArchived")}</span>
         </label>
       </div>
 


### PR DESCRIPTION
## Summary
- Treat `sessions.list` as the reliable session source for Control UI availability.
- Hide archived or terminal sessions by default and add a Sessions page `Show archived` toggle that updates the global session set.
- Keep chat session pickers constrained to the filtered available sessions and change chat hover styling to a subtle border-only state.

## Validation
- `pnpm exec oxfmt --check --threads=1 ui/src/styles/chat/grouped.css ui/src/ui/controllers/sessions.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/sessions.ts ui/src/ui/views/sessions.test.ts ui/src/ui/app.ts ui/src/ui/app-view-state.ts ui/src/ui/app-render.ts ui/src/ui/chat/session-controls.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/types.ts ui/src/i18n/locales/*.ts`
- `pnpm ui:i18n:check`
- `pnpm tsgo:test:ui`
- `pnpm test ui/src/ui/controllers/sessions.test.ts ui/src/ui/views/sessions.test.ts ui/src/ui/app-render.helpers.node.test.ts`
- `pnpm --dir ui test src/ui/views/chat.test.ts`
- `git diff --check HEAD`
- Browser preview at `http://127.0.0.1:5174/chat?session=agent%3Amain%3Amain` with console showing 0 errors
