### PR TITLE
fix(gateway): delay post-ready maintenance

### DIFF
--- a/scripts/kova-ci-summary.mjs
+++ b/scripts/kova-ci-summary.mjs
@@ -11,6 +11,8 @@ const keyMetricIds = [
   "timeToHealthReadyMs",
   "timeToListeningMs",
   "healthP95Ms",
+  "startupHealthP95Ms",
+  "postReadyHealthP95Ms",
   "peakRssMb",
   "resourcePeakGatewayRssMb",
   "cpuPercentMax",

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -54,7 +54,9 @@ vi.mock("./model-pricing-cache.js", () => ({
 
 const {
   activateGatewayScheduledServices,
+  GATEWAY_POST_READY_MAINTENANCE_DELAY_MS,
   runGatewayPostReadyMaintenance,
+  scheduleGatewayPostReadyMaintenance,
   startGatewayRuntimeServices,
 } = await import("./server-runtime-services.js");
 
@@ -241,6 +243,36 @@ describe("server-runtime-services", () => {
     expect(log.warn).toHaveBeenCalledWith(
       "gateway post-ready maintenance startup failed: Error: timers unavailable",
     );
+    expect(cron.start).toHaveBeenCalledTimes(1);
+    expect(recordPostReadyMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules post-ready maintenance after the settling window", async () => {
+    vi.useFakeTimers();
+    const startMaintenance = vi.fn(async () => null);
+    const cron = { start: vi.fn(async () => undefined) };
+    const markCronStartHandled = vi.fn();
+    const recordPostReadyMemory = vi.fn();
+
+    scheduleGatewayPostReadyMaintenance({
+      startMaintenance,
+      applyMaintenance: vi.fn(),
+      shouldStartCron: () => true,
+      markCronStartHandled,
+      cron,
+      logCron: { error: vi.fn() },
+      log: createLog(),
+      recordPostReadyMemory,
+    });
+
+    await vi.advanceTimersByTimeAsync(GATEWAY_POST_READY_MAINTENANCE_DELAY_MS - 1);
+    expect(startMaintenance).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.dynamicImportSettled();
+
+    expect(startMaintenance).toHaveBeenCalledTimes(1);
+    expect(markCronStartHandled).toHaveBeenCalledTimes(1);
     expect(cron.start).toHaveBeenCalledTimes(1);
     expect(recordPostReadyMemory).toHaveBeenCalledTimes(1);
   });

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -21,6 +21,7 @@ type GatewayPostReadyLogger = {
 type GatewayMaintenanceHandles = NonNullable<
   Awaited<ReturnType<typeof startGatewayMaintenanceTimers>>
 >;
+export const GATEWAY_POST_READY_MAINTENANCE_DELAY_MS = 2_000;
 
 export type GatewayChannelManager = Parameters<
   typeof startChannelHealthMonitor
@@ -60,7 +61,7 @@ export function startGatewayCronWithLogging(params: {
   void params.cron.start().catch((err) => params.logCron.error(`failed to start: ${String(err)}`));
 }
 
-export async function runGatewayPostReadyMaintenance(params: {
+type GatewayPostReadyMaintenanceParams = {
   startMaintenance: () => Promise<GatewayMaintenanceHandles | null>;
   applyMaintenance: (maintenance: GatewayMaintenanceHandles) => void;
   shouldStartCron: () => boolean;
@@ -69,7 +70,11 @@ export async function runGatewayPostReadyMaintenance(params: {
   logCron: { error: (message: string) => void };
   log: GatewayPostReadyLogger;
   recordPostReadyMemory: () => void;
-}): Promise<void> {
+};
+
+export async function runGatewayPostReadyMaintenance(
+  params: GatewayPostReadyMaintenanceParams,
+): Promise<void> {
   try {
     const maintenance = await params.startMaintenance();
     if (maintenance) {
@@ -86,6 +91,19 @@ export async function runGatewayPostReadyMaintenance(params: {
     });
   }
   params.recordPostReadyMemory();
+}
+
+export function scheduleGatewayPostReadyMaintenance({
+  delayMs = GATEWAY_POST_READY_MAINTENANCE_DELAY_MS,
+  ...params
+}: GatewayPostReadyMaintenanceParams & {
+  delayMs?: number;
+}): ReturnType<typeof setTimeout> {
+  const handle = setTimeout(() => {
+    void runGatewayPostReadyMaintenance(params);
+  }, delayMs);
+  handle.unref?.();
+  return handle;
 }
 
 function recoverPendingOutboundDeliveries(params: {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -97,7 +97,6 @@ export { __resetModelCatalogCacheForTest } from "./server-model-catalog.js";
 ensureOpenClawCliOnPath();
 
 const MAX_MEDIA_TTL_HOURS = 24 * 7;
-const POST_READY_MAINTENANCE_DELAY_MS = 250;
 
 type GatewayStartupChannelPlugin = {
   id: ChannelId;
@@ -1492,28 +1491,25 @@ export async function startGatewayServer(
       log.warn(`gateway: failed to promote config last-known-good backup: ${String(err)}`);
     });
     if (!minimalTestGateway) {
-      const handle = setTimeout(() => {
-        void gatewayRuntimeServices.runGatewayPostReadyMaintenance({
-          startMaintenance: earlyRuntime.startMaintenance,
-          applyMaintenance: (maintenance) => {
-            runtimeState.tickInterval = maintenance.tickInterval;
-            runtimeState.healthInterval = maintenance.healthInterval;
-            runtimeState.dedupeCleanup = maintenance.dedupeCleanup;
-            runtimeState.mediaCleanup = maintenance.mediaCleanup;
-          },
-          shouldStartCron: () => !gatewayCronStartHandled,
-          markCronStartHandled: () => {
-            gatewayCronStartHandled = true;
-          },
-          cron: runtimeState.cronState.cron,
-          logCron,
-          log,
-          recordPostReadyMemory: () => {
-            startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
-          },
-        });
-      }, POST_READY_MAINTENANCE_DELAY_MS);
-      handle.unref?.();
+      gatewayRuntimeServices.scheduleGatewayPostReadyMaintenance({
+        startMaintenance: earlyRuntime.startMaintenance,
+        applyMaintenance: (maintenance) => {
+          runtimeState.tickInterval = maintenance.tickInterval;
+          runtimeState.healthInterval = maintenance.healthInterval;
+          runtimeState.dedupeCleanup = maintenance.dedupeCleanup;
+          runtimeState.mediaCleanup = maintenance.mediaCleanup;
+        },
+        shouldStartCron: () => !gatewayCronStartHandled,
+        markCronStartHandled: () => {
+          gatewayCronStartHandled = true;
+        },
+        cron: runtimeState.cronState.cron,
+        logCron,
+        log,
+        recordPostReadyMemory: () => {
+          startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
+        },
+      });
     } else {
       startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
     }


### PR DESCRIPTION
Summary:
- delay post-ready gateway maintenance/cron startup behind a named 2s settling window
- route gateway startup through the shared post-ready scheduler and cover the timing behavior
- expose startup/post-ready health p95 keys in the OpenClaw Kova CI summary

Verification:
- pnpm test:serial src/gateway/server-runtime-services.test.ts
- Crabbox Blacksmith Testbox tbx_01kqrt04gx0nd1wfyc7fyy9akv: pnpm check:changed passed, Actions run 25304033219