### PR TITLE
fix(memory): ignore runtime dirs (_shadow/_cache/_tmp) in memory watcher

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -91,6 +91,15 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   "venv",
   ".tox",
   "__pycache__",
+  // Runtime / cache directories that may live under workspace/memory but
+  // whose contents are not user-authored memory content. Excluding them
+  // prevents high-frequency periodic writes (e.g. a daemon writing a
+  // _health.json every minute) from firing the memory watcher and
+  // scheduling watch-triggered reindex cycles that compete for the sqlite
+  // index lock.
+  "_shadow",
+  "_cache",
+  "_tmp",
 ]);
 
 const log = createSubsystemLogger("memory");

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -89,6 +89,11 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   "venv",
   ".tox",
   "__pycache__",
+  // Runtime / cache dirs (e.g. daemons writing periodic _health.json). See
+  // manager-sync-ops.ts for the matching list and rationale.
+  "_shadow",
+  "_cache",
+  "_tmp",
 ]);
 
 function qmdUsesVectors(searchMode: ResolvedQmdConfig["searchMode"]): boolean {


### PR DESCRIPTION
## Summary

The memory watcher under `workspace/memory/` only excludes source-control and language package dirs (`.git`, `node_modules`, `.venv`, ...). Plugins that write periodic runtime/health files **under** `workspace/memory/` subdirectories therefore fire the watcher on every write and schedule `sync({reason:"watch"})` cycles.

Observed case: a shadow-daemon writing `workspace/memory/_shadow/_health.json` once per 60s. The watcher fires each time, markDirty() runs, scheduleWatchSync() schedules a full sync. When the embedding pipeline is slow (rate-limited provider) or the previous sync hasn't finished, the next cycle begins before the in-flight reindex releases the sqlite index lock, producing `sync failed (watch): database is locked` and stacked reindex attempts. Enough of these stack up to leak orphan `main.sqlite.tmp-<uuid>` files and degrade the index.

## Empirical evidence (one affected production deployment)

- `sync_done` from the daemon: every ~60s (expected / correct)
- `sync failed (watch): Error: database is locked`: **29–31 / hour** during embedding-provider rate-limit windows (01:00–07:00)
- Symptom **disappeared** once rate limits eased so a single reindex could complete within 60s. The underlying watcher thrash kept running; it just stopped being visible because sqlite wasn't locked on the next cycle.
- Per-hour breakdown (`embeddings rate limited` vs `sync failed (watch)`):

```
01  34  31    high rate-limit + high lock-conflict
02  42  29
03  34  15
04  44   8
05  37  12
06   9  10
07  13   9
08   4   0    rate-limit eases, symptom vanishes
09  16   0
```

The root cause is not rate limiting — rate limiting was the factor that made the conflict visible. The root cause is that memory subdirs containing plugin runtime state are treated as user-authored memory content.

## Fix

Add `_shadow`, `_cache`, `_tmp` to `IGNORED_MEMORY_WATCH_DIR_NAMES` in both `MemoryIndexManager` (`manager-sync-ops.ts`) and `QmdManager` (`qmd-manager.ts`). Leading-underscore names are a common convention for runtime / cache areas; the list is conservative and only includes names known to appear in practice.

This targets the root cause of the high-frequency watch-triggered reindex pattern. A separate PR (https://github.com/openclaw/openclaw/pull/77119) adds a 60s throttle floor in `scheduleWatchSync()` that protects against the same failure mode when user-authored memory files themselves see rapid writes.

## Scope

- 2 files, +14 lines
- No behavior change for existing users whose workspace memory does not contain `_shadow/`, `_cache/`, or `_tmp/` dirs
- Plugins that *rely* on runtime state under these names being reindexed should relocate it (or use an opt-in `extraPaths`)