### PR TITLE
feat(openrouter): add opt-in response caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
 - Plugins/CLI: include package dependency install state in `openclaw plugins list --json` so scripts can spot missing plugin dependencies without runtime-loading plugins.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
+- Providers/OpenRouter: add opt-in response caching params that send OpenRouter's `X-OpenRouter-Cache`, `X-OpenRouter-Cache-TTL`, and cache-clear headers only on verified OpenRouter routes. Thanks @vincentkoc.
 - Plugins/update: on the beta OpenClaw update channel, default-line npm and ClawHub plugin updates try `@beta` first and fall back to default/latest when no plugin beta release exists.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.
 - Exec approvals: add a tree-sitter-backed shell command explainer for future approval and command-review surfaces. (#75004) Thanks @jesse-merhi.

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -153,6 +153,39 @@ does **not** inject those OpenRouter-specific headers or Anthropic cache markers
 ## Advanced configuration
 
 <AccordionGroup>
+  <Accordion title="Response caching">
+    OpenRouter response caching is opt-in. Enable it per OpenRouter model with
+    model params:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/auto": {
+              params: {
+                responseCache: true,
+                responseCacheTtlSeconds: 300,
+              },
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    OpenClaw sends `X-OpenRouter-Cache: true` and, when configured,
+    `X-OpenRouter-Cache-TTL`. `responseCacheClear: true` forces a refresh for
+    the current request and stores the replacement response. Snake_case aliases
+    (`response_cache`, `response_cache_ttl_seconds`, and
+    `response_cache_clear`) are also accepted.
+
+    This is separate from provider prompt caching and from OpenRouter's
+    Anthropic `cache_control` markers. It is only applied on verified
+    `openrouter.ai` routes, not custom proxy base URLs.
+
+  </Accordion>
+
   <Accordion title="Anthropic cache markers">
     On verified OpenRouter routes, Anthropic model refs keep the
     OpenRouter-specific Anthropic `cache_control` markers that OpenClaw uses for

--- a/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
@@ -110,6 +110,57 @@ describe("applyExtraParamsToAgent OpenRouter reasoning", () => {
     });
   });
 
+  it("honors narrower camelCase response cache params over wider snake_case aliases", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            params: {
+              response_cache: false,
+              response_cache_ttl_seconds: 60,
+              response_cache_clear: false,
+            },
+            models: {
+              "openrouter/auto": {
+                params: {
+                  responseCache: true,
+                  responseCacheTtlSeconds: 600,
+                  responseCacheClear: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      "openrouter",
+      "auto",
+    );
+
+    void agent.streamFn?.(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "auto",
+      } as never,
+      { messages: [] } as never,
+      {},
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "X-OpenRouter-Cache": "true",
+      "X-OpenRouter-Cache-Clear": "true",
+      "X-OpenRouter-Cache-TTL": "600",
+    });
+  });
+
   it("injects reasoning.effort when thinkingLevel is non-off for OpenRouter", () => {
     const payload = runExtraParamsPayloadCase({
       provider: "openrouter",

--- a/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
@@ -1,7 +1,10 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runExtraParamsPayloadCase } from "./pi-embedded-runner-extraparams.test-support.js";
-import { __testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
+import {
+  applyExtraParamsToAgent,
+  __testing as extraParamsTesting,
+} from "./pi-embedded-runner/extra-params.js";
 import {
   createOpenRouterSystemCacheWrapper,
   createOpenRouterWrapper,
@@ -39,7 +42,9 @@ beforeEach(() => {
       const skipReasoningInjection =
         params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
       const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
-      return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
+      return createOpenRouterSystemCacheWrapper(
+        createOpenRouterWrapper(streamFn, thinkingLevel, params.context.extraParams),
+      );
     },
   });
 });
@@ -59,6 +64,50 @@ describe("applyExtraParamsToAgent OpenRouter reasoning", () => {
 
     expect(payload).not.toHaveProperty("reasoning");
     expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("forwards opt-in response cache params as OpenRouter headers", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/auto": {
+                params: {
+                  responseCache: true,
+                  responseCacheTtlSeconds: 600,
+                },
+              },
+            },
+          },
+        },
+      },
+      "openrouter",
+      "auto",
+    );
+
+    void agent.streamFn?.(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "auto",
+      } as never,
+      { messages: [] } as never,
+      {},
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "X-OpenRouter-Cache": "true",
+      "X-OpenRouter-Cache-TTL": "600",
+    });
   });
 
   it("injects reasoning.effort when thinkingLevel is non-off for OpenRouter", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -116,6 +116,9 @@ export function resolveExtraParams(params: {
     merged.cachedContent = resolvedCachedContent;
     delete merged.cached_content;
   }
+  if (params.provider === "openrouter") {
+    canonicalizeOpenRouterResponseCacheParams(merged, [defaultParams, globalParams, agentParams]);
+  }
 
   applyDefaultOpenAIGptRuntimeParams(params, merged);
 
@@ -232,6 +235,9 @@ export function resolvePreparedExtraParams(params: {
   if (resolvedCachedContent !== undefined) {
     merged.cachedContent = resolvedCachedContent;
     delete merged.cached_content;
+  }
+  if (params.provider === "openrouter") {
+    canonicalizeOpenRouterResponseCacheParams(merged, [resolvedExtraParams, override]);
   }
   const cfg = params.cfg;
   const cacheKey = cfg ? resolvePreparedExtraParamsCacheKey(params) : undefined;
@@ -433,21 +439,74 @@ function resolveAliasedParamValue(
   snakeCaseKey: string,
   camelCaseKey: string,
 ): unknown {
+  return resolveAliasedParamValueFromKeys(sources, [snakeCaseKey, camelCaseKey]);
+}
+
+function resolveAliasedParamValueFromKeys(
+  sources: Array<Record<string, unknown> | undefined>,
+  keys: readonly string[],
+): unknown {
   let resolved: unknown = undefined;
   let seen = false;
   for (const source of sources) {
     if (!source) {
       continue;
     }
-    const hasSnakeCaseKey = Object.hasOwn(source, snakeCaseKey);
-    const hasCamelCaseKey = Object.hasOwn(source, camelCaseKey);
-    if (!hasSnakeCaseKey && !hasCamelCaseKey) {
-      continue;
+    for (const key of keys) {
+      if (!Object.hasOwn(source, key)) {
+        continue;
+      }
+      resolved = source[key];
+      seen = true;
+      break;
     }
-    resolved = hasSnakeCaseKey ? source[snakeCaseKey] : source[camelCaseKey];
-    seen = true;
   }
   return seen ? resolved : undefined;
+}
+
+function applyCanonicalAliasedParamValue(params: {
+  merged: Record<string, unknown>;
+  sources: Array<Record<string, unknown> | undefined>;
+  keys: readonly string[];
+  canonicalKey: string;
+}): void {
+  const resolved = resolveAliasedParamValueFromKeys(params.sources, params.keys);
+  if (resolved === undefined) {
+    return;
+  }
+  for (const key of params.keys) {
+    delete params.merged[key];
+  }
+  params.merged[params.canonicalKey] = resolved;
+}
+
+function canonicalizeOpenRouterResponseCacheParams(
+  merged: Record<string, unknown>,
+  sources: Array<Record<string, unknown> | undefined>,
+): void {
+  applyCanonicalAliasedParamValue({
+    merged,
+    sources,
+    keys: ["responseCache", "response_cache"],
+    canonicalKey: "responseCache",
+  });
+  applyCanonicalAliasedParamValue({
+    merged,
+    sources,
+    keys: [
+      "responseCacheTtlSeconds",
+      "response_cache_ttl_seconds",
+      "responseCacheTtl",
+      "response_cache_ttl",
+    ],
+    canonicalKey: "responseCacheTtlSeconds",
+  });
+  applyCanonicalAliasedParamValue({
+    merged,
+    sources,
+    keys: ["responseCacheClear", "response_cache_clear"],
+    canonicalKey: "responseCacheClear",
+  });
 }
 
 function createParallelToolCallsWrapper(

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -63,6 +63,118 @@ describe("proxy stream wrappers", () => {
     ]);
   });
 
+  it("adds opt-in OpenRouter response caching headers", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterWrapper(baseStreamFn, undefined, {
+      responseCache: true,
+      responseCacheTtlSeconds: 900,
+    });
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openrouter/auto",
+        baseUrl: "https://openrouter.ai/api/v1",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-OpenRouter-Cache": "true",
+      "X-OpenRouter-Cache-TTL": "900",
+    });
+  });
+
+  it("sends OpenRouter response cache disables for preset opt-outs", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterWrapper(baseStreamFn, undefined, {
+      response_cache: false,
+      response_cache_ttl_seconds: 600,
+    });
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openrouter/@preset/cached-tests",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "X-OpenRouter-Cache": "false",
+    });
+    expect(calls[0]?.headers).not.toHaveProperty("X-OpenRouter-Cache-TTL");
+  });
+
+  it("supports OpenRouter response cache refresh and TTL clamping", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterWrapper(baseStreamFn, undefined, {
+      response_cache_clear: "true",
+      response_cache_ttl: 999999,
+    });
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openrouter/auto",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(calls[0]?.headers).toMatchObject({
+      "X-OpenRouter-Cache": "true",
+      "X-OpenRouter-Cache-Clear": "true",
+      "X-OpenRouter-Cache-TTL": "86400",
+    });
+  });
+
+  it("does not add OpenRouter response caching headers to custom proxy routes", () => {
+    const calls: Array<{ headers?: Record<string, string> }> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push({ headers: options?.headers });
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterWrapper(baseStreamFn, undefined, {
+      responseCache: true,
+    });
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openrouter/auto",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(calls[0]?.headers).toBeUndefined();
+  });
+
   it("injects cache_control markers for declared OpenRouter Anthropic models on the default route", () => {
     const payload = runSystemCacheWrapper({});
 

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -17,6 +17,111 @@ function resolveKilocodeAppHeaders(): Record<string, string> {
   return { [KILOCODE_FEATURE_HEADER]: feature };
 }
 
+function readExtraParam(
+  extraParams: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): unknown {
+  if (!extraParams) {
+    return undefined;
+  }
+  for (const key of keys) {
+    if (Object.hasOwn(extraParams, key)) {
+      return extraParams[key];
+    }
+  }
+  return undefined;
+}
+
+function resolveBooleanParam(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = normalizeOptionalLowercaseString(value);
+  if (!normalized) {
+    return undefined;
+  }
+  if (["1", "true", "yes", "on", "enable", "enabled"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off", "disable", "disabled"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function resolveOpenRouterResponseCacheTtlSeconds(value: unknown): string | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseFloat(value.trim())
+        : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+  return String(Math.max(1, Math.min(86400, Math.trunc(parsed))));
+}
+
+function shouldApplyOpenRouterResponseCacheHeaders(model: Parameters<StreamFn>[0]): boolean {
+  const provider = readStringValue(model.provider);
+  const endpointClass = resolveProviderRequestPolicy({
+    provider,
+    api: readStringValue(model.api),
+    baseUrl: readStringValue(model.baseUrl),
+    capability: "llm",
+    transport: "stream",
+  }).endpointClass;
+  return (
+    endpointClass === "openrouter" ||
+    (endpointClass === "default" && normalizeOptionalLowercaseString(provider) === "openrouter")
+  );
+}
+
+function resolveOpenRouterResponseCacheHeaders(
+  model: Parameters<StreamFn>[0],
+  extraParams: Record<string, unknown> | undefined,
+): Record<string, string> | undefined {
+  if (!shouldApplyOpenRouterResponseCacheHeaders(model)) {
+    return undefined;
+  }
+  const configuredCache = resolveBooleanParam(
+    readExtraParam(extraParams, ["response_cache", "responseCache"]),
+  );
+  const clearCache = resolveBooleanParam(
+    readExtraParam(extraParams, ["response_cache_clear", "responseCacheClear"]),
+  );
+  const cacheEnabled = configuredCache ?? (clearCache ? true : undefined);
+  if (cacheEnabled === undefined) {
+    return undefined;
+  }
+
+  const headers: Record<string, string> = {
+    "X-OpenRouter-Cache": cacheEnabled ? "true" : "false",
+  };
+  if (!cacheEnabled) {
+    return headers;
+  }
+
+  const ttl = resolveOpenRouterResponseCacheTtlSeconds(
+    readExtraParam(extraParams, [
+      "response_cache_ttl_seconds",
+      "responseCacheTtlSeconds",
+      "response_cache_ttl",
+      "responseCacheTtl",
+    ]),
+  );
+  if (ttl) {
+    headers["X-OpenRouter-Cache-TTL"] = ttl;
+  }
+  if (clearCache) {
+    headers["X-OpenRouter-Cache-Clear"] = "true";
+  }
+  return headers;
+}
+
 function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkLevel): void {
   if (!payload || typeof payload !== "object") {
     return;
@@ -79,9 +184,11 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
 export function createOpenRouterWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,
+  extraParams?: Record<string, unknown>,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    const providerHeaders = resolveOpenRouterResponseCacheHeaders(model, extraParams);
     const headers = resolveProviderRequestPolicyConfig({
       provider: readStringValue(model.provider) ?? "openrouter",
       api: readStringValue(model.api),
@@ -89,6 +196,7 @@ export function createOpenRouterWrapper(
       capability: "llm",
       transport: "stream",
       callerHeaders: options?.headers,
+      providerHeaders,
       precedence: "caller-wins",
     }).headers;
     return streamWithPayloadPatch(

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -88,10 +88,10 @@ function resolveOpenRouterResponseCacheHeaders(
     return undefined;
   }
   const configuredCache = resolveBooleanParam(
-    readExtraParam(extraParams, ["response_cache", "responseCache"]),
+    readExtraParam(extraParams, ["responseCache", "response_cache"]),
   );
   const clearCache = resolveBooleanParam(
-    readExtraParam(extraParams, ["response_cache_clear", "responseCacheClear"]),
+    readExtraParam(extraParams, ["responseCacheClear", "response_cache_clear"]),
   );
   const cacheEnabled = configuredCache ?? (clearCache ? true : undefined);
   if (cacheEnabled === undefined) {
@@ -107,10 +107,10 @@ function resolveOpenRouterResponseCacheHeaders(
 
   const ttl = resolveOpenRouterResponseCacheTtlSeconds(
     readExtraParam(extraParams, [
-      "response_cache_ttl_seconds",
       "responseCacheTtlSeconds",
-      "response_cache_ttl",
+      "response_cache_ttl_seconds",
       "responseCacheTtl",
+      "response_cache_ttl",
     ]),
   );
   if (ttl) {

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -139,7 +139,7 @@ export function buildProviderStreamFamilyHooks(
             ctx.modelId === "auto" || isProxyReasoningUnsupported(ctx.modelId)
               ? undefined
               : ctx.thinkingLevel;
-          return createOpenRouterWrapper(ctx.streamFn, thinkingLevel);
+          return createOpenRouterWrapper(ctx.streamFn, thinkingLevel, ctx.extraParams);
         },
       };
     case "tool-stream-default-on":


### PR DESCRIPTION
## Summary

- Problem: OpenRouter now supports response-level caching through request headers, but OpenClaw had no provider-owned way to opt in from model params.
- Why it matters: repeated agent/test requests can reuse OpenRouter's cache without changing OpenClaw prompt-cache behavior or custom proxy routes.
- What changed: plumb OpenRouter model params into `createOpenRouterWrapper`, send `X-OpenRouter-Cache`, `X-OpenRouter-Cache-TTL`, and `X-OpenRouter-Cache-Clear` only on verified OpenRouter routes, and document the params.
- What did NOT change (scope boundary): response caching is not enabled by default, custom OpenAI-compatible proxy base URLs do not receive these headers, and Anthropic `cache_control` prompt markers stay separate.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/NousResearch/hermes-agent/pull/19132
- Related https://openrouter.ai/docs/guides/features/response-caching
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): OpenRouter added a beta response-cache header surface after the existing OpenClaw provider wrapper was built.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts`, `src/agents/pi-embedded-runner-extraparams-openrouter.test.ts`
- Scenario the test should lock in: opt-in cache headers, opt-out behavior, cache clear/TTL clamping, and custom proxy exclusion.
- Why this is the smallest reliable guardrail: the feature is pure request policy/header plumbing in the OpenRouter stream wrapper.
- Existing test that already covers this (if any): existing OpenRouter attribution and Anthropic cache marker tests cover the neighboring route guards.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenRouter model params can now opt a model into response caching:

```json5
{
  agents: {
    defaults: {
      models: {
        "openrouter/auto": {
          params: {
            responseCache: true,
            responseCacheTtlSeconds: 300,
          },
        },
      },
    },
  },
}
```

Snake_case aliases are also accepted: `response_cache`, `response_cache_ttl_seconds`, and `response_cache_clear`.

## Diagram (if applicable)

```text
Before:
OpenRouter model params -> stream wrapper -> attribution headers only

After:
OpenRouter model params -> stream wrapper -> attribution + opt-in response-cache headers -> OpenRouter
custom proxy URL      -> stream wrapper -> no OpenRouter response-cache headers
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: enabling OpenRouter response caching asks OpenRouter to cache full successful responses for the configured TTL. Mitigation: this is opt-in per model params, disabled by default, clamped to OpenRouter's documented TTL range, and applied only to verified `openrouter.ai` routes rather than arbitrary proxy URLs.

## Repro + Verification

### Environment

- OS: macOS local worktree + Blacksmith Testbox Linux runner
- Runtime/container: Node 22 / pnpm repo scripts
- Model/provider: OpenRouter stream wrapper
- Integration/channel (if any): OpenRouter provider
- Relevant config (redacted): model params only; no secrets used

### Steps

1. Configure OpenRouter model params with `responseCache: true` and optional `responseCacheTtlSeconds`.
2. Send an OpenRouter streaming request through the provider stream wrapper.
3. Inspect resolved request headers.

### Expected

- Verified OpenRouter routes receive opt-in response cache headers.
- Custom proxy base URLs do not receive OpenRouter response cache headers.
- `responseCache: false` sends the documented disable header and suppresses TTL.
- Cache clear sends `X-OpenRouter-Cache-Clear: true` with caching enabled.

### Actual

- Matches expected in unit and extra-param wrapper coverage.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test:serial src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts src/agents/pi-embedded-runner-extraparams-openrouter.test.ts -- --reporter=verbose`
  - `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/proxy-stream-wrappers.ts src/plugin-sdk/provider-stream.ts src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts src/agents/pi-embedded-runner-extraparams-openrouter.test.ts docs/providers/openrouter.md CHANGELOG.md`
  - `git diff --check`
  - `pnpm changed:lanes --json`
  - Testbox `tbx_01kqr3ncf8ztb52hvmskyhankx`: `pnpm check:changed` (GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25294249157)
- Edge cases checked: cache disable, TTL clamping, cache clear, snake_case aliases, verified OpenRouter route gating, custom proxy exclusion.
- What you did **not** verify: live OpenRouter API cache hit/miss behavior; this PR verifies header construction against documented OpenRouter request behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: optional model params documented in `docs/providers/openrouter.md`; existing configs continue unchanged.

## Risks and Mitigations

- Risk: Users may confuse OpenRouter response caching with provider prompt caching.
  - Mitigation: docs call out that this is separate from Anthropic `cache_control` and provider prompt caching.
- Risk: Vendor-specific headers could leak to custom OpenAI-compatible proxy URLs.
  - Mitigation: wrapper only emits response-cache headers on verified OpenRouter routes.
