### PR TITLE
fix(cli): clean up agent CLI runtimes

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { disposeRegisteredAgentHarnesses } from "../../agents/harness/registry.js";
 import { agentCliCommand } from "../../commands/agent-via-gateway.js";
 import {
   agentsAddCommand,
@@ -19,6 +20,22 @@ import { hasExplicitOptions } from "../command-options.js";
 import { createDefaultDeps } from "../deps.js";
 import { formatHelpExamples } from "../help-format.js";
 import { collectOption } from "./helpers.js";
+
+async function disposeAgentHarnessesForCli(): Promise<void> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      disposeRegisteredAgentHarnesses().catch(() => {}),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, 5_000);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 export function registerAgentCommands(program: Command, args: { agentChannelOptions: string }) {
   program
@@ -84,7 +101,11 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       // Build default deps (keeps parity with other commands; future-proofing).
       const deps = createDefaultDeps();
       await runCommandWithRuntime(defaultRuntime, async () => {
-        await agentCliCommand(opts, defaultRuntime, deps);
+        try {
+          await agentCliCommand(opts, defaultRuntime, deps);
+        } finally {
+          await disposeAgentHarnessesForCli();
+        }
       });
     });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -200,7 +200,12 @@ async function closeCliMemoryManagers(): Promise<void> {
       return;
     }
     const { closeActiveMemorySearchManagers } = await import("../plugins/memory-runtime.js");
-    await closeActiveMemorySearchManagers();
+    const closePromise = closeActiveMemorySearchManagers().catch(() => {});
+    const timeoutPromise = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 5_000);
+      timer.unref?.();
+    });
+    await Promise.race([closePromise, timeoutPromise]);
   } catch {
     // Best-effort teardown for short-lived CLI processes. Package updates can
     // replace hashed chunks before this finalizer runs.
@@ -352,7 +357,7 @@ export async function runCli(argv: string[] = process.argv) {
     throw new Error("--container cannot be combined with --profile/--dev");
   }
 
-  const containerTarget = maybeRunCliInContainer(originalArgv);
+  containerTarget = maybeRunCliInContainer(originalArgv);
   if (containerTarget.handled) {
     if (containerTarget.exitCode !== 0) {
       process.exitCode = containerTarget.exitCode;


### PR DESCRIPTION
## Summary
- Dispose registered agent harnesses after `openclaw agent` runs so embedded Codex app-server clients do not keep CLI processes alive.
- Bound CLI memory-manager cleanup to 5 seconds so shutdown cannot hang indefinitely.

## Verification
- `pnpm exec oxfmt --check --threads=1 src/cli/program/register.agent.ts src/cli/run-main.ts`
- `pnpm vitest run src/cli/program/register.agent.test.ts src/cli/run-main.exit.test.ts --reporter=dot`
- Local smoke: `openclaw agent --local ... --message 'Return exactly: OK'` exits 0 after printing OK.