### PR TITLE
fix(gateway): avoid false event-loop health degradation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: avoid false degraded event-loop health during rapid health/readiness/status probes unless sustained load has delay co-evidence, while keeping hard delay detection immediate. (#77028) Thanks @rubencu.
 - Gateway/agent: pass the session-key agent id into inline image attachment validation so the first image in a fresh per-agent session uses the agent's vision-capable model override instead of the text-only system default. Fixes #79407. Thanks @pandadev66.
 - Gateway/maintenance: prune dedupe overflow against a stable excess count and keep active agent retries from starting duplicate runs after cache eviction. (#73841) Thanks @thesomewhatyou.
 - Control UI/subagents: suppress internal `subagent_announce` handoff prompts from requester transcripts and hide legacy inter-session wrapper rows so completed subagent results no longer surface runtime context in WebChat history. (#79618) Thanks @joshavant.

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -1,6 +1,9 @@
 import type { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { describe, expect, it, vi } from "vitest";
-import { createGatewayEventLoopHealthMonitor } from "./event-loop-health.js";
+import {
+  classifyGatewayEventLoopHealthReasons,
+  createGatewayEventLoopHealthMonitor,
+} from "./event-loop-health.js";
 
 type CpuUsage = ReturnType<typeof process.cpuUsage>;
 type DelayMonitor = ReturnType<typeof monitorEventLoopDelay>;
@@ -19,7 +22,10 @@ function createMonitorHarness(params?: { cpuMsPerWallMs?: number; utilization?: 
   const delayMonitor = {
     enable: vi.fn(),
     disable: vi.fn(),
-    reset: vi.fn(),
+    reset: vi.fn(() => {
+      delayP99Ms = 0;
+      delayMaxMs = 0;
+    }),
     percentile: vi.fn(() => delayP99Ms * 1_000_000),
     get max() {
       return delayMaxMs * 1_000_000;
@@ -59,6 +65,7 @@ function createMonitorHarness(params?: { cpuMsPerWallMs?: number; utilization?: 
 
   return {
     monitor,
+    delayMonitor,
     cpuUsage,
     eventLoopUtilization,
     setNow: (value: number) => {
@@ -71,8 +78,92 @@ function createMonitorHarness(params?: { cpuMsPerWallMs?: number; utilization?: 
   };
 }
 
+describe("classifyGatewayEventLoopHealthReasons", () => {
+  it("does not degrade on utilization or CPU from a sub-second sample", () => {
+    expect(
+      classifyGatewayEventLoopHealthReasons({
+        intervalMs: 250,
+        delayP99Ms: 20,
+        delayMaxMs: 25,
+        utilization: 1,
+        cpuCoreRatio: 1,
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not degrade on utilization or CPU without delay co-evidence", () => {
+    expect(
+      classifyGatewayEventLoopHealthReasons({
+        intervalMs: 1_000,
+        delayP99Ms: 0,
+        delayMaxMs: 0,
+        utilization: 1,
+        cpuCoreRatio: 1,
+      }),
+    ).toEqual([]);
+  });
+
+  it("degrades on utilization and CPU after a sustained sample window with delay co-evidence", () => {
+    expect(
+      classifyGatewayEventLoopHealthReasons({
+        intervalMs: 1_000,
+        delayP99Ms: 20,
+        delayMaxMs: 25,
+        utilization: 0.99,
+        cpuCoreRatio: 0.95,
+      }),
+    ).toEqual(["event_loop_utilization", "cpu"]);
+  });
+
+  it.each([
+    {
+      cpuCoreRatio: 0.1,
+      expected: ["event_loop_utilization"],
+      name: "utilization only",
+      utilization: 0.99,
+    },
+    {
+      cpuCoreRatio: 0.95,
+      expected: ["cpu"],
+      name: "CPU only",
+      utilization: 0.1,
+    },
+    {
+      cpuCoreRatio: 0.1,
+      expected: [],
+      name: "neither load counter",
+      utilization: 0.1,
+    },
+  ] as const)(
+    "classifies delay-backed sustained load when $name is saturated",
+    ({ cpuCoreRatio, expected, utilization }) => {
+      expect(
+        classifyGatewayEventLoopHealthReasons({
+          intervalMs: 1_000,
+          delayP99Ms: 30,
+          delayMaxMs: 0,
+          utilization,
+          cpuCoreRatio,
+        }),
+      ).toEqual(expected);
+    },
+  );
+
+  it("still degrades on event-loop delay from a short sample", () => {
+    expect(
+      classifyGatewayEventLoopHealthReasons({
+        intervalMs: 250,
+        delayP99Ms: 20,
+        delayMaxMs: 1_500,
+        utilization: 0.1,
+        cpuCoreRatio: 0.1,
+      }),
+    ).toEqual(["event_loop_delay"]);
+  });
+});
+
 describe("createGatewayEventLoopHealthMonitor", () => {
-  it("waits for a sustained sample window before reporting CPU-only saturation", () => {
+  it("waits for delay co-evidence before reporting load-only saturation", () => {
     const harness = createMonitorHarness();
 
     harness.setNow(42);
@@ -82,10 +173,26 @@ describe("createGatewayEventLoopHealthMonitor", () => {
 
     harness.setNow(1_000);
     expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: false,
+      reasons: [],
+      intervalMs: 1_000,
+      delayP99Ms: 0,
+      delayMaxMs: 0,
+      utilization: 1,
+      cpuCoreRatio: 1,
+    });
+  });
+
+  it("reports CPU and utilization saturation when delay co-evidence is present", () => {
+    const harness = createMonitorHarness();
+    harness.setDelay({ p99Ms: 30 });
+    harness.setNow(1_000);
+
+    expect(harness.monitor.snapshot()).toMatchObject({
       degraded: true,
       reasons: ["event_loop_utilization", "cpu"],
       intervalMs: 1_000,
-      delayP99Ms: 0,
+      delayP99Ms: 30,
       delayMaxMs: 0,
       utilization: 1,
       cpuCoreRatio: 1,
@@ -117,5 +224,62 @@ describe("createGatewayEventLoopHealthMonitor", () => {
       utilization: 0.2,
       cpuCoreRatio: 0.1,
     });
+  });
+
+  it("keeps rate baselines and the last snapshot until a full sample window is available", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
+    harness.setNow(1_000);
+    const first = harness.monitor.snapshot();
+
+    expect(first).toEqual(expect.objectContaining({ intervalMs: 1_000 }));
+    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
+    expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(3);
+
+    harness.setNow(1_250);
+    expect(harness.monitor.snapshot()).toBe(first);
+    expect(harness.cpuUsage).toHaveBeenCalledTimes(3);
+    expect(harness.eventLoopUtilization).toHaveBeenCalledTimes(3);
+
+    harness.setNow(2_000);
+    const second = harness.monitor.snapshot();
+
+    expect(second).toEqual(expect.objectContaining({ intervalMs: 1_000 }));
+    expect(second).not.toBe(first);
+  });
+
+  it("preserves moderate delay co-evidence across rapid probes until the load window completes", () => {
+    const harness = createMonitorHarness();
+    harness.setNow(1_000);
+    const first = harness.monitor.snapshot();
+
+    harness.setDelay({ p99Ms: 30 });
+    harness.setNow(1_250);
+    expect(harness.monitor.snapshot()).toBe(first);
+
+    harness.setNow(2_000);
+    expect(harness.monitor.snapshot()).toMatchObject({
+      degraded: true,
+      reasons: ["event_loop_utilization", "cpu"],
+      intervalMs: 1_000,
+      delayP99Ms: 30,
+      delayMaxMs: 0,
+      utilization: 1,
+      cpuCoreRatio: 1,
+    });
+  });
+
+  it("clears the cached snapshot when stopped", () => {
+    const harness = createMonitorHarness({ cpuMsPerWallMs: 0.1, utilization: 0.2 });
+    harness.setNow(1_000);
+
+    expect(harness.monitor.snapshot()).toEqual(
+      expect.objectContaining({ degraded: false, intervalMs: 1_000 }),
+    );
+
+    harness.setNow(1_250);
+    harness.monitor.stop();
+
+    expect(harness.delayMonitor.disable).toHaveBeenCalledTimes(1);
+    expect(harness.monitor.snapshot()).toBeUndefined();
   });
 });

--- a/src/gateway/server/event-loop-health.ts
+++ b/src/gateway/server/event-loop-health.ts
@@ -4,6 +4,8 @@ const EVENT_LOOP_MONITOR_RESOLUTION_MS = 20;
 const EVENT_LOOP_DELAY_WARN_MS = 1_000;
 const EVENT_LOOP_UTILIZATION_WARN = 0.95;
 const CPU_CORE_RATIO_WARN = 0.9;
+// Load counters can spike during frequent short async wakeups; delay is the blocking signal.
+const LOAD_DEGRADATION_DELAY_COEVIDENCE_MS = 25;
 const SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS = 1_000;
 
 type EventLoopDelayMonitor = ReturnType<typeof monitorEventLoopDelay>;
@@ -38,6 +40,11 @@ type GatewayEventLoopHealthMonitorDeps = {
   createDelayMonitor?: EventLoopDelayMonitorFactory;
 };
 
+type GatewayEventLoopHealthMetrics = Pick<
+  GatewayEventLoopHealth,
+  "intervalMs" | "delayP99Ms" | "delayMaxMs" | "utilization" | "cpuCoreRatio"
+>;
+
 function roundMetric(value: number, digits = 3): number {
   if (!Number.isFinite(value)) {
     return 0;
@@ -50,26 +57,33 @@ function nanosecondsToMilliseconds(value: number): number {
   return roundMetric(value / 1_000_000, 1);
 }
 
-function resolveGatewayEventLoopHealthReasons(params: {
-  intervalMs: number;
-  delayP99Ms: number;
-  delayMaxMs: number;
-  utilization: number;
-  cpuCoreRatio: number;
-}): GatewayEventLoopHealthReason[] {
+export function classifyGatewayEventLoopHealthReasons(
+  metrics: GatewayEventLoopHealthMetrics,
+): GatewayEventLoopHealthReason[] {
   const reasons: GatewayEventLoopHealthReason[] = [];
-  const hasSustainedLoadWindow = params.intervalMs >= SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS;
 
   if (
-    params.delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS ||
-    params.delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS
+    metrics.delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS ||
+    metrics.delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS
   ) {
     reasons.push("event_loop_delay");
   }
-  if (hasSustainedLoadWindow && params.utilization >= EVENT_LOOP_UTILIZATION_WARN) {
+
+  if (metrics.intervalMs < SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS) {
+    return reasons;
+  }
+
+  const hasDelayCoEvidence =
+    metrics.delayP99Ms >= LOAD_DEGRADATION_DELAY_COEVIDENCE_MS ||
+    metrics.delayMaxMs >= LOAD_DEGRADATION_DELAY_COEVIDENCE_MS;
+  if (!hasDelayCoEvidence) {
+    return reasons;
+  }
+
+  if (metrics.utilization >= EVENT_LOOP_UTILIZATION_WARN) {
     reasons.push("event_loop_utilization");
   }
-  if (hasSustainedLoadWindow && params.cpuCoreRatio >= CPU_CORE_RATIO_WARN) {
+  if (metrics.cpuCoreRatio >= CPU_CORE_RATIO_WARN) {
     reasons.push("cpu");
   }
 
@@ -90,6 +104,7 @@ export function createGatewayEventLoopHealthMonitor(
   let lastWallAt = nowMs();
   let lastCpuUsage: CpuUsage | null = readCpuUsage();
   let lastEventLoopUtilization: EventLoopUtilization | null = readEventLoopUtilization();
+  let lastSnapshot: GatewayEventLoopHealth | undefined;
 
   try {
     monitor = createDelayMonitor(EVENT_LOOP_MONITOR_RESOLUTION_MS);
@@ -113,8 +128,7 @@ export function createGatewayEventLoopHealthMonitor(
         delayP99Ms >= EVENT_LOOP_DELAY_WARN_MS || delayMaxMs >= EVENT_LOOP_DELAY_WARN_MS;
 
       if (!hasDelayWarning && intervalMs < SUSTAINED_LOAD_SAMPLE_MIN_INTERVAL_MS) {
-        monitor.reset();
-        return undefined;
+        return lastSnapshot;
       }
 
       const cpuUsage = readCpuUsage(lastCpuUsage);
@@ -124,7 +138,7 @@ export function createGatewayEventLoopHealthMonitor(
       );
       const cpuTotalMs = roundMetric((cpuUsage.user + cpuUsage.system) / 1_000, 1);
       const cpuCoreRatio = roundMetric(cpuTotalMs / intervalMs);
-      const reasons = resolveGatewayEventLoopHealthReasons({
+      const reasons = classifyGatewayEventLoopHealthReasons({
         intervalMs,
         delayP99Ms,
         delayMaxMs,
@@ -132,12 +146,7 @@ export function createGatewayEventLoopHealthMonitor(
         cpuCoreRatio,
       });
 
-      monitor.reset();
-      lastWallAt = now;
-      lastCpuUsage = readCpuUsage();
-      lastEventLoopUtilization = currentEventLoopUtilization;
-
-      return {
+      const snapshot: GatewayEventLoopHealth = {
         degraded: reasons.length > 0,
         reasons,
         intervalMs,
@@ -146,6 +155,14 @@ export function createGatewayEventLoopHealthMonitor(
         utilization,
         cpuCoreRatio,
       };
+
+      monitor.reset();
+      lastWallAt = now;
+      lastCpuUsage = readCpuUsage();
+      lastEventLoopUtilization = currentEventLoopUtilization;
+      lastSnapshot = snapshot;
+
+      return snapshot;
     },
     stop: () => {
       monitor?.disable();
@@ -153,6 +170,7 @@ export function createGatewayEventLoopHealthMonitor(
       lastWallAt = 0;
       lastCpuUsage = null;
       lastEventLoopUtilization = null;
+      lastSnapshot = undefined;
     },
   };
 }


### PR DESCRIPTION
## Summary
- Classify sustained event-loop utilization and CPU saturation only when the sample also shows event-loop delay co-evidence.
- Keep hard event-loop delay detection immediate, so a true blocked loop still marks the Gateway degraded without waiting for a longer load window.
- Preserve the previous event-loop health snapshot during rapid follow-up probes, so frequent health/readiness/status polling cannot recompute noisy sub-second load samples or discard moderate delay evidence.
- Add focused gateway tests for short-window reuse, load-without-delay noise, delay-backed load classification, immediate hard-delay classification, and preserved delay co-evidence across rapid probes.

## Verification
- `pnpm test src/gateway/server/event-loop-health.test.ts`
- `pnpm test src/gateway/server/event-loop-health.test.ts -- --coverage --coverage.include=src/gateway/server/event-loop-health.ts --coverage.exclude=`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server/event-loop-health.ts src/gateway/server/event-loop-health.test.ts`
- `git diff --check`
- `pnpm changed:lanes --json`
- `codex review --base origin/main`

## Surface
- No new config surface.
- Broad validation: GitHub PR CI.

## Real behavior proof

- Behavior or issue addressed: rapid gateway health/readiness/status probes no longer let short sampling windows or CPU-only wakeups mark the Gateway degraded, while real event-loop delay remains visible in the event-loop health snapshot.
- Real environment tested: isolated macOS OpenClaw source worktree on this PR branch (`41e6a529b5`), Node 22, pnpm, separate `OPENCLAW_HOME`, channel startup skipped, auth disabled, dev Gateway bound to loopback port `18789`.
- Exact steps or command run after this patch: started the actual PR-branch Gateway and then queried `gateway health`, `channels status`, and `/readyz` against that running process.

```bash
rm -rf /tmp/openclaw-eventloop-proof-77028-rename
OPENCLAW_HOME=/tmp/openclaw-eventloop-proof-77028-rename \
OPENCLAW_PROFILE=eventloop-proof \
OPENCLAW_SKIP_CHANNELS=1 \
pnpm --silent openclaw gateway run --dev --auth none --force
```

- Evidence after fix: copied live output from the running PR-branch Gateway after the patch.

```json
{"surface":"gateway health","ok":true,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":1657,"delayP99Ms":27.9,"delayMaxMs":31.3,"utilization":0.059,"cpuCoreRatio":0.127}}
{"surface":"channels status","eventLoop":{"degraded":false,"reasons":[],"intervalMs":1657,"delayP99Ms":27.9,"delayMaxMs":31.3,"utilization":0.059,"cpuCoreRatio":0.127}}
{"surface":"readyz","probe":"1","ready":true,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":38597,"delayP99Ms":23,"delayMaxMs":66.8,"utilization":0.01,"cpuCoreRatio":0.006}}
{"surface":"readyz","probe":"2","ready":true,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":38597,"delayP99Ms":23,"delayMaxMs":66.8,"utilization":0.01,"cpuCoreRatio":0.006}}
{"surface":"readyz","probe":"3","ready":true,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":38597,"delayP99Ms":23,"delayMaxMs":66.8,"utilization":0.01,"cpuCoreRatio":0.006}}
{"surface":"readyz","probe":"4","ready":true,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":38597,"delayP99Ms":23,"delayMaxMs":66.8,"utilization":0.01,"cpuCoreRatio":0.006}}
```

- Observed result after fix: the actual Gateway stayed ready and reported non-degraded event-loop health through `gateway health`, `channels status`, and repeated `/readyz` probes. The snapshots still include real event-loop delay metrics, and the focused regression tests cover the cases where CPU/utilization become degraded only with delay co-evidence and hard delay remains immediate.
- What was not tested: full Control UI polling against the isolated Gateway; broad validation is left to GitHub PR CI.



