### PR TITLE
fix(bluebubbles): stop typing indicator after cleanup

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1702,7 +1702,16 @@ async function processMessageAfterDedupe(
   let sentMessage = false;
   let streamingActive = false;
   let typingRestartTimer: NodeJS.Timeout | undefined;
+  const pendingTypingUpdates = new Set<Promise<void>>();
   const typingRestartDelayMs = 150;
+  const trackTypingUpdate = (promise: Promise<void>) => {
+    pendingTypingUpdates.add(promise);
+    promise.then(
+      () => pendingTypingUpdates.delete(promise),
+      () => pendingTypingUpdates.delete(promise),
+    );
+    return promise;
+  };
   const clearTypingRestartTimer = () => {
     if (typingRestartTimer) {
       clearTimeout(typingRestartTimer);
@@ -1719,10 +1728,12 @@ async function processMessageAfterDedupe(
       if (!streamingActive) {
         return;
       }
-      sendBlueBubblesTyping(chatGuidForActions, true, {
-        cfg: config,
-        accountId: account.accountId,
-      }).catch((err) => {
+      trackTypingUpdate(
+        sendBlueBubblesTyping(chatGuidForActions, true, {
+          cfg: config,
+          accountId: account.accountId,
+        }),
+      ).catch((err) => {
         runtime.error?.(`[bluebubbles] typing restart failed: ${sanitizeForLog(err)}`);
       });
     }, typingRestartDelayMs);
@@ -1957,6 +1968,9 @@ async function processMessageAfterDedupe(
       Boolean(chatGuidForActions && baseUrl && password) && (streamingActive || !sentMessage);
     streamingActive = false;
     clearTypingRestartTimer();
+    if (pendingTypingUpdates.size > 0) {
+      await Promise.allSettled([...pendingTypingUpdates]);
+    }
     if (sentMessage && chatGuidForActions && ackMessageId) {
       core.channel.reactions.removeAckReactionAfterReply({
         removeAfterReply: removeAckAfterReply,
@@ -1982,10 +1996,12 @@ async function processMessageAfterDedupe(
     }
     if (shouldStopTyping && chatGuidForActions) {
       // Stop typing after streaming completes to avoid a stuck indicator.
-      sendBlueBubblesTyping(chatGuidForActions, false, {
-        cfg: config,
-        accountId: account.accountId,
-      }).catch((err) => {
+      try {
+        await sendBlueBubblesTyping(chatGuidForActions, false, {
+          cfg: config,
+          accountId: account.accountId,
+        });
+      } catch (err) {
         logTypingFailure({
           log: (msg) => logVerbose(core, runtime, msg),
           channel: "bluebubbles",
@@ -1993,7 +2009,7 @@ async function processMessageAfterDedupe(
           target: chatGuidForActions,
           error: err,
         });
-      });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles block-streaming replies could leave iMessage typing indicators visible after the OpenClaw turn finished.
- Why it matters: stale typing indicators make it look like the agent is still working even when the session has ended.
- What changed: delayed typing restart requests are tracked, final cleanup waits for any pending restart POSTs, and the final typing-stop DELETE is awaited.
- What did NOT change (scope boundary): no BlueBubbles config shape, message delivery, markdown, media, or reaction behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: BlueBubbles could schedule async `typing=true` restart requests during block streaming, while final cleanup cleared the timer and sent `typing=false` without waiting for either pending restart requests or the stop request.
- Missing detection / guardrail: the existing tests covered typing API requests but not an ordering race between delayed restart work and cleanup.
- Contributing context (if known): the issue is most visible in direct chats where the model sends the visible answer through the message tool and then finalizes privately with `NO_REPLY`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: BlueBubbles monitor/reply pipeline coverage.
- Scenario the test should lock in: a pending delayed typing restart must settle before the final typing stop is sent.
- Why this is the smallest reliable guardrail: the race is in the BlueBubbles monitor cleanup path, not the generic typing helper or BlueBubbles HTTP client.
- Existing test that already covers this (if any): existing BlueBubbles monitor and chat tests still pass.
- If no new test is added, why not: this PR currently relies on targeted regression-adjacent coverage plus live BlueBubbles verification; adding a deterministic timer/order test is a good follow-up if reviewers want more coverage in this PR.

## User-visible / Behavior Changes

BlueBubbles/iMessage typing indicators should stop after the reply turn finishes instead of reappearing or sticking due to a delayed typing restart.

## Diagram (if applicable)

```text
Before:
[block reply] -> [typing restart POST scheduled] -> [cleanup fire-and-forget stop] -> [restart can win] -> [stuck typing]

After:
[block reply] -> [typing restart POST tracked] -> [cleanup drains pending typing] -> [await stop] -> [typing cleared]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw gateway from source
- Model/provider: OpenAI Codex path using `openai/gpt-5.5`
- Integration/channel (if any): BlueBubbles direct iMessage chat
- Relevant config (redacted): BlueBubbles enabled with Private API and block streaming enabled

### Steps

1. Send a BlueBubbles direct-chat message that produces a quick visible reply.
2. Observe that typing starts, clears, and can later reappear even after the OpenClaw session has ended.
3. Apply the patch and restart the gateway.
4. Repeat the direct-chat flow.

### Expected

- Typing indicators stop after the turn finishes.

### Actual

- Before the patch, typing indicators could reappear or stick after the visible reply.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live BlueBubbles direct chat where the stuck indicator cleared after explicit stop, then the patched cleanup path was deployed and confirmed by the reporter.
- Edge cases checked: no hidden active OpenClaw task or session run remained while the indicator was visible; targeted BlueBubbles tests still pass.
- What you did **not** verify: multi-part media replies and group chats.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: awaiting the final typing stop can add a small cleanup delay when BlueBubbles is slow.
  - Mitigation: the stop path already used the configured BlueBubbles request timeout and this waits only at turn cleanup.
