### PR TITLE
docs(memory): clarify MEMORY.md maintenance expectations

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -88,7 +88,7 @@ These are the standard files OpenClaw expects inside the workspace:
     Daily memory log (one file per day). Recommended to read today + yesterday on session start.
   </Accordion>
   <Accordion title="MEMORY.md - curated long-term memory (optional)">
-    Curated long-term memory. Only load in the main, private session (not shared/group contexts). See [Memory](/concepts/memory) for the workflow and automatic memory flush.
+    Curated long-term memory: durable facts, preferences, decisions, and short summaries. Keep detailed logs in `memory/YYYY-MM-DD.md` so memory tools can retrieve them on demand without injecting them into every prompt. Only load `MEMORY.md` in the main, private session (not shared/group contexts). See [Memory](/concepts/memory) for the workflow and automatic memory flush.
   </Accordion>
   <Accordion title="skills/ - workspace skills (optional)">
     Workspace-specific skills. Highest-precedence skill location for that workspace. Overrides project agent skills, personal agent skills, managed skills, bundled skills, and `skills.load.extraDirs` when names collide.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -23,6 +23,30 @@ Your agent has three memory-related files:
 
 These files live in the agent workspace (default `~/.openclaw/workspace`).
 
+## What goes where
+
+`MEMORY.md` is the compact, curated layer. Use it for durable facts,
+preferences, standing decisions, and short summaries that should be available at
+the start of a main private session. It is not meant to be a raw transcript,
+daily log, or exhaustive archive.
+
+`memory/YYYY-MM-DD.md` files are the working layer. Use them for detailed daily
+notes, observations, session summaries, and raw context that may still be useful
+later. These files are indexed for `memory_search` and `memory_get`, but they are
+not injected into the normal bootstrap prompt on every turn.
+
+Over time, the agent is expected to distill useful material from daily notes
+into `MEMORY.md` and remove stale long-term entries. The generated workspace
+instructions and heartbeat flow can do that periodically; you do not need to
+manually edit `MEMORY.md` for every remembered detail.
+
+If `MEMORY.md` grows past the bootstrap file budget, OpenClaw keeps the file on
+disk intact but truncates the copy injected into the model context. Treat that as
+a signal to move detailed material back into `memory/*.md`, keep only the
+durable summary in `MEMORY.md`, or raise the bootstrap limits if you explicitly
+want to spend more prompt budget. Use `/context list`, `/context detail`, or
+`openclaw doctor` to see raw vs injected sizes and truncation status.
+
 <Tip>
 If you want your agent to remember something, just ask it: "Remember that I
 prefer TypeScript." It will write it to the appropriate file.

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -179,8 +179,11 @@ All of these files are **injected into the context window** on every turn unless
 a file-specific gate applies. `HEARTBEAT.md` is omitted on normal runs when
 heartbeats are disabled for the default agent or
 `agents.defaults.heartbeat.includeSystemPromptSection` is false. Keep injected
-files concise — especially `MEMORY.md`, which can grow over time and lead to
-unexpectedly high context usage and more frequent compaction.
+files concise, especially `MEMORY.md`. `MEMORY.md` is intended to stay a
+curated long-term summary; detailed daily notes belong in `memory/*.md` where
+`memory_search` and `memory_get` can retrieve them on demand. Oversized
+`MEMORY.md` files increase prompt usage and can be partially injected because of
+the bootstrap file limits below.
 
 When a session runs on the native Codex harness, Codex loads `AGENTS.md`
 through its own project-doc discovery. OpenClaw still resolves the remaining
@@ -201,6 +204,12 @@ occurs, OpenClaw can inject a concise system-prompt warning notice; control this
 `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`;
 default: `once`). Detailed raw/injected counts stay in diagnostics such as
 `/context`, `/status`, doctor, and logs.
+
+For memory files, truncation is not data loss: the file remains intact on disk,
+but the model only sees the shortened injected copy until it reads or searches
+memory directly. If `MEMORY.md` is repeatedly truncated, distill it into a
+shorter durable summary and move detailed history into `memory/*.md`, or
+intentionally raise the bootstrap limits.
 
 Sub-agent sessions only inject `AGENTS.md` and `TOOLS.md` (other bootstrap files
 are filtered out to keep the sub-agent context small).


### PR DESCRIPTION
Summary:
- Clarify that workspace `MEMORY.md` is a compact bootstrap file and detailed history belongs under `memory/*.md`.
- Document that oversized bootstrap files are truncated only in injected context, not on disk.
- Point owners to `/context list`, `/context detail`, and `openclaw doctor` for prompt-budget visibility.

Related: #76976, resubmitted after the queue-limit auto-close.

Change Type: Docs

Scope:
- Memory/storage docs
- System prompt docs
- Agent workspace docs

Root Cause:
- The docs described memory surfaces, but did not explicitly say that owners should keep `MEMORY.md` curated and move detail into daily memory files when bootstrap warnings appear.

Verification:
- `git diff --check origin/main..HEAD`
- `pnpm check:docs`
- `codex review --base origin/main`

Human Verification:
- Owner performs final manual verification outside this agent run.



## Real behavior proof

- Behavior or issue addressed: The public docs now clarify that `MEMORY.md` should stay compact and curated, detailed daily notes belong under `memory/*.md`, and bootstrap truncation only affects injected context, not the file on disk.
- Real environment tested: macOS local OpenClaw source worktree after rebasing this PR onto current `origin/main`.
- Exact steps or command run after this patch: `pnpm openclaw doctor --help` from the rebased source worktree, plus `pnpm check:docs`, `git diff --check origin/main...HEAD`, and `codex review --base origin/main` for docs validation.
- Evidence after fix: Terminal output from the real OpenClaw CLI command after dependency refresh:

```text
> openclaw@2026.5.5 openclaw /Users/.../openclaw-memory-docs
> node scripts/run-node.mjs doctor --help
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 109ms
runtime-postbuild: official channel catalog completed in 3ms
runtime-postbuild: bundled plugin runtime overlay completed in 153ms
runtime-postbuild: stable root runtime imports completed in 164ms
runtime-postbuild: stable root runtime aliases completed in 28ms
runtime-postbuild: legacy root runtime compat aliases completed in 5ms
runtime-postbuild: legacy CLI exit compat chunks completed in 1ms
runtime-postbuild: static extension assets completed in 21ms
Usage: openclaw doctor [options]
Health checks + quick fixes for the gateway and channels
Docs: https://docs.openclaw.ai/cli/doctor
```

- Observed result after fix: The real OpenClaw CLI built the runtime artifacts and exposed doctor help successfully, while the docs check accepted the updated memory/system-prompt pages with formatting clean, markdownlint `0 error(s)`, MDX check passed, i18n glossary check passed, and docs link audit `broken_links=0`.
- What was not tested: No live Gateway behavior was changed; this PR is documentation-only.
