### PR TITLE
fix(web-search): keep first-class web_search runtime providers visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/session status: keep semantic `session_status({ sessionKey: "current" })` on the live run session even before that run has a persisted session-store entry, instead of falling back to the sandbox policy key. Thanks @vincentkoc.
 - Codex: pass the live run session key into app-server dynamic tools when sandbox policy uses a separate session key, so `session_status({ sessionKey: "current" })` reports the active run instead of the sandbox policy key. Thanks @vincentkoc.
+- Web search: keep first-class assistant `web_search` auto-detect and configured runtime providers visible when active runtime metadata or the active plugin registry is incomplete. Fixes #77073.
 - Plugins/tools: mark manifest-optional sibling tools as optional even when they come from a shared non-optional factory, so cached/status/MCP metadata keeps opt-in tool policy accurate. Thanks @vincentkoc.
 - Matrix: keep `streaming.progress.toolProgress` scoped to progress draft mode, so partial and quiet Matrix previews do not lose tool progress unless `streaming.preview.toolProgress` is disabled. Thanks @vincentkoc.
 - Channels/streaming: keep `streaming.progress.toolProgress` scoped to progress draft mode, so disabling compact progress lines does not silence partial/block preview tool updates. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/session status: keep semantic `session_status({ sessionKey: "current" })` on the live run session even before that run has a persisted session-store entry, instead of falling back to the sandbox policy key. Thanks @vincentkoc.
 - Codex: pass the live run session key into app-server dynamic tools when sandbox policy uses a separate session key, so `session_status({ sessionKey: "current" })` reports the active run instead of the sandbox policy key. Thanks @vincentkoc.
-- Web search: keep first-class assistant `web_search` auto-detect and configured runtime providers visible when active runtime metadata or the active plugin registry is incomplete. Fixes #77073.
+- Web search: keep first-class assistant `web_search` auto-detect and configured runtime providers visible when active runtime metadata or the active plugin registry is incomplete. Fixes #77073. Thanks @joeykrug.
 - Plugins/tools: mark manifest-optional sibling tools as optional even when they come from a shared non-optional factory, so cached/status/MCP metadata keeps opt-in tool policy accurate. Thanks @vincentkoc.
 - Matrix: keep `streaming.progress.toolProgress` scoped to progress draft mode, so partial and quiet Matrix previews do not lose tool progress unless `streaming.preview.toolProgress` is disabled. Thanks @vincentkoc.
 - Channels/streaming: keep `streaming.progress.toolProgress` scoped to progress draft mode, so disabling compact progress lines does not silence partial/block preview tool updates. Thanks @vincentkoc.

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -47,7 +47,7 @@ describe("web_search late-bound runtime fallback", () => {
       runtimeWebSearch: {
         selectedProvider: "brave",
         providerConfigured: "brave",
-        providerSource: "plugin",
+        providerSource: "configured",
         diagnostics: [],
       },
     });
@@ -100,7 +100,7 @@ describe("web_search late-bound runtime fallback", () => {
     );
   });
 
-  it("does not prefer runtime providers when no provider id is selected anywhere", async () => {
+  it("keeps runtime provider discovery enabled when no provider id is selected anywhere", async () => {
     const { createWebSearchTool } = await import("./web-search.js");
     const tool = createWebSearchTool({
       config: {},
@@ -111,7 +111,7 @@ describe("web_search late-bound runtime fallback", () => {
 
     expect(mocks.resolveManifestContractOwnerPluginId).not.toHaveBeenCalled();
     expect(mocks.runWebSearch).toHaveBeenCalledWith(
-      expect.objectContaining({ preferRuntimeProviders: false }),
+      expect.objectContaining({ preferRuntimeProviders: true }),
     );
   });
 
@@ -138,7 +138,7 @@ describe("web_search late-bound runtime fallback", () => {
       search: {
         selectedProvider: "perplexity",
         providerConfigured: "perplexity",
-        providerSource: "plugin",
+        providerSource: "configured",
         diagnostics: [],
       },
     });
@@ -149,7 +149,7 @@ describe("web_search late-bound runtime fallback", () => {
       runtimeWebSearch: {
         selectedProvider: "brave",
         providerConfigured: "brave",
-        providerSource: "plugin",
+        providerSource: "configured",
         diagnostics: [],
       },
     });

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runWebSearch: vi.fn(),
+  resolveManifestContractOwnerPluginId: vi.fn(),
+  getActiveRuntimeWebToolsMetadata: vi.fn(),
+  getActiveSecretsRuntimeSnapshot: vi.fn(),
+}));
+
+vi.mock("../../web-search/runtime.js", () => ({
+  resolveWebSearchProviderId: vi.fn(() => "mock"),
+  runWebSearch: mocks.runWebSearch,
+}));
+
+vi.mock("../../plugins/plugin-registry.js", () => ({
+  resolveManifestContractOwnerPluginId: mocks.resolveManifestContractOwnerPluginId,
+}));
+
+vi.mock("../../secrets/runtime-web-tools-state.js", () => ({
+  getActiveRuntimeWebToolsMetadata: mocks.getActiveRuntimeWebToolsMetadata,
+}));
+
+vi.mock("../../secrets/runtime.js", () => ({
+  getActiveSecretsRuntimeSnapshot: mocks.getActiveSecretsRuntimeSnapshot,
+}));
+
+describe("web_search late-bound runtime fallback", () => {
+  beforeEach(() => {
+    mocks.runWebSearch.mockReset();
+    mocks.runWebSearch.mockResolvedValue({
+      provider: "brave",
+      result: { ok: true },
+    });
+    mocks.resolveManifestContractOwnerPluginId.mockReset();
+    mocks.resolveManifestContractOwnerPluginId.mockReturnValue(undefined);
+    mocks.getActiveRuntimeWebToolsMetadata.mockReset();
+    mocks.getActiveRuntimeWebToolsMetadata.mockReturnValue(null);
+    mocks.getActiveSecretsRuntimeSnapshot.mockReset();
+    mocks.getActiveSecretsRuntimeSnapshot.mockReturnValue(null);
+  });
+
+  it("falls back to options.runtimeWebSearch when active runtime web tools metadata is absent", async () => {
+    const { createWebSearchTool } = await import("./web-search.js");
+    const tool = createWebSearchTool({
+      config: {},
+      lateBindRuntimeConfig: true,
+      runtimeWebSearch: {
+        selectedProvider: "brave",
+        providerConfigured: "brave",
+        providerSource: "plugin",
+        diagnostics: [],
+      },
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeWebSearch: expect.objectContaining({ selectedProvider: "brave" }),
+      }),
+    );
+  });
+
+  it("falls back to options.config when getActiveSecretsRuntimeSnapshot is null", async () => {
+    const { createWebSearchTool } = await import("./web-search.js");
+    const fallbackConfig = {
+      tools: { web: { search: { provider: "brave" } } },
+    };
+    const tool = createWebSearchTool({
+      config: fallbackConfig,
+      lateBindRuntimeConfig: true,
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: fallbackConfig,
+      }),
+    );
+  });
+
+  it("uses configured provider id from config when no runtime selection is present", async () => {
+    const { createWebSearchTool } = await import("./web-search.js");
+    const config = {
+      tools: { web: { search: { provider: "Brave" } } },
+    };
+    const tool = createWebSearchTool({
+      config,
+      lateBindRuntimeConfig: true,
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.resolveManifestContractOwnerPluginId).toHaveBeenCalledWith(
+      expect.objectContaining({ value: "brave" }),
+    );
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ preferRuntimeProviders: true }),
+    );
+  });
+
+  it("does not prefer runtime providers when no provider id is selected anywhere", async () => {
+    const { createWebSearchTool } = await import("./web-search.js");
+    const tool = createWebSearchTool({
+      config: {},
+      lateBindRuntimeConfig: true,
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.resolveManifestContractOwnerPluginId).not.toHaveBeenCalled();
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ preferRuntimeProviders: false }),
+    );
+  });
+
+  it("does not prefer runtime providers when the configured provider is a bundled manifest owner", async () => {
+    mocks.resolveManifestContractOwnerPluginId.mockReturnValue("openclaw-bundled-brave");
+    const { createWebSearchTool } = await import("./web-search.js");
+    const config = {
+      tools: { web: { search: { provider: "brave" } } },
+    };
+    const tool = createWebSearchTool({
+      config,
+      lateBindRuntimeConfig: true,
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ preferRuntimeProviders: false }),
+    );
+  });
+
+  it("prefers active runtime metadata over options.runtimeWebSearch when present", async () => {
+    mocks.getActiveRuntimeWebToolsMetadata.mockReturnValue({
+      search: {
+        selectedProvider: "perplexity",
+        providerConfigured: "perplexity",
+        providerSource: "plugin",
+        diagnostics: [],
+      },
+    });
+    const { createWebSearchTool } = await import("./web-search.js");
+    const tool = createWebSearchTool({
+      config: {},
+      lateBindRuntimeConfig: true,
+      runtimeWebSearch: {
+        selectedProvider: "brave",
+        providerConfigured: "brave",
+        providerSource: "plugin",
+        diagnostics: [],
+      },
+    });
+
+    await tool?.execute("call-search", { query: "openclaw" }, undefined);
+
+    expect(mocks.runWebSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeWebSearch: expect.objectContaining({ selectedProvider: "perplexity" }),
+      }),
+    );
+  });
+});

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -89,7 +89,7 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args, signal) => {
       const runtimeWebSearch =
         options?.lateBindRuntimeConfig === true
-          ? getActiveRuntimeWebToolsMetadata()?.search
+          ? (getActiveRuntimeWebToolsMetadata()?.search ?? options?.runtimeWebSearch)
           : options?.runtimeWebSearch;
       const runtimeProviderId =
         runtimeWebSearch?.selectedProvider ?? runtimeWebSearch?.providerConfigured;
@@ -97,11 +97,20 @@ export function createWebSearchTool(options?: {
         options?.lateBindRuntimeConfig === true
           ? (getActiveSecretsRuntimeSnapshot()?.config ?? options?.config)
           : options?.config;
+      // The active gateway plugin registry may omit the configured search
+      // provider; fall back to the provider id captured in config so the
+      // first-class assistant tool still resolves the right plugin instead of
+      // reporting "no provider available".
+      const configuredProviderId =
+        typeof config?.tools?.web?.search?.provider === "string"
+          ? config.tools.web.search.provider.trim().toLowerCase()
+          : "";
+      const providerSelectionId = runtimeProviderId || configuredProviderId;
       const preferRuntimeProviders =
-        !runtimeProviderId ||
+        Boolean(providerSelectionId) &&
         !resolveManifestContractOwnerPluginId({
           contract: "webSearchProviders",
-          value: runtimeProviderId,
+          value: providerSelectionId,
           origin: "bundled",
           config,
         });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -107,7 +107,7 @@ export function createWebSearchTool(options?: {
           : "";
       const providerSelectionId = runtimeProviderId || configuredProviderId;
       const preferRuntimeProviders =
-        Boolean(providerSelectionId) &&
+        !providerSelectionId ||
         !resolveManifestContractOwnerPluginId({
           contract: "webSearchProviders",
           value: providerSelectionId,

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -332,6 +332,120 @@ describe("web-provider-runtime-shared", () => {
     );
   });
 
+  it("falls back to a scoped provider load when the active runtime registry has no web providers", () => {
+    const activeRegistry = { source: "active" };
+    const fallbackRegistry = { source: "fallback" };
+    const mapRegistryProviders = vi.fn(({ registry }) =>
+      registry === fallbackRegistry ? ["brave"] : [],
+    );
+    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
+    mocks.loadOpenClawPlugins.mockReturnValue(fallbackRegistry as never);
+
+    const result = resolvePluginWebProviders(
+      {
+        config: {},
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => undefined,
+        mapRegistryProviders,
+      },
+    );
+
+    expect(result).toEqual(["brave"]);
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+    expect(mapRegistryProviders).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fall back when the active runtime registry returns empty under an explicit empty scope", () => {
+    const activeRegistry = { source: "active" };
+    const mapRegistryProviders = vi.fn(() => []);
+    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
+
+    const result = resolvePluginWebProviders(
+      {
+        config: {},
+        onlyPluginIds: [],
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => [],
+        mapRegistryProviders,
+      },
+    );
+
+    expect(result).toEqual([]);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the direct runtime registry has no web providers", () => {
+    const activeRegistry = { source: "active" };
+    const fallbackRegistry = { source: "fallback" };
+    const mapRegistryProviders = vi.fn(({ registry }) =>
+      registry === fallbackRegistry ? ["brave"] : [],
+    );
+    mocks.getLoadedRuntimePluginRegistry.mockImplementation((args: unknown) => {
+      const requiredPluginIds = (args as { requiredPluginIds?: readonly string[] })
+        ?.requiredPluginIds;
+      if (requiredPluginIds === undefined) {
+        return activeRegistry as never;
+      }
+      return undefined;
+    });
+    mocks.loadOpenClawPlugins.mockReturnValue(fallbackRegistry as never);
+
+    const result = resolveRuntimeWebProviders(
+      {
+        config: {},
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => undefined,
+        mapRegistryProviders,
+      },
+    );
+
+    expect(result).toEqual(["brave"]);
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back when direct runtime registry returns empty under an explicit empty scope", () => {
+    const activeRegistry = { source: "active" };
+    const mapRegistryProviders = vi.fn(() => []);
+    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
+
+    const result = resolveRuntimeWebProviders(
+      {
+        config: {},
+        onlyPluginIds: [],
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => [],
+        mapRegistryProviders,
+      },
+    );
+
+    expect(result).toEqual([]);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
   it("keeps explicit setup web provider cache opt-outs", () => {
     const loadedRegistry = { source: "setup" };
     const mapRegistryProviders = vi.fn(() => ["provider"]);

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -186,17 +186,26 @@ export function resolvePluginWebProviders<TEntry>(
     workspaceDir: context.workspaceDir,
     requiredPluginIds: context.loadPluginIds,
   });
+  const scopedPluginIds = context.onlyPluginIds;
+  const hasExplicitEmptyScope = scopedPluginIds !== undefined && scopedPluginIds.length === 0;
   if (compatible) {
-    return deps.mapRegistryProviders({
+    const resolved = deps.mapRegistryProviders({
       registry: compatible,
       onlyPluginIds: context.onlyPluginIds,
     });
+    if (resolved.length > 0 || hasExplicitEmptyScope) {
+      return resolved;
+    }
+    // The active gateway plugin registry may be otherwise compatible with this
+    // config while contributing zero web providers (for example when channels,
+    // memory, harnesses, and sidecars are loaded but Brave/web providers are
+    // not). Do not treat that empty active registry as authoritative: fall
+    // through to a scoped provider load below so first-class assistant tools
+    // still see the configured provider.
   }
   if (isPluginRegistryLoadInFlight(loadOptions)) {
     return [];
   }
-  const scopedPluginIds = context.onlyPluginIds;
-  const hasExplicitEmptyScope = scopedPluginIds !== undefined && scopedPluginIds.length === 0;
   if (hasExplicitEmptyScope) {
     return [];
   }
@@ -217,10 +226,15 @@ export function resolveRuntimeWebProviders<TEntry>(
     requiredPluginIds: params.onlyPluginIds,
   });
   if (runtimeRegistry) {
-    return deps.mapRegistryProviders({
+    const resolved = deps.mapRegistryProviders({
       registry: runtimeRegistry,
       onlyPluginIds: params.onlyPluginIds,
     });
+    const hasExplicitEmptyScope =
+      params.onlyPluginIds !== undefined && params.onlyPluginIds.length === 0;
+    if (resolved.length > 0 || hasExplicitEmptyScope) {
+      return resolved;
+    }
   }
   return resolvePluginWebProviders(params, deps);
 }


### PR DESCRIPTION
## Summary

Fixes #77073 — first-class assistant `web_search` reported `web_search is disabled or no provider is available` even when `openclaw capability web search` and direct runtime provider execution succeeded against the same configured Brave plugin.

Two source-only fixes:

- **`src/agents/tools/web-search.ts`** — when `lateBindRuntimeConfig: true`:
  - `runtimeWebSearch` falls back to `options?.runtimeWebSearch` when `getActiveRuntimeWebToolsMetadata()?.search` is `null` (in agent contexts that do not share the gateway in-process runtime snapshot).
  - `config` falls back to `options?.config` when `getActiveSecretsRuntimeSnapshot()` is `null`.
  - Derives `configuredProviderId` from `config.tools.web.search.provider` and uses `runtimeProviderId || configuredProviderId` to decide `preferRuntimeProviders`, so an explicit Brave/Perplexity selection still routes through runtime provider discovery when the runtime metadata is unbound.
- **`src/plugins/web-provider-runtime-shared.ts`** — when `getLoadedRuntimePluginRegistry(...)` returns a registry that maps to zero web providers, fall through to a scoped plugin load instead of treating that empty active registry as authoritative. Explicit `onlyPluginIds: []` still short-circuits to `[]` to preserve the empty-scope contract for both `resolvePluginWebProviders` and `resolveRuntimeWebProviders`.

## Why

The active gateway plugin registry is intentionally scoped to channels, memory, harnesses, and sidecars on startup. It can be otherwise compatible with the active OpenClaw config while contributing zero web-provider entries (e.g. when Brave/web providers live in a separately-loaded plugin set). Without a fall-through, the assistant's first-class `web_search` tool sees that empty active result as authoritative and reports "no provider available" — even though `openclaw capability web search` and the direct runtime path use a scoped load and find the configured provider just fine.

Late-binding compounded the problem: in agent contexts where the active-runtime/active-secrets globals are not set, the late-bound execute lambda lost both `runtimeWebSearch` and `config`, leaving `preferRuntimeProviders` unable to route to the configured plugin.

## Test plan

- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/web-provider-runtime-shared.test.ts` — 13 / 13 passed (4 new fall-through cases added).
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/web-search.late-bind.test.ts` — 6 / 6 passed (new file, covers both `??` fallbacks, configured-provider routing, no-selection guard, bundled manifest owner precedence, and active-runtime priority).
- [x] Re-ran adjacent `web-search.test.ts` and `web-search.signal.test.ts` to confirm no regression.
- [x] `pnpm exec oxfmt --check --threads=1` on the four touched files — clean.

## Notes

- Diff is source-only. No dist bundle edits, no backup files, no shell patch scripts.
- Pre-existing failures in 7 unrelated `plugins/web-provider*` test files were observed identically with and without this branch (manifest-registry mock and source-checkout-runtime fixture issues). They are not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)