### PR TITLE
fix(plugins/loader): preserve memory supplements during non-activating lazy re-register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call: mark realtime calls completed when the realtime provider closes normally, so Twilio/OpenAI/Google realtime stop events do not leave active call records behind. Thanks @vincentkoc.
 - Gateway/update: keep the shutdown close path behind a stable runtime chunk and ship compatibility aliases for recent `server-close-*` hashes, so manual npm package replacement cannot leave an already-running Gateway unable to shut down cleanly. Fixes #77087. Thanks @westlife219.
 - Control UI/media: mint short-lived scoped tickets for assistant media fetches and render ticketed URLs instead of exposing long-lived auth tokens in chat image URLs. Fixes #70830 and #77097. Thanks @hclsys.
+- Plugins/loader: preserve active memory corpus and prompt supplements registered during non-activating lazy re-register of plugins, fixing supplement loss when the loader's snapshot/restore path runs without a re-registration. Fixes #77039. Thanks @mgustimz.
 - Exec approvals: treat POSIX `exec` as a command carrier for inline eval, shell-wrapper, and eval/source detection, so approval explanations and command-risk checks do not miss payloads hidden behind `exec`. Thanks @vincentkoc.
 - Google Meet: log the resolved audio provider model when starting Chrome and paired-node Meet talk-back bridges, so agent-mode joins show the STT model and bidi joins show the realtime voice model.
 - Diagnostics: handle missing session-tail files in cron recovery context without tripping extension test typecheck. Thanks @vincentkoc.

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2355,8 +2355,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
             capability: previousMemoryCapability,
-            corpusSupplements: previousMemoryCorpusSupplements,
-            promptSupplements: previousMemoryPromptSupplements,
+            corpusSupplements: [
+              ...previousMemoryCorpusSupplements,
+              ...memoryPluginState.corpusSupplements.filter(
+                (s) => !previousMemoryCorpusSupplements.some((p) => p.pluginId === s.pluginId),
+              ),
+            ],
+            promptSupplements: [
+              ...previousMemoryPromptSupplements,
+              ...memoryPluginState.promptSupplements.filter(
+                (s) => !previousMemoryPromptSupplements.some((p) => p.pluginId === s.pluginId),
+              ),
+            ],
           });
         }
         registry.plugins.push(record);
@@ -2370,8 +2380,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
           capability: previousMemoryCapability,
-          corpusSupplements: previousMemoryCorpusSupplements,
-          promptSupplements: previousMemoryPromptSupplements,
+          corpusSupplements: [
+            ...previousMemoryCorpusSupplements,
+            ...memoryPluginState.corpusSupplements.filter(
+              (s) => !previousMemoryCorpusSupplements.some((p) => p.pluginId === s.pluginId),
+            ),
+          ],
+          promptSupplements: [
+            ...previousMemoryPromptSupplements,
+            ...memoryPluginState.promptSupplements.filter(
+              (s) => !previousMemoryPromptSupplements.some((p) => p.pluginId === s.pluginId),
+            ),
+          ],
         });
         recordPluginError({
           logger,


### PR DESCRIPTION
## Fix for #77039

When a plugin registers a MemoryCorpusSupplement from inside `api.registerService({ start })`, the supplement is correctly added to the global corpus supplements array.

However, when lazy tool-load triggers a subsequent non-activating re-register of the same plugin, the loader snapshots the supplements **before** register and restores **after**. Since the plugin's `register()` call does not re-add the supplement (`service.start()` does not re-run), the `restoreMemoryPluginState()` call effectively **zaps** the previously registered supplement by overwriting the array with the pre-register snapshot.

### Root cause

In `loadOpenClawPlugins` (loader.ts), both the normal error-handling rollback path and the non-activating reload path call:

```ts
restoreMemoryPluginState({
  corpusSupplements: previousMemoryCorpusSupplements,  // snapshot taken before register()
  promptSupplements: previousMemoryPromptSupplements,
});
```

This blindly replaces `corpusSupplements` and `promptSupplements` with the pre-register snapshot, wiping any supplements registered by previously-active plugin instances.

### Fix

Merge snapshot + newly-registered supplements in both restore paths:


```ts
restoreMemoryPluginState({
  corpusSupplements: [
    ...previousMemoryCorpusSupplements,
    ...memoryPluginState.corpusSupplements.filter(
      (s) => !previousMemoryCorpusSupplements.some((p) => p.pluginId === s.pluginId),
    ),
  ],
  // same for promptSupplements
});
```

This preserves supplements from earlier activation cycles while still restoring the snapshot for supplements that were only registered during the failed register attempt.


Fixes #77039

---
⚠️ This PR replaces the earlier #77098, which used a helper-level idempotent fix that addressed the symptom but not the root cause.