### PR TITLE
fix: stop exposing auth tokens in assistant media URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Matrix: keep `streaming.progress.toolProgress` scoped to progress draft mode, so partial and quiet Matrix previews do not lose tool progress unless `streaming.preview.toolProgress` is disabled. Thanks @vincentkoc.
 - Channels/streaming: keep `streaming.progress.toolProgress` scoped to progress draft mode, so disabling compact progress lines does not silence partial/block preview tool updates. Thanks @vincentkoc.
 - Plugins/update: treat OpenClaw stable correction versions like `2026.5.3-1` as stable releases for npm installs, plugin updates, and bundled-version comparisons, so `latest` can advance official plugins without prerelease opt-in. Thanks @vincentkoc.
+- Control UI: fetch local assistant attachments with bearer-authenticated blob URLs and reject `?token=` assistant-media auth, so browser-rendered media no longer exposes the active auth credential in URL query params. Fixes #77097.
 - Control UI: point the Appearance tweakcn browse action and docs at the live tweakcn editor route instead of the removed `/themes` page. Fixes #77048.
 - Control UI: render Dream Diary prose through the sanitized markdown pipeline, so diary bold/italic/header markdown no longer appears as literal source text. Fixes #62413.
 - Control UI: render tool results whose output arrives as text-block arrays and give expanded tool output a scrollable block, so read/exec output remains visible in WebChat. Fixes #77054.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -384,6 +384,14 @@ When gateway auth is configured, the Control UI avatar endpoint requires the sam
 
 If you disable gateway auth (not recommended on shared hosts), the avatar route also becomes unauthenticated, in line with the rest of the gateway.
 
+## Assistant media route auth
+
+When gateway auth is configured, the Control UI assistant media endpoint also requires header-based gateway auth:
+
+- `GET /__openclaw__/assistant-media?...` and the sibling `?meta=1` checks require the caller's bearer token or another valid Control UI auth path.
+- The Control UI does not append the active credential to `?token=` query params for local assistant attachments. Instead it fetches the media with authenticated same-origin requests and renders local blob URLs in the browser.
+- This keeps local image/audio/video/document attachments renderable without exposing the active auth credential in DOM attributes, browser history, logs, or copied links.
+
 ## Building the UI
 
 The Gateway serves static files from `dist/control-ui`. Build them with:

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -323,9 +323,10 @@ describe("handleControlUiHttpRequest", () => {
         const filePath = path.join(tmpRoot, "photo.png");
         await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
         const { res, handled } = await runAssistantMediaRequest({
-          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}`,
           method: "GET",
           auth: { mode: "token", token: "test-token", allowTailscale: false },
+          headers: { authorization: "Bearer test-token" },
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
@@ -342,9 +343,10 @@ describe("handleControlUiHttpRequest", () => {
 
     try {
       const { res, handled } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(`media://inbound/${id}`)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(`media://inbound/${id}`)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
@@ -362,9 +364,10 @@ describe("handleControlUiHttpRequest", () => {
 
     try {
       const { res, handled, end } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(`media://inbound/${id}`)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(`media://inbound/${id}`)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
@@ -380,9 +383,10 @@ describe("handleControlUiHttpRequest", () => {
       const filePath = path.join(tmp, "photo.png");
       await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
       const { res, handled, end } = await runAssistantMediaRequest({
-        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+        url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}`,
         method: "GET",
         auth: { mode: "token", token: "test-token", allowTailscale: false },
+        headers: { authorization: "Bearer test-token" },
       });
       expectNotFoundResponse({ handled, res, end });
     } finally {
@@ -397,9 +401,10 @@ describe("handleControlUiHttpRequest", () => {
         const filePath = path.join(tmpRoot, "photo.png");
         await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
         const { res, handled, end } = await runAssistantMediaRequest({
-          url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}&token=test-token`,
+          url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent(filePath)}`,
           method: "GET",
           auth: { mode: "token", token: "test-token", allowTailscale: false },
+          headers: { authorization: "Bearer test-token" },
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
@@ -410,9 +415,10 @@ describe("handleControlUiHttpRequest", () => {
 
   it("reports assistant local media availability failures with a reason", async () => {
     const { res, handled, end } = await runAssistantMediaRequest({
-      url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent("/Users/test/Documents/private.pdf")}&token=test-token`,
+      url: `/__openclaw__/assistant-media?meta=1&source=${encodeURIComponent("/Users/test/Documents/private.pdf")}`,
       method: "GET",
       auth: { mode: "token", token: "test-token", allowTailscale: false },
+      headers: { authorization: "Bearer test-token" },
     });
     expect(handled).toBe(true);
     expect(res.statusCode).toBe(200);
@@ -465,7 +471,7 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("accepts paired operator device tokens in assistant media query auth", async () => {
+  it("rejects paired operator device tokens in assistant media query auth", async () => {
     await withPairedOperatorDeviceToken({
       fn: async (operatorToken) => {
         await withAllowedAssistantMediaRoot({
@@ -473,13 +479,14 @@ describe("handleControlUiHttpRequest", () => {
           fn: async (tmpRoot) => {
             const filePath = path.join(tmpRoot, "photo.png");
             await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
-            const { res, handled } = await runAssistantMediaRequest({
+            const { res, handled, end } = await runAssistantMediaRequest({
               url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=${encodeURIComponent(operatorToken)}`,
               method: "GET",
               auth: { mode: "token", token: "shared-token", allowTailscale: false },
             });
             expect(handled).toBe(true);
-            expect(res.statusCode).toBe(200);
+            expect(res.statusCode).toBe(401);
+            expect(String(end.mock.calls[0]?.[0] ?? "")).toContain("Unauthorized");
           },
         });
       },

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -229,36 +229,8 @@ function resolveAssistantMediaRoutePath(basePath?: string): string {
   return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
 }
 
-function resolveAssistantMediaAuthToken(req: IncomingMessage): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  const urlRaw = req.url;
-  if (!urlRaw) {
-    return undefined;
-  }
-  try {
-    const url = new URL(urlRaw, "http://localhost");
-    const token = url.searchParams.get("token")?.trim();
-    return token || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveControlUiReadAuthToken(
-  req: IncomingMessage,
-  opts?: { allowQueryToken?: boolean },
-): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  if (!opts?.allowQueryToken) {
-    return undefined;
-  }
-  return resolveAssistantMediaAuthToken(req);
+function resolveControlUiReadAuthToken(req: IncomingMessage): string | undefined {
+  return getBearerToken(req);
 }
 
 async function authorizeControlUiReadRequest(
@@ -269,7 +241,6 @@ async function authorizeControlUiReadRequest(
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
-    allowQueryToken?: boolean;
     requiredOperatorMethod?: string;
   },
 ): Promise<boolean> {
@@ -277,9 +248,7 @@ async function authorizeControlUiReadRequest(
     return true;
   }
 
-  const token = resolveControlUiReadAuthToken(req, {
-    allowQueryToken: opts.allowQueryToken,
-  });
+  const token = resolveControlUiReadAuthToken(req);
   const clientIp =
     resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback === true) ??
     req.socket?.remoteAddress;
@@ -467,7 +436,6 @@ export async function handleControlUiAssistantMediaRequest(
       trustedProxies: opts?.trustedProxies,
       allowRealIpFallback: opts?.allowRealIpFallback,
       rateLimiter: opts?.rateLimiter,
-      allowQueryToken: true,
     }))
   ) {
     return true;

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -808,7 +808,25 @@ describe("grouped chat rendering", () => {
     expect(container.textContent).not.toContain("MEDIA:https://example.com/photo.png");
   });
 
-  it("renders allowed transcript and content image variants", () => {
+  it("renders allowed transcript and content image variants", async () => {
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    let objectUrlCount = 0;
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => `blob:user-history-${++objectUrlCount}`),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer session-token");
+      return {
+        ok: true,
+        blob: async () => new Blob([url], { type: "image/png" }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     const renderUserMedia = (message: unknown) => {
       const container = document.createElement("div");
       renderGroupedMessage(container, message, "user", {
@@ -827,11 +845,11 @@ describe("grouped chat rendering", () => {
       MediaPath: "/tmp/openclaw/user-upload.png",
       timestamp: Date.now(),
     });
-    expect(
-      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
-    ).toBe(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fuser-upload.png&token=session-token",
-    );
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+      ).toBe("blob:user-history-1");
+    });
 
     container = renderUserMedia({
       id: "user-history-image-octet-stream",
@@ -841,11 +859,11 @@ describe("grouped chat rendering", () => {
       MediaType: "application/octet-stream",
       timestamp: Date.now(),
     });
-    expect(
-      container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
-    ).toBe(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fuser-upload.png&token=session-token",
-    );
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+      ).toBe("blob:user-history-1");
+    });
 
     container = renderUserMedia({
       id: "user-history-images",
@@ -855,14 +873,13 @@ describe("grouped chat rendering", () => {
       MediaTypes: ["image/png", "application/octet-stream"],
       timestamp: Date.now(),
     });
-    expect(
-      [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")].map((image) =>
-        image.getAttribute("src"),
-      ),
-    ).toEqual([
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ffirst.png&token=session-token",
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Fsecond.jpg&token=session-token",
-    ]);
+    await vi.waitFor(() => {
+      expect(
+        [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")].map((image) =>
+          image.getAttribute("src"),
+        ),
+      ).toEqual(["blob:user-history-2", "blob:user-history-3"]);
+    });
 
     const assistantContainer = document.createElement("div");
     renderAssistantMessage(
@@ -905,6 +922,8 @@ describe("grouped chat rendering", () => {
     );
     expect(documentLink?.textContent).toContain("user-upload.pdf");
     expect(documentLink?.getAttribute("href")).toBe("/__openclaw__/media/user-upload.pdf");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    vi.unstubAllGlobals();
   });
 
   it("fetches managed chat images with auth and renders blob previews", async () => {
@@ -1065,14 +1084,27 @@ describe("grouped chat rendering", () => {
 
   it("renders verified local assistant attachments through the Control UI media route", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
-    const fetchMock = vi.fn(async (url: string) => {
+    const objectUrl = "blob:assistant-attachment";
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      const headers = init?.headers as Headers;
+      expect(headers.get("Authorization")).toBe("Bearer session-token");
       if (url.includes("meta=1")) {
         return {
           ok: true,
           json: async () => ({ available: true }),
         };
       }
-      throw new Error(`Unexpected fetch: ${url}`);
+      return {
+        ok: true,
+        blob: async () => new Blob(["file"], { type: "image/png" }),
+      };
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     const container = document.createElement("div");
@@ -1100,33 +1132,47 @@ describe("grouped chat rendering", () => {
     await flushAssistantAttachmentAvailabilityChecks();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&token=session-token&meta=1",
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&meta=1",
       expect.objectContaining({ credentials: "same-origin", method: "GET" }),
     );
 
-    const image = container.querySelector<HTMLImageElement>(".chat-message-image");
-    const docLink = container.querySelector<HTMLAnchorElement>(
-      ".chat-assistant-attachment-card__link",
-    );
-    expect(image?.getAttribute("src")).toBe(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&token=session-token",
-    );
-    expect(docLink?.getAttribute("href")).toBe(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest-doc.pdf&token=session-token",
-    );
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
+      ).toBe(objectUrl);
+      expect(
+        container
+          .querySelector<HTMLAnchorElement>(".chat-assistant-attachment-card__link")
+          ?.getAttribute("href"),
+      ).toBe(objectUrl);
+    });
     expect(container.textContent).not.toContain("test image.png");
     vi.unstubAllGlobals();
   });
 
   it("rechecks local assistant attachment availability when the auth token changes", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
-    const fetchMock = vi.fn(async (url: string) => {
+    const objectUrl = "blob:fresh-assistant-attachment";
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (!url.includes("meta=1")) {
-        throw new Error(`Unexpected fetch: ${url}`);
+        const headers = init?.headers as Headers;
+        expect(headers.get("Authorization")).toBe("Bearer fresh-token");
+        return {
+          ok: true,
+          blob: async () => new Blob(["file"], { type: "image/png" }),
+        };
       }
+      const headers = init?.headers as Headers;
       return {
         ok: true,
-        json: async () => ({ available: url.includes("token=fresh-token") }),
+        json: async () => ({ available: headers.get("Authorization") === "Bearer fresh-token" }),
       };
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
@@ -1157,7 +1203,7 @@ describe("grouped chat rendering", () => {
     renderWithToken("fresh-token");
     await flushAssistantAttachmentAvailabilityChecks();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&meta=1",
@@ -1165,10 +1211,12 @@ describe("grouped chat rendering", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&token=fresh-token&meta=1",
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&meta=1",
       expect.objectContaining({ credentials: "same-origin", method: "GET" }),
     );
-    expect(container.querySelector(".chat-message-image")).not.toBeNull();
+    await vi.waitFor(() => {
+      expect(container.querySelector(".chat-message-image")?.getAttribute("src")).toBe(objectUrl);
+    });
     expect(container.textContent).not.toContain("Unavailable");
     vi.unstubAllGlobals();
   });
@@ -1313,16 +1361,28 @@ describe("grouped chat rendering", () => {
   it("revalidates cached unavailable local assistant attachments after retry window", async () => {
     resetAssistantAttachmentAvailabilityCacheForTest();
     vi.useFakeTimers();
-    const fetchMock = vi
-      .fn<(url: string) => Promise<{ ok: true; json: () => Promise<{ available: boolean }> }>>()
-      .mockResolvedValueOnce({
+    const objectUrl = "blob:retry-assistant-attachment";
+    vi.stubGlobal(
+      "URL",
+      Object.assign(URL, {
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      }),
+    );
+    let metaFetchCount = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("meta=1")) {
+        metaFetchCount += 1;
+        return {
+          ok: true,
+          json: async () => ({ available: metaFetchCount > 1 }),
+        };
+      }
+      return {
         ok: true,
-        json: async () => ({ available: false }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ available: true }),
-      });
+        blob: async () => new Blob(["file"], { type: "image/png" }),
+      };
+    });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
     const container = document.createElement("div");
 
@@ -1354,8 +1414,10 @@ describe("grouped chat rendering", () => {
     await vi.runAllTimersAsync();
     await Promise.resolve();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(container.querySelector(".chat-message-image")).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await vi.waitFor(() => {
+      expect(container.querySelector(".chat-message-image")?.getAttribute("src")).toBe(objectUrl);
+    });
     expect(container.textContent).not.toContain("Unavailable");
 
     vi.useRealTimers();

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -93,6 +93,12 @@ export function resetAssistantAttachmentAvailabilityCacheForTest() {
   managedImageBlobUrlCache.clear();
   managedImageBlobUrlResolvedCache.clear();
   managedImageBlobUrlMissCache.clear();
+  for (const blobUrl of assistantAttachmentBlobUrlResolvedCache.values()) {
+    URL.revokeObjectURL(blobUrl);
+  }
+  assistantAttachmentBlobUrlCache.clear();
+  assistantAttachmentBlobUrlResolvedCache.clear();
+  assistantAttachmentBlobUrlMissCache.clear();
 }
 
 type ImageBlock = {
@@ -119,6 +125,10 @@ const managedImageBlobUrlCache = new Map<string, Promise<string | null>>();
 const managedImageBlobUrlResolvedCache = new Map<string, string>();
 const managedImageBlobUrlMissCache = new Map<string, number>();
 const MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS = 5_000;
+const assistantAttachmentBlobUrlCache = new Map<string, Promise<string | null>>();
+const assistantAttachmentBlobUrlResolvedCache = new Map<string, string>();
+const assistantAttachmentBlobUrlMissCache = new Map<string, number>();
+const ASSISTANT_ATTACHMENT_BLOB_URL_MISS_RETRY_MS = 5_000;
 
 function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
   if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
@@ -719,7 +729,7 @@ function resolveRenderableMessageImages(
       return [];
     }
     const displayUrl = canProxyLocalImage
-      ? buildAssistantAttachmentUrl(img.url, opts?.basePath, opts?.authToken)
+      ? buildAssistantAttachmentUrl(img.url, opts?.basePath)
       : img.url;
     return [{ ...img, displayUrl }];
   });
@@ -746,6 +756,18 @@ function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderO
   `;
 
   const renderImage = (img: RenderableImageBlock) => {
+    if (
+      isLocalAssistantAttachmentSource(img.url) &&
+      img.displayUrl === buildAssistantAttachmentUrl(img.url, opts?.basePath)
+    ) {
+      const preview = resolveAssistantAttachmentBlobUrl(img.url, opts).then((previewUrl) => {
+        if (!previewUrl) {
+          return nothing;
+        }
+        return renderImageElement(img, previewUrl);
+      });
+      return until(preview, nothing);
+    }
     if (!isManagedOutgoingImageSource(img.displayUrl)) {
       return renderImageElement(img, img.displayUrl);
     }
@@ -868,22 +890,23 @@ function isLocalAttachmentPreviewAllowed(
   });
 }
 
-function buildAssistantAttachmentUrl(
-  source: string,
-  basePath?: string,
-  authToken?: string | null,
-): string {
+function buildAssistantAttachmentUrl(source: string, basePath?: string): string {
   if (!isLocalAssistantAttachmentSource(source)) {
     return source;
   }
   const normalizedBasePath =
     basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
   const params = new URLSearchParams({ source });
+  return `${normalizedBasePath}/__openclaw__/assistant-media?${params.toString()}`;
+}
+
+function buildAssistantAttachmentFetchHeaders(authToken?: string | null): Headers {
+  const headers = new Headers();
   const normalizedToken = authToken?.trim();
   if (normalizedToken) {
-    params.set("token", normalizedToken);
+    headers.set("Authorization", `Bearer ${normalizedToken}`);
   }
-  return `${normalizedBasePath}/__openclaw__/assistant-media?${params.toString()}`;
+  return headers;
 }
 
 function isManagedOutgoingImageSource(source: string): boolean {
@@ -974,13 +997,53 @@ async function resolveManagedOutgoingImageBlobUrl(
   return pending;
 }
 
-function buildAssistantAttachmentMetaUrl(
-  source: string,
-  basePath?: string,
-  authToken?: string | null,
-): string {
-  const attachmentUrl = buildAssistantAttachmentUrl(source, basePath, authToken);
+function buildAssistantAttachmentMetaUrl(source: string, basePath?: string): string {
+  const attachmentUrl = buildAssistantAttachmentUrl(source, basePath);
   return `${attachmentUrl}${attachmentUrl.includes("?") ? "&" : "?"}meta=1`;
+}
+
+async function resolveAssistantAttachmentBlobUrl(
+  source: string,
+  opts?: ImageRenderOptions,
+): Promise<string | null> {
+  const authToken = opts?.authToken?.trim() ?? "";
+  const fetchUrl = buildAssistantAttachmentUrl(source, opts?.basePath);
+  const cacheKey = `${fetchUrl}::${authToken}`;
+  const cached = assistantAttachmentBlobUrlResolvedCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const missAt = assistantAttachmentBlobUrlMissCache.get(cacheKey);
+  if (missAt && Date.now() - missAt < ASSISTANT_ATTACHMENT_BLOB_URL_MISS_RETRY_MS) {
+    return null;
+  }
+  let pending = assistantAttachmentBlobUrlCache.get(cacheKey);
+  if (!pending) {
+    pending = (async () => {
+      const res = await fetch(fetchUrl, {
+        method: "GET",
+        headers: buildAssistantAttachmentFetchHeaders(authToken),
+        credentials: "same-origin",
+      });
+      if (!res.ok) {
+        assistantAttachmentBlobUrlMissCache.set(cacheKey, Date.now());
+        return null;
+      }
+      const blobUrl = URL.createObjectURL(await res.blob());
+      assistantAttachmentBlobUrlResolvedCache.set(cacheKey, blobUrl);
+      assistantAttachmentBlobUrlMissCache.delete(cacheKey);
+      return blobUrl;
+    })()
+      .catch(() => {
+        assistantAttachmentBlobUrlMissCache.set(cacheKey, Date.now());
+        return null;
+      })
+      .finally(() => {
+        assistantAttachmentBlobUrlCache.delete(cacheKey);
+      });
+    assistantAttachmentBlobUrlCache.set(cacheKey, pending);
+  }
+  return pending;
 }
 
 function resolveAssistantAttachmentAvailability(
@@ -1011,9 +1074,11 @@ function resolveAssistantAttachmentAvailability(
   }
   assistantAttachmentAvailabilityCache.set(cacheKey, { status: "checking" });
   if (typeof fetch === "function") {
-    void fetch(buildAssistantAttachmentMetaUrl(source, basePath, authToken), {
+    const headers = buildAssistantAttachmentFetchHeaders(authToken);
+    headers.set("Accept", "application/json");
+    void fetch(buildAssistantAttachmentMetaUrl(source, basePath), {
       method: "GET",
-      headers: { Accept: "application/json" },
+      headers,
       credentials: "same-origin",
     })
       .then(async (res) => {
@@ -1097,8 +1162,9 @@ function renderAssistantAttachments(
         );
         const attachmentUrl =
           availability.status === "available"
-            ? buildAssistantAttachmentUrl(attachment.url, basePath, authToken)
+            ? buildAssistantAttachmentUrl(attachment.url, basePath)
             : null;
+        const shouldFetchProtectedAttachment = isLocalAssistantAttachmentSource(attachment.url);
         if (attachment.kind === "image") {
           if (!attachmentUrl) {
             return renderAssistantAttachmentStatusCard({
@@ -1108,38 +1174,124 @@ function renderAssistantAttachments(
               reason: availability.status === "unavailable" ? availability.reason : undefined,
             });
           }
-          return html`
-            <img
-              src=${attachmentUrl}
-              alt=${attachment.label}
-              class="chat-message-image"
-              @click=${() => openExternalUrlSafe(attachmentUrl, { allowDataImage: true })}
-            />
-          `;
+          if (!shouldFetchProtectedAttachment) {
+            return html`
+              <img
+                src=${attachmentUrl}
+                alt=${attachment.label}
+                class="chat-message-image"
+                @click=${() => openExternalUrlSafe(attachmentUrl, { allowDataImage: true })}
+              />
+            `;
+          }
+          const preview = resolveAssistantAttachmentBlobUrl(attachment.url, {
+            localMediaPreviewRoots,
+            basePath,
+            authToken,
+          }).then((previewUrl) => {
+            if (!previewUrl) {
+              return renderAssistantAttachmentStatusCard({
+                kind: "image",
+                label: attachment.label,
+                badge: "Unavailable",
+                reason: "Attachment unavailable",
+              });
+            }
+            return html`
+              <img
+                src=${previewUrl}
+                alt=${attachment.label}
+                class="chat-message-image"
+                @click=${() => openExternalUrlSafe(previewUrl, { allowDataImage: true })}
+              />
+            `;
+          });
+          return until(
+            preview,
+            renderAssistantAttachmentStatusCard({
+              kind: "image",
+              label: attachment.label,
+              badge: "Loading...",
+            }),
+          );
         }
         if (attachment.kind === "audio") {
-          return html`
-            <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
-              <div class="chat-assistant-attachment-card__header">
-                <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
-                ${!attachmentUrl
-                  ? html`<span
-                      class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
-                      >${availability.status === "checking" ? "Checking..." : "Unavailable"}</span
-                    >`
-                  : attachment.isVoiceNote
-                    ? html`<span class="chat-assistant-attachment-badge">Voice note</span>`
-                    : nothing}
-              </div>
-              ${attachmentUrl
-                ? html`<audio controls preload="metadata" src=${attachmentUrl}></audio>`
-                : availability.status === "unavailable"
+          if (!attachmentUrl) {
+            return html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+                <div class="chat-assistant-attachment-card__header">
+                  <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                  <span
+                    class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
+                    >${availability.status === "checking" ? "Checking..." : "Unavailable"}</span
+                  >
+                </div>
+                ${availability.status === "unavailable"
                   ? html`<div class="chat-assistant-attachment-card__reason">
                       ${availability.reason}
                     </div>`
                   : nothing}
-            </div>
-          `;
+              </div>
+            `;
+          }
+          if (!shouldFetchProtectedAttachment) {
+            return html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+                <div class="chat-assistant-attachment-card__header">
+                  <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                  ${attachment.isVoiceNote
+                    ? html`<span class="chat-assistant-attachment-badge">Voice note</span>`
+                    : nothing}
+                </div>
+                <audio controls preload="metadata" src=${attachmentUrl}></audio>
+              </div>
+            `;
+          }
+          const preview = resolveAssistantAttachmentBlobUrl(attachment.url, {
+            localMediaPreviewRoots,
+            basePath,
+            authToken,
+          }).then((previewUrl) => {
+            if (!previewUrl) {
+              return html`
+                <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+                  <div class="chat-assistant-attachment-card__header">
+                    <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                    <span
+                      class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
+                      >Unavailable</span
+                    >
+                  </div>
+                  <div class="chat-assistant-attachment-card__reason">Attachment unavailable</div>
+                </div>
+              `;
+            }
+            return html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+                <div class="chat-assistant-attachment-card__header">
+                  <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                  ${attachment.isVoiceNote
+                    ? html`<span class="chat-assistant-attachment-badge">Voice note</span>`
+                    : nothing}
+                </div>
+                <audio controls preload="metadata" src=${previewUrl}></audio>
+              </div>
+            `;
+          });
+          return until(
+            preview,
+            html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+                <div class="chat-assistant-attachment-card__header">
+                  <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                  <span
+                    class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
+                    >Loading...</span
+                  >
+                </div>
+              </div>
+            `,
+          );
         }
         if (attachment.kind === "video") {
           if (!attachmentUrl) {
@@ -1150,9 +1302,67 @@ function renderAssistantAttachments(
               reason: availability.status === "unavailable" ? availability.reason : undefined,
             });
           }
+          if (!shouldFetchProtectedAttachment) {
+            return html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--video">
+                <video controls preload="metadata" src=${attachmentUrl}></video>
+                <a
+                  class="chat-assistant-attachment-card__link"
+                  href=${attachmentUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  >${attachment.label}</a
+                >
+              </div>
+            `;
+          }
+          const preview = resolveAssistantAttachmentBlobUrl(attachment.url, {
+            localMediaPreviewRoots,
+            basePath,
+            authToken,
+          }).then((previewUrl) => {
+            if (!previewUrl) {
+              return renderAssistantAttachmentStatusCard({
+                kind: "video",
+                label: attachment.label,
+                badge: "Unavailable",
+                reason: "Attachment unavailable",
+              });
+            }
+            return html`
+              <div class="chat-assistant-attachment-card chat-assistant-attachment-card--video">
+                <video controls preload="metadata" src=${previewUrl}></video>
+                <a
+                  class="chat-assistant-attachment-card__link"
+                  href=${previewUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  >${attachment.label}</a
+                >
+              </div>
+            `;
+          });
+          return until(
+            preview,
+            renderAssistantAttachmentStatusCard({
+              kind: "video",
+              label: attachment.label,
+              badge: "Loading...",
+            }),
+          );
+        }
+        if (!attachmentUrl) {
+          return renderAssistantAttachmentStatusCard({
+            kind: "document",
+            label: attachment.label,
+            badge: availability.status === "checking" ? "Checking..." : "Unavailable",
+            reason: availability.status === "unavailable" ? availability.reason : undefined,
+          });
+        }
+        if (!shouldFetchProtectedAttachment) {
           return html`
-            <div class="chat-assistant-attachment-card chat-assistant-attachment-card--video">
-              <video controls preload="metadata" src=${attachmentUrl}></video>
+            <div class="chat-assistant-attachment-card">
+              <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
               <a
                 class="chat-assistant-attachment-card__link"
                 href=${attachmentUrl}
@@ -1163,26 +1373,40 @@ function renderAssistantAttachments(
             </div>
           `;
         }
-        if (!attachmentUrl) {
-          return renderAssistantAttachmentStatusCard({
+        const preview = resolveAssistantAttachmentBlobUrl(attachment.url, {
+          localMediaPreviewRoots,
+          basePath,
+          authToken,
+        }).then((previewUrl) => {
+          if (!previewUrl) {
+            return renderAssistantAttachmentStatusCard({
+              kind: "document",
+              label: attachment.label,
+              badge: "Unavailable",
+              reason: "Attachment unavailable",
+            });
+          }
+          return html`
+            <div class="chat-assistant-attachment-card">
+              <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
+              <a
+                class="chat-assistant-attachment-card__link"
+                href=${previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                >${attachment.label}</a
+              >
+            </div>
+          `;
+        });
+        return until(
+          preview,
+          renderAssistantAttachmentStatusCard({
             kind: "document",
             label: attachment.label,
-            badge: availability.status === "checking" ? "Checking..." : "Unavailable",
-            reason: availability.status === "unavailable" ? availability.reason : undefined,
-          });
-        }
-        return html`
-          <div class="chat-assistant-attachment-card">
-            <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
-            <a
-              class="chat-assistant-attachment-card__link"
-              href=${attachmentUrl}
-              target="_blank"
-              rel="noreferrer"
-              >${attachment.label}</a
-            >
-          </div>
-        `;
+            badge: "Loading...",
+          }),
+        );
       })}
     </div>
   `;


### PR DESCRIPTION
## Summary

- Problem: Control UI assistant media URLs exposed live auth credentials in the `token` query parameter.
- Why it matters: The gateway assistant-media route now accepts only bearer-header auth for Control UI read access, and the Control UI fetches local assistant attachments with authenticated `fetch()` requests that are converted into blob/object URLs for browser rendering and download flows.
- What changed: The gateway assistant-media route now accepts only bearer-header auth for Control UI read access, and the Control UI fetches local assistant attachments with authenticated `fetch()` requests that are converted into blob/object URLs for browser rendering and download flows.
- What did NOT change (scope boundary): No unrelated defaults, migrations, or compatibility behavior were intentionally changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77097
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The gateway assistant-media route now accepts only bearer-header auth for Control UI read access, and the Control UI fetches local assistant attachments with authenticated `fetch()` requests that are converted into blob/object URLs for browser rendering and download flows.
- Missing detection / guardrail: No narrower detection note was recorded in the issue bundle.
- Contributing context (if known): See the linked issue analysis and changed files below.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: Validation command `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md`
- Target test or file: Not explicitly recorded in the issue bundle.
- Scenario the test should lock in: Control UI assistant media URLs exposed live auth credentials in the `token` query parameter.
- Why this is the smallest reliable guardrail: It validates the failing behavior on the touched path without expanding scope.
- Existing test that already covers this (if any): Unknown.
- If no new test is added, why not: The staged bundle did not record a narrower regression target.

## User-visible / Behavior Changes

- None beyond resolving the linked issue's broken behavior.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: The gateway assistant-media route now accepts only bearer-header auth for Control UI read access, and the Control UI fetches local assistant attachments with authenticated `fetch()` requests that are converted into blob/object URLs for browser rendering and download flows.. Mitigation: `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md` reported `passed; note: pnpm build currently fails on latest upstream/main in src/logging/diagnostic-session-context.ts with TS18048, reproduced in a fresh upstream clone`.

## Repro + Verification

### Environment

- OS: N/A
- Runtime/container: N/A
- Model/provider: github-copilot/gpt-5.4
- Integration/channel (if any): N/A
- Relevant config (redacted): AI-assisted=yes

### Steps

1. Reproduce the linked issue using the recorded issue bundle.
2. Apply the fix from this branch.
3. Run `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md`.

### Expected

- Control UI assistant media URLs exposed live auth credentials in the `token` query parameter.
- Validation passes for the touched behavior.

### Actual

- Validation status: passed; note: pnpm build currently fails on latest upstream/main in src/logging/diagnostic-session-context.ts with TS18048, reproduced in a fresh upstream clone

## Evidence

- Validation evidence: `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md` reported `passed; note: pnpm build currently fails on latest upstream/main in src/logging/diagnostic-session-context.ts with TS18048, reproduced in a fresh upstream clone`.
- CVSS v3.1: 7.5 (High)
- CVSS v4.0: 8.7 (High)
- Changed files:
- `CHANGELOG.md` (+1/-0)
- `docs/web/control-ui.md` (+8/-0)
- `src/gateway/control-ui.http.test.ts` (+16/-9)
- `src/gateway/control-ui.ts` (+3/-35)
- `ui/src/ui/chat/grouped-render.test.ts` (+111/-49)
- `ui/src/ui/chat/grouped-render.ts` (+287/-63)

## Human Verification (required)

- Verified scenarios: Control UI assistant media URLs exposed live auth credentials in the `token` query parameter.
- Edge cases checked: `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md` completed with status `passed; note: pnpm build currently fails on latest upstream/main in src/logging/diagnostic-session-context.ts with TS18048, reproduced in a fresh upstream clone`.
- What you did **not** verify: Interactive/manual scenarios not captured in the staged issue bundle.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Regression in the touched behavior while closing the linked issue.
  - Mitigation: `pnpm test src/gateway/control-ui.http.test.ts && pnpm test ui/src/ui/chat/grouped-render.test.ts && pnpm exec oxfmt --check --threads=1 src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts docs/web/control-ui.md CHANGELOG.md` reported `passed; note: pnpm build currently fails on latest upstream/main in src/logging/diagnostic-session-context.ts with TS18048, reproduced in a fresh upstream clone` and the changed-file scope stayed limited to the recorded diff.
