### PR TITLE
perf(plugins): memoize loadPluginManifestRegistryForInstalledIndex

### DIFF
--- a/src/plugins/installed-plugin-index-store.ts
+++ b/src/plugins/installed-plugin-index-store.ts
@@ -27,6 +27,7 @@ import {
   type LoadInstalledPluginIndexParams,
   type RefreshInstalledPluginIndexParams,
 } from "./installed-plugin-index.js";
+import { clearManifestRegistryInstalledCache } from "./manifest-registry-installed.js";
 export {
   resolveInstalledPluginIndexStorePath,
   type InstalledPluginIndexStoreOptions,
@@ -177,6 +178,7 @@ export async function writePersistedInstalledPluginIndex(
     },
   );
   clearCurrentPluginMetadataSnapshotState();
+  clearManifestRegistryInstalledCache();
   return filePath;
 }
 
@@ -187,6 +189,7 @@ export function writePersistedInstalledPluginIndexSync(
   const filePath = resolveInstalledPluginIndexStorePath(options);
   saveJsonFile(filePath, { ...index, warning: INSTALLED_PLUGIN_INDEX_WARNING });
   clearCurrentPluginMetadataSnapshotState();
+  clearManifestRegistryInstalledCache();
   return filePath;
 }
 

--- a/src/plugins/manifest-registry-installed.memo.test.ts
+++ b/src/plugins/manifest-registry-installed.memo.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Focused tests for the LRU memoization layer added to
+ * loadPluginManifestRegistryForInstalledIndex.
+ *
+ * These tests verify:
+ * - Cache hit returns the same object reference.
+ * - Different pluginIds subsets produce separate entries (no cross-bleed).
+ * - Different policyHash invalidates.
+ * - Mutation of installs.json mtime invalidates the entry.
+ * - clearCurrentPluginMetadataSnapshotState() (via clearManifestRegistryInstalledCache) clears the cache.
+ * - LRU eviction at the configured cap (16 entries).
+ *
+ * Uses a dedicated temp directory per test.  No real ~/.openclaw files are read
+ * or written — installs.json is placed in a temp stateDir when needed.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import {
+  clearManifestRegistryInstalledCache,
+  loadPluginManifestRegistryForInstalledIndex,
+} from "./manifest-registry-installed.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  cleanupTrackedTempDirs(tempDirs);
+  clearManifestRegistryInstalledCache();
+});
+
+function makeTempDir(): string {
+  return makeTrackedTempDir("openclaw-memo-test", tempDirs);
+}
+
+function writePlugin(rootDir: string, pluginId: string, modelPrefix: string): void {
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "index.ts"),
+    "throw new Error('runtime entry should not load while reading manifests');\n",
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: pluginId,
+      configSchema: { type: "object" },
+      providers: [pluginId],
+      modelSupport: { modelPrefixes: [modelPrefix] },
+    }),
+    "utf8",
+  );
+}
+
+function createIndex(
+  rootDir: string,
+  overrides: Partial<InstalledPluginIndex> = {},
+): InstalledPluginIndex {
+  return {
+    version: 1,
+    hostContractVersion: "2026.4.25",
+    compatRegistryVersion: "compat-v1",
+    migrationVersion: 1,
+    policyHash: "policy-v1",
+    generatedAtMs: 1777118400000,
+    installRecords: {},
+    plugins: [
+      {
+        pluginId: "test-plugin",
+        manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+        manifestHash: "manifest-hash",
+        source: path.join(rootDir, "index.ts"),
+        rootDir,
+        origin: "global",
+        enabled: true,
+        startup: {
+          sidecar: false,
+          memory: false,
+          deferConfiguredChannelFullLoadUntilAfterListen: false,
+          agentHarnesses: [],
+        },
+        compat: [],
+      },
+    ],
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+const BASE_ENV = {
+  OPENCLAW_VERSION: "2026.4.25",
+  VITEST: "true",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadPluginManifestRegistryForInstalledIndex — LRU memoization", () => {
+  it("cache hit returns the same object reference for identical params", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "test-plugin", "test-");
+    const index = createIndex(rootDir);
+
+    const first = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+    const second = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it("different pluginIds subsets produce separate cache entries (no cross-bleed)", () => {
+    const rootDirA = makeTempDir();
+    const rootDirB = path.join(makeTempDir(), "plugin-b");
+    writePlugin(rootDirA, "plugin-a", "prefix-a-");
+    writePlugin(rootDirB, "plugin-b", "prefix-b-");
+
+    const index: InstalledPluginIndex = {
+      version: 1,
+      hostContractVersion: "2026.4.25",
+      compatRegistryVersion: "compat-v1",
+      migrationVersion: 1,
+      policyHash: "policy-v1",
+      generatedAtMs: 1777118400000,
+      installRecords: {},
+      plugins: [
+        {
+          pluginId: "plugin-a",
+          manifestPath: path.join(rootDirA, "openclaw.plugin.json"),
+          manifestHash: "hash-a",
+          source: path.join(rootDirA, "index.ts"),
+          rootDir: rootDirA,
+          origin: "global",
+          enabled: true,
+          startup: {
+            sidecar: false,
+            memory: false,
+            deferConfiguredChannelFullLoadUntilAfterListen: false,
+            agentHarnesses: [],
+          },
+          compat: [],
+        },
+        {
+          pluginId: "plugin-b",
+          manifestPath: path.join(rootDirB, "openclaw.plugin.json"),
+          manifestHash: "hash-b",
+          source: path.join(rootDirB, "index.ts"),
+          rootDir: rootDirB,
+          origin: "global",
+          enabled: true,
+          startup: {
+            sidecar: false,
+            memory: false,
+            deferConfiguredChannelFullLoadUntilAfterListen: false,
+            agentHarnesses: [],
+          },
+          compat: [],
+        },
+      ],
+      diagnostics: [],
+    };
+
+    const onlyA = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      pluginIds: ["plugin-a"],
+    });
+    const onlyB = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      pluginIds: ["plugin-b"],
+    });
+
+    expect(onlyA).not.toBe(onlyB);
+    expect(onlyA.plugins.map((p) => p.id)).toEqual(["plugin-a"]);
+    expect(onlyB.plugins.map((p) => p.id)).toEqual(["plugin-b"]);
+
+    // Confirm each is cached independently
+    const onlyAAgain = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      pluginIds: ["plugin-a"],
+    });
+    expect(onlyAAgain).toBe(onlyA);
+  });
+
+  it("different policyHash produces a separate cache entry", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "test-plugin", "test-");
+
+    const indexV1 = createIndex(rootDir, { policyHash: "policy-v1" });
+    const indexV2 = createIndex(rootDir, { policyHash: "policy-v2" });
+
+    const first = loadPluginManifestRegistryForInstalledIndex({
+      index: indexV1,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+    const second = loadPluginManifestRegistryForInstalledIndex({
+      index: indexV2,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    // Different keys → different entries, not the same reference
+    expect(second).not.toBe(first);
+
+    // Each is independently cached
+    const firstAgain = loadPluginManifestRegistryForInstalledIndex({
+      index: indexV1,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+    expect(firstAgain).toBe(first);
+  });
+
+  it("installs.json mtime change invalidates the cache entry", () => {
+    const rootDir = makeTempDir();
+    const stateDir = makeTempDir();
+    writePlugin(rootDir, "test-plugin", "test-");
+    const index = createIndex(rootDir);
+
+    // Write an installs.json into the temp stateDir so we can control its mtime.
+    writePersistedInstalledPluginIndexSync(index, { stateDir });
+    // Re-clear because writePersistedInstalledPluginIndexSync calls clearManifestRegistryInstalledCache.
+    clearManifestRegistryInstalledCache();
+
+    const env = { ...BASE_ENV, OPENCLAW_STATE_DIR: stateDir };
+
+    const first = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env,
+      includeDisabled: true,
+    });
+    // Confirm it was cached.
+    expect(loadPluginManifestRegistryForInstalledIndex({ index, env, includeDisabled: true })).toBe(
+      first,
+    );
+
+    // Bump installs.json mtime to simulate a background install.
+    const indexFilePath = path.join(stateDir, "plugins", "installs.json");
+    const futureTime = new Date(Date.now() + 10_000);
+    fs.utimesSync(indexFilePath, futureTime, futureTime);
+
+    // Next call should detect the stale mtime and rebuild (different reference).
+    const second = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env,
+      includeDisabled: true,
+    });
+    expect(second).not.toBe(first);
+  });
+
+  it("clearManifestRegistryInstalledCache() evicts all entries", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "test-plugin", "test-");
+    const index = createIndex(rootDir);
+
+    const first = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    clearManifestRegistryInstalledCache();
+
+    const second = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    expect(second).not.toBe(first);
+  });
+
+  it("writePersistedInstalledPluginIndexSync() clears the cache (integration with store)", () => {
+    const rootDir = makeTempDir();
+    const stateDir = makeTempDir();
+    writePlugin(rootDir, "test-plugin", "test-");
+    const index = createIndex(rootDir);
+    const env = { ...BASE_ENV, OPENCLAW_STATE_DIR: stateDir };
+
+    // Prime the cache.
+    writePersistedInstalledPluginIndexSync(index, { stateDir });
+    clearManifestRegistryInstalledCache(); // reset after the write above
+
+    const first = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env,
+      includeDisabled: true,
+    });
+    // Confirm cached.
+    expect(loadPluginManifestRegistryForInstalledIndex({ index, env, includeDisabled: true })).toBe(
+      first,
+    );
+
+    // A persist-write should clear the cache.
+    writePersistedInstalledPluginIndexSync(index, { stateDir });
+
+    const second = loadPluginManifestRegistryForInstalledIndex({
+      index,
+      env,
+      includeDisabled: true,
+    });
+    expect(second).not.toBe(first);
+  });
+
+  it("LRU evicts the least-recently-used entry when the cache reaches capacity (16)", () => {
+    const CACHE_CAP = 16;
+    // We need 17 distinct cache keys → 17 distinct policyHash values.
+    const entries: Array<{ rootDir: string; index: InstalledPluginIndex }> = [];
+    for (let i = 0; i <= CACHE_CAP; i++) {
+      const rootDir = makeTempDir();
+      writePlugin(rootDir, "test-plugin", `prefix-${i}-`);
+      entries.push({
+        rootDir,
+        index: createIndex(rootDir, { policyHash: `policy-${i}` }),
+      });
+    }
+
+    // Fill the cache with entries 0..15 (CACHE_CAP entries).
+    const registries: PluginManifestRegistry[] = [];
+    for (let i = 0; i < CACHE_CAP; i++) {
+      registries.push(
+        loadPluginManifestRegistryForInstalledIndex({
+          index: entries[i].index,
+          env: BASE_ENV,
+          includeDisabled: true,
+        }),
+      );
+    }
+
+    // Touch entry 0 to make it the most recently used (moves it to the end).
+    loadPluginManifestRegistryForInstalledIndex({
+      index: entries[0].index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    // Insert entry 16 → cache is over capacity, should evict the LRU entry (entry 1).
+    const registry16 = loadPluginManifestRegistryForInstalledIndex({
+      index: entries[CACHE_CAP].index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+
+    // Entry 16 should now be cached.
+    expect(
+      loadPluginManifestRegistryForInstalledIndex({
+        index: entries[CACHE_CAP].index,
+        env: BASE_ENV,
+        includeDisabled: true,
+      }),
+    ).toBe(registry16);
+
+    // Entry 0 should still be cached (we touched it recently).
+    expect(
+      loadPluginManifestRegistryForInstalledIndex({
+        index: entries[0].index,
+        env: BASE_ENV,
+        includeDisabled: true,
+      }),
+    ).toBe(registries[0]);
+
+    // Entry 1 should have been evicted (LRU).
+    const evictedResult = loadPluginManifestRegistryForInstalledIndex({
+      index: entries[1].index,
+      env: BASE_ENV,
+      includeDisabled: true,
+    });
+    expect(evictedResult).not.toBe(registries[1]);
+  });
+});
+
+// Keep the type import happy for the test above.
+type PluginManifestRegistry = ReturnType<typeof loadPluginManifestRegistryForInstalledIndex>;

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -6,13 +6,17 @@ import {
   writePersistedInstalledPluginIndex,
 } from "./installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
-import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
+import {
+  clearManifestRegistryInstalledCache,
+  loadPluginManifestRegistryForInstalledIndex,
+} from "./manifest-registry-installed.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
   cleanupTrackedTempDirs(tempDirs);
+  clearManifestRegistryInstalledCache();
 });
 
 function makeTempDir() {
@@ -93,6 +97,8 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     writePlugin(rootDir, "installed", "updated-installed-");
     const nextMtime = new Date(Date.now() + 5000);
     fs.utimesSync(manifestPath, nextMtime, nextMtime);
+    // Simulate the install flow that always clears the manifest-registry cache.
+    clearManifestRegistryInstalledCache();
 
     const second = loadPluginManifestRegistryForInstalledIndex({
       index,

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCompatibilityHostVersion } from "../version.js";
 import type { PluginCandidate } from "./discovery.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
+import { resolveInstalledPluginIndexStorePath } from "./installed-plugin-index-store-path.js";
 import type { InstalledPluginIndex, InstalledPluginIndexRecord } from "./installed-plugin-index.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index.js";
 import { loadPluginManifestRegistry, type PluginManifestRegistry } from "./manifest-registry.js";
@@ -14,6 +16,104 @@ import {
   type PackageManifest,
 } from "./manifest.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
+
+// ---------------------------------------------------------------------------
+// Bounded LRU memoization cache
+// ---------------------------------------------------------------------------
+
+const MANIFEST_REGISTRY_INSTALLED_CACHE_MAX_ENTRIES = 16;
+
+type ManifestRegistryCacheEntry = {
+  registry: PluginManifestRegistry;
+  /** mtime (ms) of the persisted installs.json at the time the entry was built; null if the file was absent. */
+  indexMtimeMs: number | null;
+  /** env used to locate the persisted index path, so we can re-stat the same file on hit. */
+  env: NodeJS.ProcessEnv;
+};
+
+/**
+ * Module-level LRU cache.  Map insertion order == LRU order: oldest (least
+ * recently used) entry is the first key returned by `map.keys()`.
+ */
+const manifestRegistryInstalledCache = new Map<string, ManifestRegistryCacheEntry>();
+
+function buildManifestRegistryCacheKey(params: {
+  index: InstalledPluginIndex;
+  env: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+  pluginIds?: readonly string[] | null;
+  includeDisabled?: boolean;
+}): string {
+  const sortedPluginIds = params.pluginIds?.length ? [...params.pluginIds].toSorted() : null;
+  // Use the full index fingerprint (includes per-manifest safeFileSignature/mtime)
+  // rather than just policyHash so that manifest file edits invalidate the key.
+  // resolveInstalledManifestRegistryIndexFingerprint does O(n) statSync calls,
+  // which is far cheaper than the O(n) readFileSync+JSON.parse calls we're caching.
+  const indexFingerprint = resolveInstalledManifestRegistryIndexFingerprint(params.index);
+  return hashJson({
+    indexFingerprint,
+    includeDisabled: params.includeDisabled ?? false,
+    pluginIds: sortedPluginIds,
+    workspaceDir: params.workspaceDir ?? "",
+    hostContractVersion: resolveCompatibilityHostVersion(params.env),
+  });
+}
+
+function resolveIndexStoreMtimeMs(env: NodeJS.ProcessEnv): number | null {
+  try {
+    const indexPath = resolveInstalledPluginIndexStorePath({ env });
+    return fs.statSync(indexPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function getCachedManifestRegistry(key: string): ManifestRegistryCacheEntry | undefined {
+  const entry = manifestRegistryInstalledCache.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  // Defensive secondary: if installs.json is newer than when we cached, evict.
+  const currentMtimeMs = resolveIndexStoreMtimeMs(entry.env);
+  if (
+    currentMtimeMs !== null &&
+    (entry.indexMtimeMs === null || currentMtimeMs > entry.indexMtimeMs)
+  ) {
+    manifestRegistryInstalledCache.delete(key);
+    return undefined;
+  }
+  // Refresh LRU position (move to end).
+  manifestRegistryInstalledCache.delete(key);
+  manifestRegistryInstalledCache.set(key, entry);
+  return entry;
+}
+
+function setCachedManifestRegistry(key: string, entry: ManifestRegistryCacheEntry): void {
+  if (
+    manifestRegistryInstalledCache.size >= MANIFEST_REGISTRY_INSTALLED_CACHE_MAX_ENTRIES &&
+    !manifestRegistryInstalledCache.has(key)
+  ) {
+    // Evict least-recently-used (first entry in insertion-order Map).
+    const oldestKey = manifestRegistryInstalledCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      manifestRegistryInstalledCache.delete(oldestKey);
+    }
+  }
+  // Delete first so the re-set moves the key to the end (latest position).
+  manifestRegistryInstalledCache.delete(key);
+  manifestRegistryInstalledCache.set(key, entry);
+}
+
+/**
+ * Clears the entire manifest-registry-installed LRU cache.
+ *
+ * Called by `clearCurrentPluginMetadataSnapshotState()` co-callers in
+ * `installed-plugin-index-store.ts` whenever the persisted index is written,
+ * ensuring stale entries are never served after an install/refresh.
+ */
+export function clearManifestRegistryInstalledCache(): void {
+  manifestRegistryInstalledCache.clear();
+}
 
 function resolvePackageJsonPath(record: InstalledPluginIndexRecord): string | undefined {
   if (!record.packageJson?.path) {
@@ -164,13 +264,47 @@ export function loadPluginManifestRegistryForInstalledIndex(params: {
   includeDisabled?: boolean;
   bundledChannelConfigCollector?: BundledChannelConfigCollector;
 }): PluginManifestRegistry {
+  // Short-circuit: empty pluginIds is always an empty registry — no need to cache.
+  if (params.pluginIds && params.pluginIds.length === 0) {
+    return { plugins: [], diagnostics: [] };
+  }
+
+  const env = params.env ?? process.env;
+
+  // Bypass cache when a bundledChannelConfigCollector is supplied (stateful
+  // collector; result must not be shared across callers).
+  if (!params.bundledChannelConfigCollector) {
+    const cacheKey = buildManifestRegistryCacheKey({
+      index: params.index,
+      env,
+      workspaceDir: params.workspaceDir,
+      pluginIds: params.pluginIds ?? null,
+      includeDisabled: params.includeDisabled,
+    });
+    const hit = getCachedManifestRegistry(cacheKey);
+    if (hit) {
+      return hit.registry;
+    }
+
+    const registry = buildManifestRegistry(params, env);
+    setCachedManifestRegistry(cacheKey, {
+      registry,
+      indexMtimeMs: resolveIndexStoreMtimeMs(env),
+      env,
+    });
+    return registry;
+  }
+
+  return buildManifestRegistry(params, env);
+}
+
+function buildManifestRegistry(
+  params: Parameters<typeof loadPluginManifestRegistryForInstalledIndex>[0],
+  env: NodeJS.ProcessEnv,
+): PluginManifestRegistry {
   return tracePluginLifecyclePhase(
     "manifest registry",
     () => {
-      if (params.pluginIds && params.pluginIds.length === 0) {
-        return { plugins: [], diagnostics: [] };
-      }
-      const env = params.env ?? process.env;
       const pluginIdSet = params.pluginIds?.length ? new Set(params.pluginIds) : null;
       const diagnostics = pluginIdSet
         ? params.index.diagnostics.filter((diagnostic) => {


### PR DESCRIPTION
## What

Adds a bounded 16-entry LRU memoization cache to
`loadPluginManifestRegistryForInstalledIndex` in
`src/plugins/manifest-registry-installed.ts`.

The function is called from 82 sites and previously performed ~3 s of synchronous file I/O on every invocation — reading, parsing and fingerprinting all 120 installed-plugin manifests via `realpathSync`, `statSync`, `readFileSync`, and `parseJsonWithJson5Fallback`.  With no result caching every LLM attempt (`runEmbeddedAttempt` → `createOpenClawTools`) paid this cost, producing a ~3–6 s CPU spike every heartbeat and agent turn.

**Beads**: openclaw-at1  
**Parent investigation**: openclaw-5bb  
**CPU profile report**: `~/reports/gateway-60s-cpu-spike-2026-05-04.md`

## How

**Cache key** — a SHA-256 hash of:
- Full index fingerprint via `resolveInstalledManifestRegistryIndexFingerprint` (which already includes per-plugin `safeFileSignature` mtime/size checks, so manifest edits naturally invalidate the key without requiring a separate mtime guard on individual manifests)
- `includeDisabled`
- sorted `pluginIds` subset (or null for "all")
- `workspaceDir`
- `hostContractVersion` from `resolveCompatibilityHostVersion(env)`

**LRU eviction** — Map insertion-order eviction: the entry with the oldest last-use is deleted when the cache exceeds 16 slots. Cache hits move the entry to the end of the Map (latest position).

**Primary invalidation** — `clearManifestRegistryInstalledCache()` is exported and called by both `writePersistedInstalledPluginIndex` and `writePersistedInstalledPluginIndexSync` in `installed-plugin-index-store.ts`, alongside the existing `clearCurrentPluginMetadataSnapshotState()` call. Every install/refresh flow already goes through those writers, so the cache is always cleared when plugins change.

**Defensive secondary invalidation** — on cache HIT, `statSync` the persisted installs.json path and evict the entry if its mtime is newer than the mtime recorded when the entry was inserted. This catches out-of-process writes that bypass the normal store API.

**Bypass** — calls that supply a `bundledChannelConfigCollector` skip the cache (the collector is stateful and must not be shared across callers).

## Tests

New focused test file `src/plugins/manifest-registry-installed.memo.test.ts` (7 tests):
- Cache hit returns the same object reference.
- Different pluginIds subsets produce separate cache entries.
- Different policyHash produces separate entries.
- Bumping installs.json mtime evicts the cached entry.
- `clearManifestRegistryInstalledCache()` evicts all entries.
- `writePersistedInstalledPluginIndexSync()` clears the cache (store integration).
- LRU eviction correctly evicts the LRU entry at capacity (16).

Existing tests in `manifest-registry-installed.test.ts` updated:
- Added `afterEach(() => clearManifestRegistryInstalledCache())` for test isolation.
- The "manifest file changes" test now calls `clearManifestRegistryInstalledCache()` between the two calls, matching production behavior (manifest changes always accompany an install operation that clears the cache).

## Validation

```
pnpm tsgo:core               → only pre-existing upstream errors (web-tree-sitter, session-entry-slot-keys)
pnpm tsgo:core:test          → same pre-existing errors only
vitest plugins config        → 142/142 test files, 1740/1740 tests ✓
pnpm oxlint changed files    → 0 warnings, 0 errors ✓
config:schema:gen --check    → no output (no schema changes) ✓
```