### PR TITLE
fix(bonjour): classify ciao 'Could not find valid addresses' assertion as non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Bonjour/ciao: classify the `Could not find valid addresses for interface` AssertionError thrown by `@homebridge/ciao`'s `NetworkManager.getCurrentNetworkInterfaces` for IPv6-only or otherwise address-less interfaces (e.g. Fly.io WireGuard `fdaa::/120` interfaces) as a non-fatal `no-valid-addresses` condition, so an unhandled rejection no longer crashes the gateway and tells systemd to restart-loop. The classifier emits a single warning and skips watchdog recovery because the interface state will not change without external intervention. Fixes #76499. Thanks @lonexreb.
 - Plugins/onboarding: trust optional official plugin and web-search installs selected from the official catalog so npm security scanning treats them like other source-linked official install paths. Thanks @vincentkoc.
 - CLI/plugins: keep `plugins enable` and `plugins disable` from creating unconfigured channel config sections, so channel plugins with required setup fields no longer fail validation during lifecycle probes. Thanks @vincentkoc.
 - Agents/sessions: keep delayed `sessions_send` A2A replies alive after soft wait-window timeouts, while preserving terminal run timeouts and avoiding stale target replies in requester sessions. Fixes #76443. Thanks @ryswork1993 and @vincentkoc.

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -399,6 +399,14 @@ export async function startGatewayBonjourAdvertiser(
         logger.warn(
           `bonjour: disabling mDNS — networkInterfaces() unavailable in this environment: ${classification.formatted}`,
         );
+      } else if (classification.kind === "no-valid-addresses") {
+        // IPv6-only or otherwise address-less interfaces (e.g. Fly.io WireGuard)
+        // make ciao throw "Could not find valid addresses for interface". The
+        // interface state will not change without external intervention, so a
+        // recovery retry would hit the same assertion. Surface a warning only.
+        logger.warn(
+          `bonjour: skipping mDNS for interface without valid addresses: ${classification.formatted}`,
+        );
       } else {
         const label =
           classification.kind === "netmask-assertion"
@@ -537,7 +545,15 @@ export async function startGatewayBonjourAdvertiser(
             svc,
           )}): ${classification.formatted}`,
         );
-        requestCiaoRecovery?.(classification);
+        // Skip recovery for terminal-state classifications: the underlying
+        // condition will not change without external intervention, so retrying
+        // would just re-enter the same failure.
+        if (
+          classification.kind !== "interface-enumeration-failure" &&
+          classification.kind !== "no-valid-addresses"
+        ) {
+          requestCiaoRecovery?.(classification);
+        }
         return;
       }
       logger.warn(

--- a/extensions/bonjour/src/ciao.test.ts
+++ b/extensions/bonjour/src/ciao.test.ts
@@ -125,6 +125,28 @@ describe("bonjour-ciao", () => {
     expect(ignoreCiaoUnhandledRejection(error)).toBe(true);
   });
 
+  // Regression for #76499: IPv6-only interfaces (e.g. Fly.io WireGuard with
+  // a single fdaa::/120 address) make ciao throw an AssertionError that
+  // bubbled past the classifier and crashed the gateway. The new classifier
+  // entry must catch it as a non-fatal "no-valid-addresses" condition.
+  it("classifies missing-valid-addresses assertions as non-fatal (#76499)", () => {
+    const err = Object.assign(
+      new Error("Could not find valid addresses for interface 'fly-redis'"),
+      { name: "AssertionError" },
+    );
+    expect(classifyCiaoUnhandledRejection(err)).toEqual({
+      kind: "no-valid-addresses",
+      formatted: "AssertionError: Could not find valid addresses for interface 'fly-redis'",
+    });
+  });
+
+  it("suppresses missing-valid-addresses assertions at the unhandled-rejection boundary (#76499)", () => {
+    const err = Object.assign(new Error("Could not find valid addresses for interface 'wg0'"), {
+      name: "AssertionError",
+    });
+    expect(ignoreCiaoUnhandledRejection(err)).toBe(true);
+  });
+
   it("classifies networkInterfaces SystemError failures (restricted sandboxes)", () => {
     const err = Object.assign(
       new Error("A system error occurred: uv_interface_addresses returned Unknown system error 1"),

--- a/extensions/bonjour/src/ciao.ts
+++ b/extensions/bonjour/src/ciao.ts
@@ -11,13 +11,20 @@ const CIAO_SELF_PROBE_MESSAGE_RE =
 // can refuse os.networkInterfaces(), which ciao calls during NetworkManager init.
 // Node surfaces this as a SystemError mentioning the libuv syscall by name.
 const CIAO_INTERFACE_ENUMERATION_FAILURE_RE = /\bUV_INTERFACE_ADDRESSES\b/u;
+// IPv6-only interfaces (e.g. Fly.io WireGuard interfaces with a single fdaa::/120
+// address) and other interfaces ciao does not consider to have a valid address
+// trip an AssertionError in NetworkManager.getCurrentNetworkInterfaces. Treat
+// this as a non-fatal warning: the interface state will not change without
+// external intervention, so a recovery retry would just hit the same assertion.
+const CIAO_NO_VALID_ADDRESSES_RE = /COULD NOT FIND VALID ADDRESSES FOR INTERFACE/u;
 
 export type CiaoProcessErrorClassification =
   | { kind: "cancellation"; formatted: string }
   | { kind: "interface-assertion"; formatted: string }
   | { kind: "netmask-assertion"; formatted: string }
   | { kind: "self-probe"; formatted: string }
-  | { kind: "interface-enumeration-failure"; formatted: string };
+  | { kind: "interface-enumeration-failure"; formatted: string }
+  | { kind: "no-valid-addresses"; formatted: string };
 
 function collectCiaoProcessErrorCandidates(reason: unknown): unknown[] {
   const queue: unknown[] = [reason];
@@ -77,6 +84,9 @@ export function classifyCiaoProcessError(reason: unknown): CiaoProcessErrorClass
     }
     if (CIAO_INTERFACE_ENUMERATION_FAILURE_RE.test(message)) {
       return { kind: "interface-enumeration-failure", formatted };
+    }
+    if (CIAO_NO_VALID_ADDRESSES_RE.test(message)) {
+      return { kind: "no-valid-addresses", formatted };
     }
   }
   return null;


### PR DESCRIPTION
## Summary

Adds a sixth ciao process-error classification, `no-valid-addresses`, that catches the `AssertionError: Could not find valid addresses for interface '<name>'` that `@homebridge/ciao`'s `NetworkManager.getCurrentNetworkInterfaces` throws when an interface lacks an address ciao considers valid. The bonjour classifier had no entry for this string, so the rejection bubbled past `handleCiaoProcessError`, hit the global unhandled-rejection handler, the gateway exited 1, and systemd restart-looped it.

The most common trigger is an interface with only IPv6 addresses (Fly.io WireGuard `fly-redis` interfaces with a single `fdaa::/120` address, IPv6-only stacks, link-local-only NICs). The interface state will not change without external intervention, so the new handler emits a single warning and **skips** `requestCiaoRecovery` — a recovery retry would just re-enter the same assertion.

This follows the established pattern from #73231 (`classify ciao IPv4 changed assertion`) and #73029 (`suppress ciao crash when networkInterfaces() is denied`): narrow classifier additions for distinct ciao failure modes, treated as non-fatal warnings.

## Changes

- `extensions/bonjour/src/ciao.ts` — Add `CIAO_NO_VALID_ADDRESSES_RE`, extend `CiaoProcessErrorClassification` discriminated union with `"no-valid-addresses"`, and add the regex check in `classifyCiaoProcessError`.
- `extensions/bonjour/src/advertiser.ts` — Add a `"no-valid-addresses"` branch in `handleCiaoProcessError` (warn-only, no recovery) and update `handleAdvertiseFailure` to skip `requestCiaoRecovery` for terminal-state classifications (`interface-enumeration-failure`, `no-valid-addresses`).
- `extensions/bonjour/src/ciao.test.ts` — Two regression tests covering both the classifier-result path and the unhandled-rejection-boundary path.
- `CHANGELOG.md` — Unreleased > Fixes entry.

## Test plan

- [x] `pnpm test extensions/bonjour/src/ciao.test.ts` — 17/17 (15 existing + 2 new) pass
- [x] `pnpm test extensions/bonjour/` — 49/49 pass
- [x] `pnpm check:changed` — typecheck core, typecheck core tests, typecheck extensions, typecheck extensions tests, lint extensions, import-cycles, runtime sidecar loaders, dup:check, conflict-markers, changelog-attributions all green
- [x] `pnpm exec oxfmt --check` on touched files — clean
- [ ] Live-verify on an IPv6-only interface — not feasible locally; the new test mocks the AssertionError shape from the issue's repro logs and the fix follows the same control-flow seam as #73029 / #73231.

Fixes #76499.
