### PR TITLE
fix(tests): repair regressions from 3434cfa381 (Model fields, mock isolation)

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -48,6 +48,9 @@ function testModelDefinition(id: string): Model<Api> {
   return {
     id,
     name: id,
+    api: "openai-completions",
+    provider: "openai",
+    baseUrl: "https://api.example.com/v1",
     reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
-import { getImageGenerationProvider, listImageGenerationProviders } from "./provider-registry.js";
+import type * as ProviderRegistry from "./provider-registry.js";
 
 const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
   resolvePluginCapabilityProvidersMock: vi.fn<() => ImageGenerationProviderPlugin[]>(() => []),
@@ -10,6 +10,9 @@ const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
 vi.mock("../plugins/capability-provider-runtime.js", () => ({
   resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
 }));
+
+let getImageGenerationProvider: typeof ProviderRegistry.getImageGenerationProvider;
+let listImageGenerationProviders: typeof ProviderRegistry.listImageGenerationProviders;
 
 function createProvider(
   params: Pick<ImageGenerationProviderPlugin, "id"> & Partial<ImageGenerationProviderPlugin>,
@@ -28,9 +31,12 @@ function createProvider(
 }
 
 describe("image-generation provider registry", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
+    ({ getImageGenerationProvider, listImageGenerationProviders } =
+      await import("./provider-registry.js"));
   });
 
   it("delegates provider resolution to the capability provider boundary", () => {

--- a/src/video-generation/provider-registry.test.ts
+++ b/src/video-generation/provider-registry.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { VideoGenerationProviderPlugin } from "../plugins/types.js";
-import { getVideoGenerationProvider, listVideoGenerationProviders } from "./provider-registry.js";
+import type * as ProviderRegistry from "./provider-registry.js";
 
 const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
   resolvePluginCapabilityProvidersMock: vi.fn<() => VideoGenerationProviderPlugin[]>(() => []),
@@ -9,6 +9,9 @@ const { resolvePluginCapabilityProvidersMock } = vi.hoisted(() => ({
 vi.mock("../plugins/capability-provider-runtime.js", () => ({
   resolvePluginCapabilityProviders: resolvePluginCapabilityProvidersMock,
 }));
+
+let getVideoGenerationProvider: typeof ProviderRegistry.getVideoGenerationProvider;
+let listVideoGenerationProviders: typeof ProviderRegistry.listVideoGenerationProviders;
 
 function createProvider(
   params: Pick<VideoGenerationProviderPlugin, "id"> & Partial<VideoGenerationProviderPlugin>,
@@ -24,9 +27,12 @@ function createProvider(
 }
 
 describe("video-generation provider registry", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     resolvePluginCapabilityProvidersMock.mockReset();
     resolvePluginCapabilityProvidersMock.mockReturnValue([]);
+    ({ getVideoGenerationProvider, listVideoGenerationProviders } =
+      await import("./provider-registry.js"));
   });
 
   it("delegates provider resolution to the capability provider boundary", () => {


### PR DESCRIPTION
## Summary

`3434cfa381 test: speed up import-heavy suites` introduced two regressions that break local `pnpm check:changed` and any PR-head CI run that completes before main's runs are auto-cancelled by newer pushes:

- `src/agents/model-auth.profiles.test.ts` — fails `tsgo:core:test` with `TS2739: Type ... is missing the following properties from type 'Model<Api>': api, provider, baseUrl`.
- `src/{image,video}-generation/provider-registry.test.ts` — three runtime tests fail per file (`delegates provider resolution to the capability provider boundary`, `uses active plugin providers without loading from disk`, `ignores prototype-like provider ids and aliases`) because the bundled-provider list leaks through the mock.

## Root cause

1. The new `testModelDefinition` helper omits the `api`, `provider`, `baseUrl` fields that `Model<Api>` (from `@mariozechner/pi-ai`) requires. The strict typecheck lane catches it.
2. The provider-registry tests were switched from `vi.resetModules()` + dynamic `await import("./provider-registry.js")` to a top-level static import. The registry caches its first `resolvePluginCapabilityProviders()` result on initial module evaluation, so without `resetModules` every `beforeEach` re-uses that first cached list. The mock's `mockReturnValue([])` is never observed by the SUT and the bundled provider list leaks through.

## Fix

1. Add the three missing fields to `testModelDefinition` with neutral dummy values. The tests don't assert on those fields; they only need them to satisfy the type.
2. Restore the original lazy-import-per-test pattern (`let getX: typeof ProviderRegistry.getX; ...; beforeEach(async () => { vi.resetModules(); ...; ({ getX, listX } = await import("./provider-registry.js")); })`) in both `image-generation/provider-registry.test.ts` and `video-generation/provider-registry.test.ts`.

The intent of `3434cfa381` was to skip `vi.resetModules()` for speed — happy to defer to a different speedup approach (e.g. dependency-injecting the resolver into the registry so module reset is unnecessary) if maintainers prefer that direction.

## Verification

- `pnpm test src/agents/model-auth.profiles.test.ts src/image-generation/provider-registry.test.ts src/video-generation/provider-registry.test.ts` — 51 + 3 + 3 passing on this branch.
- `pnpm tsgo:core:test` — clean.
- `pnpm exec oxfmt --check` — clean on touched files.

## Test plan

- [ ] Open this PR; confirm `check-test-types` and `checks-node-core-fast` lanes are green on the head SHA.
- [ ] Confirm no behavior change to non-test code.

No CHANGELOG entry — pure test repair.
