### PR TITLE
fix(gateway): clamp unbound websocket auth scopes [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -31,6 +31,24 @@ export function resolveGatewayConfigPath(snapshot?: Pick<ConfigWriteSnapshot, "p
   return snapshot?.path ?? createConfigIO().configPath;
 }
 
+function normalizeStringListForAuthCompare(items: readonly string[] | undefined): string[] {
+  return [...(items ?? [])].toSorted();
+}
+
+function normalizeTrustedProxyAuthForCompare(auth: ReturnType<typeof resolveGatewayAuth>): {
+  userHeader: string | undefined;
+  requiredHeaders: string[];
+  allowUsers: string[];
+  allowLoopback: boolean | undefined;
+} {
+  return {
+    userHeader: auth.trustedProxy?.userHeader,
+    requiredHeaders: normalizeStringListForAuthCompare(auth.trustedProxy?.requiredHeaders),
+    allowUsers: normalizeStringListForAuthCompare(auth.trustedProxy?.allowUsers),
+    allowLoopback: auth.trustedProxy?.allowLoopback,
+  };
+}
+
 export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawConfig): boolean {
   const prevResolvedAuth = resolveGatewayAuth({
     authConfig: prev.gateway?.auth,
@@ -47,8 +65,14 @@ export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawC
       return true;
     }
     return (
-      !isDeepStrictEqual(prevResolvedAuth.trustedProxy, nextResolvedAuth.trustedProxy) ||
-      !isDeepStrictEqual(prev.gateway?.trustedProxies ?? [], next.gateway?.trustedProxies ?? [])
+      !isDeepStrictEqual(
+        normalizeTrustedProxyAuthForCompare(prevResolvedAuth),
+        normalizeTrustedProxyAuthForCompare(nextResolvedAuth),
+      ) ||
+      !isDeepStrictEqual(
+        normalizeStringListForAuthCompare(prev.gateway?.trustedProxies),
+        normalizeStringListForAuthCompare(next.gateway?.trustedProxies),
+      )
     );
   }
 

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -13,7 +13,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
-import { resolveEffectiveSharedGatewayAuth } from "../auth.js";
+import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
 import { buildGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
 import { formatControlPlaneActor, type ControlPlaneActor } from "../control-plane-audit.js";
@@ -32,6 +32,26 @@ export function resolveGatewayConfigPath(snapshot?: Pick<ConfigWriteSnapshot, "p
 }
 
 export function didSharedGatewayAuthChange(prev: OpenClawConfig, next: OpenClawConfig): boolean {
+  const prevResolvedAuth = resolveGatewayAuth({
+    authConfig: prev.gateway?.auth,
+    env: process.env,
+    tailscaleMode: prev.gateway?.tailscale?.mode,
+  });
+  const nextResolvedAuth = resolveGatewayAuth({
+    authConfig: next.gateway?.auth,
+    env: process.env,
+    tailscaleMode: next.gateway?.tailscale?.mode,
+  });
+  if (prevResolvedAuth.mode === "trusted-proxy" || nextResolvedAuth.mode === "trusted-proxy") {
+    if (prevResolvedAuth.mode !== nextResolvedAuth.mode) {
+      return true;
+    }
+    return (
+      !isDeepStrictEqual(prevResolvedAuth.trustedProxy, nextResolvedAuth.trustedProxy) ||
+      !isDeepStrictEqual(prev.gateway?.trustedProxies ?? [], next.gateway?.trustedProxies ?? [])
+    );
+  }
+
   const prevAuth = resolveEffectiveSharedGatewayAuth({
     authConfig: prev.gateway?.auth,
     env: process.env,

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -168,6 +168,46 @@ describe("config shared auth disconnects", () => {
     expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
   });
 
+  it("disconnects gateway-auth clients when active trusted-proxy policy changes", async () => {
+    const prevConfig: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            allowUsers: ["alice@example.com"],
+          },
+        },
+        trustedProxies: ["127.0.0.1"],
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options, disconnectClientsUsingSharedGatewayAuth } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({
+          gateway: {
+            auth: {
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowUsers: ["bob@example.com"],
+              },
+            },
+          },
+        }),
+        restartDelayMs: 1_000,
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
+  });
+
   it("still schedules a direct restart for hot mode when the reloader cannot apply the change", async () => {
     const prevConfig: OpenClawConfig = {
       gateway: {

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -208,6 +208,83 @@ describe("config shared auth disconnects", () => {
     expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
   });
 
+  it("disconnects gateway-auth clients when trusted-proxy source list changes", async () => {
+    const prevConfig: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+          },
+        },
+        trustedProxies: ["127.0.0.1"],
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options, disconnectClientsUsingSharedGatewayAuth } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({
+          gateway: {
+            trustedProxies: ["10.0.0.10"],
+          },
+        }),
+        restartDelayMs: 1_000,
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not disconnect gateway-auth clients when trusted-proxy lists are reordered", async () => {
+    const prevConfig: OpenClawConfig = {
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
+            allowUsers: ["alice@example.com", "bob@example.com"],
+          },
+        },
+        trustedProxies: ["127.0.0.1", "10.0.0.10"],
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options, disconnectClientsUsingSharedGatewayAuth } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({
+          gateway: {
+            auth: {
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                requiredHeaders: ["x-forwarded-host", "x-forwarded-proto"],
+                allowUsers: ["bob@example.com", "alice@example.com"],
+              },
+            },
+            trustedProxies: ["10.0.0.10", "127.0.0.1"],
+          },
+        }),
+        restartDelayMs: 1_000,
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
+  });
+
   it("still schedules a direct restart for hot mode when the reloader cannot apply the change", async () => {
     const prevConfig: OpenClawConfig = {
       gateway: {

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -332,7 +332,7 @@ describe("gateway auth compatibility baseline", () => {
       }
     });
 
-    test("keeps auth-none control ui first-connect token handoff unchanged", async () => {
+    test("keeps auth-none control ui first-connect token absence unchanged", async () => {
       const ws = await openWs(port, { origin: originForPort(port) });
       try {
         const deviceIdentityPath = path.join(
@@ -353,7 +353,7 @@ describe("gateway auth compatibility baseline", () => {
               };
             }
           | undefined;
-        expect(typeof helloOk?.auth?.deviceToken).toBe("string");
+        expect(helloOk?.auth?.deviceToken).toBeUndefined();
       } finally {
         ws.close();
       }

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -6,7 +6,9 @@ import {
   connectReq,
   CONTROL_UI_CLIENT,
   ConnectErrorDetailCodes,
+  createSignedDevice,
   getFreePort,
+  readConnectChallengeNonce,
   openWs,
   originForPort,
   rpcReq,
@@ -347,6 +349,63 @@ describe("gateway auth compatibility baseline", () => {
             }
           | undefined;
         expect(helloOk?.auth?.deviceToken).toBeUndefined();
+      } finally {
+        ws.close();
+      }
+    });
+
+    test("keeps auth-none control ui stale-key token handoff unchanged", async () => {
+      const ws = await openWs(port);
+      try {
+        const { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem } =
+          await import("../infra/device-identity.js");
+        const { approveDevicePairing, requestDevicePairing } =
+          await import("../infra/device-pairing.js");
+        const nonce = await readConnectChallengeNonce(ws);
+        const identityPath = path.join(
+          os.tmpdir(),
+          `openclaw-auth-none-control-ui-${process.pid}-${port}.json`,
+        );
+        const staleIdentityPath = path.join(
+          os.tmpdir(),
+          `openclaw-auth-none-control-ui-stale-${process.pid}-${port}.json`,
+        );
+        const { identity, device } = await createSignedDevice({
+          token: null,
+          scopes: ["operator.read"],
+          clientId: CONTROL_UI_CLIENT.id,
+          clientMode: CONTROL_UI_CLIENT.mode,
+          identityPath,
+          nonce,
+        });
+        const staleIdentity = loadOrCreateDeviceIdentity(staleIdentityPath);
+        const pending = await requestDevicePairing({
+          deviceId: identity.deviceId,
+          publicKey: publicKeyRawBase64UrlFromPem(staleIdentity.publicKeyPem),
+          clientId: CONTROL_UI_CLIENT.id,
+          clientMode: CONTROL_UI_CLIENT.mode,
+          role: "operator",
+          scopes: ["operator.read"],
+        });
+        await approveDevicePairing(pending.request.requestId, {
+          callerScopes: ["operator.admin"],
+        });
+
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          client: { ...CONTROL_UI_CLIENT },
+          scopes: ["operator.read"],
+          device,
+        });
+        expect(res.ok).toBe(true);
+        const helloOk = res.payload as
+          | {
+              auth?: {
+                deviceToken?: unknown;
+              };
+            }
+          | undefined;
+        expect(typeof helloOk?.auth?.deviceToken).toBe("string");
       } finally {
         ws.close();
       }

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -314,7 +314,7 @@ describe("gateway auth compatibility baseline", () => {
       testState.gatewayAuth = { mode: "none" };
       delete process.env.OPENCLAW_GATEWAY_TOKEN;
       port = await getFreePort();
-      server = await startGatewayServer(port);
+      server = await startGatewayServer(port, { controlUiEnabled: true });
     });
 
     afterAll(async () => {
@@ -332,13 +332,18 @@ describe("gateway auth compatibility baseline", () => {
       }
     });
 
-    test("keeps auth-none control ui first-connect token absence unchanged", async () => {
-      const ws = await openWs(port);
+    test("keeps auth-none control ui first-connect token handoff unchanged", async () => {
+      const ws = await openWs(port, { origin: originForPort(port) });
       try {
+        const deviceIdentityPath = path.join(
+          os.tmpdir(),
+          `openclaw-auth-none-control-ui-first-${process.pid}-${port}.json`,
+        );
         const res = await connectReq(ws, {
           skipDefaultAuth: true,
           client: { ...CONTROL_UI_CLIENT },
           scopes: ["operator.read"],
+          deviceIdentityPath,
         });
         expect(res.ok).toBe(true);
         const helloOk = res.payload as
@@ -348,14 +353,14 @@ describe("gateway auth compatibility baseline", () => {
               };
             }
           | undefined;
-        expect(helloOk?.auth?.deviceToken).toBeUndefined();
+        expect(typeof helloOk?.auth?.deviceToken).toBe("string");
       } finally {
         ws.close();
       }
     });
 
     test("keeps auth-none control ui stale-key token handoff unchanged", async () => {
-      const ws = await openWs(port);
+      const ws = await openWs(port, { origin: originForPort(port) });
       try {
         const { loadOrCreateDeviceIdentity, publicKeyRawBase64UrlFromPem } =
           await import("../infra/device-identity.js");

--- a/src/gateway/server.auth.compat-baseline.test.ts
+++ b/src/gateway/server.auth.compat-baseline.test.ts
@@ -329,5 +329,27 @@ describe("gateway auth compatibility baseline", () => {
         ws.close();
       }
     });
+
+    test("keeps auth-none control ui first-connect token absence unchanged", async () => {
+      const ws = await openWs(port);
+      try {
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          client: { ...CONTROL_UI_CLIENT },
+          scopes: ["operator.read"],
+        });
+        expect(res.ok).toBe(true);
+        const helloOk = res.payload as
+          | {
+              auth?: {
+                deviceToken?: unknown;
+              };
+            }
+          | undefined;
+        expect(helloOk?.auth?.deviceToken).toBeUndefined();
+      } finally {
+        ws.close();
+      }
+    });
   });
 });

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -314,6 +314,68 @@ export function registerControlUiAndPairingSuite(): void {
     });
   });
 
+  test("clamps trusted-proxy control ui scopes for unpaired device identity", async () => {
+    const { replaceConfigFile } = await import("../config/config.js");
+    testState.gatewayAuth = undefined;
+    testState.gatewayControlUi = {
+      ...testState.gatewayControlUi,
+      allowedOrigins: ["https://localhost"],
+    };
+    await replaceConfigFile({
+      nextConfig: {
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: {
+              userHeader: "x-forwarded-user",
+              requiredHeaders: ["x-forwarded-proto"],
+              allowLoopback: true,
+            },
+          },
+          trustedProxies: ["127.0.0.1"],
+          controlUi: {
+            allowedOrigins: ["https://localhost"],
+          },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
+    await withControlUiGatewayServer(async ({ port }) => {
+      const ws = await openWs(port, TRUSTED_PROXY_CONTROL_UI_HEADERS);
+      try {
+        const challengeNonce = await readConnectChallengeNonce(ws);
+        const { device } = await createSignedDevice({
+          token: null,
+          role: "operator",
+          scopes: ["operator.admin"],
+          clientId: CONTROL_UI_CLIENT.id,
+          clientMode: CONTROL_UI_CLIENT.mode,
+          nonce: challengeNonce,
+        });
+        const res = await connectReq(ws, {
+          skipDefaultAuth: true,
+          scopes: ["operator.admin"],
+          device,
+          client: { ...CONTROL_UI_CLIENT },
+        });
+        expect(res.ok).toBe(true);
+        const payload = res.payload as
+          | {
+              auth?: { scopes?: string[]; deviceToken?: string };
+            }
+          | undefined;
+        expect(payload?.auth?.scopes).toEqual([]);
+        expect(payload?.auth?.deviceToken).toBeUndefined();
+
+        const admin = await rpcReq(ws, "set-heartbeats", { enabled: false });
+        expect(admin.ok).toBe(false);
+        expect(admin.error?.message ?? "").toContain("missing scope");
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
   test("allows localhost ui clients without device identity when insecure auth is enabled", async () => {
     testState.gatewayControlUi = { allowInsecureAuth: true };
     const { server, ws, port, prevToken } = await startControlUiServerWithClient("secret", {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -735,9 +735,13 @@ export async function startGatewayServer(
         env: process.env,
         tailscaleMode,
       }),
+      config.gateway?.trustedProxies,
     );
   const resolveCurrentSharedGatewaySessionGeneration = () =>
-    resolveSharedGatewaySessionGeneration(getResolvedAuth());
+    resolveSharedGatewaySessionGeneration(
+      getResolvedAuth(),
+      getRuntimeConfig().gateway?.trustedProxies,
+    );
   const resolveSharedGatewaySessionGenerationForRuntimeSnapshot = () =>
     resolveSharedGatewaySessionGeneration(
       resolveGatewayAuth({
@@ -746,6 +750,7 @@ export async function startGatewayServer(
         env: process.env,
         tailscaleMode,
       }),
+      getRuntimeConfig().gateway?.trustedProxies,
     );
   const sharedGatewaySessionGenerationState: SharedGatewaySessionGenerationState = {
     current: resolveCurrentSharedGatewaySessionGeneration(),

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Socket } from "node:net";
 import type { RawData, WebSocket, WebSocketServer } from "ws";
+import { getRuntimeConfig } from "../../config/io.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -205,7 +206,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     resolvedAuth,
     getResolvedAuth = () => resolvedAuth,
     getRequiredSharedGatewaySessionGeneration = () =>
-      resolveSharedGatewaySessionGeneration(getResolvedAuth()),
+      resolveSharedGatewaySessionGeneration(
+        getResolvedAuth(),
+        getRuntimeConfig().gateway?.trustedProxies,
+      ),
     rateLimiter,
     browserRateLimiter,
     isStartupPending,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1139,6 +1139,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               hasServerApprovedDeviceTokenBaseline = true;
             } else if (trustedProxyAuthOk) {
               clearUnboundScopes();
+            } else if (
+              skipControlUiPairingForDevice ||
+              (skipLocalBackendSelfPairing && authMethod !== "device-token")
+            ) {
+              hasServerApprovedDeviceTokenBaseline = true;
             }
           } else {
             hasServerApprovedDeviceTokenBaseline = true;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -837,9 +837,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           rejectUnauthorized(authResult);
           return;
         }
-        if (authMethod === "token" || authMethod === "password") {
-          const sharedGatewaySessionGeneration =
-            resolveSharedGatewaySessionGeneration(resolvedAuth);
+        if (authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy") {
+          const sharedGatewaySessionGeneration = resolveSharedGatewaySessionGeneration(
+            resolvedAuth,
+            trustedProxies,
+          );
           const requiredSharedGatewaySessionGeneration =
             getRequiredSharedGatewaySessionGeneration?.();
           if (
@@ -874,6 +876,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           resolvedAuth.mode,
           authMethod,
         );
+        let hasServerApprovedDeviceTokenBaseline = false;
         if (device && devicePublicKey) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {
@@ -1133,8 +1136,12 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               if (!ok) {
                 return;
               }
+              hasServerApprovedDeviceTokenBaseline = true;
+            } else if (trustedProxyAuthOk) {
+              clearUnboundScopes();
             }
           } else {
+            hasServerApprovedDeviceTokenBaseline = true;
             const claimedPlatform = connectParams.client.platform;
             const pairedPlatform = paired.platform;
             const claimedDeviceFamily = connectParams.client.deviceFamily;
@@ -1222,9 +1229,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
         }
 
-        const deviceToken = device
-          ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
-          : null;
+        const deviceToken =
+          device && hasServerApprovedDeviceTokenBaseline
+            ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
+            : null;
         const bootstrapDeviceTokens: Array<{
           deviceToken: string;
           role: string;
@@ -1303,9 +1311,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         const canvasCapabilityExpiresAtMs = canvasCapability
           ? Date.now() + CANVAS_CAPABILITY_TTL_MS
           : undefined;
-        const usesSharedGatewayAuth = authMethod === "token" || authMethod === "password";
+        const usesSharedGatewayAuth =
+          authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
         const sharedGatewaySessionGeneration = usesSharedGatewayAuth
-          ? resolveSharedGatewaySessionGeneration(resolvedAuth)
+          ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
           : undefined;
         const scopedCanvasHostUrl =
           canvasHostUrl && canvasCapability

--- a/src/gateway/server/ws-shared-generation.test.ts
+++ b/src/gateway/server/ws-shared-generation.test.ts
@@ -8,12 +8,12 @@ describe("resolveSharedGatewaySessionGeneration", () => {
       allowTailscale: false,
       trustedProxy: {
         userHeader: "x-forwarded-user",
-        requiredHeaders: ["x-forwarded-proto"],
-        allowUsers: ["alice@example.com"],
+        requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
+        allowUsers: ["alice@example.com", "bob@example.com"],
       },
     };
 
-    const base = resolveSharedGatewaySessionGeneration(baseAuth, ["127.0.0.1"]);
+    const base = resolveSharedGatewaySessionGeneration(baseAuth, ["127.0.0.1", "10.0.0.10"]);
     expect(base).toBeDefined();
     expect(
       resolveSharedGatewaySessionGeneration(
@@ -21,13 +21,26 @@ describe("resolveSharedGatewaySessionGeneration", () => {
           ...baseAuth,
           trustedProxy: {
             ...baseAuth.trustedProxy,
-            allowUsers: ["bob@example.com"],
+            requiredHeaders: ["x-forwarded-host", "x-forwarded-proto"],
+            allowUsers: ["bob@example.com", "alice@example.com"],
           },
         },
-        ["127.0.0.1"],
+        ["10.0.0.10", "127.0.0.1"],
+      ),
+    ).toBe(base);
+    expect(
+      resolveSharedGatewaySessionGeneration(
+        {
+          ...baseAuth,
+          trustedProxy: {
+            ...baseAuth.trustedProxy,
+            allowUsers: ["carol@example.com"],
+          },
+        },
+        ["127.0.0.1", "10.0.0.10"],
       ),
     ).not.toBe(base);
-    expect(resolveSharedGatewaySessionGeneration(baseAuth, ["10.0.0.10"])).not.toBe(base);
+    expect(resolveSharedGatewaySessionGeneration(baseAuth, ["10.0.0.11"])).not.toBe(base);
   });
 
   it("keeps shared-secret generations independent from proxy allowlists", () => {

--- a/src/gateway/server/ws-shared-generation.test.ts
+++ b/src/gateway/server/ws-shared-generation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
+
+describe("resolveSharedGatewaySessionGeneration", () => {
+  it("tracks trusted-proxy policy inputs", () => {
+    const baseAuth = {
+      mode: "trusted-proxy" as const,
+      allowTailscale: false,
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+        requiredHeaders: ["x-forwarded-proto"],
+        allowUsers: ["alice@example.com"],
+      },
+    };
+
+    const base = resolveSharedGatewaySessionGeneration(baseAuth, ["127.0.0.1"]);
+    expect(base).toBeDefined();
+    expect(
+      resolveSharedGatewaySessionGeneration(
+        {
+          ...baseAuth,
+          trustedProxy: {
+            ...baseAuth.trustedProxy,
+            allowUsers: ["bob@example.com"],
+          },
+        },
+        ["127.0.0.1"],
+      ),
+    ).not.toBe(base);
+    expect(resolveSharedGatewaySessionGeneration(baseAuth, ["10.0.0.10"])).not.toBe(base);
+  });
+
+  it("keeps shared-secret generations independent from proxy allowlists", () => {
+    const auth = {
+      mode: "token" as const,
+      allowTailscale: false,
+      token: "shared-token",
+    };
+
+    expect(resolveSharedGatewaySessionGeneration(auth, ["127.0.0.1"])).toBe(
+      resolveSharedGatewaySessionGeneration(auth, ["10.0.0.10"]),
+    );
+  });
+});

--- a/src/gateway/server/ws-shared-generation.ts
+++ b/src/gateway/server/ws-shared-generation.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { GatewayTrustedProxyConfig } from "../../config/types.gateway.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 
 function resolveSharedSecret(
@@ -18,14 +19,41 @@ function resolveSharedSecret(
   return null;
 }
 
+function normalizeTrustedProxyConfig(trustedProxy: GatewayTrustedProxyConfig | undefined): {
+  userHeader: string | undefined;
+  requiredHeaders: string[];
+  allowUsers: string[];
+  allowLoopback: boolean | undefined;
+} {
+  return {
+    userHeader: trustedProxy?.userHeader,
+    requiredHeaders: [...(trustedProxy?.requiredHeaders ?? [])],
+    allowUsers: [...(trustedProxy?.allowUsers ?? [])],
+    allowLoopback: trustedProxy?.allowLoopback,
+  };
+}
+
 export function resolveSharedGatewaySessionGeneration(
   auth: ResolvedGatewayAuth,
+  trustedProxies?: readonly string[],
 ): string | undefined {
   const shared = resolveSharedSecret(auth);
-  if (!shared) {
-    return undefined;
+  if (shared) {
+    return createHash("sha256")
+      .update(`${shared.mode}\u0000${shared.secret}`, "utf8")
+      .digest("base64url");
   }
-  return createHash("sha256")
-    .update(`${shared.mode}\u0000${shared.secret}`, "utf8")
-    .digest("base64url");
+  if (auth.mode === "trusted-proxy") {
+    return createHash("sha256")
+      .update(
+        JSON.stringify({
+          mode: auth.mode,
+          trustedProxy: normalizeTrustedProxyConfig(auth.trustedProxy),
+          trustedProxies: [...(trustedProxies ?? [])],
+        }),
+        "utf8",
+      )
+      .digest("base64url");
+  }
+  return undefined;
 }

--- a/src/gateway/server/ws-shared-generation.ts
+++ b/src/gateway/server/ws-shared-generation.ts
@@ -27,8 +27,8 @@ function normalizeTrustedProxyConfig(trustedProxy: GatewayTrustedProxyConfig | u
 } {
   return {
     userHeader: trustedProxy?.userHeader,
-    requiredHeaders: [...(trustedProxy?.requiredHeaders ?? [])],
-    allowUsers: [...(trustedProxy?.allowUsers ?? [])],
+    requiredHeaders: [...(trustedProxy?.requiredHeaders ?? [])].toSorted(),
+    allowUsers: [...(trustedProxy?.allowUsers ?? [])].toSorted(),
     allowLoopback: trustedProxy?.allowLoopback,
   };
 }
@@ -49,7 +49,7 @@ export function resolveSharedGatewaySessionGeneration(
         JSON.stringify({
           mode: auth.mode,
           trustedProxy: normalizeTrustedProxyConfig(auth.trustedProxy),
-          trustedProxies: [...(trustedProxies ?? [])],
+          trustedProxies: [...(trustedProxies ?? [])].toSorted(),
         }),
         "utf8",
       )


### PR DESCRIPTION
## Summary

- Problem: trusted-proxy Control UI WebSocket sessions could retain client-requested operator scopes without a paired or otherwise approved scope baseline.
- Why it matters: Gateway RPC authorization uses cached WebSocket client scopes after connect.
- What changed: unapproved trusted-proxy Control UI scopes are clamped before device-token issuance and session caching; trusted-proxy auth policy now participates in WebSocket auth-generation invalidation.
- What did NOT change (scope boundary): paired devices, approved scope upgrades, bootstrap-approved flows, and shared token/password generation handling remain supported.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [x] This PR addresses a bug or regression

## Root Cause (if applicable)

- Root cause: the connect path used device-object presence as the boundary for preserving requested scopes, even when the device was not paired or approved.
- Missing detection / guardrail: no regression test covered signed-but-unapproved trusted-proxy Control UI connects with elevated requested scopes.
- Contributing context (if known): trusted-proxy sessions had no equivalent auth-generation guard when proxy auth policy changed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.auth.control-ui.suite.ts`, `src/gateway/server/ws-shared-generation.test.ts`, `src/gateway/server-methods/config.shared-auth.test.ts`
- Scenario the test should lock in: unapproved trusted-proxy Control UI device scopes are clamped, no device token is returned, admin-gated RPCs are rejected, and trusted-proxy policy changes invalidate gateway-auth sessions.
- Why this is the smallest reliable guardrail: it exercises the connect invariant at the WebSocket boundary and covers the generation helper separately.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Trusted-proxy Control UI WebSocket connects no longer gain operator scopes from the connect frame unless those scopes are backed by a paired/approved baseline. Active trusted-proxy WebSocket sessions are invalidated when the trusted-proxy auth policy changes.

## Diagram (if applicable)

```text
Before:
connect request -> signed unpaired device -> requested scopes cached

After:
connect request -> signed unpaired device -> scopes clamped -> cached session has no unapproved scopes
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: device tokens are withheld unless the connect flow has a paired or approved baseline; cached WebSocket scopes are reduced when no baseline exists; trusted-proxy policy changes invalidate affected sessions.

## Repro + Verification

### Environment

- OS: Not run locally
- Runtime/container: Not run locally
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI WebSocket
- Relevant config (redacted): trusted-proxy gateway auth with configured trusted proxy source and user header

### Steps

1. Start a Gateway with trusted-proxy auth enabled for Control UI WebSocket access.
2. Connect with a signed but unpaired Control UI device and requested operator admin scope.
3. Attempt an admin-gated Gateway RPC after connect.
4. Change trusted-proxy auth policy while a trusted-proxy session is active.

### Expected

- Unapproved requested scopes are clamped to an empty scope set.
- No device token is returned for the unapproved device.
- Admin-gated RPCs are rejected without an approved scope baseline.
- Active trusted-proxy sessions are closed when trusted-proxy policy changes.

### Actual

- Implemented expected behavior in the Gateway WebSocket connect flow and auth-generation handling.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Not run locally due supervisor constraints.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the WebSocket connect path, device-token issuance boundary, cached client scope assignment, trusted-proxy policy generation, and config write invalidation path.
- Edge cases checked: paired-device baseline remains eligible for token issuance; token/password generation remains independent of trusted-proxy allowlists.
- What you did **not** verify: local test execution and CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: deployments relying on unapproved client-declared scopes for trusted-proxy Control UI sessions will lose those scopes.
  - Mitigation: scope-bearing sessions must use an approved paired-device, bootstrap, or pairing baseline.
