### PR TITLE
fix(plugins): treat CalVer correction versions as compatible with plugin API ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/config: restore legacy group chat config migrations for `routing.allowFrom`, `routing.groupChat.*`, and `channels.telegram.requireMention` so upgrades keep WhatsApp, Telegram, and iMessage group mention gates and history settings instead of leaving configs invalid or silently blocked. Thanks @scoootscooob.
 - CLI/update: make package-update follow-up processes write completion results and exit explicitly, so Windows packaged upgrades do not hang after the new package finishes post-core plugin work. Thanks @vincentkoc.
 - Release validation: skip Slack live QA unless Slack credentials are explicitly configured, so release gates can keep proving non-Slack surfaces while Slack is still local and credential-gated. Thanks @vincentkoc.
-- Plugins/update: treat OpenClaw CalVer correction versions like `2026.5.3-1` as satisfying base plugin API ranges, so correction builds can install plugins that require the base runtime API. Fixes #77293. Thanks @p3nchan.
+- Plugins/update: treat OpenClaw CalVer correction versions like `2026.5.3-1` as satisfying base plugin API ranges, so correction builds can install plugins that require the base runtime API. Fixes #77293. (#77450) Thanks @p3nchan.
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/config: restore legacy group chat config migrations for `routing.allowFrom`, `routing.groupChat.*`, and `channels.telegram.requireMention` so upgrades keep WhatsApp, Telegram, and iMessage group mention gates and history settings instead of leaving configs invalid or silently blocked. Thanks @scoootscooob.
 - CLI/update: make package-update follow-up processes write completion results and exit explicitly, so Windows packaged upgrades do not hang after the new package finishes post-core plugin work. Thanks @vincentkoc.
 - Release validation: skip Slack live QA unless Slack credentials are explicitly configured, so release gates can keep proving non-Slack surfaces while Slack is still local and credential-gated. Thanks @vincentkoc.
+- Plugins/update: treat OpenClaw CalVer correction versions like `2026.5.3-1` as satisfying base plugin API ranges, so correction builds can install plugins that require the base runtime API. Fixes #77293. Thanks @p3nchan.
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -100,6 +100,12 @@ describe("clawhub helpers", () => {
     expect(satisfiesPluginApiRange("invalid", "^1.2.0")).toBe(false);
   });
 
+  it("treats OpenClaw CalVer correction versions as stable plugin API hosts", () => {
+    expect(satisfiesPluginApiRange("2026.5.3-1", ">=2026.5.3")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.5.3-2", ">=2026.5.3")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.5.3-beta.1", ">=2026.5.3")).toBe(false);
+  });
+
   it("accepts legacy bare major.minor plugin api ranges as lower bounds", () => {
     expect(satisfiesPluginApiRange("2026.5.2", "2026.4")).toBe(true);
     expect(satisfiesPluginApiRange("2026.4.0", "2026.4")).toBe(true);

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -542,6 +542,13 @@ function satisfiesSemverRange(version: string, range: string): boolean {
   return tokens.every((token) => satisfiesComparator(version, token));
 }
 
+const OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN = /^[vV]?(\d{4}\.\d{1,2}\.\d{1,2})-\d+$/;
+
+function normalizeCalVerCorrectionForPluginApi(pluginApiVersion: string): string {
+  const match = OPENCLAW_CALVER_STABLE_CORRECTION_PATTERN.exec(pluginApiVersion.trim());
+  return match?.[1] ?? pluginApiVersion;
+}
+
 function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "search">): URL {
   const url = new URL(params.path, `${normalizeBaseUrl(params.baseUrl)}/`);
   for (const [key, value] of Object.entries(params.search ?? {})) {
@@ -1046,7 +1053,10 @@ export function satisfiesPluginApiRange(
   if (!pluginApiRange) {
     return true;
   }
-  return satisfiesSemverRange(pluginApiVersion, pluginApiRange);
+  return satisfiesSemverRange(
+    normalizeCalVerCorrectionForPluginApi(pluginApiVersion),
+    pluginApiRange,
+  );
 }
 
 export function satisfiesGatewayMinimum(

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -852,6 +852,36 @@ describe("installPluginFromClawHub", () => {
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
   });
 
+  it("installs when a CalVer correction runtime satisfies the base plugin API range", async () => {
+    resolveCompatibilityHostVersionMock.mockReturnValueOnce("2026.5.3-1");
+    fetchClawHubPackageVersionMock.mockResolvedValueOnce({
+      version: {
+        version: "2026.5.3",
+        createdAt: 0,
+        changelog: "",
+        sha256hash: "a9eac48c6129bc44b6f93c9a9f48f6c700d191b7279a1e1915f28df6f59bb1af",
+        compatibility: {
+          pluginApiRange: ">=2026.5.3",
+          minGatewayVersion: "2026.3.0",
+        },
+      },
+    });
+
+    const result = await installPluginFromClawHub({
+      spec: "clawhub:demo",
+      baseUrl: "https://clawhub.ai",
+    });
+
+    expectSuccessfulClawHubInstall(result);
+    expect(downloadClawHubPackageArchiveMock).toHaveBeenCalledTimes(1);
+    expect(installPluginFromArchiveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        archivePath: "/tmp/clawhub-demo/archive.zip",
+      }),
+    );
+    expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not let a wildcard plugin API range hide an invalid runtime version", async () => {
     resolveCompatibilityHostVersionMock.mockReturnValueOnce("invalid");
     fetchClawHubPackageVersionMock.mockResolvedValueOnce({


### PR DESCRIPTION
## Problem

OpenClaw stable correction builds such as `2026.5.3-1` can expose that exact runtime version to ClawHub plugin compatibility checks. A plugin that declares `compatibility.pluginApiRange: ">=2026.5.3"` is then rejected even though the correction build should remain compatible with the base stable plugin API.

## Root Cause

The install path rejects packages in `src/plugins/clawhub.ts:986`-`995` when `satisfiesPluginApiRange(runtimeVersion, compatibility.pluginApiRange)` returns false. That predicate in `src/infra/clawhub.ts:1049`-`1059` used the generic semver comparator directly. Generic parsing in `src/infra/semver-compare.ts:29`-`44` treats `2026.5.3-1` as a prerelease, and prereleases compare lower than `2026.5.3` at `src/infra/semver-compare.ts:47`-`56`.

## Fix

- Add a plugin-API-local CalVer correction normalizer in `src/infra/clawhub.ts` for host versions matching `^[vV]?\d{4}\.\d{1,2}\.\d{1,2}-\d+$`.
- Normalize only that plugin API runtime input before range comparison.
- Leave `resolveCompatibilityHostVersion` unchanged so other runtime/version surfaces keep the real correction version.
- Keep non-numeric prereleases such as `2026.5.3-beta.1` below the stable base.

## Test Coverage

- `src/infra/clawhub.test.ts`: covers `2026.5.3-1` and `2026.5.3-2` satisfying `>=2026.5.3`, while `2026.5.3-beta.1` remains incompatible.
- `src/plugins/clawhub.test.ts`: covers a ClawHub install fixture where runtime `2026.5.3-1` accepts package range `>=2026.5.3`, while existing incompatible old-runtime coverage remains intact.
- `pnpm test src/infra/clawhub.test.ts src/plugins/clawhub.test.ts`
- `pnpm test test/scripts/check-openclaw-package-tarball.test.ts test/scripts/postinstall-bundled-plugins.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/clawhub.ts src/infra/clawhub.test.ts src/plugins/clawhub.test.ts CHANGELOG.md`

Fixes #77293