### PR TITLE
fix(media): ship sharp for packaged image ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -585,6 +585,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
@@ -608,6 +609,19 @@ Docs: https://docs.openclaw.ai
 - Codex harness: preserve app-server usage-limit reset details and deliver OpenClaw-owned runtime failure notices through tool-only source-reply mode, so Telegram and other chat channels tell users when Codex subscription limits or API failures block a turn instead of going silent. (#77557) Thanks @pashpashpash.
 - Agents/OpenAI: default direct OpenAI Responses models to the SSE transport instead of WebSocket auto-selection, preventing pi runtime chat turns from hanging on servers where the WebSocket path stalls while the OpenAI HTTP stream works. Thanks @vincentkoc.
 - Plugins/update: repair missing plugin-local `openclaw` peer links before skipping unchanged npm plugin updates, so current external Codex installs can recover `openclaw/plugin-sdk/*` resolution during OTA repair. (#77544) Thanks @ProspectOre.
+- TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
+- Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
+- Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.
+- Providers/Fireworks: expose Kimi models as thinking-off-only and keep K2.5/K2.6 requests on `thinking: disabled`, so manual model switches do not send Fireworks-rejected `reasoning*` parameters. Refs #74289. Thanks @frankekn.
+- WhatsApp responsiveness: stop only verified stale local TUI clients when they degrade the Gateway event loop and delay replies. Thanks @vincentkoc.
+- Hooks/session-memory: add collision suffixes to fallback memory filenames so repeated `/new` or `/reset` captures in the same minute do not overwrite the earlier session archive. Thanks @vincentkoc.
+- Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
+- Video generation: accept provider-specific aspect-ratio and resolution hints at the tool boundary, normalize `720P` to MiniMax's supported `768P`, and stop sending Google `generateAudio` on Gemini video requests so provider fallback can recover from model-specific parameter differences. Thanks @vincentkoc.
+- OpenAI/Google Meet: fail realtime voice connection attempts when the socket closes before `session.updated`, avoiding stuck Meet joins waiting on a bridge that never became ready. Thanks @vincentkoc.
+- Hooks/session-memory: run reset memory capture off the command reply path and make model-generated memory filename slugs opt-in with `llmSlug: true`, so `/new` and `/reset` no longer block WhatsApp and other message-channel reset replies on hook housekeeping or a nested model call. Thanks @vincentkoc.
+- CLI/gateway: pause non-TTY stdin after full CLI command completion and stop `openclaw agent` from falling back to embedded mode after gateway request/auth failures, so parent help commands exit cleanly and scoped delivery probes surface the real Gateway error immediately. Thanks @vincentkoc.
+- Gateway/model catalog: cache empty read-only model catalog results until reload, so TUI and control-plane refresh loops cannot hammer plugin metadata reads when no usable models are currently discovered. Thanks @vincentkoc.
+
 - Discord/replies: treat failed final reply delivery as a failed turn instead of counting it as a delivered automatic visible reply, so guild/channel turns no longer show done when the final message was dropped. Fixes #77520. Thanks @Patrick-Erichsen.
 - Discord: prefer IPv4 for Discord REST and gateway WebSocket startup paths so IPv4-only networks no longer stall before Gateway READY and inbound message dispatch. Fixes #77398; refs #77526. Thanks @Beandon13.
 - Channels/plugins: key bundled package-state probes, env/config presence, and read-only command defaults by channel id instead of manifest plugin id, preserving setup and native-command detection for channel plugins whose package id differs from the channel alias. Thanks @vincentkoc.
@@ -625,6 +639,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/chat: clear the active reply-run guard before draining queued same-session follow-up turns, so sequential `chat.send` calls no longer trip `ReplyRunAlreadyActiveError` every other request. Fixes #77485. Thanks @bws14email.
 - Agents/media: avoid sending generated image, video, and music attachments twice when streamed reply text arrives before the final `MEDIA:` directive.
 - CLI/sessions: cap `openclaw sessions` output to the newest 100 rows by default and add `--limit <n|all>` plus JSON pagination metadata, so repeated machine polling of large session stores cannot fan out into unbounded per-row enrichment/output work. Fixes #77500. Thanks @Kaotic3.
+- Media/image attachments: ship `sharp` with the packaged root runtime so bundled image operations can process local images after global installs. Thanks @Fuma2013.
 - Doctor/config: restore legacy group chat config migrations for `routing.allowFrom`, `routing.groupChat.*`, and `channels.telegram.requireMention` so upgrades keep WhatsApp, Telegram, and iMessage group mention gates and history settings instead of leaving configs invalid or silently blocked. Thanks @scoootscooob.
 - CLI/update: make package-update follow-up processes write completion results and exit explicitly, so Windows packaged upgrades do not hang after the new package finishes post-core plugin work. Thanks @vincentkoc.
 - Release validation: skip Slack live QA unless Slack credentials are explicitly configured, so release gates can keep proving non-Slack surfaces while Slack is still local and credential-gated. Thanks @vincentkoc.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -72,6 +72,7 @@ const rootBundledPluginRuntimeDependencies = [
   "node-edge-tts",
   "openshell",
   "pdfjs-dist",
+  "sharp",
   "tokenjuice",
 ] as const;
 

--- a/package.json
+++ b/package.json
@@ -1735,6 +1735,7 @@
     "playwright-core": "1.59.1",
     "proxy-agent": "^8.0.1",
     "qrcode": "1.5.4",
+    "sharp": "^0.34.5",
     "tar": "7.5.14",
     "tokenjuice": "0.7.0",
     "tree-sitter-bash": "^0.25.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       qrcode:
         specifier: 1.5.4
         version: 1.5.4
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tar:
         specifier: 7.5.14
         version: 7.5.14

--- a/scripts/root-dependency-ownership-audit.mjs
+++ b/scripts/root-dependency-ownership-audit.mjs
@@ -28,6 +28,10 @@ const ROOT_OWNED_EXTENSION_RUNTIME_DEPENDENCIES = new Map([
     "playwright-core",
     "keep at root; the internal browser runtime is shipped with core even though downloadable browser-adjacent plugins also declare it",
   ],
+  [
+    "sharp",
+    "keep at root; packaged core image-attachment paths load the bundled media-understanding-core public image ops before plugin-local runtime dependencies are installed",
+  ],
 ]);
 
 function readJson(filePath) {

--- a/src/plugin-sdk/qa-runner-runtime.integration.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.integration.test.ts
@@ -55,7 +55,13 @@ describe("plugin-sdk qa-runner-runtime linked plugin smoke", () => {
       }),
       "utf8",
     );
-    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+    };
 
     fs.mkdirSync(pluginDir, { recursive: true });
     fs.writeFileSync(
@@ -106,7 +112,7 @@ describe("plugin-sdk qa-runner-runtime linked plugin smoke", () => {
 
     const module = await import("./qa-runner-runtime.js");
 
-    expect(module.listQaRunnerCliContributions()).toEqual([
+    expect(module.listQaRunnerCliContributions({ env })).toEqual([
       {
         pluginId: "qa-linked",
         commandName: "linked",

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -146,8 +146,10 @@ function loadQaRunnerRuntimeSurface(
   });
 }
 
-export function listQaRunnerCliContributions(): readonly QaRunnerCliContribution[] {
-  const env = resolvePrivateQaBundledPluginsEnv();
+export function listQaRunnerCliContributions(options?: {
+  env?: NodeJS.ProcessEnv;
+}): readonly QaRunnerCliContribution[] {
+  const env = options?.env ?? resolvePrivateQaBundledPluginsEnv();
   const contributions = new Map<string, QaRunnerCliContribution>();
 
   for (const plugin of listDeclaredQaRunnerPlugins(env)) {


### PR DESCRIPTION
## Summary
- add `sharp` to the root runtime dependencies so packaged image attachment ops can resolve it
- keep the lockfile importer in sync
- document `sharp` as a root-owned bundled extension runtime dependency in the ownership audit

## Why
`media-understanding-core` declares and dynamically imports `sharp`, but packaged/global OpenClaw installs do not install nested bundled-extension dependencies at runtime. Core image attachment paths load the bundled `media-understanding-core` public image ops directly, so `sharp` must be resolvable from the packaged OpenClaw runtime root.

Without this, local image analysis can fail with:

```text
Optional dependency sharp is required for image attachment processing
```

## Verification
- `corepack pnpm deps:root-ownership:check`
- `PATH=/tmp/openclaw-pnpm-shim:$PATH corepack pnpm check:changed`
- `corepack pnpm format:check package.json pnpm-lock.yaml scripts/root-dependency-ownership-audit.mjs`

## Real behavior proof
- **Behavior or issue addressed:** Packaged/global OpenClaw image attachment processing could not load `sharp` from the runtime root, causing local image analysis to fail with `Optional dependency sharp is required for image attachment processing`.
- **Real environment tested:** macOS Mac mini, global packaged OpenClaw install at `/opt/homebrew/lib/node_modules/openclaw`, OpenClaw `2026.5.3 (06d46f7)`, Node `v25.9.0`, local PNG file from the real OpenClaw workspace.
- **Exact steps or command run after this patch:** Ran `openclaw --version`, then executed the packaged runtime image ops from `/opt/homebrew/lib/node_modules/openclaw/dist/extensions/media-understanding-core/image-ops.js` with `createMediaAttachmentImageOps({maxInputPixels: 5000000})` and called `getImageMetadata('/Users/thomas/.openclaw/workspace/assets/nero/nero-telegram-avatar-calm-electric-guardian-2026-05-03.png')`.
- **Evidence after fix:** Terminal output from the real packaged runtime:

```text
$ openclaw --version
OpenClaw 2026.5.3 (06d46f7)

$ node - <<'NODE'
const {createMediaAttachmentImageOps}=require('/opt/homebrew/lib/node_modules/openclaw/dist/extensions/media-understanding-core/image-ops.js');
(async()=>{
 const ops=createMediaAttachmentImageOps({maxInputPixels: 5000000});
 const meta=await ops.getImageMetadata('/Users/thomas/.openclaw/workspace/assets/nero/nero-telegram-avatar-calm-electric-guardian-2026-05-03.png');
 console.log(JSON.stringify(meta));
})();
NODE
{"width":1024,"height":1024}
```

- **Observed result after fix:** The packaged runtime image ops resolved `sharp` successfully and returned the real local PNG metadata `{"width":1024,"height":1024}` instead of throwing the missing-optional-dependency error.
- **What was not tested:** A newly published npm tarball containing this PR was not installed because the package has not been released yet; the runtime behavior was proven against the same packaged global runtime path with `sharp` made resolvable from the runtime dependency graph.

## Local reproduction / smoke
On a global `2026.5.3` install, installing `sharp@0.34.5` at the global Node prefix makes the packaged `dist/extensions/media-understanding-core/image-ops.js` resolve `sharp` and read image metadata successfully, confirming the missing runtime dependency is the blocker.
