### PR TITLE
fix(ui): dismissable talk error banner + disable talk button when no voice provider

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -416,6 +416,20 @@
   color: var(--danger);
 }
 
+.pill__dismiss {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0 0 0 0.5em;
+  opacity: 0.7;
+  line-height: 1;
+}
+
+.pill__dismiss:hover {
+  opacity: 1;
+}
+
 /* ===========================================
    Theme Orb
    =========================================== */

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1575,7 +1575,7 @@ export function renderApp(state: AppViewState) {
                     `
                   : nothing}
                 ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
+                  ? html`<div class="pill danger"><span>${state.lastError}</span><button class="pill__dismiss" @click=${() => dismissChatError(state)} aria-label="Dismiss error">${icons.x}</button></div>`
                   : nothing}
                 ${isChat ? renderChatControls(state) : nothing}
               </div>
@@ -2371,6 +2371,7 @@ export function renderApp(state: AppViewState) {
               realtimeTalkStatus: state.realtimeTalkStatus,
               realtimeTalkDetail: state.realtimeTalkDetail,
               realtimeTalkTranscript: state.realtimeTalkTranscript,
+              realtimeTalkProviderAvailable: state.realtimeTalkProviderAvailable,
               connected: state.connected,
               canSend: state.connected,
               disabledReason: chatDisabledReason,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -119,6 +119,7 @@ export type AppViewState = {
   realtimeTalkStatus: RealtimeTalkStatus;
   realtimeTalkDetail: string | null;
   realtimeTalkTranscript: string | null;
+  realtimeTalkProviderAvailable: boolean | null;
   chatManualRefreshInFlight: boolean;
   chatMobileControlsOpen: boolean;
   nodesLoading: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -224,6 +224,7 @@ export class OpenClawApp extends LitElement {
   @state() realtimeTalkStatus: RealtimeTalkStatus = "idle";
   @state() realtimeTalkDetail: string | null = null;
   @state() realtimeTalkTranscript: string | null = null;
+  @state() realtimeTalkProviderAvailable: boolean | null = null;
   private realtimeTalkSession: RealtimeTalkSession | null = null;
   @state() chatManualRefreshInFlight = false;
   @state() chatMobileControlsOpen = false;
@@ -924,6 +925,7 @@ export class OpenClawApp extends LitElement {
     this.realtimeTalkStatus = "connecting";
     this.realtimeTalkDetail = null;
     this.realtimeTalkTranscript = null;
+    this.realtimeTalkProviderAvailable = null;
     const session = new RealtimeTalkSession(this.client, this.sessionKey, {
       onStatus: (status, detail) => {
         this.realtimeTalkStatus = status;
@@ -948,6 +950,9 @@ export class OpenClawApp extends LitElement {
       this.realtimeTalkStatus = "error";
       this.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
       this.lastError = this.realtimeTalkDetail;
+      if (this.realtimeTalkDetail.toLowerCase().includes("no realtime voice provider")) {
+        this.realtimeTalkProviderAvailable = false;
+      }
     }
   }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -357,6 +357,7 @@ function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {
       realtimeTalkStatus: "idle",
       realtimeTalkDetail: null,
       realtimeTalkTranscript: null,
+      realtimeTalkProviderAvailable: null,
       connected: true,
       canSend: true,
       disabledReason: null,
@@ -502,6 +503,7 @@ describe("chat voice controls", () => {
       error: 'Realtime voice provider "openai" is not configured',
       realtimeTalkStatus: "error",
       realtimeTalkDetail: 'Realtime voice provider "openai" is not configured',
+      realtimeTalkProviderAvailable: null,
       onDismissError,
     });
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -77,6 +77,7 @@ export type ChatProps = {
   realtimeTalkStatus?: RealtimeTalkStatus;
   realtimeTalkDetail?: string | null;
   realtimeTalkTranscript?: string | null;
+  realtimeTalkProviderAvailable?: boolean | null;
   connected: boolean;
   canSend: boolean;
   disabledReason: string | null;
@@ -1305,9 +1306,17 @@ export function renderChat(props: ChatProps) {
                       ? "agent-chat__input-btn--talk"
                       : ""}"
                     @click=${props.onToggleRealtimeTalk}
-                    title=${props.realtimeTalkActive ? "Stop Talk" : "Start Talk"}
-                    aria-label=${props.realtimeTalkActive ? "Stop Talk" : "Start Talk"}
-                    ?disabled=${!props.connected}
+                    title=${props.realtimeTalkProviderAvailable === false
+                      ? "No voice provider configured"
+                      : props.realtimeTalkActive
+                        ? "Stop Talk"
+                        : "Start Talk"}
+                    aria-label=${props.realtimeTalkProviderAvailable === false
+                      ? "No voice provider configured"
+                      : props.realtimeTalkActive
+                        ? "Stop Talk"
+                        : "Start Talk"}
+                    ?disabled=${!props.connected || props.realtimeTalkProviderAvailable === false}
                   >
                     ${props.realtimeTalkActive ? icons.volume2 : icons.radio}
                   </button>


### PR DESCRIPTION
Fixes #77071

## Problem
When clicking "Start Talk" without a realtime voice provider configured, an error banner appears and cannot be dismissed — it persists indefinitely.

## Changes

### 1. Dismissable error banner
- Added a close (X) button to the error pill banner in the topbar
- Clicking it calls the existing `dismissChatError()` function to clear the error
- Added `pill__dismiss` CSS styles for the close button

### 2. Disable Talk button when no voice provider configured
- Added `realtimeTalkProviderAvailable` state (null = unknown, false = no provider)
- When Talk fails with "No realtime voice provider registered" error, sets the flag to false
- Talk button is disabled with tooltip "No voice provider configured" when the flag is false
- Prevents users from triggering the error in the first place