### PR TITLE
fix: clear BlueBubbles typing after actions

### DIFF
--- a/extensions/bluebubbles/src/actions.runtime.ts
+++ b/extensions/bluebubbles/src/actions.runtime.ts
@@ -5,6 +5,7 @@ import {
   leaveBlueBubblesChat as leaveBlueBubblesChatImpl,
   removeBlueBubblesParticipant as removeBlueBubblesParticipantImpl,
   renameBlueBubblesChat as renameBlueBubblesChatImpl,
+  sendBlueBubblesTyping as sendBlueBubblesTypingImpl,
   setGroupIconBlueBubbles as setGroupIconBlueBubblesImpl,
   unsendBlueBubblesMessage as unsendBlueBubblesMessageImpl,
 } from "./chat.js";
@@ -22,6 +23,7 @@ export const blueBubblesActionsRuntime = {
   leaveBlueBubblesChat: leaveBlueBubblesChatImpl,
   removeBlueBubblesParticipant: removeBlueBubblesParticipantImpl,
   renameBlueBubblesChat: renameBlueBubblesChatImpl,
+  sendBlueBubblesTyping: sendBlueBubblesTypingImpl,
   setGroupIconBlueBubbles: setGroupIconBlueBubblesImpl,
   unsendBlueBubblesMessage: unsendBlueBubblesMessageImpl,
   resolveBlueBubblesMessageId: resolveBlueBubblesMessageIdImpl,

--- a/extensions/bluebubbles/src/actions.test.ts
+++ b/extensions/bluebubbles/src/actions.test.ts
@@ -1,7 +1,7 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { sendBlueBubblesAttachment } from "./attachments.js";
-import { editBlueBubblesMessage, setGroupIconBlueBubbles } from "./chat.js";
+import { editBlueBubblesMessage, sendBlueBubblesTyping, setGroupIconBlueBubbles } from "./chat.js";
 import { resolveBlueBubblesMessageId } from "./monitor-reply-cache.js";
 import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import { sendBlueBubblesReaction } from "./reactions.js";
@@ -24,6 +24,7 @@ vi.mock("./send.js", () => ({
 
 vi.mock("./chat.js", () => ({
   editBlueBubblesMessage: vi.fn().mockResolvedValue(undefined),
+  sendBlueBubblesTyping: vi.fn().mockResolvedValue(undefined),
   unsendBlueBubblesMessage: vi.fn().mockResolvedValue(undefined),
   renameBlueBubblesChat: vi.fn().mockResolvedValue(undefined),
   setGroupIconBlueBubbles: vi.fn().mockResolvedValue(undefined),
@@ -387,6 +388,11 @@ describe("bluebubblesMessageActions", () => {
           messageGuid: "msg-123",
           emoji: "❤️",
         }),
+      );
+      expect(sendBlueBubblesTyping).toHaveBeenCalledWith(
+        "iMessage;-;+15551234567",
+        false,
+        expect.objectContaining({ cfg: expect.any(Object), accountId: undefined }),
       );
       // jsonResult returns { content: [...], details: payload }
       expect(result).toMatchObject({

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -250,6 +250,7 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
         partIndex: typeof partIndex === "number" ? partIndex : undefined,
         opts,
       });
+      await runtime.sendBlueBubblesTyping(resolvedChatGuid, false, opts);
 
       return jsonResult({ ok: true, ...(remove ? { removed: true } : { added: emoji }) });
     }

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1702,7 +1702,16 @@ async function processMessageAfterDedupe(
   let sentMessage = false;
   let streamingActive = false;
   let typingRestartTimer: NodeJS.Timeout | undefined;
+  const pendingTypingUpdates = new Set<Promise<void>>();
   const typingRestartDelayMs = 150;
+  const trackTypingUpdate = (promise: Promise<void>) => {
+    pendingTypingUpdates.add(promise);
+    promise.then(
+      () => pendingTypingUpdates.delete(promise),
+      () => pendingTypingUpdates.delete(promise),
+    );
+    return promise;
+  };
   const clearTypingRestartTimer = () => {
     if (typingRestartTimer) {
       clearTimeout(typingRestartTimer);
@@ -1719,10 +1728,12 @@ async function processMessageAfterDedupe(
       if (!streamingActive) {
         return;
       }
-      sendBlueBubblesTyping(chatGuidForActions, true, {
-        cfg: config,
-        accountId: account.accountId,
-      }).catch((err) => {
+      trackTypingUpdate(
+        sendBlueBubblesTyping(chatGuidForActions, true, {
+          cfg: config,
+          accountId: account.accountId,
+        }),
+      ).catch((err) => {
         runtime.error?.(`[bluebubbles] typing restart failed: ${sanitizeForLog(err)}`);
       });
     }, typingRestartDelayMs);
@@ -1957,6 +1968,9 @@ async function processMessageAfterDedupe(
       Boolean(chatGuidForActions && baseUrl && password) && (streamingActive || !sentMessage);
     streamingActive = false;
     clearTypingRestartTimer();
+    if (pendingTypingUpdates.size > 0) {
+      await Promise.allSettled([...pendingTypingUpdates]);
+    }
     if (sentMessage && chatGuidForActions && ackMessageId) {
       core.channel.reactions.removeAckReactionAfterReply({
         removeAfterReply: removeAckAfterReply,
@@ -1982,10 +1996,12 @@ async function processMessageAfterDedupe(
     }
     if (shouldStopTyping && chatGuidForActions) {
       // Stop typing after streaming completes to avoid a stuck indicator.
-      sendBlueBubblesTyping(chatGuidForActions, false, {
-        cfg: config,
-        accountId: account.accountId,
-      }).catch((err) => {
+      try {
+        await sendBlueBubblesTyping(chatGuidForActions, false, {
+          cfg: config,
+          accountId: account.accountId,
+        });
+      } catch (err) {
         logTypingFailure({
           log: (msg) => logVerbose(core, runtime, msg),
           channel: "bluebubbles",
@@ -1993,7 +2009,7 @@ async function processMessageAfterDedupe(
           target: chatGuidForActions,
           error: err,
         });
-      });
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles typing indicators can remain visible after post-turn message reaction work or after delayed block-stream typing restarts race with the final typing-stop cleanup.
- Why it matters: iMessage recipients may see your Claw as still typing even though the visible reply/action is already done.
- What changed: BlueBubbles message reaction actions now explicitly clear typing after the reaction finishes. The reply monitor now tracks delayed typing restart promises, waits for them in cleanup, and awaits/logs the final typing-stop call instead of firing it in the background.
- What did NOT change (scope boundary): No Control UI changes. No changelog entry in this PR; changelog is handled during landing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The BlueBubbles message action path sent reaction actions but did not explicitly clear typing state afterward. Separately, delayed block-stream typing restart calls were fire-and-forget, so a pending restart could race with the final typing-stop cleanup.
- Missing detection / guardrail: No regression assertion covered typing cleanup after the reaction action path, and the monitor typing lifecycle was not guarded against pending restart promises during cleanup.
- Contributing context (if known): Post-turn work can continue after the visible reply is delivered, so stale typing state is visible even when no additional message text is coming.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/bluebubbles/src/actions.test.ts`, existing BlueBubbles monitor tests via `pnpm test:extension bluebubbles`
- Scenario the test should lock in: A BlueBubbles reaction action clears typing for the resolved chat GUID after the reaction call completes; the monitor cleanup waits for pending typing updates and awaits the final stop call.
- Why this is the smallest reliable guardrail: The action unit test covers the exact action adapter boundary without requiring a live BlueBubbles/iMessage round trip. The monitor change is covered through the BlueBubbles extension lane that exercises the reply lifecycle.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

BlueBubbles recipients should no longer see stale typing indicators after message reaction actions finish or after post-reply typing restart cleanup races.

## Diagram (if applicable)

```text
Before:
[reaction action] -> [reaction sent] -> [typing may remain active]
[block reply] -> [typing restart scheduled] -> [final stop may race with restart]

After:
[reaction action] -> [reaction sent] -> [typing cleared]
[block reply] -> [typing restarts tracked] -> [cleanup waits] -> [typing stopped]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source worktree from `origin/main`
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles
- Relevant config (redacted): N/A

### Steps

1. Trigger a BlueBubbles message reaction action after a turn.
2. Trigger a BlueBubbles reply path that can schedule block-stream typing restarts.
3. Observe whether the recipient sees a stale typing indicator after the action/reply completes.
4. Run the BlueBubbles extension test lane.

### Expected

Typing is cleared after the reaction action completes, and reply cleanup waits for pending typing updates before sending the final typing-stop call.

### Actual

With this branch, the action path calls `sendBlueBubblesTyping(..., false, ...)` after the reaction call, and monitor cleanup tracks pending typing restart promises before awaiting the final stop call.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec oxfmt --check --threads=1 extensions/bluebubbles/src/actions.runtime.ts extensions/bluebubbles/src/actions.test.ts extensions/bluebubbles/src/actions.ts extensions/bluebubbles/src/monitor-processing.ts`; `pnpm test:extension bluebubbles`.
- Edge cases checked: The regression assertion verifies the resolved chat GUID and passes `accountId: undefined` through the existing options shape. Monitor cleanup waits for pending restart promises before stopping typing.
- What you did **not** verify: Full `pnpm build`, full `pnpm check`, full `pnpm test`, and a live BlueBubbles/iMessage E2E run from this clean worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Clearing typing after reaction actions could clear a typing state started by overlapping work in the same chat.
  - Mitigation: This is scoped to the resolved chat GUID and runs after the action path finishes; it uses the existing BlueBubbles typing API and only clears stale state for this completed action.
- Risk: Awaiting typing cleanup can keep the turn open slightly longer while BlueBubbles acknowledges the stop call.
  - Mitigation: The call was already being made; awaiting it makes lifecycle ordering deterministic and logs failures through the existing typing failure path.
