### PR TITLE
fix(cron): keep run timeout out of model idle watchdog

### DIFF
--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -81,9 +81,13 @@ describe("resolveLlmIdleTimeoutMs", () => {
     expect(resolveLlmIdleTimeoutMs({ cfg, trigger: "cron" })).toBe(0);
   });
 
-  it("caps agents.defaults.timeoutSeconds for cron before disabling the default idle timeout", () => {
+  it("does not convert cron run timeouts into model idle watchdogs", () => {
+    expect(resolveLlmIdleTimeoutMs({ trigger: "cron", runTimeoutMs: 600_000 })).toBe(0);
+  });
+
+  it("does not convert agents.defaults.timeoutSeconds into a cron model idle watchdog", () => {
     const cfg = { agents: { defaults: { timeoutSeconds: 300 } } } as OpenClawConfig;
-    expect(resolveLlmIdleTimeoutMs({ cfg, trigger: "cron" })).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+    expect(resolveLlmIdleTimeoutMs({ cfg, trigger: "cron" })).toBe(0);
   });
 
   it.each([

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -137,16 +137,16 @@ export function resolveLlmIdleTimeoutMs(params?: {
     return clampTimeoutMs(Math.min(modelRequestTimeoutMs, ...timeoutBounds));
   }
 
+  if (params?.trigger === "cron") {
+    return 0;
+  }
+
   if (typeof runTimeoutMs === "number" && Number.isFinite(runTimeoutMs) && runTimeoutMs > 0) {
     return clampImplicitTimeoutMs(runTimeoutMs);
   }
 
   if (agentTimeoutMs !== undefined) {
     return clampImplicitTimeoutMs(agentTimeoutMs);
-  }
-
-  if (params?.trigger === "cron") {
-    return 0;
   }
 
   // The default watchdog is a network-silence-as-hang guard for cloud providers.


### PR DESCRIPTION
## Summary

Fixes isolated cron runs where a configured cron `timeoutSeconds` could be reused as the embedded model idle watchdog input, causing long-running cron jobs to fail with the model-idle-timeout error before the cron wall-clock deadline.

## Changes

- Keeps cron-triggered embedded runs on the cron-specific idle-watchdog behavior unless a model provider request timeout is explicitly configured.
- Adds regression coverage for positive cron run timeouts so `timeoutSeconds: 600` no longer becomes a capped model idle watchdog.
- Preserves provider `requestTimeoutMs` behavior and its existing bounds against outer run/agent timeouts.

## Testing

- `pnpm test src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts src/cron/service/timeout-policy.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/llm-idle-timeout.ts src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts`
- `pnpm check:changed`

Fixes openclaw/openclaw#76331
