### PR TITLE
fix(sessions): fire command:new hook against parent session on sessions.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/sessions: fire the `command:new` internal hook against the parent session when `sessions.create` is called with a `parentSessionKey` (Control UI `/new` flow), restoring `session-memory` and custom `command:new` hook delivery after commit 37aebf612b rerouted the typed-`/new` path away from `sendChatMessageNow`. Fixes #76957. Thanks @hclsys.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Tools/BTW: add `/side` as a text and native slash-command alias for `/btw` side questions.
 - Agents/tools: skip optional media and PDF tool factories when the effective tool denylist already blocks them, avoiding unnecessary hot-path setup for tools that will be filtered out before model use. (#76773) Thanks @dorukardahan.

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -24,6 +24,7 @@ import {
 } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  createInternalHookEvent,
   hasInternalHookListeners,
   triggerInternalHook,
   type SessionPatchHookContext,
@@ -998,6 +999,24 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         return;
       }
       canonicalParentSessionKey = parent.canonicalKey;
+    }
+    // When creating a new session from a parent (Control UI /new flow), fire the command:new
+    // internal hook against the parent session so bundled hooks like session-memory can capture
+    // the outgoing session before the switch. Without this, commit 37aebf612b's change from
+    // sendChatMessageNow("/new") to sessions.create silently breaks hook delivery (#76957).
+    if (canonicalParentSessionKey && hasInternalHookListeners("command", "new")) {
+      const { entry: parentEntry } = loadSessionEntry(canonicalParentSessionKey);
+      const parentAgentId = normalizeAgentId(
+        resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? resolveDefaultAgentId(cfg),
+      );
+      const hookEvent = createInternalHookEvent("command", "new", canonicalParentSessionKey, {
+        sessionEntry: parentEntry,
+        previousSessionEntry: parentEntry,
+        commandSource: "webchat",
+        cfg,
+        workspaceDir: resolveAgentWorkspaceDir(cfg, parentAgentId),
+      });
+      await triggerInternalHook(hookEvent);
     }
     const loweredRequestedKey = normalizeOptionalLowercaseString(requestedKey);
     const key = requestedKey


### PR DESCRIPTION
## Problem

Typing `/new` in the Control UI no longer fires `command:new` internal hooks, breaking the bundled `session-memory` hook and any custom hooks listening on `command:new`.

**Root cause:** Commit `37aebf612b` (`fix(control-ui): create sessions for typed /new`, fixing #69599) rerouted the `/new` slash-command dispatch from:

```typescript
// Before — dispatched through Gateway command handler → fires command:new hooks
await sendChatMessageNow(host, "/new", { refreshSessions: true, ... });
```

to:

```typescript
// After — calls sessions.create directly → fires no lifecycle hooks
await host.onSlashAction("new-session");
// → createChatSessionInternal() → createSessionAndRefresh() → sessions.create RPC
```

`sessions.create` creates the session entry but never emits `command:new` (or `before_reset`) hooks against the parent session. The gateway logs confirm: `[ws] ⇄ res ✓ sessions.create 93ms` with zero hook activity — compare with `/reset` which produces `[hooks/session-memory] Hook triggered for reset/new command`.

TUI and CLI `/new` paths go through `performGatewaySessionReset` and are unaffected.

## Fix

In `sessions.create`, when a `parentSessionKey` is provided (this is the "new session from existing" = `/new` flow), emit the `command:new` internal hook against the parent session before creating the new session:

```typescript
if (canonicalParentSessionKey && hasInternalHookListeners("command", "new")) {
  const { entry: parentEntry } = loadSessionEntry(canonicalParentSessionKey);
  const parentAgentId = normalizeAgentId(
    resolveAgentIdFromSessionKey(canonicalParentSessionKey) ?? resolveDefaultAgentId(cfg),
  );
  const hookEvent = createInternalHookEvent("command", "new", canonicalParentSessionKey, {
    sessionEntry: parentEntry,
    previousSessionEntry: parentEntry,
    commandSource: "webchat",
    cfg,
    workspaceDir: resolveAgentWorkspaceDir(cfg, parentAgentId),
  });
  await triggerInternalHook(hookEvent);
}
```

This mirrors the hook emission in `performGatewaySessionReset` (which handles TUI/CLI `/new`). The `hasInternalHookListeners` guard keeps this path zero-cost when no hooks are registered.

**Files changed:** `src/gateway/server-methods/sessions.ts` (1 import added, 17 lines added in `sessions.create`)

Fixes #76957.