### PR TITLE
fix(plugin-auto-enable): use plugin manifest id over built-in channel alias when no preferOver (#77441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins/auto-enable: use the plugin manifest id (not the built-in channel alias) when a plugin claiming a built-in channel id (e.g. `telegram`, `wecom`) does not declare `preferOver`, so `plugins.allow` and `plugins.entries` are keyed by the actual plugin id rather than the channel id. (#77452) Thanks @hclsys.
 - Plugins/active-memory: skip session-store channel entries that contain `:` when resolving the recall subagent's channel, so QQ c2c agent IDs (e.g. `c2c:10D4F7C2…`) and other scoped conversation IDs do not reach bundled-plugin `dirName` validation and crash the recall run. The same guard already applied to explicit `channelId` params (#76704); this extends it to store-derived channels. (#77396) Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -332,6 +332,23 @@ describe("applyPluginAutoEnable channels", () => {
       expect(result.config.plugins?.allow).toBeUndefined();
       expect(result.changes).toEqual([]);
     });
+
+    it("uses plugin manifest id (not built-in channel alias) when plugin id differs from channel id", () => {
+      // Regression: builtInId ('telegram') was incorrectly preferred over
+      // claims[0].plugin.id ('telegram-openclaw-plugin') when no preferOver was declared.
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { telegram: { botToken: "tok" } },
+        },
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          { id: "telegram-openclaw-plugin", channels: ["telegram"] },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.["telegram-openclaw-plugin"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.telegram).toBeUndefined();
+    });
   });
 
   describe("preferOver channel prioritization", () => {

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -303,7 +303,7 @@ function collectPluginIdsForConfiguredChannel(
   if (preferredIds.size > 0) {
     return [...preferredIds].toSorted((left, right) => left.localeCompare(right));
   }
-  return [builtInId ?? claims[0]?.plugin.id ?? normalizedChannelId];
+  return [claims[0]?.plugin.id ?? normalizedChannelId];
 }
 
 function collectConfiguredChannelIds(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {


### PR DESCRIPTION
## Problem

When `collectPluginIdsForConfiguredChannel` found a plugin claiming a built-in channel id (e.g. `telegram`, `wecom`) but that plugin did not declare `preferOver`, `builtInId` (the raw channel alias) took priority over `claims[0].plugin.id` (the actual plugin manifest id):

```typescript
// Before — builtInId 'telegram' wins over 'telegram-openclaw-plugin'
return [builtInId ?? claims[0]?.plugin.id ?? normalizedChannelId];
```

This caused `plugins.allow` and `plugins.entries` to be keyed by the channel alias (e.g. `telegram`) instead of the actual plugin id (e.g. `telegram-openclaw-plugin`), so the configured channel plugin was never correctly auto-enabled.

## Fix

Drop `builtInId ??` from the fallthrough case. When `claims.length === 0` the function already returns `[builtInId]` at line 283, so the fallthrough is only reached when at least one plugin claims the channel — in that case the plugin's own id should always win.

```typescript
// After — plugin manifest id wins
return [claims[0]?.plugin.id ?? normalizedChannelId];
```

## Test

Added regression test in `plugin-auto-enable.channels.test.ts`: configures `telegram` channel with a manifest plugin id `telegram-openclaw-plugin` (no `preferOver`) and asserts the auto-enable entry is keyed by `telegram-openclaw-plugin`, not `telegram`.

16/16 tests pass.

Fixes #77441