### PR TITLE
fix: replace extensions with runtimeExtensions in npm package manifest

### DIFF
--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -307,4 +307,76 @@ describe("probeTelegram retry logic", () => {
 
     expect(resolveTelegramFetch).toHaveBeenCalledTimes(1);
   });
+
+  it("uses httpTimeoutMs from network config for per-request timeout", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(new Error("Request aborted"));
+          return;
+        }
+        // This never resolves - the timeout should abort it
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchMock as unknown as typeof fetch);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    vi.useFakeTimers();
+    try {
+      // Set httpTimeoutMs to 2000ms but total budget to 10000ms
+      const probePromise = probeTelegram(`${token}-httptimeout`, 10_000, {
+        network: {
+          httpTimeoutMs: 2_000,
+        },
+      });
+
+      // Fast-forward past the httpTimeoutMs of 2000ms
+      await vi.advanceTimersByTimeAsync(2_100);
+
+      const result = await probePromise;
+
+      // Should fail due to httpTimeoutMs timeout, not the full budget
+      expect(result.ok).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("respects total budget even when httpTimeoutMs is larger", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(new Error("Request aborted"));
+          return;
+        }
+        // This never resolves - the timeout should abort it
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchMock as unknown as typeof fetch);
+    resolveTelegramFetch.mockImplementation((proxyFetch?: typeof fetch) => proxyFetch ?? fetch);
+    makeProxyFetch.mockImplementation(() => fetchMock as unknown as typeof fetch);
+    vi.useFakeTimers();
+    try {
+      // Set httpTimeoutMs to 20000ms but total budget to only 500ms
+      const probePromise = probeTelegram(`${token}-smallbudget`, 500, {
+        network: {
+          httpTimeoutMs: 20_000,
+        },
+      });
+
+      // Fast-forward past the total budget of 500ms
+      await vi.advanceTimersByTimeAsync(600);
+
+      const result = await probePromise;
+
+      // Should fail due to total budget being exhausted, not httpTimeoutMs
+      expect(result.ok).toBe(false);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -154,6 +154,15 @@ export async function probeTelegram(
   const retryDelayMs = Math.max(50, Math.min(1000, Math.floor(timeoutBudgetMs / 5)));
   const resolveRemainingBudgetMs = () => Math.max(0, deadlineMs - Date.now());
 
+  // Resolve per-request HTTP timeout from network config (allows faster fail-fast on IPv6 issues)
+  const configuredHttpTimeoutMs = options?.network?.httpTimeoutMs;
+  const resolveRequestTimeoutMs = (remainingBudgetMs: number): number => {
+    if (typeof configuredHttpTimeoutMs === "number" && configuredHttpTimeoutMs > 0) {
+      return Math.max(1, Math.min(configuredHttpTimeoutMs, remainingBudgetMs));
+    }
+    return Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs));
+  };
+
   const result: TelegramProbe = {
     ok: false,
     status: null,
@@ -175,7 +184,7 @@ export async function probeTelegram(
         meRes = await fetchWithTimeout(
           `${base}/getMe`,
           {},
-          Math.max(1, Math.min(timeoutBudgetMs, remainingBudgetMs)),
+          resolveRequestTimeoutMs(remainingBudgetMs),
           fetcher,
         );
         break;
@@ -238,7 +247,7 @@ export async function probeTelegram(
           const webhookRes = await fetchWithTimeout(
             `${base}/getWebhookInfo`,
             {},
-            Math.max(1, Math.min(timeoutBudgetMs, webhookRemainingBudgetMs)),
+            resolveRequestTimeoutMs(webhookRemainingBudgetMs),
             fetcher,
           );
           const webhookJson = (await webhookRes.json()) as {

--- a/scripts/lib/plugin-npm-package-manifest.mjs
+++ b/scripts/lib/plugin-npm-package-manifest.mjs
@@ -80,6 +80,8 @@ export function resolveAugmentedPluginNpmPackageJson(params) {
     peerDependenciesMeta: plan.packagePeerMetadata.peerDependenciesMeta,
     openclaw: {
       ...plan.packageJson.openclaw,
+      // Replace extensions with compiled runtimeExtensions paths for npm publishing
+      extensions: plan.runtimeExtensions,
       runtimeExtensions: plan.runtimeExtensions,
       ...(plan.runtimeSetupEntry ? { runtimeSetupEntry: plan.runtimeSetupEntry } : {}),
     },

--- a/src/config/sessions/transcript-append.ts
+++ b/src/config/sessions/transcript-append.ts
@@ -117,7 +117,30 @@ async function migrateLinearTranscriptToParentLinked(transcriptPath: string): Pr
   leafId?: string;
 }> {
   const raw = await fs.readFile(transcriptPath, "utf-8");
-  const existingIds = new Set<string>();
+  // First pass: collect all existing IDs already in the file so we preserve them.
+  // This ensures idempotency - running migration multiple times produces the same result.
+  const seenIds = new Set<string>();
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const record = parsed as Record<string, unknown>;
+        if (record.type !== "session") {
+          const id = normalizeEntryId(record.id);
+          if (id !== undefined) {
+            seenIds.add(id);
+          }
+        }
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  const existingIds = new Set<string>(seenIds);
   const output: string[] = [];
   let previousId: string | null = null;
   let leafId: string | undefined;
@@ -141,9 +164,13 @@ async function migrateLinearTranscriptToParentLinked(transcriptPath: string): Pr
       output.push(JSON.stringify({ ...record, version: CURRENT_SESSION_VERSION }));
       continue;
     }
+    // Preserve existing valid IDs that are already in the file.
+    // Only generate new IDs for entries without valid existing IDs.
     const id = normalizeEntryId(record.id) ?? generateEntryId(existingIds);
     existingIds.add(id);
-    record.id = id;
+    if (!Object.hasOwn(record, "id") || normalizeEntryId(record.id) === undefined) {
+      record.id = id;
+    }
     if (!Object.hasOwn(record, "parentId")) {
       record.parentId = previousId;
     }

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -51,6 +51,14 @@ export type TelegramNetworkConfig = {
    */
   dnsResultOrder?: "ipv4first" | "verbatim";
   /**
+   * HTTP request timeout in milliseconds for Telegram API calls (including health probes).
+   * Lower values (e.g., 5000) cause probes to fail fast when Telegram is unreachable,
+   * preventing gateway event loop blocking. Higher values allow more time for slow
+   * responses but increase blocking duration on network issues.
+   * Default: 15000 (15 seconds).
+   */
+  httpTimeoutMs?: number;
+  /**
    * Dangerous opt-in for Telegram media downloads in trusted fake-IP or
    * transparent-proxy environments that resolve api.telegram.org to
    * private/internal/special-use addresses.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -276,6 +276,15 @@ export const TelegramAccountSchemaBase = z
       .object({
         autoSelectFamily: z.boolean().optional(),
         dnsResultOrder: z.enum(["ipv4first", "verbatim"]).optional(),
+        httpTimeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .max(60_000)
+          .optional()
+          .describe(
+            "HTTP request timeout in milliseconds for Telegram API calls (including health probes). Lower values (e.g., 5000) cause probes to fail fast when Telegram is unreachable, preventing gateway event loop blocking. Default: 15000.",
+          ),
         dangerouslyAllowPrivateNetwork: z
           .boolean()
           .optional()

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -424,6 +424,49 @@ export function clearContextEnginesForOwner(owner: string): void {
   }
 }
 
+/**
+ * A serializable snapshot of a registered context engine for cache restore.
+ */
+export type RegisteredContextEngineEntry = {
+  id: string;
+  factory: ContextEngineFactory;
+  owner: string;
+};
+
+/**
+ * List all registered context engines with their factories and owners.
+ * Used for caching and restoring plugin state.
+ */
+export function listRegisteredContextEngines(): RegisteredContextEngineEntry[] {
+  const entries: RegisteredContextEngineEntry[] = [];
+  for (const [id, entry] of getContextEngineRegistryState().engines.entries()) {
+    entries.push({ id, factory: entry.factory, owner: entry.owner });
+  }
+  return entries;
+}
+
+/**
+ * Restore previously cached context engines. Clears existing plugin-owned engines
+ * first, then re-registers all entries from the cache.
+ */
+export function restoreRegisteredContextEngines(entries: RegisteredContextEngineEntry[]): void {
+  // Clear all plugin-owned context engines first
+  const registry = getContextEngineRegistryState().engines;
+  for (const [id, entry] of registry.entries()) {
+    if (entry.owner.startsWith("plugin:")) {
+      registry.delete(id);
+    }
+  }
+  // Restore all cached entries
+  for (const { id, factory, owner } of entries) {
+    if (id === defaultSlotIdForKey("contextEngine") && owner !== CORE_CONTEXT_ENGINE_OWNER) {
+      // Skip restoring the default engine slot with a non-core owner
+      continue;
+    }
+    registry.set(id, { factory, owner });
+  }
+}
+
 function describeResolvedContextEngineContractError(
   engineId: string,
   engine: unknown,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -8,6 +8,11 @@ import {
 } from "../agents/harness/registry.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
+import {
+  listRegisteredContextEngines,
+  restoreRegisteredContextEngines,
+  type RegisteredContextEngineEntry,
+} from "../context-engine/registry.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -244,6 +249,7 @@ type CachedPluginState = {
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
   memoryEmbeddingProviders: ReturnType<typeof listRegisteredMemoryEmbeddingProviders>;
   memoryPromptSupplements: ReturnType<typeof listMemoryPromptSupplements>;
+  contextEngines: RegisteredContextEngineEntry[];
 };
 
 const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
@@ -1482,6 +1488,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         );
         restorePluginInteractiveHandlers(cached.state.interactiveHandlers ?? []);
         restoreRegisteredMemoryEmbeddingProviders(cached.state.memoryEmbeddingProviders);
+        restoreRegisteredContextEngines(cached.state.contextEngines);
         restoreMemoryPluginState({
           capability: cached.state.memoryCapability,
           corpusSupplements: cached.state.memoryCorpusSupplements,
@@ -2400,6 +2407,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           compactionProviders: listRegisteredCompactionProviders(),
           memoryEmbeddingProviders: listRegisteredMemoryEmbeddingProviders(),
           memoryPromptSupplements: listMemoryPromptSupplements(),
+          contextEngines: listRegisteredContextEngines(),
         },
         onlyPluginIds,
       );

--- a/test/plugin-npm-package-manifest.test.ts
+++ b/test/plugin-npm-package-manifest.test.ts
@@ -147,7 +147,8 @@ describe("plugin npm package manifest staging", () => {
     const originalText = readFileSync(join(packageDir, "package.json"), "utf8");
     withAugmentedPluginNpmManifestForPackage({ repoRoot: repoDir, packageDir }, () => {
       const stagedPackageJson = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
-      expect(stagedPackageJson.openclaw.extensions).toEqual(["./index.ts"]);
+      // extensions should be replaced with compiled runtimeExtensions paths for npm publishing
+      expect(stagedPackageJson.openclaw.extensions).toEqual(["./dist/index.js"]);
       expect(stagedPackageJson.openclaw.runtimeExtensions).toEqual(["./dist/index.js"]);
       expect(stagedPackageJson.openclaw.runtimeSetupEntry).toBe("./dist/setup-entry.js");
       expect(stagedPackageJson.files).toContain("dist/**");

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -14,7 +14,7 @@
     background var(--duration-fast) ease-out,
     box-shadow var(--duration-fast) ease-out;
   max-height: 120px;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .chat-tool-card--expanded {

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -2,7 +2,7 @@
 
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
-import { renderToolCard } from "./tool-cards.ts";
+import { extractToolCards, renderToolCard } from "./tool-cards.ts";
 
 vi.mock("../icons.ts", () => ({
   icons: {},
@@ -184,5 +184,46 @@ describe("tool-cards", () => {
         entryUrl: "/__openclaw__/canvas/documents/cv_sidebar/index.html",
       }),
     );
+  });
+
+  describe("extractToolCards", () => {
+    it("extracts output from inline tool_result with array content blocks", () => {
+      const message = {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            id: "call_1",
+            name: "read",
+            input: '{"path": "/test/file.txt"}',
+          },
+          {
+            type: "tool_result",
+            tool_call_id: "call_1",
+            content: [
+              { type: "text", text: "Line 1 of file" },
+              { type: "text", text: "Line 2 of file" },
+            ],
+          },
+        ],
+      };
+
+      const cards = extractToolCards(message, "msg_1");
+      expect(cards).toHaveLength(1);
+      expect(cards[0].outputText).toBe("Line 1 of file\nLine 2 of file");
+    });
+
+    it("extracts output from standalone tool message with array content blocks", () => {
+      const message = {
+        role: "tool",
+        toolName: "read",
+        content: [{ type: "text", text: "File content here" }],
+      };
+
+      const cards = extractToolCards(message, "msg_2");
+      expect(cards).toHaveLength(1);
+      expect(cards[0].name).toBe("read");
+      expect(cards[0].outputText).toBe("File content here");
+    });
   });
 });

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -48,6 +48,24 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.content === "string") {
     return item.content;
   }
+  // Handle array content blocks (modern tool result format)
+  // e.g., [{ type: "text", text: "..." }] or [{ type: "text", text: "..." }, { type: "image", ... }]
+  if (Array.isArray(item.content)) {
+    const parts: string[] = [];
+    for (const block of item.content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        parts.push((block as { text: string }).text);
+      }
+    }
+    if (parts.length > 0) {
+      return parts.join("\n");
+    }
+  }
   return undefined;
 }
 


### PR DESCRIPTION
- **fix(telegram): add httpTimeoutMs config for health probe timeout control**
- **fix: make migrateLinearTranscriptToParentLinked idempotent**
- **fix(webchat): render read tool output and fix exec output overflow**
- **fix: persist and restore registered context engines in plugin cache**
- **fix: replace extensions with runtimeExtensions in npm package manifest**
