### PR TITLE
fix(plugins): resolve npm channel plugin contract files from dist/ subdirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/install: let official plugin reinstall recovery repair source-only installed runtime shadows, so `openclaw plugins install npm:@openclaw/discord --force` can replace the bad package instead of stopping at stale config validation. Thanks @vincentkoc.
 - Plugins/commands: allow the official ClawHub Codex plugin package to keep reserved `/codex` command ownership, matching the existing npm-managed Codex package behavior. Thanks @vincentkoc.
 - Auth/OpenAI Codex: rewrite invalidated per-agent Codex auth-order and session profile overrides toward a healthy relogin profile, so revoked OAuth accounts do not stay pinned after signing in again. Thanks @BunsDev.
+- Plugins/secrets: resolve npm channel plugin contract files from the `dist/` subdirectory so npm-installed channel plugins load their secret contracts correctly. Fixes #77241.
 - Plugins/commands: scope QQBot framework slash commands to the QQBot channel so `/bot-*` command handlers and native specs do not leak onto unrelated chat surfaces. Thanks @vincentkoc.
 - fix: harden backend message action gateway routing [AI]. (#76374) Thanks @pgondhi987.
 - Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/install: let official plugin reinstall recovery repair source-only installed runtime shadows, so `openclaw plugins install npm:@openclaw/discord --force` can replace the bad package instead of stopping at stale config validation. Thanks @vincentkoc.
 - Plugins/commands: allow the official ClawHub Codex plugin package to keep reserved `/codex` command ownership, matching the existing npm-managed Codex package behavior. Thanks @vincentkoc.
 - Auth/OpenAI Codex: rewrite invalidated per-agent Codex auth-order and session profile overrides toward a healthy relogin profile, so revoked OAuth accounts do not stay pinned after signing in again. Thanks @BunsDev.
-- Plugins/secrets: resolve npm channel plugin contract files from the `dist/` subdirectory so npm-installed channel plugins load their secret contracts correctly. Fixes #77241.
+- Plugins/secrets: resolve npm channel plugin contract files from the `dist/` subdirectory so npm-installed channel plugins load their secret contracts correctly. Fixes #77241. Thanks @colin-chang.
 - Plugins/commands: scope QQBot framework slash commands to the QQBot channel so `/bot-*` command handlers and native specs do not leak onto unrelated chat surfaces. Thanks @vincentkoc.
 - fix: harden backend message action gateway routing [AI]. (#76374) Thanks @pgondhi987.
 - Gate QQBot streaming command auth [AI]. (#76375) Thanks @pgondhi987.

--- a/src/secrets/channel-contract-api.external.test.ts
+++ b/src/secrets/channel-contract-api.external.test.ts
@@ -65,6 +65,48 @@ module.exports = {
   };
 }
 
+function writeExternalChannelPluginInDist(params: { pluginId: string; channelId: string }) {
+  const rootDir = makeTrackedTempDir("openclaw-channel-secret-contract", tempDirs);
+  const distDir = path.join(rootDir, "dist");
+  fs.mkdirSync(distDir);
+  fs.writeFileSync(
+    path.join(distDir, "secret-contract-api.cjs"),
+    `
+module.exports = {
+  secretTargetRegistryEntries: [
+    {
+      id: "channels.${params.channelId}.token",
+      targetType: "channels.${params.channelId}.token",
+      configFile: "openclaw.json",
+      pathPattern: "channels.${params.channelId}.token",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true
+    }
+  ],
+  collectRuntimeConfigAssignments(params) {
+    params.context.assignments.push({
+      path: "channels.${params.channelId}.token",
+      ref: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      expected: "string",
+      apply() {}
+    });
+  }
+};
+`,
+    "utf8",
+  );
+  return {
+    id: params.pluginId,
+    origin: "global",
+    channels: [params.channelId],
+    channelConfigs: {},
+    rootDir,
+  };
+}
+
 describe("external channel secret contract api", () => {
   beforeEach(() => {
     loadPluginMetadataSnapshotMock.mockReset();
@@ -77,6 +119,29 @@ describe("external channel secret contract api", () => {
 
   it("loads root secret-contract-api sidecars for external channel plugins", () => {
     const record = writeExternalChannelPlugin({ pluginId: "discord", channelId: "discord" });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [record],
+    });
+
+    const api = loadChannelSecretContractApi({
+      channelId: "discord",
+      config: { channels: { discord: {} } },
+      env: {},
+      loadablePluginOrigins: new Map([["discord", "global"]]),
+    });
+
+    expect(api?.secretTargetRegistryEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "channels.discord.token",
+        }),
+      ]),
+    );
+    expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
+  });
+
+  it("loads secret-contract-api from dist/ subdirectory for npm-installed plugins", () => {
+    const record = writeExternalChannelPluginInDist({ pluginId: "discord", channelId: "discord" });
     loadPluginMetadataSnapshotMock.mockReturnValue({
       plugins: [record],
     });

--- a/src/secrets/channel-contract-api.external.test.ts
+++ b/src/secrets/channel-contract-api.external.test.ts
@@ -65,6 +65,77 @@ module.exports = {
   };
 }
 
+function writeExternalChannelPluginWithBoth(params: { pluginId: string; channelId: string }) {
+  const rootDir = makeTrackedTempDir("openclaw-channel-secret-contract", tempDirs);
+  fs.writeFileSync(
+    path.join(rootDir, "secret-contract-api.cjs"),
+    `
+module.exports = {
+  secretTargetRegistryEntries: [
+    {
+      id: "channels.${params.channelId}.token",
+      targetType: "channels.${params.channelId}.token",
+      configFile: "openclaw.json",
+      pathPattern: "channels.${params.channelId}.token",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true
+    }
+  ],
+  collectRuntimeConfigAssignments(params) {
+    params.context.assignments.push({
+      path: "channels.${params.channelId}.token",
+      ref: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      expected: "string",
+      apply() {}
+    });
+  }
+};
+`,
+    "utf8",
+  );
+  const distDir = path.join(rootDir, "dist");
+  fs.mkdirSync(distDir);
+  fs.writeFileSync(
+    path.join(distDir, "secret-contract-api.cjs"),
+    `
+module.exports = {
+  secretTargetRegistryEntries: [
+    {
+      id: "channels.${params.channelId}.dist-token",
+      targetType: "channels.${params.channelId}.dist-token",
+      configFile: "openclaw.json",
+      pathPattern: "channels.${params.channelId}.dist-token",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true
+    }
+  ],
+  collectRuntimeConfigAssignments(params) {
+    params.context.assignments.push({
+      path: "channels.${params.channelId}.dist-token",
+      ref: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN_DIST" },
+      expected: "string",
+      apply() {}
+    });
+  }
+};
+`,
+    "utf8",
+  );
+  return {
+    id: params.pluginId,
+    origin: "global",
+    channels: [params.channelId],
+    channelConfigs: {},
+    rootDir,
+  };
+}
+
 function writeExternalChannelPluginInDist(params: { pluginId: string; channelId: string }) {
   const rootDir = makeTrackedTempDir("openclaw-channel-secret-contract", tempDirs);
   const distDir = path.join(rootDir, "dist");
@@ -177,5 +248,38 @@ describe("external channel secret contract api", () => {
     });
 
     expect(api).toBeUndefined();
+  });
+
+  it("prefers root-level contract over dist/ when both exist", () => {
+    const record = writeExternalChannelPluginWithBoth({
+      pluginId: "discord",
+      channelId: "discord",
+    });
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [record],
+    });
+
+    const api = loadChannelSecretContractApi({
+      channelId: "discord",
+      config: { channels: { discord: {} } },
+      env: {},
+      loadablePluginOrigins: new Map([["discord", "global"]]),
+    });
+
+    expect(api?.secretTargetRegistryEntries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "channels.discord.token",
+        }),
+      ]),
+    );
+    expect(api?.secretTargetRegistryEntries).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "channels.discord.dist-token",
+        }),
+      ]),
+    );
+    expect(api?.collectRuntimeConfigAssignments).toBeTypeOf("function");
   });
 });

--- a/src/secrets/channel-contract-api.ts
+++ b/src/secrets/channel-contract-api.ts
@@ -99,6 +99,21 @@ function resolvePluginContractApiPath(rootDir: string): string | null {
       return candidate;
     }
   }
+  const distDir = path.join(rootDir, "dist");
+  if (fs.existsSync(distDir)) {
+    for (const extension of orderedContractApiExtensions()) {
+      const candidate = path.join(distDir, `secret-contract-api${extension}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+    for (const extension of orderedContractApiExtensions()) {
+      const candidate = path.join(distDir, `contract-api${extension}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

Fixes #77241 — `resolvePluginContractApiPath()` does not search the `dist/` subdirectory, causing all npm-installed channel plugins to silently fail to load their secret contracts.

## Root Cause

`resolvePluginContractApiPath(rootDir)` only searches `rootDir` directly for `secret-contract-api.{ext}` and `contract-api.{ext}`. npm packages conventionally compile output to a `dist/` subdirectory, so the function returns `null` for any npm-installed channel plugin (including `@openclaw/discord`). This means Discord accounts configured via SecretRefs silently fail to start.

## Fix

Add `dist/` as an additional search directory in `resolvePluginContractApiPath`, checked after the existing root-level search. This matches the pattern already used by `public-surface-runtime.ts` and `bundled-channel-runtime.ts` for other plugin artifact resolution.

## Changes

- **`src/secrets/channel-contract-api.ts`**: After exhausting root-level candidates, check `path.join(rootDir, 'dist')` for the same contract files
- **`src/secrets/channel-contract-api.external.test.ts`**: Add test verifying contract discovery from `dist/` subdirectory
- **`CHANGELOG.md`**: Entry under Fixes

## Testing

- `npx vitest run src/secrets/channel-contract-api.external.test.ts` — 3/3 passed ✅
- New test creates a temp dir with contract file in `dist/` subdirectory and confirms `loadChannelSecretContractApi` resolves it correctly