### PR TITLE
fix(telegram): preserve spacing before numbered sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Gateway/agents: keep structured reasons when active-run queueing fails and deprecate the legacy boolean queue helper, so steering and subagent wake diagnostics distinguish completed, non-streaming, and compacting runs. Fixes #80156. Thanks @markus-lassfolk.
 - Agents/UI: compact exec and tool progress rows by hiding redundant shell tool names, replacing known workspace paths with short context markers, and preserving Discord trace scrubbing for compact command lines.
 - ACPX: run and await the embedded ACP backend startup probe by default so the gateway `ready` signal no longer fires before the acpx runtime has either become usable or reported a probe failure; set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to restore lazy startup. Fixes #79596. Thanks @bzelones.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -95,6 +95,33 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toBe("<tg-spoiler><b>secret</b> text</tg-spoiler>");
   });
 
+  it("preserves spacing between Telegram bullet blocks and following numbered sections", () => {
+    const input = [
+      "2. Main invariants:",
+      "",
+      "  • Raw Log is source of truth.",
+      "  • Autonomy starts only with report/draft.",
+      "3. Cognee is a candidate:",
+      "",
+      "  • bake-off first;",
+      "  • decide keep/adopt/hybrid later.",
+      "4. Project Flow slices:",
+    ].join("\n");
+
+    const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
+
+    expect(res).toContain("report/draft.\n\n3. Cognee");
+    expect(res).toContain("keep/adopt/hybrid later.\n\n4. Project");
+  });
+
+  it("does not insert Telegram list boundary spacing inside fenced code", () => {
+    const input = ["```", "  • literal bullet", "3. literal number", "```"].join("\n");
+
+    const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
+
+    expect(res).toBe("<pre><code>  • literal bullet\n3. literal number\n</code></pre>");
+  });
+
   it("does not treat single pipe as spoiler", () => {
     const res = markdownToTelegramHtml("(￣_￣|) face");
     expect(res).not.toContain("tg-spoiler");

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml, splitTelegramHtmlChunks } from "./format.js";
+import {
+  markdownToTelegramChunks,
+  markdownToTelegramHtml,
+  splitTelegramHtmlChunks,
+} from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -114,12 +118,40 @@ describe("markdownToTelegramHtml", () => {
     expect(res).toContain("keep/adopt/hybrid later.\n\n4. Project");
   });
 
+  it("preserves Telegram list boundary spacing in chunked rendering", () => {
+    const input = [
+      "2. Main invariants:",
+      "",
+      "  • Raw Log is source of truth.",
+      "  • Autonomy starts only with report/draft.",
+      "3. Cognee is a candidate:",
+    ].join("\n");
+
+    const res = markdownToTelegramChunks(input, 4096)
+      .map((chunk) => chunk.html)
+      .join("");
+
+    expect(res).toContain("report/draft.\n\n3. Cognee");
+  });
+
   it("does not insert Telegram list boundary spacing inside fenced code", () => {
     const input = ["```", "  • literal bullet", "3. literal number", "```"].join("\n");
 
     const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
 
     expect(res).toBe("<pre><code>  • literal bullet\n3. literal number\n</code></pre>");
+  });
+
+  it("does not insert Telegram list boundary spacing inside indented code", () => {
+    const input = ["    • literal bullet", "    3. literal number"].join("\n");
+
+    const res = markdownToTelegramHtml(input, { wrapFileRefs: false });
+    const chunks = markdownToTelegramChunks(input, 4096)
+      .map((chunk) => chunk.html)
+      .join("");
+
+    expect(res).toBe("<pre><code>• literal bullet\n3. literal number\n</code></pre>");
+    expect(chunks).toBe(res);
   });
 
   it("does not treat single pipe as spoiler", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -73,7 +73,11 @@ function renderTelegramHtml(ir: MarkdownIR): string {
 }
 
 function leadingWhitespaceLength(line: string): number {
-  return line.match(/^[ \t]*/)?.[0]?.length ?? 0;
+  let length = 0;
+  while (line[length] === " " || line[length] === "\t") {
+    length++;
+  }
+  return length;
 }
 
 function isTelegramBulletLine(line: string): boolean {
@@ -84,28 +88,37 @@ function isTelegramListBoundaryLine(line: string): boolean {
   return /^[ \t]*(?:\d+\.|#{1,6})[ \t]+\S/.test(line);
 }
 
+function isMarkdownIndentedCodeLine(line: string): boolean {
+  return /^(?: {4}|\t)/.test(line);
+}
+
+function shouldPreserveTelegramListBoundarySpacing(previous: string, next: string): boolean {
+  return (
+    !isMarkdownIndentedCodeLine(previous) &&
+    !isMarkdownIndentedCodeLine(next) &&
+    isTelegramBulletLine(previous) &&
+    isTelegramListBoundaryLine(next) &&
+    leadingWhitespaceLength(next) <= leadingWhitespaceLength(previous)
+  );
+}
+
 function preserveTelegramListBoundarySpacing(markdown: string): string {
   const lines = markdown.split("\n");
   const out: string[] = [];
   let inFence = false;
+  let previousLine = "";
 
   for (const line of lines) {
     const normalizedLine = line.replace(/\r$/, "");
     const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
-    if (!inFence && out.length > 0) {
-      const previous = out[out.length - 1] ?? "";
-      if (
-        isTelegramBulletLine(previous) &&
-        isTelegramListBoundaryLine(normalizedLine) &&
-        leadingWhitespaceLength(normalizedLine) <= leadingWhitespaceLength(previous)
-      ) {
-        out.push("");
-      }
+    if (!inFence && shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine)) {
+      out.push("");
     }
     out.push(line);
     if (isFenceLine) {
       inFence = !inFence;
     }
+    previousLine = normalizedLine;
   }
 
   return out.join("\n");

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -72,11 +72,50 @@ function renderTelegramHtml(ir: MarkdownIR): string {
   });
 }
 
+function leadingWhitespaceLength(line: string): number {
+  return line.match(/^[ \t]*/)?.[0]?.length ?? 0;
+}
+
+function isTelegramBulletLine(line: string): boolean {
+  return /^[ \t]*(?:[•*+-])[ \t]+\S/.test(line);
+}
+
+function isTelegramListBoundaryLine(line: string): boolean {
+  return /^[ \t]*(?:\d+\.|#{1,6})[ \t]+\S/.test(line);
+}
+
+function preserveTelegramListBoundarySpacing(markdown: string): string {
+  const lines = markdown.split("\n");
+  const out: string[] = [];
+  let inFence = false;
+
+  for (const line of lines) {
+    const normalizedLine = line.replace(/\r$/, "");
+    const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
+    if (!inFence && out.length > 0) {
+      const previous = out[out.length - 1] ?? "";
+      if (
+        isTelegramBulletLine(previous) &&
+        isTelegramListBoundaryLine(normalizedLine) &&
+        leadingWhitespaceLength(normalizedLine) <= leadingWhitespaceLength(previous)
+      ) {
+        out.push("");
+      }
+    }
+    out.push(line);
+    if (isFenceLine) {
+      inFence = !inFence;
+    }
+  }
+
+  return out.join("\n");
+}
+
 export function markdownToTelegramHtml(
   markdown: string,
   options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
 ): string {
-  const ir = markdownToIR(markdown ?? "", {
+  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
     linkify: true,
     enableSpoilers: true,
     headingStyle: "none",
@@ -458,7 +497,7 @@ export function markdownToTelegramChunks(
   limit: number,
   options: { tableMode?: MarkdownTableMode } = {},
 ): TelegramFormattedChunk[] {
-  const ir = markdownToIR(markdown ?? "", {
+  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
     linkify: true,
     enableSpoilers: true,
     headingStyle: "none",


### PR DESCRIPTION
## Summary

- Preserve a blank line when Telegram markdown-ish output transitions from a bullet block to a following numbered section or heading.
- Apply the normalization before Telegram markdown IR rendering, including chunked rendering.
- Add regression coverage for the observed numbered-section boundary and for fenced/indented code blocks.

Fixes #76998.

## Real behavior proof

- Behavior or issue addressed: Telegram replies dropped the blank line between a manually indented bullet block and the next numbered section.
- Real environment tested: Crabbox real Telegram Desktop session with a real Telegram user sending into the shared group and the SUT bot replying through OpenClaw Telegram.
- Exact steps or command run after this patch: Send the reported prompt shape through the Telegram group; the mock model returns the bullet block followed by numbered sections; compare `main` and PR head replies in Telegram Desktop.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): PR-head Telegram Desktop recording GIF: https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-76999/comparison-highres-publish/20260510-101243-137064000/pr-76999-after.gif
- Observed result after fix: `main` reply text had `report/draft.\n3. Cognee`; PR head reply text has `report/draft.\n\n3. Cognee`.
- What was not tested: No additional gaps
- Before evidence (optional but encouraged): main-before Telegram Desktop recording GIF: https://artifacts.openclaw.ai/crabbox-artifacts/hi%40obviy.us/pr-76999/comparison-highres-publish/20260510-101243-137064000/main-before.gif

## Test

- `pnpm test extensions/telegram/src/format.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts CHANGELOG.md`
