### PR TITLE
fix(tui): abort run during pre-event waiting gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI/escape abort: track the in-flight runId after `chat.send` resolves so pressing Esc during the gap before the first gateway event aborts the run instead of repeatedly printing `no active run`. Fixes #1296. Thanks @Lukavyi and @romneyda.
 - Gateway/status: label Linux managed gateway services as `systemd user`, making status output explicit about the user-service scope instead of implying a system-level unit. Thanks @vincentkoc.
 - Plugins/install: remove the previous managed plugin directory when a reinstall switches sources, so stale ClawHub and npm copies no longer keep duplicate plugin ids in discovery after the new install wins. Thanks @vincentkoc.
 - Plugins/install: let official plugin reinstall recovery repair source-only installed runtime shadows, so `openclaw plugins install npm:@openclaw/discord --force` can replace the bad package instead of stopping at stale config validation. Thanks @vincentkoc.

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -59,6 +59,7 @@ function createHarness(params?: {
     currentSessionId: params?.currentSessionId ?? null,
     activeChatRunId: params?.activeChatRunId ?? null,
     pendingOptimisticUserMessage: params?.pendingOptimisticUserMessage ?? false,
+    pendingChatRunId: null as string | null,
     isConnected: params?.isConnected ?? true,
     sessionInfo: {},
   };
@@ -290,6 +291,29 @@ describe("tui command handlers", () => {
     expect(noteLocalRunId).not.toHaveBeenCalled();
     expect(state.activeChatRunId).toBeNull();
     expect(state.pendingOptimisticUserMessage).toBe(true);
+  });
+
+  it("tracks the in-flight runId so escape can abort during the wait", async () => {
+    const sendChat = vi.fn().mockResolvedValue({ runId: "ignored" });
+    const { handleCommand, state } = createHarness({ sendChat });
+
+    await handleCommand("hello");
+
+    const sentRunId = (sendChat.mock.calls[0]?.[0] as { runId: string }).runId;
+    expect(typeof sentRunId).toBe("string");
+    expect(sentRunId.length).toBeGreaterThan(0);
+    expect(state.activeChatRunId).toBeNull();
+    expect(state.pendingChatRunId).toBe(sentRunId);
+  });
+
+  it("clears the pending runId if sendChat fails", async () => {
+    const sendChat = vi.fn().mockRejectedValue(new Error("boom"));
+    const { handleCommand, state } = createHarness({ sendChat });
+
+    await handleCommand("hello");
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.pendingOptimisticUserMessage).toBe(false);
   });
 
   it("sends /btw without hijacking the active main run", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -642,8 +642,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         runId,
       });
       if (!isBtw) {
-        // Gateway has registered the run by this point. Track the runId so
-        // escape can abort during the gap before the first event echoes back.
         state.pendingChatRunId = runId;
         setActivityStatus("waiting");
         tui.requestRender();

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -642,6 +642,9 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         runId,
       });
       if (!isBtw) {
+        // Gateway has registered the run by this point. Track the runId so
+        // escape can abort during the gap before the first event echoes back.
+        state.pendingChatRunId = runId;
         setActivityStatus("waiting");
         tui.requestRender();
       }
@@ -654,6 +657,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       }
       if (!isBtw) {
         state.pendingOptimisticUserMessage = false;
+        state.pendingChatRunId = null;
         state.activeChatRunId = null;
       }
       chatLog.addSystem(`${isBtw ? "btw failed" : "send failed"}: ${String(err)}`);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -529,6 +529,26 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(loadHistory).not.toHaveBeenCalled();
   });
 
+  it("clears pendingChatRunId when an event for that runId arrives", () => {
+    const { state, handleChatEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: null,
+        pendingOptimisticUserMessage: true,
+        pendingChatRunId: "run-pending",
+      },
+    });
+
+    handleChatEvent({
+      runId: "run-pending",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "hi" },
+    });
+
+    expect(state.pendingChatRunId).toBeNull();
+    expect(state.activeChatRunId).toBe("run-pending");
+  });
+
   function createConcurrentRunHarness(localContent = "partial") {
     const { state, chatLog, setActivityStatus, loadHistory, handleChatEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -173,6 +173,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     streamAssembler = new TuiStreamAssembler();
     pendingHistoryRefresh = false;
     state.pendingOptimisticUserMessage = false;
+    state.pendingChatRunId = null;
     reconnectPendingRunId = null;
     clearLocalRunIds?.();
     clearLocalBtwRunIds?.();
@@ -367,6 +368,9 @@ export function createEventHandlers(context: EventHandlerContext) {
         noteLocalRunId?.(evt.runId);
         state.pendingOptimisticUserMessage = false;
       }
+    }
+    if (state.pendingChatRunId === evt.runId) {
+      state.pendingChatRunId = null;
     }
     if (evt.state === "delta") {
       // Arm watchdog and mark streaming on every delta, even when the visible

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -338,6 +338,46 @@ describe("tui session actions", () => {
     expect(state.activeChatRunId).toBeNull();
   });
 
+  it("aborts the in-flight runId when only pendingChatRunId is set", async () => {
+    const abortChat = vi.fn().mockResolvedValue({ ok: true, aborted: true });
+    const addSystem = vi.fn();
+    const setActivityStatus = vi.fn();
+    const state = createBaseState({
+      activeChatRunId: null,
+      pendingChatRunId: "run-pending",
+    });
+
+    const { abortActive } = createSessionActions({
+      client: { listSessions: vi.fn(), abortChat } as unknown as TuiBackend,
+      chatLog: {
+        addSystem,
+        clearAll: vi.fn(),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      btw: createBtwPresenter(),
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn((raw?: string) => raw ?? "agent:main:main"),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus,
+    });
+
+    await abortActive();
+
+    expect(abortChat).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      runId: "run-pending",
+    });
+    expect(addSystem).not.toHaveBeenCalledWith("no active run");
+    expect(state.pendingChatRunId).toBeNull();
+    expect(setActivityStatus).toHaveBeenCalledWith("aborted");
+  });
+
   it("remembers the selected session after history loads", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -377,6 +377,7 @@ export function createSessionActions(context: SessionActionContext) {
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
+    state.pendingChatRunId = null;
     setActivityStatus("idle");
     state.currentSessionId = null;
     // Session keys can move backwards in updatedAt ordering; drop previous session freshness
@@ -391,7 +392,8 @@ export function createSessionActions(context: SessionActionContext) {
   };
 
   const abortActive = async () => {
-    if (!state.activeChatRunId) {
+    const runId = state.activeChatRunId ?? state.pendingChatRunId ?? null;
+    if (!runId) {
       chatLog.addSystem("no active run");
       tui.requestRender();
       return;
@@ -399,8 +401,9 @@ export function createSessionActions(context: SessionActionContext) {
     try {
       await client.abortChat({
         sessionKey: state.currentSessionKey,
-        runId: state.activeChatRunId,
+        runId,
       });
+      state.pendingChatRunId = null;
       setActivityStatus("aborted");
     } catch (err) {
       chatLog.addSystem(`abort failed: ${String(err)}`);

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -127,6 +127,7 @@ export type TuiStateAccess = {
   currentSessionId: string | null;
   activeChatRunId: string | null;
   pendingOptimisticUserMessage?: boolean;
+  pendingChatRunId?: string | null;
   queuedMessages?: QueuedMessage[];
   historyLoaded: boolean;
   sessionInfo: SessionInfo;

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -317,6 +317,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   let currentSessionId: string | null = null;
   let activeChatRunId: string | null = null;
   let pendingOptimisticUserMessage = false;
+  let pendingChatRunId: string | null = null;
   let historyLoaded = false;
   let isConnected = false;
   let wasDisconnected = false;
@@ -394,6 +395,12 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     },
     set pendingOptimisticUserMessage(value) {
       pendingOptimisticUserMessage = value;
+    },
+    get pendingChatRunId() {
+      return pendingChatRunId;
+    },
+    set pendingChatRunId(value) {
+      pendingChatRunId = value ?? null;
     },
     get historyLoaded() {
       return historyLoaded;


### PR DESCRIPTION
## Summary

Per docs, esc should abort current run. As far as I can tell this hasn't worked fully since initial TUI commit.

BEFORE:
(pressing esc repeatedly doesn't abort)

<img width="1776" height="874" alt="image" src="https://github.com/user-attachments/assets/8be3a644-7a99-4f8c-bafd-b2197bfe9df5" />

AFTER:
(run aborted successfully)

<img width="234" height="111" alt="image" src="https://github.com/user-attachments/assets/dc45977e-8f4e-43e5-9805-d072b0028590" />

# AI GENERATED SUMMARY:

`docs/web/tui.md:91` documents **Esc: abort active run** and `/help` lists `/abort` — both route through `abortActive`, which short-circuits with `no active run` whenever `state.activeChatRunId` is null. That field is only populated when the *first* gateway chat event echoes back, so during the gap between `chat.send` resolving and the first event arriving, Esc and `/abort` are no-ops while the spinner keeps running.

Fix: track the runId from `client.sendChat` in a new `state.pendingChatRunId` as soon as it resolves. `abortActive` falls back to it when `activeChatRunId` is null. The first event for that runId clears the pending field as `activeChatRunId` binds. Errors, session switches, and `syncSessionKey` reset all clear it.

## Has Esc ever worked here?

No — the gap has existed since the first TUI commit (`08ce608ae7`, Jan 3 2026). `runId` was assigned *after* `await client.sendChat(...)` from day one. `32cfc49002` (Jan 14) added the `"no active run"` text users see today. `61a0b02931` (#54722, Mar 28) didn't introduce the gap; it renamed the symptom by replacing the immediate `state.activeChatRunId = runId` with `pendingOptimisticUserMessage`.

## Related

- **#1296** by @Lukavyi (closed for inactivity) — same bug, same diagnosis. Their proposal used a server-side `sessionKey`-only abort fallback; this PR uses a client-side runId tracker so the strict `chat.abort { runId }` contract stays unchanged.
- **#66991** (closed) — adjacent `--deliver: false` case where events never arrive; gateway-side fix doesn't help when events arrive eventually-but-slowly.
- **#33102** — open `--deliver` default ergonomics; intentionally out of scope.
- **#38501**, **#54789**, **PR #44223** (Ctrl+C precedence), **PR #67017** (closed `--deliver` flip) — different scenarios; compatible with this fix.

## Doesn't undo prior fixes

`pendingOptimisticUserMessage` and `noteLocalRunId` behave exactly as before — the new field is parallel, not a replacement. `/btw` / `/side` continue to use the existing `localBtwRunIds` Set; `pendingChatRunId` is only set for non-`/btw` sends.

## Verification

- `tui-session-actions.test.ts:341` is the regression test: `abortActive` calls `client.abortChat` with `pendingChatRunId` when `activeChatRunId` is null, asserts `"no active run"` is **not** printed, and status flips to `"aborted"`. Fails before this fix.
- Plus 3 unit tests covering set-on-send, clear-on-send-failure, and clear-on-event-arrival.
- `pnpm test:changed` — 38 shards passed. `pnpm tsgo`, `pnpm check:test-types`, `pnpm lint:core`, `oxfmt --check` on touched files — all clean.

## Credit

@Lukavyi for the diagnosis in #1296.

## Test plan

- [ ] `openclaw tui`, send a message that takes a few seconds before the first delta, press Esc during the spinner — confirm the run aborts and status flips to `aborted` instead of `no active run`.
- [ ] Press Esc with no active/pending run — still prints `no active run`.
- [ ] Send a message, let it finalize normally — no leftover `pendingChatRunId` on next send.
- [ ] `/abort` exhibits the same fixed behavior.