### PR TITLE
fix(qqbot): keep private commands off framework surface [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.
 - Cron: surface failed isolated-run diagnostics in `cron show`, status, and run history when requested tools are unavailable, so blocked cron runs report the actual tool-policy failure instead of a misleading green result. Fixes #75763. Thanks @RyanSandoval.

--- a/extensions/qqbot/src/bridge/commands/framework-registration.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-registration.ts
@@ -1,14 +1,14 @@
 /**
- * Register all `requireAuth: true` slash commands with the framework via
+ * Register slash commands that are allowed on the framework surface via
  * `api.registerCommand`.
  *
  * Routing through the framework lets `resolveCommandAuthorization()` apply
  * `commands.allowFrom.qqbot` precedence and the `qqbot:` prefix normalization
  * before any QQBot command handler runs.
  *
- * This module is intentionally thin: it wires the engine-side command
- * registry (`getFrameworkCommands`) to the framework registration surface via
- * the three single-responsibility helpers in this directory.
+ * This module is intentionally thin: it wires the engine-side command registry
+ * (`getFrameworkCommands`) to the framework registration surface via the three
+ * single-responsibility helpers in this directory.
  */
 
 import type { OpenClawPluginApi, PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";

--- a/extensions/qqbot/src/command-auth.test.ts
+++ b/extensions/qqbot/src/command-auth.test.ts
@@ -8,10 +8,8 @@
  *   "qqbot:<id>" in channel.allowFrom matches the inbound event.senderId "<id>".
  *   Verified against the normalization logic in the gateway.ts inbound path.
  *
- * Note: commands.allowFrom.qqbot precedence over channel allowFrom is enforced
- * by the framework's resolveCommandAuthorization(). QQBot routes requireAuth:true
- * commands through the framework (api.registerCommand), so that behavior is
- * covered by the framework's own tests rather than duplicated here.
+ * Note: framework command authorization precedence is covered by the
+ * framework's own tests rather than duplicated here.
  */
 
 import { describe, expect, it } from "vitest";

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -29,16 +29,19 @@ function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): S
 }
 
 describe("QQBot framework slash commands", () => {
-  it("does not expose private-only admin commands through the framework registry", () => {
-    const names = getFrameworkCommands().map((command) => command.name);
+  it("exposes private-only admin commands with private-chat metadata", () => {
+    const commands = getFrameworkCommands();
+    const names = commands.map((command) => command.name);
 
-    expect(names).not.toContain("bot-approve");
-    expect(names).not.toContain("bot-clear-storage");
-    expect(names).not.toContain("bot-logs");
-    expect(names).not.toContain("bot-streaming");
+    expect(names).toEqual(
+      expect.arrayContaining(["bot-approve", "bot-clear-storage", "bot-logs", "bot-streaming"]),
+    );
+    for (const commandName of ["bot-approve", "bot-clear-storage", "bot-logs", "bot-streaming"]) {
+      expect(commands.find((command) => command.name === commandName)?.c2cOnly).toBe(true);
+    }
   });
 
-  it("keeps private-only auth commands out of framework registration", () => {
+  it("preserves private-only auth metadata for framework registration", () => {
     const registry = new SlashCommandRegistry();
     registry.register({
       name: "private-admin",
@@ -54,13 +57,15 @@ describe("QQBot framework slash commands", () => {
       handler: () => "ok",
     });
 
-    expect(registry.getFrameworkCommands().map((command) => command.name)).toEqual([
-      "shared-admin",
-    ]);
+    const commands = registry.getFrameworkCommands();
+
+    expect(commands.map((command) => command.name)).toEqual(["private-admin", "shared-admin"]);
+    expect(commands.find((command) => command.name === "private-admin")?.c2cOnly).toBe(true);
+    expect(commands.find((command) => command.name === "shared-admin")?.c2cOnly).toBeUndefined();
   });
 
-  it("keeps bot-streaming out of framework registration", () => {
-    expect(getFrameworkCommands().map((command) => command.name)).not.toContain("bot-streaming");
+  it("routes bot-streaming through the auth-gated framework registry", () => {
+    expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-streaming");
   });
 
   it("does not write streaming config when the sender is not command-authorized", async () => {

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolveQQBotCommandsAllowFrom, resolveSlashCommandAuth } from "./slash-command-auth.js";
 import { getWrittenQQBotConfig, installCommandRuntime } from "./slash-command-test-support.js";
 import { getFrameworkCommands, matchSlashCommand } from "./slash-commands-impl.js";
-import type { SlashCommandContext } from "./slash-commands.js";
+import { SlashCommandRegistry, type SlashCommandContext } from "./slash-commands.js";
 
 function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
   return {
@@ -29,12 +29,38 @@ function createStreamingContext(overrides: Partial<SlashCommandContext> = {}): S
 }
 
 describe("QQBot framework slash commands", () => {
-  it("routes bot-approve through the auth-gated framework registry", () => {
-    expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-approve");
+  it("does not expose private-only admin commands through the framework registry", () => {
+    const names = getFrameworkCommands().map((command) => command.name);
+
+    expect(names).not.toContain("bot-approve");
+    expect(names).not.toContain("bot-clear-storage");
+    expect(names).not.toContain("bot-logs");
+    expect(names).not.toContain("bot-streaming");
   });
 
-  it("routes bot-streaming through the auth-gated framework registry", () => {
-    expect(getFrameworkCommands().map((command) => command.name)).toContain("bot-streaming");
+  it("keeps private-only auth commands out of framework registration", () => {
+    const registry = new SlashCommandRegistry();
+    registry.register({
+      name: "private-admin",
+      description: "private admin command",
+      requireAuth: true,
+      c2cOnly: true,
+      handler: () => "ok",
+    });
+    registry.register({
+      name: "shared-admin",
+      description: "shared admin command",
+      requireAuth: true,
+      handler: () => "ok",
+    });
+
+    expect(registry.getFrameworkCommands().map((command) => command.name)).toEqual([
+      "shared-admin",
+    ]);
+  });
+
+  it("keeps bot-streaming out of framework registration", () => {
+    expect(getFrameworkCommands().map((command) => command.name)).not.toContain("bot-streaming");
   });
 
   it("does not write streaming config when the sender is not command-authorized", async () => {

--- a/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands-impl.ts
@@ -32,8 +32,8 @@ export function initCommands(port: CommandsPort): void {
 }
 
 /**
- * Return all commands that require authorization, for registration with the
- * framework via api.registerCommand() in registerFull().
+ * Return commands that may be registered with the framework via
+ * api.registerCommand() in registerFull().
  */
 export function getFrameworkCommands(): QQBotFrameworkCommand[] {
   return registry.getFrameworkCommands();

--- a/extensions/qqbot/src/engine/commands/slash-commands.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands.ts
@@ -113,10 +113,10 @@ export class SlashCommandRegistry {
     // Always register in the pre-dispatch map so QQ message-flow slash
     // commands can match and execute directly (with requireAuth gating).
     this.commands.set(key, cmd);
-    // Auth-gated commands may also be exposed to the framework command
-    // surface, but private-chat-only commands must stay on the QQBot message
-    // path so their channel and allowFrom checks remain intact.
-    if (cmd.requireAuth && !cmd.c2cOnly) {
+    // Auth-gated commands are exposed to the framework command surface.
+    // Private-chat-only metadata is preserved so the bridge can enforce the
+    // same routing restriction before dispatching handlers.
+    if (cmd.requireAuth) {
       this.frameworkCommands.set(key, cmd);
     }
   }

--- a/extensions/qqbot/src/engine/commands/slash-commands.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands.ts
@@ -100,8 +100,8 @@ function lc(s: string): string {
  * Slash command registry.
  *
  * Maintains two maps:
- * - `commands` — pre-dispatch commands (requireAuth: false)
- * - `frameworkCommands` — auth-gated commands (requireAuth: true)
+ * - `commands` — QQBot message-flow commands
+ * - `frameworkCommands` — auth-gated commands that are safe on the framework surface
  */
 export class SlashCommandRegistry {
   private readonly commands = new Map<string, SlashCommand>();
@@ -113,14 +113,15 @@ export class SlashCommandRegistry {
     // Always register in the pre-dispatch map so QQ message-flow slash
     // commands can match and execute directly (with requireAuth gating).
     this.commands.set(key, cmd);
-    // Auth-gated commands are additionally exposed to the framework command
-    // surface (api.registerCommand) for CLI / control-plane invocation.
-    if (cmd.requireAuth) {
+    // Auth-gated commands may also be exposed to the framework command
+    // surface, but private-chat-only commands must stay on the QQBot message
+    // path so their channel and allowFrom checks remain intact.
+    if (cmd.requireAuth && !cmd.c2cOnly) {
       this.frameworkCommands.set(key, cmd);
     }
   }
 
-  /** Return all auth-gated commands for framework registration. */
+  /** Return all commands that may be registered on the framework surface. */
   getFrameworkCommands(): QQBotFrameworkCommand[] {
     return Array.from(this.frameworkCommands.values()).map((cmd) => ({
       name: cmd.name,


### PR DESCRIPTION
## Summary

- Problem: QQBot private-only authenticated slash commands were also published through the generic plugin command registry.
- Why it matters: the generic command path cannot preserve QQBot private-chat routing and QQBot allow-list checks for those commands.
- What changed: private-only authenticated QQBot slash commands now remain on the QQBot message-flow path and are skipped by framework command registration.
- What did NOT change (scope boundary): direct QQBot slash command dispatch, command handlers, config schema, and plugin manifests are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR addresses a bug or regression

## Root Cause (if applicable)

- Root cause: `SlashCommandRegistry.register()` copied every `requireAuth: true` QQBot slash command into `frameworkCommands`, including commands marked `c2cOnly`.
- Missing detection / guardrail: no regression test asserted that private-only authenticated QQBot commands are excluded from framework registration.
- Contributing context (if known): framework command registration adapts plugin command context into QQBot slash command context, but it is not the QQBot private message path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts`
- Scenario the test should lock in: private-only authenticated QQBot slash commands are not returned by `getFrameworkCommands()`, while non-private authenticated commands can still be exposed.
- Why this is the smallest reliable guardrail: the registry export is the point where QQBot command scope is copied into the framework surface.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

QQBot private-only authenticated commands are no longer available through non-QQBot generic command surfaces. They remain available through the QQBot private message command path for authorized QQBot senders.

## Diagram (if applicable)

```text
Before:
QQBot private command -> requireAuth registry copy -> generic framework command

After:
QQBot private command -> QQBot message-flow command only -> QQBot private route and allow-list checks
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: The generic command surface is narrowed for QQBot private-only authenticated commands. Mitigation is a registry guard plus regression coverage.

## Repro + Verification

### Environment

- OS: Not run locally
- Runtime/container: Not run locally
- Model/provider: N/A
- Integration/channel (if any): QQBot
- Relevant config (redacted): N/A

### Steps

1. Inspect QQBot slash command registry export behavior.
2. Confirm private-only authenticated commands are excluded from framework registration.
3. Confirm a non-private authenticated command registered in a local test registry is still returned for framework registration.

### Expected

- Private-only authenticated QQBot commands stay out of the framework command list.

### Actual

- The updated registry filters private-only authenticated commands from the framework command list.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

No command execution evidence is attached because branch metadata was drafted under task constraints that prohibited shell, git, and package-manager commands.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: read the changed registry and test code to confirm the framework export now checks `!cmd.c2cOnly`; reviewed the focused test assertions.
- Edge cases checked: non-private authenticated commands remain eligible for framework registration in the unit test.
- What you did **not** verify: package scripts, test execution, formatting, typecheck, or CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a workflow relying on invoking QQBot private-only commands from a generic command surface will no longer work.
  - Mitigation: those commands remain available through the QQBot private message path, which matches their command metadata.

AI-assisted: yes.
