### PR TITLE
fix(feishu): keep group_topic message-tool replies inside the topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/groups: include the recent local chat window and nearby reply-target window as generic inbound context so stale reply ancestry does not overshadow the live group conversation.
 - Plugins/Nix: allow externally configured plugin roots under `/nix/store` to load in `OPENCLAW_NIX_MODE=1` while keeping normal external plugin hardlink rejection unchanged. Thanks @joshp123.
 - Nextcloud Talk: include the required bot `response` feature in setup, explain missing `--feature response` on rejected sends, and surface missing response capability in doctor/status checks. Fixes #78935. (#79657) Thanks @joshavant.
+- Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Infra/fetch-timeout: pass `operation` and `url` context to `buildTimeoutAbortSignal` from the music-generate reference fetch and the Matrix guarded redirect transport, so the `fetch timeout reached; aborting operation` warning carries actionable structured fields instead of a bare line. Fixes #79195. Thanks @pandadev66.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+### Fixes
+
+- Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
+
 ## 2026.5.9
 
 ### Changes
@@ -207,7 +215,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/groups: include the recent local chat window and nearby reply-target window as generic inbound context so stale reply ancestry does not overshadow the live group conversation.
 - Plugins/Nix: allow externally configured plugin roots under `/nix/store` to load in `OPENCLAW_NIX_MODE=1` while keeping normal external plugin hardlink rejection unchanged. Thanks @joshp123.
 - Nextcloud Talk: include the required bot `response` feature in setup, explain missing `--feature response` on rejected sends, and surface missing response capability in doctor/status checks. Fixes #78935. (#79657) Thanks @joshavant.
-- Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Infra/fetch-timeout: pass `operation` and `url` context to `buildTimeoutAbortSignal` from the music-generate reference fetch and the Matrix guarded redirect transport, so the `fetch timeout reached; aborting operation` warning carries actionable structured fields instead of a bare line. Fixes #79195. Thanks @pandadev66.

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -578,6 +578,149 @@ describe("feishuPlugin actions", () => {
     });
   });
 
+  it("auto-threads `send` text against the inbound trigger in group_topic sessions", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1:topic:om_inbound",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: "om_inbound",
+      replyInThread: true,
+    });
+  });
+
+  it("auto-threads `send` cards against the inbound trigger in group_topic sessions", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_topic_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        presentation: {
+          title: "Topic update",
+          blocks: [{ type: "text", text: "topic reply" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1:topic:om_inbound",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_inbound",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("auto-threads `send` media against the inbound trigger in group_topic sessions", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_topic_media",
+      details: { messageId: "om_topic_media", chatId: "oc_group_1" },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "topic reply",
+        media: "/tmp/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1:topic:om_inbound",
+      toolContext: { currentMessageId: "om_inbound" },
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "om_inbound",
+      }),
+    );
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ replyToId: expect.anything() }),
+    );
+  });
+
+  it("auto-threads `send` in group_topic_sender sessions too", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1:topic:om_inbound:sender:ou_user",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_inbound",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("does not auto-thread `send` in plain group sessions (no topic)", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_plain", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "plain group reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1",
+      toolContext: { currentMessageId: "om_inbound" },
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "plain group reply",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
+  it("does not auto-thread `send` in group_topic when no inbound currentMessageId is available", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_topic", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", text: "topic reply" },
+      cfg,
+      accountId: undefined,
+      sessionKey: "feishu:group:oc_group_1:topic:om_inbound",
+      toolContext: {},
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "topic reply",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
   it("creates pins", async () => {
     createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import type {
   ChannelMessageActionAdapter,
+  ChannelMessageActionContext,
   ChannelMessageToolDiscovery,
 } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
@@ -349,6 +350,49 @@ function areAnyFeishuReactionActionsEnabled(cfg: ClawdbotConfig): boolean {
     }
   }
   return false;
+}
+
+function isFeishuGroupTopicSessionKey(sessionKey: string | null | undefined): boolean {
+  if (typeof sessionKey !== "string" || !sessionKey) {
+    return false;
+  }
+  const parsed = parseFeishuConversationId({ conversationId: sessionKey });
+  return parsed?.scope === "group_topic" || parsed?.scope === "group_topic_sender";
+}
+
+type FeishuActionReplyAnchor = {
+  replyToMessageId: string | undefined;
+  replyInThread: boolean;
+};
+
+type FeishuSendActionContext = Pick<
+  ChannelMessageActionContext,
+  "action" | "params" | "sessionKey" | "toolContext"
+>;
+
+function resolveFeishuTopicAutoThreadAnchor(ctx: FeishuSendActionContext): string | undefined {
+  if (ctx.action !== "send") {
+    return undefined;
+  }
+  if (!isFeishuGroupTopicSessionKey(ctx.sessionKey)) {
+    return undefined;
+  }
+  const inbound = ctx.toolContext?.currentMessageId;
+  return typeof inbound === "string" && inbound.length > 0 ? inbound : undefined;
+}
+
+function buildFeishuSendReplyAnchor(ctx: FeishuSendActionContext): FeishuActionReplyAnchor {
+  if (ctx.action === "thread-reply") {
+    return {
+      replyToMessageId: resolveFeishuMessageId(ctx.params),
+      replyInThread: true,
+    };
+  }
+  const autoThreadId = resolveFeishuTopicAutoThreadAnchor(ctx);
+  return {
+    replyToMessageId: autoThreadId,
+    replyInThread: autoThreadId !== undefined,
+  };
 }
 
 function isSupportedFeishuDirectConversationId(conversationId: string): boolean {
@@ -754,8 +798,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (!to) {
               throw new Error(`Feishu ${ctx.action} requires a target (to).`);
             }
-            const replyToMessageId =
-              ctx.action === "thread-reply" ? resolveFeishuMessageId(ctx.params) : undefined;
+            const { replyToMessageId, replyInThread } = buildFeishuSendReplyAnchor(ctx);
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
@@ -791,7 +834,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 card,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             } else if (mediaUrl) {
               result = await sendMedia!({
@@ -801,7 +844,9 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 mediaUrl,
                 accountId: ctx.accountId ?? undefined,
                 mediaLocalRoots: ctx.mediaLocalRoots,
-                replyToId: replyToMessageId,
+                ...(replyInThread
+                  ? { threadId: replyToMessageId }
+                  : { replyToId: replyToMessageId }),
                 ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
               });
             } else {
@@ -811,7 +856,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 text: text!,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
-                replyInThread: ctx.action === "thread-reply",
+                replyInThread,
               });
             }
             return jsonActionResult({

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -958,6 +958,58 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
     );
     expect(sendMessageFeishuMock.mock.calls[0][0].replyToMessageId).toBeUndefined();
   });
+
+  it("propagates threadId as replyInThread=true to sendMessageFeishu", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "topic reply",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_topic_root",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("propagates threadId as replyInThread=true to sendStructuredCardFeishu when renderMode=card", async () => {
+    await sendText({
+      cfg: cardRenderConfig,
+      to: "chat_1",
+      text: "```code```",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_topic_root",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("prefers replyToId over threadId for plain text (inline reply, no auto-thread)", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "inline reply",
+      replyToId: "om_inline",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_inline",
+        replyInThread: false,
+      }),
+    );
+  });
 });
 
 describe("feishuOutbound.sendMedia replyToId forwarding", () => {

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -1072,6 +1072,25 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     );
   });
 
+  it("treats whitespace-only replyToId as absent for replyInThread (falls back to threadId)", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "",
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "   ",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_topic_root",
+        replyInThread: true,
+      }),
+    );
+  });
+
   it("forwards audioAsVoice to sendMediaFeishu", async () => {
     await feishuOutbound.sendMedia?.({
       cfg: emptyConfig,

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -978,6 +978,44 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     expect(sendMediaFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_reply_target",
+        replyInThread: false,
+      }),
+    );
+  });
+
+  it("forwards threadId as replyInThread=true to sendMediaFeishu", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "",
+      mediaUrl: "https://example.com/image.png",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_topic_root",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("prefers replyToId over threadId (inline reply) when both are set", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "",
+      mediaUrl: "https://example.com/image.png",
+      replyToId: "om_inline",
+      threadId: "om_topic_root",
+      accountId: "main",
+    });
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_inline",
+        replyInThread: false,
       }),
     );
   });

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -381,6 +381,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
         to: "chat_1",
         text: "hello",
         replyToMessageId: "om_thread_2",
+        replyInThread: true,
         accountId: "main",
       }),
     );

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -417,8 +417,9 @@ function resolveFeishuMediaReplyMode(params: {
   replyToId?: string | null;
   threadId?: string | number | null;
 }): FeishuMediaReplyMode {
+  const trimmedReplyToId = params.replyToId?.trim() || undefined;
   const replyToMessageId = resolveReplyToMessageId(params);
-  const replyInThread = params.threadId != null && !params.replyToId;
+  const replyInThread = params.threadId != null && !trimmedReplyToId;
   return { replyToMessageId, replyInThread };
 }
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -631,6 +631,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text,
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread: threadId != null && !replyToId,
         });
       }
 
@@ -662,6 +663,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text,
         accountId: accountId ?? undefined,
         replyToMessageId,
+        replyInThread: threadId != null && !replyToId,
       });
     },
     sendMedia: async ({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -604,7 +604,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       identity,
     }) => {
-      const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
+        replyToId,
+        threadId,
+      });
       // Scheme A compatibility shim:
       // when upstream accidentally returns a local image path as plain text,
       // auto-upload and send as Feishu image message instead of leaking path text.
@@ -617,6 +620,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             mediaUrl: localImagePath,
             accountId: accountId ?? undefined,
             replyToMessageId,
+            replyInThread,
             mediaLocalRoots,
           });
         } catch (err) {
@@ -632,7 +636,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text,
           accountId: accountId ?? undefined,
           replyToMessageId,
-          replyInThread: threadId != null && !replyToId,
+          replyInThread,
         });
       }
 
@@ -653,7 +657,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           to,
           text,
           replyToMessageId,
-          replyInThread: threadId != null && !replyToId,
+          replyInThread,
           accountId: accountId ?? undefined,
           header: header?.title ? header : undefined,
         });
@@ -664,7 +668,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text,
         accountId: accountId ?? undefined,
         replyToMessageId,
-        replyInThread: threadId != null && !replyToId,
+        replyInThread,
       });
     },
     sendMedia: async ({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -408,6 +408,20 @@ function resolveReplyToMessageId(params: {
   return trimmed || undefined;
 }
 
+type FeishuMediaReplyMode = {
+  replyToMessageId: string | undefined;
+  replyInThread: boolean;
+};
+
+function resolveFeishuMediaReplyMode(params: {
+  replyToId?: string | null;
+  threadId?: string | number | null;
+}): FeishuMediaReplyMode {
+  const replyToMessageId = resolveReplyToMessageId(params);
+  const replyInThread = params.threadId != null && !params.replyToId;
+  return { replyToMessageId, replyInThread };
+}
+
 async function sendCommentThreadReply(params: {
   cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
   to: string;
@@ -456,9 +470,10 @@ async function sendOutboundText(params: {
   to: string;
   text: string;
   replyToMessageId?: string;
+  replyInThread?: boolean;
   accountId?: string;
 }) {
-  const { cfg, to, text, accountId, replyToMessageId } = params;
+  const { cfg, to, text, accountId, replyToMessageId, replyInThread } = params;
   const commentResult = await sendCommentThreadReply({
     cfg,
     to,
@@ -474,10 +489,17 @@ async function sendOutboundText(params: {
   const renderMode = account.config?.renderMode ?? "auto";
 
   if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return sendMarkdownCardFeishu({ cfg, to, text, accountId, replyToMessageId });
+    return sendMarkdownCardFeishu({
+      cfg,
+      to,
+      text,
+      accountId,
+      replyToMessageId,
+      replyInThread,
+    });
   }
 
-  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
+  return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId, replyInThread });
 }
 
 export const feishuOutbound: ChannelOutboundAdapter = {
@@ -653,7 +675,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       replyToId,
       threadId,
     }) => {
-      const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const { replyToMessageId, replyInThread } = resolveFeishuMediaReplyMode({
+        replyToId,
+        threadId,
+      });
       const commentTarget = parseFeishuCommentTarget(to);
       if (commentTarget) {
         const commentText = [text?.trim(), mediaUrl?.trim()].filter(Boolean).join("\n\n");
@@ -663,6 +688,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text: commentText || mediaUrl || text || "",
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread,
         });
       }
 
@@ -681,6 +707,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           text,
           accountId: accountId ?? undefined,
           replyToMessageId,
+          replyInThread,
         });
       }
 
@@ -694,6 +721,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             accountId: accountId ?? undefined,
             mediaLocalRoots,
             replyToMessageId,
+            replyInThread,
             ...(audioAsVoice === true ? { audioAsVoice: true } : {}),
           });
           if (result.voiceIntentDegradedToFile && text?.trim()) {
@@ -703,6 +731,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
               text,
               accountId: accountId ?? undefined,
               replyToMessageId,
+              replyInThread,
             });
           }
           return result;
@@ -717,6 +746,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             text: fallbackText,
             accountId: accountId ?? undefined,
             replyToMessageId,
+            replyInThread,
           });
         }
       }
@@ -728,6 +758,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         text: text ?? "",
         accountId: accountId ?? undefined,
         replyToMessageId,
+        replyInThread,
       });
     },
   }),


### PR DESCRIPTION
## Summary

Fixes #74903.

When a Feishu group chat message lands in a `group_topic`-scoped session, the assistant's `message(action="send")` reply was posting at the group root instead of inside the topic (话题). Auto-thread `send` against the inbound trigger when the active session scope is `group_topic` or `group_topic_sender`, and propagate the topic-thread decision uniformly through text, card, and media sends. Plain group sessions stay unthreaded.

## Root cause

`extensions/feishu/src/channel.ts` only set `replyToMessageId` / `replyInThread` for explicit `action: "thread-reply"`; a topic-scoped `send` left both unset, so Feishu posted to the chat root. The runtime `sendMedia` adapter in `extensions/feishu/src/outbound.ts` likewise forwarded only `replyToMessageId` to `sendMediaFeishu`, dropping the thread-mode flag for media sends.

## Changes

- `extensions/feishu/src/channel.ts` — add `isFeishuGroupTopicSessionKey()` plus typed helpers (`resolveFeishuTopicAutoThreadAnchor`, `buildFeishuSendReplyAnchor`) so the action handler derives `{ replyToMessageId, replyInThread }` once and forwards it uniformly to text, card, **and** media sends.
- `extensions/feishu/src/outbound.ts` — extend `sendOutboundText` to accept and forward `replyInThread`; the runtime `sendMedia` adapter resolves `{ replyToMessageId, replyInThread }` via a new `resolveFeishuMediaReplyMode()` helper and propagates `replyInThread` to every `sendMediaFeishu` / `sendOutboundText` sub-call (mainline, post-voice fallback, catch fallback, no-media branch).
- Tests:
  - `extensions/feishu/src/channel.test.ts` — six new cases: text/card/media auto-thread in `group_topic`, `group_topic_sender` variant, no auto-thread for plain group, no auto-thread when `currentMessageId` is missing.
  - `extensions/feishu/src/outbound.test.ts` — `threadId` → `replyInThread=true`, and `replyToId` precedence over `threadId`.

## Real behavior proof

**Behavior or issue addressed:** Feishu group_topic sessions where the assistant uses `message(action="send")` were posting visible replies at the group root instead of inside the topic thread (话题), as described in #74903. After the fix, topic-scoped `send` actions auto-thread against the inbound trigger and the visible reply lands inside the topic. Plain group `send` actions remain unthreaded so they continue to post at the chat root.

**Real environment tested:** Local macOS Mac mini gateway (`launchctl gui/$(id -u)/ai.openclaw.gateway`) running the patch on top of upstream main (`ba675d8964 test: clarify secrets warning assertion`), bundled `extensions/feishu` channel in WebSocket mode, real Lark tenant bot `cli_a972e47287b8de17` joined to a Lark group with `groupSessionScope: "group_topic"`. Agent runtime: `openai-codex/gpt-5.5` via `@openai/codex@0.129.0`. Live HTTPS calls to `open.larksuite.com`/`open.feishu.cn` returned real `messageId` values (`om_x100b50…`).

**Exact steps or command run after this patch:**
1. `cd /Users/a1111/openclaw && pnpm install && pnpm build` (rebuilds `dist/index.js` with the patched feishu sources)
2. `launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway` (restart gateway)
3. Send Lark message inside a topic: long-press an existing message → Reply → `@speedy_lark_bot thread test again`
4. Send Lark message at root (no topic): `@speedy_lark_bot root test again`
5. Tail gateway runtime logs and Codex rollout: `tail -F /Users/a1111/.openclaw/logs/gateway.log /tmp/openclaw/openclaw-2026-05-08.log` and inspect `/Users/a1111/.openclaw/agents/main/agent/codex-home/sessions/2026/05/08/rollout-*.jsonl`

**Evidence after fix:**

Topic send — runtime log excerpt and Codex rollout terminal output captured live from the running gateway:

```
[feishu] feishu[main]: received message from ou_5b28…7087 in oc_02de…e754 (group)
[feishu] feishu[main]: group session scope=group_topic, peer=oc_02de…e754:topic:om_x100b50ec1c0c2c…
[feishu] feishu[main]: dispatching to agent (session=agent:main:feishu:group:oc_02de…e754:topic:om_x100b50ec1c0c2c…)
[feishu] feishu[main]: dispatch complete (queuedFinal=false, replies=0)
```

Codex rollout (`rollout-2026-05-08T17-01-30-…jsonl`, captured directly from disk after the live turn ran on the patched build):

```
CALL message: {"accountId":"main","action":"send","target":"chat:oc_02de…e754","threadId":"om_x100b50ec1c0c2c…","message":"hi 👋"}
OUT:          {"ok":true,"channel":"feishu","action":"send","messageId":"om_x100b50ecebef50a8ee8209cfac962bd","chatId":"oc_02de…e754",…}
```

Root send — runtime log excerpt and rollout terminal output from the same live setup:

```
[feishu] feishu[main]: received message from ou_5b28…7087 in oc_02de…e754 (group)
[feishu] feishu[main]: group session scope=group_topic, peer=oc_02de…e754      ← no :topic: segment
[feishu] feishu[main]: dispatching to agent (session=agent:main:feishu:group:oc_02de…e754)
[feishu] feishu[main]: dispatch complete (queuedFinal=false, replies=0)
```

```
CALL message: {"accountId":"main","action":"send","message":"got it, root message received ✅"}
OUT:          {"ok":true,"channel":"feishu","action":"send","messageId":"om_x100b50edbffa34b0ee762157221c95d",…}
```

**Observed result after fix:**
- Topic test: `isFeishuGroupTopicSessionKey()` returned true on the `:topic:` session key, the action handler set `replyInThread=true` and `replyToMessageId=<inbound message id>`, the Lark Open API send returned `ok:true` with `messageId=om_x100b50ecebef50a8ee8209cfac962bd`, and the bot reply was visible **inside the topic thread** in the Lark client. (Pre-fix on the same setup: same Codex tool call landed at the group root.)
- Root test: session key had no `:topic:` segment, the handler left `replyInThread=false` and `replyToMessageId=undefined`, the send returned `ok:true` with `messageId=om_x100b50edbffa34b0ee762157221c95d`, and the bot reply was visible **at the top of the group** (no regression).
- No errors in `/Users/a1111/.openclaw/logs/gateway.err.log` during either turn.

**What was not tested:** Card and media auto-thread paths were not exercised on the live Lark group during this run because the bundled Codex agent on this gateway only emits text replies; their behavior is covered by the new unit tests in `channel.test.ts` (`auto-threads send cards…` and `auto-threads send media…`). `group_topic_sender` scope was likewise covered by unit test only.

## Test plan

- [x] Unit: `pnpm vitest run extensions/feishu/src/channel.test.ts extensions/feishu/src/outbound.test.ts` (90/90 passing)
- [x] Live Lark group with `groupSessionScope: "group_topic"`: topic reply lands inside the topic
- [x] Live Lark group with `groupSessionScope: "group_topic"`: root message reply lands at top of group (no regression)