### PR TITLE
test(proxy): keep managed proxy cert fixture in temp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Proxy/debugging: disable debug proxy CONNECT upstream forwarding while managed proxy mode is active unless `OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY=1` is explicitly set for approved local diagnostics.
+
 - Google Meet: route stateful CLI session commands through the gateway-owned runtime so joined realtime sessions survive after the starting CLI process exits. Fixes #76344. Thanks @coltonharris-wq.
 - Memory/status: keep plain `openclaw memory status` and `openclaw memory status --json` on the cheap read-only path by reserving vector and embedding provider probes for `--deep` or `--index`. Fixes #76769. Thanks @daruire.
 - Telegram: suppress stale same-session replies when a newer accepted message arrives before an older in-flight Telegram dispatch finalizes. Fixes #76642. Thanks @chinar-amrutkar.

--- a/docs/cli/proxy.md
+++ b/docs/cli/proxy.md
@@ -68,6 +68,7 @@ semantics.
 
 - `start` defaults to `127.0.0.1` unless `--host` is set.
 - `run` starts a local debug proxy and then runs the command after `--`.
+- The debug proxy's CONNECT forwarding opens upstream TCP sockets for diagnostics. When OpenClaw managed proxy mode is active, CONNECT forwarding is disabled by default; set `OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY=1` only for approved local diagnostics.
 - `validate` exits with code 1 when proxy config or destination checks fail.
 - Captures are local debugging data; use `openclaw proxy purge` when finished.
 

--- a/docs/security/network-proxy.md
+++ b/docs/security/network-proxy.md
@@ -193,6 +193,7 @@ proxy:
 
 - The proxy improves coverage for process-local JavaScript HTTP and WebSocket clients, but it is not an OS-level network sandbox.
 - Raw `net`, `tls`, and `http2` sockets, native addons, and child processes may bypass Node-level proxy routing unless they inherit and respect proxy environment variables.
+- The local debug proxy is diagnostic tooling and its CONNECT upstream forwarding is disabled by default while managed proxy mode is active; enable direct CONNECT forwarding only for approved local diagnostics.
 - User local WebUIs and local model servers should be allowlisted in the operator proxy policy when needed; OpenClaw does not expose a general local-network bypass for them.
 - Gateway control-plane proxy bypass is intentionally limited to `localhost` and literal loopback IP URLs. Use `ws://127.0.0.1:18789`, `ws://[::1]:18789`, or `ws://localhost:18789` for local direct Gateway control-plane connections; other hostnames route like ordinary hostname-based traffic.
 - OpenClaw does not inspect, test, or certify your proxy policy.

--- a/src/proxy-capture/proxy-server.managed-proxy.test.ts
+++ b/src/proxy-capture/proxy-server.managed-proxy.test.ts
@@ -1,25 +1,29 @@
-import { rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { assertDebugProxyDirectConnectAllowed, startDebugProxyServer } from "./proxy-server.js";
 
-const testBlobDir = ".tmp-debug-proxy-test-blobs";
-const testCertDir = ".tmp-debug-proxy-test-certs";
+let testRoot: string | undefined;
 
 async function cleanupTestDirs(): Promise<void> {
-  await Promise.all([
-    rm(testBlobDir, { recursive: true, force: true }),
-    rm(testCertDir, { recursive: true, force: true }),
-  ]);
+  if (!testRoot) {
+    return;
+  }
+  const root = testRoot;
+  testRoot = undefined;
+  await rm(root, { recursive: true, force: true });
 }
 
-function makeSettings() {
+async function makeSettings() {
+  testRoot = await mkdtemp(join(tmpdir(), "openclaw-debug-proxy-managed-proxy-"));
   return {
     enabled: true,
     required: false,
     dbPath: ":memory:",
-    blobDir: testBlobDir,
-    certDir: testCertDir,
+    blobDir: join(testRoot, "blobs"),
+    certDir: join(testRoot, "certs"),
     sessionId: "debug-proxy-managed-proxy-test",
     sourceProcess: "test",
   };
@@ -90,7 +94,7 @@ describe("debug proxy managed-proxy CONNECT policy", () => {
 
   it("rejects CONNECT upstreams before opening direct sockets while managed proxy mode is active", async () => {
     process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
-    const server = await startDebugProxyServer({ settings: makeSettings() });
+    const server = await startDebugProxyServer({ settings: await makeSettings() });
     try {
       const response = await connectThroughProxy(server.proxyUrl);
 

--- a/src/proxy-capture/proxy-server.managed-proxy.test.ts
+++ b/src/proxy-capture/proxy-server.managed-proxy.test.ts
@@ -1,0 +1,103 @@
+import { rm } from "node:fs/promises";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { assertDebugProxyDirectConnectAllowed, startDebugProxyServer } from "./proxy-server.js";
+
+const testBlobDir = ".tmp-debug-proxy-test-blobs";
+const testCertDir = ".tmp-debug-proxy-test-certs";
+
+async function cleanupTestDirs(): Promise<void> {
+  await Promise.all([
+    rm(testBlobDir, { recursive: true, force: true }),
+    rm(testCertDir, { recursive: true, force: true }),
+  ]);
+}
+
+function makeSettings() {
+  return {
+    enabled: true,
+    required: false,
+    dbPath: ":memory:",
+    blobDir: testBlobDir,
+    certDir: testCertDir,
+    sessionId: "debug-proxy-managed-proxy-test",
+    sourceProcess: "test",
+  };
+}
+
+async function connectThroughProxy(proxyUrl: string): Promise<string> {
+  const target = new URL(proxyUrl);
+  const socket = new Socket();
+  let data = "";
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk) => {
+    data += chunk;
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.connect(Number(target.port), target.hostname, resolve);
+  });
+  socket.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
+  await new Promise<void>((resolve) => socket.once("end", resolve));
+  socket.destroy();
+  return data;
+}
+
+describe("debug proxy managed-proxy CONNECT policy", () => {
+  const originalProxyActive = process.env["OPENCLAW_PROXY_ACTIVE"];
+  const originalAllowDirect =
+    process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"];
+
+  beforeEach(async () => {
+    await cleanupTestDirs();
+    delete process.env["OPENCLAW_PROXY_ACTIVE"];
+    delete process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"];
+  });
+
+  afterEach(async () => {
+    if (originalProxyActive === undefined) {
+      delete process.env["OPENCLAW_PROXY_ACTIVE"];
+    } else {
+      process.env["OPENCLAW_PROXY_ACTIVE"] = originalProxyActive;
+    }
+    if (originalAllowDirect === undefined) {
+      delete process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"];
+    } else {
+      process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"] =
+        originalAllowDirect;
+    }
+    await cleanupTestDirs();
+  });
+
+  it("allows direct CONNECT upstreams when managed proxy mode is inactive", () => {
+    expect(() => assertDebugProxyDirectConnectAllowed()).not.toThrow();
+  });
+
+  it("rejects direct CONNECT upstreams while managed proxy mode is active", () => {
+    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
+
+    expect(() => assertDebugProxyDirectConnectAllowed()).toThrow(
+      /Debug proxy CONNECT upstream forwarding is disabled/,
+    );
+  });
+
+  it("allows direct CONNECT upstreams with explicit diagnostic override", () => {
+    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
+    process.env["OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY"] = "1";
+
+    expect(() => assertDebugProxyDirectConnectAllowed()).not.toThrow();
+  });
+
+  it("rejects CONNECT upstreams before opening direct sockets while managed proxy mode is active", async () => {
+    process.env["OPENCLAW_PROXY_ACTIVE"] = "1";
+    const server = await startDebugProxyServer({ settings: makeSettings() });
+    try {
+      const response = await connectThroughProxy(server.proxyUrl);
+
+      expect(response).toContain("502 Bad Gateway");
+      expect(response).toContain("Debug proxy CONNECT upstream forwarding is disabled");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -8,6 +8,28 @@ import { ensureDebugProxyCa } from "./ca.js";
 import type { DebugProxySettings } from "./env.js";
 import { getDebugProxyCaptureStore } from "./store.sqlite.js";
 
+const TRUTHY_ENV = new Set(["1", "true", "yes", "on"]);
+const DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE =
+  "OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY";
+
+function isManagedProxyActive(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env["OPENCLAW_PROXY_ACTIVE"] === "1";
+}
+
+function allowsDirectConnectWithManagedProxy(env: NodeJS.ProcessEnv = process.env): boolean {
+  return TRUTHY_ENV.has((env[DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE] ?? "").toLowerCase());
+}
+
+export function assertDebugProxyDirectConnectAllowed(env: NodeJS.ProcessEnv = process.env): void {
+  if (!isManagedProxyActive(env) || allowsDirectConnectWithManagedProxy(env)) {
+    return;
+  }
+  throw new Error(
+    "Debug proxy CONNECT upstream forwarding is disabled while managed proxy mode is active. " +
+      `Set ${DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE}=1 only for approved local diagnostics.`,
+  );
+}
+
 type DebugProxyServerHandle = {
   proxyUrl: string;
   stop: () => Promise<void>;
@@ -187,6 +209,26 @@ export async function startDebugProxyServer(params: {
       path: req.url ?? "",
       headersJson: JSON.stringify(req.headers),
     });
+    try {
+      assertDebugProxyDirectConnectAllowed();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      store.recordEvent({
+        sessionId: params.settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: params.settings.sourceProcess,
+        protocol: "connect",
+        direction: "local",
+        kind: "error",
+        flowId,
+        host: hostname,
+        path: req.url ?? "",
+        errorText: message,
+      });
+      clientSocket.end(`HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\n${message}`);
+      return;
+    }
     const upstreamSocket = net.connect(port, hostname, () => {
       clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       if (head.length > 0) {


### PR DESCRIPTION
## Summary
- stack on #77010 to address the test-fixture review finding
- allocate the managed-proxy debug proxy blob/cert fixture under os.tmpdir()
- remove the per-test temp root during cleanup so generated root-ca-key.pem is not created under the checkout

## Test
- pnpm exec oxfmt --check --threads=1 src/proxy-capture/proxy-server.managed-proxy.test.ts
- OPENCLAW_LOCAL_CHECK=0 pnpm test src/proxy-capture/proxy-server.managed-proxy.test.ts src/proxy-capture/proxy-server.test.ts src/proxy-capture/runtime.test.ts src/proxy-capture/env.test.ts
- OPENCLAW_LOCAL_CHECK=0 pnpm check:changed -- --base upstream/main --head HEAD

Stacked on #77010.