### PR TITLE
fix(agents): resolve providerless configured cron models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/models: resolve provider-less persisted OpenRouter cron model overrides through `agents.defaults.models`, so nested OpenRouter model IDs do not fail the allowlist after the provider prefix is stripped. Fixes #77234. Thanks @clawoneloke.
 - fix: harden backend message action gateway routing [AI]. (#76374) Thanks @pgondhi987.
 - Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.
 - Plugins/install: suppress dangerous-pattern scanner warnings for trusted official OpenClaw npm installs, so installing `@openclaw/discord` no longer prints credential-harvesting warnings for the official package.

--- a/src/agents/model-selection-resolve.test.ts
+++ b/src/agents/model-selection-resolve.test.ts
@@ -37,6 +37,31 @@ describe("model-selection-resolve OpenRouter compat aliases", () => {
     });
   });
 
+  it("resolves configured OpenRouter models when persisted without the provider prefix", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openrouter/arcee-ai/trinity-large-preview:free": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveAllowedModelRef({
+        cfg,
+        catalog: [],
+        raw: "arcee-ai/trinity-large-preview:free",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+      }),
+    ).toEqual({
+      key: "openrouter/arcee-ai/trinity-large-preview:free",
+      ref: { provider: "openrouter", model: "arcee-ai/trinity-large-preview:free" },
+    });
+  });
+
   it("resolves openrouter:auto through the canonical OpenRouter auto model", () => {
     const cfg = {
       agents: {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -807,11 +807,23 @@ export function resolveAllowedModelRefFromAliasIndex(params: {
   }
 
   const status = params.getStatus(resolved.ref);
-  if (!status.allowed) {
-    return { error: `model not allowed: ${status.key}` };
+  if (status.allowed) {
+    return { ref: resolved.ref, key: status.key };
   }
 
-  return { ref: resolved.ref, key: status.key };
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: trimmed,
+  });
+  if (inferredProvider && inferredProvider !== resolved.ref.provider) {
+    const inferredRef = normalizeModelRef(inferredProvider, trimmed);
+    const inferredStatus = params.getStatus(inferredRef);
+    if (inferredStatus.allowed) {
+      return { ref: inferredRef, key: inferredStatus.key };
+    }
+  }
+
+  return { error: `model not allowed: ${status.key}` };
 }
 
 export function buildConfiguredModelCatalog(params: { cfg: OpenClawConfig }): ModelCatalogEntry[] {


### PR DESCRIPTION
## Summary

- Problem: cron `payload.model` overrides could be checked after a provider prefix was stripped, e.g. `arcee-ai/trinity-large-preview:free`, while the allowlist only contained `openrouter/arcee-ai/trinity-large-preview:free`.
- Why it matters: configured OpenRouter models in `agents.defaults.models` were rejected when used by cron despite being explicitly allowed.
- What changed: when the first parse is not allowed, model selection now infers a unique provider from configured models using the full raw model id, then re-checks that inferred provider/model key.
- What did NOT change (scope boundary): no changes to cron storage, model catalog loading, aliases, fallback ordering, or provider auth behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77234
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: provider/model parsing treated a provider-less nested OpenRouter model id as if its first path segment were the provider before allowlist checking.
- Missing detection / guardrail: resolver coverage did not include a configured `openrouter/<nested-model>` allowlist entry checked against the same nested model id without the provider prefix.
- Contributing context (if known): cron model override storage can preserve the model id separately from provider identity.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-selection-resolve.test.ts`
- Scenario the test should lock in: `arcee-ai/trinity-large-preview:free` resolves to the configured `openrouter/arcee-ai/trinity-large-preview:free` allowlist key.
- Why this is the smallest reliable guardrail: the bug is in shared model selection/allowlist resolution before cron executes a turn.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Cron jobs whose OpenRouter model override is checked without the provider prefix now pass the configured `agents.defaults.models` allowlist when that nested model id uniquely belongs to OpenRouter.

## Diagram (if applicable)

```text
Before:
payload.model arcee-ai/trinity-large-preview:free -> parsed as arcee-ai/trinity-large-preview:free -> allowlist miss

After:
payload.model arcee-ai/trinity-large-preview:free -> infer openrouter from configured models -> openrouter/arcee-ai/trinity-large-preview:free -> allowed
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Debian 13 container
- Runtime/container: Node v20.19.2 locally (repo warns it wants Node >=22.14.0)
- Model/provider: OpenRouter model-selection fixture
- Integration/channel (if any): cron isolated agent model selection
- Relevant config (redacted): `agents.defaults.models["openrouter/arcee-ai/trinity-large-preview:free"]`

### Steps

1. Configure `agents.defaults.models` with `openrouter/arcee-ai/trinity-large-preview:free`.
2. Resolve cron-style payload model `arcee-ai/trinity-large-preview:free` through `resolveAllowedModelRef`.
3. Check the returned allowlist key.

### Expected

- The model resolves to provider `openrouter` and key `openrouter/arcee-ai/trinity-large-preview:free`.

### Actual

- Before this patch, the model resolved as provider `arcee-ai` and was rejected as not allowed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/model-selection-resolve.test.ts src/cron/isolated-agent.model-formatting.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/model-selection-shared.ts src/agents/model-selection-resolve.test.ts CHANGELOG.md`
  - `git diff --check`
- Edge cases checked: existing OpenRouter compat alias tests, proxy provider id test, and cron model-formatting tests still pass.
- What you did **not** verify: full `pnpm check:changed` remains blocked by an unrelated current-main core-test type error in `src/agents/model-auth.profiles.test.ts:48` under this local Node v20.19.2 environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: provider inference could accidentally allow an ambiguous nested model id.
  - Mitigation: the fallback only runs when the configured-model scan finds exactly one provider and the inferred provider/model still passes the existing allowlist status check.
