### PR TITLE
Improve Gemini realtime voice parity for Twilio Meet joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Highlights
 
 - Plugins/file-transfer: add bundled file-transfer plugin with `file_fetch`, `dir_list`, `dir_fetch`, and `file_write` agent tools for binary file ops on paired nodes; default-deny per-node path policy under `plugins.entries.file-transfer.config.nodes` with operator approval, symlink traversal refused by default (opt-in `followSymlinks`), and a 16 MB byte ceiling per round-trip. (#74742) Thanks @omarshahine.
+- Google Meet/Voice Call: make Twilio dial-in joins speak through the realtime Gemini voice bridge with paced audio streaming, backpressure-aware buffering, barge-in queue clearing, and no TwiML fallback during realtime speech, giving Meet participants a much snappier OpenClaw voice agent. (#77064) Thanks @scoootscooob.
 
 ### Changes
 
@@ -58,7 +59,6 @@ Docs: https://docs.openclaw.ai
 - Control UI: point the Appearance tweakcn browse action and docs at the live tweakcn editor route instead of the removed `/themes` page. Fixes #77048.
 - Control UI: render Dream Diary prose through the sanitized markdown pipeline, so diary bold/italic/header markdown no longer appears as literal source text. Fixes #62413.
 - Control UI: render tool results whose output arrives as text-block arrays and give expanded tool output a scrollable block, so read/exec output remains visible in WebChat. Fixes #77054.
-- Voice Call/Google Meet: pace Twilio realtime audio, clear queued playback on local speech starts, and enable Gemini Live session resumption plus context compression defaults for lower-latency Meet dial-in joins. (#77064) Thanks @scoootscooob.
 - MCP: include serialized conversation/message payloads in the primary text content for `conversations_list` and `messages_read`, while preserving `structuredContent` for capable clients. Fixes #77024.
 - Media: treat `EPERM` from the post-write media fsync step as best-effort, allowing WebChat and channel uploads to finish on Windows filesystems that reject `fsync` after a successful write. Fixes #76844.
 - Diagnostics: keep webhook/message OTEL attributes and Prometheus delivery labels low-cardinality and omit raw chat/message IDs from spans, so progress-draft and message-tool modes do not leak high-cardinality messaging identifiers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: point the Appearance tweakcn browse action and docs at the live tweakcn editor route instead of the removed `/themes` page. Fixes #77048.
 - Control UI: render Dream Diary prose through the sanitized markdown pipeline, so diary bold/italic/header markdown no longer appears as literal source text. Fixes #62413.
 - Control UI: render tool results whose output arrives as text-block arrays and give expanded tool output a scrollable block, so read/exec output remains visible in WebChat. Fixes #77054.
+- Voice Call/Google Meet: pace Twilio realtime audio, clear queued playback on local speech starts, and enable Gemini Live session resumption plus context compression defaults for lower-latency Meet dial-in joins. (#77064) Thanks @scoootscooob.
 - MCP: include serialized conversation/message payloads in the primary text content for `conversations_list` and `messages_read`, while preserving `structuredContent` for capable clients. Fixes #77024.
 - Media: treat `EPERM` from the post-write media fsync step as best-effort, allowing WebChat and channel uploads to finish on Windows filesystems that reject `fsync` after a successful write. Fixes #76844.
 - Diagnostics: keep webhook/message OTEL attributes and Prometheus delivery labels low-cardinality and omit raw chat/message IDs from spans, so progress-draft and message-tool modes do not leak high-cardinality messaging identifiers.

--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -445,7 +445,7 @@ Enable the Voice Call plugin on the Gateway host, not on the Chrome node:
 ```json5
 {
   plugins: {
-    allow: ["google-meet", "voice-call"],
+    allow: ["google-meet", "voice-call", "google"],
     entries: {
       "google-meet": {
         enabled: true,
@@ -458,7 +458,23 @@ Enable the Voice Call plugin on the Gateway host, not on the Chrome node:
         enabled: true,
         config: {
           provider: "twilio",
+          inboundPolicy: "allowlist",
+          realtime: {
+            enabled: true,
+            provider: "google",
+            instructions: "Join this Google Meet as an OpenClaw agent. Be brief.",
+            toolPolicy: "safe-read-only",
+            providers: {
+              google: {
+                silenceDurationMs: 500,
+                startSensitivity: "high",
+              },
+            },
+          },
         },
+      },
+      google: {
+        enabled: true,
       },
     },
   },
@@ -472,7 +488,11 @@ secrets out of `openclaw.json`:
 export TWILIO_ACCOUNT_SID=AC...
 export TWILIO_AUTH_TOKEN=...
 export TWILIO_FROM_NUMBER=+15550001234
+export GEMINI_API_KEY=...
 ```
+
+Use `realtime.provider: "openai"` with the OpenAI provider plugin and
+`OPENAI_API_KEY` instead if that is your realtime voice provider.
 
 Restart or reload the Gateway after enabling `voice-call`; plugin config changes
 do not appear in an already running Gateway process until it reloads.

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -250,6 +250,9 @@ Current runtime behaviour:
     Defaults: API key from `realtime.providers.google.apiKey`,
     `GEMINI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY`; model
     `gemini-2.5-flash-native-audio-preview-12-2025`; voice `Kore`.
+    `sessionResumption` and `contextWindowCompression` default on for longer,
+    reconnectable calls. Use `silenceDurationMs`, `startSensitivity`, and
+    `endSensitivity` to tune faster turn-taking on telephony audio.
 
     ```json5
     {
@@ -270,6 +273,8 @@ Current runtime behaviour:
                     apiKey: "${GEMINI_API_KEY}",
                     model: "gemini-2.5-flash-native-audio-preview-12-2025",
                     voice: "Kore",
+                    silenceDurationMs: 500,
+                    startSensitivity: "high",
                   },
                 },
               },

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -343,6 +343,8 @@ Gemini Live API for backend audio bridges such as Voice Call and Google Meet.
 | Activity handling     | `...google.activityHandling`                                        | Google default, `start-of-activity-interrupts`                                        |
 | Turn coverage         | `...google.turnCoverage`                                            | Google default, `only-activity`                                                       |
 | Disable auto VAD      | `...google.automaticActivityDetectionDisabled`                      | `false`                                                                               |
+| Session resumption    | `...google.sessionResumption`                                       | `true`                                                                                |
+| Context compression   | `...google.contextWindowCompression`                                | `true`                                                                                |
 | API key               | `...google.apiKey`                                                  | Falls back to `models.providers.google.apiKey`, `GEMINI_API_KEY`, or `GOOGLE_API_KEY` |
 
 Example Voice Call realtime config:

--- a/extensions/google-meet/src/voice-call-gateway.test.ts
+++ b/extensions/google-meet/src/voice-call-gateway.test.ts
@@ -28,7 +28,7 @@ describe("Google Meet voice-call gateway", () => {
     gatewayMocks.startGatewayClientWhenEventLoopReady.mockClear();
   });
 
-  it("starts Twilio Meet calls, sends delayed DTMF, then speaks the intro", async () => {
+  it("starts Twilio Meet calls, sends delayed DTMF, then speaks the intro without TwiML fallback", async () => {
     const config = resolveGoogleMeetConfig({
       voiceCall: {
         gatewayUrl: "ws://127.0.0.1:18789",
@@ -70,10 +70,39 @@ describe("Google Meet voice-call gateway", () => {
       "voicecall.speak",
       {
         callId: "call-1",
+        allowTwimlFallback: false,
         message: "Say exactly: I'm here and listening.",
       },
       { timeoutMs: 30_000 },
     );
     expect(gatewayMocks.request).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips the intro without failing when the realtime bridge is not ready", async () => {
+    gatewayMocks.request
+      .mockResolvedValueOnce({ callId: "call-1" })
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: false, error: "No active realtime bridge for call" });
+    const config = resolveGoogleMeetConfig({
+      voiceCall: {
+        gatewayUrl: "ws://127.0.0.1:18789",
+        dtmfDelayMs: 1,
+        postDtmfSpeechDelayMs: 1,
+      },
+    });
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    const result = await joinMeetViaVoiceCallGateway({
+      config,
+      dialInNumber: "+15551234567",
+      dtmfSequence: "123456#",
+      logger,
+      message: "Say exactly: I'm here and listening.",
+    });
+
+    expect(result).toMatchObject({ callId: "call-1", dtmfSent: true, introSent: false });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Skipped intro speech because realtime bridge was not ready"),
+    );
   });
 });

--- a/extensions/google-meet/src/voice-call-gateway.ts
+++ b/extensions/google-meet/src/voice-call-gateway.ts
@@ -145,17 +145,23 @@ export async function joinMeetViaVoiceCallGateway(params: {
         "voicecall.speak",
         {
           callId: start.callId,
+          allowTwimlFallback: false,
           message: params.message,
         },
         { timeoutMs: params.config.voiceCall.requestTimeoutMs },
       )) as VoiceCallSpeakResult;
       if (spoken.success === false) {
-        throw new Error(spoken.error || "voicecall.speak failed");
+        params.logger?.warn?.(
+          `[google-meet] Skipped intro speech because realtime bridge was not ready: ${
+            spoken.error || "voicecall.speak failed"
+          }`,
+        );
+      } else {
+        introSent = true;
+        params.logger?.info(
+          `[google-meet] Intro speech requested after Meet dial sequence: callId=${start.callId}`,
+        );
       }
-      introSent = true;
-      params.logger?.info(
-        `[google-meet] Intro speech requested after Meet dial sequence: callId=${start.callId}`,
-      );
     }
     return {
       callId: start.callId,

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -107,6 +107,8 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       turnCoverage: "only-activity",
       automaticActivityDetectionDisabled: false,
       enableAffectiveDialog: undefined,
+      sessionResumption: undefined,
+      contextWindowCompression: undefined,
       thinkingLevel: undefined,
       thinkingBudget: undefined,
     });
@@ -181,6 +183,8 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
           },
           turnCoverage: "TURN_INCLUDES_ONLY_ACTIVITY",
         },
+        sessionResumption: {},
+        contextWindowCompression: { slidingWindow: {} },
         tools: [
           {
             functionDeclarations: [
@@ -310,6 +314,42 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
         },
       },
     });
+  });
+
+  it("can opt out of Google Live session resumption and context compression", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: {
+        apiKey: "gemini-key",
+        contextWindowCompression: false,
+        sessionResumption: false,
+      },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    expect(lastConnectParams().config).not.toHaveProperty("contextWindowCompression");
+    expect(lastConnectParams().config).not.toHaveProperty("sessionResumption");
+  });
+
+  it("captures Google Live resumption handles and reuses them on reconnect", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onmessage({
+      sessionResumptionUpdate: { resumable: true, newHandle: "resume-1" },
+    });
+
+    await bridge.connect();
+
+    expect(lastConnectParams().config.sessionResumption).toEqual({ handle: "resume-1" });
   });
 
   it("waits for setup completion before draining audio and firing ready", async () => {

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -411,6 +411,32 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(session.sendRealtimeInput).toHaveBeenCalledWith({ audioStreamEnd: true });
   });
 
+  it("fuses telephony mu-law conversion into the Gemini 16 kHz PCM input frame", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+    lastConnectParams().callbacks.onopen();
+    lastConnectParams().callbacks.onmessage({ setupComplete: { sessionId: "session-1" } });
+
+    bridge.sendAudio(Buffer.from([0xff, 0x00]));
+
+    expect(session.sendRealtimeInput).toHaveBeenCalledWith({
+      audio: {
+        data: expect.any(String),
+        mimeType: "audio/pcm;rate=16000",
+      },
+    });
+    const sent = Buffer.from(session.sendRealtimeInput.mock.calls[0]?.[0].audio.data, "base64");
+    expect(Array.from({ length: sent.length / 2 }, (_, i) => sent.readInt16LE(i * 2))).toEqual([
+      0, -16062, -32124, -32124,
+    ]);
+  });
+
   it("accepts PCM16 24 kHz audio without the telephony mu-law hop", async () => {
     const provider = buildGoogleRealtimeVoiceProvider();
     const bridge = provider.createBridge({

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -1,20 +1,20 @@
 import { randomUUID } from "node:crypto";
-import {
+import type {
   ActivityHandling,
   Behavior,
   EndSensitivity,
+  FunctionDeclaration,
+  FunctionResponse,
   FunctionResponseScheduling,
+  LiveConnectConfig,
+  LiveServerContent,
+  LiveServerMessage,
+  LiveServerToolCall,
   Modality,
+  RealtimeInputConfig,
   StartSensitivity,
+  ThinkingConfig,
   TurnCoverage,
-  type FunctionDeclaration,
-  type FunctionResponse,
-  type LiveConnectConfig,
-  type LiveServerContent,
-  type LiveServerMessage,
-  type LiveServerToolCall,
-  type RealtimeInputConfig,
-  type ThinkingConfig,
 } from "@google/genai";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import type {
@@ -47,7 +47,7 @@ const GOOGLE_REALTIME_BROWSER_API_VERSION = "v1alpha";
 const GOOGLE_REALTIME_BROWSER_WEBSOCKET_URL =
   "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1alpha.GenerativeService.BidiGenerateContentConstrained";
 const MAX_PENDING_AUDIO_CHUNKS = 320;
-const DEFAULT_AUDIO_STREAM_END_SILENCE_MS = 700;
+const DEFAULT_AUDIO_STREAM_END_SILENCE_MS = 500;
 const GOOGLE_REALTIME_BROWSER_SESSION_TTL_MS = 30 * 60 * 1000;
 const GOOGLE_REALTIME_BROWSER_NEW_SESSION_TTL_MS = 60 * 1000;
 
@@ -70,6 +70,8 @@ type GoogleRealtimeVoiceProviderConfig = {
   turnCoverage?: GoogleRealtimeTurnCoverage;
   automaticActivityDetectionDisabled?: boolean;
   enableAffectiveDialog?: boolean;
+  sessionResumption?: boolean;
+  contextWindowCompression?: boolean;
   thinkingLevel?: GoogleRealtimeThinkingLevel;
   thinkingBudget?: number;
 };
@@ -90,6 +92,8 @@ type GoogleRealtimeLiveConfig = {
   turnCoverage?: GoogleRealtimeTurnCoverage;
   automaticActivityDetectionDisabled?: boolean;
   enableAffectiveDialog?: boolean;
+  sessionResumption?: boolean;
+  contextWindowCompression?: boolean;
   thinkingLevel?: GoogleRealtimeThinkingLevel;
   thinkingBudget?: number;
 };
@@ -209,6 +213,8 @@ function normalizeProviderConfig(
     turnCoverage: asTurnCoverage(raw?.turnCoverage),
     automaticActivityDetectionDisabled: asBoolean(raw?.automaticActivityDetectionDisabled),
     enableAffectiveDialog: asBoolean(raw?.enableAffectiveDialog),
+    sessionResumption: asBoolean(raw?.sessionResumption),
+    contextWindowCompression: asBoolean(raw?.contextWindowCompression),
     thinkingLevel: asThinkingLevel(raw?.thinkingLevel),
     thinkingBudget: asFiniteNumber(raw?.thinkingBudget),
   };
@@ -223,9 +229,9 @@ function mapStartSensitivity(
 ): StartSensitivity | undefined {
   switch (value) {
     case "high":
-      return StartSensitivity.START_SENSITIVITY_HIGH;
+      return "START_SENSITIVITY_HIGH" as StartSensitivity;
     case "low":
-      return StartSensitivity.START_SENSITIVITY_LOW;
+      return "START_SENSITIVITY_LOW" as StartSensitivity;
     default:
       return undefined;
   }
@@ -236,9 +242,9 @@ function mapEndSensitivity(
 ): EndSensitivity | undefined {
   switch (value) {
     case "high":
-      return EndSensitivity.END_SENSITIVITY_HIGH;
+      return "END_SENSITIVITY_HIGH" as EndSensitivity;
     case "low":
-      return EndSensitivity.END_SENSITIVITY_LOW;
+      return "END_SENSITIVITY_LOW" as EndSensitivity;
     default:
       return undefined;
   }
@@ -249,9 +255,9 @@ function mapActivityHandling(
 ): ActivityHandling | undefined {
   switch (value) {
     case "no-interruption":
-      return ActivityHandling.NO_INTERRUPTION;
+      return "NO_INTERRUPTION" as ActivityHandling;
     case "start-of-activity-interrupts":
-      return ActivityHandling.START_OF_ACTIVITY_INTERRUPTS;
+      return "START_OF_ACTIVITY_INTERRUPTS" as ActivityHandling;
     default:
       return undefined;
   }
@@ -260,11 +266,11 @@ function mapActivityHandling(
 function mapTurnCoverage(value: GoogleRealtimeTurnCoverage | undefined): TurnCoverage | undefined {
   switch (value) {
     case "only-activity":
-      return TurnCoverage.TURN_INCLUDES_ONLY_ACTIVITY;
+      return "TURN_INCLUDES_ONLY_ACTIVITY" as TurnCoverage;
     case "all-input":
-      return TurnCoverage.TURN_INCLUDES_ALL_INPUT;
+      return "TURN_INCLUDES_ALL_INPUT" as TurnCoverage;
     case "audio-activity-and-all-video":
-      return TurnCoverage.TURN_INCLUDES_AUDIO_ACTIVITY_AND_ALL_VIDEO;
+      return "TURN_INCLUDES_AUDIO_ACTIVITY_AND_ALL_VIDEO" as TurnCoverage;
     default:
       return undefined;
   }
@@ -316,7 +322,7 @@ function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): Func
       parametersJsonSchema: tool.parameters,
     };
     if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      declaration.behavior = Behavior.NON_BLOCKING;
+      declaration.behavior = "NON_BLOCKING" as Behavior;
     }
     return declaration;
   });
@@ -325,7 +331,7 @@ function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): Func
 function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveConnectConfig {
   const functionDeclarations = buildFunctionDeclarations(config.tools);
   return {
-    responseModalities: [Modality.AUDIO],
+    responseModalities: ["AUDIO" as Modality],
     ...(typeof config.temperature === "number" && config.temperature > 0
       ? { temperature: config.temperature }
       : {}),
@@ -359,7 +365,7 @@ function buildBrowserInitialSetup(model: string) {
     setup: {
       model: toGoogleModelResource(model),
       generationConfig: {
-        responseModalities: [Modality.AUDIO],
+        responseModalities: ["AUDIO" as Modality],
       },
       inputAudioTranscription: {},
       outputAudioTranscription: {},
@@ -403,6 +409,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private audioStreamEnded = false;
   private pendingFunctionNames = new Map<string, string>();
   private readonly audioFormat: RealtimeVoiceAudioFormat;
+  private resumptionHandle: string | undefined;
 
   constructor(private readonly config: GoogleRealtimeVoiceBridgeConfig) {
     this.audioFormat = config.audioFormat ?? REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ;
@@ -425,7 +432,17 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
     this.session = (await ai.live.connect({
       model: this.config.model ?? GOOGLE_REALTIME_DEFAULT_MODEL,
-      config: buildGoogleLiveConnectConfig(this.config),
+      config: {
+        ...buildGoogleLiveConnectConfig(this.config),
+        ...(this.config.sessionResumption === false
+          ? {}
+          : {
+              sessionResumption: this.resumptionHandle ? { handle: this.resumptionHandle } : {},
+            }),
+        ...(this.config.contextWindowCompression === false
+          ? {}
+          : { contextWindowCompression: { slidingWindow: {} } }),
+      },
       callbacks: {
         onopen: () => {
           this.connected = true;
@@ -548,7 +565,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
             : { output: result },
       };
       if (isConsultTool) {
-        functionResponse.scheduling = FunctionResponseScheduling.WHEN_IDLE;
+        functionResponse.scheduling = "WHEN_IDLE" as FunctionResponseScheduling;
         if (options?.willContinue === true) {
           functionResponse.willContinue = true;
         }
@@ -607,6 +624,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private handleMessage(message: LiveServerMessage): void {
+    this.captureSessionLifecycle(message);
     if (message.setupComplete) {
       this.handleSetupComplete();
     }
@@ -615,6 +633,20 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     }
     if (message.toolCall) {
       this.handleToolCall(message.toolCall);
+    }
+  }
+
+  private captureSessionLifecycle(message: LiveServerMessage): void {
+    const raw = message as unknown as {
+      goAway?: { timeLeft?: string };
+      sessionResumptionUpdate?: { newHandle?: string; resumable?: boolean };
+    };
+    const update = raw.sessionResumptionUpdate;
+    if (update?.resumable && update.newHandle) {
+      this.resumptionHandle = update.newHandle;
+    }
+    if (raw.goAway?.timeLeft) {
+      this.config.onError?.(new Error(`Google Live session goAway: ${raw.goAway.timeLeft}`));
     }
   }
 
@@ -784,6 +816,8 @@ export function buildGoogleRealtimeVoiceProvider(): RealtimeVoiceProviderPlugin 
         turnCoverage: config.turnCoverage,
         automaticActivityDetectionDisabled: config.automaticActivityDetectionDisabled,
         enableAffectiveDialog: config.enableAffectiveDialog,
+        sessionResumption: config.sessionResumption,
+        contextWindowCompression: config.contextWindowCompression,
         thinkingLevel: config.thinkingLevel,
         thinkingBudget: config.thinkingBudget,
       });

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -50,6 +50,11 @@ const MAX_PENDING_AUDIO_CHUNKS = 320;
 const DEFAULT_AUDIO_STREAM_END_SILENCE_MS = 500;
 const GOOGLE_REALTIME_BROWSER_SESSION_TTL_MS = 30 * 60 * 1000;
 const GOOGLE_REALTIME_BROWSER_NEW_SESSION_TTL_MS = 60 * 1000;
+const MULAW_LINEAR_SAMPLES = new Int16Array(256);
+
+for (let i = 0; i < MULAW_LINEAR_SAMPLES.length; i += 1) {
+  MULAW_LINEAR_SAMPLES[i] = decodeMulawSample(i);
+}
 
 type GoogleRealtimeSensitivity = "low" | "high";
 type GoogleRealtimeThinkingLevel = "minimal" | "low" | "medium" | "high";
@@ -330,6 +335,8 @@ function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): Func
 
 function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveConnectConfig {
   const functionDeclarations = buildFunctionDeclarations(config.tools);
+  const realtimeInputConfig = buildRealtimeInputConfig(config);
+  const thinkingConfig = buildThinkingConfig(config);
   return {
     responseModalities: ["AUDIO" as Modality],
     ...(typeof config.temperature === "number" && config.temperature > 0
@@ -344,15 +351,13 @@ function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveCon
     },
     systemInstruction: config.instructions,
     ...(functionDeclarations.length > 0 ? { tools: [{ functionDeclarations }] } : {}),
-    ...(buildRealtimeInputConfig(config)
-      ? { realtimeInputConfig: buildRealtimeInputConfig(config) }
-      : {}),
+    ...(realtimeInputConfig ? { realtimeInputConfig } : {}),
     inputAudioTranscription: {},
     outputAudioTranscription: {},
     ...(typeof config.enableAffectiveDialog === "boolean"
       ? { enableAffectiveDialog: config.enableAffectiveDialog }
       : {}),
-    ...(buildThinkingConfig(config) ? { thinkingConfig: buildThinkingConfig(config) } : {}),
+    ...(thinkingConfig ? { thinkingConfig } : {}),
   };
 }
 
@@ -487,12 +492,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       this.audioStreamEnded = false;
     }
 
-    const pcm = this.toInputPcm(audio);
-    const pcm16k = resamplePcm(
-      pcm,
-      this.audioFormat.sampleRateHz,
-      GOOGLE_REALTIME_INPUT_SAMPLE_RATE,
-    );
+    const pcm16k = this.toGoogleInputPcm16k(audio);
     this.session.sendRealtimeInput({
       audio: {
         data: pcm16k.toString("base64"),
@@ -617,6 +617,21 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     return this.audioFormat.encoding === "pcm16" ? audio : mulawToPcm(audio);
   }
 
+  private toGoogleInputPcm16k(audio: Buffer): Buffer {
+    if (
+      this.audioFormat.encoding === "g711_ulaw" &&
+      this.audioFormat.sampleRateHz === 8_000 &&
+      GOOGLE_REALTIME_INPUT_SAMPLE_RATE === 16_000
+    ) {
+      return convertMulaw8kToPcm16k(audio);
+    }
+    return resamplePcm(
+      this.toInputPcm(audio),
+      this.audioFormat.sampleRateHz,
+      GOOGLE_REALTIME_INPUT_SAMPLE_RATE,
+    );
+  }
+
   private toOutputAudio(pcm: Buffer, sampleRate: number): Buffer {
     return this.audioFormat.encoding === "pcm16"
       ? resamplePcm(pcm, sampleRate, this.audioFormat.sampleRateHz)
@@ -724,6 +739,30 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       });
     }
   }
+}
+
+function convertMulaw8kToPcm16k(muLaw: Buffer): Buffer {
+  if (muLaw.length === 0) {
+    return Buffer.alloc(0);
+  }
+  const pcm = Buffer.alloc(muLaw.length * 4);
+  for (let i = 0; i < muLaw.length; i += 1) {
+    const current = MULAW_LINEAR_SAMPLES[muLaw[i] ?? 0] ?? 0;
+    const next = MULAW_LINEAR_SAMPLES[muLaw[i + 1] ?? muLaw[i] ?? 0] ?? current;
+    pcm.writeInt16LE(current, i * 4);
+    pcm.writeInt16LE(Math.round((current + next) / 2), i * 4 + 2);
+  }
+  return pcm;
+}
+
+function decodeMulawSample(value: number): number {
+  const muLaw = ~value & 0xff;
+  const sign = muLaw & 0x80;
+  const exponent = (muLaw >> 4) & 0x07;
+  const mantissa = muLaw & 0x0f;
+  let sample = ((mantissa << 3) + 132) << exponent;
+  sample -= 132;
+  return sign ? -sample : sample;
 }
 
 async function createGoogleRealtimeBrowserSession(

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -466,6 +466,30 @@ describe("voice-call plugin", () => {
     expect(respond.mock.calls[0]).toEqual([true, { success: true }]);
   });
 
+  it("does not fall back to one-shot TwiML speak when realtime-only speech is requested", async () => {
+    runtimeStub.config.realtime.enabled = true;
+    const { methods } = setup({ provider: "mock" });
+    const handler = methods.get("voicecall.speak") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+    const respond = vi.fn();
+
+    await handler?.({
+      params: { allowTwimlFallback: false, callId: "call-1", message: "hello" },
+      respond,
+    });
+
+    expect(runtimeStub.webhookServer.speakRealtime).toHaveBeenCalledWith("call-1", "hello");
+    expect(runtimeStub.manager.speak).not.toHaveBeenCalled();
+    expect(respond.mock.calls[0]).toEqual([
+      true,
+      { success: false, error: "No active realtime bridge for call" },
+    ]);
+  });
+
   it("reports ended call history when speaking to a stale call", async () => {
     runtimeStub.manager.getCall = vi.fn(() => undefined);
     runtimeStub.manager.getCallByProviderCallId = vi.fn(() => undefined);

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -29,6 +29,7 @@ const callGatewayFromCliMock = vi.fn();
 
 type Registered = {
   methods: Map<string, unknown>;
+  methodScopes: Map<string, string | undefined>;
   tools: unknown[];
   service?: Parameters<OpenClawPluginApi["registerService"]>[0];
 };
@@ -108,6 +109,7 @@ function createServiceContext(): Parameters<NonNullable<Registered["service"]>["
 
 function setup(config: Record<string, unknown>): Registered {
   const methods = new Map<string, unknown>();
+  const methodScopes = new Map<string, string | undefined>();
   const tools: unknown[] = [];
   let service: Registered["service"];
   const api = createTestPluginApi({
@@ -120,7 +122,10 @@ function setup(config: Record<string, unknown>): Registered {
     pluginConfig: config,
     runtime: { tts: { textToSpeechTelephony: vi.fn() } } as unknown as OpenClawPluginApi["runtime"],
     logger: noopLogger,
-    registerGatewayMethod: (method: string, handler: unknown) => methods.set(method, handler),
+    registerGatewayMethod: (method: string, handler: unknown, opts?: { scope?: string }) => {
+      methods.set(method, handler);
+      methodScopes.set(method, opts?.scope);
+    },
     registerTool: (tool: unknown) => tools.push(tool),
     registerCli: () => {},
     registerService: (registeredService) => {
@@ -129,7 +134,7 @@ function setup(config: Record<string, unknown>): Registered {
     resolvePath: (p: string) => p,
   });
   plugin.register(api);
-  return { methods, tools, service };
+  return { methods, methodScopes, tools, service };
 }
 
 function envRef(id: string) {
@@ -361,6 +366,24 @@ describe("voice-call plugin", () => {
     const [ok, payload] = respond.mock.calls[0];
     expect(ok).toBe(true);
     expect(payload.callId).toBe("call-1");
+  });
+
+  it("registers voice call gateway methods with least-privilege scopes", () => {
+    const { methodScopes } = setup({ provider: "mock" });
+
+    for (const method of [
+      "voicecall.initiate",
+      "voicecall.start",
+      "voicecall.continue",
+      "voicecall.continue.start",
+      "voicecall.speak",
+      "voicecall.dtmf",
+      "voicecall.end",
+    ]) {
+      expect(methodScopes.get(method)).toBe("operator.write");
+    }
+    expect(methodScopes.get("voicecall.continue.result")).toBe("operator.read");
+    expect(methodScopes.get("voicecall.status")).toBe("operator.read");
   });
 
   it("preserves mode on legacy voicecall.start", async () => {

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -589,9 +589,9 @@ export default definePluginEntry({
             respondError(respond, "to required", ErrorCodes.INVALID_REQUEST);
             return;
           }
-          const rt = await ensureRuntime();
           const mode =
             params?.mode === "notify" || params?.mode === "conversation" ? params.mode : undefined;
+          const rt = await ensureRuntime();
           await initiateCallAndRespond({
             rt,
             respond,

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -22,6 +22,9 @@ import {
 import type { CoreConfig } from "./src/core-bridge.js";
 import { createVoiceCallContinueOperationStore } from "./src/gateway-continue-operation.js";
 
+const VOICE_CALL_WRITE_METHOD_SCOPE = { scope: "operator.write" as const };
+const VOICE_CALL_READ_METHOD_SCOPE = { scope: "operator.read" as const };
+
 const voiceCallConfigSchema = {
   parse(value: unknown): VoiceCallConfig {
     const normalized = normalizeVoiceCallLegacyConfigInput(value);
@@ -415,6 +418,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -432,6 +436,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -452,6 +457,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -473,6 +479,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_READ_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -508,6 +515,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -531,6 +539,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -553,6 +562,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -576,6 +586,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_READ_METHOD_SCOPE,
     );
 
     api.registerGatewayMethod(
@@ -604,6 +615,7 @@ export default definePluginEntry({
           sendError(respond, err);
         }
       },
+      VOICE_CALL_WRITE_METHOD_SCOPE,
     );
 
     api.registerTool({

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -504,6 +504,13 @@ export default definePluginEntry({
               respond(true, { success: true });
               return;
             }
+            if (params?.allowTwimlFallback === false) {
+              respond(true, {
+                success: false,
+                error: realtimeResult.error ?? "Realtime bridge is not active",
+              });
+              return;
+            }
           }
           const result = await request.rt.manager.speak(request.callId, request.message);
           if (!result.success) {

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RealtimeMulawSpeechStartDetector,
+  RealtimeTwilioAudioPacer,
+  calculateMulawRms,
+} from "./realtime-audio-pacer.js";
+
+describe("RealtimeTwilioAudioPacer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("paces realtime audio as 20ms telephony frames before marks", async () => {
+    vi.useFakeTimers();
+    const sent: unknown[] = [];
+    const pacer = new RealtimeTwilioAudioPacer({
+      streamSid: "MZ-test",
+      sendJson: (message) => {
+        sent.push(message);
+        return true;
+      },
+    });
+
+    pacer.sendAudio(Buffer.alloc(320, 0x7f));
+    pacer.sendMark("audio-1");
+
+    expect(sent).toHaveLength(1);
+    expect(
+      Buffer.from((sent[0] as { media: { payload: string } }).media.payload, "base64"),
+    ).toHaveLength(160);
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sent).toHaveLength(2);
+    expect(
+      Buffer.from((sent[1] as { media: { payload: string } }).media.payload, "base64"),
+    ).toHaveLength(160);
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(sent[2]).toEqual({
+      event: "mark",
+      streamSid: "MZ-test",
+      mark: { name: "audio-1" },
+    });
+  });
+
+  it("clears queued audio immediately", async () => {
+    vi.useFakeTimers();
+    const sent: unknown[] = [];
+    const pacer = new RealtimeTwilioAudioPacer({
+      streamSid: "MZ-test",
+      sendJson: (message) => {
+        sent.push(message);
+        return true;
+      },
+    });
+
+    pacer.sendAudio(Buffer.alloc(480, 0x7f));
+    pacer.clearAudio();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(sent).toHaveLength(2);
+    expect(sent[1]).toEqual({ event: "clear", streamSid: "MZ-test" });
+  });
+});
+
+describe("RealtimeMulawSpeechStartDetector", () => {
+  it("detects a speech start after consecutive loud chunks and resets after quiet", () => {
+    const detector = new RealtimeMulawSpeechStartDetector({
+      requiredLoudChunks: 2,
+      requiredQuietChunks: 2,
+      rmsThreshold: 0.02,
+    });
+    const silence = Buffer.alloc(160, 0xff);
+    const speech = Buffer.alloc(160, 0x00);
+
+    expect(calculateMulawRms(silence)).toBeLessThan(0.02);
+    expect(calculateMulawRms(speech)).toBeGreaterThan(0.02);
+    expect(detector.accept(speech)).toBe(false);
+    expect(detector.accept(speech)).toBe(true);
+    expect(detector.accept(speech)).toBe(false);
+    expect(detector.accept(silence)).toBe(false);
+    expect(detector.accept(silence)).toBe(false);
+    expect(detector.accept(speech)).toBe(false);
+    expect(detector.accept(speech)).toBe(true);
+  });
+});

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -1,0 +1,176 @@
+import { mulawToPcm } from "openclaw/plugin-sdk/realtime-voice";
+
+const TELEPHONY_SAMPLE_RATE = 8_000;
+const TELEPHONY_CHUNK_BYTES = 160;
+const TELEPHONY_CHUNK_MS = 20;
+const DEFAULT_SPEECH_RMS_THRESHOLD = 0.02;
+const DEFAULT_REQUIRED_LOUD_CHUNKS = 2;
+const DEFAULT_REQUIRED_QUIET_CHUNKS = 10;
+
+type RealtimeTwilioAudioQueueItem =
+  | {
+      chunk: Buffer;
+      durationMs: number;
+      type: "audio";
+    }
+  | {
+      name: string;
+      type: "mark";
+    };
+
+export type RealtimeTwilioAudioPacerSendJson = (message: unknown) => boolean;
+
+export class RealtimeTwilioAudioPacer {
+  private queue: RealtimeTwilioAudioQueueItem[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly params: {
+      sendJson: RealtimeTwilioAudioPacerSendJson;
+      streamSid: string;
+    },
+  ) {}
+
+  sendAudio(muLaw: Buffer): void {
+    if (this.closed || muLaw.length === 0) {
+      return;
+    }
+    for (let offset = 0; offset < muLaw.length; offset += TELEPHONY_CHUNK_BYTES) {
+      const chunk = Buffer.from(muLaw.subarray(offset, offset + TELEPHONY_CHUNK_BYTES));
+      this.queue.push({
+        type: "audio",
+        chunk,
+        durationMs: Math.max(1, Math.round((chunk.length / TELEPHONY_SAMPLE_RATE) * 1000)),
+      });
+    }
+    this.ensurePump();
+  }
+
+  sendMark(name: string): void {
+    if (this.closed || !name) {
+      return;
+    }
+    this.queue.push({ type: "mark", name });
+    this.ensurePump();
+  }
+
+  clearAudio(): void {
+    if (this.closed) {
+      return;
+    }
+    this.clearTimer();
+    this.queue = [];
+    this.params.sendJson({ event: "clear", streamSid: this.params.streamSid });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.clearTimer();
+    this.queue = [];
+  }
+
+  private clearTimer(): void {
+    if (!this.timer) {
+      return;
+    }
+    clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private ensurePump(): void {
+    if (!this.timer) {
+      this.pump();
+    }
+  }
+
+  private pump(): void {
+    this.timer = null;
+    if (this.closed) {
+      return;
+    }
+    const item = this.queue.shift();
+    if (!item) {
+      return;
+    }
+
+    let delayMs = 0;
+    let sent = true;
+    if (item.type === "audio") {
+      sent = this.params.sendJson({
+        event: "media",
+        streamSid: this.params.streamSid,
+        media: { payload: item.chunk.toString("base64") },
+      });
+      delayMs = item.durationMs || TELEPHONY_CHUNK_MS;
+    } else {
+      sent = this.params.sendJson({
+        event: "mark",
+        streamSid: this.params.streamSid,
+        mark: { name: item.name },
+      });
+    }
+
+    if (!sent) {
+      this.queue = [];
+      return;
+    }
+    if (this.queue.length > 0) {
+      this.timer = setTimeout(() => this.pump(), delayMs);
+    }
+  }
+}
+
+export function calculateMulawRms(muLaw: Buffer): number {
+  if (muLaw.length === 0) {
+    return 0;
+  }
+  const pcm = mulawToPcm(muLaw);
+  const samples = Math.floor(pcm.length / 2);
+  if (samples === 0) {
+    return 0;
+  }
+  let sum = 0;
+  for (let i = 0; i < samples; i += 1) {
+    const normalized = pcm.readInt16LE(i * 2) / 32768;
+    sum += normalized * normalized;
+  }
+  return Math.sqrt(sum / samples);
+}
+
+export class RealtimeMulawSpeechStartDetector {
+  private loudChunks = 0;
+  private quietChunks = DEFAULT_REQUIRED_QUIET_CHUNKS;
+  private speaking = false;
+
+  constructor(
+    private readonly params: {
+      requiredLoudChunks?: number;
+      requiredQuietChunks?: number;
+      rmsThreshold?: number;
+    } = {},
+  ) {}
+
+  accept(muLaw: Buffer): boolean {
+    const rms = calculateMulawRms(muLaw);
+    const threshold = this.params.rmsThreshold ?? DEFAULT_SPEECH_RMS_THRESHOLD;
+    if (rms >= threshold) {
+      this.quietChunks = 0;
+      this.loudChunks += 1;
+      const requiredLoudChunks = this.params.requiredLoudChunks ?? DEFAULT_REQUIRED_LOUD_CHUNKS;
+      if (!this.speaking && this.loudChunks >= requiredLoudChunks) {
+        this.speaking = true;
+        return true;
+      }
+      return false;
+    }
+
+    this.loudChunks = 0;
+    this.quietChunks += 1;
+    const requiredQuietChunks = this.params.requiredQuietChunks ?? DEFAULT_REQUIRED_QUIET_CHUNKS;
+    if (this.quietChunks >= requiredQuietChunks) {
+      this.speaking = false;
+    }
+    return false;
+  }
+}

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -1,11 +1,15 @@
-import { mulawToPcm } from "openclaw/plugin-sdk/realtime-voice";
-
 const TELEPHONY_SAMPLE_RATE = 8_000;
 const TELEPHONY_CHUNK_BYTES = 160;
 const TELEPHONY_CHUNK_MS = 20;
 const DEFAULT_SPEECH_RMS_THRESHOLD = 0.02;
 const DEFAULT_REQUIRED_LOUD_CHUNKS = 2;
 const DEFAULT_REQUIRED_QUIET_CHUNKS = 10;
+const PCM16_MAX_AMPLITUDE = 32768;
+const MULAW_LINEAR_SAMPLES = new Int16Array(256);
+
+for (let i = 0; i < MULAW_LINEAR_SAMPLES.length; i += 1) {
+  MULAW_LINEAR_SAMPLES[i] = decodeMulawSample(i);
+}
 
 type RealtimeTwilioAudioQueueItem =
   | {
@@ -125,17 +129,12 @@ export function calculateMulawRms(muLaw: Buffer): number {
   if (muLaw.length === 0) {
     return 0;
   }
-  const pcm = mulawToPcm(muLaw);
-  const samples = Math.floor(pcm.length / 2);
-  if (samples === 0) {
-    return 0;
-  }
   let sum = 0;
-  for (let i = 0; i < samples; i += 1) {
-    const normalized = pcm.readInt16LE(i * 2) / 32768;
+  for (let i = 0; i < muLaw.length; i += 1) {
+    const normalized = (MULAW_LINEAR_SAMPLES[muLaw[i] ?? 0] ?? 0) / PCM16_MAX_AMPLITUDE;
     sum += normalized * normalized;
   }
-  return Math.sqrt(sum / samples);
+  return Math.sqrt(sum / muLaw.length);
 }
 
 export class RealtimeMulawSpeechStartDetector {
@@ -173,4 +172,14 @@ export class RealtimeMulawSpeechStartDetector {
     }
     return false;
   }
+}
+
+function decodeMulawSample(value: number): number {
+  const muLaw = ~value & 0xff;
+  const sign = muLaw & 0x80;
+  const exponent = (muLaw >> 4) & 0x07;
+  const mantissa = muLaw & 0x0f;
+  let sample = ((mantissa << 3) + 132) << exponent;
+  sample -= 132;
+  return sign ? -sample : sample;
 }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -16,6 +16,10 @@ import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
+import {
+  RealtimeMulawSpeechStartDetector,
+  RealtimeTwilioAudioPacer,
+} from "./realtime-audio-pacer.js";
 
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
@@ -29,6 +33,7 @@ export type ToolHandlerFn = (
 const STREAM_TOKEN_TTL_MS = 30_000;
 const DEFAULT_HOST = "localhost:8443";
 const MAX_REALTIME_MESSAGE_BYTES = 256 * 1024;
+const MAX_REALTIME_WS_BUFFERED_BYTES = 1024 * 1024;
 
 function normalizePath(pathname: string): string {
   const trimmed = pathname.trim();
@@ -179,7 +184,8 @@ export class RealtimeCallHandler {
               ? (msg.media as Record<string, unknown>)
               : undefined;
           if (msg.event === "media" && typeof mediaData?.payload === "string") {
-            bridge.sendAudio(Buffer.from(mediaData.payload, "base64"));
+            const audio = Buffer.from(mediaData.payload, "base64");
+            bridge.sendAudio(audio);
             if (typeof mediaData.timestamp === "number") {
               bridge.setMediaTimestamp(mediaData.timestamp);
             } else if (typeof mediaData.timestamp === "string") {
@@ -278,7 +284,24 @@ export class RealtimeCallHandler {
       this.endCallInManager(callSid, callId, reason);
     };
 
-    const bridge = createRealtimeVoiceBridgeSession({
+    const sendJson = (message: unknown): boolean => {
+      if (ws.readyState !== WebSocket.OPEN) {
+        return false;
+      }
+      if (ws.bufferedAmount > MAX_REALTIME_WS_BUFFERED_BYTES) {
+        ws.close(1013, "Backpressure: send buffer exceeded");
+        return false;
+      }
+      ws.send(JSON.stringify(message));
+      if (ws.bufferedAmount > MAX_REALTIME_WS_BUFFERED_BYTES) {
+        ws.close(1013, "Backpressure: send buffer exceeded");
+        return false;
+      }
+      return true;
+    };
+    const audioPacer = new RealtimeTwilioAudioPacer({ streamSid, sendJson });
+    const speechDetector = new RealtimeMulawSpeechStartDetector();
+    const session = createRealtimeVoiceBridgeSession({
       provider: this.realtimeProvider,
       providerConfig: this.providerConfig,
       instructions: this.config.instructions,
@@ -288,19 +311,13 @@ export class RealtimeCallHandler {
       audioSink: {
         isOpen: () => ws.readyState === WebSocket.OPEN,
         sendAudio: (muLaw) => {
-          ws.send(
-            JSON.stringify({
-              event: "media",
-              streamSid,
-              media: { payload: muLaw.toString("base64") },
-            }),
-          );
+          audioPacer.sendAudio(muLaw);
         },
         clearAudio: () => {
-          ws.send(JSON.stringify({ event: "clear", streamSid }));
+          audioPacer.clearAudio();
         },
         sendMark: (markName) => {
-          ws.send(JSON.stringify({ event: "mark", streamSid, mark: { name: markName } }));
+          audioPacer.sendMark(markName);
         },
       },
       onTranscript: (role, text, isFinal) => {
@@ -367,24 +384,32 @@ export class RealtimeCallHandler {
           });
       },
     });
-    this.activeBridgesByCallId.set(callId, bridge);
-    this.activeBridgesByCallId.set(callSid, bridge);
-    const closeBridge = bridge.close.bind(bridge);
-    bridge.close = () => {
+    this.activeBridgesByCallId.set(callId, session);
+    this.activeBridgesByCallId.set(callSid, session);
+    const sendAudioToSession = session.sendAudio.bind(session);
+    session.sendAudio = (audio) => {
+      if (speechDetector.accept(audio)) {
+        audioPacer.clearAudio();
+      }
+      sendAudioToSession(audio);
+    };
+    const closeSession = session.close.bind(session);
+    session.close = () => {
       this.activeBridgesByCallId.delete(callId);
       this.activeBridgesByCallId.delete(callSid);
       this.partialUserTranscriptsByCallId.delete(callId);
-      closeBridge();
+      audioPacer.close();
+      closeSession();
     };
 
-    bridge.connect().catch((error: Error) => {
+    session.connect().catch((error: Error) => {
       console.error("[voice-call] Failed to connect realtime bridge:", error);
-      bridge.close();
+      session.close();
       emitCallEnd("error");
       ws.close(1011, "Failed to connect");
     });
 
-    return bridge;
+    return session;
   }
 
   private registerCallInManager(


### PR DESCRIPTION
## What bug / behavior this fixes

Google Meet joins over Twilio were noticeably laggier than the Paradigm-style Gemini Live path. The main gaps were outbound model audio being dumped into Twilio faster than telephony playback, barge-in waiting on provider interruption instead of clearing local queued audio immediately, and Gemini Live sessions not using the newer resumption/compression controls by default.

## What changed

- Pace outbound Twilio realtime audio as 20 ms G.711 frames and send marks only after queued audio has been flushed.
- Add a lightweight inbound mu-law speech-start detector so caller barge-in clears the local Twilio playback queue immediately before forwarding audio to the realtime provider.
- Default Google Gemini Live calls to faster silence endpointing, session resumption, and sliding-window context compression, with opt-out config covered by tests.
- Preserve `voicecall.start` conversation mode for GMeet dial-in flows.
- Update Google Meet and Voice Call docs with the plugin allow/config shape and Gemini realtime tuning knobs.

## Evidence

- `pnpm test extensions/google/realtime-voice-provider.test.ts`
- `pnpm test extensions/voice-call/src/webhook/realtime-audio-pacer.test.ts extensions/voice-call/src/webhook/realtime-handler.test.ts extensions/voice-call/index.test.ts`
- `pnpm check:changed` reached extension typecheck and extension test typecheck successfully, then failed in `lint:extensions` on an unrelated existing lint finding in `extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts:105`; that file is not in this branch diff versus `origin/main`.

## Notes

- I did not run a live Twilio/Google Meet smoke because no live dial-in target/PIN was provided in this thread.
