### PR TITLE
docs(cli-backends): clarify /think and /reasoning are inert on CLI backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/cli-backends: call out that `/think` and `/reasoning` directives are inert against CLI backends because OpenClaw spawns the underlying CLI with a fixed argv. Refs #77303. Thanks @lonexreb.
 - Docker/Gateway: harden the gateway container by dropping `NET_RAW` and `NET_ADMIN` capabilities and enabling `no-new-privileges` in the bundled `docker-compose.yml`. Thanks @VintageAyu.
 - Telegram: accept plugin-owned numeric forum-topic targets in the agent message tool and keep reply-dispatch provider chunks behind a real stable runtime alias during in-place package updates. Fixes #77137. Thanks @richardmqq.
 - Channels/WhatsApp: support explicit WhatsApp Channel/Newsletter `@newsletter` outbound message targets with channel session metadata instead of DM routing. Fixes #13417; carries forward the narrow outbound target idea from #13424. Thanks @vincentkoc and @agentz-manfred.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -401,6 +401,17 @@ children and Streamable HTTP/SSE streams do not outlive the run.
 - **Codex CLI sessions** resume via text output (no JSONL), which is less
   structured than the initial `--json` run. OpenClaw sessions still work
   normally.
+- **`/think` and `/reasoning` directives are inert against CLI backends.**
+  CLI backends spawn the underlying CLI with a fixed argv (see
+  [Defaults (plugin-owned)](#defaults-plugin-owned)) and OpenClaw does not
+  rewrite that argv per request from the session's stored thinking or
+  reasoning level. `/status` still surfaces the stored level for the active
+  session, but it only takes effect on API-mode providers — for example,
+  switching from `claude-cli` (subscription) to `anthropic` (API key) on the
+  same Anthropic model. When you need extended thinking on a CLI subscription
+  path, drive the underlying CLI's own thinking/effort UI directly (for the
+  Anthropic CLI, that is `claude`'s in-TUI thinking budget), or move the
+  agent to an API-mode provider for that conversation.
 
 ## Troubleshooting
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -36,6 +36,7 @@ title: "Thinking levels"
   - MiniMax (`minimax/*`) on the Anthropic-compatible streaming path defaults to `thinking: { type: "disabled" }` unless you explicitly set thinking in model params or request params. This avoids leaked `reasoning_content` deltas from MiniMax's non-native Anthropic stream format.
   - Z.AI (`zai/*`) only supports binary thinking (`on`/`off`). Any non-`off` level is treated as `on` (mapped to `low`).
   - Moonshot (`moonshot/*`) maps `/think off` to `thinking: { type: "disabled" }` and any non-`off` level to `thinking: { type: "enabled" }`. When thinking is enabled, Moonshot only accepts `tool_choice` `auto|none`; OpenClaw normalizes incompatible values to `auto`.
+- **CLI backends do not honor `/think` or `/reasoning`.** When a session is bound to a CLI backend (for example `claude-cli`, `codex-cli`, `gemini-cli`), OpenClaw spawns the underlying CLI with a fixed argv and does not rewrite that argv per request from the stored thinking level. `/status` keeps showing the stored level, but it only takes effect when the conversation is routed through an API-mode provider on the same model. See [CLI backends - Limitations](/gateway/cli-backends#limitations).
 
 ## Resolution order
 


### PR DESCRIPTION
## Summary

Refs #77303 — operators driving Anthropic Claude through `claude-cli`
(subscription) report that `/status` shows a thinking level but no thinking
blocks ever arrive. The reporter found the underlying claude CLI accepts
`--effort <low|medium|high|xhigh|max>` but OpenClaw never passes it.

This is the contract today: the `CliBackendPlugin` config in
`extensions/anthropic/cli-backend.ts` (and `codex`/`gemini` equivalents)
declares a fixed argv. The CLI runner in `src/agents/cli-runner/*` does not
read `thinkingLevel` / `reasoningLevel` from session state, and
`CliBackendPrepareExecutionContext` exposes env/cleanup hooks only — there is
no per-request argv-rewrite seam. Adding one would be a Plugin-SDK boundary
change, so this PR takes the documentation path the bug filer suggested as
option (b).

## Changes

- `docs/gateway/cli-backends.md` Limitations: explain why CLI-backend argv
  stays fixed, what `/status` ends up showing, and what to do instead (drive
  the underlying CLI's own thinking UI directly, or move the conversation to
  an API-mode provider on the same model).
- `docs/tools/thinking.md` Provider notes: cross-link the CLI-backend
  limitation so users hunting for `/think` from the thinking docs land on it.
- CHANGELOG entry under Unreleased > Changes.

## Verification

- `pnpm exec oxfmt --check --threads=1 docs/gateway/cli-backends.md docs/tools/thinking.md CHANGELOG.md` — clean.
- Docs-only change; no source touched, no test/build gate required.

## Notes for maintainers

Option (a) from the issue (plumbing `thinkingLevel` → `--effort` for
claude-cli) is a deliberate non-goal of this PR — it would require:

1. Threading `thinkingLevel` through `prepareCliRun` into the spawn argv
   construction.
2. A new SDK seam (e.g. `prepareArgs(ctx)` on `CliBackendPlugin`) so each
   backend can map its own thinking levels to its own flag dialect
   (`--effort` for `claude`, distinct args for `codex`/`gemini`).
3. Per-backend dialect mappings.

That's owner work given the SDK boundary impact (per `extensions/CLAUDE.md`
and `src/plugin-sdk/CLAUDE.md`). This docs PR keeps users from being
surprised by the inert toggle while that larger seam is considered.

## Closes

Refs #77303

## Real behavior proof

This is a docs-only change to `docs/gateway/cli-backends.md` and `docs/tools/thinking.md`. Proof is the rendered limitation note: users reading either page now see the explicit "`/think` and `/reasoning` directives are inert against CLI backends" caveat. The underlying behavior was already verifiable — `extensions/anthropic/cli-backend.ts` declares static argv and `src/agents/cli-runner/helpers.ts:380` (`buildCliArgs`) does not consume per-request thinking levels — so this PR documents the existing contract without changing it.
