### PR TITLE
fix(whatsapp): downgrade recovered watchdog disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ Docs: https://docs.openclaw.ai
 - iMessage: emit a WARN log when an action is blocked because the imsg private API bridge is not attached, so operators see the silent-drop in `~/.openclaw/logs/openclaw.log` instead of having to read per-session trajectory JSONL `tool.result` payloads. Common after a gateway restart un-injects the dylib from Messages.app. (#80035) Thanks @omarshahine.
 - Codex: cross-fill missing `thread.id` and `thread.sessionId` before schema validation so live Codex app-server responses that omit `sessionId` no longer fail `thread/start` or `thread/resume`. Fixes #80124. (#80137) Thanks @kagura-agent.
 - Agents/Pi: wait for embedded abort cleanup to settle before releasing the session write lock, preventing follow-up turns from racing previous prompt teardown. (#80239) Thanks @samzong.
+- WhatsApp: downgrade OpenClaw watchdog-triggered Web reconnects from runtime errors to recovery warnings and clear the recovered reconnect status after the next healthy connection. (#77026) Thanks @rubencu.
 
 ## 2026.5.9
 

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -40,6 +40,7 @@ function requireOnMessage(
 
 async function startWatchdogScenario(params: {
   monitorWebChannel: typeof import("./auto-reply/monitor.js").monitorWebChannel;
+  statusSink?: Parameters<typeof startWebAutoReplyMonitor>[0]["statusSink"];
 }) {
   const sleep = vi.fn(async () => {});
   const scripted = createScriptedWebListenerFactory();
@@ -50,6 +51,7 @@ async function startWatchdogScenario(params: {
     heartbeatSeconds: 60,
     messageTimeoutMs: 30,
     watchdogCheckMs: 5,
+    statusSink: params.statusSink,
   });
 
   await vi.waitFor(
@@ -351,8 +353,10 @@ describe("web auto-reply connection", () => {
   it("forces reconnect when watchdog closes without onClose", async () => {
     vi.useFakeTimers();
     try {
-      const { scripted, controller, run } = await startWatchdogScenario({
+      const statuses: Array<Record<string, unknown>> = [];
+      const { scripted, controller, run, runtime } = await startWatchdogScenario({
         monitorWebChannel,
+        statusSink: (status) => statuses.push({ ...status }),
       });
 
       await vi.advanceTimersByTimeAsync(200);
@@ -368,6 +372,38 @@ describe("web auto-reply connection", () => {
       scripted.resolveClose(1, { status: 499, isLoggedOut: false });
       await Promise.resolve();
       await run;
+
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("WhatsApp Web watchdog is recovering a stale connection"),
+      );
+      expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("status 499"));
+      expect(
+        statuses.some(
+          (status) =>
+            status.healthState === "reconnecting" &&
+            status.reconnectAttempts === 1 &&
+            (status.lastDisconnect as { status?: number } | null)?.status === 499,
+        ),
+      ).toBe(true);
+      expect(
+        statuses.every(
+          (status) =>
+            !(
+              status.lastDisconnect &&
+              typeof status.lastDisconnect === "object" &&
+              "expected" in status.lastDisconnect
+            ),
+        ),
+      ).toBe(true);
+      expect(
+        statuses.some(
+          (status) =>
+            status.connected === true &&
+            status.healthState === "healthy" &&
+            status.reconnectAttempts === 0 &&
+            status.lastDisconnect === null,
+        ),
+      ).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.test.ts
@@ -60,4 +60,58 @@ describe("createWebChannelStatusController", () => {
     expect(last.connected).toBe(true);
     expect(last.lastTransportActivityAt).toBe(1000);
   });
+
+  it("clears watchdog recovery history once the socket is healthy again", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 499,
+      error: "status=499",
+      reconnectAttempts: 1,
+      healthState: "reconnecting",
+      watchdogRecovery: true,
+    });
+    expect(patches.at(-1)!.lastDisconnect).toEqual({
+      at: 2000,
+      status: 499,
+      error: "status=499",
+      loggedOut: false,
+    });
+    controller.noteConnected(3000);
+
+    const last = patches.at(-1)!;
+    expect(last.connected).toBe(true);
+    expect(last.healthState).toBe("healthy");
+    expect(last.reconnectAttempts).toBe(0);
+    expect(last.lastDisconnect).toBeNull();
+  });
+
+  it("keeps non-watchdog reconnect history after the socket reconnects", () => {
+    const patches: Record<string, unknown>[] = [];
+    const controller = createWebChannelStatusController((s) => patches.push({ ...s }));
+
+    controller.noteConnected(1000);
+    controller.noteClose({
+      at: 2000,
+      statusCode: 408,
+      error: "status=408",
+      reconnectAttempts: 1,
+      healthState: "reconnecting",
+    });
+    controller.noteConnected(3000);
+
+    const last = patches.at(-1)!;
+    expect(last.connected).toBe(true);
+    expect(last.healthState).toBe("healthy");
+    expect(last.reconnectAttempts).toBe(1);
+    expect(last.lastDisconnect).toEqual({
+      at: 2000,
+      status: 408,
+      error: "status=408",
+      loggedOut: false,
+    });
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor-state.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor-state.ts
@@ -16,6 +16,7 @@ function isTerminalHealthState(healthState: WebChannelHealthState | undefined): 
 }
 
 export function createWebChannelStatusController(statusSink?: (status: WebChannelStatus) => void) {
+  let lastDisconnectWasWatchdogRecovery = false;
   const status: WebChannelStatus = {
     running: true,
     connected: false,
@@ -39,6 +40,11 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
     noteConnected(at = Date.now()) {
       Object.assign(status, createConnectedChannelStatusPatch(at));
       Object.assign(status, createTransportActivityStatusPatch(at));
+      if (lastDisconnectWasWatchdogRecovery) {
+        status.lastDisconnect = null;
+        status.reconnectAttempts = 0;
+        lastDisconnectWasWatchdogRecovery = false;
+      }
       status.lastError = null;
       status.healthState = "healthy";
       emit();
@@ -78,8 +84,10 @@ export function createWebChannelStatusController(statusSink?: (status: WebChanne
       error?: string;
       reconnectAttempts: number;
       healthState: WebChannelHealthState;
+      watchdogRecovery?: boolean;
     }) {
       const at = params.at ?? Date.now();
+      lastDisconnectWasWatchdogRecovery = params.watchdogRecovery === true;
       status.connected = false;
       status.lastEventAt = at;
       status.lastDisconnect = {

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -11,6 +11,7 @@ import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import {
   defaultRuntime,
   formatDurationPrecise,
+  warn,
   type RuntimeEnv,
 } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
@@ -18,6 +19,7 @@ import { resolveWhatsAppAccount, resolveWhatsAppMediaMaxBytes } from "../account
 import { WHATSAPP_AUTH_UNSTABLE_CODE, WhatsAppAuthUnstableError } from "../auth-store.js";
 import {
   WhatsAppConnectionController,
+  WHATSAPP_WATCHDOG_TIMEOUT_ERROR,
   type ManagedWhatsAppListener,
 } from "../connection-controller.js";
 import { attachWebInboxToSocket, type WhatsAppGroupMetadataCache } from "../inbound/monitor.js";
@@ -566,11 +568,14 @@ export async function monitorWebChannel(
         break;
       }
 
+      const isWatchdogRecoveryReconnect =
+        decision.normalized.error === WHATSAPP_WATCHDOG_TIMEOUT_ERROR;
       statusController.noteClose({
         statusCode: decision.normalized.statusCode,
         error: decision.normalized.errorText,
         reconnectAttempts: decision.reconnectAttempts,
         healthState: decision.healthState,
+        watchdogRecovery: isWatchdogRecoveryReconnect,
       });
       reconnectLogger.info(
         {
@@ -582,9 +587,14 @@ export async function monitorWebChannel(
         },
         "web reconnect: scheduling retry",
       );
-      runtime.error(
-        `WhatsApp Web connection closed (status ${decision.normalized.statusLabel}). Retry ${decision.reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(decision.delayMs ?? 0)}… (${decision.normalized.errorText})`,
-      );
+      const reconnectMessage = isWatchdogRecoveryReconnect
+        ? `WhatsApp Web watchdog is recovering a stale connection (status ${decision.normalized.statusLabel}). Retry ${decision.reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(decision.delayMs ?? 0)}.`
+        : `WhatsApp Web connection closed (status ${decision.normalized.statusLabel}). Retry ${decision.reconnectAttempts}/${reconnectPolicy.maxAttempts || "∞"} in ${formatDurationPrecise(decision.delayMs ?? 0)}… (${decision.normalized.errorText})`;
+      if (isWatchdogRecoveryReconnect) {
+        runtime.log(warn(reconnectMessage));
+      } else {
+        runtime.error(reconnectMessage);
+      }
       await controller.closeCurrentConnection();
       try {
         await controller.waitBeforeRetry(decision.delayMs ?? 0);

--- a/extensions/whatsapp/src/connection-controller.ts
+++ b/extensions/whatsapp/src/connection-controller.ts
@@ -23,6 +23,7 @@ const WHATSAPP_LOGGED_OUT_RELINK_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please rerun openclaw channels login and scan the QR again.";
 export const WHATSAPP_LOGGED_OUT_QR_MESSAGE =
   "WhatsApp reported the session is logged out. Cleared cached web session; please scan a new QR.";
+export const WHATSAPP_WATCHDOG_TIMEOUT_ERROR = "watchdog-timeout";
 
 type TimerHandle = ReturnType<typeof setInterval>;
 type WaSocket = Awaited<ReturnType<typeof createWaSocket>>;
@@ -641,7 +642,7 @@ export class WhatsAppConnectionController {
       this.forceClose({
         status: 499,
         isLoggedOut: false,
-        error: "watchdog-timeout",
+        error: WHATSAPP_WATCHDOG_TIMEOUT_ERROR,
       });
     }, this.watchdogCheckMs);
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: WhatsApp's own watchdog closes stale/degraded Web connections with status `499` to recover, but the reconnect path surfaced that watchdog recovery as a runtime error and left recent-reconnect status behind after the next healthy connect.
- Why it matters: a recovered stale transport could look like a user-visible WhatsApp failure even when the gateway recovered and the account was linked/connected again.
- What changed: the watchdog close now carries the shared internal `WHATSAPP_WATCHDOG_TIMEOUT_ERROR` marker, the retry log is warning-style for that watchdog recovery path, and watchdog recovery status is cleared only after the socket becomes healthy again.
- What did NOT change (scope boundary): non-watchdog disconnects, logged-out/conflict handling, retry limits, reconnect backoff, auth repair, channel configuration, and public status payload shape are unchanged. `CHANGELOG.md` is intentionally untouched for this contributor PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: watchdog recovery from stale WhatsApp Web transport no longer appears as a user-facing runtime error or persistent unhealthy reconnect status after the account reconnects.
- Real environment tested: local macOS OpenClaw checkout on PR commit `fa403de6755e446f60544e5216152381fad1b4bd`, real configured WhatsApp account with phone/account details redacted.
- Exact steps or command run after this patch:
  - Start branch gateway on a throwaway loopback port and query `health` plus `channels.status` over gateway RPC.
  - Run the production WhatsApp `monitorWebChannel` gateway monitor from this checkout against the same real default WhatsApp auth state with shortened internal watchdog timing only (`messageTimeoutMs=3000`, `watchdogCheckMs=250`, `transportTimeoutMs=60000`) so the watchdog path can be observed without waiting for the production-length window.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[status] {"connected":false,"healthState":"starting","lastDisconnect":null,"reconnectAttempts":0,"running":true}
[status] {"connected":true,"healthState":"healthy","lastDisconnect":null,"reconnectAttempts":0,"running":true}
[status] {"connected":true,"healthState":"stale","lastDisconnect":null,"reconnectAttempts":0,"running":true}
[status] {"connected":false,"healthState":"reconnecting","lastDisconnect":{"status":499,"error":"status=499","loggedOut":false,"hasExpectedField":false},"reconnectAttempts":1,"running":true}
[runtime.log] WhatsApp Web watchdog is recovering a stale connection (status 499). Retry 1/2 in 500ms.
[status] {"connected":true,"healthState":"healthy","lastDisconnect":null,"reconnectAttempts":0,"running":true}
[proof] {"ok":true,"watchdogLog":true,"runtime499Error":false,"reconnectSnapshot":true,"healthyAfterReconnect":true,"timeoutReached":false}
```

Gateway RPC health/status on the same branch also reported the real account linked/connected/healthy after the patch:

```json
{
  "health": {
    "ok": true,
    "channels": {
      "whatsapp": {
        "running": true,
        "configured": true,
        "healthState": "healthy",
        "reconnectAttempts": 0,
        "lastError": null
      }
    },
    "eventLoop": {
      "degraded": false,
      "reasons": []
    }
  },
  "channelsStatus": {
    "whatsappAccounts": [
      {
        "accountId": "default",
        "enabled": true,
        "configured": true,
        "linked": true,
        "running": true,
        "connected": true,
        "healthState": "healthy",
        "statusState": "linked",
        "reconnectAttempts": 0,
        "lastDisconnect": null,
        "lastError": null
      }
    ]
  }
}
```

- Observed result after fix: the watchdog-forced `status 499` reconnect logs through `runtime.log` as watchdog recovery from a stale transport, does not call `runtime.error`, emits the normal public reconnecting status without an `expected` field, and clears `lastDisconnect`/`reconnectAttempts` after the next healthy connection.
- What was not tested: production-length natural watchdog timing; the live proof uses shortened internal monitor timing to force the same branch quickly.
- Before evidence (optional but encouraged): prior live gateway logs showed repeated `WhatsApp watchdog timeout (app-silent) - restarting connection` followed by user-facing `WhatsApp Web connection closed (status 499)` reconnect errors for the watchdog's own close reason.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the watchdog forced a close with the same generic retry path as real disconnects, so the monitor could not distinguish an intentional watchdog recovery of a stale transport from an unexpected WhatsApp Web close.
- Missing detection / guardrail: existing tests covered reconnecting after watchdog close, but did not assert the user-facing log level or the status snapshot cleanup after the successful reconnect.
- Contributing context (if known): status issue reporting keys off `lastDisconnect` and `reconnectAttempts`, so watchdog recoveries need to be cleared once the socket is healthy.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
  - `extensions/whatsapp/src/auto-reply/monitor-state.test.ts`
  - `extensions/whatsapp/src/status-issues.test.ts`
- Scenario the test should lock in: a watchdog-forced `status 499` reconnect logs as a watchdog recovery warning, never calls `runtime.error`, emits only the normal reconnecting public status shape, and clears `lastDisconnect`/`reconnectAttempts` after the next healthy connection; ordinary recent disconnects still report status issues.
- Why this is the smallest reliable guardrail: the e2e harness exercises the real Web auto-reply monitor/controller path with shortened watchdog timings, while the unit status-controller test locks the narrow cleanup branch.
- Existing test that already covers this (if any): existing reconnect e2e coverage proved a retry happened, but not the user-facing log/status behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Watchdog recovery from stale WhatsApp Web transport now shows as a warning-style reconnect log instead of a runtime error. Real disconnects, logged-out states, session conflicts, and exhausted retry attempts still surface as errors.

## Diagram (if applicable)

```text
Before:
watchdog timeout -> forced close status 499 -> generic reconnect error -> stale recent-reconnect status

After:
watchdog timeout -> forced close status 499 + watchdog marker -> warning -> healthy reconnect clears watchdog recovery status
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout, Node via repo scripts and bundled Node 24 runtime for the one-off live monitor proof
- Model/provider: N/A
- Integration/channel (if any): WhatsApp plugin, real configured account details redacted
- Relevant config (redacted): WhatsApp enabled and linked; gateway run on loopback throwaway port with `auth none`

### Steps

1. Start the rebased branch gateway on a throwaway loopback port.
2. Query `health` and `channels.status` through gateway RPC.
3. Run the production WhatsApp monitor against the real linked auth state with shortened internal watchdog timing to force the watchdog reconnect path.
4. Run the focused WhatsApp watchdog/status tests and changed gate.

### Expected

- The branch gateway starts and WhatsApp reports linked/connected/healthy with no retained disconnect/error.
- A watchdog-forced reconnect logs a watchdog recovery warning without calling `runtime.error`.
- Watchdog recovery status clears after the next healthy connection.

### Actual

- Gateway `health`: `ok=true`, WhatsApp `running=true`, `configured=true`, `healthState=healthy`, `reconnectAttempts=0`, `lastError=null`.
- Gateway `channels.status`: WhatsApp account `linked=true`, `running=true`, `connected=true`, `healthState=healthy`, `statusState=linked`, `reconnectAttempts=0`, `lastDisconnect=null`, `lastError=null`.
- Live watchdog proof: `ok=true`, `watchdogLog=true`, `runtime499Error=false`, `reconnectSnapshot=true`, `healthyAfterReconnect=true`.
- Focused tests and `pnpm check:changed` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
pnpm test extensions/whatsapp/src/auto-reply/monitor-state.test.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts extensions/whatsapp/src/status-issues.test.ts

Test Files  1 passed (1) in vitest.e2e.config.ts
Tests       21 passed (21)
Test Files  2 passed (2) in vitest.extension-whatsapp.config.ts
Tests       13 passed (13)

pnpm check:changed
lanes=extensions, extensionTests
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).

git diff --check origin/main...HEAD
passed

codex review --base origin/main
No actionable correctness issues were found in the diff.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: rebased onto latest `origin/main` at the time of the rebase; no `CHANGELOG.md` diff remains; live foreground gateway starts from this branch; WhatsApp is linked/connected/healthy through gateway RPC; live watchdog reconnect path is forced against a real linked WhatsApp auth state; watchdog recovery branch has e2e assertions for log level, status cleanup, and no leaked `expected` field in the public status payload; changed gate passes.
- Edge cases checked: non-watchdog retry path still calls `runtime.error`; terminal logged-out/conflict branches are untouched; ordinary recent disconnect status issue coverage still passes via `status-issues.test.ts`.
- What you did **not** verify: production-length natural watchdog timing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: watchdog recovery reconnects could hide a real disconnect if detection were too broad.
  - Mitigation: the downgrade only applies when the close reason is the exact watchdog marker produced by the watchdog force-close path; all other retry, terminal, logged-out, and conflict paths keep their previous behavior.

