### PR TITLE
fix(deepseek): expose v4 max thinking levels in policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- DeepSeek: expose the V4 `xhigh` and `max` thinking levels through the bundled provider policy surface, so fallback `/think` resolution matches the runtime provider hook. Fixes #77139. Thanks @Thiagocsoaresbh.
+- Gateway/startup: keep model-catalog test helpers and run-session lookup code out of the hot `server.impl` import graph, reducing default gateway benchmark readiness latency.
+- Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Gateway/startup: keep model-catalog test helpers and run-session lookup code out of the hot `server.impl` import graph, reducing default gateway benchmark readiness latency.
 - Channels/streaming: add unified `streaming.mode: "progress"` drafts with auto single-word status labels and shared progress configuration across Discord, Telegram, Matrix, Slack, and Microsoft Teams.
 - Slack/streaming: add `streaming.progress.render: "rich"` for Block Kit progress drafts backed by structured progress line data.

--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -1,27 +1,12 @@
-import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
-import { isDeepSeekV4ModelId } from "./models.js";
 import { applyDeepSeekConfig, DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildDeepSeekProvider } from "./provider-catalog.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
+import { resolveDeepSeekV4ThinkingProfile } from "./thinking.js";
 
 const PROVIDER_ID = "deepseek";
-const V4_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
-
-function buildDeepSeekV4ThinkingLevel(id: (typeof V4_THINKING_LEVEL_IDS)[number]) {
-  return { id };
-}
-
-const DEEPSEEK_V4_THINKING_PROFILE = {
-  levels: V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
-  defaultLevel: "high",
-} satisfies ProviderThinkingProfile;
-
-function resolveDeepSeekV4ThinkingProfile(modelId: string): ProviderThinkingProfile | undefined {
-  return isDeepSeekV4ModelId(modelId) ? DEEPSEEK_V4_THINKING_PROFILE : undefined;
-}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,

--- a/extensions/deepseek/provider-policy-api.test.ts
+++ b/extensions/deepseek/provider-policy-api.test.ts
@@ -1,8 +1,35 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
-import { normalizeConfig } from "./provider-policy-api.js";
+import { normalizeConfig, resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("deepseek provider-policy-api", () => {
+  it("exposes xhigh and max thinking levels for DeepSeek V4 models", () => {
+    const profile = resolveThinkingProfile({
+      provider: "deepseek",
+      modelId: "deepseek-v4-pro",
+    });
+
+    expect(profile?.defaultLevel).toBe("high");
+    expect(profile?.levels.map((level) => level.id)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+
+  it("does not expose a thinking profile for non-V4 models", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "deepseek",
+        modelId: "deepseek-chat",
+      }),
+    ).toBeNull();
+  });
+
   it("hydrates contextWindow and cost from catalog for known models", () => {
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.deepseek.com",

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -1,9 +1,36 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { DEEPSEEK_MODEL_CATALOG } from "./models.js";
+import { DEEPSEEK_MODEL_CATALOG, isDeepSeekV4ModelId } from "./models.js";
 
 type ModelDefinitionDraft = Partial<ModelDefinitionConfig> &
   Pick<ModelDefinitionConfig, "id" | "name">;
+
+const DEEPSEEK_V4_THINKING_LEVEL_IDS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+function buildDeepSeekV4ThinkingLevel(id: (typeof DEEPSEEK_V4_THINKING_LEVEL_IDS)[number]) {
+  return { id };
+}
+
+const DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: DEEPSEEK_V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+export function resolveThinkingProfile(params: {
+  provider: string;
+  modelId: string;
+}): ProviderThinkingProfile | null {
+  return isDeepSeekV4ModelId(params.modelId) ? DEEPSEEK_V4_THINKING_PROFILE : null;
+}
 
 /**
  * Build a lookup from the bundled DeepSeek model catalog so we can hydrate

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -1,35 +1,13 @@
-import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { DEEPSEEK_MODEL_CATALOG, isDeepSeekV4ModelId } from "./models.js";
+import { DEEPSEEK_MODEL_CATALOG } from "./models.js";
+import { resolveDeepSeekV4ThinkingProfile } from "./thinking.js";
 
 type ModelDefinitionDraft = Partial<ModelDefinitionConfig> &
   Pick<ModelDefinitionConfig, "id" | "name">;
 
-const DEEPSEEK_V4_THINKING_LEVEL_IDS = [
-  "off",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-] as const;
-
-function buildDeepSeekV4ThinkingLevel(id: (typeof DEEPSEEK_V4_THINKING_LEVEL_IDS)[number]) {
-  return { id };
-}
-
-const DEEPSEEK_V4_THINKING_PROFILE = {
-  levels: DEEPSEEK_V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
-  defaultLevel: "high",
-} satisfies ProviderThinkingProfile;
-
-export function resolveThinkingProfile(params: {
-  provider: string;
-  modelId: string;
-}): ProviderThinkingProfile | null {
-  return isDeepSeekV4ModelId(params.modelId) ? DEEPSEEK_V4_THINKING_PROFILE : null;
+export function resolveThinkingProfile(params: { provider: string; modelId: string }) {
+  return resolveDeepSeekV4ThinkingProfile(params.modelId) ?? null;
 }
 
 /**

--- a/extensions/deepseek/thinking.ts
+++ b/extensions/deepseek/thinking.ts
@@ -1,0 +1,27 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import { isDeepSeekV4ModelId } from "./models.js";
+
+const DEEPSEEK_V4_THINKING_LEVEL_IDS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+
+function buildDeepSeekV4ThinkingLevel(id: (typeof DEEPSEEK_V4_THINKING_LEVEL_IDS)[number]) {
+  return { id };
+}
+
+const DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: DEEPSEEK_V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+export function resolveDeepSeekV4ThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  return isDeepSeekV4ModelId(modelId) ? DEEPSEEK_V4_THINKING_PROFILE : undefined;
+}


### PR DESCRIPTION
## Summary

- Problem: The Control UI `/think` picker could omit `xhigh` and `max` for native DeepSeek V4 models when thinking resolution used the bundled provider policy surface.
- Why it matters: Users selecting `deepseek/deepseek-v4-pro` or `deepseek/deepseek-v4-flash` should be able to choose the documented maximum reasoning levels from the UI.
- What changed: Added `resolveThinkingProfile` to DeepSeek's provider policy API and covered the V4/non-V4 behavior with unit tests.
- What did NOT change (scope boundary): Did not change the runtime DeepSeek provider hook, which already exposed the correct V4 thinking profile.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77139
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: DeepSeek's runtime provider hook exposed the V4 thinking profile, but the lightweight bundled provider policy API did not export `resolveThinkingProfile`.
- Missing detection / guardrail: There was no provider-policy unit test verifying that DeepSeek V4 policy resolution exposes `xhigh` and `max`.
- Contributing context (if known): Non-runtime thinking resolution can fall back to `resolveBundledProviderPolicySurface(...).resolveThinkingProfile`, so missing policy support caused callers to see only the base thinking levels.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/deepseek/provider-policy-api.test.ts`
- Scenario the test should lock in: DeepSeek V4 policy resolution exposes `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; non-V4 models do not get the V4 thinking profile.
- Why this is the smallest reliable guardrail: The bug is isolated to the lightweight provider policy surface, so a focused provider-policy unit test covers the failing path.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The Control UI `/think` picker can surface `xhigh` and `max` for native DeepSeek V4 models when it resolves thinking options through the bundled provider policy surface.

## Diagram (if applicable)

```text
Before:
[/think picker] -> [bundled DeepSeek provider policy] -> [no resolveThinkingProfile] -> [base levels only]

After:
[/think picker] -> [bundled DeepSeek provider policy] -> [DeepSeek V4 thinking profile] -> [xhigh and max available]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: WSL
- Runtime/container: Node.js 22.22.2, pnpm 10.33.2
- Model/provider: `deepseek/deepseek-v4-pro`
- Integration/channel (if any): Control UI `/think` picker
- Relevant config (redacted): N/A

### Steps

1. Resolve the bundled DeepSeek provider policy surface for a DeepSeek V4 model.
2. Request the thinking profile for `deepseek-v4-pro`.
3. Verify the returned levels include `xhigh` and `max`.

### Expected

- DeepSeek V4 thinking profile includes `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.

### Actual

- Before this fix, the policy artifact did not export `resolveThinkingProfile`, so fallback callers could only see the base levels.
- After this fix, the provider-policy test verifies all expected V4 levels.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm exec vitest run extensions/deepseek/provider-policy-api.test.ts --reporter=verbose

Test Files  1 passed (1)
Tests       12 passed (12)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - DeepSeek V4 policy profile exposes `xhigh` and `max`.
  - DeepSeek V4 policy profile keeps `high` as the default level.
  - Non-V4 DeepSeek models do not receive the V4 thinking profile.
  - Existing DeepSeek provider policy metadata hydration tests still pass.
- Edge cases checked:
  - `deepseek-chat` returns no V4 thinking profile.
- What you did **not** verify:
  - Live Control UI browser autocomplete was not manually replayed.
  - Full repository test suite was not run.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The provider policy surface could drift from the runtime DeepSeek thinking profile in the future.
  - Mitigation: Added provider-policy unit coverage for the expected DeepSeek V4 thinking levels.
