### PR TITLE
fix(whatsapp): honor group visible reply mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Google Meet: grant Meet media permissions through the Playwright browser context when CDP grants do not affect the attached Chrome page, and report in-call microphone/speaker permission problems instead of marking realtime speech ready.
 - QA/Slack: fail the live mention-gating scenario on any unexpected SUT reply, even when the reply does not echo the expected marker. Thanks @vincentkoc.
 - Tlon: expose `groupInviteAllowlist` in the channel config schema and clarify that group invite auto-accept fails closed without an invite allowlist. Thanks @vincentkoc.
+- Channels/WhatsApp: apply the shared group/channel visible-reply mode during inbound dispatch so group replies stay message-tool-only by default without overriding direct-chat harness defaults. Refs #75178 and #67394. Thanks @scoootscooob.
 - Control UI/WebChat: collapse duplicate in-flight internal text sends onto the active Gateway run so rapid repeat submits do not start fresh `agent:main:main` dispatches. Fixes #75737. Thanks @dsdsddd1 and @BunsDev.
 - Mattermost: accept the documented `channels.mattermost.streaming` config and honor `streaming: "off"` by disabling draft preview posts. Thanks @vincentkoc.
 - Mattermost: expose streaming progress config labels and help text in generated channel config metadata so Control UI/docs can explain the new `channels.mattermost.streaming.progress.*` fields. Thanks @vincentkoc.

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.runtime.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.runtime.ts
@@ -5,6 +5,7 @@ export {
   getAgentScopedMediaLocalRoots,
   jidToE164,
   logVerbose,
+  resolveChannelSourceReplyDeliveryMode,
   resolveChunkMode,
   resolveIdentityNamePrefix,
   resolveInboundLastRouteSessionKey,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -627,16 +627,16 @@ describe("whatsapp inbound dispatch", () => {
     expect(getCapturedReplyOptions()?.disableBlockStreaming).toBeUndefined();
   });
 
-  it("keeps WhatsApp direct replies automatic by default", async () => {
+  it("leaves WhatsApp direct reply mode unset by default", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "direct" },
       msg: makeMsg({ from: "+15550001000", chatType: "direct" }),
     });
 
     expect(getCapturedReplyOptions()).toMatchObject({
-      sourceReplyDeliveryMode: "automatic",
       disableBlockStreaming: false,
     });
+    expect(getCapturedReplyOptions()?.sourceReplyDeliveryMode).toBeUndefined();
   });
 
   it("defaults WhatsApp group replies to message-tool-only and disables source streaming", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -36,6 +36,28 @@ vi.mock("./runtime-api.js", () => ({
     return phone ? `+${phone}` : null;
   },
   logVerbose: () => {},
+  resolveChannelSourceReplyDeliveryMode: ({
+    cfg,
+    ctx,
+  }: {
+    cfg: {
+      messages?: {
+        visibleReplies?: "automatic" | "message_tool";
+        groupChat?: { visibleReplies?: "automatic" | "message_tool" };
+      };
+    };
+    ctx: { ChatType?: string; CommandSource?: "native" };
+  }) => {
+    if (ctx.CommandSource === "native") {
+      return "automatic";
+    }
+    if (ctx.ChatType === "group" || ctx.ChatType === "channel") {
+      const configuredMode =
+        cfg.messages?.groupChat?.visibleReplies ?? cfg.messages?.visibleReplies;
+      return configuredMode === "automatic" ? "automatic" : "message_tool_only";
+    }
+    return cfg.messages?.visibleReplies === "message_tool" ? "message_tool_only" : "automatic";
+  },
   resolveChunkMode: () => "length",
   resolveIdentityNamePrefix: (cfg: {
     agents?: { list?: Array<{ id?: string; default?: boolean; identity?: { name?: string } }> };
@@ -137,6 +159,17 @@ function getCapturedOnError() {
       };
     }
   )?.dispatcherOptions?.onError;
+}
+
+function getCapturedReplyOptions() {
+  return (
+    capturedDispatchParams as {
+      replyOptions?: {
+        disableBlockStreaming?: boolean;
+        sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
+      };
+    }
+  )?.replyOptions;
 }
 
 type BufferedReplyParams = Parameters<typeof dispatchWhatsAppBufferedReply>[0];
@@ -575,13 +608,7 @@ describe("whatsapp inbound dispatch", () => {
   it("maps WhatsApp blockStreaming=true to disableBlockStreaming=false", async () => {
     await dispatchBufferedReply();
 
-    expect(
-      (
-        capturedDispatchParams as {
-          replyOptions?: { disableBlockStreaming?: boolean };
-        }
-      )?.replyOptions?.disableBlockStreaming,
-    ).toBe(false);
+    expect(getCapturedReplyOptions()?.disableBlockStreaming).toBe(false);
   });
 
   it("maps WhatsApp blockStreaming=false to disableBlockStreaming=true", async () => {
@@ -589,13 +616,7 @@ describe("whatsapp inbound dispatch", () => {
       cfg: { channels: { whatsapp: { blockStreaming: false } } } as never,
     });
 
-    expect(
-      (
-        capturedDispatchParams as {
-          replyOptions?: { disableBlockStreaming?: boolean };
-        }
-      )?.replyOptions?.disableBlockStreaming,
-    ).toBe(true);
+    expect(getCapturedReplyOptions()?.disableBlockStreaming).toBe(true);
   });
 
   it("leaves disableBlockStreaming undefined when WhatsApp blockStreaming is unset", async () => {
@@ -603,13 +624,47 @@ describe("whatsapp inbound dispatch", () => {
       cfg: { channels: { whatsapp: {} } } as never,
     });
 
-    expect(
-      (
-        capturedDispatchParams as {
-          replyOptions?: { disableBlockStreaming?: boolean };
-        }
-      )?.replyOptions?.disableBlockStreaming,
-    ).toBeUndefined();
+    expect(getCapturedReplyOptions()?.disableBlockStreaming).toBeUndefined();
+  });
+
+  it("keeps WhatsApp direct replies automatic by default", async () => {
+    await dispatchBufferedReply({
+      context: { Body: "hi", ChatType: "direct" },
+      msg: makeMsg({ from: "+15550001000", chatType: "direct" }),
+    });
+
+    expect(getCapturedReplyOptions()).toMatchObject({
+      sourceReplyDeliveryMode: "automatic",
+      disableBlockStreaming: false,
+    });
+  });
+
+  it("defaults WhatsApp group replies to message-tool-only and disables source streaming", async () => {
+    await dispatchBufferedReply({
+      context: { Body: "hi", ChatType: "group" },
+      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group" }),
+    });
+
+    expect(getCapturedReplyOptions()).toMatchObject({
+      sourceReplyDeliveryMode: "message_tool_only",
+      disableBlockStreaming: true,
+    });
+  });
+
+  it("honors automatic visible replies for WhatsApp groups", async () => {
+    await dispatchBufferedReply({
+      cfg: {
+        channels: { whatsapp: { blockStreaming: true } },
+        messages: { groupChat: { visibleReplies: "automatic" } },
+      } as never,
+      context: { Body: "hi", ChatType: "group" },
+      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group" }),
+    });
+
+    expect(getCapturedReplyOptions()).toMatchObject({
+      sourceReplyDeliveryMode: "automatic",
+      disableBlockStreaming: false,
+    });
   });
 
   it("treats block-only turns as visible replies instead of silent turns", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -314,14 +314,18 @@ export async function dispatchWhatsAppBufferedReply(params: {
     accountId: params.route.accountId,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
-  const sourceReplyDeliveryMode = resolveChannelSourceReplyDeliveryMode({
-    cfg: params.cfg,
-    ctx: {
-      ChatType:
-        typeof params.context.ChatType === "string" ? params.context.ChatType : params.msg.chatType,
-      CommandSource: params.context.CommandSource === "native" ? "native" : undefined,
-    },
-  });
+  const sourceReplyChatType =
+    typeof params.context.ChatType === "string" ? params.context.ChatType : params.msg.chatType;
+  const sourceReplyDeliveryMode =
+    sourceReplyChatType === "group" || sourceReplyChatType === "channel"
+      ? resolveChannelSourceReplyDeliveryMode({
+          cfg: params.cfg,
+          ctx: {
+            ChatType: sourceReplyChatType,
+            CommandSource: params.context.CommandSource === "native" ? "native" : undefined,
+          },
+        })
+      : undefined;
   const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
   const disableBlockStreaming = sourceRepliesAreToolOnly
     ? true
@@ -413,7 +417,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
     },
     replyOptions: {
       disableBlockStreaming,
-      sourceReplyDeliveryMode,
+      ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,
     },
   });

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -15,6 +15,7 @@ import {
   getAgentScopedMediaLocalRoots,
   jidToE164,
   logVerbose,
+  resolveChannelSourceReplyDeliveryMode,
   resolveChunkMode,
   resolveIdentityNamePrefix,
   resolveInboundLastRouteSessionKey,
@@ -313,7 +314,18 @@ export async function dispatchWhatsAppBufferedReply(params: {
     accountId: params.route.accountId,
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
-  const disableBlockStreaming = resolveWhatsAppDisableBlockStreaming(params.cfg);
+  const sourceReplyDeliveryMode = resolveChannelSourceReplyDeliveryMode({
+    cfg: params.cfg,
+    ctx: {
+      ChatType:
+        typeof params.context.ChatType === "string" ? params.context.ChatType : params.msg.chatType,
+      CommandSource: params.context.CommandSource === "native" ? "native" : undefined,
+    },
+  });
+  const sourceRepliesAreToolOnly = sourceReplyDeliveryMode === "message_tool_only";
+  const disableBlockStreaming = sourceRepliesAreToolOnly
+    ? true
+    : resolveWhatsAppDisableBlockStreaming(params.cfg);
   let didSendReply = false;
   let didLogHeartbeatStrip = false;
 
@@ -401,6 +413,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
     },
     replyOptions: {
       disableBlockStreaming,
+      sourceReplyDeliveryMode,
       onModelSelected: params.onModelSelected,
     },
   });

--- a/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/runtime-api.ts
@@ -2,7 +2,10 @@ export { resolveIdentityNamePrefix } from "openclaw/plugin-sdk/agent-runtime";
 export { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-envelope";
 export { resolveInboundSessionEnvelopeContext } from "openclaw/plugin-sdk/channel-inbound";
 export { toLocationContext } from "openclaw/plugin-sdk/channel-location";
-export { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
+export {
+  createChannelReplyPipeline,
+  resolveChannelSourceReplyDeliveryMode,
+} from "openclaw/plugin-sdk/channel-reply-pipeline";
 export { shouldComputeCommandAuthorized } from "openclaw/plugin-sdk/command-detection";
 export { resolveChannelContextVisibilityMode } from "../config.runtime.js";
 export { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4616,6 +4616,31 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(mocks.routeReply).not.toHaveBeenCalled();
   });
 
+  it("keeps default direct source delivery automatic", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
+      return { text: "visible direct reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        SessionKey: "agent:main:telegram:direct:U1",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "visible direct reply" }),
+    );
+  });
+
   it("uses harness defaults for direct source delivery when config is unset", async () => {
     setNoAbort();
     registerAgentHarness({


### PR DESCRIPTION
## What bug this fixes

WhatsApp inbound dispatch did not pass the shared source reply delivery mode into `dispatchReplyFromConfig`. That meant WhatsApp group/channel turns did not get the same `message_tool_only` behavior as Discord/Slack/Telegram, and direct-message turns were not covered by the shared direct-default regression tests.

This is the WhatsApp side of the recent group visible-replies upgrade reports: group/channel source final replies should be private by default and require the message tool, while direct messages should remain automatic unless explicitly configured otherwise.

## Affected surface

- WhatsApp auto-reply dispatch for group/channel vs direct chats.
- Shared auto-reply reply-mode coverage for direct source delivery.

## Why this fix

The shared channel reply pipeline already exposes `resolveChannelSourceReplyDeliveryMode`, so the WhatsApp monitor now uses that same SDK helper and forwards the resulting `sourceReplyDeliveryMode` through `replyOptions`. For tool-only source replies, WhatsApp also disables source block streaming so group/channel drafts do not leak before the model uses the message tool.

This keeps the policy in the shared resolver instead of adding a WhatsApp-specific fork.

## Validation

- `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts`
- `pnpm test extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts`
- `pnpm check:changed`
