### PR TITLE
[codex] TUI: simplify stale response notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/update: keep externalized bundled npm bridge updates on the normal plugin security scanner path instead of granting source-linked official trust without artifact provenance. (#76765) Thanks @Lucenx9.
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
 - Doctor/plugins: install configured missing official plugins such as Discord and Brave during doctor/update repair, auto-enable repaired provider plugins, preserve config when a download fails, and stop auto-enable from inventing plugin entries when no manifest declares a configured channel. Fixes #76872. Thanks @jack-stormentswe.
+- TUI: replace the stale-response watchdog notice with plain user-facing copy so stalled replies no longer surface backend or streaming internals.
 
 ## 2026.5.2
 

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -894,6 +894,9 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 });
 
 describe("tui-event-handlers: streaming watchdog", () => {
+  const expectedTimeoutMessage =
+    "This response is taking longer than expected. Send another message to continue.";
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -971,7 +974,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledWith(expect.stringContaining("streaming watchdog"));
+    expect(chatLog.addSystem).toHaveBeenCalledWith(expectedTimeoutMessage);
 
     handlers.dispose?.();
   });
@@ -1177,9 +1180,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
     expect(loadHistory).toHaveBeenCalledTimes(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(
-      expect.stringContaining("streaming watchdog"),
-    );
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
 
     handlers.dispose?.();
   });
@@ -1206,9 +1207,7 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     const statusCalls = setActivityStatus.mock.calls.map((c) => c[0]);
     expect(statusCalls.filter((s) => s === "idle").length).toBe(1);
-    expect(chatLog.addSystem).not.toHaveBeenCalledWith(
-      expect.stringContaining("streaming watchdog"),
-    );
+    expect(chatLog.addSystem).not.toHaveBeenCalledWith(expectedTimeoutMessage);
     expect(state.activeChatRunId).toBeNull();
 
     handlers.dispose?.();

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -49,6 +49,8 @@ type EventHandlerContext = {
 };
 
 const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
+const STREAMING_WATCHDOG_USER_MESSAGE =
+  "This response is taking longer than expected. Send another message to continue.";
 
 export function createEventHandlers(context: EventHandlerContext) {
   const {
@@ -129,11 +131,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         return;
       }
       flushPendingHistoryRefreshIfIdle();
-      chatLog.addSystem(
-        `streaming watchdog: no stream updates for ${Math.round(
-          streamingWatchdogMs / 1000,
-        )}s; resetting status. The backend may have dropped this run silently — send a new message to resync.`,
-      );
+      chatLog.addSystem(STREAMING_WATCHDOG_USER_MESSAGE);
       tui.requestRender();
     }, streamingWatchdogMs);
     const maybeUnref = (streamingWatchdogTimer as { unref?: () => void }).unref;


### PR DESCRIPTION
## Summary

- Replace the TUI stale-response watchdog notice with plain user-facing copy.
- Keep the existing watchdog recovery behavior intact, including the silent reconnect/history reload path.
- Update TUI event-handler coverage to assert the new copy and guard the paths that should not show it.

## Why

The previous message exposed implementation details like "streaming watchdog", "backend", "run", and "resync". That made a recoverable stale-response state sound like an internal failure report. The new copy tells users only what matters: the response is taking longer than expected, and they can send another message to continue.

## Testing

- `pnpm test src/tui/tui-event-handlers.test.ts`
