### PR TITLE
fix(plugins): forward install records to channel catalog registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify that IRC uses raw TCP/TLS sockets outside operator-managed forward proxy routing, so direct IRC egress should be explicitly approved before enabling IRC. Thanks @jesse-merhi.
 - Dependencies: refresh runtime and provider packages including Pi 0.73.0, ACPX adapters, OpenAI, Anthropic, Slack, and TypeScript native preview, while keeping the Bedrock runtime installer override pinned below the Windows ARM Node 24 npm resolver failure.
 - Contributor PRs: require external pull requests to include after-fix real behavior proof from a real OpenClaw setup, with terminal screenshots, console output, redacted runtime logs, linked artifacts, and copied live output treated as valid evidence while unit tests, mocks, lint, typechecks, snapshots, and CI remain supplemental only.
+- Plugins/catalog: add an `@tencent-weixin/openclaw-weixin` external entry pinned to `2.4.1` so onboarding and `openclaw channels add` can install the Tencent Weixin (personal WeChat) channel by default. (#77269) Thanks @pumpkinxing1.
 
 ### Fixes
 
@@ -333,6 +334,7 @@ Docs: https://docs.openclaw.ai
 - Install/postinstall: skip noisy compile-cache prune warnings when `EACCES`/`EPERM` prevent removing shared `/tmp/node-compile-cache` entries owned by another user. Fixes #76353. (#76362) Thanks @RayWoo and @neeravmakwana.
 - Agents/messaging: surface CLI subprocess watchdog/turn timeout messages to chat users when verbose failures are off, instead of collapsing them into generic external-run failure copy. Fixes #77007. (#77015) Thanks @neeravmakwana.
 - Agents/sessions: after embedded Pi runs, append assistant-visible reply text to session JSONL only when Pi did not already persist an equivalent tail assistant entry, without re-mirroring the user prompt Pi owns. Fixes #77823. (#77839) Thanks @neeravmakwana.
+- Plugins/CLI: load the install-records ledger when listing channel-catalog entries, so npm-installed third-party channel plugins resolve through `openclaw channels login`/`channels add` instead of failing with `Unsupported channel`. (#77269) Thanks @pumpkinxing1.
 
 ## 2026.5.3-1
 

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -97,7 +97,7 @@
           "label": "Weixin",
           "selectionLabel": "Weixin（微信）",
           "detailLabel": "Weixin",
-          "docsPath": "/plugins/community#weixin",
+          "docsPath": "/channels/wechat",
           "docsLabel": "weixin",
           "blurb": "Personal WeChat messaging via QR-code login.",
           "aliases": ["weixin", "wechat", "微信"],

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -114,8 +114,9 @@
           }
         },
         "install": {
-          "npmSpec": "@tencent-weixin/openclaw-weixin",
+          "npmSpec": "@tencent-weixin/openclaw-weixin@2.4.1",
           "defaultChoice": "npm",
+          "expectedIntegrity": "sha512-FZnUVMQRpKGTKezeplr/DYal+5RSif2tXE51pljIFrO8rn7bVnnvpbj81/i9UMrYbuGiom1sl8OeSDzWRDKGhQ==",
           "minHostVersion": ">=2026.3.22"
         }
       }

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -83,6 +83,44 @@
       }
     },
     {
+      "name": "@tencent-weixin/openclaw-weixin",
+      "description": "OpenClaw Weixin channel plugin by the Tencent Weixin team.",
+      "source": "external",
+      "kind": "channel",
+      "openclaw": {
+        "plugin": {
+          "id": "openclaw-weixin",
+          "label": "Weixin"
+        },
+        "channel": {
+          "id": "openclaw-weixin",
+          "label": "Weixin",
+          "selectionLabel": "Weixin（微信）",
+          "detailLabel": "Weixin",
+          "docsPath": "/plugins/community#weixin",
+          "docsLabel": "weixin",
+          "blurb": "Personal WeChat messaging via QR-code login.",
+          "aliases": ["weixin", "wechat", "微信"],
+          "order": 75
+        },
+        "channelConfigs": {
+          "openclaw-weixin": {
+            "label": "Weixin",
+            "description": "Personal WeChat conversation channel.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "install": {
+          "npmSpec": "@tencent-weixin/openclaw-weixin",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.3.22"
+        }
+      }
+    },
+    {
       "name": "@openclaw/bluebubbles",
       "description": "OpenClaw BlueBubbles channel plugin",
       "source": "official",

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -200,14 +200,14 @@ describe("doctor stale plugin config helpers", () => {
   it("removes stale third-party channel config and dependent channel refs", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["discord", "openclaw-weixin"],
+        allow: ["discord", "missing-chat-plugin"],
         entries: {
           discord: { enabled: true },
-          "openclaw-weixin": { enabled: true },
+          "missing-chat-plugin": { enabled: true },
         },
       },
       channels: {
-        "openclaw-weixin": {
+        "missing-chat-plugin": {
           enabled: true,
           token: "stale",
         },
@@ -216,7 +216,7 @@ describe("doctor stale plugin config helpers", () => {
         },
         modelByChannel: {
           openai: {
-            "openclaw-weixin": "openai/gpt-5.4",
+            "missing-chat-plugin": "openai/gpt-5.4",
             telegram: "openai/gpt-5.4",
           },
         },
@@ -224,7 +224,7 @@ describe("doctor stale plugin config helpers", () => {
       agents: {
         defaults: {
           heartbeat: {
-            target: "openclaw-weixin",
+            target: "missing-chat-plugin",
             every: "30m",
           },
         },
@@ -232,7 +232,7 @@ describe("doctor stale plugin config helpers", () => {
           {
             id: "pi",
             heartbeat: {
-              target: "openclaw-weixin",
+              target: "missing-chat-plugin",
             },
           },
           {
@@ -246,17 +246,17 @@ describe("doctor stale plugin config helpers", () => {
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- plugins.allow: removed 1 stale plugin id (openclaw-weixin)",
-      "- plugins.entries: removed 1 stale plugin entry (openclaw-weixin)",
-      "- channels: removed 1 stale channel config (openclaw-weixin)",
-      "- agents heartbeat: removed 2 stale heartbeat targets (openclaw-weixin)",
-      "- channels.modelByChannel: removed 1 stale channel model override (openclaw-weixin)",
+      "- plugins.allow: removed 1 stale plugin id (missing-chat-plugin)",
+      "- plugins.entries: removed 1 stale plugin entry (missing-chat-plugin)",
+      "- channels: removed 1 stale channel config (missing-chat-plugin)",
+      "- agents heartbeat: removed 2 stale heartbeat targets (missing-chat-plugin)",
+      "- channels.modelByChannel: removed 1 stale channel model override (missing-chat-plugin)",
     ]);
     expect(result.config.plugins?.allow).toEqual(["discord"]);
     expect(result.config.plugins?.entries).toEqual({
       discord: { enabled: true },
     });
-    expect(result.config.channels?.["openclaw-weixin"]).toBeUndefined();
+    expect(result.config.channels?.["missing-chat-plugin"]).toBeUndefined();
     expect(result.config.channels?.telegram).toEqual({ botToken: "keep" });
     expect(result.config.channels?.modelByChannel).toEqual({
       openai: {
@@ -304,25 +304,25 @@ describe("doctor stale plugin config helpers", () => {
 
   it("uses missing persisted install records as stale channel evidence", () => {
     installedPluginIndexMocks.loadInstalledPluginIndexInstallRecordsSync.mockReturnValue({
-      "openclaw-weixin": {
+      "missing-chat-plugin": {
         source: "npm",
-        resolvedName: "@tencent-weixin/openclaw-weixin",
+        resolvedName: "@example/missing-chat-plugin",
         installedAt: "2026-04-12T00:00:00.000Z",
       },
     });
 
     const result = maybeRepairStalePluginConfig({
       channels: {
-        "openclaw-weixin": {
+        "missing-chat-plugin": {
           enabled: true,
         },
       },
     } as OpenClawConfig);
 
     expect(result.changes).toEqual([
-      "- channels: removed 1 stale channel config (openclaw-weixin)",
+      "- channels: removed 1 stale channel config (missing-chat-plugin)",
     ]);
-    expect(result.config.channels?.["openclaw-weixin"]).toBeUndefined();
+    expect(result.config.channels?.["missing-chat-plugin"]).toBeUndefined();
   });
 
   it("does not auto-repair stale refs while plugin discovery has errors", () => {

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -51,6 +51,7 @@ const EXPECTED_EMPTY_CONFIG_GATEWAY_STARTUP_PLUGIN_IDS = [
   "acpx",
   "browser",
   "device-pair",
+  "discord",
   "file-transfer",
   "memory-core",
   "phone-control",

--- a/src/plugins/channel-catalog-registry.test.ts
+++ b/src/plugins/channel-catalog-registry.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import type { PluginCandidate, PluginDiscoveryResult } from "./discovery.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("./discovery.js");
+  vi.doUnmock("./installed-plugin-index-records.js");
+});
+
+const ENV: NodeJS.ProcessEnv = { HOME: "/tmp/openclaw-test-home" };
+
+const RECORDS: Record<string, PluginInstallRecord> = {
+  weixin: {
+    source: "npm",
+    spec: "@tencent-weixin/openclaw-weixin@2.3.7",
+    installPath:
+      "/tmp/openclaw-test-home/.openclaw/npm/node_modules/@tencent-weixin/openclaw-weixin",
+  } as PluginInstallRecord,
+};
+
+function emptyDiscoveryResult(): PluginDiscoveryResult {
+  return {
+    candidates: [] as PluginCandidate[],
+    diagnostics: [],
+  };
+}
+
+async function loadWithMocks(params: {
+  loadRecords?: (env: NodeJS.ProcessEnv | undefined) => Record<string, PluginInstallRecord>;
+}): Promise<{
+  module: typeof import("./channel-catalog-registry.js");
+  discoverSpy: ReturnType<typeof vi.fn>;
+  loadRecordsSpy: ReturnType<typeof vi.fn>;
+}> {
+  vi.resetModules();
+  const discoverSpy = vi.fn(() => emptyDiscoveryResult());
+  const loadRecordsSpy = vi.fn((opts: { env?: NodeJS.ProcessEnv } = {}) => {
+    return params.loadRecords ? params.loadRecords(opts.env) : RECORDS;
+  });
+
+  vi.doMock("./discovery.js", () => ({ discoverOpenClawPlugins: discoverSpy }));
+  vi.doMock("./installed-plugin-index-records.js", () => ({
+    loadInstalledPluginIndexInstallRecordsSync: loadRecordsSpy,
+  }));
+
+  const module = await import("./channel-catalog-registry.js");
+  return { module, discoverSpy, loadRecordsSpy };
+}
+
+describe("listChannelCatalogEntries", () => {
+  it("forwards lazily loaded install records to discovery when origin is unspecified", async () => {
+    const { module, discoverSpy, loadRecordsSpy } = await loadWithMocks({});
+
+    module.listChannelCatalogEntries({ env: ENV });
+
+    expect(loadRecordsSpy).toHaveBeenCalledTimes(1);
+    expect(loadRecordsSpy).toHaveBeenCalledWith({ env: ENV });
+    expect(discoverSpy).toHaveBeenCalledTimes(1);
+    expect(discoverSpy.mock.calls[0][0]).toMatchObject({
+      env: ENV,
+      installRecords: RECORDS,
+    });
+  });
+
+  it("skips ledger lookup when origin is 'bundled' and omits installRecords", async () => {
+    const { module, discoverSpy, loadRecordsSpy } = await loadWithMocks({});
+
+    module.listChannelCatalogEntries({ origin: "bundled", env: ENV });
+
+    expect(loadRecordsSpy).not.toHaveBeenCalled();
+    expect(discoverSpy).toHaveBeenCalledTimes(1);
+    expect(discoverSpy.mock.calls[0][0]).not.toHaveProperty("installRecords");
+  });
+
+  it("uses caller-supplied install records verbatim and does not load the ledger", async () => {
+    const { module, discoverSpy, loadRecordsSpy } = await loadWithMocks({});
+    const supplied: Record<string, PluginInstallRecord> = {
+      slack: {
+        source: "npm",
+        spec: "@openclaw/slack@1.0.0",
+      } as PluginInstallRecord,
+    };
+
+    module.listChannelCatalogEntries({ env: ENV, installRecords: supplied });
+
+    expect(loadRecordsSpy).not.toHaveBeenCalled();
+    expect(discoverSpy.mock.calls[0][0]).toMatchObject({ installRecords: supplied });
+  });
+
+  it("omits installRecords from discovery when the ledger is empty", async () => {
+    const { module, discoverSpy, loadRecordsSpy } = await loadWithMocks({
+      loadRecords: () => ({}),
+    });
+
+    module.listChannelCatalogEntries({ env: ENV });
+
+    expect(loadRecordsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverSpy.mock.calls[0][0]).not.toHaveProperty("installRecords");
+  });
+
+  it("treats ledger read errors as a soft fallback (no installRecords propagated)", async () => {
+    const { module, discoverSpy, loadRecordsSpy } = await loadWithMocks({
+      loadRecords: () => {
+        throw new Error("simulated reader failure");
+      },
+    });
+
+    expect(() => module.listChannelCatalogEntries({ env: ENV })).not.toThrow();
+
+    expect(loadRecordsSpy).toHaveBeenCalledTimes(1);
+    expect(discoverSpy).toHaveBeenCalledTimes(1);
+    expect(discoverSpy.mock.calls[0][0]).not.toHaveProperty("installRecords");
+  });
+});

--- a/src/plugins/channel-catalog-registry.test.ts
+++ b/src/plugins/channel-catalog-registry.test.ts
@@ -6,7 +6,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
   vi.doUnmock("./discovery.js");
-  vi.doUnmock("./installed-plugin-index-records.js");
+  vi.doUnmock("./installed-plugin-index-record-reader.js");
 });
 
 const ENV: NodeJS.ProcessEnv = { HOME: "/tmp/openclaw-test-home" };
@@ -41,7 +41,7 @@ async function loadWithMocks(params: {
   });
 
   vi.doMock("./discovery.js", () => ({ discoverOpenClawPlugins: discoverSpy }));
-  vi.doMock("./installed-plugin-index-records.js", () => ({
+  vi.doMock("./installed-plugin-index-record-reader.js", () => ({
     loadInstalledPluginIndexInstallRecordsSync: loadRecordsSpy,
   }));
 

--- a/src/plugins/channel-catalog-registry.ts
+++ b/src/plugins/channel-catalog-registry.ts
@@ -1,4 +1,6 @@
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import {
   loadPluginManifest,
   type PluginPackageChannel,
@@ -21,11 +23,20 @@ export function listChannelCatalogEntries(
     origin?: PluginOrigin;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
+    /**
+     * Optional override.  When omitted and `origin !== "bundled"`, the persisted
+     * plugin install ledger is loaded synchronously so that npm-installed
+     * channels stored outside the discovery roots are visible to the catalog.
+     * Bundled-only callers skip the load to avoid the disk read.
+     */
+    installRecords?: Record<string, PluginInstallRecord>;
   } = {},
 ): PluginChannelCatalogEntry[] {
+  const installRecords = resolveInstallRecords(params);
   return discoverOpenClawPlugins({
     workspaceDir: params.workspaceDir,
     env: params.env,
+    ...(installRecords && Object.keys(installRecords).length > 0 ? { installRecords } : {}),
   }).candidates.flatMap((candidate) => {
     if (params.origin && candidate.origin !== params.origin) {
       return [];
@@ -52,4 +63,22 @@ export function listChannelCatalogEntries(
       },
     ];
   });
+}
+
+function resolveInstallRecords(params: {
+  origin?: PluginOrigin;
+  env?: NodeJS.ProcessEnv;
+  installRecords?: Record<string, PluginInstallRecord>;
+}): Record<string, PluginInstallRecord> | undefined {
+  if (params.installRecords) {
+    return params.installRecords;
+  }
+  if (params.origin === "bundled") {
+    return undefined;
+  }
+  try {
+    return loadInstalledPluginIndexInstallRecordsSync(params.env ? { env: params.env } : {});
+  } catch {
+    return undefined;
+  }
 }

--- a/src/plugins/channel-catalog-registry.ts
+++ b/src/plugins/channel-catalog-registry.ts
@@ -1,6 +1,6 @@
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { discoverOpenClawPlugins } from "./discovery.js";
-import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
+import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-record-reader.js";
 import {
   loadPluginManifest,
   type PluginPackageChannel,


### PR DESCRIPTION
## Summary

- **Problem:** `listChannelCatalogEntries` in `src/plugins/channel-catalog-registry.ts` calls `discoverOpenClawPlugins` without forwarding `installRecords`. As a result, channels installed via `openclaw plugins install <npm-spec>` are absent from the CLI channel catalog—`openclaw channels add --channel <id>` and `openclaw channels login --channel <id>` report `Unsupported channel: <id>` / `Unknown channel: <id>` even though the ledger entry under `~/.openclaw/plugins/installs.json` is healthy.
- **Why it matters:** Every third-party npm-installed channel plugin is unreachable through the channels CLI surface. Bundled plugins (qqbot, telegram, slack, etc.) take the `stock` discovery path and were unaffected, which masked the regression.
- **What changed:** `listChannelCatalogEntries` now lazy-loads the persisted plugin install ledger via `loadInstalledPluginIndexInstallRecordsSync` when the caller does not specify `origin === "bundled"`, and forwards the records to discovery. Bundled-only callers continue to skip the disk read. Callers that already hold a record map can pass it via the new optional `installRecords` parameter to skip the lazy load. Reader errors fall back silently to "no install records" (no behavioural regression).
- **What did NOT change (scope boundary):** Other `discoverOpenClawPlugins` consumers (`bundled-capability-runtime.ts`, `bundled-sources.ts`, `config-contracts.ts`) are untouched—they target bundled-only paths or pre-load records elsewhere. No public manifest/contract types changed. `manifest-registry.ts`, `loader.ts`, and `installed-plugin-index-registry.ts` were already forwarding `installRecords` correctly; this PR only reaches feature parity for the channel-catalog-registry path.

This PR also registers \`@tencent-weixin/openclaw-weixin\` in \`scripts/lib/official-external-channel-catalog.json\` so the channel appears in onboarding flows that consult the catalog directly (mirroring the WeCom and Yuanbao entries).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra (catalog entry addition)

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** \`listChannelCatalogEntries\` predates the move to the persisted install ledger as the canonical source for npm-installed plugin discovery (see \`installed-plugin-index-registry.ts\`, \`manifest-registry.ts\`, and \`loader.ts\`, which all forward \`installRecords\` to \`discoverOpenClawPlugins\`). The catalog-registry consumer was missed during that migration.
- **Missing detection / guardrail:** No test asserted that \`listChannelCatalogEntries\` could see npm-installed plugins. The closest existing coverage (\`bundled-channel-catalog-read.fail-soft.test.ts\`) only exercises the bundled soft-fail path; the \`discoverOpenClawPlugins\` tests don't reach this consumer.
- **Contributing context:** The CLI surface (\`channels add\`, \`channels login\`) reaches \`listChannelCatalogEntries\` indirectly through \`listChannelPluginCatalogEntries\` in \`src/channels/plugins/catalog.ts\`. The bundled discovery path stays green even with this bug, so bundled channel tests didn't catch it.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- **Target test or file:** \`src/plugins/channel-catalog-registry.test.ts\` (new)
- **Scenario the test should lock in:** When \`origin !== "bundled"\`, \`listChannelCatalogEntries\` MUST forward install records to \`discoverOpenClawPlugins\`. When \`origin === "bundled"\`, the ledger MUST NOT be read. Caller-supplied \`installRecords\` MUST replace the lazy load. Empty ledgers and reader errors MUST omit \`installRecords\` from the discovery call without throwing.
- **Why this is the smallest reliable guardrail:** The bug was a silently-omitted argument; the test mocks both \`discoverOpenClawPlugins\` and the ledger reader, then asserts the call signature, so any future regression that drops the parameter again surfaces immediately.
- **Existing test that already covers this:** None.
- **If no new test is added, why not:** N/A.

## User-visible / Behavior Changes

- \`openclaw channels add --channel <id>\` and \`openclaw channels login --channel <id>\` now resolve npm-installed channel plugins recorded in \`~/.openclaw/plugins/installs.json\`. Previously they returned \`Unsupported channel: <id>\` / \`Unknown channel: <id>\` for any third-party plugin.
- \`@tencent-weixin/openclaw-weixin\` appears in the official external channel catalog (\`source: "external"\`, \`kind: "channel"\`).

## Diagram

\`\`\`text
Before:
  channels add/login → listChannelCatalogEntries → discoverOpenClawPlugins({ workspaceDir, env })
                                                                              ^ no installRecords; npm-installed plugins invisible to catalog

After:
  channels add/login → listChannelCatalogEntries
                          ├─ if origin !== "bundled": loadInstalledPluginIndexInstallRecordsSync()
                          └─ discoverOpenClawPlugins({ workspaceDir, env, installRecords })
                                                                              ^ npm-installed plugins discoverable
\`\`\`

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No** (\`~/.openclaw/plugins/installs.json\` was already read by sibling discovery callers)
- If any \`Yes\`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (TencentOS, x64)
- Runtime/container: Node v22.x, host source checkout via \`pnpm install && pnpm start\`
- Model/provider: N/A
- Integration/channel: \`openclaw-weixin\`
- Relevant config (redacted): \`OPENCLAW_STATE_DIR=/tmp/openclaw-fix-verify\`

### Steps

1. \`pnpm install\`
2. \`OPENCLAW_STATE_DIR=/tmp/openclaw-fix-verify pnpm start plugins install @tencent-weixin/openclaw-weixin\`
3. \`OPENCLAW_STATE_DIR=/tmp/openclaw-fix-verify pnpm start channels add --channel openclaw-weixin --account default ...\`

### Expected

- Channel resolves; the per-channel \`applyAccountConfig\` flow runs.

### Actual

- Before fix: \`Unknown channel: openclaw-weixin\`.
- After fix: channel resolves and the add flow proceeds.

## Evidence

- [x] Failing test/log before + passing after — 5 unit cases in \`src/plugins/channel-catalog-registry.test.ts\` (all pass via \`npx vitest run src/plugins/channel-catalog-registry.test.ts\`).
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- **Verified scenarios:**
  - Local source checkout on Linux. Installed \`@tencent-weixin/openclaw-weixin@2.4.1\` against an isolated \`OPENCLAW_STATE_DIR\`; ledger entry verified; \`pnpm start channels add --channel openclaw-weixin\` now resolves the channel through the patched catalog path.
  - 5/5 unit tests in the new \`channel-catalog-registry.test.ts\` cover lazy-load, bundled-skip, caller-supplied, empty-ledger, and reader-error paths.
- **Edge cases checked:**
  - Bundled-only callers continue to skip the ledger read (no extra disk I/O).
  - Reader failure does not throw — silently falls back to no \`installRecords\`.
- **What I did NOT verify:**
  - Non-Linux environments (macOS, Windows).
  - End-to-end UX in onboarding/control-ui surfaces (beyond the channels CLI).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** \`loadInstalledPluginIndexInstallRecordsSync\` performs a synchronous disk read on every catalog list call when \`origin\` is unspecified. This is consistent with sibling discovery consumers (\`installed-plugin-index-registry.ts\`, \`loader.ts\`, etc.) but adds one ledger read on hot CLI paths like \`channels add\`.
  - **Mitigation:** Bundled-only callers skip the read. Callers that already loaded records can pass \`installRecords\` to avoid the duplicate read.
- **Risk:** The new catalog entry intentionally omits \`expectedIntegrity\` (\`npmSpec\` is unpinned, matching the \`@openclaw/*\` entries). External-source entries like \`wecom\` and \`yuanbao\` are version-pinned.
  - **Mitigation:** Treat the entry as discovery metadata only; install integrity is enforced by the install ledger, not the catalog file. We can pin the spec + integrity in a follow-up once a stable release line is in place.