### PR TITLE
[AI-assisted] fix: secrets apply preserves auth-profile keyRef holding a SecretRef object

### DIFF
--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -303,6 +303,50 @@ describe("secrets apply", () => {
     expect(nextEnv).toContain("UNRELATED=value");
   });
 
+  it("preserves auth-profile keyRef when it holds a SecretRef object (#77300)", async () => {
+    const secretRef = { source: "file", provider: "local_keys", id: "/OPENAI_API_KEY" };
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: secretRef,
+        },
+      },
+    });
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: {
+            ...createOpenAiProviderConfig(),
+            apiKey: "secretref-managed",
+          },
+        },
+      },
+    });
+
+    const plan = createPlan({
+      targets: [createOpenAiProviderTarget()],
+      options: createOneWayScrubOptions(),
+    });
+
+    const applied = await runSecretsApply({ plan, env: fixture.env, write: true });
+    expect(applied.mode).toBe("write");
+
+    const nextAuthStore = JSON.parse(await fs.readFile(fixture.authStorePath, "utf8")) as {
+      profiles: {
+        "openai:default": {
+          key?: string;
+          keyRef?: unknown;
+        };
+      };
+    };
+
+    expect(nextAuthStore.profiles["openai:default"].key).toBeUndefined();
+    expect(nextAuthStore.profiles["openai:default"].keyRef).toEqual(secretRef);
+  });
+
   it("skips exec SecretRef checks during dry-run unless explicitly allowed", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -411,7 +411,10 @@ function scrubAuthStoresForProviderTargets(params: {
           delete profile.profile[profile.valueField];
           mutated = true;
         }
-        if (profile.refField in profile.profile) {
+        // Preserve refField when it holds a SecretRef object — the auth
+        // profile is the canonical credential source and takes precedence
+        // over models.providers.<X>.apiKey (see REF_SHADOWED audit note).
+        if (profile.refField in profile.profile && !isRecord(profile.refValue)) {
           delete profile.profile[profile.refField];
           mutated = true;
         }


### PR DESCRIPTION
## Summary

Fixes #77300.

`secrets apply` with `scrubAuthProfilesForProviderTargets=true` unconditionally deleted both the plaintext value field and the ref field from matching auth profiles. When the `keyRef` held a valid SecretRef object (the canonical credential source per the `REF_SHADOWED` audit note), this silently stripped the credential reference, leaving the auth profile credentialless with no audit signal.

## Root Cause

In `src/secrets/apply.ts`, `scrubAuthStoresForProviderTargets` deleted `profile.refField` without checking whether the value was a SecretRef object or a plaintext string. Both were treated identically.

## Fix

Guard the `refField` deletion with `!isRecord(profile.refValue)` so that:
- **Plaintext ref values** (strings) are still scrubbed as before.
- **SecretRef objects** (records with `source`/`provider`/`id`) are preserved, since the auth profile is the canonical credential source.

## Regression Test Plan

Added a test case `"preserves auth-profile keyRef when it holds a SecretRef object (#77300)"` that:
1. Seeds an auth profile with a SecretRef `keyRef` (no plaintext key).
2. Runs `secrets apply` with `scrubAuthProfilesForProviderTargets: true`.
3. Asserts the `keyRef` is preserved and the plaintext `key` field remains absent.

All 18 tests in `src/secrets/apply.test.ts` pass.

## Security Impact

None. This change makes the scrub more conservative — it preserves existing SecretRef objects instead of deleting them. No new credential exposure paths are introduced.

## Files Changed

- `src/secrets/apply.ts` — guard `refField` deletion with `isRecord` check (1 line)
- `src/secrets/apply.test.ts` — regression test for #77300
