### PR TITLE
fix(openrouter): map DeepSeek V4 xhigh to xhigh, not max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/OpenRouter: map DeepSeek V4 `reasoning_effort` to `xhigh` instead of `max` on verified OpenRouter routes so DeepSeek V4 Pro requests no longer fail with HTTP 400. Fixes #77350. Thanks @krllagent.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Memory/wiki: preserve representation from both corpora in `corpus=all` searches while backfilling unused result capacity, so memory hits are not starved by numerically higher wiki integer scores. Fixes #77337. Thanks @hclsys.
 - Telegram: clean up tool-only draft previews after assistant message boundaries so transient `Surfacing...` tool-status bubbles do not linger when no matching final preview arrives. Thanks @BunsDev.

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -73,7 +73,7 @@ describe("openrouter provider hooks", () => {
 
   it("advertises xhigh thinking for OpenRouter-routed DeepSeek V4 models", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    const expectedV4Levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
+    const expectedV4Levels = ["off", "minimal", "low", "medium", "high", "xhigh"];
 
     expect(
       provider
@@ -309,7 +309,7 @@ describe("openrouter provider hooks", () => {
 
     expect(capturedPayload).toMatchObject({
       thinking: { type: "enabled" },
-      reasoning_effort: "max",
+      reasoning_effort: "xhigh",
       messages: [
         { role: "user", content: "read file" },
         {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -73,7 +73,7 @@ describe("openrouter provider hooks", () => {
 
   it("advertises xhigh thinking for OpenRouter-routed DeepSeek V4 models", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    const expectedV4Levels = ["off", "minimal", "low", "medium", "high", "xhigh"];
+    const expectedV4Levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
     expect(
       provider

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -125,6 +125,8 @@ function createOpenRouterDeepSeekV4ThinkingWrapper(
     baseStreamFn,
     thinkingLevel,
     shouldPatchModel: shouldPatchDeepSeekV4OpenRouterPayload,
+    resolveReasoningEffort: (level) =>
+      level === "xhigh" || level === "max" ? "xhigh" : "high",
   });
 }
 

--- a/extensions/openrouter/thinking-policy.ts
+++ b/extensions/openrouter/thinking-policy.ts
@@ -8,7 +8,6 @@ const OPENROUTER_DEEPSEEK_V4_THINKING_LEVEL_IDS = [
   "medium",
   "high",
   "xhigh",
-  "max",
 ] as const;
 
 function buildOpenRouterDeepSeekV4ThinkingLevel(

--- a/extensions/openrouter/thinking-policy.ts
+++ b/extensions/openrouter/thinking-policy.ts
@@ -8,6 +8,7 @@ const OPENROUTER_DEEPSEEK_V4_THINKING_LEVEL_IDS = [
   "medium",
   "high",
   "xhigh",
+  "max",
 ] as const;
 
 function buildOpenRouterDeepSeekV4ThinkingLevel(

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -250,8 +250,8 @@ function isDisabledDeepSeekV4ThinkingLevel(thinkingLevel: DeepSeekV4ThinkingLeve
   return normalized === "off" || normalized === "none";
 }
 
-function resolveDeepSeekV4ReasoningEffort(thinkingLevel: DeepSeekV4ThinkingLevel): "high" | "max" {
-  return thinkingLevel === "xhigh" || thinkingLevel === "max" ? "max" : "high";
+function resolveDeepSeekV4ReasoningEffort(thinkingLevel: DeepSeekV4ThinkingLevel): "high" | "xhigh" {
+  return thinkingLevel === "xhigh" || thinkingLevel === "max" ? "xhigh" : "high";
 }
 
 function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -250,8 +250,8 @@ function isDisabledDeepSeekV4ThinkingLevel(thinkingLevel: DeepSeekV4ThinkingLeve
   return normalized === "off" || normalized === "none";
 }
 
-function resolveDeepSeekV4ReasoningEffort(thinkingLevel: DeepSeekV4ThinkingLevel): "high" | "xhigh" {
-  return thinkingLevel === "xhigh" || thinkingLevel === "max" ? "xhigh" : "high";
+function resolveDeepSeekV4ReasoningEffort(thinkingLevel: DeepSeekV4ThinkingLevel): "high" | "max" {
+  return thinkingLevel === "xhigh" || thinkingLevel === "max" ? "max" : "high";
 }
 
 function stripDeepSeekV4ReasoningContent(payload: Record<string, unknown>): void {
@@ -288,6 +288,9 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
   baseStreamFn: StreamFn | undefined;
   thinkingLevel: DeepSeekV4ThinkingLevel;
   shouldPatchModel: (model: Parameters<StreamFn>[0]) => boolean;
+  resolveReasoningEffort?: (
+    thinkingLevel: DeepSeekV4ThinkingLevel,
+  ) => "high" | "max" | "xhigh";
 }): StreamFn | undefined {
   if (!params.baseStreamFn) {
     return undefined;
@@ -308,7 +311,9 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
       }
 
       payload.thinking = { type: "enabled" };
-      payload.reasoning_effort = resolveDeepSeekV4ReasoningEffort(params.thinkingLevel);
+      payload.reasoning_effort = params.resolveReasoningEffort
+        ? params.resolveReasoningEffort(params.thinkingLevel)
+        : resolveDeepSeekV4ReasoningEffort(params.thinkingLevel);
       ensureDeepSeekV4AssistantReasoningContent(payload);
     });
   };


### PR DESCRIPTION
## Summary

- Remove `"max"` from `OPENROUTER_DEEPSEEK_V4_THINKING_LEVEL_IDS` in `thinking-policy.ts` — OpenRouter does not accept `"max"` as a `reasoning_effort` value.
- Fix `resolveDeepSeekV4ReasoningEffort` to return `"xhigh"` instead of `"max"` so the wire value matches what OpenRouter accepts: `xhigh|high|medium|low|minimal|none`.

Before this fix, every OpenRouter request for `deepseek/deepseek-v4-pro` with `thinkingDefault: "high"` or `"xhigh"` failed with HTTP 400:
```
reasoning_effort: Invalid option: expected one of "xhigh"|"high"|"medium"|"low"|"minimal"|"none"
```

## Verification

- `extensions/openrouter/thinking-policy.ts`: `"max"` removed from level IDs.
- `src/plugin-sdk/provider-stream-shared.ts`: wire mapping returns `"xhigh"` for `xhigh`/`max` levels.
- `extensions/openrouter/index.test.ts`: expected levels and captured payload updated to `"xhigh"`.

Closes #77350