### PR TITLE
[codex] Keep pnpm source installs compatible with Baileys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: use config-only runtime snapshots for plugin tool registration and live runtime config getters, avoiding expensive full secrets snapshot clones on the core-plugin-tools prep path. Fixes #76295.
 - Agents/tools: honor the effective tool denylist before constructing optional PDF/media tool factories, so `tools.deny: ["pdf"]` skips PDF setup before later policy filtering. Fixes #76997.
 - Agents/bootstrap: keep pending `BOOTSTRAP.md` and bootstrap truncation notices in system-prompt Project Context instead of copying setup text or raw warning diagnostics into WebChat user/runtime context. Fixes #76946.
-- Channels/WhatsApp: allow `@whiskeysockets/libsignal-node` in `onlyBuiltDependencies` so pnpm v9+ `blockExoticSubdeps` no longer rejects the baileys git-tarball subdep and silences all inbound agent replies. Fixes #76539. Thanks @ottodeng and @vincentkoc.
+- Channels/WhatsApp: explicitly keep pnpm source installs compatible with Baileys' git-hosted libsignal subdependency so hardened `blockExoticSubdeps` defaults do not reject fresh workspace installs. Fixes #76539. Thanks @ottodeng and @vincentkoc.
 - Gateway/install: keep `.env`-managed values in the macOS LaunchAgent env file while still tracking `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`, so regenerated services do not boot without managed auth/provider keys. Fixes #75374.
 - Gateway/restart: verify listener PIDs by argv when `lsof` reports only the Node process name, so stale gateway cleanup can find macOS `cnode` listeners. Fixes #70664.
 - Gateway/logging: expand leading `~` in `logging.file` before creating the file logger, preventing startup crash loops for home-relative log paths. Fixes #73587.

--- a/docs/plugins/dependency-resolution.md
+++ b/docs/plugins/dependency-resolution.md
@@ -107,6 +107,10 @@ In source checkouts, OpenClaw treats the repository as a pnpm monorepo. After
 workspace dependencies are available and edits are picked up directly. Source
 checkout development is pnpm-only; plain `npm install` at the repository root is
 not a supported way to prepare bundled plugin dependencies.
+The workspace explicitly disables `blockExoticSubdeps` because the WhatsApp
+plugin's Baileys dependency still resolves libsignal from a git-hosted
+subdependency; packaged/plugin installs use npm and do not depend on that pnpm
+workspace setting.
 
 | Install shape                    | Bundled plugin location               | Dependency owner                                                     |
 | -------------------------------- | ------------------------------------- | -------------------------------------------------------------------- |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
   - packages/*
   - extensions/*
 
+blockExoticSubdeps: false
+
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:

--- a/test/scripts/pnpm-workspace-config.test.ts
+++ b/test/scripts/pnpm-workspace-config.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+type PnpmWorkspaceConfig = {
+  blockExoticSubdeps?: unknown;
+  onlyBuiltDependencies?: unknown;
+};
+
+describe("pnpm workspace config", () => {
+  it("keeps the Baileys git-hosted libsignal dependency installable", () => {
+    const config = parse(readFileSync("pnpm-workspace.yaml", "utf8")) as PnpmWorkspaceConfig;
+
+    expect(config.blockExoticSubdeps).toBe(false);
+    expect(config.onlyBuiltDependencies).toEqual(
+      expect.arrayContaining(["@whiskeysockets/baileys"]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- explicitly set `blockExoticSubdeps: false` in `pnpm-workspace.yaml` so source checkouts keep resolving WhatsApp/Baileys' git-hosted libsignal subdependency when pnpm's hardened exotic-subdependency mode is enabled
- correct the changelog wording from the earlier `onlyBuiltDependencies`-based claim and document why the workspace setting exists
- add a focused config regression test for the pnpm workspace setting

Fixes #76539.

## Verification

- Local: `pnpm install --frozen-lockfile --ignore-scripts`
- Local: `pnpm exec oxfmt --check --threads=1 test/scripts/pnpm-workspace-config.test.ts`
- Local: `pnpm test test/scripts/pnpm-workspace-config.test.ts`
- Local: `git diff --check`
- Crabbox/Testbox: `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:changed` (`tbx_01kqrb0y7jytcz7espq0z9bhdq`, exit 0)

## Repro Notes

- Crabbox minimal Baileys repro with current `onlyBuiltDependencies` shape still failed with `ERR_PNPM_EXOTIC_SUBDEP` when `block-exotic-subdeps=true`.
- The same minimal repro passed after setting `blockExoticSubdeps: false`.
- Clean latest `origin/main` source install with the committed lockfile passed, and `openclaw plugins install @openclaw/whatsapp@beta` from `openclaw@latest` passed, confirming the remaining risk is source/workspace resolution when pnpm's exotic-subdependency guard is active.
