### PR TITLE
[AI-assisted] fix(mcp): return tool data in primary content field (#77024)

### DIFF
--- a/src/mcp/channel-shared-summarize.test.ts
+++ b/src/mcp/channel-shared-summarize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { summarizeResult } from "./channel-shared.js";
+
+describe("summarizeResult", () => {
+  it("returns count-only text when no data is provided", () => {
+    const result = summarizeResult("messages", 3);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toBe("messages: 3");
+  });
+
+  it("includes serialized data in text when data is provided", () => {
+    const data = [{ id: "a", role: "user", content: "hello" }];
+    const result = summarizeResult("messages", 1, data);
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).toContain("messages: 1");
+    expect(result.content[0].text).toContain('"id": "a"');
+    expect(result.content[0].text).toContain('"role": "user"');
+  });
+
+  it("handles empty array data", () => {
+    const result = summarizeResult("messages", 0, []);
+    expect(result.content[0].text).toBe("messages: 0\n[]");
+  });
+
+  it("handles undefined data same as no-data", () => {
+    const result = summarizeResult("events", 5, undefined);
+    expect(result.content[0].text).toBe("events: 5");
+  });
+});

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -143,9 +143,12 @@ export function resolveMessageId(entry: Record<string, unknown>): string | undef
 export function summarizeResult(
   label: string,
   count: number,
+  data?: unknown,
 ): { content: Array<{ type: "text"; text: string }> } {
+  const summary = `${label}: ${count}`;
+  const text = data !== undefined ? `${summary}\n${JSON.stringify(data, null, 2)}` : summary;
   return {
-    content: [{ type: "text", text: `${label}: ${count}` }],
+    content: [{ type: "text", text }],
   };
 }
 

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -34,7 +34,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async (args) => {
       const conversations = await bridge.listConversations(args);
       return {
-        ...summarizeResult("conversations", conversations.length),
+        ...summarizeResult("conversations", conversations.length, conversations),
         structuredContent: { conversations },
       };
     },
@@ -69,7 +69,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async ({ session_key, limit }) => {
       const messages = await bridge.readMessages(session_key, limit ?? 20);
       return {
-        ...summarizeResult("messages", messages.length),
+        ...summarizeResult("messages", messages.length, messages),
         structuredContent: { messages },
       };
     },
@@ -94,7 +94,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       }
       const attachments = extractAttachmentsFromMessage(message);
       return {
-        ...summarizeResult("attachments", attachments.length),
+        ...summarizeResult("attachments", attachments.length, attachments),
         structuredContent: { attachments, message },
       };
     },
@@ -114,7 +114,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
         limit ?? 20,
       );
       return {
-        ...summarizeResult("events", events.length),
+        ...summarizeResult("events", events.length, events),
         structuredContent: { events, next_cursor: nextCursor },
       };
     },
@@ -163,7 +163,7 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
     async () => {
       const approvals = bridge.listPendingApprovals();
       return {
-        ...summarizeResult("approvals", approvals.length),
+        ...summarizeResult("approvals", approvals.length, approvals),
         structuredContent: { approvals },
       };
     },


### PR DESCRIPTION
## Summary

Fixes #77024

The MCP channel tools (`conversations_list`, `messages_read`, `attachments_fetch`, `events_poll`, `permissions_list_open`) were returning actual data exclusively in `structuredContent`, which MCP clients (including Claude.ai) cannot read. Only the primary `content` field is consumed by MCP clients, so they saw only a count like `"messages: 5"` with no actual data.

## Root Cause

`summarizeResult()` in `src/mcp/channel-shared.ts` produced only a count summary string in the `content` field. The real data was placed in a `structuredContent` property that is not part of the MCP tool response specification consumed by clients.

## Changes

- **`src/mcp/channel-shared.ts`**: Added an optional `data` parameter to `summarizeResult()`. When provided, the data is JSON-serialized and appended to the content text after the count summary line.
- **`src/mcp/channel-tools.ts`**: Updated all 5 call sites (`conversations_list`, `messages_read`, `attachments_fetch`, `events_poll`, `permissions_list_open`) to pass their data arrays to `summarizeResult()`.
- `structuredContent` is preserved unchanged for backward compatibility with any clients that do read it.

## Regression Test Plan

- Added `src/mcp/channel-shared-summarize.test.ts` with 4 tests covering: count-only (no data), data serialization, empty array, and undefined data.
- All existing tests pass (4/4 passed).

## Security Impact

None. This change only affects the text representation of data that was already being returned in `structuredContent`. No new data is exposed.