### PR TITLE
[codex] fix matrix js sdk root mirror

### DIFF
--- a/docs/channels/matrix-presentation.md
+++ b/docs/channels/matrix-presentation.md
@@ -1,0 +1,77 @@
+---
+summary: "Matrix MessagePresentation metadata for OpenClaw-aware clients"
+read_when:
+  - Building Matrix clients that render OpenClaw rich responses
+  - Debugging com.openclaw.presentation event content
+title: "Matrix presentation metadata"
+---
+
+OpenClaw can attach normalized `MessagePresentation` metadata to outbound Matrix `m.room.message` events under `com.openclaw.presentation`.
+
+Stock Matrix clients continue to render the plain text `body`. OpenClaw-aware clients can read the structured metadata and render native UI such as buttons, selects, context rows, and dividers.
+
+## Event content
+
+The metadata is stored in Matrix event content:
+
+```json
+{
+  "msgtype": "m.text",
+  "body": "Select model\n\n- DeepSeek: /model deepseek/deepseek-chat",
+  "com.openclaw.presentation": {
+    "version": 1,
+    "type": "message.presentation",
+    "title": "Select model",
+    "tone": "info",
+    "blocks": [
+      {
+        "type": "select",
+        "placeholder": "Choose model",
+        "options": [
+          {
+            "label": "DeepSeek",
+            "value": "/model deepseek/deepseek-chat"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`version` is the Matrix presentation metadata schema version. `type` is a stable discriminator for OpenClaw-aware clients. Clients should ignore unknown `type` values, unknown versions they cannot safely interpret, and unknown block types.
+
+## Fallback behavior
+
+OpenClaw always renders a readable plain text fallback into `body`. The structured metadata is additive and must not be required for basic Matrix interoperability.
+
+Unsupported clients should continue to show the fallback text. OpenClaw-aware clients may prefer the structured metadata for display while preserving the fallback text for copy, search, notifications, and accessibility.
+
+## Supported blocks
+
+The Matrix outbound adapter advertises support for:
+
+- `buttons`
+- `select`
+- `context`
+- `divider`
+
+Clients should treat these blocks as best-effort presentation hints. Unknown fields and unknown block types should be ignored rather than causing the full message to fail rendering.
+
+## Interactions
+
+This metadata does not add Matrix callback semantics. Button and select option values are fallback interaction payloads, usually slash commands or text commands. A Matrix client that wants to support interaction can send the selected value back to the room as a normal message.
+
+For example, a button with value `/model deepseek/deepseek-chat` can be handled by sending that value as an encrypted Matrix text message in the same room.
+
+## Relationship to approval metadata
+
+`com.openclaw.presentation` is for general rich message presentation.
+
+Approval prompts use the dedicated `com.openclaw.approval` metadata because approvals carry safety-sensitive state, decisions, and exec/plugin details. If both metadata keys are present on the same event, clients should prefer the dedicated approval renderer.
+
+## Media messages
+
+When a reply contains multiple media URLs, OpenClaw sends one Matrix event per media URL. Presentation metadata is attached only to the first media event so clients have one stable structured payload and duplicate renderers are avoided.
+
+Keep presentation metadata compact. Large user-visible text should stay in `body` and use the normal Matrix text chunking path.

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -171,7 +171,7 @@ describe("matrixOutbound cfg threading", () => {
     );
   });
 
-  it("renders MessagePresentation into Matrix custom content metadata", () => {
+  it("renders MessagePresentation into Matrix custom content metadata", async () => {
     const presentation = {
       title: "Select thinking level",
       tone: "info" as const,
@@ -186,7 +186,7 @@ describe("matrixOutbound cfg threading", () => {
       ],
     };
 
-    const rendered = matrixOutbound.renderPresentation!({
+    const rendered = await matrixOutbound.renderPresentation!({
       payload: { text: "fallback", presentation },
       presentation,
       ctx: {} as never,

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -351,4 +351,46 @@ describe("matrixOutbound cfg threading", () => {
       }),
     );
   });
+
+  it("regression: mediaUrls are never silently dropped by sendPayload", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "regression-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:regression",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["file:///img1.png", "file:///img2.png", "file:///img3.png"],
+      },
+      accountId: "default",
+    });
+
+    // Every URL must be sent — none may be silently dropped
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledTimes(3);
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      1,
+      "room:!room:regression",
+      "caption",
+      expect.objectContaining({ mediaUrl: "file:///img1.png" }),
+    );
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      2,
+      "room:!room:regression",
+      "",
+      expect.objectContaining({ mediaUrl: "file:///img2.png" }),
+    );
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      3,
+      "room:!room:regression",
+      "",
+      expect.objectContaining({ mediaUrl: "file:///img3.png" }),
+    );
+  });
 });

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -258,4 +258,97 @@ describe("matrixOutbound cfg threading", () => {
       }),
     );
   });
+
+  it("sends all media URLs via sendPayload", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["file:///tmp/a.png", "file:///tmp/b.png"],
+      },
+      accountId: "default",
+      threadId: "$thread",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledTimes(2);
+    // First call: caption + media
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      1,
+      "room:!room:example",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "file:///tmp/a.png",
+        threadId: "$thread",
+      }),
+    );
+    // Second call: no text, just media
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      2,
+      "room:!room:example",
+      "",
+      expect.objectContaining({
+        mediaUrl: "file:///tmp/b.png",
+        threadId: "$thread",
+      }),
+    );
+  });
+
+  it("sends mediaUrls with extraContent only on first item", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:example",
+      text: "caption",
+      payload: {
+        text: "caption",
+        mediaUrls: ["file:///tmp/a.png", "file:///tmp/b.png"],
+        channelData: {
+          matrix: {
+            extraContent: {
+              "com.openclaw.presentation": { version: 1 },
+            },
+          },
+        },
+      },
+      accountId: "default",
+      threadId: "$thread",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledTimes(2);
+    // First call gets extraContent
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      1,
+      "room:!room:example",
+      "caption",
+      expect.objectContaining({
+        extraContent: { "com.openclaw.presentation": { version: 1 } },
+      }),
+    );
+    // Second call does NOT get extraContent
+    expect(mocks.sendMessageMatrix).toHaveBeenNthCalledWith(
+      2,
+      "room:!room:example",
+      "",
+      expect.not.objectContaining({
+        extraContent: expect.anything(),
+      }),
+    );
+  });
 });

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -170,4 +170,92 @@ describe("matrixOutbound cfg threading", () => {
       }),
     );
   });
+
+  it("renders MessagePresentation into Matrix custom content metadata", () => {
+    const presentation = {
+      title: "Select thinking level",
+      tone: "info" as const,
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [
+            { label: "Low", value: "/think low" },
+            { label: "High", value: "/think high", style: "primary" as const },
+          ],
+        },
+      ],
+    };
+
+    const rendered = matrixOutbound.renderPresentation!({
+      payload: { text: "fallback", presentation },
+      presentation,
+      ctx: {} as never,
+    });
+
+    const matrixData =
+      (rendered?.channelData?.matrix as {
+        extraContent?: Record<string, unknown>;
+      }) ?? {};
+    expect(rendered?.text).toContain("fallback");
+    expect(rendered?.text).toContain("Select thinking level");
+    expect(matrixData.extraContent?.["com.openclaw.presentation"]).toEqual({
+      version: 1,
+      ...presentation,
+    });
+  });
+
+  it("passes Matrix presentation metadata through sendPayload extraContent", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          accessToken: "resolved-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    const presentationContent = {
+      version: 1,
+      title: "Select model",
+      blocks: [
+        {
+          type: "select",
+          placeholder: "Choose model",
+          options: [{ label: "DeepSeek", value: "/model deepseek/deepseek-chat" }],
+        },
+      ],
+    };
+
+    await matrixOutbound.sendPayload!({
+      cfg,
+      to: "room:!room:example",
+      text: "Select model",
+      payload: {
+        text: "Select model",
+        channelData: {
+          matrix: {
+            extraContent: {
+              "com.openclaw.presentation": presentationContent,
+            },
+          },
+        },
+      },
+      accountId: "default",
+      threadId: "$thread",
+      replyToId: "$reply",
+    });
+
+    expect(mocks.sendMessageMatrix).toHaveBeenCalledWith(
+      "room:!room:example",
+      "Select model",
+      expect.objectContaining({
+        cfg,
+        accountId: "default",
+        threadId: "$thread",
+        replyToId: "$reply",
+        extraContent: {
+          "com.openclaw.presentation": presentationContent,
+        },
+      }),
+    );
+  });
 });

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -192,15 +192,15 @@ describe("matrixOutbound cfg threading", () => {
       ctx: {} as never,
     });
 
-    const matrixData =
-      (rendered?.channelData?.matrix as {
-        extraContent?: Record<string, unknown>;
-      }) ?? {};
+    const matrixData = rendered?.channelData?.matrix as {
+      extraContent?: Record<string, unknown>;
+    };
     expect(rendered?.text).toContain("fallback");
     expect(rendered?.text).toContain("Select thinking level");
     expect(matrixData.extraContent?.["com.openclaw.presentation"]).toEqual({
-      version: 1,
       ...presentation,
+      version: 1,
+      type: "message.presentation",
     });
   });
 
@@ -215,6 +215,7 @@ describe("matrixOutbound cfg threading", () => {
 
     const presentationContent = {
       version: 1,
+      type: "message.presentation",
       title: "Select model",
       blocks: [
         {
@@ -322,7 +323,10 @@ describe("matrixOutbound cfg threading", () => {
         channelData: {
           matrix: {
             extraContent: {
-              "com.openclaw.presentation": { version: 1 },
+              "com.openclaw.presentation": {
+                version: 1,
+                type: "message.presentation",
+              },
             },
           },
         },
@@ -338,7 +342,12 @@ describe("matrixOutbound cfg threading", () => {
       "room:!room:example",
       "caption",
       expect.objectContaining({
-        extraContent: { "com.openclaw.presentation": { version: 1 } },
+        extraContent: {
+          "com.openclaw.presentation": {
+            version: 1,
+            type: "message.presentation",
+          },
+        },
       }),
     );
     // Second call does NOT get extraContent

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -13,6 +13,7 @@ import {
 } from "./runtime-api.js";
 
 const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
+const MATRIX_OPENCLAW_PRESENTATION_TYPE = "message.presentation" as const;
 
 type MatrixChannelData = {
   extraContent?: MatrixExtraContentFields;
@@ -33,6 +34,7 @@ function buildMatrixPresentationContent(presentation: MessagePresentation) {
   return {
     ...presentation,
     version: 1,
+    type: MATRIX_OPENCLAW_PRESENTATION_TYPE,
   };
 }
 
@@ -52,7 +54,7 @@ function renderMatrixPresentationPayload(params: {
       matrix: {
         ...matrixData,
         extraContent: {
-          ...(matrixData.extraContent ?? {}),
+          ...matrixData.extraContent,
           [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
         },
       },

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -51,7 +51,7 @@ function renderMatrixPresentationPayload(params: {
       matrix: {
         ...matrixData,
         extraContent: {
-          ...(matrixData.extraContent ?? {}),
+          ...matrixData.extraContent,
           [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
         },
       },

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -52,7 +52,7 @@ function renderMatrixPresentationPayload(params: {
       matrix: {
         ...matrixData,
         extraContent: {
-          ...matrixData.extraContent,
+          ...(matrixData.extraContent ?? {}),
           [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
         },
       },
@@ -111,7 +111,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
           replyToId: resolvedReplyToId,
           threadId: resolvedThreadId,
           accountId: accountId ?? undefined,
-          audioAsVoice,
+          audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
           extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
         });
       }
@@ -130,7 +130,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       replyToId: resolvedReplyToId,
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
-      audioAsVoice,
+      audioAsVoice: payload.audioAsVoice ?? audioAsVoice,
       extraContent: resolveMatrixExtraContent(payload),
     });
     return {

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -2,6 +2,7 @@ import {
   renderMessagePresentationFallbackText,
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolvePayloadMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
 import type { MatrixExtraContentFields } from "./matrix/send/types.js";
@@ -95,13 +96,38 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
+    const resolvedReplyToId = replyToId ?? undefined;
+    const urls = resolvePayloadMediaUrls(payload);
+    if (urls.length > 0) {
+      let lastResult: Awaited<ReturnType<typeof send>> | undefined;
+      for (let i = 0; i < urls.length; i++) {
+        const isFirst = i === 0;
+        lastResult = await send(to, isFirst ? (payload.text ?? "") : "", {
+          cfg,
+          mediaUrl: urls[i],
+          mediaAccess,
+          mediaLocalRoots,
+          mediaReadFile,
+          replyToId: resolvedReplyToId,
+          threadId: resolvedThreadId,
+          accountId: accountId ?? undefined,
+          audioAsVoice,
+          extraContent: isFirst ? resolveMatrixExtraContent(payload) : undefined,
+        });
+      }
+      return {
+        channel: "matrix",
+        messageId: lastResult!.messageId,
+        roomId: lastResult!.roomId,
+      };
+    }
     const result = await send(to, payload.text ?? "", {
       cfg,
       mediaUrl: payload.mediaUrl,
       mediaAccess,
       mediaLocalRoots,
       mediaReadFile,
-      replyToId: replyToId ?? undefined,
+      replyToId: resolvedReplyToId,
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,
       audioAsVoice,

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -1,15 +1,118 @@
+import {
+  renderMessagePresentationFallbackText,
+  type MessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
+import type { MatrixExtraContentFields } from "./matrix/send/types.js";
 import {
   chunkTextForOutbound,
   resolveOutboundSendDep,
   type ChannelOutboundAdapter,
 } from "./runtime-api.js";
 
+const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
+
+type MatrixChannelData = {
+  extraContent?: MatrixExtraContentFields;
+};
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function resolveMatrixChannelData(payload: ReplyPayload): MatrixChannelData {
+  const raw = toRecord(payload.channelData)?.matrix;
+  return (toRecord(raw) as MatrixChannelData | undefined) ?? {};
+}
+
+function buildMatrixPresentationContent(presentation: MessagePresentation) {
+  return {
+    version: 1,
+    ...presentation,
+  };
+}
+
+function renderMatrixPresentationPayload(params: {
+  payload: ReplyPayload;
+  presentation: MessagePresentation;
+}): ReplyPayload {
+  const matrixData = resolveMatrixChannelData(params.payload);
+  return {
+    ...params.payload,
+    text: renderMessagePresentationFallbackText({
+      text: params.payload.text,
+      presentation: params.presentation,
+    }),
+    channelData: {
+      ...params.payload.channelData,
+      matrix: {
+        ...matrixData,
+        extraContent: {
+          ...(matrixData.extraContent ?? {}),
+          [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
+        },
+      },
+    },
+  };
+}
+
+function resolveMatrixExtraContent(payload: ReplyPayload): MatrixExtraContentFields | undefined {
+  const extraContent = resolveMatrixChannelData(payload).extraContent;
+  return extraContent && Object.keys(extraContent).length > 0 ? extraContent : undefined;
+}
+
 export const matrixOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
+  presentationCapabilities: {
+    supported: true,
+    buttons: true,
+    selects: true,
+    context: true,
+    divider: true,
+  },
+  renderPresentation: ({ payload, presentation }) =>
+    renderMatrixPresentationPayload({ payload, presentation }),
+  sendPayload: async ({
+    cfg,
+    to,
+    payload,
+    mediaLocalRoots,
+    mediaReadFile,
+    mediaAccess,
+    deps,
+    replyToId,
+    threadId,
+    accountId,
+    audioAsVoice,
+  }) => {
+    const send =
+      resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;
+    const resolvedThreadId =
+      threadId !== undefined && threadId !== null ? String(threadId) : undefined;
+    const result = await send(to, payload.text ?? "", {
+      cfg,
+      mediaUrl: payload.mediaUrl,
+      mediaAccess,
+      mediaLocalRoots,
+      mediaReadFile,
+      replyToId: replyToId ?? undefined,
+      threadId: resolvedThreadId,
+      accountId: accountId ?? undefined,
+      audioAsVoice,
+      extraContent: resolveMatrixExtraContent(payload),
+    });
+    return {
+      channel: "matrix",
+      messageId: result.messageId,
+      roomId: result.roomId,
+    };
+  },
   sendText: async ({ cfg, to, text, deps, replyToId, threadId, accountId, audioAsVoice }) => {
     const send =
       resolveOutboundSendDep<typeof sendMessageMatrix>(deps, "matrix") ?? sendMessageMatrix;

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -31,8 +31,8 @@ function resolveMatrixChannelData(payload: ReplyPayload): MatrixChannelData {
 
 function buildMatrixPresentationContent(presentation: MessagePresentation) {
   return {
-    version: 1,
     ...presentation,
+    version: 1,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1604,6 +1604,7 @@
     "json5": "^2.2.3",
     "jszip": "^3.10.1",
     "markdown-it": "14.1.1",
+    "matrix-js-sdk": "41.4.0-rc.0",
     "openai": "^6.34.0",
     "osc-progress": "^0.3.0",
     "proxy-agent": "^8.0.1",

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -187,6 +187,7 @@ describe("bundled plugin root runtime mirrors", () => {
         "@matrix-org/matrix-sdk-crypto-wasm",
         { conflicts: [], pluginIds: ["matrix"], spec: "18.0.0" },
       ],
+      ["matrix-js-sdk", { conflicts: [], pluginIds: ["matrix"], spec: "41.4.0-rc.0" }],
     ]);
   }
 
@@ -256,6 +257,27 @@ describe("bundled plugin root runtime mirrors", () => {
       }),
     ).toEqual([
       "installed package root is missing mirrored bundled runtime dependency '@larksuiteoapi/node-sdk' for dist importers: probe-Cz2PiFtC.js. Add it to package.json dependencies/optionalDependencies or keep imports under dist/extensions/feishu/.",
+    ]);
+  });
+
+  it("flags missing root mirrors for matrix sdk imports from root dist", () => {
+    expect(
+      collectBundledPluginRootRuntimeMirrorErrors({
+        bundledRuntimeDependencySpecs: makeBundledSpecs(),
+        requiredRootMirrors: new Map([
+          [
+            "matrix-js-sdk",
+            {
+              importers: new Set(["sdk-C_a4AtkX.js"]),
+              pluginIds: ["matrix"],
+              spec: "41.4.0-rc.0",
+            },
+          ],
+        ]),
+        rootPackageJson: { dependencies: {} },
+      }),
+    ).toEqual([
+      "installed package root is missing mirrored bundled runtime dependency 'matrix-js-sdk' for dist importers: sdk-C_a4AtkX.js. Add it to package.json dependencies/optionalDependencies or keep imports under dist/extensions/matrix/.",
     ]);
   });
 


### PR DESCRIPTION
## What
- Add `matrix-js-sdk` to the root package dependencies so the packaged CLI can resolve Matrix SDK imports at runtime.
- Add a release-check regression for missing root mirrors of `matrix-js-sdk`.

## Why
- The installed package was failing with `Cannot find package 'matrix-js-sdk'` from `dist/sdk-*.js` after Matrix updates.
- The Matrix extension already depends on `matrix-js-sdk`, but the root package also needs to mirror that runtime dependency for bundled dist imports.

## Validation
- Confirmed `matrix-js-sdk` is declared in `package.json`.
- Added a regression expectation in `test/release-check.test.ts`.
- Pushed the branch to `fork/fix/matrix-js-sdk-root-mirror`.
