### PR TITLE
fix: clear BlueBubbles typing after actions

### DIFF
--- a/extensions/bluebubbles/src/actions.runtime.ts
+++ b/extensions/bluebubbles/src/actions.runtime.ts
@@ -5,6 +5,7 @@ import {
   leaveBlueBubblesChat as leaveBlueBubblesChatImpl,
   removeBlueBubblesParticipant as removeBlueBubblesParticipantImpl,
   renameBlueBubblesChat as renameBlueBubblesChatImpl,
+  sendBlueBubblesTyping as sendBlueBubblesTypingImpl,
   setGroupIconBlueBubbles as setGroupIconBlueBubblesImpl,
   unsendBlueBubblesMessage as unsendBlueBubblesMessageImpl,
 } from "./chat.js";
@@ -22,6 +23,7 @@ export const blueBubblesActionsRuntime = {
   leaveBlueBubblesChat: leaveBlueBubblesChatImpl,
   removeBlueBubblesParticipant: removeBlueBubblesParticipantImpl,
   renameBlueBubblesChat: renameBlueBubblesChatImpl,
+  sendBlueBubblesTyping: sendBlueBubblesTypingImpl,
   setGroupIconBlueBubbles: setGroupIconBlueBubblesImpl,
   unsendBlueBubblesMessage: unsendBlueBubblesMessageImpl,
   resolveBlueBubblesMessageId: resolveBlueBubblesMessageIdImpl,

--- a/extensions/bluebubbles/src/actions.test.ts
+++ b/extensions/bluebubbles/src/actions.test.ts
@@ -1,7 +1,7 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { sendBlueBubblesAttachment } from "./attachments.js";
-import { editBlueBubblesMessage, setGroupIconBlueBubbles } from "./chat.js";
+import { editBlueBubblesMessage, sendBlueBubblesTyping, setGroupIconBlueBubbles } from "./chat.js";
 import { resolveBlueBubblesMessageId } from "./monitor-reply-cache.js";
 import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import { sendBlueBubblesReaction } from "./reactions.js";
@@ -24,6 +24,7 @@ vi.mock("./send.js", () => ({
 
 vi.mock("./chat.js", () => ({
   editBlueBubblesMessage: vi.fn().mockResolvedValue(undefined),
+  sendBlueBubblesTyping: vi.fn().mockResolvedValue(undefined),
   unsendBlueBubblesMessage: vi.fn().mockResolvedValue(undefined),
   renameBlueBubblesChat: vi.fn().mockResolvedValue(undefined),
   setGroupIconBlueBubbles: vi.fn().mockResolvedValue(undefined),
@@ -387,6 +388,11 @@ describe("bluebubblesMessageActions", () => {
           messageGuid: "msg-123",
           emoji: "❤️",
         }),
+      );
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        "iMessage;-;+15551234567",
+        false,
+        expect.objectContaining({ cfg: expect.any(Object), accountId: undefined }),
       );
       // jsonResult returns { content: [...], details: payload }
       expect(result).toMatchObject({

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -250,6 +250,7 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
         partIndex: typeof partIndex === "number" ? partIndex : undefined,
         opts,
       });
+      await runtime.sendBlueBubblesTyping(resolvedChatGuid, false, opts);
 
       return jsonResult({ ok: true, ...(remove ? { removed: true } : { added: emoji }) });
     }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -316,6 +316,27 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("renders a browser-friendly missing assets page", async () => {
+    const { res, end, setHeader } = makeMockHttpResponse();
+
+    const handled = await handleControlUiHttpRequest(
+      { url: "/", method: "GET" } as IncomingMessage,
+      res,
+      {
+        root: { kind: "missing" },
+      },
+    );
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "text/html; charset=utf-8");
+    const body = String(end.mock.calls[0]?.[0] ?? "");
+    expect(body).toContain("<title>Control UI Assets Missing</title>");
+    expect(body).toContain("Control UI assets are missing");
+    expect(body).toContain("pnpm ui:build");
+    expect(body).toContain("pnpm ui:dev");
+  });
+
   it("serves assistant local media through the control ui media route", async () => {
     await withAllowedAssistantMediaRoot({
       prefix: "ui-media-",

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -37,7 +37,6 @@ import { buildControlUiCspHeader, computeInlineScriptHashes } from "./control-ui
 import {
   isReadHttpMethod,
   respondNotFound as respondControlUiNotFound,
-  respondPlainText,
 } from "./control-ui-http-utils.js";
 import { classifyControlUiRequest } from "./control-ui-routing.js";
 import {
@@ -59,8 +58,6 @@ const ROOT_PREFIX = "/";
 const CONTROL_UI_ASSISTANT_MEDIA_PREFIX = "/__openclaw__/assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_SCOPE = "assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_TTL_MS = 5 * 60 * 1000;
-const CONTROL_UI_ASSETS_MISSING_MESSAGE =
-  "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.";
 const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
 const CONTROL_UI_OPERATOR_ROLE = "operator";
 const controlUiAssistantMediaTicketSecret = randomBytes(32);
@@ -180,19 +177,96 @@ function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
+function escapeHtml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+function renderControlUiAssetsMissingHtml(options?: { configuredRootPath?: string }): string {
+  const configuredRoot = options?.configuredRootPath?.trim();
+  const rootDetails = configuredRoot
+    ? `<p class="detail">Configured root: <code>${escapeHtml(configuredRoot)}</code></p>`
+    : "";
+  const rootFix = configuredRoot
+    ? `<li>Update <code>gateway.controlUi.root</code> if it points at the wrong build output.</li>`
+    : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Control UI Assets Missing</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f7f5;
+      color: #1f2933;
+    }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+    main {
+      width: min(680px, 100%);
+      border: 1px solid color-mix(in srgb, currentColor 16%, transparent);
+      border-radius: 8px;
+      background: color-mix(in srgb, Canvas 92%, transparent);
+      padding: 28px;
+      box-shadow: 0 18px 44px color-mix(in srgb, #0f172a 12%, transparent);
+    }
+    h1 {
+      margin: 0 0 10px;
+      font-size: 24px;
+      line-height: 1.2;
+    }
+    p, li {
+      line-height: 1.55;
+    }
+    .detail {
+      color: color-mix(in srgb, currentColor 72%, transparent);
+    }
+    code {
+      border-radius: 6px;
+      padding: 2px 6px;
+      background: color-mix(in srgb, currentColor 10%, transparent);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.95em;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        background: #111827;
+        color: #f3f4f6;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Control UI assets are missing</h1>
+    <p>The Gateway is running, but the static Control UI bundle is not available yet.</p>
+    ${rootDetails}
+    <ol>
+      <li>From the OpenClaw repo, run <code>pnpm ui:build</code>.</li>
+      <li>During Control UI development, run <code>pnpm ui:dev</code> instead.</li>
+      ${rootFix}
+      <li>Refresh this page after the build finishes.</li>
+    </ol>
+  </main>
+</body>
+</html>`;
+}
+
 function respondControlUiAssetsUnavailable(
   res: ServerResponse,
   options?: { configuredRootPath?: string },
 ) {
-  if (options?.configuredRootPath) {
-    respondPlainText(
-      res,
-      503,
-      `Control UI assets not found at ${options.configuredRootPath}. Build them with \`pnpm ui:build\` (auto-installs UI deps), or update gateway.controlUi.root.`,
-    );
-    return;
-  }
-  respondPlainText(res, 503, CONTROL_UI_ASSETS_MISSING_MESSAGE);
+  res.statusCode = 503;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache");
+  res.end(renderControlUiAssetsMissingHtml(options));
 }
 
 function respondHeadForFile(req: IncomingMessage, res: ServerResponse, filePath: string): boolean {

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -684,7 +684,7 @@ describe("gateway plugin HTTP auth boundary", () => {
 
         expect(handlePluginRequest).toHaveBeenCalledTimes(1);
         expect(response.res.statusCode).toBe(503);
-        expect(response.getBody()).toContain("Control UI assets not found");
+        expect(response.getBody()).toContain("Control UI assets are missing");
       },
     });
   });


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles typing indicators could remain visible after post-turn message action work, and the Control UI missing-assets path returned a raw 503 text error in browsers.
- Why it matters: iMessage users can see stale typing after a reply/action has finished, and local web users get a confusing UX when the UI bundle has not been built.
- What changed: BlueBubbles reaction actions now clear typing after the action finishes; the Control UI missing-assets response now renders an HTML page with `pnpm ui:build` / `pnpm ui:dev` guidance.
- What did NOT change (scope boundary): No changelog entry in this PR; changelog is handled during landing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The BlueBubbles message action path did not explicitly clear typing state after reaction/action work completed. The Control UI missing-assets path optimized for machine-readable/plain text output even for browser navigation.
- Missing detection / guardrail: No regression assertion covered typing cleanup after a message reaction action, and no HTTP test covered browser-facing missing asset rendering.
- Contributing context (if known): Post-turn work can continue after the visible reply is delivered, making stale typing state visible even though no additional message text is being sent.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/bluebubbles/src/actions.test.ts`, `src/gateway/control-ui.http.test.ts`, `src/gateway/server.plugin-http-auth.test.ts`
- Scenario the test should lock in: BlueBubbles reaction actions clear typing after completion; missing Control UI assets render an HTML 503 page with build/dev instructions.
- Why this is the smallest reliable guardrail: These tests cover the exact integration boundaries that regressed without requiring live iMessage or a built UI bundle.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- BlueBubbles recipients should no longer see stale typing indicators after message reaction actions finish.
- Opening the Control UI without built assets now shows a browser-friendly 503 page with next-step commands.

## Diagram (if applicable)

```text
Before:
[post-turn reaction action] -> [typing state may remain active]
[GET / without UI assets] -> [raw 503 text]

After:
[post-turn reaction action] -> [typing cleared] -> [no stale indicator]
[GET / without UI assets] -> [HTML 503 guidance page]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles; Gateway Control UI
- Relevant config (redacted): N/A

### Steps

1. Run BlueBubbles message action tests.
2. Run Gateway Control UI HTTP tests with missing assets.
3. Manually confirm BlueBubbles typing no longer sticks after the tested action path.

### Expected

- Typing is cleared after action completion.
- Missing Control UI assets render a useful HTML response.

### Actual

- Matches expected with this branch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test:extension bluebubbles`; `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui.http.test.ts src/gateway/server.plugin-http-auth.test.ts`; user confirmed the BlueBubbles behavior works.
- Edge cases checked: Missing Control UI root returns status 503, HTML content type, and includes both build/dev commands.
- What you did **not** verify: Full `pnpm build`, full `pnpm check`, full `pnpm test`, and live Control UI screenshot.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Clearing typing after reaction actions could mask typing state from other simultaneous work in the same chat.
  - Mitigation: The clear happens after this action path completes and uses the existing BlueBubbles typing API; it is scoped to the resolved chat GUID.
