### PR TITLE
Highlight exec command risks in Web approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,7 @@ Docs: https://docs.openclaw.ai
 - Config/Nix: keep startup-derived plugin enablement, gateway auth tokens, control UI origins, and owner-display secrets runtime-only instead of rewriting `openclaw.json`; in Nix mode, config writers, mutating `openclaw update`, plugin lifecycle mutators, and doctor repair/token-generation now refuse with agent-first nix-openclaw guidance. (#78047) Thanks @joshp123.
 - Agents/context engine: invalidate cached assembled context views when source history shrinks or assembly fails, preventing stale pre-reset history from being reused. Fixes #77968. (#78163) Thanks @brokemac79 and @ChrisBot2026.
 - Plugin SDK: add a generic `api.runtime.llm.complete` host completion helper with runtime-derived caller attribution, config-gated model/agent overrides, session-bound context-engine access, request-scoped config, audit metadata, and normalized usage attribution. (#64294) Thanks @DaevMithran.
+- Control UI/exec approvals: highlight parsed shell command fragments that may deserve extra review in approval prompts. (#77153) Thanks @jesse-merhi.
 
 ### Breaking
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5144,6 +5144,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
     public let security: AnyCodable?
     public let ask: AnyCodable?
     public let warningtext: AnyCodable?
+    public let commandspans: [[String: AnyCodable]]?
     public let agentid: AnyCodable?
     public let resolvedpath: AnyCodable?
     public let sessionkey: AnyCodable?
@@ -5166,6 +5167,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         security: AnyCodable?,
         ask: AnyCodable?,
         warningtext: AnyCodable?,
+        commandspans: [[String: AnyCodable]]?,
         agentid: AnyCodable?,
         resolvedpath: AnyCodable?,
         sessionkey: AnyCodable?,
@@ -5187,6 +5189,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         self.security = security
         self.ask = ask
         self.warningtext = warningtext
+        self.commandspans = commandspans
         self.agentid = agentid
         self.resolvedpath = resolvedpath
         self.sessionkey = sessionkey
@@ -5210,6 +5213,7 @@ public struct ExecApprovalRequestParams: Codable, Sendable {
         case security
         case ask
         case warningtext = "warningText"
+        case commandspans = "commandSpans"
         case agentid = "agentId"
         case resolvedpath = "resolvedPath"
         case sessionkey = "sessionKey"

--- a/src/agents/bash-tools.exec-approval-request.runtime.ts
+++ b/src/agents/bash-tools.exec-approval-request.runtime.ts
@@ -1,0 +1,10 @@
+import { explainShellCommand, formatCommandSpans } from "../infra/command-explainer/index.js";
+import type { ExecApprovalCommandSpan } from "../infra/exec-approvals.js";
+
+export async function resolveExecApprovalCommandSpans(
+  command: string,
+): Promise<ExecApprovalCommandSpan[] | undefined> {
+  const explanation = await explainShellCommand(command);
+  const commandSpans = formatCommandSpans(explanation);
+  return commandSpans.length > 0 ? commandSpans : undefined;
+}

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -10,11 +10,13 @@ vi.mock("./tools/gateway.js", () => ({
 
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let requestExecApprovalDecision: typeof import("./bash-tools.exec-approval-request.js").requestExecApprovalDecision;
+let registerExecApprovalRequestForHost: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequestForHost;
 
 describe("requestExecApprovalDecision", () => {
   beforeAll(async () => {
     ({ callGatewayTool } = await import("./tools/gateway.js"));
-    ({ requestExecApprovalDecision } = await import("./bash-tools.exec-approval-request.js"));
+    ({ requestExecApprovalDecision, registerExecApprovalRequestForHost } =
+      await import("./bash-tools.exec-approval-request.js"));
   });
 
   beforeEach(() => {
@@ -173,5 +175,82 @@ describe("requestExecApprovalDecision", () => {
 
     expect(result).toBe("deny");
     expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(1);
+  });
+
+  it("adds command explanation highlights to host approval registration payloads", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id",
+      command: 'ls | grep "stuff" | python -c \'print("hi")\'',
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.request",
+      expect.anything(),
+      expect.objectContaining({
+        commandExplanationHighlights: expect.arrayContaining([
+          expect.objectContaining({ kind: "command", severity: "info" }),
+          expect.objectContaining({ kind: "risk", severity: "danger" }),
+        ]),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses system run plan command text for host approval explanations", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id",
+      systemRunPlan: {
+        argv: ["node", "-e", "console.log(1)"],
+        cwd: "/tmp/project",
+        commandText: 'node -e "console.log(1)"',
+        agentId: null,
+        sessionKey: null,
+      },
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.request",
+      expect.anything(),
+      expect.objectContaining({
+        commandExplanationHighlights: expect.arrayContaining([
+          expect.objectContaining({ kind: "command", severity: "info" }),
+          expect.objectContaining({ kind: "risk", severity: "danger" }),
+        ]),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("keeps explicit command explanation lines", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
+
+    await registerExecApprovalRequestForHost({
+      approvalId: "approval-id",
+      command: "echo hi",
+      commandExplanationLines: ["custom line"],
+      workdir: "/tmp/project",
+      host: "node",
+      security: "allowlist",
+      ask: "always",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.request",
+      expect.anything(),
+      expect.objectContaining({ commandExplanationLines: ["custom line"] }),
+      expect.anything(),
+    );
   });
 });

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -4,6 +4,30 @@ import {
   DEFAULT_APPROVAL_TIMEOUT_MS,
 } from "./bash-tools.exec-runtime.js";
 
+const commandExplainerMock = vi.hoisted(() => ({
+  importCount: 0,
+  explainShellCommand: vi.fn(async (command: string): Promise<string> => command),
+  formatCommandSpans: vi.fn((command: string) => {
+    if (command.startsWith("node ")) {
+      return [{ startIndex: 0, endIndex: 4 }];
+    }
+    return [
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 0, endIndex: 4 },
+      { startIndex: 5, endIndex: 9 },
+      { startIndex: 20, endIndex: 26 },
+    ];
+  }),
+}));
+
+vi.mock("../infra/command-explainer/index.js", () => {
+  commandExplainerMock.importCount += 1;
+  return {
+    explainShellCommand: commandExplainerMock.explainShellCommand,
+    formatCommandSpans: commandExplainerMock.formatCommandSpans,
+  };
+});
+
 vi.mock("./tools/gateway.js", () => ({
   callGatewayTool: vi.fn(),
 }));
@@ -21,6 +45,12 @@ describe("requestExecApprovalDecision", () => {
 
   beforeEach(() => {
     vi.mocked(callGatewayTool).mockClear();
+    commandExplainerMock.explainShellCommand.mockClear();
+    commandExplainerMock.formatCommandSpans.mockClear();
+  });
+
+  it("does not load the command explainer when importing approval requests", () => {
+    expect(commandExplainerMock.importCount).toBe(0);
   });
 
   it("returns string decisions", async () => {

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -177,7 +177,7 @@ describe("requestExecApprovalDecision", () => {
     expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(1);
   });
 
-  it("adds command explanation highlights to host approval registration payloads", async () => {
+  it("adds command spans to host approval registration payloads", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
 
     await registerExecApprovalRequestForHost({
@@ -193,9 +193,10 @@ describe("requestExecApprovalDecision", () => {
       "exec.approval.request",
       expect.anything(),
       expect.objectContaining({
-        commandExplanationHighlights: expect.arrayContaining([
-          expect.objectContaining({ kind: "command", severity: "info" }),
-          expect.objectContaining({ kind: "risk", severity: "danger" }),
+        commandSpans: expect.arrayContaining([
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 5, endIndex: 9 },
+          { startIndex: 20, endIndex: 26 },
         ]),
       }),
       expect.anything(),
@@ -224,22 +225,19 @@ describe("requestExecApprovalDecision", () => {
       "exec.approval.request",
       expect.anything(),
       expect.objectContaining({
-        commandExplanationHighlights: expect.arrayContaining([
-          expect.objectContaining({ kind: "command", severity: "info" }),
-          expect.objectContaining({ kind: "risk", severity: "danger" }),
-        ]),
+        commandSpans: expect.arrayContaining([{ startIndex: 0, endIndex: 4 }]),
       }),
       expect.anything(),
     );
   });
 
-  it("keeps explicit command explanation lines", async () => {
+  it("keeps explicit command spans", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
 
     await registerExecApprovalRequestForHost({
       approvalId: "approval-id",
       command: "echo hi",
-      commandExplanationLines: ["custom line"],
+      commandSpans: [{ startIndex: 0, endIndex: 4 }],
       workdir: "/tmp/project",
       host: "node",
       security: "allowlist",
@@ -249,7 +247,7 @@ describe("requestExecApprovalDecision", () => {
     expect(callGatewayTool).toHaveBeenCalledWith(
       "exec.approval.request",
       expect.anything(),
-      expect.objectContaining({ commandExplanationLines: ["custom line"] }),
+      expect.objectContaining({ commandSpans: [{ startIndex: 0, endIndex: 4 }] }),
       expect.anything(),
     );
   });

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,3 +1,8 @@
+import {
+  explainShellCommand,
+  formatCommandExplanationHighlights,
+  formatCommandExplanationLines,
+} from "../infra/command-explainer/index.js";
 import type { ExecAsk, ExecSecurity, SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
@@ -18,6 +23,8 @@ export type RequestExecApprovalDecisionParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
+  commandExplanationLines?: string[];
+  commandExplanationHighlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -47,6 +54,8 @@ function buildExecApprovalRequestToolParams(
     security: params.security,
     ask: params.ask,
     warningText: params.warningText,
+    commandExplanationLines: params.commandExplanationLines,
+    commandExplanationHighlights: params.commandExplanationHighlights,
     agentId: params.agentId,
     resolvedPath: params.resolvedPath,
     sessionKey: params.sessionKey,
@@ -159,6 +168,8 @@ type HostExecApprovalParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
+  commandExplanationLines?: string[];
+  commandExplanationHighlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -201,6 +212,32 @@ export function buildExecApprovalTurnSourceContext(
   };
 }
 
+function resolveExplanationCommand(
+  params: Pick<HostExecApprovalParams, "command" | "systemRunPlan">,
+): string | undefined {
+  return params.command ?? params.systemRunPlan?.commandText;
+}
+
+async function resolveCommandExplanation(command: string | undefined): Promise<{
+  lines?: string[];
+  highlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
+}> {
+  if (!command) {
+    return {};
+  }
+  try {
+    const explanation = await explainShellCommand(command);
+    const lines = formatCommandExplanationLines(explanation);
+    const highlights = formatCommandExplanationHighlights(explanation);
+    return {
+      lines: lines.length > 0 ? lines : undefined,
+      highlights: highlights.length > 0 ? highlights : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 function buildHostApprovalDecisionParams(
   params: HostExecApprovalParams,
 ): RequestExecApprovalDecisionParams {
@@ -216,6 +253,8 @@ function buildHostApprovalDecisionParams(
     security: params.security,
     ask: params.ask,
     warningText: params.warningText,
+    commandExplanationLines: params.commandExplanationLines,
+    commandExplanationHighlights: params.commandExplanationHighlights,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,
@@ -225,16 +264,34 @@ function buildHostApprovalDecisionParams(
   };
 }
 
+async function buildHostApprovalDecisionParamsWithExplanation(
+  params: HostExecApprovalParams,
+): Promise<RequestExecApprovalDecisionParams> {
+  const explanation =
+    params.commandExplanationLines && params.commandExplanationHighlights
+      ? {}
+      : await resolveCommandExplanation(resolveExplanationCommand(params));
+  return buildHostApprovalDecisionParams({
+    ...params,
+    commandExplanationLines: params.commandExplanationLines ?? explanation.lines,
+    commandExplanationHighlights: params.commandExplanationHighlights ?? explanation.highlights,
+  });
+}
+
 export async function requestExecApprovalDecisionForHost(
   params: HostExecApprovalParams,
 ): Promise<string | null> {
-  return await requestExecApprovalDecision(buildHostApprovalDecisionParams(params));
+  return await requestExecApprovalDecision(
+    await buildHostApprovalDecisionParamsWithExplanation(params),
+  );
 }
 
 export async function registerExecApprovalRequestForHost(
   params: HostExecApprovalParams,
 ): Promise<ExecApprovalRegistration> {
-  return await registerExecApprovalRequest(buildHostApprovalDecisionParams(params));
+  return await registerExecApprovalRequest(
+    await buildHostApprovalDecisionParamsWithExplanation(params),
+  );
 }
 
 export async function registerExecApprovalRequestForHostOrThrow(

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,5 +1,10 @@
 import { explainShellCommand, formatCommandSpans } from "../infra/command-explainer/index.js";
-import type { ExecAsk, ExecSecurity, SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import type {
+  ExecApprovalCommandSpan,
+  ExecAsk,
+  ExecSecurity,
+  SystemRunApprovalPlan,
+} from "../infra/exec-approvals.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
@@ -19,7 +24,7 @@ export type RequestExecApprovalDecisionParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
-  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
+  commandSpans?: ExecApprovalCommandSpan[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -162,7 +167,7 @@ type HostExecApprovalParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
-  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
+  commandSpans?: ExecApprovalCommandSpan[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -205,26 +210,22 @@ export function buildExecApprovalTurnSourceContext(
   };
 }
 
-function resolveExplanationCommand(
+function resolveCommandTextForSpans(
   params: Pick<HostExecApprovalParams, "command" | "systemRunPlan">,
-): string | undefined {
-  return params.command ?? params.systemRunPlan?.commandText;
+): string | null {
+  const command = params.command ?? params.systemRunPlan?.commandText;
+  return command && command.length > 0 ? command : null;
 }
 
-async function resolveCommandExplanation(command: string | undefined): Promise<{
-  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
-}> {
-  if (!command) {
-    return {};
-  }
+async function resolveCommandSpans(
+  command: string,
+): Promise<ExecApprovalCommandSpan[] | undefined> {
   try {
     const explanation = await explainShellCommand(command);
     const commandSpans = formatCommandSpans(explanation);
-    return {
-      commandSpans: commandSpans.length > 0 ? commandSpans : undefined,
-    };
+    return commandSpans.length > 0 ? commandSpans : undefined;
   } catch {
-    return {};
+    return undefined;
   }
 }
 
@@ -253,15 +254,17 @@ function buildHostApprovalDecisionParams(
   };
 }
 
-async function buildHostApprovalDecisionParamsWithExplanation(
+async function buildHostApprovalDecisionParamsWithCommandSpans(
   params: HostExecApprovalParams,
 ): Promise<RequestExecApprovalDecisionParams> {
-  const explanation = params.commandSpans
-    ? {}
-    : await resolveCommandExplanation(resolveExplanationCommand(params));
+  if (params.commandSpans) {
+    return buildHostApprovalDecisionParams(params);
+  }
+  const command = resolveCommandTextForSpans(params);
+  const commandSpans = command ? await resolveCommandSpans(command) : undefined;
   return buildHostApprovalDecisionParams({
     ...params,
-    commandSpans: params.commandSpans ?? explanation.commandSpans,
+    commandSpans,
   });
 }
 
@@ -269,7 +272,7 @@ export async function requestExecApprovalDecisionForHost(
   params: HostExecApprovalParams,
 ): Promise<string | null> {
   return await requestExecApprovalDecision(
-    await buildHostApprovalDecisionParamsWithExplanation(params),
+    await buildHostApprovalDecisionParamsWithCommandSpans(params),
   );
 }
 
@@ -277,7 +280,7 @@ export async function registerExecApprovalRequestForHost(
   params: HostExecApprovalParams,
 ): Promise<ExecApprovalRegistration> {
   return await registerExecApprovalRequest(
-    await buildHostApprovalDecisionParamsWithExplanation(params),
+    await buildHostApprovalDecisionParamsWithCommandSpans(params),
   );
 }
 

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,4 +1,3 @@
-import { explainShellCommand, formatCommandSpans } from "../infra/command-explainer/index.js";
 import type {
   ExecApprovalCommandSpan,
   ExecAsk,
@@ -11,6 +10,17 @@ import {
   DEFAULT_APPROVAL_TIMEOUT_MS,
 } from "./bash-tools.exec-runtime.js";
 import { callGatewayTool } from "./tools/gateway.js";
+
+type ExecApprovalCommandSpansRuntime =
+  typeof import("./bash-tools.exec-approval-request.runtime.js");
+
+let execApprovalCommandSpansRuntimePromise: Promise<ExecApprovalCommandSpansRuntime> | null = null;
+
+function loadExecApprovalCommandSpansRuntime(): Promise<ExecApprovalCommandSpansRuntime> {
+  execApprovalCommandSpansRuntimePromise ??=
+    import("./bash-tools.exec-approval-request.runtime.js");
+  return execApprovalCommandSpansRuntimePromise;
+}
 
 export type RequestExecApprovalDecisionParams = {
   id: string;
@@ -217,9 +227,8 @@ async function resolveCommandSpans(
     return undefined;
   }
   try {
-    const explanation = await explainShellCommand(command);
-    const commandSpans = formatCommandSpans(explanation);
-    return commandSpans.length > 0 ? commandSpans : undefined;
+    const { resolveExecApprovalCommandSpans } = await loadExecApprovalCommandSpansRuntime();
+    return await resolveExecApprovalCommandSpans(command);
   } catch {
     return undefined;
   }

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -210,16 +210,12 @@ export function buildExecApprovalTurnSourceContext(
   };
 }
 
-function resolveCommandTextForSpans(
-  params: Pick<HostExecApprovalParams, "command" | "systemRunPlan">,
-): string | null {
-  const command = params.command ?? params.systemRunPlan?.commandText;
-  return command && command.length > 0 ? command : null;
-}
-
 async function resolveCommandSpans(
-  command: string,
+  command: string | undefined,
 ): Promise<ExecApprovalCommandSpan[] | undefined> {
+  if (!command) {
+    return undefined;
+  }
   try {
     const explanation = await explainShellCommand(command);
     const commandSpans = formatCommandSpans(explanation);
@@ -229,9 +225,12 @@ async function resolveCommandSpans(
   }
 }
 
-function buildHostApprovalDecisionParams(
+async function buildHostApprovalDecisionParams(
   params: HostExecApprovalParams,
-): RequestExecApprovalDecisionParams {
+): Promise<RequestExecApprovalDecisionParams> {
+  const commandSpans =
+    params.commandSpans ??
+    (await resolveCommandSpans(params.command ?? params.systemRunPlan?.commandText));
   return {
     id: params.approvalId,
     command: params.command,
@@ -244,7 +243,7 @@ function buildHostApprovalDecisionParams(
     security: params.security,
     ask: params.ask,
     warningText: params.warningText,
-    commandSpans: params.commandSpans,
+    commandSpans,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,
@@ -254,34 +253,16 @@ function buildHostApprovalDecisionParams(
   };
 }
 
-async function buildHostApprovalDecisionParamsWithCommandSpans(
-  params: HostExecApprovalParams,
-): Promise<RequestExecApprovalDecisionParams> {
-  if (params.commandSpans) {
-    return buildHostApprovalDecisionParams(params);
-  }
-  const command = resolveCommandTextForSpans(params);
-  const commandSpans = command ? await resolveCommandSpans(command) : undefined;
-  return buildHostApprovalDecisionParams({
-    ...params,
-    commandSpans,
-  });
-}
-
 export async function requestExecApprovalDecisionForHost(
   params: HostExecApprovalParams,
 ): Promise<string | null> {
-  return await requestExecApprovalDecision(
-    await buildHostApprovalDecisionParamsWithCommandSpans(params),
-  );
+  return await requestExecApprovalDecision(await buildHostApprovalDecisionParams(params));
 }
 
 export async function registerExecApprovalRequestForHost(
   params: HostExecApprovalParams,
 ): Promise<ExecApprovalRegistration> {
-  return await registerExecApprovalRequest(
-    await buildHostApprovalDecisionParamsWithCommandSpans(params),
-  );
+  return await registerExecApprovalRequest(await buildHostApprovalDecisionParams(params));
 }
 
 export async function registerExecApprovalRequestForHostOrThrow(

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,8 +1,4 @@
-import {
-  explainShellCommand,
-  formatCommandExplanationHighlights,
-  formatCommandExplanationLines,
-} from "../infra/command-explainer/index.js";
+import { explainShellCommand, formatCommandSpans } from "../infra/command-explainer/index.js";
 import type { ExecAsk, ExecSecurity, SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
@@ -23,8 +19,7 @@ export type RequestExecApprovalDecisionParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
-  commandExplanationLines?: string[];
-  commandExplanationHighlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
+  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -54,8 +49,7 @@ function buildExecApprovalRequestToolParams(
     security: params.security,
     ask: params.ask,
     warningText: params.warningText,
-    commandExplanationLines: params.commandExplanationLines,
-    commandExplanationHighlights: params.commandExplanationHighlights,
+    commandSpans: params.commandSpans,
     agentId: params.agentId,
     resolvedPath: params.resolvedPath,
     sessionKey: params.sessionKey,
@@ -168,8 +162,7 @@ type HostExecApprovalParams = {
   security: ExecSecurity;
   ask: ExecAsk;
   warningText?: string;
-  commandExplanationLines?: string[];
-  commandExplanationHighlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
+  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
   agentId?: string;
   resolvedPath?: string;
   sessionKey?: string;
@@ -219,19 +212,16 @@ function resolveExplanationCommand(
 }
 
 async function resolveCommandExplanation(command: string | undefined): Promise<{
-  lines?: string[];
-  highlights?: import("../infra/exec-approvals.js").ExecApprovalCommandHighlight[];
+  commandSpans?: import("../infra/exec-approvals.js").ExecApprovalCommandSpan[];
 }> {
   if (!command) {
     return {};
   }
   try {
     const explanation = await explainShellCommand(command);
-    const lines = formatCommandExplanationLines(explanation);
-    const highlights = formatCommandExplanationHighlights(explanation);
+    const commandSpans = formatCommandSpans(explanation);
     return {
-      lines: lines.length > 0 ? lines : undefined,
-      highlights: highlights.length > 0 ? highlights : undefined,
+      commandSpans: commandSpans.length > 0 ? commandSpans : undefined,
     };
   } catch {
     return {};
@@ -253,8 +243,7 @@ function buildHostApprovalDecisionParams(
     security: params.security,
     ask: params.ask,
     warningText: params.warningText,
-    commandExplanationLines: params.commandExplanationLines,
-    commandExplanationHighlights: params.commandExplanationHighlights,
+    commandSpans: params.commandSpans,
     ...buildExecApprovalRequesterContext({
       agentId: params.agentId,
       sessionKey: params.sessionKey,
@@ -267,14 +256,12 @@ function buildHostApprovalDecisionParams(
 async function buildHostApprovalDecisionParamsWithExplanation(
   params: HostExecApprovalParams,
 ): Promise<RequestExecApprovalDecisionParams> {
-  const explanation =
-    params.commandExplanationLines && params.commandExplanationHighlights
-      ? {}
-      : await resolveCommandExplanation(resolveExplanationCommand(params));
+  const explanation = params.commandSpans
+    ? {}
+    : await resolveCommandExplanation(resolveExplanationCommand(params));
   return buildHostApprovalDecisionParams({
     ...params,
-    commandExplanationLines: params.commandExplanationLines ?? explanation.lines,
-    commandExplanationHighlights: params.commandExplanationHighlights ?? explanation.highlights,
+    commandSpans: params.commandSpans ?? explanation.commandSpans,
   });
 }
 

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -1,12 +1,11 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
+import type { ToolFsPolicy } from "./tool-fs-policy.types.js";
 import { isToolAllowedByPolicies } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
-export type ToolFsPolicy = {
-  workspaceOnly: boolean;
-};
+export type { ToolFsPolicy } from "./tool-fs-policy.types.js";
 
 export function createToolFsPolicy(params: { workspaceOnly?: boolean }): ToolFsPolicy {
   return {

--- a/src/agents/tool-fs-policy.types.ts
+++ b/src/agents/tool-fs-policy.types.ts
@@ -1,0 +1,3 @@
+export type ToolFsPolicy = {
+  workspaceOnly: boolean;
+};

--- a/src/gateway/protocol/exec-approvals-validators.test.ts
+++ b/src/gateway/protocol/exec-approvals-validators.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { validateExecApprovalsNodeSetParams, validateExecApprovalsSetParams } from "./index.js";
+import {
+  validateExecApprovalRequestParams,
+  validateExecApprovalsNodeSetParams,
+  validateExecApprovalsSetParams,
+} from "./index.js";
 
 describe("exec approvals protocol validators", () => {
   it("accepts runtime-owned allowlist metadata on gateway and node set payloads", () => {
@@ -69,6 +73,29 @@ describe("exec approvals protocol validators", () => {
           },
         },
         baseHash: "abc123",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires command spans to have non-negative starts and positive exclusive ends", () => {
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        commandSpans: [{ startIndex: 0, endIndex: 4 }],
+      }),
+    ).toBe(true);
+
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        commandSpans: [{ startIndex: 0, endIndex: 0 }],
+      }),
+    ).toBe(false);
+
+    expect(
+      validateExecApprovalRequestParams({
+        command: "echo hi",
+        commandSpans: [{ startIndex: -1, endIndex: 4 }],
       }),
     ).toBe(false);
   });

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -133,6 +133,22 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
     security: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     ask: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    commandExplanationLines: Type.Optional(Type.Array(Type.String())),
+    commandExplanationHighlights: Type.Optional(
+      Type.Array(
+        Type.Object(
+          {
+            startIndex: Type.Integer({ minimum: 0 }),
+            endIndex: Type.Integer({ minimum: 0 }),
+            kind: Type.Union([Type.Literal("command"), Type.Literal("risk")]),
+            severity: Type.Optional(
+              Type.Union([Type.Literal("info"), Type.Literal("warning"), Type.Literal("danger")]),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    ),
     agentId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     resolvedPath: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     sessionKey: Type.Optional(Type.Union([Type.String(), Type.Null()])),

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -137,8 +137,15 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
       Type.Array(
         Type.Object(
           {
-            startIndex: Type.Integer({ minimum: 0 }),
-            endIndex: Type.Integer({ minimum: 0 }),
+            startIndex: Type.Integer({
+              minimum: 0,
+              description: "Inclusive UTF-16 code unit offset into command.",
+            }),
+            endIndex: Type.Integer({
+              minimum: 1,
+              description:
+                "Exclusive UTF-16 code unit offset into command; must be greater than startIndex and no greater than command.length.",
+            }),
           },
           { additionalProperties: false },
         ),

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -133,17 +133,12 @@ export const ExecApprovalRequestParamsSchema = Type.Object(
     security: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     ask: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     warningText: Type.Optional(Type.Union([Type.String(), Type.Null()])),
-    commandExplanationLines: Type.Optional(Type.Array(Type.String())),
-    commandExplanationHighlights: Type.Optional(
+    commandSpans: Type.Optional(
       Type.Array(
         Type.Object(
           {
             startIndex: Type.Integer({ minimum: 0 }),
             endIndex: Type.Integer({ minimum: 0 }),
-            kind: Type.Union([Type.Literal("command"), Type.Literal("risk")]),
-            severity: Type.Optional(
-              Type.Union([Type.Literal("info"), Type.Literal("warning"), Type.Literal("danger")]),
-            ),
           },
           { additionalProperties: false },
         ),

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -134,6 +134,13 @@ export function createExecApprovalHandlers(
         security?: string;
         ask?: string;
         warningText?: string | null;
+        commandExplanationLines?: string[];
+        commandExplanationHighlights?: {
+          startIndex: number;
+          endIndex: number;
+          kind: "command" | "risk";
+          severity?: "info" | "warning" | "danger";
+        }[];
         agentId?: string;
         resolvedPath?: string;
         sessionKey?: string;
@@ -215,6 +222,15 @@ export function createExecApprovalHandlers(
         cwd: effectiveCwd,
         sanitizeText: sanitizeExecApprovalWarningText,
       });
+      const commandExplanationLines = Array.isArray(p.commandExplanationLines)
+        ? p.commandExplanationLines
+            .map((line) => sanitizeExecApprovalWarningText(line))
+            .map((line) => normalizeOptionalString(line))
+            .filter((line): line is string => Boolean(line))
+        : undefined;
+      const sanitizedCommandText = sanitizeExecApprovalDisplayText(effectiveCommandText);
+      const commandExplanationHighlights =
+        sanitizedCommandText === effectiveCommandText ? p.commandExplanationHighlights : undefined;
       const systemRunBinding =
         host === "node"
           ? buildSystemRunApprovalBinding({
@@ -234,7 +250,7 @@ export function createExecApprovalHandlers(
         return;
       }
       const request = {
-        command: sanitizeExecApprovalDisplayText(effectiveCommandText),
+        command: sanitizedCommandText,
         commandPreview:
           host === "node" || !approvalContext.commandPreview
             ? undefined
@@ -250,6 +266,8 @@ export function createExecApprovalHandlers(
         ask: p.ask ?? null,
         warningText: warningText ? sanitizeExecApprovalWarningText(warningText) : null,
         commandAnalysis,
+        commandExplanationLines,
+        commandExplanationHighlights,
         allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: p.ask ?? null }),
         agentId: effectiveAgentId ?? null,
         resolvedPath: p.resolvedPath ?? null,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -49,6 +49,35 @@ type ExecApprovalIosPushDelivery = {
   handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
 };
 
+function normalizeCommandSpans(
+  spans: { startIndex: number; endIndex: number }[] | undefined,
+  commandLength: number,
+): { startIndex: number; endIndex: number }[] | undefined {
+  if (!spans) {
+    return undefined;
+  }
+  const candidates = spans
+    .filter(
+      (span) =>
+        Number.isSafeInteger(span.startIndex) &&
+        Number.isSafeInteger(span.endIndex) &&
+        span.startIndex >= 0 &&
+        span.endIndex > span.startIndex &&
+        span.endIndex <= commandLength,
+    )
+    .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
+  const accepted: { startIndex: number; endIndex: number }[] = [];
+  let cursor = 0;
+  for (const span of candidates) {
+    if (span.startIndex < cursor) {
+      continue;
+    }
+    accepted.push({ startIndex: span.startIndex, endIndex: span.endIndex });
+    cursor = span.endIndex;
+  }
+  return accepted.length > 0 ? accepted : undefined;
+}
+
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
   opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: ExecApprovalIosPushDelivery },
@@ -184,7 +213,7 @@ export function createExecApprovalHandlers(
         );
         return;
       }
-      if (!effectiveCommandText) {
+      if (effectiveCommandText.trim().length === 0) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "command is required"));
         return;
       }
@@ -221,7 +250,9 @@ export function createExecApprovalHandlers(
       });
       const sanitizedCommandText = sanitizeExecApprovalDisplayText(effectiveCommandText);
       const commandSpans =
-        sanitizedCommandText === effectiveCommandText ? p.commandSpans : undefined;
+        sanitizedCommandText === effectiveCommandText
+          ? normalizeCommandSpans(p.commandSpans, sanitizedCommandText.length)
+          : undefined;
       const systemRunBinding =
         host === "node"
           ? buildSystemRunApprovalBinding({

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -134,12 +134,9 @@ export function createExecApprovalHandlers(
         security?: string;
         ask?: string;
         warningText?: string | null;
-        commandExplanationLines?: string[];
-        commandExplanationHighlights?: {
+        commandSpans?: {
           startIndex: number;
           endIndex: number;
-          kind: "command" | "risk";
-          severity?: "info" | "warning" | "danger";
         }[];
         agentId?: string;
         resolvedPath?: string;
@@ -222,15 +219,9 @@ export function createExecApprovalHandlers(
         cwd: effectiveCwd,
         sanitizeText: sanitizeExecApprovalWarningText,
       });
-      const commandExplanationLines = Array.isArray(p.commandExplanationLines)
-        ? p.commandExplanationLines
-            .map((line) => sanitizeExecApprovalWarningText(line))
-            .map((line) => normalizeOptionalString(line))
-            .filter((line): line is string => Boolean(line))
-        : undefined;
       const sanitizedCommandText = sanitizeExecApprovalDisplayText(effectiveCommandText);
-      const commandExplanationHighlights =
-        sanitizedCommandText === effectiveCommandText ? p.commandExplanationHighlights : undefined;
+      const commandSpans =
+        sanitizedCommandText === effectiveCommandText ? p.commandSpans : undefined;
       const systemRunBinding =
         host === "node"
           ? buildSystemRunApprovalBinding({
@@ -266,8 +257,7 @@ export function createExecApprovalHandlers(
         ask: p.ask ?? null,
         warningText: warningText ? sanitizeExecApprovalWarningText(warningText) : null,
         commandAnalysis,
-        commandExplanationLines,
-        commandExplanationHighlights,
+        commandSpans,
         allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: p.ask ?? null }),
         agentId: effectiveAgentId ?? null,
         resolvedPath: p.resolvedPath ?? null,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1442,6 +1442,58 @@ describe("exec approval handlers", () => {
     expect(request["warningText"]).not.toContain("\\u{A}");
   });
 
+  it("preserves command analysis and accepts command explanation metadata", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        timeoutMs: 10,
+        command: "ls | python -c 'print(1)'",
+        commandExplanationLines: [""],
+        commandExplanationHighlights: [
+          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+          { startIndex: 3, endIndex: 8, kind: "risk", severity: "warning" },
+          { startIndex: 9, endIndex: 18, kind: "risk", severity: "danger" },
+        ],
+      },
+    });
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    expect(requested).toBeTruthy();
+    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+    expect(request["commandAnalysis"]).toEqual(
+      expect.objectContaining({ commandCount: 1, nestedCommandCount: 0 }),
+    );
+    expect(request["commandExplanationLines"]).toEqual([]);
+    expect(request["commandExplanationHighlights"]).toEqual([
+      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+      { startIndex: 3, endIndex: 8, kind: "risk", severity: "warning" },
+      { startIndex: 9, endIndex: 18, kind: "risk", severity: "danger" },
+    ]);
+  });
+
+  it("drops command explanation highlights when command display sanitization changes offsets", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        timeoutMs: 10,
+        command: "ls\u0000 | python -c 'print(1)'",
+        commandExplanationHighlights: [
+          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+          { startIndex: 6, endIndex: 15, kind: "risk", severity: "danger" },
+        ],
+      },
+    });
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
+    expect(request["command"]).not.toBe("ls\u0000 | python -c 'print(1)'");
+    expect(request["commandExplanationHighlights"]).toBeUndefined();
+  });
+
   it("accepts resolve during broadcast", async () => {
     const manager = new ExecApprovalManager();
     const handlers = createExecApprovalHandlers(manager);

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -947,6 +947,28 @@ describe("exec approval handlers", () => {
     );
   });
 
+  it("rejects whitespace-only approval commands without trimming display text", async () => {
+    const { handlers, respond, context } = createExecApprovalFixture();
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        command: "   ",
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "command is required",
+      }),
+    );
+  });
+
   it("returns pending approval details for exec.approval.get", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
 
@@ -1442,7 +1464,7 @@ describe("exec approval handlers", () => {
     expect(request["warningText"]).not.toContain("\\u{A}");
   });
 
-  it("preserves command analysis and accepts command spans", async () => {
+  it("preserves command analysis and normalizes command spans", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
     await requestExecApproval({
       handlers,
@@ -1452,8 +1474,11 @@ describe("exec approval handlers", () => {
         timeoutMs: 10,
         command: "ls | python -c 'print(1)'",
         commandSpans: [
-          { startIndex: 0, endIndex: 2 },
           { startIndex: 5, endIndex: 11 },
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 1, endIndex: 4 },
+          { startIndex: 12, endIndex: 999 },
+          { startIndex: 11, endIndex: 11 },
         ],
       },
     });

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1442,7 +1442,7 @@ describe("exec approval handlers", () => {
     expect(request["warningText"]).not.toContain("\\u{A}");
   });
 
-  it("preserves command analysis and accepts command explanation metadata", async () => {
+  it("preserves command analysis and accepts command spans", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
     await requestExecApproval({
       handlers,
@@ -1451,11 +1451,9 @@ describe("exec approval handlers", () => {
       params: {
         timeoutMs: 10,
         command: "ls | python -c 'print(1)'",
-        commandExplanationLines: [""],
-        commandExplanationHighlights: [
-          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-          { startIndex: 3, endIndex: 8, kind: "risk", severity: "warning" },
-          { startIndex: 9, endIndex: 18, kind: "risk", severity: "danger" },
+        commandSpans: [
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 5, endIndex: 11 },
         ],
       },
     });
@@ -1465,15 +1463,13 @@ describe("exec approval handlers", () => {
     expect(request["commandAnalysis"]).toEqual(
       expect.objectContaining({ commandCount: 1, nestedCommandCount: 0 }),
     );
-    expect(request["commandExplanationLines"]).toEqual([]);
-    expect(request["commandExplanationHighlights"]).toEqual([
-      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-      { startIndex: 3, endIndex: 8, kind: "risk", severity: "warning" },
-      { startIndex: 9, endIndex: 18, kind: "risk", severity: "danger" },
+    expect(request["commandSpans"]).toEqual([
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 5, endIndex: 11 },
     ]);
   });
 
-  it("drops command explanation highlights when command display sanitization changes offsets", async () => {
+  it("drops command spans when command display sanitization changes offsets", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
     await requestExecApproval({
       handlers,
@@ -1482,16 +1478,16 @@ describe("exec approval handlers", () => {
       params: {
         timeoutMs: 10,
         command: "ls\u0000 | python -c 'print(1)'",
-        commandExplanationHighlights: [
-          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-          { startIndex: 6, endIndex: 15, kind: "risk", severity: "danger" },
+        commandSpans: [
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 6, endIndex: 12 },
         ],
       },
     });
     const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
     const request = (requested?.payload as { request?: Record<string, unknown> })?.request ?? {};
     expect(request["command"]).not.toBe("ls\u0000 | python -c 'print(1)'");
-    expect(request["commandExplanationHighlights"]).toBeUndefined();
+    expect(request["commandSpans"]).toBeUndefined();
   });
 
   it("accepts resolve during broadcast", async () => {

--- a/src/infra/approval-view-model.test.ts
+++ b/src/infra/approval-view-model.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildPendingApprovalView } from "./approval-view-model.js";
+import type { ExecApprovalRequest } from "./exec-approvals.js";
+
+describe("buildPendingApprovalView", () => {
+  it("passes command analysis through exec approval views", () => {
+    const request: ExecApprovalRequest = {
+      id: "approval-id",
+      createdAtMs: 1,
+      expiresAtMs: 2,
+      request: {
+        command: 'ls | grep "stuff" | python -c \'print("hi")\'',
+        host: "node",
+        ask: "always",
+        commandAnalysis: {
+          commandCount: 1,
+          nestedCommandCount: 0,
+          riskKinds: ["inline-eval"],
+          warningLines: ["Contains inline-eval: python -c"],
+        },
+      },
+    };
+
+    const view = buildPendingApprovalView(request);
+
+    expect(view.approvalKind).toBe("exec");
+    if (view.approvalKind !== "exec") {
+      throw new Error("expected exec approval view");
+    }
+    expect(view.commandAnalysis?.warningLines).toEqual(["Contains inline-eval: python -c"]);
+  });
+});

--- a/src/infra/command-explainer/extract.test.ts
+++ b/src/infra/command-explainer/extract.test.ts
@@ -593,9 +593,41 @@ describe("command explainer tree-sitter runtime", () => {
       expect.objectContaining({ kind: "command-carrier", command: "find", flag: "-exec" }),
     );
 
+    const findInline = await explainShellCommand("find . -exec python -c 'print(1)' {} \\;");
+    expect(findInline.risks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "command-carrier", command: "find", flag: "-exec" }),
+        expect.objectContaining({ kind: "inline-eval", command: "find", flag: "-exec" }),
+      ]),
+    );
+
+    const xargsWithValueOption = await explainShellCommand(
+      'printf "%s\\n" a b | xargs -n 1 sh -c "echo {}"',
+    );
+    expect(xargsWithValueOption.nestedCommands.map((command) => command.executable)).toContain(
+      "echo",
+    );
+
     const xargs = await explainShellCommand('printf "%s\\n" a b | xargs -I{} sh -c "echo {}"');
     expect(xargs.risks).toContainEqual(
       expect.objectContaining({ kind: "command-carrier", command: "xargs" }),
+    );
+    expect(xargs.nestedCommands).toContainEqual(
+      expect.objectContaining({ context: "wrapper-payload", executable: "echo" }),
+    );
+
+    const findShell = await explainShellCommand(
+      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\;',
+    );
+    expect(findShell.topLevelCommands.map((step) => step.executable)).toEqual(["find"]);
+    expect(findShell.nestedCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ context: "wrapper-payload", executable: "echo" }),
+        expect.objectContaining({ context: "wrapper-payload", executable: "node" }),
+      ]),
+    );
+    expect(findShell.risks).toContainEqual(
+      expect.objectContaining({ kind: "inline-eval", command: "node", flag: "-e" }),
     );
 
     const envSplitString = await explainShellCommand("env -S 'sh -c \"id\"'");

--- a/src/infra/command-explainer/extract.test.ts
+++ b/src/infra/command-explainer/extract.test.ts
@@ -593,41 +593,9 @@ describe("command explainer tree-sitter runtime", () => {
       expect.objectContaining({ kind: "command-carrier", command: "find", flag: "-exec" }),
     );
 
-    const findInline = await explainShellCommand("find . -exec python -c 'print(1)' {} \\;");
-    expect(findInline.risks).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ kind: "command-carrier", command: "find", flag: "-exec" }),
-        expect.objectContaining({ kind: "inline-eval", command: "find", flag: "-exec" }),
-      ]),
-    );
-
-    const xargsWithValueOption = await explainShellCommand(
-      'printf "%s\\n" a b | xargs -n 1 sh -c "echo {}"',
-    );
-    expect(xargsWithValueOption.nestedCommands.map((command) => command.executable)).toContain(
-      "echo",
-    );
-
     const xargs = await explainShellCommand('printf "%s\\n" a b | xargs -I{} sh -c "echo {}"');
     expect(xargs.risks).toContainEqual(
       expect.objectContaining({ kind: "command-carrier", command: "xargs" }),
-    );
-    expect(xargs.nestedCommands).toContainEqual(
-      expect.objectContaining({ context: "wrapper-payload", executable: "echo" }),
-    );
-
-    const findShell = await explainShellCommand(
-      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\;',
-    );
-    expect(findShell.topLevelCommands.map((step) => step.executable)).toEqual(["find"]);
-    expect(findShell.nestedCommands).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ context: "wrapper-payload", executable: "echo" }),
-        expect.objectContaining({ context: "wrapper-payload", executable: "node" }),
-      ]),
-    );
-    expect(findShell.risks).toContainEqual(
-      expect.objectContaining({ kind: "inline-eval", command: "node", flag: "-e" }),
     );
 
     const envSplitString = await explainShellCommand("env -S 'sh -c \"id\"'");

--- a/src/infra/command-explainer/extract.ts
+++ b/src/infra/command-explainer/extract.ts
@@ -2,6 +2,7 @@ import type { Node as TreeSitterNode } from "web-tree-sitter";
 import type { InterpreterInlineEvalHit } from "../command-analysis/inline-eval.js";
 import {
   detectCarriedShellBuiltinArgv,
+  detectCarrierInlineEvalArgv as detectSharedCarrierInlineEvalArgv,
   detectCommandCarrierArgv,
   detectInlineEvalArgv,
   detectShellWrapperThroughCarrierArgv,
@@ -893,8 +894,91 @@ function shellWrapperPayloadForParsing(
   return { command: payload, spanBase };
 }
 
+function findExecArgv(argv: string[]): string[] | null {
+  const flagIndex = argv.findIndex((arg) => ["-exec", "-execdir", "-ok", "-okdir"].includes(arg));
+  if (flagIndex < 0) {
+    return null;
+  }
+  const terminatorIndex = argv.findIndex(
+    (arg, index) => index > flagIndex && (arg === ";" || arg === "\\;" || arg === "+"),
+  );
+  const endIndex = terminatorIndex < 0 ? argv.length : terminatorIndex;
+  const carried = argv.slice(flagIndex + 1, endIndex).filter((arg) => arg !== "{}");
+  return carried.length > 0 ? carried : null;
+}
+
+const XARGS_VALUE_OPTIONS = new Set([
+  "-I",
+  "--replace",
+  "-E",
+  "--eof",
+  "-n",
+  "--max-args",
+  "-L",
+  "--max-lines",
+  "-P",
+  "--max-procs",
+  "-s",
+  "--max-chars",
+]);
+
+function xargsCommandArgv(argv: string[]): string[] | null {
+  if (normalizeExecutableToken(argv[0] ?? "") !== "xargs") {
+    return null;
+  }
+  let commandStart = -1;
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index] ?? "";
+    if (arg === "--") {
+      commandStart = index + 1;
+      break;
+    }
+    if (XARGS_VALUE_OPTIONS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (
+      arg.startsWith("--replace=") ||
+      arg.startsWith("--eof=") ||
+      arg.startsWith("--max-args=") ||
+      arg.startsWith("--max-lines=") ||
+      arg.startsWith("--max-procs=") ||
+      arg.startsWith("--max-chars=") ||
+      /^-[ILnPsE].+/.test(arg)
+    ) {
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      continue;
+    }
+    commandStart = index;
+    break;
+  }
+  return commandStart >= 0 ? argv.slice(commandStart) : null;
+}
+
+function carrierShellWrapperPayloadForParsing(
+  argv: string[],
+  argumentsList: CommandArgument[],
+  dynamicArguments: DynamicArgument[],
+): { command: string; spanBase: SpanBase } | null {
+  const executable = normalizeExecutableToken(argv[0] ?? "");
+  const carriedArgv =
+    executable === "find"
+      ? findExecArgv(argv)
+      : executable === "xargs"
+        ? xargsCommandArgv(argv)
+        : null;
+  return carriedArgv
+    ? shellWrapperPayloadForParsing(carriedArgv, argumentsList, dynamicArguments)
+    : null;
+}
+
 type InlineEvalHit = InterpreterInlineEvalHit;
 
+function detectCarrierInlineEvalArgv(argv: string[]): InlineEvalHit | null {
+  return detectSharedCarrierInlineEvalArgv(argv);
+}
 function recordInlineEvalRisk(
   inlineEval: InlineEvalHit,
   text: string,
@@ -939,7 +1023,7 @@ function recordCommandRisks(
   }
   const normalizedExecutable = normalizeExecutableToken(executable);
   recordDynamicArgumentRisks(normalizedExecutable, dynamicArguments, output);
-  const inlineEval = detectInlineEvalArgv(argv);
+  const inlineEval = detectInlineEvalArgv(argv) ?? detectCarrierInlineEvalArgv(argv);
   if (inlineEval) {
     recordInlineEvalRisk(inlineEval, text, span, output);
   }
@@ -1082,11 +1166,13 @@ async function walk(
       if (step.executable) {
         output.commands.push(step);
         recordCommandRisks(parsed.argv, parsed.dynamicArguments, node.text, span, output);
-        const wrapperPayload = shellWrapperPayloadForParsing(
-          parsed.argv,
-          parsed.arguments,
-          parsed.dynamicArguments,
-        );
+        const wrapperPayload =
+          shellWrapperPayloadForParsing(parsed.argv, parsed.arguments, parsed.dynamicArguments) ??
+          carrierShellWrapperPayloadForParsing(
+            parsed.argv,
+            parsed.arguments,
+            parsed.dynamicArguments,
+          );
         if (wrapperPayload && state.wrapperPayloadDepth < MAX_WRAPPER_PAYLOAD_DEPTH) {
           const wrapperTree = await parseBashForCommandExplanation(wrapperPayload.command);
           const wrapperSpanBase = spanBaseForParserSource(

--- a/src/infra/command-explainer/extract.ts
+++ b/src/infra/command-explainer/extract.ts
@@ -894,91 +894,7 @@ function shellWrapperPayloadForParsing(
   return { command: payload, spanBase };
 }
 
-function findExecArgv(argv: string[]): string[] | null {
-  const flagIndex = argv.findIndex((arg) => ["-exec", "-execdir", "-ok", "-okdir"].includes(arg));
-  if (flagIndex < 0) {
-    return null;
-  }
-  const terminatorIndex = argv.findIndex(
-    (arg, index) => index > flagIndex && (arg === ";" || arg === "\\;" || arg === "+"),
-  );
-  const endIndex = terminatorIndex < 0 ? argv.length : terminatorIndex;
-  const carried = argv.slice(flagIndex + 1, endIndex).filter((arg) => arg !== "{}");
-  return carried.length > 0 ? carried : null;
-}
-
-const XARGS_VALUE_OPTIONS = new Set([
-  "-I",
-  "--replace",
-  "-E",
-  "--eof",
-  "-n",
-  "--max-args",
-  "-L",
-  "--max-lines",
-  "-P",
-  "--max-procs",
-  "-s",
-  "--max-chars",
-]);
-
-function xargsCommandArgv(argv: string[]): string[] | null {
-  if (normalizeExecutableToken(argv[0] ?? "") !== "xargs") {
-    return null;
-  }
-  let commandStart = -1;
-  for (let index = 1; index < argv.length; index += 1) {
-    const arg = argv[index] ?? "";
-    if (arg === "--") {
-      commandStart = index + 1;
-      break;
-    }
-    if (XARGS_VALUE_OPTIONS.has(arg)) {
-      index += 1;
-      continue;
-    }
-    if (
-      arg.startsWith("--replace=") ||
-      arg.startsWith("--eof=") ||
-      arg.startsWith("--max-args=") ||
-      arg.startsWith("--max-lines=") ||
-      arg.startsWith("--max-procs=") ||
-      arg.startsWith("--max-chars=") ||
-      /^-[ILnPsE].+/.test(arg)
-    ) {
-      continue;
-    }
-    if (arg.startsWith("-")) {
-      continue;
-    }
-    commandStart = index;
-    break;
-  }
-  return commandStart >= 0 ? argv.slice(commandStart) : null;
-}
-
-function carrierShellWrapperPayloadForParsing(
-  argv: string[],
-  argumentsList: CommandArgument[],
-  dynamicArguments: DynamicArgument[],
-): { command: string; spanBase: SpanBase } | null {
-  const executable = normalizeExecutableToken(argv[0] ?? "");
-  const carriedArgv =
-    executable === "find"
-      ? findExecArgv(argv)
-      : executable === "xargs"
-        ? xargsCommandArgv(argv)
-        : null;
-  return carriedArgv
-    ? shellWrapperPayloadForParsing(carriedArgv, argumentsList, dynamicArguments)
-    : null;
-}
-
 type InlineEvalHit = InterpreterInlineEvalHit;
-
-function detectCarrierInlineEvalArgv(argv: string[]): InlineEvalHit | null {
-  return detectSharedCarrierInlineEvalArgv(argv);
-}
 function recordInlineEvalRisk(
   inlineEval: InlineEvalHit,
   text: string,
@@ -1023,7 +939,7 @@ function recordCommandRisks(
   }
   const normalizedExecutable = normalizeExecutableToken(executable);
   recordDynamicArgumentRisks(normalizedExecutable, dynamicArguments, output);
-  const inlineEval = detectInlineEvalArgv(argv) ?? detectCarrierInlineEvalArgv(argv);
+  const inlineEval = detectInlineEvalArgv(argv) ?? detectSharedCarrierInlineEvalArgv(argv);
   if (inlineEval) {
     recordInlineEvalRisk(inlineEval, text, span, output);
   }
@@ -1170,13 +1086,11 @@ async function walk(
       if (step.executable) {
         output.commands.push(step);
         recordCommandRisks(parsed.argv, parsed.dynamicArguments, node.text, span, output);
-        const wrapperPayload =
-          shellWrapperPayloadForParsing(parsed.argv, parsed.arguments, parsed.dynamicArguments) ??
-          carrierShellWrapperPayloadForParsing(
-            parsed.argv,
-            parsed.arguments,
-            parsed.dynamicArguments,
-          );
+        const wrapperPayload = shellWrapperPayloadForParsing(
+          parsed.argv,
+          parsed.arguments,
+          parsed.dynamicArguments,
+        );
         if (wrapperPayload && state.wrapperPayloadDepth < MAX_WRAPPER_PAYLOAD_DEPTH) {
           const wrapperTree = await parseBashForCommandExplanation(wrapperPayload.command);
           const wrapperSpanBase = spanBaseForParserSource(

--- a/src/infra/command-explainer/extract.ts
+++ b/src/infra/command-explainer/extract.ts
@@ -1162,6 +1162,10 @@ async function walk(
         argv: parsed.argv,
         text: node.text,
         span,
+        executableSpan:
+          nameNode !== null
+            ? spanFromNode(nameNode, state.spanBase)
+            : (parsed.arguments[0]?.span ?? span),
       };
       if (step.executable) {
         output.commands.push(step);

--- a/src/infra/command-explainer/format.test.ts
+++ b/src/infra/command-explainer/format.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { explainShellCommand } from "./extract.js";
+import { formatCommandExplanationHighlights, formatCommandExplanationLines } from "./format.js";
+import type { CommandExplanation } from "./types.js";
+
+const span = {
+  startIndex: 0,
+  endIndex: 1,
+  startPosition: { row: 0, column: 0 },
+  endPosition: { row: 0, column: 1 },
+};
+
+describe("formatCommandExplanationLines", () => {
+  it("summarizes top-level commands and inline eval", () => {
+    const explanation: CommandExplanation = {
+      ok: true,
+      source: 'ls | grep "stuff" | python -c \'print("hi")\'',
+      shapes: ["pipeline"],
+      topLevelCommands: [
+        { context: "top-level", executable: "ls", argv: ["ls"], text: "ls", span },
+        {
+          context: "top-level",
+          executable: "grep",
+          argv: ["grep", "stuff"],
+          text: 'grep "stuff"',
+          span,
+        },
+        {
+          context: "top-level",
+          executable: "python",
+          argv: ["python", "-c", 'print("hi")'],
+          text: "python -c 'print(\"hi\")'",
+          span,
+        },
+      ],
+      nestedCommands: [],
+      risks: [
+        {
+          kind: "inline-eval",
+          command: "python",
+          flag: "-c",
+          text: "python -c 'print(\"hi\")'",
+          span,
+        },
+      ],
+    };
+
+    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+  });
+
+  it("summarizes recursive carrier commands with plain risk copy", () => {
+    const explanation: CommandExplanation = {
+      ok: true,
+      source: "find ... -exec sh -c 'echo; node -e'",
+      shapes: [],
+      topLevelCommands: [
+        { context: "top-level", executable: "find", argv: ["find"], text: "find", span },
+      ],
+      nestedCommands: [
+        { context: "wrapper-payload", executable: "echo", argv: ["echo"], text: "echo", span },
+        {
+          context: "wrapper-payload",
+          executable: "node",
+          argv: ["node", "-e", "1"],
+          text: "node -e 1",
+          span,
+        },
+      ],
+      risks: [
+        { kind: "command-carrier", command: "find", flag: "-exec", text: "find -exec", span },
+        { kind: "inline-eval", command: "node", flag: "-e", text: "node -e 1", span },
+      ],
+    };
+
+    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+    expect(
+      formatCommandExplanationHighlights(explanation).map((highlight) => ({
+        kind: highlight.kind,
+        severity: highlight.severity,
+      })),
+    ).toEqual([
+      { kind: "command", severity: "info" },
+      { kind: "command", severity: "info" },
+      { kind: "command", severity: "info" },
+      { kind: "risk", severity: "warning" },
+      { kind: "risk", severity: "danger" },
+    ]);
+  });
+
+  it("anchors command highlights to executable tokens after env assignments", async () => {
+    const explanation = await explainShellCommand("FOO=1 python -c 'print(1)'");
+    const commandHighlight = formatCommandExplanationHighlights(explanation).find(
+      (highlight) => highlight.kind === "command",
+    );
+
+    expect(commandHighlight).toEqual(
+      expect.objectContaining({ startIndex: 6, endIndex: 12, kind: "command" }),
+    );
+  });
+
+  it("formats mixed pipeline and nested find exec with separate sections", async () => {
+    const explanation = await explainShellCommand(
+      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\; | grep checking | python -c \'print("ok")\'',
+    );
+
+    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+    expect(formatCommandExplanationHighlights(explanation)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "risk", severity: "warning" }),
+        expect.objectContaining({ kind: "risk", severity: "danger" }),
+      ]),
+    );
+  });
+
+  it("does not highlight synthetic xargs inline-eval placeholders", () => {
+    const explanation: CommandExplanation = {
+      ok: true,
+      source: "xargs -n 1 sh -c 'echo {}'",
+      shapes: [],
+      topLevelCommands: [
+        {
+          context: "top-level",
+          executable: "xargs",
+          argv: ["xargs"],
+          text: "xargs -n 1 sh -c 'echo {}'",
+          span,
+        },
+      ],
+      nestedCommands: [],
+      risks: [
+        {
+          kind: "inline-eval",
+          command: "xargs",
+          flag: "<command>",
+          text: "xargs -n 1 sh -c 'echo {}'",
+          span,
+        },
+      ],
+    };
+
+    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+    expect(formatCommandExplanationHighlights(explanation)).toEqual([
+      expect.objectContaining({ kind: "command", severity: "info" }),
+    ]);
+  });
+
+  it("summarizes nested command substitution without raw payloads", () => {
+    const explanation: CommandExplanation = {
+      ok: true,
+      source: "echo $(whoami)",
+      shapes: [],
+      topLevelCommands: [
+        {
+          context: "top-level",
+          executable: "echo",
+          argv: ["echo", "$(...)"],
+          text: "echo $(whoami)",
+          span,
+        },
+      ],
+      nestedCommands: [
+        {
+          context: "command-substitution",
+          executable: "whoami",
+          argv: ["whoami"],
+          text: "whoami",
+          span,
+        },
+      ],
+      risks: [{ kind: "command-substitution", text: "$(whoami)", span }],
+    };
+
+    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+  });
+});

--- a/src/infra/command-explainer/format.test.ts
+++ b/src/infra/command-explainer/format.test.ts
@@ -69,15 +69,15 @@ describe("formatCommandSpans", () => {
     expect(formatCommandSpans(explanation)).toContainEqual({ startIndex: 6, endIndex: 12 });
   });
 
-  it("includes nested executable spans from carrier shell payloads", async () => {
+  it("includes nested executable spans from shell wrapper payloads", async () => {
     const explanation = await explainShellCommand(
-      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\;',
+      'sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh file.ts',
     );
 
     const commandTexts = formatCommandSpans(explanation).map((commandSpan) =>
       explanation.source.slice(commandSpan.startIndex, commandSpan.endIndex),
     );
-    expect(commandTexts).toEqual(expect.arrayContaining(["find", "echo", "node"]));
+    expect(commandTexts).toEqual(expect.arrayContaining(["sh", "echo", "node"]));
   });
 
   it("ignores invalid executable spans", () => {

--- a/src/infra/command-explainer/format.test.ts
+++ b/src/infra/command-explainer/format.test.ts
@@ -1,36 +1,47 @@
 import { describe, expect, it } from "vitest";
 import { explainShellCommand } from "./extract.js";
-import { formatCommandExplanationHighlights, formatCommandExplanationLines } from "./format.js";
-import type { CommandExplanation } from "./types.js";
+import { formatCommandSpans } from "./format.js";
+import type { CommandExplanation, SourceSpan } from "./types.js";
 
-const span = {
-  startIndex: 0,
-  endIndex: 1,
-  startPosition: { row: 0, column: 0 },
-  endPosition: { row: 0, column: 1 },
-};
+function span(startIndex: number, endIndex: number): SourceSpan {
+  return {
+    startIndex,
+    endIndex,
+    startPosition: { row: 0, column: startIndex },
+    endPosition: { row: 0, column: endIndex },
+  };
+}
 
-describe("formatCommandExplanationLines", () => {
-  it("summarizes top-level commands and inline eval", () => {
+describe("formatCommandSpans", () => {
+  it("returns executable token spans without risk or severity metadata", () => {
     const explanation: CommandExplanation = {
       ok: true,
       source: 'ls | grep "stuff" | python -c \'print("hi")\'',
       shapes: ["pipeline"],
       topLevelCommands: [
-        { context: "top-level", executable: "ls", argv: ["ls"], text: "ls", span },
+        {
+          context: "top-level",
+          executable: "ls",
+          argv: ["ls"],
+          text: "ls",
+          span: span(0, 2),
+          executableSpan: span(0, 2),
+        },
         {
           context: "top-level",
           executable: "grep",
           argv: ["grep", "stuff"],
           text: 'grep "stuff"',
-          span,
+          span: span(5, 17),
+          executableSpan: span(5, 9),
         },
         {
           context: "top-level",
           executable: "python",
           argv: ["python", "-c", 'print("hi")'],
           text: "python -c 'print(\"hi\")'",
-          span,
+          span: span(20, 42),
+          executableSpan: span(20, 26),
         },
       ],
       nestedCommands: [],
@@ -40,136 +51,54 @@ describe("formatCommandExplanationLines", () => {
           command: "python",
           flag: "-c",
           text: "python -c 'print(\"hi\")'",
-          span,
+          span: span(20, 42),
         },
       ],
     };
 
-    expect(formatCommandExplanationLines(explanation)).toEqual([]);
-  });
-
-  it("summarizes recursive carrier commands with plain risk copy", () => {
-    const explanation: CommandExplanation = {
-      ok: true,
-      source: "find ... -exec sh -c 'echo; node -e'",
-      shapes: [],
-      topLevelCommands: [
-        { context: "top-level", executable: "find", argv: ["find"], text: "find", span },
-      ],
-      nestedCommands: [
-        { context: "wrapper-payload", executable: "echo", argv: ["echo"], text: "echo", span },
-        {
-          context: "wrapper-payload",
-          executable: "node",
-          argv: ["node", "-e", "1"],
-          text: "node -e 1",
-          span,
-        },
-      ],
-      risks: [
-        { kind: "command-carrier", command: "find", flag: "-exec", text: "find -exec", span },
-        { kind: "inline-eval", command: "node", flag: "-e", text: "node -e 1", span },
-      ],
-    };
-
-    expect(formatCommandExplanationLines(explanation)).toEqual([]);
-    expect(
-      formatCommandExplanationHighlights(explanation).map((highlight) => ({
-        kind: highlight.kind,
-        severity: highlight.severity,
-      })),
-    ).toEqual([
-      { kind: "command", severity: "info" },
-      { kind: "command", severity: "info" },
-      { kind: "command", severity: "info" },
-      { kind: "risk", severity: "warning" },
-      { kind: "risk", severity: "danger" },
+    expect(formatCommandSpans(explanation)).toEqual([
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 5, endIndex: 9 },
+      { startIndex: 20, endIndex: 26 },
     ]);
   });
 
-  it("anchors command highlights to executable tokens after env assignments", async () => {
+  it("anchors command spans to executable tokens after env assignments", async () => {
     const explanation = await explainShellCommand("FOO=1 python -c 'print(1)'");
-    const commandHighlight = formatCommandExplanationHighlights(explanation).find(
-      (highlight) => highlight.kind === "command",
-    );
 
-    expect(commandHighlight).toEqual(
-      expect.objectContaining({ startIndex: 6, endIndex: 12, kind: "command" }),
-    );
+    expect(formatCommandSpans(explanation)).toContainEqual({ startIndex: 6, endIndex: 12 });
   });
 
-  it("formats mixed pipeline and nested find exec with separate sections", async () => {
+  it("includes nested executable spans from carrier shell payloads", async () => {
     const explanation = await explainShellCommand(
-      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\; | grep checking | python -c \'print("ok")\'',
+      'find . -maxdepth 2 -name "*.ts" -exec sh -c \'echo checking "$1"; node -e "console.log(process.argv[1])" "$1"\' sh {} \\;',
     );
 
-    expect(formatCommandExplanationLines(explanation)).toEqual([]);
-    expect(formatCommandExplanationHighlights(explanation)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ kind: "risk", severity: "warning" }),
-        expect.objectContaining({ kind: "risk", severity: "danger" }),
-      ]),
+    const commandTexts = formatCommandSpans(explanation).map((commandSpan) =>
+      explanation.source.slice(commandSpan.startIndex, commandSpan.endIndex),
     );
+    expect(commandTexts).toEqual(expect.arrayContaining(["find", "echo", "node"]));
   });
 
-  it("does not highlight synthetic xargs inline-eval placeholders", () => {
+  it("ignores invalid executable spans", () => {
     const explanation: CommandExplanation = {
       ok: true,
-      source: "xargs -n 1 sh -c 'echo {}'",
-      shapes: [],
-      topLevelCommands: [
-        {
-          context: "top-level",
-          executable: "xargs",
-          argv: ["xargs"],
-          text: "xargs -n 1 sh -c 'echo {}'",
-          span,
-        },
-      ],
-      nestedCommands: [],
-      risks: [
-        {
-          kind: "inline-eval",
-          command: "xargs",
-          flag: "<command>",
-          text: "xargs -n 1 sh -c 'echo {}'",
-          span,
-        },
-      ],
-    };
-
-    expect(formatCommandExplanationLines(explanation)).toEqual([]);
-    expect(formatCommandExplanationHighlights(explanation)).toEqual([
-      expect.objectContaining({ kind: "command", severity: "info" }),
-    ]);
-  });
-
-  it("summarizes nested command substitution without raw payloads", () => {
-    const explanation: CommandExplanation = {
-      ok: true,
-      source: "echo $(whoami)",
+      source: "echo hi",
       shapes: [],
       topLevelCommands: [
         {
           context: "top-level",
           executable: "echo",
-          argv: ["echo", "$(...)"],
-          text: "echo $(whoami)",
-          span,
+          argv: ["echo", "hi"],
+          text: "echo hi",
+          span: span(0, 7),
+          executableSpan: span(4, 4),
         },
       ],
-      nestedCommands: [
-        {
-          context: "command-substitution",
-          executable: "whoami",
-          argv: ["whoami"],
-          text: "whoami",
-          span,
-        },
-      ],
-      risks: [{ kind: "command-substitution", text: "$(whoami)", span }],
+      nestedCommands: [],
+      risks: [],
     };
 
-    expect(formatCommandExplanationLines(explanation)).toEqual([]);
+    expect(formatCommandSpans(explanation)).toEqual([]);
   });
 });

--- a/src/infra/command-explainer/format.ts
+++ b/src/infra/command-explainer/format.ts
@@ -1,0 +1,78 @@
+import type { ExecApprovalCommandHighlight } from "../exec-approvals.js";
+import type { CommandExplanation } from "./types.js";
+
+function spanToHighlight(
+  span: { startIndex: number; endIndex: number },
+  kind: ExecApprovalCommandHighlight["kind"],
+  severity: NonNullable<ExecApprovalCommandHighlight["severity"]>,
+): ExecApprovalCommandHighlight | null {
+  if (!Number.isSafeInteger(span.startIndex) || !Number.isSafeInteger(span.endIndex)) {
+    return null;
+  }
+  if (span.startIndex < 0 || span.endIndex <= span.startIndex) {
+    return null;
+  }
+  return { startIndex: span.startIndex, endIndex: span.endIndex, kind, severity };
+}
+
+function executableHighlightSpan(command: CommandExplanation["topLevelCommands"][number]): {
+  startIndex: number;
+  endIndex: number;
+} {
+  const relativeStart = command.text.indexOf(command.executable);
+  const startIndex =
+    relativeStart >= 0 ? command.span.startIndex + relativeStart : command.span.startIndex;
+  return { startIndex, endIndex: startIndex + command.executable.length };
+}
+
+export function formatCommandExplanationHighlights(
+  explanation: CommandExplanation,
+): ExecApprovalCommandHighlight[] {
+  const highlights: ExecApprovalCommandHighlight[] = [];
+
+  for (const command of [...explanation.topLevelCommands, ...explanation.nestedCommands]) {
+    const commandHighlight = spanToHighlight(executableHighlightSpan(command), "command", "info");
+    if (commandHighlight) {
+      highlights.push(commandHighlight);
+    }
+  }
+
+  for (const risk of explanation.risks) {
+    if (risk.kind === "command-carrier") {
+      const riskText = risk.flag ?? risk.command;
+      const relativeStart = risk.text.indexOf(riskText);
+      const startIndex =
+        relativeStart >= 0 ? risk.span.startIndex + relativeStart : risk.span.startIndex;
+      const riskHighlight = spanToHighlight(
+        { startIndex, endIndex: startIndex + riskText.length },
+        "risk",
+        "warning",
+      );
+      if (riskHighlight) {
+        highlights.push(riskHighlight);
+      }
+      continue;
+    }
+    if (risk.kind === "inline-eval") {
+      const riskText = `${risk.command} ${risk.flag}`;
+      const relativeStart = risk.text.indexOf(riskText);
+      if (relativeStart < 0) {
+        continue;
+      }
+      const startIndex = risk.span.startIndex + relativeStart;
+      const riskHighlight = spanToHighlight(
+        { startIndex, endIndex: startIndex + riskText.length },
+        "risk",
+        "danger",
+      );
+      if (riskHighlight) {
+        highlights.push(riskHighlight);
+      }
+    }
+  }
+  return highlights;
+}
+
+export function formatCommandExplanationLines(_explanation: CommandExplanation): string[] {
+  return [];
+}

--- a/src/infra/command-explainer/format.ts
+++ b/src/infra/command-explainer/format.ts
@@ -1,78 +1,27 @@
-import type { ExecApprovalCommandHighlight } from "../exec-approvals.js";
+import type { ExecApprovalCommandSpan } from "../exec-approvals.js";
 import type { CommandExplanation } from "./types.js";
 
-function spanToHighlight(
-  span: { startIndex: number; endIndex: number },
-  kind: ExecApprovalCommandHighlight["kind"],
-  severity: NonNullable<ExecApprovalCommandHighlight["severity"]>,
-): ExecApprovalCommandHighlight | null {
+function spanToCommandSpan(span: {
+  startIndex: number;
+  endIndex: number;
+}): ExecApprovalCommandSpan | null {
   if (!Number.isSafeInteger(span.startIndex) || !Number.isSafeInteger(span.endIndex)) {
     return null;
   }
   if (span.startIndex < 0 || span.endIndex <= span.startIndex) {
     return null;
   }
-  return { startIndex: span.startIndex, endIndex: span.endIndex, kind, severity };
+  return { startIndex: span.startIndex, endIndex: span.endIndex };
 }
 
-function executableHighlightSpan(command: CommandExplanation["topLevelCommands"][number]): {
-  startIndex: number;
-  endIndex: number;
-} {
-  const relativeStart = command.text.indexOf(command.executable);
-  const startIndex =
-    relativeStart >= 0 ? command.span.startIndex + relativeStart : command.span.startIndex;
-  return { startIndex, endIndex: startIndex + command.executable.length };
-}
-
-export function formatCommandExplanationHighlights(
-  explanation: CommandExplanation,
-): ExecApprovalCommandHighlight[] {
-  const highlights: ExecApprovalCommandHighlight[] = [];
+export function formatCommandSpans(explanation: CommandExplanation): ExecApprovalCommandSpan[] {
+  const commandSpans: ExecApprovalCommandSpan[] = [];
 
   for (const command of [...explanation.topLevelCommands, ...explanation.nestedCommands]) {
-    const commandHighlight = spanToHighlight(executableHighlightSpan(command), "command", "info");
-    if (commandHighlight) {
-      highlights.push(commandHighlight);
+    const commandSpan = spanToCommandSpan(command.executableSpan);
+    if (commandSpan) {
+      commandSpans.push(commandSpan);
     }
   }
-
-  for (const risk of explanation.risks) {
-    if (risk.kind === "command-carrier") {
-      const riskText = risk.flag ?? risk.command;
-      const relativeStart = risk.text.indexOf(riskText);
-      const startIndex =
-        relativeStart >= 0 ? risk.span.startIndex + relativeStart : risk.span.startIndex;
-      const riskHighlight = spanToHighlight(
-        { startIndex, endIndex: startIndex + riskText.length },
-        "risk",
-        "warning",
-      );
-      if (riskHighlight) {
-        highlights.push(riskHighlight);
-      }
-      continue;
-    }
-    if (risk.kind === "inline-eval") {
-      const riskText = `${risk.command} ${risk.flag}`;
-      const relativeStart = risk.text.indexOf(riskText);
-      if (relativeStart < 0) {
-        continue;
-      }
-      const startIndex = risk.span.startIndex + relativeStart;
-      const riskHighlight = spanToHighlight(
-        { startIndex, endIndex: startIndex + riskText.length },
-        "risk",
-        "danger",
-      );
-      if (riskHighlight) {
-        highlights.push(riskHighlight);
-      }
-    }
-  }
-  return highlights;
-}
-
-export function formatCommandExplanationLines(_explanation: CommandExplanation): string[] {
-  return [];
+  return commandSpans;
 }

--- a/src/infra/command-explainer/index.ts
+++ b/src/infra/command-explainer/index.ts
@@ -1,4 +1,5 @@
 export { explainShellCommand } from "./extract.js";
+export { formatCommandExplanationHighlights, formatCommandExplanationLines } from "./format.js";
 export type {
   CommandContext,
   CommandExplanation,

--- a/src/infra/command-explainer/index.ts
+++ b/src/infra/command-explainer/index.ts
@@ -1,5 +1,5 @@
 export { explainShellCommand } from "./extract.js";
-export { formatCommandExplanationHighlights, formatCommandExplanationLines } from "./format.js";
+export { formatCommandSpans } from "./format.js";
 export type {
   CommandContext,
   CommandExplanation,

--- a/src/infra/command-explainer/types.ts
+++ b/src/infra/command-explainer/types.ts
@@ -31,6 +31,7 @@ export type CommandStep = {
   argv: string[];
   text: string;
   span: SourceSpan;
+  executableSpan: SourceSpan;
 };
 
 export type CommandRisk =

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -8,6 +8,7 @@ import {
   buildExecApprovalRequestMessage,
   createExecApprovalForwarder,
 } from "./exec-approval-forwarder.js";
+import type { ExecApprovalRequest } from "./exec-approvals.js";
 
 const baseRequest = {
   id: "req-1",
@@ -308,7 +309,11 @@ async function expectSessionFilterRequestResult(params: {
   expect(deliver).toHaveBeenCalledTimes(params.expectedDeliveryCount);
 }
 
-async function expectForwardedApprovalText(params: { command?: string; expectedText: string }) {
+async function expectForwardedApprovalText(params: {
+  command?: string;
+  request?: Partial<ExecApprovalRequest["request"]>;
+  expectedText: string;
+}) {
   vi.useFakeTimers();
   const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
   await expect(
@@ -317,6 +322,7 @@ async function expectForwardedApprovalText(params: { command?: string; expectedT
       request: {
         ...baseRequest.request,
         ...(params.command ? { command: params.command } : {}),
+        ...params.request,
       },
     }),
   ).resolves.toBe(true);
@@ -357,6 +363,19 @@ describe("exec approval forwarder", () => {
 
     await vi.advanceTimersByTimeAsync(baseRequest.expiresAtMs - baseRequest.createdAtMs);
     expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("includes command explanation lines in forwarded exec approval messages", async () => {
+    await expectForwardedApprovalText({
+      request: {
+        commandExplanationLines: [
+          "Runs 3 programs: ls, grep, and python.",
+          "Warning: python -c runs inline code.",
+        ],
+      },
+      expectedText:
+        "Command explanation:\nRuns 3 programs: ls, grep, and python.\nWarning: python -c runs inline code.",
+    });
   });
 
   it("forwards to explicit targets and expires", async () => {
@@ -592,6 +611,26 @@ describe("exec approval forwarder", () => {
     );
     expect(text).toContain("Command analysis:");
     expect(text).toContain("- Contains inline-eval: python3 -c");
+  });
+
+  it("preserves explicit command explanation line formatting in fallback delivery text", async () => {
+    const text = buildExecApprovalRequestMessage(
+      {
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          commandExplanationLines: [
+            "Risks:",
+            "• python -c can run arbitrary code on your computer.",
+          ],
+        },
+      },
+      1000,
+    );
+
+    expect(text).toContain("Command explanation:\nRisks:\n• python -c can run arbitrary code");
+    expect(text).not.toContain("- Risks:");
+    expect(text).not.toContain("- • python -c");
   });
 
   it("omits allow-always from forwarded fallback text when ask=always", async () => {

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -365,19 +365,6 @@ describe("exec approval forwarder", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
   });
 
-  it("includes command explanation lines in forwarded exec approval messages", async () => {
-    await expectForwardedApprovalText({
-      request: {
-        commandExplanationLines: [
-          "Runs 3 programs: ls, grep, and python.",
-          "Warning: python -c runs inline code.",
-        ],
-      },
-      expectedText:
-        "Command explanation:\nRuns 3 programs: ls, grep, and python.\nWarning: python -c runs inline code.",
-    });
-  });
-
   it("forwards to explicit targets and expires", async () => {
     vi.useFakeTimers();
     const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
@@ -611,26 +598,6 @@ describe("exec approval forwarder", () => {
     );
     expect(text).toContain("Command analysis:");
     expect(text).toContain("- Contains inline-eval: python3 -c");
-  });
-
-  it("preserves explicit command explanation line formatting in fallback delivery text", async () => {
-    const text = buildExecApprovalRequestMessage(
-      {
-        ...baseRequest,
-        request: {
-          ...baseRequest.request,
-          commandExplanationLines: [
-            "Risks:",
-            "• python -c can run arbitrary code on your computer.",
-          ],
-        },
-      },
-      1000,
-    );
-
-    expect(text).toContain("Command explanation:\nRisks:\n• python -c can run arbitrary code");
-    expect(text).not.toContain("- Risks:");
-    expect(text).not.toContain("- • python -c");
   });
 
   it("omits allow-always from forwarded fallback text when ask=always", async () => {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -257,6 +257,12 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
     lines.push("Command:");
     lines.push(command.text);
   }
+  const explanationLines = request.request.commandExplanationLines
+    ?.map((line) => line.trim())
+    .filter(Boolean);
+  if (explanationLines?.length) {
+    lines.push("", "Command explanation:", ...explanationLines);
+  }
   if (request.request.cwd) {
     lines.push(`CWD: ${request.request.cwd}`);
   }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -257,12 +257,6 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
     lines.push("Command:");
     lines.push(command.text);
   }
-  const explanationLines = request.request.commandExplanationLines
-    ?.map((line) => line.trim())
-    .filter(Boolean);
-  if (explanationLines?.length) {
-    lines.push("", "Command explanation:", ...explanationLines);
-  }
   if (request.request.cwd) {
     lines.push(`CWD: ${request.request.cwd}`);
   }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -109,6 +109,13 @@ export type SystemRunApprovalPlan = {
   mutableFileOperand?: SystemRunApprovalFileOperand | null;
 };
 
+export type ExecApprovalCommandHighlight = {
+  startIndex: number;
+  endIndex: number;
+  kind: "command" | "risk";
+  severity?: "info" | "warning" | "danger";
+};
+
 export type ExecApprovalRequestPayload = {
   command: string;
   commandPreview?: string | null;
@@ -124,6 +131,8 @@ export type ExecApprovalRequestPayload = {
   ask?: string | null;
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;
+  commandExplanationLines?: string[];
+  commandExplanationHighlights?: ExecApprovalCommandHighlight[];
   allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -109,11 +109,9 @@ export type SystemRunApprovalPlan = {
   mutableFileOperand?: SystemRunApprovalFileOperand | null;
 };
 
-export type ExecApprovalCommandHighlight = {
+export type ExecApprovalCommandSpan = {
   startIndex: number;
   endIndex: number;
-  kind: "command" | "risk";
-  severity?: "info" | "warning" | "danger";
 };
 
 export type ExecApprovalRequestPayload = {
@@ -131,8 +129,7 @@ export type ExecApprovalRequestPayload = {
   ask?: string | null;
   warningText?: string | null;
   commandAnalysis?: CommandExplanationSummary | null;
-  commandExplanationLines?: string[];
-  commandExplanationHighlights?: ExecApprovalCommandHighlight[];
+  commandSpans?: ExecApprovalCommandSpan[];
   allowedDecisions?: readonly ExecApprovalDecision[];
   agentId?: string | null;
   resolvedPath?: string | null;

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -1,4 +1,4 @@
-import type { ToolFsPolicy } from "../agents/tool-fs-policy.js";
+import type { ToolFsPolicy } from "../agents/tool-fs-policy.types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookEntry } from "../hooks/types.js";

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4041,14 +4041,9 @@ td.data-table-key-col {
   font-size: 13px;
 }
 
-.exec-approval-command-highlight {
+.exec-approval-command-span {
   border-radius: 3px;
   padding: 0 2px;
-}
-
-.exec-approval-command-highlight.info,
-.exec-approval-command-highlight.warning,
-.exec-approval-command-highlight.danger {
   background: color-mix(in srgb, #f97316 34%, transparent);
   color: var(--fg);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4041,6 +4041,18 @@ td.data-table-key-col {
   font-size: 13px;
 }
 
+.exec-approval-command-highlight {
+  border-radius: 3px;
+  padding: 0 2px;
+}
+
+.exec-approval-command-highlight.info,
+.exec-approval-command-highlight.warning,
+.exec-approval-command-highlight.danger {
+  background: color-mix(in srgb, #f97316 34%, transparent);
+  color: var(--fg);
+}
+
 .exec-approval-meta {
   margin-top: 12px;
   display: grid;

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -427,7 +427,7 @@ describe("connectGateway", () => {
     expect(host.lastErrorCode).toBeNull();
   });
 
-  it("routes exec approval requested events with command explanation highlights", () => {
+  it("routes exec approval requested events with command spans", () => {
     const { host, client } = connectHostGateway();
 
     client.emitEvent({
@@ -437,10 +437,7 @@ describe("connectGateway", () => {
         request: {
           command: 'ls | grep "stuff" | python -c \'print("hi")\'',
           host: "gateway",
-          commandExplanationLines: [],
-          commandExplanationHighlights: [
-            { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
-          ],
+          commandSpans: [{ startIndex: 20, endIndex: 26 }],
         },
         createdAtMs: Date.now(),
         expiresAtMs: Date.now() + 60_000,
@@ -448,9 +445,8 @@ describe("connectGateway", () => {
     });
 
     expect(host.execApprovalQueue).toHaveLength(1);
-    expect(host.execApprovalQueue[0]?.request.commandExplanationLines).toBeUndefined();
-    expect(host.execApprovalQueue[0]?.request.commandExplanationHighlights).toEqual([
-      { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+    expect(host.execApprovalQueue[0]?.request.commandSpans).toEqual([
+      { startIndex: 20, endIndex: 26 },
     ]);
   });
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -427,6 +427,33 @@ describe("connectGateway", () => {
     expect(host.lastErrorCode).toBeNull();
   });
 
+  it("routes exec approval requested events with command explanation highlights", () => {
+    const { host, client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "exec.approval.requested",
+      payload: {
+        id: "approval-explain-1",
+        request: {
+          command: 'ls | grep "stuff" | python -c \'print("hi")\'',
+          host: "gateway",
+          commandExplanationLines: [],
+          commandExplanationHighlights: [
+            { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+          ],
+        },
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 60_000,
+      },
+    });
+
+    expect(host.execApprovalQueue).toHaveLength(1);
+    expect(host.execApprovalQueue[0]?.request.commandExplanationLines).toBeUndefined();
+    expect(host.execApprovalQueue[0]?.request.commandExplanationHighlights).toEqual([
+      { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+    ]);
+  });
+
   it("preserves pending approval requests across reconnect", () => {
     const host = createHost();
     host.execApprovalQueue = [

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -96,3 +96,41 @@ describe("parsePluginApprovalRequested", () => {
     expect(result!.request.sessionKey).toBeNull();
   });
 });
+
+describe("parseExecApprovalRequested command explanations", () => {
+  it("preserves command text spacing for highlight offsets", () => {
+    const parsed = parseExecApprovalRequested({
+      id: "approval-spaces-1",
+      request: { command: "  python -c 'print(1)'" },
+      createdAtMs: 1,
+      expiresAtMs: 2,
+    });
+
+    expect(parsed?.request.command).toBe("  python -c 'print(1)'");
+  });
+
+  it("preserves command explanation lines and highlight severities from exec approval events", () => {
+    const parsed = parseExecApprovalRequested({
+      id: "approval-explain-1",
+      request: {
+        command: "ls | grep stuff",
+        commandExplanationLines: ["", 123],
+        commandExplanationHighlights: [
+          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+          { startIndex: 5, endIndex: 9, kind: "risk", severity: "warning" },
+          { startIndex: 10, endIndex: 15, kind: "risk", severity: "danger" },
+          { startIndex: 16, endIndex: 20, kind: "risk", severity: "loud" },
+        ],
+      },
+      createdAtMs: 1,
+      expiresAtMs: 2,
+    });
+
+    expect(parsed?.request.commandExplanationLines).toBeUndefined();
+    expect(parsed?.request.commandExplanationHighlights).toEqual([
+      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+      { startIndex: 5, endIndex: 9, kind: "risk", severity: "warning" },
+      { startIndex: 10, endIndex: 15, kind: "risk", severity: "danger" },
+    ]);
+  });
+});

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -109,6 +109,17 @@ describe("parseExecApprovalRequested command spans", () => {
     expect(parsed?.request.command).toBe("  python -c 'print(1)'");
   });
 
+  it("rejects whitespace-only command text", () => {
+    expect(
+      parseExecApprovalRequested({
+        id: "approval-blank-1",
+        request: { command: "   " },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      }),
+    ).toBeNull();
+  });
+
   it("preserves valid command spans from exec approval events", () => {
     const parsed = parseExecApprovalRequested({
       id: "approval-explain-1",

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -97,8 +97,8 @@ describe("parsePluginApprovalRequested", () => {
   });
 });
 
-describe("parseExecApprovalRequested command explanations", () => {
-  it("preserves command text spacing for highlight offsets", () => {
+describe("parseExecApprovalRequested command spans", () => {
+  it("preserves command text spacing for span offsets", () => {
     const parsed = parseExecApprovalRequested({
       id: "approval-spaces-1",
       request: { command: "  python -c 'print(1)'" },
@@ -109,28 +109,28 @@ describe("parseExecApprovalRequested command explanations", () => {
     expect(parsed?.request.command).toBe("  python -c 'print(1)'");
   });
 
-  it("preserves command explanation lines and highlight severities from exec approval events", () => {
+  it("preserves valid command spans from exec approval events", () => {
     const parsed = parseExecApprovalRequested({
       id: "approval-explain-1",
       request: {
         command: "ls | grep stuff",
-        commandExplanationLines: ["", 123],
-        commandExplanationHighlights: [
-          { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-          { startIndex: 5, endIndex: 9, kind: "risk", severity: "warning" },
-          { startIndex: 10, endIndex: 15, kind: "risk", severity: "danger" },
-          { startIndex: 16, endIndex: 20, kind: "risk", severity: "loud" },
+        commandSpans: [
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 5, endIndex: 9 },
+          { startIndex: 10, endIndex: 15 },
+          { startIndex: 16, endIndex: 20 },
+          { startIndex: 8, endIndex: 8 },
         ],
       },
       createdAtMs: 1,
       expiresAtMs: 2,
     });
 
-    expect(parsed?.request.commandExplanationLines).toBeUndefined();
-    expect(parsed?.request.commandExplanationHighlights).toEqual([
-      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-      { startIndex: 5, endIndex: 9, kind: "risk", severity: "warning" },
-      { startIndex: 10, endIndex: 15, kind: "risk", severity: "danger" },
+    expect(parsed?.request.commandSpans).toEqual([
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 5, endIndex: 9 },
+      { startIndex: 10, endIndex: 15 },
+      { startIndex: 16, endIndex: 20 },
     ]);
   });
 });

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -130,6 +130,7 @@ describe("parseExecApprovalRequested command spans", () => {
           { startIndex: 5, endIndex: 9 },
           { startIndex: 10, endIndex: 15 },
           { startIndex: 16, endIndex: 20 },
+          { startIndex: -1, endIndex: 2 },
           { startIndex: 8, endIndex: 8 },
         ],
       },
@@ -141,7 +142,6 @@ describe("parseExecApprovalRequested command spans", () => {
       { startIndex: 0, endIndex: 2 },
       { startIndex: 5, endIndex: 9 },
       { startIndex: 10, endIndex: 15 },
-      { startIndex: 16, endIndex: 20 },
     ]);
   });
 });

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -9,6 +9,13 @@ export type ExecApprovalRequestPayload = {
   agentId?: string | null;
   resolvedPath?: string | null;
   sessionKey?: string | null;
+  commandExplanationLines?: readonly string[];
+  commandExplanationHighlights?: readonly {
+    startIndex: number;
+    endIndex: number;
+    kind: "command" | "risk";
+    severity?: "info" | "warning" | "danger";
+  }[];
 };
 
 export type ExecApprovalRequest = {
@@ -34,6 +41,58 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function parseCommandExplanationHighlights(value: unknown):
+  | {
+      startIndex: number;
+      endIndex: number;
+      kind: "command" | "risk";
+      severity?: "info" | "warning" | "danger";
+    }[]
+  | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const highlights = value.filter(
+    (
+      item,
+    ): item is {
+      startIndex: number;
+      endIndex: number;
+      kind: "command" | "risk";
+      severity?: "info" | "warning" | "danger";
+    } => {
+      if (!isRecord(item)) {
+        return false;
+      }
+      const { startIndex, endIndex, kind, severity } = item;
+      return (
+        Number.isSafeInteger(startIndex) &&
+        Number.isSafeInteger(endIndex) &&
+        typeof startIndex === "number" &&
+        typeof endIndex === "number" &&
+        endIndex > startIndex &&
+        (kind === "command" || kind === "risk") &&
+        (severity === undefined ||
+          severity === "info" ||
+          severity === "warning" ||
+          severity === "danger")
+      );
+    },
+  );
+  return highlights.length > 0 ? highlights : undefined;
+}
+
+function parseCommandExplanationLines(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const lines = value
+    .filter((line): line is string => typeof line === "string")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.length > 0 ? lines : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -43,7 +102,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
   if (!id || !isRecord(request)) {
     return null;
   }
-  const command = normalizeOptionalString(request.command) ?? "";
+  const command = typeof request.command === "string" ? request.command : "";
   if (!command) {
     return null;
   }
@@ -64,6 +123,10 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
+      commandExplanationLines: parseCommandExplanationLines(request.commandExplanationLines),
+      commandExplanationHighlights: parseCommandExplanationHighlights(
+        request.commandExplanationHighlights,
+      ),
     },
     createdAtMs,
     expiresAtMs,

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -80,7 +80,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
     return null;
   }
   const command = typeof request.command === "string" ? request.command : "";
-  if (!command) {
+  if (command.trim().length === 0) {
     return null;
   }
   const createdAtMs = typeof payload.createdAtMs === "number" ? payload.createdAtMs : 0;

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -9,12 +9,9 @@ export type ExecApprovalRequestPayload = {
   agentId?: string | null;
   resolvedPath?: string | null;
   sessionKey?: string | null;
-  commandExplanationLines?: readonly string[];
-  commandExplanationHighlights?: readonly {
+  commandSpans?: readonly {
     startIndex: number;
     endIndex: number;
-    kind: "command" | "risk";
-    severity?: "info" | "warning" | "danger";
   }[];
 };
 
@@ -41,56 +38,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function parseCommandExplanationHighlights(value: unknown):
+function parseCommandSpans(value: unknown):
   | {
       startIndex: number;
       endIndex: number;
-      kind: "command" | "risk";
-      severity?: "info" | "warning" | "danger";
     }[]
   | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  const highlights = value.filter(
+  const spans = value.filter(
     (
       item,
     ): item is {
       startIndex: number;
       endIndex: number;
-      kind: "command" | "risk";
-      severity?: "info" | "warning" | "danger";
     } => {
       if (!isRecord(item)) {
         return false;
       }
-      const { startIndex, endIndex, kind, severity } = item;
+      const { startIndex, endIndex } = item;
       return (
         Number.isSafeInteger(startIndex) &&
         Number.isSafeInteger(endIndex) &&
         typeof startIndex === "number" &&
         typeof endIndex === "number" &&
-        endIndex > startIndex &&
-        (kind === "command" || kind === "risk") &&
-        (severity === undefined ||
-          severity === "info" ||
-          severity === "warning" ||
-          severity === "danger")
+        endIndex > startIndex
       );
     },
   );
-  return highlights.length > 0 ? highlights : undefined;
-}
-
-function parseCommandExplanationLines(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const lines = value
-    .filter((line): line is string => typeof line === "string")
-    .map((line) => line.trim())
-    .filter(Boolean);
-  return lines.length > 0 ? lines : undefined;
+  return spans.length > 0 ? spans : undefined;
 }
 
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
@@ -123,10 +100,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
-      commandExplanationLines: parseCommandExplanationLines(request.commandExplanationLines),
-      commandExplanationHighlights: parseCommandExplanationHighlights(
-        request.commandExplanationHighlights,
-      ),
+      commandSpans: parseCommandSpans(request.commandSpans),
     },
     createdAtMs,
     expiresAtMs,

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -38,7 +38,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function parseCommandSpans(value: unknown):
+function parseCommandSpans(
+  value: unknown,
+  commandLength: number,
+):
   | {
       startIndex: number;
       endIndex: number;
@@ -63,7 +66,9 @@ function parseCommandSpans(value: unknown):
         Number.isSafeInteger(endIndex) &&
         typeof startIndex === "number" &&
         typeof endIndex === "number" &&
-        endIndex > startIndex
+        startIndex >= 0 &&
+        endIndex > startIndex &&
+        endIndex <= commandLength
       );
     },
   );
@@ -100,7 +105,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
-      commandSpans: parseCommandSpans(request.commandSpans),
+      commandSpans: parseCommandSpans(request.commandSpans, command.length),
     },
     createdAtMs,
     expiresAtMs,

--- a/ui/src/ui/views/exec-approval.browser.test.ts
+++ b/ui/src/ui/views/exec-approval.browser.test.ts
@@ -1,0 +1,53 @@
+import { html, render } from "lit";
+import { expect, test } from "vitest";
+import { i18n } from "../../i18n/index.ts";
+import type { AppViewState } from "../app-view-state.ts";
+import { renderExecApprovalPrompt } from "./exec-approval.ts";
+
+const root = document.createElement("div");
+document.body.append(root);
+
+test("renders command explanation highlights in Chromium approval modal", async () => {
+  await i18n.setLocale("en");
+  render(
+    renderExecApprovalPrompt({
+      execApprovalQueue: [
+        {
+          id: "approval-browser-1",
+          kind: "exec",
+          request: {
+            command: 'ls | grep "stuff" | python -c \'print("hi")\'',
+            host: "gateway",
+            security: "allowlist",
+            ask: "always",
+            commandExplanationLines: [
+              "Risks:",
+              "• python -c can run arbitrary code on your computer.",
+            ],
+            commandExplanationHighlights: [
+              { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+              { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+            ],
+          },
+          createdAtMs: Date.now() - 1_000,
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+      execApprovalBusy: false,
+      execApprovalError: null,
+      handleExecApprovalDecision: async () => undefined,
+    } as unknown as AppViewState),
+    root,
+  );
+
+  const infoHighlight = root.querySelector(".exec-approval-command-highlight.command.info");
+  const dangerHighlight = root.querySelector(".exec-approval-command-highlight.risk.danger");
+
+  expect(infoHighlight?.textContent).toBe("ls");
+  expect(dangerHighlight?.textContent).toBe("python -c");
+  expect(root.querySelector(".exec-approval-explanation")?.textContent).toContain(
+    "python -c can run arbitrary code on your computer.",
+  );
+
+  render(html``, root);
+});

--- a/ui/src/ui/views/exec-approval.browser.test.ts
+++ b/ui/src/ui/views/exec-approval.browser.test.ts
@@ -7,7 +7,7 @@ import { renderExecApprovalPrompt } from "./exec-approval.ts";
 const root = document.createElement("div");
 document.body.append(root);
 
-test("renders command explanation highlights in Chromium approval modal", async () => {
+test("renders command spans in Chromium approval modal", async () => {
   await i18n.setLocale("en");
   render(
     renderExecApprovalPrompt({
@@ -20,13 +20,9 @@ test("renders command explanation highlights in Chromium approval modal", async 
             host: "gateway",
             security: "allowlist",
             ask: "always",
-            commandExplanationLines: [
-              "Risks:",
-              "• python -c can run arbitrary code on your computer.",
-            ],
-            commandExplanationHighlights: [
-              { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-              { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+            commandSpans: [
+              { startIndex: 0, endIndex: 2 },
+              { startIndex: 20, endIndex: 29 },
             ],
           },
           createdAtMs: Date.now() - 1_000,
@@ -40,14 +36,11 @@ test("renders command explanation highlights in Chromium approval modal", async 
     root,
   );
 
-  const infoHighlight = root.querySelector(".exec-approval-command-highlight.command.info");
-  const dangerHighlight = root.querySelector(".exec-approval-command-highlight.risk.danger");
-
-  expect(infoHighlight?.textContent).toBe("ls");
-  expect(dangerHighlight?.textContent).toBe("python -c");
-  expect(root.querySelector(".exec-approval-explanation")?.textContent).toContain(
-    "python -c can run arbitrary code on your computer.",
+  const spans = [...root.querySelectorAll(".exec-approval-command-span")].map(
+    (span) => span.textContent,
   );
+
+  expect(spans).toEqual(["ls", "python -c"]);
 
   render(html``, root);
 });

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -141,6 +141,33 @@ describe("approval and confirmation modals", () => {
     );
   });
 
+  it("renders command explanation highlights in exec approvals", async () => {
+    const request = createExecRequest();
+    request.request.command = 'ls | grep "stuff" | python -c \'print("hi")\'';
+    request.request.commandExplanationLines = [
+      "Risks:",
+      "• python -c can run arbitrary code on your computer.",
+    ];
+    request.request.commandExplanationHighlights = [
+      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
+      { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+    ];
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
+
+    await getRenderedDialog();
+
+    expect(container.querySelector(".exec-approval-explanation")?.textContent).toContain(
+      "python -c can run arbitrary code on your computer.",
+    );
+    expect(
+      container.querySelector(".exec-approval-command-highlight.command.info")?.textContent,
+    ).toBe("ls");
+    expect(
+      container.querySelector(".exec-approval-command-highlight.risk.danger")?.textContent,
+    ).toBe("python -c");
+  });
+
   it("maps Escape to exec denial when approval is idle", async () => {
     const handleExecApprovalDecision = vi.fn(async () => undefined);
     render(renderExecApprovalPrompt(createExecState({ handleExecApprovalDecision })), container);

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -141,31 +141,22 @@ describe("approval and confirmation modals", () => {
     );
   });
 
-  it("renders command explanation highlights in exec approvals", async () => {
+  it("renders command spans in exec approvals", async () => {
     const request = createExecRequest();
     request.request.command = 'ls | grep "stuff" | python -c \'print("hi")\'';
-    request.request.commandExplanationLines = [
-      "Risks:",
-      "• python -c can run arbitrary code on your computer.",
-    ];
-    request.request.commandExplanationHighlights = [
-      { startIndex: 0, endIndex: 2, kind: "command", severity: "info" },
-      { startIndex: 20, endIndex: 29, kind: "risk", severity: "danger" },
+    request.request.commandSpans = [
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 20, endIndex: 29 },
     ];
 
     render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);
 
     await getRenderedDialog();
 
-    expect(container.querySelector(".exec-approval-explanation")?.textContent).toContain(
-      "python -c can run arbitrary code on your computer.",
+    const spans = [...container.querySelectorAll(".exec-approval-command-span")].map(
+      (span) => span.textContent,
     );
-    expect(
-      container.querySelector(".exec-approval-command-highlight.command.info")?.textContent,
-    ).toBe("ls");
-    expect(
-      container.querySelector(".exec-approval-command-highlight.risk.danger")?.textContent,
-    ).toBe("python -c");
+    expect(spans).toEqual(["ls", "python -c"]);
   });
 
   it("maps Escape to exec denial when approval is idle", async () => {

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -146,7 +146,10 @@ describe("approval and confirmation modals", () => {
     request.request.command = 'ls | grep "stuff" | python -c \'print("hi")\'';
     request.request.commandSpans = [
       { startIndex: 0, endIndex: 2 },
+      { startIndex: 5, endIndex: 5 },
+      { startIndex: 8.5, endIndex: 10 },
       { startIndex: 20, endIndex: 29 },
+      { startIndex: 30, endIndex: 200 },
     ];
 
     render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [request] })), container);

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -32,9 +32,58 @@ function renderMetaRow(label: string, value?: string | null, opts?: { path?: boo
   </div>`;
 }
 
+function renderHighlightedCommand(request: ExecApprovalRequestPayload) {
+  const highlights = [...(request.commandExplanationHighlights ?? [])]
+    .filter(
+      (highlight) => highlight.startIndex >= 0 && highlight.endIndex <= request.command.length,
+    )
+    .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
+  const accepted: typeof highlights = [];
+  let cursor = 0;
+  for (const highlight of highlights) {
+    if (highlight.startIndex < cursor) {
+      continue;
+    }
+    accepted.push(highlight);
+    cursor = highlight.endIndex;
+  }
+  if (accepted.length === 0) {
+    return html`<div class="exec-approval-command mono">${request.command}</div>`;
+  }
+  const parts = [];
+  cursor = 0;
+  for (const highlight of accepted) {
+    if (highlight.startIndex > cursor) {
+      parts.push(request.command.slice(cursor, highlight.startIndex));
+    }
+    const severity = highlight.severity ?? (highlight.kind === "risk" ? "danger" : "info");
+    parts.push(
+      html`<mark class=${`exec-approval-command-highlight ${highlight.kind} ${severity}`}
+        >${request.command.slice(highlight.startIndex, highlight.endIndex)}</mark
+      >`,
+    );
+    cursor = highlight.endIndex;
+  }
+  if (cursor < request.command.length) {
+    parts.push(request.command.slice(cursor));
+  }
+  return html`<div class="exec-approval-command mono">${parts}</div>`;
+}
+
+function renderCommandExplanation(lines?: readonly string[]) {
+  const visibleLines = lines?.map((line) => line.trim()).filter(Boolean) ?? [];
+  if (visibleLines.length === 0) {
+    return nothing;
+  }
+  return html`<div class="exec-approval-explanation" aria-label="Command explanation">
+    ${visibleLines.map((line) => html`<div>${line}</div>`)}
+  </div>`;
+}
+
 function renderExecBody(request: ExecApprovalRequestPayload) {
   return html`
-    <div class="exec-approval-command mono">${request.command}</div>
+    ${renderHighlightedCommand(request)}
+    ${renderCommandExplanation(request.commandExplanationLines)}
     <div class="exec-approval-meta">
       ${renderMetaRow(t("execApproval.labels.host"), request.host)}
       ${renderMetaRow(t("execApproval.labels.agent"), request.agentId)}

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -34,7 +34,14 @@ function renderMetaRow(label: string, value?: string | null, opts?: { path?: boo
 
 function renderCommandWithSpans(request: ExecApprovalRequestPayload) {
   const commandSpans = [...(request.commandSpans ?? [])]
-    .filter((span) => span.startIndex >= 0 && span.endIndex <= request.command.length)
+    .filter(
+      (span) =>
+        Number.isSafeInteger(span.startIndex) &&
+        Number.isSafeInteger(span.endIndex) &&
+        span.startIndex >= 0 &&
+        span.endIndex > span.startIndex &&
+        span.endIndex <= request.command.length,
+    )
     .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
   const accepted: typeof commandSpans = [];
   let cursor = 0;

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -32,37 +32,34 @@ function renderMetaRow(label: string, value?: string | null, opts?: { path?: boo
   </div>`;
 }
 
-function renderHighlightedCommand(request: ExecApprovalRequestPayload) {
-  const highlights = [...(request.commandExplanationHighlights ?? [])]
-    .filter(
-      (highlight) => highlight.startIndex >= 0 && highlight.endIndex <= request.command.length,
-    )
+function renderCommandWithSpans(request: ExecApprovalRequestPayload) {
+  const commandSpans = [...(request.commandSpans ?? [])]
+    .filter((span) => span.startIndex >= 0 && span.endIndex <= request.command.length)
     .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
-  const accepted: typeof highlights = [];
+  const accepted: typeof commandSpans = [];
   let cursor = 0;
-  for (const highlight of highlights) {
-    if (highlight.startIndex < cursor) {
+  for (const span of commandSpans) {
+    if (span.startIndex < cursor) {
       continue;
     }
-    accepted.push(highlight);
-    cursor = highlight.endIndex;
+    accepted.push(span);
+    cursor = span.endIndex;
   }
   if (accepted.length === 0) {
     return html`<div class="exec-approval-command mono">${request.command}</div>`;
   }
   const parts = [];
   cursor = 0;
-  for (const highlight of accepted) {
-    if (highlight.startIndex > cursor) {
-      parts.push(request.command.slice(cursor, highlight.startIndex));
+  for (const span of accepted) {
+    if (span.startIndex > cursor) {
+      parts.push(request.command.slice(cursor, span.startIndex));
     }
-    const severity = highlight.severity ?? (highlight.kind === "risk" ? "danger" : "info");
     parts.push(
-      html`<mark class=${`exec-approval-command-highlight ${highlight.kind} ${severity}`}
-        >${request.command.slice(highlight.startIndex, highlight.endIndex)}</mark
+      html`<mark class="exec-approval-command-span"
+        >${request.command.slice(span.startIndex, span.endIndex)}</mark
       >`,
     );
-    cursor = highlight.endIndex;
+    cursor = span.endIndex;
   }
   if (cursor < request.command.length) {
     parts.push(request.command.slice(cursor));
@@ -70,20 +67,9 @@ function renderHighlightedCommand(request: ExecApprovalRequestPayload) {
   return html`<div class="exec-approval-command mono">${parts}</div>`;
 }
 
-function renderCommandExplanation(lines?: readonly string[]) {
-  const visibleLines = lines?.map((line) => line.trim()).filter(Boolean) ?? [];
-  if (visibleLines.length === 0) {
-    return nothing;
-  }
-  return html`<div class="exec-approval-explanation" aria-label="Command explanation">
-    ${visibleLines.map((line) => html`<div>${line}</div>`)}
-  </div>`;
-}
-
 function renderExecBody(request: ExecApprovalRequestPayload) {
   return html`
-    ${renderHighlightedCommand(request)}
-    ${renderCommandExplanation(request.commandExplanationLines)}
+    ${renderCommandWithSpans(request)}
     <div class="exec-approval-meta">
       ${renderMetaRow(t("execApproval.labels.host"), request.host)}
       ${renderMetaRow(t("execApproval.labels.agent"), request.agentId)}


### PR DESCRIPTION
## Summary

Builds on the merged shell command explainer and surfaces parser-backed command highlights in the Web exec approval modal.

- computes command explanation highlight metadata when registering host exec approvals
- passes highlight metadata through gateway validation, broadcasts, and approval view models
- renders command/risk highlights in the Web approval command block
- keeps explicit `commandExplanationLines` API passthrough for future/non-Web callers, but does not generate visible risk text by default
- adds regression coverage for parser-backed highlights, schema pass-through, and Web UI rendering

## Scope

This PR is intentionally Web UI focused. Native chat approval cards and other approval surfaces can consume the shared metadata in follow-up work.

This PR does not change exec authorization policy, allowlist matching, allow-always behavior, or native chat approval rendering.

## Test plan

- `OPENCLAW_LOCAL_CHECK=0 pnpm --dir .worktrees/command-explanation-ui test src/infra/command-explainer/extract.test.ts src/infra/command-explainer/format.test.ts src/agents/bash-tools.exec-approval-request.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/approval-view-model.test.ts src/gateway/server-methods/server-methods.test.ts ui/src/ui/controllers/exec-approval.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/views/exec-approval.test.ts`
- `pnpm --dir .worktrees/command-explanation-ui/ui exec vitest run --config vitest.config.ts --project browser src/ui/views/exec-approval.browser.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm --dir .worktrees/command-explanation-ui lint:core -- src/infra/command-explainer/format.ts ui/src/ui/views/exec-approval.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm --dir .worktrees/command-explanation-ui check:changed`
