### PR TITLE
fix #77137: Telegram message tool rejects numeric group topic targets while group replies default to message_too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,6 +413,7 @@ Docs: https://docs.openclaw.ai
 - Agents/reply context: label replied-to messages as the current user message target in model-visible metadata, so short replies are grounded to their explicit reply target instead of nearby chat history. (#76817) Thanks @obviyus.
 - Doctor/plugins: install configured missing official plugins such as Discord and Brave during doctor/update repair, auto-enable repaired provider plugins, preserve config when a download fails, and stop auto-enable from inventing plugin entries when no manifest declares a configured channel. Fixes #76872. Thanks @jack-stormentswe.
 - TUI: replace the stale-response watchdog notice with plain user-facing copy so stalled replies no longer surface backend or streaming internals. (#77120) Thanks @davemorin.
+- Channels/message-tool: fall back to the bundled plugin registry for target normalization, id-like detection, and plugin target resolution when the loaded runtime registry has no entry for the channel, so the agent `message` tool accepts Telegram numeric group and forum-topic targets (e.g. `-1003577364307:topic:1189`) that the CLI already normalizes without errors. Fixes #77137.
 
 ## 2026.5.2
 

--- a/extensions/telegram/src/targets.test.ts
+++ b/extensions/telegram/src/targets.test.ts
@@ -271,6 +271,44 @@ describe("telegram target normalization", () => {
     expect(looksLikeTelegramTargetId("tg:group:-100123")).toBe(true);
     expect(looksLikeTelegramTargetId("hello world")).toBe(false);
   });
+
+  it("recognizes numeric group topic targets with topic marker", () => {
+    expect(looksLikeTelegramTargetId("-1003577364307:topic:1189")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("-1003577364307:topic:1189")).toBe(
+      "telegram:-1003577364307:topic:1189",
+    );
+  });
+
+  it("recognizes numeric group targets with colon-separated thread id", () => {
+    expect(looksLikeTelegramTargetId("-1003577364307:1189")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("-1003577364307:1189")).toBe(
+      "telegram:-1003577364307:1189",
+    );
+  });
+
+  it("recognizes plain numeric group chat ids without prefix", () => {
+    expect(looksLikeTelegramTargetId("-1003577364307")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("-1003577364307")).toBe("telegram:-1003577364307");
+  });
+
+  it("recognizes telegram-prefixed numeric group ids", () => {
+    expect(looksLikeTelegramTargetId("telegram:-1003577364307")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("telegram:-1003577364307")).toBe(
+      "telegram:-1003577364307",
+    );
+  });
+
+  it("recognizes telegram-prefixed numeric group ids with topic marker", () => {
+    expect(looksLikeTelegramTargetId("telegram:-1003577364307:topic:1189")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("telegram:-1003577364307:topic:1189")).toBe(
+      "telegram:-1003577364307:topic:1189",
+    );
+  });
+
+  it("recognizes numeric direct chat ids", () => {
+    expect(looksLikeTelegramTargetId("123456789")).toBe(true);
+    expect(normalizeTelegramMessagingTarget("123456789")).toBe("telegram:123456789");
+  });
 });
 
 installMaybePersistResolvedTelegramTargetTests({ includeGatewayScopeCases: true });

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -1,3 +1,4 @@
+import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded-read.js";
 import type { ChannelDirectoryEntryKind, ChannelId } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -33,7 +34,7 @@ function resolveTargetNormalizer(channelId: ChannelId): TargetNormalizer {
   if (cached && cached.version === version) {
     return cached.normalizer;
   }
-  const plugin = getLoadedChannelPluginForRead(channelId);
+  const plugin = getLoadedChannelPluginForRead(channelId) ?? getChannelPlugin(channelId);
   const normalizer = plugin?.messaging?.normalizeTarget;
   targetNormalizerCacheByChannelId.set(channelId, {
     version,
@@ -85,8 +86,9 @@ export function looksLikeTargetId(params: {
 }): boolean {
   const normalizedInput =
     params.normalized ?? normalizeTargetForProvider(params.channel, params.raw);
-  const lookup = getLoadedChannelPluginForRead(params.channel)?.messaging?.targetResolver
-    ?.looksLikeId;
+  const channelPlugin =
+    getLoadedChannelPluginForRead(params.channel) ?? getChannelPlugin(params.channel);
+  const lookup = channelPlugin?.messaging?.targetResolver?.looksLikeId;
   if (lookup) {
     return lookup(params.raw, normalizedInput ?? params.raw);
   }
@@ -117,7 +119,9 @@ export async function maybeResolvePluginMessagingTarget(params: {
   if (!normalizedInput) {
     return undefined;
   }
-  const resolver = getLoadedChannelPluginForRead(params.channel)?.messaging?.targetResolver;
+  const channelPlugin =
+    getLoadedChannelPluginForRead(params.channel) ?? getChannelPlugin(params.channel);
+  const resolver = channelPlugin?.messaging?.targetResolver;
   if (!resolver?.resolveTarget) {
     return undefined;
   }

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   listGroupsLive: vi.fn(),
   resolveTarget: vi.fn(),
   getChannelPlugin: vi.fn(),
+  getLoadedChannelPluginForRead: vi.fn(),
   getActivePluginChannelRegistryVersion: vi.fn(() => 1),
 }));
 
@@ -24,7 +25,8 @@ vi.mock("../../channels/plugins/index.js", () => ({
 }));
 
 vi.mock("../../channels/plugins/registry-loaded-read.js", () => ({
-  getLoadedChannelPluginForRead: (...args: unknown[]) => mocks.getChannelPlugin(...args),
+  getLoadedChannelPluginForRead: (...args: unknown[]) =>
+    mocks.getLoadedChannelPluginForRead(...args),
 }));
 
 vi.mock("../../plugins/runtime.js", () => ({
@@ -45,8 +47,13 @@ beforeEach(() => {
   mocks.listGroupsLive.mockReset();
   mocks.resolveTarget.mockReset();
   mocks.getChannelPlugin.mockReset();
+  mocks.getLoadedChannelPluginForRead.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReturnValue(1);
+  // Default: getLoadedChannelPluginForRead mirrors getChannelPlugin for backward compat.
+  mocks.getLoadedChannelPluginForRead.mockImplementation((...args: unknown[]) =>
+    mocks.getChannelPlugin(...args),
+  );
   resetDirectoryCache();
 });
 
@@ -228,5 +235,80 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     });
 
     expect(formatTargetDisplay({ channel: "forum", target: "forum:12345" })).toBe("12345");
+  });
+
+  it("resolves plugin id-like targets when only the bundled registry has the plugin", async () => {
+    // Simulate the scenario where getLoadedChannelPluginForRead finds nothing
+    // but getChannelPlugin (with bundled fallback) still returns the plugin.
+    mocks.getLoadedChannelPluginForRead.mockReturnValue(undefined);
+    mocks.getChannelPlugin.mockReturnValue({
+      messaging: {
+        targetResolver: {
+          looksLikeId: (raw: string) => /^-?\d+$/.test(raw),
+          hint: "<chatId>",
+        },
+      },
+    });
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "telegram",
+      input: "-1003577364307",
+    });
+    expect(result.target.source).toBe("normalized");
+    expect(result.target.to).toBe("-1003577364307");
+  });
+
+  it("resolves plugin-normalized targets when only the bundled registry normalizer is available", async () => {
+    mocks.getLoadedChannelPluginForRead.mockReturnValue(undefined);
+    mocks.getChannelPlugin.mockReturnValue({
+      messaging: {
+        normalizeTarget: (raw: string) =>
+          raw.startsWith("tg:") ? `tg:${raw.slice(3)}` : `mychat:${raw}`,
+        targetResolver: {
+          looksLikeId: () => true,
+        },
+      },
+    });
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "mychat",
+      input: "12345",
+    });
+    expect(result.target.source).toBe("normalized");
+    expect(result.target.to).toBe("mychat:12345");
+  });
+
+  it("falls back to getChannelPlugin directory when plugins are only in bundled registry", async () => {
+    mocks.getLoadedChannelPluginForRead.mockReturnValue(undefined);
+    const entry: ChannelDirectoryEntry = { kind: "group", id: "group:general", name: "general" };
+    mocks.getChannelPlugin.mockReturnValue({
+      directory: {
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          looksLikeId: () => false,
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    });
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listGroupsLive.mockResolvedValue([entry]);
+    mocks.resolveTarget.mockResolvedValue({
+      to: "group:general",
+      kind: "group",
+      source: "directory",
+    });
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "mychat",
+      input: "general",
+    });
+    expect(result.target.source).toBe("directory");
+    expect(result.target.to).toBe("mychat:group:general");
   });
 });


### PR DESCRIPTION
## Summary
Fixes #77137

### Issue
[Telegram message tool rejects numeric group topic targets while group replies default to message_tool](https://github.com/openclaw/openclaw/issues/77137)

### Changes
- fix: resolve issue #77137

### Changed Files
```
CHANGELOG.md                               |  1 +
 extensions/telegram/src/targets.test.ts    | 38 ++++++++++++++
 src/infra/outbound/target-normalization.ts | 12 +++--
 src/infra/outbound/target-resolver.test.ts | 84 +++++++++++++++++++++++++++++-
 4 files changed, 130 insertions(+), 5 deletions(-)
```