### PR TITLE
fix(cli-output): extract runtime errors from result.errors[] for session_expired classification

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -5,7 +5,11 @@ import {
   parseCliJson,
   parseCliJsonl,
 } from "./cli-output.js";
-import { createClaudeApiErrorFixture } from "./test-helpers/claude-api-error-fixture.js";
+import { classifyFailoverReason } from "./pi-embedded-helpers.js";
+import {
+  createClaudeApiErrorFixture,
+  createClaudeNoConversationFoundFixture,
+} from "./test-helpers/claude-api-error-fixture.js";
 
 describe("parseCliJson", () => {
   it("recovers mixed-output Claude session metadata from embedded JSON objects", () => {
@@ -406,6 +410,29 @@ describe("parseCliJsonl", () => {
     const result = extractCliErrorMessage(jsonl);
 
     expect(result).toBe(message);
+  });
+
+  it("extracts runtime errors from result.errors[] (e.g. 'No conversation found ...')", () => {
+    // Regression: claude --resume <stale-uuid> emits the failure as
+    // {"type":"result","is_error":true,"errors":[<msg>],"result":null}.
+    // Without reading the `errors` array, the message never reaches
+    // classifyFailoverReason and the binding stays stale.
+    const { message, jsonl } = createClaudeNoConversationFoundFixture();
+    const result = extractCliErrorMessage(jsonl);
+
+    expect(result).toBe(message);
+  });
+
+  it("classifies extracted result.errors[] message as session_expired", () => {
+    // End-to-end: extract → classify must yield "session_expired" so the
+    // attempt-execution catch block clears cliSessionBindings and retries
+    // without --resume.
+    const { jsonl } = createClaudeNoConversationFoundFixture();
+    const message = extractCliErrorMessage(jsonl);
+    expect(message).toBeTruthy();
+
+    const reason = classifyFailoverReason(message ?? "", { provider: "claude-cli" });
+    expect(reason).toBe("session_expired");
   });
 });
 

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -228,6 +228,24 @@ function collectExplicitCliErrorText(parsed: Record<string, unknown>): string {
     return unwrapCliErrorText(parsed.result);
   }
 
+  // Claude CLI emits errors at runtime as a top-level `errors: string[]`
+  // array on `result` messages with `is_error: true`, e.g.
+  //   {"type":"result","subtype":"error_during_execution","is_error":true,
+  //    "result":null,"errors":["No conversation found with session ID: ..."]}
+  // Without this branch, the inner string is invisible to
+  // classifyFailoverReason → reason defaults to "unknown" → the
+  // session_expired catch in attempt-execution.ts never fires → the
+  // stale cliSessionBindings entry persists → every subsequent turn
+  // fails the same way. See OpenClaw issues #61390, #73073, #70177.
+  if (parsed.is_error === true && Array.isArray(parsed.errors)) {
+    const errorTexts = parsed.errors
+      .filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+      .map((entry) => entry.trim());
+    if (errorTexts.length > 0) {
+      return unwrapCliErrorText(errorTexts.join("; "));
+    }
+  }
+
   if (parsed.type === "assistant") {
     const text = collectCliText(parsed.message);
     if (/^\s*API Error:/i.test(text)) {

--- a/src/agents/test-helpers/claude-api-error-fixture.ts
+++ b/src/agents/test-helpers/claude-api-error-fixture.ts
@@ -1,6 +1,48 @@
 const CLAUDE_API_ERROR_MESSAGE =
   "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.";
 
+/**
+ * Stream-json output observed when `claude --resume <uuid>` is invoked with
+ * a session ID that no longer exists on disk (or never did). The runtime
+ * error string lands in the top-level `errors: string[]` array on the final
+ * `result` message — not in `result`/`message`/`error` fields.
+ *
+ * Captured from claude-cli 2.1.119 in production after dashboard chat
+ * bricked at 30-min heartbeat cadence with the same stale binding.
+ */
+export function createClaudeNoConversationFoundFixture() {
+  const sessionId = "390db08a-5288-4622-9ee6-6594428f60b7";
+  const resultSessionId = "059d8e2d-3983-4a21-8f5d-bb11e0ebde4d";
+  const message = `No conversation found with session ID: ${sessionId}`;
+  return {
+    sessionId,
+    message,
+    jsonl: [
+      JSON.stringify({
+        type: "result",
+        subtype: "error_during_execution",
+        duration_ms: 0,
+        duration_api_ms: 0,
+        is_error: true,
+        num_turns: 0,
+        stop_reason: null,
+        session_id: resultSessionId,
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          output_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [],
+        uuid: "49107c9e-3cb9-4476-9ff8-b4e05a6cf6c2",
+        errors: [message],
+      }),
+    ].join("\n"),
+  };
+}
+
 export function createClaudeApiErrorFixture() {
   const apiError = `API Error: 400 ${JSON.stringify({
     type: "error",


### PR DESCRIPTION
## Bug

Dashboard chat (and any session-reusing surface) deterministically bricks
once the bound `cliSessionBindings.claude-cli.sessionId` no longer
resolves to an on-disk session file. Both `sonnet` and `opus` failover
attempts then exit in <3s with `error=FailoverError reason=unknown
detail="Claude CLI failed."`, and the catch in
`src/agents/command/attempt-execution.ts:513` only fires on
`reason === "session_expired"` — so the stale binding is never cleared
and every subsequent turn fails the same way.

## Repro

1. Get OpenClaw to bind a session that later disappears (claude --resume
   garbage collection, claude restart, or a user manually removing
   `~/.claude/projects/<project>/<uuid>.jsonl`).
2. Trigger a turn (any user/heartbeat). Observe the gateway log:

```
[agent/cli-backend] cli exec: provider=claude-cli model=sonnet
   useResume=true session=present resumeSession=<sha-fingerprint>
   reuse=reusable historyPrompt=none
[agent/cli-backend] claude live session turn failed:
   provider=claude-cli model=claude-sonnet-4-6 durationMs=2865
   error=FailoverError
[model-fallback/decision] decision=candidate_failed reason=unknown
   detail=Claude CLI failed.
```

The actual stderr (captured via wrapper):

```
No conversation found with session ID: 390db08a-5288-4622-9ee6-6594428f60b7
```

The corresponding stdout `result` line:

```json
{"type":"result","subtype":"error_during_execution","is_error":true,
 "result":null,
 "errors":["No conversation found with session ID: 390db08a-..."]}
```

## Root cause

`isCliSessionExpiredErrorMessage` already includes "no conversation
found" in its pattern list (`src/agents/pi-embedded-helpers/errors.ts:1291`)
— so once the message reaches it, classification is correct.

But the message **never reaches it**: `extractCliErrorMessage` →
`collectExplicitCliErrorText` only inspects:

- `parsed.error` / `parsed.message` (nested)
- `parsed.result` (when string AND `is_error: true`)
- `parsed.message` (when `type: "assistant"` AND text matches `/^\s*API
  Error:/i`)
- `parsed.message`/`content`/`result` (when `type: "error"`)

Claude CLI emits this particular failure as `{"type":"result",
"is_error":true,"result":null,"errors":[<msg>]}`. None of the existing
branches match (`result` is `null`, not a string), so extractor returns
`""`, the FailoverError is built with the fallback `"Claude CLI failed."`
text, and `classifyFailoverReason("Claude CLI failed.")` returns null →
`reason = "unknown"` → catch block doesn't fire → binding stays stale.

## Fix

Add one branch to `collectExplicitCliErrorText` that reads the top-level
`errors: string[]` array on `is_error: true` messages.

After this change, the same failure produces:

```
[model-fallback/decision] reason=session_expired
```

…the catch in `attempt-execution.ts:513` fires, `clearCliSessionInStore`
runs, the next turn starts fresh (`useResume=false session=none`), and
the chat keeps working.

## Test

Two new tests in `src/agents/cli-output.test.ts`:

1. `extractCliErrorMessage` returns the expected error string from the
   new fixture.
2. End-to-end: `classifyFailoverReason(extractCliErrorMessage(...))`
   returns `"session_expired"`.

Fixture (`createClaudeNoConversationFoundFixture`) is built from a real
captured failure, not synthetic.

## Closes / relates to

- #61390 (added "no conversation found" to the pattern list — that fix
  was correct but the message path was already broken before reaching
  the pattern matcher; this PR completes the original intent)
- #73073 (Telegram DM cliSessionBindings not updated after
  session_expired retry)
- #70177 (Telegram DM amnesia — cliSessionBindings stores claude-cli
  sessionId with no backing transcript)

## Risk

Low. The change adds a new branch to error extraction that fires only
when `is_error === true && Array.isArray(errors)`. No existing branch is
modified. No public surface change. The new classification path
(session_expired → clear binding → retry) is the well-tested existing
recovery path; this PR just feeds it correctly.

## Captured artifacts

If helpful for reviewers, the original captured trace is at the
reporter's machine (`/tmp/openclaw-claude-trace/<ts>/{argv,stderr,
stdout,exit}`). Available on request.
