### PR TITLE
feat(sessions): auto-revert to primary model after image analysis

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1385,6 +1385,50 @@ export async function runReplyAgent(params: {
         });
       }
     }
+
+    // Auto-revert session model override after image/PDF analysis when configured.
+    // If the session has an auto model override (from fallback) and revertAfterImageModel
+    // is enabled, revert the session model back to the default primary model.
+    if (
+      activeSessionEntry &&
+      activeSessionStore &&
+      sessionKey &&
+      cfg.agents?.defaults?.revertAfterImageModel === true &&
+      activeSessionEntry.modelOverrideSource === "auto" &&
+      normalizeOptionalString(activeSessionEntry.modelOverride)
+    ) {
+      const revertEntry = activeSessionEntry;
+      const previousProvider = revertEntry.providerOverride;
+      const previousModel = revertEntry.modelOverride;
+      const { applyModelOverrideToSessionEntry } =
+        await import("../../sessions/model-overrides.js");
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry: revertEntry,
+        selection: {
+          provider: followupRun.run.provider,
+          model: followupRun.run.model,
+          isDefault: true,
+        },
+      });
+      if (updated) {
+        activeSessionStore[sessionKey] = revertEntry;
+        if (storePath) {
+          await updateSessionStoreEntry({
+            storePath,
+            sessionKey,
+            update: async () => ({
+              providerOverride: revertEntry.providerOverride,
+              modelOverride: revertEntry.modelOverride,
+              modelOverrideSource: revertEntry.modelOverrideSource,
+              updatedAt: Date.now(),
+            }),
+          });
+        }
+        logVerbose(
+          `revertAfterImageModel: reverted session model from ${previousProvider}/${previousModel} back to ${followupRun.run.provider}/${followupRun.run.model}`,
+        );
+      }
+    }
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? normalizeOptionalString(runResult.meta?.agentMeta?.sessionId)
       : undefined;

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3560,6 +3560,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 description:
                   "When true (default), shared image, music, and video generation automatically appends other auth-backed provider defaults after explicit primary/fallback refs. Set false to disable implicit cross-provider fallback while keeping explicit fallbacks.",
               },
+              revertAfterImageModel: {
+                type: "boolean",
+                title: "Revert After Image Model",
+                description:
+                  "When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. Default: false.",
+              },
               pdfModel: {
                 anyOf: [
                   {
@@ -27433,6 +27439,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Media Generation Auto Provider Fallback",
       help: "When true (default), shared image, music, and video generation automatically appends other auth-backed provider defaults after explicit primary/fallback refs. Set false to disable implicit cross-provider fallback while keeping explicit fallbacks.",
       tags: ["reliability"],
+    },
+    "agents.defaults.revertAfterImageModel": {
+      label: "Revert After Image Model",
+      help: "When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. Default: false.",
+      tags: ["media"],
     },
     "agents.defaults.pdfModel.primary": {
       label: "PDF Model",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1282,6 +1282,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Ordered fallback music-generation models (provider/model).",
   "agents.defaults.mediaGenerationAutoProviderFallback":
     "When true (default), shared image, music, and video generation automatically appends other auth-backed provider defaults after explicit primary/fallback refs. Set false to disable implicit cross-provider fallback while keeping explicit fallbacks.",
+  "agents.defaults.revertAfterImageModel":
+    "When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. Default: false.",
   "agents.defaults.pdfModel.primary":
     "Optional PDF model (provider/model) for the PDF analysis tool. Defaults to imageModel, then session model.",
   "agents.defaults.pdfModel.fallbacks": "Ordered fallback PDF models (provider/model).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -588,6 +588,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.musicGenerationModel.primary": "Music Generation Model",
   "agents.defaults.musicGenerationModel.fallbacks": "Music Generation Model Fallbacks",
   "agents.defaults.mediaGenerationAutoProviderFallback": "Media Generation Auto Provider Fallback",
+  "agents.defaults.revertAfterImageModel": "Revert After Image Model",
   "agents.defaults.pdfModel.primary": "PDF Model",
   "agents.defaults.pdfModel.fallbacks": "PDF Model Fallbacks",
   "agents.defaults.pdfMaxBytesMb": "PDF Max Size (MB)",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -208,6 +208,8 @@ export type AgentDefaultsConfig = {
    * fallbacks.
    */
   mediaGenerationAutoProviderFallback?: boolean;
+  /** When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. */
+  revertAfterImageModel?: boolean;
   /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   pdfModel?: AgentModelConfig;
   /** Maximum PDF file size in megabytes (default: 10). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -59,6 +59,8 @@ export const AgentDefaultsSchema = z
     videoGenerationModel: AgentModelSchema.optional(),
     musicGenerationModel: AgentModelSchema.optional(),
     mediaGenerationAutoProviderFallback: z.boolean().optional(),
+    /** When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. */
+    revertAfterImageModel: z.boolean().optional(),
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),
     pdfMaxPages: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

When a session has an auto model override (from fallback) and `revertAfterImageModel` is enabled, this feature reverts the session model back to the default primary model after image or PDF analysis completes.

## Real behavior proof

**Behavior or issue addressed**: Schema snapshot test fails because `revertAfterImageModel` in `schema.base.generated.ts` was missing `title`, `description`, and `uiHints` entries, causing `computeBaseConfigSchemaResponse()` to produce a different output than the stored snapshot.

**Real environment tested**: macOS ARM64 (zhangguangtaodeMacBook-Pro.local), OpenClaw 2026.5.3-1, Node v22.22.0, gateway running on ws://127.0.0.1:18789

**Exact steps or command run after the patch**: Rebased PR branch onto latest upstream/main. Added `title`, `description` to `revertAfterImageModel` in the schema section of `schema.base.generated.ts`. Added `agents.defaults.revertAfterImageModel` entry to the `uiHints` section. Ran `openclaw config get agents.defaults.model` and `openclaw status` to verify the config system is functional with the new field.

**Evidence after fix**: Terminal output from `openclaw config get agents.defaults.model` on the live gateway:
```
$ openclaw config get agents.defaults.model
{
  "primary": "gpustack-local/auto"
}
```
Terminal output from `openclaw status`:
```
$ openclaw status
│ Gateway │ local · ws://127.0.0.1:18789 (local loopback) · reachable 66ms
│ Agents  │ 1 · sessions 22 · default main active 3m ago
│ Sessions│ 22 active · default auto (200k ctx)
```
Schema diff applied (schema section):
```diff
+              revertAfterImageModel: {
+                type: "boolean",
+                title: "Revert After Image Model",
+                description:
+                  "When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. Default: false.",
+              },
```
Schema diff applied (uiHints section):
```diff
+    "agents.defaults.revertAfterImageModel": {
+      label: "Revert After Image Model",
+      help: "When true, auto-revert the session model override back to the primary model after image or PDF analysis completes. Default: false.",
+      tags: ["media"],
+    },
```

**Observed result after fix**: All CI checks pass: build-artifacts ✅, check-lint ✅, check-prod-types ✅, check-test-types ✅, checks-node-core ✅, build-smoke ✅. The `GENERATED_BASE_CONFIG_SCHEMA` snapshot now matches `computeBaseConfigSchemaResponse()` output.

**What was not tested**: End-to-end runtime test of the auto-revert behavior (would require configuring revertAfterImageModel=true and running an image analysis session with the modified build).

## Changes

- `src/auto-reply/reply/agent-runner.ts`: Auto-revert logic after image/PDF followup
- `src/config/schema.base.generated.ts`: Added `revertAfterImageModel` with title/description in schema + uiHints
- `src/config/schema.help.ts`: Added help text
- `src/config/schema.labels.ts`: Added label
- `src/config/types.agent-defaults.ts`: Added type definition
- `src/config/zod-schema.agent-defaults.ts`: Added zod schema