### PR TITLE
fix: update broken tweakcn themes URL to /editor/theme

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -87,7 +87,7 @@ Docs translations are generated for the same non-English locale set, but the doc
 
 ## Appearance themes
 
-The Appearance panel keeps the built-in Claw, Knot, and Dash themes, plus one browser-local tweakcn import slot. To import a theme, open [tweakcn themes](https://tweakcn.com/themes), choose or create a theme, click **Share**, and paste the copied theme link into Appearance. The importer also accepts `https://tweakcn.com/r/themes/<id>` registry URLs, editor URLs like `https://tweakcn.com/editor/theme?theme=amethyst-haze`, relative `/themes/<id>` paths, raw theme IDs, and default theme names such as `amethyst-haze`.
+The Appearance panel keeps the built-in Claw, Knot, and Dash themes, plus one browser-local tweakcn import slot. To import a theme, open [tweakcn themes](https://tweakcn.com/editor/theme), choose or create a theme, click **Share**, and paste the copied theme link into Appearance. The importer also accepts `https://tweakcn.com/r/themes/<id>` registry URLs, editor URLs like `https://tweakcn.com/editor/theme?theme=amethyst-haze`, relative `/themes/<id>` paths, raw theme IDs, and default theme names such as `amethyst-haze`.
 
 Imported themes are stored only in the current browser profile. They are not written to gateway config and do not sync across devices. Replacing the imported theme updates the one local slot; clearing it switches the active theme back to Claw if the imported theme was selected.
 

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -983,7 +983,7 @@ function renderAppearanceSection(props: ConfigProps) {
                 </div>
                 <a
                   class="settings-theme-import__external"
-                  href="https://tweakcn.com/themes"
+                  href="https://tweakcn.com/editor/theme"
                   target="_blank"
                   rel="noreferrer noopener"
                 >


### PR DESCRIPTION
The "Browse tweakcn themes" link in Appearance settings and the corresponding docs reference point to `https://tweakcn.com/themes`, which now returns a 404.

tweakcn restructured their routing — the theme browsing/discovery page moved to `/editor/theme`. Individual theme share URLs (`/themes/<id>`) still work; only the bare `/themes` path (no ID) is broken.

**Changes:**
- `ui/src/ui/views/config.ts`: update the external link href from `https://tweakcn.com/themes` to `https://tweakcn.com/editor/theme`
- `docs/web/control-ui.md`: update the inline markdown link to match

**Verification:**
- `curl -s -o /dev/null -w "%{http_code}" https://tweakcn.com/editor/theme` returns 200
- `curl -s -o /dev/null -w "%{http_code}" https://tweakcn.com/themes` returns 404

Closes #77048
