### PR TITLE
fix(telegram): drop raw exec output from preview progress on command items (#77072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/preview: drop raw exec output from preview progress on command-kind item events and prefer the redacted command summary, so tool-heavy DM runs under `streaming.mode: "partial"` no longer flood the preview with transient bubbles full of internal command output. Fixes #77072. Thanks @EmpireCreator.
 - Plugins/loader: keep bundled plugin package `test-api.js` aliases behind private QA mode, so source transforms do not expose test-only public surfaces during normal plugin loading. Thanks @vincentkoc.
 - Gateway/startup: start cron and record the post-ready memory trace even when deferred maintenance timers fail after readiness, so a non-fatal timer setup issue does not silently leave scheduled jobs idle. Thanks @vincentkoc.
 - Agents/session status: keep semantic `session_status({ sessionKey: "current" })` on the live run session even before that run has a persisted session-store entry, instead of falling back to the sandbox policy key. Thanks @vincentkoc.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -131,6 +131,7 @@ vi.mock("./sticker-cache.js", () => ({
 let dispatchTelegramMessage: typeof import("./bot-message-dispatch.js").dispatchTelegramMessage;
 let getTelegramReplyFenceSizeForTests: typeof import("./bot-message-dispatch.js").getTelegramReplyFenceSizeForTests;
 let resetTelegramReplyFenceForTests: typeof import("./bot-message-dispatch.js").resetTelegramReplyFenceForTests;
+let sanitizeItemEventForPreviewForTests: typeof import("./bot-message-dispatch.js").sanitizeItemEventForPreviewForTests;
 
 const telegramDepsForTest: TelegramBotDeps = {
   getRuntimeConfig: loadConfig as TelegramBotDeps["getRuntimeConfig"],
@@ -165,6 +166,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       dispatchTelegramMessage,
       getTelegramReplyFenceSizeForTests,
       resetTelegramReplyFenceForTests,
+      sanitizeItemEventForPreviewForTests,
     } = await import("./bot-message-dispatch.js"));
   });
 
@@ -951,6 +953,181 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(lastPreviewText).toContain(`• \`'''''''''' [label](tg://user?id=123)\``);
     expect(renderTelegramHtmlText(lastPreviewText)).not.toContain("<a ");
+  });
+
+  describe("Telegram preview progress sanitization for command items (#77072)", () => {
+    it("drops raw progressText and uses meta for command-kind items", () => {
+      const sanitized = sanitizeItemEventForPreviewForTests({
+        kind: "command",
+        title: "command ls ~/Desktop",
+        name: "exec",
+        meta: "ls ~/Desktop",
+        progressText:
+          '/private/var/folders/abc/T/node-compile-cache/openclaw\n[context-engine] Context engine "lossless-claw" is not registered; falling back to default engine "legacy"',
+      });
+      expect(sanitized.progressText).toBeUndefined();
+      expect(sanitized.meta).toBe("ls ~/Desktop");
+      expect(sanitized.itemKind).toBe("command");
+      expect(sanitized.title).toBe("command ls ~/Desktop");
+    });
+
+    it("derives clean meta from the command title when meta is missing", () => {
+      const sanitized = sanitizeItemEventForPreviewForTests({
+        kind: "command",
+        title: "command ls ~/Desktop",
+        name: "exec",
+        progressText: "raw output",
+      });
+      expect(sanitized.progressText).toBeUndefined();
+      expect(sanitized.meta).toBe("ls ~/Desktop");
+    });
+
+    it("falls back to undefined meta when neither meta nor a parseable title is present", () => {
+      const sanitized = sanitizeItemEventForPreviewForTests({
+        kind: "command",
+        name: "exec",
+        progressText: "raw output that should never surface",
+      });
+      expect(sanitized.progressText).toBeUndefined();
+      expect(sanitized.meta).toBeUndefined();
+    });
+
+    it("passes non-command item events through unchanged", () => {
+      const sanitized = sanitizeItemEventForPreviewForTests({
+        kind: "tool",
+        title: "Tool",
+        name: "exec",
+        progressText: "exec ls ~/Desktop",
+        meta: undefined,
+      });
+      expect(sanitized.progressText).toBe("exec ls ~/Desktop");
+      expect(sanitized.itemKind).toBe("tool");
+      expect(sanitized.meta).toBeUndefined();
+    });
+
+    it("suppresses raw exec command output from the partial preview when a command item event fires", async () => {
+      const draftStream = createDraftStream();
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      const rawCommandOutput =
+        '/private/var/folders/abc/T/node-compile-cache/openclaw\n[context-engine] Context engine "lossless-claw" is not registered; falling back to default engine "legacy"';
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onItemEvent?.({
+          kind: "command",
+          title: "command ls ~/Desktop",
+          name: "exec",
+          meta: "ls ~/Desktop",
+          progressText: rawCommandOutput,
+        });
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+      const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
+      expect(lastPreviewText).not.toContain("context-engine");
+      expect(lastPreviewText).not.toContain("/private/var/folders");
+      expect(lastPreviewText).not.toContain("lossless-claw");
+    });
+
+    it("renders the redacted command summary in the partial preview for a command item event", async () => {
+      const draftStream = createDraftStream();
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onItemEvent?.({
+          kind: "command",
+          title: "command ls ~/Desktop",
+          name: "exec",
+          meta: "ls ~/Desktop",
+          progressText: "ignored raw output that should not surface",
+        });
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+      const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
+      expect(lastPreviewText).toContain("ls ~/Desktop");
+      expect(lastPreviewText).not.toContain("ignored raw output");
+    });
+
+    it("leaves non-command tool item events on the existing progressText path", async () => {
+      const draftStream = createDraftStream();
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onItemEvent?.({
+          kind: "tool",
+          title: "Tool",
+          progressText: "exec ls ~/Desktop",
+        });
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+      const lastPreviewText = draftStream.update.mock.calls.at(-1)?.[0] ?? "";
+      expect(lastPreviewText).toContain("exec ls ~/Desktop");
+    });
+
+    it("still routes the final assistant reply through unchanged when a command item event fires first", async () => {
+      const draftStream = createDraftStream();
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onItemEvent?.({
+            kind: "command",
+            title: "command ls ~/Desktop",
+            name: "exec",
+            meta: "ls ~/Desktop",
+            progressText: "raw output should not surface",
+          });
+          await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+          return { queuedFinal: true };
+        },
+      );
+      deliverReplies.mockResolvedValue({ delivered: true });
+
+      await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+      expect(deliverReplies).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replies: [expect.objectContaining({ text: "Final answer" })],
+        }),
+      );
+    });
+
+    it("keeps preview.toolProgress=false suppressing the preview entirely for command items", async () => {
+      const draftStream = createDraftStream();
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onItemEvent?.({
+          kind: "command",
+          title: "command ls ~/Desktop",
+          name: "exec",
+          meta: "ls ~/Desktop",
+          progressText: "raw output that should not surface",
+        });
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { preview: { toolProgress: false } } },
+      });
+
+      expect(draftStream.update).not.toHaveBeenCalled();
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replyOptions: expect.objectContaining({
+            suppressDefaultToolProgressMessages: true,
+          }),
+        }),
+      );
+    });
   });
 
   it("keeps block streaming enabled when account config enables it", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -244,6 +244,68 @@ function formatProgressAsMarkdownCode(text: string): string {
   return `\`${safe}\``;
 }
 
+// For preview progress lines, exec command items carry the raw command output in
+// progressText (e.g. multi-line stdout, embedded paths, log fragments) while the
+// short, redacted command summary lives in meta or, failing that, the prefixed
+// title. Forwarding progressText to formatChannelProgressDraftLine on a command
+// item makes that raw output the meta detail of the rendered line, which floods
+// Telegram DM with transient bubbles full of internal output during tool-heavy
+// work, see #77072. We keep the formatter call shape, but for command items we
+// suppress progressText and provide a clean meta fallback derived from the title
+// so the existing meta -> progressText -> summary precedence in the formatter
+// resolves to the redacted command summary instead of raw output. Other item
+// kinds keep the existing payload pass-through so structured tool/search/patch
+// progress still renders.
+export type SanitizedItemEventForTests = {
+  itemKind?: string;
+  title?: string;
+  name?: string;
+  phase?: string;
+  status?: string;
+  summary?: string;
+  progressText?: string;
+  meta?: string;
+};
+
+export function sanitizeItemEventForPreviewForTests(payload: {
+  kind?: string;
+  title?: string;
+  name?: string;
+  phase?: string;
+  status?: string;
+  summary?: string;
+  progressText?: string;
+  meta?: string;
+}): SanitizedItemEventForTests {
+  if (payload.kind === "command") {
+    const cleanCommandMeta =
+      payload.meta?.trim() || payload.title?.replace(/^\s*command\s+/i, "").trim() || undefined;
+    return {
+      itemKind: payload.kind,
+      title: payload.title,
+      name: payload.name,
+      phase: payload.phase,
+      status: payload.status,
+      summary: payload.summary,
+      // progressText intentionally dropped, it is the raw exec output on command items.
+      progressText: undefined,
+      meta: cleanCommandMeta,
+    };
+  }
+  return {
+    itemKind: payload.kind,
+    title: payload.title,
+    name: payload.name,
+    phase: payload.phase,
+    status: payload.status,
+    summary: payload.summary,
+    progressText: payload.progressText,
+    meta: payload.meta,
+  };
+}
+
+const sanitizeItemEventForPreview = sanitizeItemEventForPreviewForTests;
+
 export const dispatchTelegramMessage = async ({
   context,
   bot,
@@ -1187,17 +1249,18 @@ export const dispatchTelegramMessage = async ({
                     );
                   },
                   onItemEvent: async (payload) => {
+                    const sanitized = sanitizeItemEventForPreview(payload);
                     await pushPreviewToolProgress(
                       formatChannelProgressDraftLine({
                         event: "item",
-                        itemKind: payload.kind,
-                        title: payload.title,
-                        name: payload.name,
-                        phase: payload.phase,
-                        status: payload.status,
-                        summary: payload.summary,
-                        progressText: payload.progressText,
-                        meta: payload.meta,
+                        itemKind: sanitized.itemKind,
+                        title: sanitized.title,
+                        name: sanitized.name,
+                        phase: sanitized.phase,
+                        status: sanitized.status,
+                        summary: sanitized.summary,
+                        progressText: sanitized.progressText,
+                        meta: sanitized.meta,
                       }),
                     );
                   },


### PR DESCRIPTION
## What

When a Telegram DM session runs under `channels.telegram.streaming.mode = "partial"` and the agent does tool-heavy work, the preview message gets repeatedly rewritten with transient bubbles full of internal command output, command text, file paths, and log fragments before the final answer arrives. The reporter showed this leaks `/private/var/...` paths, `[context-engine]` log lines, and other raw exec output, which makes a healthy tool-using agent look broken or noisy. I reproduced this locally with a Telegram bot in DM mode under `streaming.mode = "partial"`, sent a tool-heavy prompt that triggered a series of exec calls, and confirmed the noise was as the reporter described.

## Why

The Telegram dispatch path in `extensions/telegram/src/bot-message-dispatch.ts` forwards every `onItemEvent` payload into `formatChannelProgressDraftLine` more or less verbatim, including `progressText`. The agent layer at `src/agents/pi-embedded-subscribe.handlers.tools.ts` emits a separate `kind: "command"` item event for exec calls, and on that event `progressText` is set to the raw exec output (`extractToolResultText(sanitized)`), while the redacted, short command summary lives in `title` and `meta`. Inside `formatChannelProgressDraftLine` the meta detail of an item line resolves to `meta ?? progressText ?? summary`, so as soon as the agent layer emits an updated command item without `meta` populated, the formatter falls back to `progressText`, which is the raw output, and that becomes the preview bubble. Multiple updates per command create the flood.

This is a Telegram-owned routing problem, not a core formatter problem, since the formatter is doing what its precedence rules say and other channels can pick a different sanitization stance. Per the AGENTS.md owner-boundary rule, I kept the fix inside `extensions/telegram` and did not touch core, the formatter, or the SDK-side `ChannelProgressDraftLineInput` shape.

## What I changed

- `extensions/telegram/src/bot-message-dispatch.ts`: added a small private helper, exported under `sanitizeItemEventForPreviewForTests` so a unit test can exercise the pure logic. For `kind: "command"`, the helper drops `progressText` and provides a clean `meta` fallback derived from `payload.meta?.trim()` first, then from `title.replace(/^\s*command\s+/i, "").trim()` second, then `undefined`. For every other item kind the helper passes the payload through unchanged.
- `extensions/telegram/src/bot-message-dispatch.test.ts`: added a new `describe("Telegram preview progress sanitization for command items (#77072)")` block with 9 vitest cases.
- `CHANGELOG.md`: one entry under `Unreleased > Fixes` crediting @EmpireCreator.

## What did not change

- No new config option, the existing `channels.telegram.streaming.preview.toolProgress = false` opt-out still works
- Final answer delivery, error delivery, media payloads, approval payloads, plan updates, command-output completion lines, and patch summary lines flow through their existing paths
- Core, `src/plugin-sdk/channel-streaming.ts`, the formatter, the `AgentItemEventData` shape, and the agent tool handler are all untouched
- Discord, Slack, Matrix, and other channels that consume the same `onItemEvent` shape are unaffected

## How I tested it

9 vitest cases in `extensions/telegram/src/bot-message-dispatch.test.ts`:

1. drops raw progressText and uses meta for command-kind items (pure helper)
2. derives clean meta from the command title when meta is missing (pure helper)
3. falls back to undefined meta when neither meta nor a parseable title is present (pure helper)
4. passes non-command item events through unchanged (pure helper, regression guard)
5. suppresses raw exec command output from the partial preview when a command item event fires (dispatch end-to-end)
6. renders the redacted command summary in the partial preview for a command item event (dispatch end-to-end)
7. leaves non-command tool item events on the existing progressText path (dispatch end-to-end, regression guard)
8. still routes the final assistant reply through unchanged when a command item event fires first (dispatch end-to-end, regression guard)
9. keeps preview.toolProgress=false suppressing the preview entirely for command items (dispatch end-to-end, regression guard for the existing opt-out)

Manual reproduction: I configured a Telegram bot under `channels.telegram.streaming.mode = "partial"`, sent a tool-heavy prompt that triggered a sequence of exec calls including `find` and `search`, and watched the preview message in DM. Before the patch, the preview message kept rewriting itself with transient bubbles containing raw stdout, file paths, and log fragments. After the patch, the preview shows the redacted command summary line and updates cleanly between commands, the final answer arrives unchanged, and the existing `preview.toolProgress: false` config still suppresses the preview entirely.

## Validation

`pnpm vitest run extensions/telegram/src/bot-message-dispatch.test.ts`, 122 passed, 1 unrelated pre-existing failure on upstream/main.

## AI / vibe-coding disclosure

- AI-assisted with Claude Opus 4.7 (Anthropic). Marked per CONTRIBUTING.md.
- 9 unit + integration tests added and hand-reviewed against the dispatch path.
- I did not run `pnpm check:changed` or `pnpm exec oxfmt --check` from clawsweeper's acceptance criteria locally, will address Codex review feedback on the PR if it surfaces format or unrelated typecheck issues.
- Will resolve clawsweeper / Codex review conversations as they come in.

Closes #77072. Thanks @EmpireCreator for the report.