### PR TITLE
feat(cron): add agentId filtering to cron list

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4172,6 +4172,7 @@ public struct CronListParams: Codable, Sendable {
     public let enabled: AnyCodable?
     public let sortby: AnyCodable?
     public let sortdir: AnyCodable?
+    public let agentid: String?
 
     public init(
         includedisabled: Bool?,
@@ -4180,7 +4181,8 @@ public struct CronListParams: Codable, Sendable {
         query: String?,
         enabled: AnyCodable?,
         sortby: AnyCodable?,
-        sortdir: AnyCodable?)
+        sortdir: AnyCodable?,
+        agentid: String?)
     {
         self.includedisabled = includedisabled
         self.limit = limit
@@ -4189,6 +4191,7 @@ public struct CronListParams: Codable, Sendable {
         self.enabled = enabled
         self.sortby = sortby
         self.sortdir = sortdir
+        self.agentid = agentid
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4199,6 +4202,7 @@ public struct CronListParams: Codable, Sendable {
         case enabled
         case sortby = "sortBy"
         case sortdir = "sortDir"
+        case agentid = "agentId"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4172,6 +4172,7 @@ public struct CronListParams: Codable, Sendable {
     public let enabled: AnyCodable?
     public let sortby: AnyCodable?
     public let sortdir: AnyCodable?
+    public let agentid: String?
 
     public init(
         includedisabled: Bool?,
@@ -4180,7 +4181,8 @@ public struct CronListParams: Codable, Sendable {
         query: String?,
         enabled: AnyCodable?,
         sortby: AnyCodable?,
-        sortdir: AnyCodable?)
+        sortdir: AnyCodable?,
+        agentid: String?)
     {
         self.includedisabled = includedisabled
         self.limit = limit
@@ -4189,6 +4191,7 @@ public struct CronListParams: Codable, Sendable {
         self.enabled = enabled
         self.sortby = sortby
         self.sortdir = sortdir
+        self.agentid = agentid
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4199,6 +4202,7 @@ public struct CronListParams: Codable, Sendable {
         case enabled
         case sortby = "sortBy"
         case sortdir = "sortDir"
+        case agentid = "agentId"
     }
 }
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -307,6 +307,7 @@ export const CronToolSchema = Type.Object(
     contextMessages: Type.Optional(
       Type.Number({ minimum: 0, maximum: REMINDER_CONTEXT_MESSAGES_MAX }),
     ),
+    agentId: Type.Optional(Type.String({ description: "Filter by agent id (list action)" })),
   },
   { additionalProperties: true },
 );
@@ -570,7 +571,7 @@ Main-session cron jobs enqueue system events for heartbeat handling. Isolated cr
 
 ACTIONS:
 - status: Check cron scheduler status
-- list: List jobs (use includeDisabled:true to include disabled)
+- list: List jobs (use includeDisabled:true to include disabled; agentId filters by agent, auto-filled from session)
 - add: Create job (requires job object, see schema below)
 - update: Modify job (requires jobId + patch object)
 - remove: Delete job (requires jobId)
@@ -653,12 +654,21 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
       switch (action) {
         case "status":
           return jsonResult(await callGateway("cron.status", gatewayOpts, {}));
-        case "list":
+        case "list": {
+          const cfg = getRuntimeConfig();
+          const listAgentId =
+            typeof params.agentId === "string" && params.agentId.trim()
+              ? params.agentId.trim()
+              : opts?.agentSessionKey
+                ? resolveSessionAgentId({ sessionKey: opts.agentSessionKey, config: cfg })
+                : undefined;
           return jsonResult(
             await callGateway("cron.list", gatewayOpts, {
               includeDisabled: Boolean(params.includeDisabled),
+              agentId: listAgentId,
             }),
           );
+        }
         case "add": {
           // Flat-params recovery: non-frontier models (e.g. Grok) sometimes flatten
           // job properties to the top level alongside `action` instead of nesting

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -45,12 +45,17 @@ export function registerCronListCommand(cron: Command) {
       .command("list")
       .description("List cron jobs")
       .option("--all", "Include disabled jobs", false)
+      .option("--agent <id>", "Filter by agent id")
       .option("--json", "Output JSON", false)
       .action(async (opts) => {
         try {
-          const res = await callGatewayFromCli("cron.list", opts, {
+          const listParams: Record<string, unknown> = {
             includeDisabled: Boolean(opts.all),
-          });
+          };
+          if (opts.agent) {
+            listParams.agentId = opts.agent;
+          }
+          const res = await callGatewayFromCli("cron.list", opts, listParams);
           if (opts.json) {
             printCronJson(res);
             return;

--- a/src/cron/service/list-page-types.ts
+++ b/src/cron/service/list-page-types.ts
@@ -12,6 +12,7 @@ export type CronListPageOptions = {
   enabled?: CronJobsEnabledFilter;
   sortBy?: CronJobsSortBy;
   sortDir?: CronSortDir;
+  agentId?: string;
 };
 
 export type CronListPageResult<TJobs extends readonly CronJob[] = CronJob[]> = {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -286,6 +286,9 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
       if (enabledFilter === "disabled" && isJobEnabled(job)) {
         return false;
       }
+      if (opts?.agentId && job.agentId !== opts.agentId) {
+        return false;
+      }
       if (!query) {
         return true;
       }

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -288,6 +288,7 @@ export const CronListParamsSchema = Type.Object(
     enabled: Type.Optional(CronJobsEnabledFilterSchema),
     sortBy: Type.Optional(CronJobsSortBySchema),
     sortDir: Type.Optional(CronSortDirSchema),
+    agentId: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -199,6 +199,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled?: "all" | "enabled" | "disabled";
       sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
       sortDir?: "asc" | "desc";
+      agentId?: string;
     };
     const page = await context.cron.listPage({
       includeDisabled: p.includeDisabled,
@@ -208,6 +209,7 @@ export const cronHandlers: GatewayRequestHandlers = {
       enabled: p.enabled,
       sortBy: p.sortBy,
       sortDir: p.sortDir,
+      agentId: p.agentId,
     });
     const deliveryPreviews = await resolveCronDeliveryPreviews({
       cfg: context.getRuntimeConfig(),


### PR DESCRIPTION
## Summary

Adds optional `agentId` parameter to `cron list` action, allowing agents to filter cron jobs by their own agentId. This reduces noise in multi-agent setups where each agent sees all jobs across all agents.

Closes #77118

## Changes

- **Protocol schema**: add optional `agentId` to `CronListParamsSchema`
- **Service types**: add `agentId` to `CronListPageOptions`
- **Service ops**: filter by `agentId` when provided in `listPage()`
- **Gateway handler**: pass through `agentId` param
- **Agent tool**: auto-fill `agentId` from session context (mirrors existing behavior in `cron add`)
- **CLI**: add `--agent <id>` option to `openclaw cron list`

## Behavior

| Caller | agentId behavior |
|--------|-----------------|
| Agent tool (no explicit agentId) | Auto-filled from calling agent session |
| Agent tool (explicit agentId) | Uses the provided value |
| CLI without --agent | Shows all jobs (backward compatible) |
| CLI with --agent my-agent | Filters to that agent |
