### PR TITLE
fix(qqbot): preserve framework command authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ Docs: https://docs.openclaw.ai
 - TUI: replace the stale-response watchdog notice with plain user-facing copy so stalled replies no longer surface backend or streaming internals. (#77120) Thanks @davemorin.
 - Security/Windows: validate `SystemRoot`/`WINDIR` env values through the Windows install-root validator and add them to the dangerous-host-env policy when resolving `icacls.exe`/`whoami.exe` for `openclaw security audit`, so workspace `.env` overrides and bare command names cannot redirect Windows ACL helpers to attacker-controlled binaries. (#74458) Thanks @mmaps.
 - Security/Windows: pin Windows registry-probe `reg.exe` resolution to the canonical Windows install root in install-root probing, so `SystemRoot`/`WINDIR` env overrides cannot redirect registry queries during Windows host detection. (#74454) Thanks @mmaps.
+- QQBot: preserve the framework command authorization decision when converting framework command contexts into engine slash command contexts, so downstream slash handlers see `commandAuthorized` matching the channel's resolved `isAuthorizedSender` instead of a hardcoded `true`. (#77453) Thanks @drobison00.
 
 ## 2026.5.3-1
 

--- a/extensions/qqbot/src/bridge/commands/framework-context-adapter.test.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-context-adapter.test.ts
@@ -1,0 +1,55 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import { buildFrameworkSlashContext } from "./framework-context-adapter.js";
+
+function createCommandContext(isAuthorizedSender: boolean): PluginCommandContext {
+  return {
+    senderId: "SENDER_OPENID",
+    channel: "qqbot",
+    isAuthorizedSender,
+    args: "on",
+    commandBody: "/bot-streaming on",
+    config: {} as OpenClawConfig,
+    from: "qqbot:c2c:SENDER_OPENID",
+    requestConversationBinding: async () => undefined,
+    detachConversationBinding: async () => ({ removed: false }),
+    getCurrentConversationBinding: async () => null,
+  } as unknown as PluginCommandContext;
+}
+
+describe("buildFrameworkSlashContext", () => {
+  it("preserves the framework authorization decision in the slash context", () => {
+    const authorized = buildFrameworkSlashContext({
+      ctx: createCommandContext(true),
+      account: {
+        accountId: "default",
+        enabled: true,
+        appId: "app",
+        clientSecret: "secret",
+        secretSource: "config",
+        markdownSupport: true,
+        config: {},
+      },
+      from: { msgType: "c2c", targetType: "c2c", targetId: "SENDER_OPENID" },
+      commandName: "bot-streaming",
+    });
+    const unauthorized = buildFrameworkSlashContext({
+      ctx: createCommandContext(false),
+      account: {
+        accountId: "default",
+        enabled: true,
+        appId: "app",
+        clientSecret: "secret",
+        secretSource: "config",
+        markdownSupport: true,
+        config: {},
+      },
+      from: { msgType: "c2c", targetType: "c2c", targetId: "SENDER_OPENID" },
+      commandName: "bot-streaming",
+    });
+
+    expect(authorized.commandAuthorized).toBe(true);
+    expect(unauthorized.commandAuthorized).toBe(false);
+  });
+});

--- a/extensions/qqbot/src/bridge/commands/framework-context-adapter.ts
+++ b/extensions/qqbot/src/bridge/commands/framework-context-adapter.ts
@@ -54,7 +54,7 @@ export function buildFrameworkSlashContext({
     accountId: account.accountId,
     appId: account.appId,
     accountConfig: account.config as unknown as Record<string, unknown>,
-    commandAuthorized: true,
+    commandAuthorized: ctx.isAuthorizedSender,
     queueSnapshot: { ...DEFAULT_QUEUE_SNAPSHOT },
   };
 }


### PR DESCRIPTION
# fix(qqbot): preserve framework command authorization

## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: QQBot's framework slash-command adapter hardcoded `commandAuthorized: true` when converting framework command contexts into engine slash command contexts.
- Why it matters: that value could mislead command handlers that rely on the slash context's authorization state.
- What changed: the adapter now copies `ctx.isAuthorizedSender`, with a unit test covering both authorized and unauthorized inputs.
- What did NOT change (scope boundary): no command registration, pre-dispatch routing, access policy, CI, workflow, release, or infrastructure behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #546
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the framework context adapter used a constant `true` instead of preserving the framework's resolved `isAuthorizedSender` decision.
- Missing detection / guardrail: no unit test asserted how `buildFrameworkSlashContext` maps framework authorization into slash command authorization.
- Contributing context (if known): the framework registration path already marks these commands as `requireAuth`, but the converted slash context still carried an inaccurate authorization field.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/bridge/commands/framework-context-adapter.test.ts`
- Scenario the test should lock in: framework command contexts with `isAuthorizedSender: true` and `false` produce slash contexts with matching `commandAuthorized` values.
- Why this is the smallest reliable guardrail: it directly tests the adapter field mapping where the regression existed.
- Existing test that already covers this (if any): none found for the adapter mapping.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: task workspace container
- Model/provider: N/A
- Integration/channel (if any): QQBot
- Relevant config (redacted): N/A

### Steps

1. Inspect `extensions/qqbot/src/bridge/commands/framework-context-adapter.ts`.
2. Observe that the adapter previously set `commandAuthorized` independently of `PluginCommandContext.isAuthorizedSender`.
3. Run the targeted QQBot adapter and command tests.
4. Run the extension test type-check.

### Expected

- `commandAuthorized` in the built slash context matches `ctx.isAuthorizedSender`.
- The focused QQBot tests and extension test type-check pass.

### Actual

- `commandAuthorized` now matches `ctx.isAuthorizedSender`.
- `pnpm exec vitest run --environment node extensions/qqbot/src/bridge/commands/framework-context-adapter.test.ts extensions/qqbot/src/bridge/commands/framework-registration.test.ts extensions/qqbot/src/engine/commands/slash-commands-impl.test.ts` passed: 3 files, 11 tests.
- `pnpm tsgo:extensions:test` passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: authorized and unauthorized framework command contexts preserve their authorization state in the slash context; existing QQBot framework registration and slash command auth tests still pass.
- Edge cases checked: extension test type-check validates the new typed fixtures.
- What you did **not** verify: full repository test suite and live QQBot platform behavior.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: framework handlers that accidentally depended on the inaccurate hardcoded authorization value may now see `false`.
  - Mitigation: framework commands are already registered with `requireAuth`; this patch makes the slash context match that resolved authorization state.