### PR TITLE
fix(control-ui): reserve safe-area-inset-bottom on sticky chat compose for iOS PWA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: reserve `safe-area-inset-bottom` on the sticky chat composer so installed iOS PWA users see the input above the home-indicator. Fixes #76505. Thanks @lonexreb.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3653,6 +3653,12 @@ td.data-table-key-col {
   z-index: 5;
   margin-top: 0;
   padding-top: 12px;
+  /* iOS PWA standalone (`display: standalone` + `viewport-fit=cover`) clips
+     the bottom toolbar (send/voice/attach) behind the home indicator since
+     the bottom edge sits inside the unsafe inset. Reserve room for the inset
+     on every sticky chat compose, not just the focus mode. In regular Safari
+     env(safe-area-inset-bottom) resolves to 0 so the layout is unchanged. See #76505. */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   background: linear-gradient(180deg, transparent 0%, var(--bg) 40%);
 }
 


### PR DESCRIPTION
## Summary

Adds `padding-bottom: env(safe-area-inset-bottom, 0px)` to `.shell--chat .chat-compose` so the Control UI sticky chat compose reserves room for the iOS home indicator. Without this, the bottom toolbar row (send / voice / attach / + / download) is clipped behind the home indicator when the Control UI is launched as a `display: standalone` Home Screen PWA on iOS.

## Why

From the issue: `index.html` declares `viewport-fit=cover` and the manifest declares `"display": "standalone"`. When users add the Control UI to their iOS Home Screen and launch it from there, the sticky chat compose pinned to `bottom: 0` sits inside the unsafe inset, so the home indicator clips the toolbar. Regular Safari works because Safari's own chrome adds bottom padding that the standalone PWA doesn't have.

The existing `.shell--chat-focus .chat-compose` rule already accounts for this (`calc(12px + env(safe-area-inset-bottom, 0px))`); this PR brings the base `.shell--chat .chat-compose` (the non-focus sticky compose, which is what most users see) to parity.

## Changes

- `ui/src/styles/components.css` — Add `padding-bottom: env(safe-area-inset-bottom, 0px)` to `.shell--chat .chat-compose` with an inline comment that names the standalone-mode trigger and links #76505 so future readers don't drop the rule.
- `CHANGELOG.md` — Unreleased > Fixes entry credited to me.

## Why this is safe for non-iOS / non-PWA layouts

`env(safe-area-inset-bottom)` resolves to `0px` everywhere except viewports that report a nonzero bottom safe-area inset (essentially: iOS PWAs, certain Android system UI configurations). The fallback `0px` keeps regular Safari, desktop browsers, and the focus-mode compose layout unchanged.

## Test plan

- [x] `pnpm exec oxfmt --check` on touched files — clean
- [x] CSS-only change; no JS / TS / typecheck surface touched.
- [ ] Live verification on iOS PWA — not available locally; the rule mirrors the existing focus-mode handling and the safe-area inset is the documented iOS compose-bar fix path (`viewport-fit=cover` + `env(safe-area-inset-bottom)` is the canonical pattern).

Fixes #76505.

## Real behavior proof

```

```