### PR TITLE
fix(auto-reply): suppress stale foreground replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1082,7 +1082,7 @@ Docs: https://docs.openclaw.ai
 - CLI/doctor: trust a ready gateway memory probe when CLI-side active memory backend resolution is unavailable, preventing false "No active memory plugin is registered" warnings for healthy runtime setups. Fixes #76792. Thanks @som-686.
 - Memory/status: keep plain `openclaw memory status` and `openclaw memory status --json` on the cheap read-only path by reserving vector and embedding provider probes for `--deep` or `--index`. Fixes #76769. Thanks @daruire.
 - Telegram: suppress stale same-session replies when a newer accepted message arrives before an older in-flight Telegram dispatch finalizes. Fixes #76642. Thanks @chinar-amrutkar.
-- Auto-reply: suppress stale foreground replies when a newer same-session inbound message starts before an older in-flight dispatch finalizes. Fixes #76905. Thanks @sbmilburn.
+- Auto-reply: suppress stale foreground replies when a newer same-session inbound message starts before an older in-flight dispatch finalizes. Fixes #76905. Thanks @MkDev11.
 - Gateway/diagnostics: throttle repeated long-running active-work session warnings so healthy cron or subagent runs no longer print the same `recovery=none` line every heartbeat.
 - Gateway/diagnostics: keep non-blocking active-work and transient event-loop max-spike liveness diagnostics out of the default gateway console while preserving structured diagnostic events and warnings for queued, stalled, and recovery-eligible work.
 - Slack: collapse routine Socket Mode pong-timeout reconnects into one OpenClaw reconnect line and suppress the duplicate Slack SDK pong warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1082,6 +1082,7 @@ Docs: https://docs.openclaw.ai
 - CLI/doctor: trust a ready gateway memory probe when CLI-side active memory backend resolution is unavailable, preventing false "No active memory plugin is registered" warnings for healthy runtime setups. Fixes #76792. Thanks @som-686.
 - Memory/status: keep plain `openclaw memory status` and `openclaw memory status --json` on the cheap read-only path by reserving vector and embedding provider probes for `--deep` or `--index`. Fixes #76769. Thanks @daruire.
 - Telegram: suppress stale same-session replies when a newer accepted message arrives before an older in-flight Telegram dispatch finalizes. Fixes #76642. Thanks @chinar-amrutkar.
+- Auto-reply: suppress stale foreground replies when a newer same-session inbound message starts before an older in-flight dispatch finalizes. Fixes #76905. Thanks @sbmilburn.
 - Gateway/diagnostics: throttle repeated long-running active-work session warnings so healthy cron or subagent runs no longer print the same `recovery=none` line every heartbeat.
 - Gateway/diagnostics: keep non-blocking active-work and transient event-loop max-spike liveness diagnostics out of the default gateway console while preserving structured diagnostic events and warnings for queued, stalled, and recovery-eligible work.
 - Slack: collapse routine Socket Mode pong-timeout reconnects into one OpenClaw reconnect line and suppress the duplicate Slack SDK pong warning.

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -28,12 +28,10 @@ type Delivery = {
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
+  const promise = new Promise<T>((res) => {
     resolve = res;
-    reject = rej;
   });
-  return { promise, resolve, reject };
+  return { promise, resolve };
 }
 
 function queuedFinalResult() {
@@ -88,7 +86,6 @@ describe("foreground reply freshness", () => {
   it("suppresses an older foreground final after a newer inbound turn starts for the same session target", async () => {
     const deliveries: Delivery[] = [];
     const olderStarted = createDeferred<void>();
-    const newerStarted = createDeferred<void>();
     const releaseOlderFinal = createDeferred<void>();
 
     hoisted.dispatchReplyFromConfigMock.mockImplementation(
@@ -100,7 +97,6 @@ describe("foreground reply freshness", () => {
           return queuedFinalResult();
         }
         if (params.ctx.MessageSid === "new-message") {
-          newerStarted.resolve();
           params.dispatcher.sendFinalReply({ text: "new final" });
           return queuedFinalResult();
         }
@@ -114,12 +110,10 @@ describe("foreground reply freshness", () => {
     );
     await olderStarted.promise;
 
-    const newerDispatch = dispatchWithDeliveries(
+    const newerResult = await dispatchWithDeliveries(
       buildForegroundCtx({ MessageSid: "new-message" }),
       deliveries,
     );
-    await newerStarted.promise;
-    const newerResult = await newerDispatch;
 
     releaseOlderFinal.resolve();
     const olderResult = await olderDispatch;
@@ -139,10 +133,9 @@ describe("foreground reply freshness", () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
-    const newerStarted = createDeferred<void>();
-    const beforeDeliver = vi.fn(async () => {
+    const beforeDeliver = vi.fn(() => {
       beforeDeliverStarted.resolve();
-      return await releaseBeforeDeliver.promise;
+      return releaseBeforeDeliver.promise;
     });
 
     hoisted.dispatchReplyFromConfigMock.mockImplementation(
@@ -152,7 +145,6 @@ describe("foreground reply freshness", () => {
           return queuedFinalResult();
         }
         if (params.ctx.MessageSid === "new-message") {
-          newerStarted.resolve();
           return {
             queuedFinal: false,
             counts: { tool: 0, block: 0, final: 0 },
@@ -173,7 +165,6 @@ describe("foreground reply freshness", () => {
       buildForegroundCtx({ MessageSid: "new-message" }),
       deliveries,
     );
-    await newerStarted.promise;
 
     releaseBeforeDeliver.resolve({ text: "old rewritten final" });
     const olderResult = await olderDispatch;
@@ -193,7 +184,6 @@ describe("foreground reply freshness", () => {
   it("keeps concurrent foreground finals isolated for different targets sharing a session", async () => {
     const deliveries: Delivery[] = [];
     const firstStarted = createDeferred<void>();
-    const secondStarted = createDeferred<void>();
     const releaseFirstFinal = createDeferred<void>();
 
     hoisted.dispatchReplyFromConfigMock.mockImplementation(
@@ -205,7 +195,6 @@ describe("foreground reply freshness", () => {
           return queuedFinalResult();
         }
         if (params.ctx.MessageSid === "second-chat") {
-          secondStarted.resolve();
           params.dispatcher.sendFinalReply({ text: "second chat final" });
           return queuedFinalResult();
         }
@@ -234,7 +223,6 @@ describe("foreground reply freshness", () => {
       }),
       deliveries,
     );
-    await secondStarted.promise;
     await expect(secondDispatch).resolves.toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
+import { buildTestCtx } from "./reply/test-ctx.js";
+import type { FinalizedMsgContext, MsgContext } from "./templating.js";
+import type { ReplyPayload } from "./types.js";
+
+type DispatchReplyFromConfigFn =
+  typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
+type DispatchReplyFromConfigParams = Parameters<DispatchReplyFromConfigFn>[0];
+
+const hoisted = vi.hoisted(() => ({
+  dispatchReplyFromConfigMock: vi.fn(),
+}));
+
+vi.mock("./reply/dispatch-from-config.js", () => ({
+  dispatchReplyFromConfig: (...args: Parameters<DispatchReplyFromConfigFn>) =>
+    hoisted.dispatchReplyFromConfigMock(...args),
+}));
+
+const { dispatchInboundMessageWithBufferedDispatcher } = await import("./dispatch.js");
+
+type Delivery = {
+  kind: "tool" | "block" | "final";
+  text: string | undefined;
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function queuedFinalResult() {
+  return {
+    queuedFinal: true,
+    counts: { tool: 0, block: 0, final: 1 },
+  };
+}
+
+function buildForegroundCtx(overrides: Partial<MsgContext> = {}): FinalizedMsgContext {
+  return buildTestCtx({
+    SessionKey: "agent:main:whatsapp:direct:+1000",
+    AccountId: "default",
+    From: "whatsapp:+1000",
+    To: "whatsapp:bot",
+    ChatType: "direct",
+    Provider: "whatsapp",
+    Surface: "whatsapp",
+    OriginatingChannel: "whatsapp",
+    OriginatingTo: "whatsapp:+1000",
+    ...overrides,
+  });
+}
+
+function dispatchWithDeliveries(
+  ctx: FinalizedMsgContext,
+  deliveries: Delivery[],
+  dispatcherOptions: { beforeDeliver?: ReplyDispatchBeforeDeliver } = {},
+) {
+  return dispatchInboundMessageWithBufferedDispatcher({
+    ctx,
+    cfg: {} as OpenClawConfig,
+    dispatcherOptions: {
+      ...dispatcherOptions,
+      deliver: async (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => {
+        deliveries.push({ kind: info.kind, text: payload.text });
+      },
+    },
+  });
+}
+
+describe("foreground reply freshness", () => {
+  beforeEach(() => {
+    resetGlobalHookRunner();
+    hoisted.dispatchReplyFromConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    resetGlobalHookRunner();
+  });
+
+  it("suppresses an older foreground final after a newer inbound turn starts for the same session target", async () => {
+    const deliveries: Delivery[] = [];
+    const olderStarted = createDeferred<void>();
+    const newerStarted = createDeferred<void>();
+    const releaseOlderFinal = createDeferred<void>();
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          olderStarted.resolve();
+          await releaseOlderFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          newerStarted.resolve();
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+    );
+    await olderStarted.promise;
+
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await newerStarted.promise;
+    const newerResult = await newerDispatch;
+
+    releaseOlderFinal.resolve();
+    const olderResult = await olderDispatch;
+
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(olderResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+  });
+
+  it("suppresses an older foreground final when a newer inbound starts while beforeDeliver is pending", async () => {
+    const deliveries: Delivery[] = [];
+    const beforeDeliverStarted = createDeferred<void>();
+    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const newerStarted = createDeferred<void>();
+    const beforeDeliver = vi.fn(async () => {
+      beforeDeliverStarted.resolve();
+      return await releaseBeforeDeliver.promise;
+    });
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          newerStarted.resolve();
+          return {
+            queuedFinal: false,
+            counts: { tool: 0, block: 0, final: 0 },
+          };
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      { beforeDeliver },
+    );
+    await beforeDeliverStarted.promise;
+
+    const newerResult = await dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await newerStarted.promise;
+
+    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
+    const olderResult = await olderDispatch;
+
+    expect(beforeDeliver).toHaveBeenCalledTimes(1);
+    expect(newerResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(olderResult).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([]);
+  });
+
+  it("keeps concurrent foreground finals isolated for different targets sharing a session", async () => {
+    const deliveries: Delivery[] = [];
+    const firstStarted = createDeferred<void>();
+    const secondStarted = createDeferred<void>();
+    const releaseFirstFinal = createDeferred<void>();
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "first-chat") {
+          firstStarted.resolve();
+          await releaseFirstFinal.promise;
+          params.dispatcher.sendFinalReply({ text: "first chat final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "second-chat") {
+          secondStarted.resolve();
+          params.dispatcher.sendFinalReply({ text: "second chat final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const sharedSessionKey = "agent:main:main";
+    const firstDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({
+        MessageSid: "first-chat",
+        SessionKey: sharedSessionKey,
+        From: "whatsapp:+1000",
+        OriginatingTo: "whatsapp:+1000",
+      }),
+      deliveries,
+    );
+    await firstStarted.promise;
+
+    const secondDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({
+        MessageSid: "second-chat",
+        SessionKey: sharedSessionKey,
+        From: "whatsapp:+3000",
+        OriginatingTo: "whatsapp:+3000",
+      }),
+      deliveries,
+    );
+    await secondStarted.promise;
+    await expect(secondDispatch).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+
+    releaseFirstFinal.resolve();
+    await expect(firstDispatch).resolves.toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "second chat final" },
+      { kind: "final", text: "first chat final" },
+    ]);
+  });
+});

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -26,6 +26,87 @@ import type { ReplyDispatcher } from "./reply/reply-dispatcher.types.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
 import type { GetReplyOptions, ReplyPayload } from "./types.js";
 
+type ForegroundReplyFenceState = {
+  generation: number;
+  activeDispatches: number;
+};
+
+type ForegroundReplyFenceSnapshot = {
+  key: string;
+  generation: number;
+};
+
+const foregroundReplyFenceByKey = new Map<string, ForegroundReplyFenceState>();
+
+function normalizeForegroundReplyFencePart(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveForegroundReplyFenceKey(finalized: FinalizedMsgContext): string | undefined {
+  const sessionKey = normalizeForegroundReplyFencePart(finalized.SessionKey);
+  const channel =
+    normalizeForegroundReplyFencePart(finalized.OriginatingChannel) ??
+    normalizeForegroundReplyFencePart(finalized.Surface) ??
+    normalizeForegroundReplyFencePart(finalized.Provider);
+  const target =
+    normalizeForegroundReplyFencePart(finalized.OriginatingTo) ??
+    normalizeForegroundReplyFencePart(finalized.NativeChannelId) ??
+    normalizeForegroundReplyFencePart(finalized.From) ??
+    normalizeForegroundReplyFencePart(finalized.To);
+
+  if (!sessionKey || !channel || !target) {
+    return undefined;
+  }
+
+  return JSON.stringify([
+    "foreground",
+    channel,
+    normalizeForegroundReplyFencePart(finalized.AccountId) ?? "default",
+    sessionKey,
+    normalizeChatType(finalized.ChatType) ?? "unknown",
+    target,
+  ]);
+}
+
+function beginForegroundReplyFence(
+  finalized: FinalizedMsgContext,
+): ForegroundReplyFenceSnapshot | undefined {
+  const key = resolveForegroundReplyFenceKey(finalized);
+  if (!key) {
+    return undefined;
+  }
+  const state = foregroundReplyFenceByKey.get(key) ?? {
+    generation: 0,
+    activeDispatches: 0,
+  };
+  state.generation += 1;
+  state.activeDispatches += 1;
+  foregroundReplyFenceByKey.set(key, state);
+  return {
+    key,
+    generation: state.generation,
+  };
+}
+
+function isForegroundReplyFenceSuperseded(snapshot: ForegroundReplyFenceSnapshot): boolean {
+  return (foregroundReplyFenceByKey.get(snapshot.key)?.generation ?? 0) !== snapshot.generation;
+}
+
+function endForegroundReplyFence(snapshot: ForegroundReplyFenceSnapshot): void {
+  const state = foregroundReplyFenceByKey.get(snapshot.key);
+  if (!state) {
+    return;
+  }
+  state.activeDispatches -= 1;
+  if (state.activeDispatches <= 0) {
+    foregroundReplyFenceByKey.delete(snapshot.key);
+  }
+}
+
 function resolveDispatcherSilentReplyContext(
   ctx: MsgContext | FinalizedMsgContext,
   cfg: OpenClawConfig,
@@ -200,9 +281,28 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onBlockReply">;
   replyResolver?: GetReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const silentReplyContext = resolveDispatcherSilentReplyContext(params.ctx, params.cfg);
-  const beforeDeliver =
-    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(params.ctx);
+  const finalized = finalizeInboundContext(params.ctx);
+  const foregroundReplyFence = beginForegroundReplyFence(finalized);
+  let foregroundReplyFenceActive = true;
+  const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
+  const configuredBeforeDeliver =
+    params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
+  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined = foregroundReplyFence
+    ? async (payload, info) => {
+        const isSuperseded = () =>
+          foregroundReplyFenceActive && isForegroundReplyFenceSuperseded(foregroundReplyFence);
+        if (isSuperseded()) {
+          return null;
+        }
+        const deliverPayload = configuredBeforeDeliver
+          ? await configuredBeforeDeliver(payload, info)
+          : payload;
+        if (!deliverPayload || isSuperseded()) {
+          return null;
+        }
+        return deliverPayload;
+      }
+    : configuredBeforeDeliver;
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
       ...params.dispatcherOptions,
@@ -211,7 +311,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     });
   try {
     return await dispatchInboundMessage({
-      ctx: params.ctx,
+      ctx: finalized,
       cfg: params.cfg,
       dispatcher,
       replyResolver: params.replyResolver,
@@ -221,6 +321,10 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       },
     });
   } finally {
+    if (foregroundReplyFence) {
+      foregroundReplyFenceActive = false;
+      endForegroundReplyFence(foregroundReplyFence);
+    }
     markRunComplete();
     markDispatchIdle();
   }

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -92,8 +92,13 @@ function beginForegroundReplyFence(
   };
 }
 
-function isForegroundReplyFenceSuperseded(snapshot: ForegroundReplyFenceSnapshot): boolean {
-  return (foregroundReplyFenceByKey.get(snapshot.key)?.generation ?? 0) !== snapshot.generation;
+function isForegroundReplyFenceSuperseded(
+  snapshot: ForegroundReplyFenceSnapshot | undefined,
+): boolean {
+  return Boolean(
+    snapshot &&
+    (foregroundReplyFenceByKey.get(snapshot.key)?.generation ?? 0) !== snapshot.generation,
+  );
 }
 
 function endForegroundReplyFence(snapshot: ForegroundReplyFenceSnapshot): void {
@@ -283,26 +288,24 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
   const foregroundReplyFence = beginForegroundReplyFence(finalized);
-  let foregroundReplyFenceActive = true;
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const configuredBeforeDeliver =
     params.dispatcherOptions.beforeDeliver ?? buildMessageSendingBeforeDeliver(finalized);
-  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined = foregroundReplyFence
-    ? async (payload, info) => {
-        const isSuperseded = () =>
-          foregroundReplyFenceActive && isForegroundReplyFenceSuperseded(foregroundReplyFence);
-        if (isSuperseded()) {
-          return null;
+  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
+    foregroundReplyFence || configuredBeforeDeliver
+      ? async (payload, info) => {
+          if (isForegroundReplyFenceSuperseded(foregroundReplyFence)) {
+            return null;
+          }
+          const deliverPayload = configuredBeforeDeliver
+            ? await configuredBeforeDeliver(payload, info)
+            : payload;
+          if (!deliverPayload || isForegroundReplyFenceSuperseded(foregroundReplyFence)) {
+            return null;
+          }
+          return deliverPayload;
         }
-        const deliverPayload = configuredBeforeDeliver
-          ? await configuredBeforeDeliver(payload, info)
-          : payload;
-        if (!deliverPayload || isSuperseded()) {
-          return null;
-        }
-        return deliverPayload;
-      }
-    : configuredBeforeDeliver;
+      : undefined;
   const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     createReplyDispatcherWithTyping({
       ...params.dispatcherOptions,
@@ -322,7 +325,6 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     });
   } finally {
     if (foregroundReplyFence) {
-      foregroundReplyFenceActive = false;
       endForegroundReplyFence(foregroundReplyFence);
     }
     markRunComplete();


### PR DESCRIPTION
## Summary

- Problem: older in-flight foreground auto-reply runs could deliver a final reply after a newer inbound message started for the same session target.
- Why it matters: messaging channels can show stale tool-turn completions as if they answered the latest user message.
- What changed: added a shared buffered-dispatch freshness guard that suppresses superseded foreground replies before delivery.
- What did NOT change (scope boundary): no provider replay/cache behavior, WhatsApp-specific routing, or background completion notification semantics were changed.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #76905
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: older in-flight foreground auto-reply finals are suppressed when a newer inbound WhatsApp-style turn starts for the same channel/account/session/target before the older final is delivered.
- Real environment tested: Linux container in `/root/mkdev11/openclaw`, Node v22.22.1, pnpm 10.33.2, PR branch `fix/issue-76905-whatsapp-stale-final` at `92148e40c818bdca1d9e5ef3554712159eddae40`.
- Exact steps or command run after this patch: Ran a local Node harness with `node --import tsx -e` that imported the real `dispatchInboundMessageWithBufferedDispatcher`, created two finalized WhatsApp-style inbound contexts for the same session target, held the older reply resolver until after the newer dispatch completed, then released the older final.
- Evidence after fix: Terminal output from the real dispatch module run:
```json
{
  "newerResult": {
    "queuedFinal": true,
    "counts": {
      "tool": 0,
      "block": 0,
      "final": 1
    }
  },
  "olderResult": {
    "queuedFinal": false,
    "counts": {
      "tool": 0,
      "block": 0,
      "final": 0
    }
  },
  "deliveries": [
    {
      "kind": "final",
      "text": "new final"
    }
  ]
}
```
- Observed result after fix: The newer final was delivered, the older final was not delivered, and the older dispatch reconciled to `queuedFinal=false` with `counts.final=0`.
- What was not tested: A live WhatsApp account plus live provider race was not replayed; this proof exercises the real shared OpenClaw buffered dispatch path with local WhatsApp-style contexts and a deterministic delayed resolver.
- Before evidence (optional but encouraged): Before this patch, the shared buffered dispatch path had no foreground freshness fence, so an older final could still enter delivery after a newer same-target turn began.

## Root Cause 

- Root cause: buffered foreground reply delivery did not verify that the originating inbound turn was still the newest active turn for the same channel/account/session/target before delivering a final payload.
- Missing detection / guardrail: no shared freshness guard existed in the generic auto-reply delivery path.
- Contributing context (if known): active-run steering can record a newer inbound message while an older tool-backed run is still finalizing.

## Regression Test Plan 

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/dispatch.freshness.test.ts`
- Scenario the test should lock in: an older foreground final is suppressed after a newer inbound turn starts for the same session target.
- Why this is the smallest reliable guardrail: it exercises the shared buffered dispatch path directly without requiring live WhatsApp or provider timing.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Older stale foreground replies are suppressed when a newer inbound message starts for the same channel/account/session/target before the older dispatch finalizes.

## Diagram

```text
Before:
message A -> long tool run -> message B starts -> final from A is delivered

After:
message A -> long tool run -> message B starts -> final from A is suppressed
```

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): shared auto-reply dispatch; regression models WhatsApp-style foreground context
- Relevant config (redacted): default test config

### Steps

1. Start a foreground buffered dispatch for one session target.
2. Start a newer foreground buffered dispatch for the same session target before the older final is delivered.
3. Let the newer final deliver, then let the older final attempt delivery.

### Expected

- The newer final is delivered.
- The older final is cancelled before delivery and removed from queued final counts.

### Actual

- Matches expected with the new regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - stale same-session same-target final is suppressed
  - concurrent different-target finals sharing a session are not suppressed
  - existing dispatch lifecycle tests still pass
- Edge cases checked:
  - missing or different target keys do not collide
  - cancellation reconciles queued final counts
  - repo formatting and changed-file checks pass
- What you did **not** verify:
  - live WhatsApp plus Codex provider reproduction

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the guard could suppress a reply that intentionally completes after a newer foreground message.
  - Mitigation: the key is scoped by channel, account, session, chat type, and target, and only applies to the shared foreground buffered delivery path.
