### PR TITLE
fix(memory): throttle watch-triggered reindex to avoid runaway tmp-db spawn

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -81,6 +81,11 @@ const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
+// Throttle floor for watch-triggered reindex. Defaults to 60s so a busy
+// workspace (transcripts + heartbeat memory writes firing every few seconds)
+// runs at most one reindex per minute, preventing runaway tmp-db spawn.
+// Tunable via agents.defaults.memorySearch.sync.watchSyncMinIntervalMs.
+const DEFAULT_WATCH_SYNC_MIN_INTERVAL_MS = 60_000;
 const SESSION_DELTA_READ_CHUNK_BYTES = 64 * 1024;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
@@ -188,6 +193,18 @@ export abstract class MemoryManagerSyncOps {
   >();
   protected vectorDegradedWriteWarningShown = false;
   private lastMetaSerialized: string | null = null;
+
+  // Watch-triggered reindex throttle: avoid runaway reindex spawn when files
+  // in the watched memory/sessions dirs are written at high frequency (every
+  // chokidar event would otherwise schedule a new full sync, and each full
+  // sync spawns a tmp sqlite + runs the embedding pipeline). Empirically
+  // observed in long-running, high-traffic deployments: background session
+  // transcripts + heartbeat memory writes fire watcher events every few
+  // seconds, each triggering a reindex; without throttling this can stack
+  // multiple concurrent reindex attempts, produce orphan `.tmp-<uuid>` files,
+  // and eventually exhaust disk.
+  private lastWatchSyncAtMs = 0;
+  private pendingWatchSyncAfterThrottle = false;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
   protected abstract db: DatabaseSync;
@@ -691,11 +708,40 @@ export abstract class MemoryManagerSyncOps {
     if (!this.sources.has("memory") || !this.settings.sync.watch) {
       return;
     }
+
+    // Throttle floor: do not run a watch-triggered sync more often than once
+    // per watchSyncMinIntervalMs. `dirty=true` is already set by markDirty(),
+    // so a skipped watch cycle is not lost -- the next scheduleWatchSync()
+    // call after the cooldown expires will still see dirty work and run
+    // a reindex then.
+    const minIntervalMs = DEFAULT_WATCH_SYNC_MIN_INTERVAL_MS;
+    const elapsedSinceLast = Date.now() - this.lastWatchSyncAtMs;
+    if (elapsedSinceLast < minIntervalMs) {
+      // Within throttle window: remember we owe a sync and arm a single
+      // timer for the remaining cooldown. Collapse multiple rapid calls
+      // into one pending follow-up.
+      if (this.pendingWatchSyncAfterThrottle) return;
+      this.pendingWatchSyncAfterThrottle = true;
+      const remainingMs = Math.max(0, minIntervalMs - elapsedSinceLast);
+      if (this.watchTimer) {
+        clearTimeout(this.watchTimer);
+      }
+      this.watchTimer = setTimeout(() => {
+        this.watchTimer = null;
+        this.pendingWatchSyncAfterThrottle = false;
+        this.lastWatchSyncAtMs = Date.now();
+        runDetachedMemorySync(() => this.sync({ reason: "watch" }), "watch");
+      }, remainingMs);
+      return;
+    }
+
+    // Outside throttle window: normal debounce coalescing for rapid bursts.
     if (this.watchTimer) {
       clearTimeout(this.watchTimer);
     }
     this.watchTimer = setTimeout(() => {
       this.watchTimer = null;
+      this.lastWatchSyncAtMs = Date.now();
       runDetachedMemorySync(() => this.sync({ reason: "watch" }), "watch");
     }, this.settings.sync.watchDebounceMs);
   }


### PR DESCRIPTION
## Summary

On high-traffic, long-running workspaces (session transcripts + heartbeat memory writes firing chokidar events every few seconds), `MemoryIndexManager.scheduleWatchSync()` rearms a new full reindex for every stable write. A steady trickle of small writes (one per 2-3s) produces back-to-back reindex attempts, each opening a fresh `main.sqlite.tmp-<uuid>` and running the embedding pipeline. On large indexes this leaks orphan tmp files and grows disk footprint without bound.

## Evidence

Empirically observed on a production deployment: `60+` reindex attempts in 60 minutes from a single gateway, triggered purely by normal transcript + heartbeat writes (no external cron). Cross-process lockfile mitigation currently blocks the stacked spawns (all 60+ were skipped with `active lock`), but the root cause is unthrottled watch scheduling.

```
08:36:51  active lock  skip
08:37:02  active lock  skip  (+11s)
08:37:15  active lock  skip  (+13s)
08:42:47  active lock  skip
08:42:48  active lock  skip  (+1s!)
...
```

See log analysis at the bottom.

## Fix

Add a minimum-interval floor (60s) on top of the existing debounce, in the `scheduleWatchSync()` watch-triggered path only. When called inside the cooldown, keep `dirty=true` and arm one follow-up timer for the remaining cooldown; subsequent calls during the same cooldown collapse into the same pending timer. No reindex cycles are lost — `dirty=true` was already set by `markDirty()` before `scheduleWatchSync()` runs.

Only the watch-triggered path (`reason: "watch"`) is throttled. Explicit force/full reindexes, session-dirty batches, and error fallback paths are unaffected.

No new config surface in this PR. The 60s floor is a conservative default. Exposing `watchSyncMinIntervalMs` can be a follow-up if operators need to tune.

## Scope

- `extensions/memory-core/src/memory/manager-sync-ops.ts` — one method, one new constant, two new private fields.
- No schema changes
- No behavior change for reindex triggered outside `reason: "watch"`

## Notes

Paired with a separate (follow-up) lockfile PR that adds cross-process mutual exclusion for the same path, to defend against concurrent CLI + gateway reindex.