### PR TITLE
fix: preserve gateway install env sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.
+- Gateway/install: preserve service environment value-source metadata in `openclaw gateway install`, so systemd reinstall paths keep env-file-backed secrets out of inline unit metadata. Refs #77406. Thanks @brokemac79.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/auth: update successful model auth profile status with one locked store write, reducing post-model reply latency from duplicate `auth-profiles.json` saves. Thanks @mcaxtr.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Docs: https://docs.openclaw.ai
 - Google/Gemini: normalize retired nested Gemini 3 Pro Preview ids while converting manifest catalog rows into emitted provider config, so `google/gemini-3.1-pro-preview` is used for testing instead of `google/gemini-3-pro-preview`.
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.
-- Gateway/install: preserve service environment value-source metadata in `openclaw gateway install`, so systemd reinstall paths keep env-file-backed secrets out of inline unit metadata. Refs #77406. Thanks @brokemac79.
+- Gateway/install: preserve service environment value-source metadata in `openclaw gateway install`, so systemd reinstall paths keep env-file-backed secrets out of inline unit metadata. Refs #77406, #77427. Thanks @stainlu and @brokemac79.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/auth: update successful model auth profile status with one locked store write, reducing post-model reply latency from duplicate `auth-profiles.json` saves. Thanks @mcaxtr.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -31,7 +31,15 @@ const resolveGatewayAuthMock = vi.hoisted(() =>
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
 const randomTokenMock = vi.hoisted(() => vi.fn(() => "generated-token"));
 const createInstallPlanFixture = vi.hoisted(() => {
-  return async (params?: { wrapperPath?: string; env?: Record<string, string | undefined> }) => {
+  return async (params?: {
+    wrapperPath?: string;
+    env?: Record<string, string | undefined>;
+  }): Promise<{
+    programArguments: string[];
+    workingDirectory: string;
+    environment: Record<string, string | undefined>;
+    environmentValueSources?: Record<string, string | undefined>;
+  }> => {
     const environment: Record<string, string | undefined> = {};
     if (params?.wrapperPath || params?.env?.OPENCLAW_WRAPPER) {
       environment.OPENCLAW_WRAPPER = params.wrapperPath ?? params.env?.OPENCLAW_WRAPPER;
@@ -48,7 +56,7 @@ const createInstallPlanFixture = vi.hoisted(() => {
 const buildGatewayInstallPlanMock = vi.hoisted(() => vi.fn(createInstallPlanFixture));
 const parsePortMock = vi.hoisted(() => vi.fn(() => null));
 const isGatewayDaemonRuntimeMock = vi.hoisted(() => vi.fn(() => true));
-const installDaemonServiceAndEmitMock = vi.hoisted(() => vi.fn(async () => {}));
+const installDaemonServiceAndEmitMock = vi.hoisted(() => vi.fn(async (_params?: unknown) => {}));
 
 const actionState = vi.hoisted(() => ({
   warnings: [] as string[],
@@ -224,6 +232,7 @@ describe("runDaemonInstall", () => {
     installDaemonServiceAndEmitMock.mockReset();
     service.isLoaded.mockReset();
     service.stage.mockReset();
+    service.install.mockReset();
     service.readCommand.mockReset();
     resetRuntimeCapture();
     actionState.warnings.length = 0;
@@ -254,6 +263,7 @@ describe("runDaemonInstall", () => {
     installDaemonServiceAndEmitMock.mockResolvedValue(undefined);
     service.isLoaded.mockResolvedValue(false);
     service.stage.mockResolvedValue(undefined);
+    service.install.mockResolvedValue(undefined);
     service.readCommand.mockResolvedValue(null);
     resolveNodeStartupTlsEnvironmentMock.mockReturnValue({
       NODE_EXTRA_CA_CERTS: undefined,
@@ -294,6 +304,35 @@ describe("runDaemonInstall", () => {
         warning.includes("gateway.auth.token is SecretRef-managed"),
       ),
     ).toBe(true);
+  });
+
+  it("passes service environment value sources through to service install", async () => {
+    buildGatewayInstallPlanMock.mockResolvedValueOnce({
+      programArguments: ["openclaw", "gateway", "run"],
+      workingDirectory: "/tmp",
+      environment: {
+        OPENROUTER_API_KEY: "or-operator-key",
+      },
+      environmentValueSources: {
+        OPENROUTER_API_KEY: "file",
+      },
+    });
+    installDaemonServiceAndEmitMock.mockImplementationOnce(async (params?: unknown) => {
+      await (params as { install: () => Promise<void> }).install();
+    });
+
+    await runDaemonInstall({ json: true });
+
+    expect(service.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: {
+          OPENROUTER_API_KEY: "or-operator-key",
+        },
+        environmentValueSources: {
+          OPENROUTER_API_KEY: "file",
+        },
+      }),
+    );
   });
 
   it("does not treat env-template gateway.auth.token as plaintext during install", async () => {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -160,6 +160,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         runtime: runtimeRaw,
         wrapperPath,
         existingEnvironment: existingServiceEnv,
+        existingEnvironmentValueSources: existingServiceCommand?.environmentValueSources,
         config: cfg,
       });
       if (autoRefreshMessage) {
@@ -207,21 +208,23 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     }
   }
 
-  const { programArguments, workingDirectory, environment } = await buildGatewayInstallPlan({
-    env: installEnv,
-    port,
-    runtime: runtimeRaw,
-    wrapperPath,
-    existingEnvironment: existingServiceEnv,
-    warn: (message) => {
-      if (json) {
-        warnings.push(message);
-      } else {
-        defaultRuntime.log(message);
-      }
-    },
-    config: cfg,
-  });
+  const { programArguments, workingDirectory, environment, environmentValueSources } =
+    await buildGatewayInstallPlan({
+      env: installEnv,
+      port,
+      runtime: runtimeRaw,
+      wrapperPath,
+      existingEnvironment: existingServiceEnv,
+      existingEnvironmentValueSources: existingServiceCommand?.environmentValueSources,
+      warn: (message) => {
+        if (json) {
+          warnings.push(message);
+        } else {
+          defaultRuntime.log(message);
+        }
+      },
+      config: cfg,
+    });
 
   await installDaemonServiceAndEmit({
     serviceNoun: "Gateway",
@@ -236,6 +239,7 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
         programArguments,
         workingDirectory,
         environment,
+        environmentValueSources,
       });
     },
   });
@@ -249,6 +253,7 @@ async function getGatewayServiceAutoRefreshMessage(params: {
   runtime: GatewayDaemonRuntime;
   wrapperPath?: string;
   existingEnvironment?: Record<string, string | undefined>;
+  existingEnvironmentValueSources?: GatewayServiceCommandConfig["environmentValueSources"];
   config: OpenClawConfig;
 }): Promise<string | undefined> {
   try {
@@ -264,6 +269,7 @@ async function getGatewayServiceAutoRefreshMessage(params: {
         runtime: params.runtime,
         wrapperPath: params.wrapperPath,
         existingEnvironment: params.existingEnvironment,
+        existingEnvironmentValueSources: params.existingEnvironmentValueSources,
         warn: () => undefined,
         config: params.config,
       });
@@ -284,6 +290,7 @@ async function getGatewayServiceAutoRefreshMessage(params: {
         runtime: params.runtime,
         wrapperPath: params.wrapperPath,
         existingEnvironment: params.existingEnvironment,
+        existingEnvironmentValueSources: params.existingEnvironmentValueSources,
         warn: () => undefined,
         config: params.config,
       });


### PR DESCRIPTION
Summary
- Preserve buildGatewayInstallPlan environmentValueSources in the primary gateway install CLI path.
- Pass existing service environmentValueSources into install auto-refresh planning, matching doctor/configure/onboard install paths.
- Add a regression test so env-file-backed service values keep their source metadata through the install handoff.

Behavior
Refs #77406. The bug was that openclaw gateway install computed service value-source metadata, but dropped it before calling the platform service installer. Systemd uses that metadata to distinguish inline Environment values from EnvironmentFile-backed values, so forced reinstalls could lose the env-file-backed secret shape that the rest of the service repair code expects.

## Real behavior proof

- Behavior or issue addressed: `openclaw gateway install --force` must preserve service env value-source metadata so env-file-backed secrets stay in `gateway.systemd.env` instead of being rewritten as inline `Environment=` values.
- Real environment tested: local OpenClaw checkout at `e6219d939bad787f30e421f48bace12902ee2ea5`, macOS host, Node v22.22.0, pnpm 10.33.2, temporary OpenClaw HOME/state dir. The command exercised production `stageSystemdService`/systemd unit rendering; `systemctl status` was shimmed to return success so no host service manager was modified.
- Exact steps or command run after this patch: ran a `pnpm exec tsx -e` proof script that created a temporary systemd unit/env-file setup with `environmentValueSources: { OPENROUTER_API_KEY: "file", OPENCLAW_GATEWAY_TOKEN: "inline-and-file" }`, then staged the service through OpenClaw's production systemd writer.
- Evidence after fix:

```
staged=true
unit_has_environment_file=true
unit_inline_gateway_token=true
unit_inline_openrouter_key=false
env_file_preserves_openrouter_key=true
env_file_drops_stale_gateway_token=true
```

- Observed result after fix: the staged unit kept the provider key out of inline unit metadata, preserved the env-file-backed provider key in `gateway.systemd.env`, and removed the stale file copy of the inline-managed gateway token.
- What was not tested: actual host `systemctl --user enable/restart`; the proof intentionally avoided mutating the host service manager.

Verification
- `pnpm test src/cli/daemon-cli/install.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/daemon-cli/install.ts src/cli/daemon-cli/install.test.ts`
- `git diff --check upstream/main...HEAD`
- `pnpm exec tsx -e '<temporary systemd stage proof>'`

Notes
- Blacksmith Testbox is not installed in this shell, so broad changed-gate proof is left to PR CI.
