### PR TITLE
fix(memory): skip cron warnings without gateway context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.
 - Memory: keep `memory_search` result `corpus` labels aligned with the hit source, so session transcript hits surface as `sessions` and memory-file hits stay `memory`. Fixes #72885. (#71898, #72886) Thanks @rubencu.
 - Codex app-server: default native plugin app tool approvals to automatic so non-destructive read tools run when destructive actions are disabled.

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1374,9 +1374,7 @@ describe("gateway startup reconciliation", () => {
         { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
       );
 
-      expect(logger.warn).not.toHaveBeenCalledWith(
-        expect.stringContaining("cron service unavailable"),
-      );
+      expectLogNotContains(logger.warn, "cron service unavailable");
     } finally {
       clearInternalHooks();
     }
@@ -1422,7 +1420,7 @@ describe("gateway startup reconciliation", () => {
         { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
       );
 
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
+      expectLogContains(logger.warn, "cron service unavailable");
     } finally {
       clearInternalHooks();
     }

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -1339,7 +1339,96 @@ describe("gateway startup reconciliation", () => {
     }
   });
 
-  it("still warns on runtime reconciliation when cron remains unavailable (preserves #69939 genuine-failure signal)", async () => {
+  it("keeps ordinary heartbeat reconciliation quiet when no gateway cron context is available", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      await beforeAgentReply(
+        { cleanedBody: "" },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
+      );
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("cron service unavailable"),
+      );
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("still warns on gateway runtime reconciliation when cron remains unavailable", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  frequency: "15 4 * * *",
+                  timezone: "UTC",
+                },
+              },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, {
+        config: api.config,
+        getCron: () => undefined,
+      });
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
+      await beforeAgentReply(
+        { cleanedBody: "" },
+        { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("cron service unavailable"));
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("still warns on managed runtime reconciliation when cron remains unavailable (preserves #69939 genuine-failure signal)", async () => {
     clearInternalHooks();
     const logger = createLogger();
     const onMock = vi.fn();
@@ -1374,12 +1463,12 @@ describe("gateway startup reconciliation", () => {
       });
       expect(logger.warn).not.toHaveBeenCalled();
 
-      // Now a runtime heartbeat reconciliation happens and cron is still missing
+      // Now a managed runtime reconciliation happens and cron is still missing
       // (e.g. the cron service genuinely failed to initialize). The warning must fire.
       const beforeAgentReply = getBeforeAgentReplyHandler(onMock);
       await beforeAgentReply(
-        { cleanedBody: "" },
-        { trigger: "heartbeat", workspaceDir: ".", sessionKey: "agent:main:main:heartbeat" },
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "cron", workspaceDir: ".", sessionKey: "agent:main:cron:job-managed" },
       );
 
       expectLogContains(logger.warn, "cron service unavailable");

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -718,6 +718,9 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     }
   };
 
+  const hasCronManagementContext = (): boolean =>
+    Boolean(resolveStartupCron || gatewayContext?.getCron);
+
   const disposeStartupCronRetry = (): void => {
     disposed = true;
     clearStartupCronRetry();
@@ -888,9 +891,6 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
         return undefined;
       }
       const currentConfig = resolveCurrentConfig();
-      const config = await reconcileManagedDreamingCron({
-        reason: "runtime",
-      });
       const hasManagedDreamingToken = includesSystemEventToken(
         event.cleanedBody,
         DREAMING_SYSTEM_EVENT_TEXT,
@@ -898,7 +898,15 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
       const isManagedHeartbeatTrigger =
         ctx.trigger === "heartbeat" && hasPendingManagedDreamingCronEvent(ctx.sessionKey);
       const isManagedCronTrigger = ctx.trigger === "cron";
-      if (!hasManagedDreamingToken || (!isManagedHeartbeatTrigger && !isManagedCronTrigger)) {
+      const shouldHandleManagedDreaming =
+        hasManagedDreamingToken && (isManagedHeartbeatTrigger || isManagedCronTrigger);
+      if (!shouldHandleManagedDreaming && !hasCronManagementContext()) {
+        return undefined;
+      }
+      const config = await reconcileManagedDreamingCron({
+        reason: "runtime",
+      });
+      if (!shouldHandleManagedDreaming) {
         return undefined;
       }
       return await runShortTermDreamingPromotionIfTriggered({


### PR DESCRIPTION
## Summary

- Problem: ordinary isolated cron agent runs can load `memory-core` without the gateway cron-management handle, then log `managed dreaming cron could not be reconciled (cron service unavailable)` even though the run is not a managed dreaming event.
- Why it matters: the warning looks like a broken managed Memory Dreaming Promotion job, but it is emitted from an unrelated cron hook context.
- What changed: runtime reconciliation now runs only for managed dreaming events or when a gateway cron-management context exists; managed dreaming cron triggers and gateway runtime reconciliation still warn when cron is genuinely unavailable.
- What did NOT change (scope boundary): no config surface, no cron storage migration, no delivery behavior, no CHANGELOG entry.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: #69939 (preserves the real cron-unavailable warning signal)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: non-managed cron hook contexts should not emit the managed dreaming cron-unavailable warning.
- Real environment tested: local macOS loopback Gateway with isolated temp `OPENCLAW_STATE_DIR`, isolated temp `OPENCLAW_CONFIG_PATH`, `memory-core` dreaming enabled, auth disabled only for the disposable loopback proof gateway.
- Exact steps or command run after this patch:

```bash
pnpm openclaw --no-color --log-level debug gateway run --allow-unconfigured --auth none --port 19328 --force --verbose --ws-log compact
pnpm openclaw --no-color cron add --name "PR 77027 ordinary cron proof branch" --at 20m --session isolated --message "ordinary cron proof for PR 77027" --no-deliver --timeout-seconds 1 --json --url ws://127.0.0.1:19328 --token none
pnpm openclaw --no-color cron run 674c0b72-4cff-4aa4-8ef9-e02b5fba2d41 --expect-final --timeout 20000 --url ws://127.0.0.1:19328 --token none
rg -n "674c0b72|managed dreaming cron could not be reconciled|before_agent_reply" /tmp/openclaw/openclaw-2026-05-10.log
```

- Evidence after fix (copied live output from the branch Gateway log):

```text
2026-05-10T10:42:16.591-04:00 cron: job created jobId=674c0b72-4cff-4aa4-8ef9-e02b5fba2d41
2026-05-10T10:42:30.224-04:00 [hooks] running before_agent_reply (1 handlers, first-claim wins)
2026-05-10T10:42:30.623-04:00 agent harness selected sessionKey=agent:main:cron:674c0b72-4cff-4aa4-8ef9-e02b5fba2d41:run:6da830d0-0280-426c-b3e6-f1a532436a14
2026-05-10T10:42:31.211-04:00 run_completed sessionKey=agent:main:cron:674c0b72-4cff-4aa4-8ef9-e02b5fba2d41:run:6da830d0-0280-426c-b3e6-f1a532436a14
```

- Observed result after fix: the same non-managed cron path still ran `before_agent_reply`, but no `memory-core: managed dreaming cron could not be reconciled (cron service unavailable).` warning was emitted for the branch run. The proof job intentionally used `--timeout-seconds 1`, so the later cron timeout is unrelated to the hook warning under test.
- What was not tested: external channel delivery and full-suite/Testbox validation; broad validation is GitHub PR CI for this contributor PR.
- Before evidence (pre-fix main snapshot `fa2b97da4a`, same isolated gateway shape):

```text
2026-05-10T10:41:00.963-04:00 cron: job created jobId=aecdd217-87fa-4cc9-a23f-590fa544278e
2026-05-10T10:41:12.133-04:00 [hooks] running before_agent_reply (1 handlers, first-claim wins)
2026-05-10T10:41:12.189-04:00 memory-core: managed dreaming cron could not be reconciled (cron service unavailable).
```

## Root Cause (if applicable)

- Root cause: `before_agent_reply` reconciled the managed dreaming cron before checking whether the event was a managed dreaming trigger. Isolated cron agent runs do not carry the gateway cron-management handle, so unrelated cron runs could produce a managed-dreaming warning.
- Missing detection / guardrail: tests covered startup warning demotion and real runtime failure warnings, but not the no-gateway-context non-managed cron/heartbeat path.
- Contributing context (if known): managed dreaming cron reconciliation is gateway-owned, while isolated cron agent hooks can run in a request context that has no cron service handle.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming.test.ts`
- Scenario the test should lock in: ordinary heartbeat without a gateway cron context stays quiet, gateway runtime reconciliation still warns when cron remains unavailable, and managed cron-trigger reconciliation still warns when cron remains unavailable.
- Why this is the smallest reliable guardrail: the bug is in the memory-core hook predicate, and the tests directly exercise every new branch without needing a full Gateway process.
- Existing test that already covers this (if any): existing managed dreaming trigger tests cover promotion behavior, but not this warning predicate.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The non-actionable memory-core cron warning is no longer printed for unrelated cron/heartbeat hook contexts that cannot manage cron. Real managed dreaming and gateway cron-unavailable warnings are preserved.

## Diagram (if applicable)

```text
Before:
ordinary cron run -> before_agent_reply -> reconcile managed dreaming cron without gateway cron handle -> misleading warning

After:
ordinary cron run -> before_agent_reply -> no managed token + no cron-management context -> skip managed cron reconciliation
managed dreaming run or gateway cron context -> before_agent_reply -> reconcile managed dreaming cron -> warn only if cron is genuinely unavailable
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout, `pnpm openclaw`, isolated loopback Gateway
- Model/provider: configured default `openai/gpt-5.5`; proof job intentionally timed out before model output
- Integration/channel (if any): Gateway cron RPC, no external channel delivery
- Relevant config (redacted): `plugins.entries.memory-core.config.dreaming.enabled=true`, `dreaming.frequency="0 3 * * *"`, `gateway.auth.mode=none` only in disposable loopback proof state

### Steps

1. Start a loopback Gateway with memory-core dreaming enabled.
2. Add an ordinary isolated cron job with an ordinary message, not the managed dreaming token.
3. Force-run that cron job through `openclaw cron run`.
4. Inspect the Gateway log around the job id and `before_agent_reply` hook.

### Expected

- Current main: emits the misleading memory-core cron-unavailable warning.
- This branch: does not emit that warning for the ordinary cron job.

### Actual

- Current main emitted `memory-core: managed dreaming cron could not be reconciled (cron service unavailable).`
- This branch ran the same hook path and did not emit that warning.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional local validation:

```bash
pnpm test extensions/memory-core/src/dreaming.test.ts
pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/dreaming.ts extensions/memory-core/src/dreaming.test.ts
git diff --check origin/main...HEAD
pnpm changed:lanes --json
codex review --base origin/main
```

Results:

```text
Test Files  1 passed (1)
Tests  46 passed (46)
All matched files use the correct format.
changed:lanes -> extensions=true, extensionTests=true; paths limited to memory-core dreaming source/test.
codex review --base origin/main -> no actionable regression found.
CI after push: `check-lint` and `check-additional-extension-bundled` failed on GitHub synthetic merge commit `f069e70c` with `call[0] ?? ""` lint errors in base-side files `extensions/memory-core/src/dreaming-phases.test.ts` and `extensions/synology-chat/src/channel.test.ts`; the branch-head bundled-extension lint run passes locally.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: current-main live Gateway ordinary cron run reproduces the warning; branch live Gateway ordinary cron run does not emit the warning; focused unit tests cover quiet and preserved-warning branches.
- Edge cases checked: gateway runtime reconciliation still warns when cron remains unavailable; managed cron-trigger reconciliation still warns when cron remains unavailable.
- What you did **not** verify: external channel delivery, full local suite, Testbox. Broad validation is PR CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations were addressed by this update.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a real cron-service failure could be hidden in a non-managed hook context.
  - Mitigation: contexts that can manage cron and managed dreaming cron triggers still reconcile and warn; tests cover both preserved warning paths.

