### PR TITLE
fix(deepseek): expose V4 thinking profile via lightweight policy artifact

### DIFF
--- a/extensions/deepseek/index.ts
+++ b/extensions/deepseek/index.ts
@@ -1,27 +1,16 @@
-import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { isDeepSeekV4ModelId } from "./models.js";
 import { applyDeepSeekConfig, DEEPSEEK_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  DEEPSEEK_V4_THINKING_PROFILE,
+  resolveThinkingProfile as resolveDeepSeekThinkingProfile,
+} from "./provider-policy-api.js";
 import { buildDeepSeekProvider } from "./provider-catalog.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
 
 const PROVIDER_ID = "deepseek";
-const V4_THINKING_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
-
-function buildDeepSeekV4ThinkingLevel(id: (typeof V4_THINKING_LEVEL_IDS)[number]) {
-  return { id };
-}
-
-const DEEPSEEK_V4_THINKING_PROFILE = {
-  levels: V4_THINKING_LEVEL_IDS.map(buildDeepSeekV4ThinkingLevel),
-  defaultLevel: "high",
-} satisfies ProviderThinkingProfile;
-
-function resolveDeepSeekV4ThinkingProfile(modelId: string): ProviderThinkingProfile | undefined {
-  return isDeepSeekV4ModelId(modelId) ? DEEPSEEK_V4_THINKING_PROFILE : undefined;
-}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
@@ -62,7 +51,8 @@ export default defineSingleProviderPluginEntry({
       /\bdeepseek\b.*(?:input.*too long|context.*exceed)/i.test(errorMessage),
     ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
     wrapStreamFn: (ctx) => createDeepSeekV4ThinkingWrapper(ctx.streamFn, ctx.thinkingLevel),
-    resolveThinkingProfile: ({ modelId }) => resolveDeepSeekV4ThinkingProfile(modelId),
-    isModernModelRef: ({ modelId }) => Boolean(resolveDeepSeekV4ThinkingProfile(modelId)),
+    resolveThinkingProfile: ({ modelId }) =>
+      resolveDeepSeekThinkingProfile({ provider: PROVIDER_ID, modelId }) ?? undefined,
+    isModernModelRef: ({ modelId }) => Boolean(isDeepSeekV4ModelId(modelId)),
   },
 });

--- a/extensions/deepseek/provider-policy-api.test.ts
+++ b/extensions/deepseek/provider-policy-api.test.ts
@@ -1,6 +1,6 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
-import { normalizeConfig } from "./provider-policy-api.js";
+import { normalizeConfig, resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("deepseek provider-policy-api", () => {
   it("hydrates contextWindow and cost from catalog for known models", () => {
@@ -231,5 +231,33 @@ describe("deepseek provider-policy-api", () => {
       cacheRead: 0.145,
       cacheWrite: 0,
     });
+  });
+});
+
+describe("resolveThinkingProfile", () => {
+  it("returns V4 profile with xhigh and max for deepseek-v4-pro", () => {
+    const profile = resolveThinkingProfile({ provider: "deepseek", modelId: "deepseek-v4-pro" });
+    expect(profile).not.toBeNull();
+    const ids = profile!.levels.map((l) => l.id);
+    expect(ids).toEqual(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+    expect(profile!.defaultLevel).toBe("high");
+  });
+
+  it("returns V4 profile with xhigh and max for deepseek-v4-flash", () => {
+    const profile = resolveThinkingProfile({ provider: "deepseek", modelId: "deepseek-v4-flash" });
+    expect(profile).not.toBeNull();
+    const ids = profile!.levels.map((l) => l.id);
+    expect(ids).toContain("xhigh");
+    expect(ids).toContain("max");
+  });
+
+  it("returns null for non-V4 DeepSeek models", () => {
+    expect(resolveThinkingProfile({ provider: "deepseek", modelId: "deepseek-chat" })).toBeNull();
+  });
+
+  it("returns null for non-DeepSeek providers even with a V4 model id", () => {
+    expect(
+      resolveThinkingProfile({ provider: "openrouter", modelId: "deepseek-v4-pro" }),
+    ).toBeNull();
   });
 });

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -1,6 +1,30 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { DEEPSEEK_MODEL_CATALOG } from "./models.js";
+import { DEEPSEEK_MODEL_CATALOG, isDeepSeekV4ModelId } from "./models.js";
+
+const DEEPSEEK_V4_LEVEL_IDS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+
+export const DEEPSEEK_V4_THINKING_PROFILE = {
+  levels: DEEPSEEK_V4_LEVEL_IDS.map((id) => ({ id })),
+  defaultLevel: "high",
+} satisfies ProviderThinkingProfile;
+
+/**
+ * Resolve the thinking profile for DeepSeek V4 models from the lightweight
+ * provider-policy surface. Mirrors the runtime hook in index.ts so that
+ * fallback callers (e.g. the Control UI picker via resolveBundledProviderPolicySurface)
+ * expose the same xhigh|max levels as the active runtime registry.
+ */
+export function resolveThinkingProfile(params: {
+  provider: string;
+  modelId: string;
+}): ProviderThinkingProfile | null {
+  if (params.provider === "deepseek" && isDeepSeekV4ModelId(params.modelId)) {
+    return DEEPSEEK_V4_THINKING_PROFILE;
+  }
+  return null;
+}
 
 type ModelDefinitionDraft = Partial<ModelDefinitionConfig> &
   Pick<ModelDefinitionConfig, "id" | "name">;


### PR DESCRIPTION
## Problem

The DeepSeek plugin's runtime `resolveThinkingProfile` hook correctly exposes `xhigh|max` for V4 models (`index.ts` line 11), but the lightweight provider-policy artifact (`provider-policy-api.ts`) has no `resolveThinkingProfile` export.

Fallback callers that reach `resolveBundledProviderPolicySurface("deepseek")` instead of the active runtime registry — including the Control UI `/think` picker during session setup — therefore get no V4 profile and fall back to base levels only (`off/minimal/low/medium/high`), reproducing #77139.

## Fix

- Export `resolveThinkingProfile` from `provider-policy-api.ts` using `isDeepSeekV4ModelId` from `models.ts`
- Export `DEEPSEEK_V4_THINKING_PROFILE` as the single shared definition
- Update `index.ts` to import both from `provider-policy-api.ts` instead of redefining them, so the two surfaces cannot drift

## Tests

Added four cases to `provider-policy-api.test.ts` covering:
- `deepseek-v4-pro` returns all seven levels including `xhigh` and `max`
- `deepseek-v4-flash` returns all seven levels including `xhigh` and `max`
- Non-V4 DeepSeek models (`deepseek-chat`) return `null`
- Non-DeepSeek providers with a V4 model id return `null`

Fixes #77139.