### PR TITLE
Fix diffs viewer TTL config and LAN route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,6 +664,7 @@ Docs: https://docs.openclaw.ai
 - CLI/launcher: forward termination signals to compile-cache respawn children, so killing a wrapper process no longer leaves the security audit worker orphaned. Fixes #77458. Thanks @jaikharbanda.
 - Plugins/registry: recover managed-npm external plugins from the owned npm root when a stale persisted registry would otherwise hide them after package-manager upgrades. Fixes #77266. Thanks @p3nchan.
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
+- Diffs plugin: accept `defaults.ttlSeconds` as a plugin-wide artifact lifetime default, so LAN-viewable diff links can keep their configured six-hour TTL without doctor quarantining the plugin entry.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,7 +664,7 @@ Docs: https://docs.openclaw.ai
 - CLI/launcher: forward termination signals to compile-cache respawn children, so killing a wrapper process no longer leaves the security audit worker orphaned. Fixes #77458. Thanks @jaikharbanda.
 - Plugins/registry: recover managed-npm external plugins from the owned npm root when a stale persisted registry would otherwise hide them after package-manager upgrades. Fixes #77266. Thanks @p3nchan.
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
-- Diffs plugin: accept `defaults.ttlSeconds` as a plugin-wide artifact lifetime default, so LAN-viewable diff links can keep their configured six-hour TTL without doctor quarantining the plugin entry.
+- Diffs plugin: accept `defaults.ttlSeconds` as a plugin-wide artifact lifetime default, so LAN-viewable diff links can keep their configured six-hour TTL without doctor quarantining the plugin entry. (#77456) Thanks @VACInc.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -288,6 +288,7 @@ Set plugin-wide defaults in `~/.openclaw/openclaw.json`:
             fileScale: 2,
             fileMaxWidth: 960,
             mode: "both",
+            ttlSeconds: 21600,
           },
         },
       },
@@ -312,6 +313,7 @@ Supported defaults:
 - `fileScale`
 - `fileMaxWidth`
 - `mode`
+- `ttlSeconds`
 
 Explicit tool parameters override these defaults.
 

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -106,6 +106,7 @@ Set plugin-wide defaults in `~/.openclaw/openclaw.json`:
             fileScale: 2,
             fileMaxWidth: 960,
             mode: "both",
+            ttlSeconds: 21600,
           },
         },
       },
@@ -120,6 +121,7 @@ Security options:
 
 - `security.allowRemoteViewer` (default `false`): allows non-loopback access to `/plugins/diffs/view/...` token URLs
 - `viewerBaseUrl` (optional): persistent viewer-link origin/path fallback for shareable URLs
+- `defaults.ttlSeconds` (default `1800`, max `21600`): default artifact lifetime for viewer and standalone file outputs
 
 Example:
 

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "diffs",
   "activation": {
-    "onStartup": false
+    "onStartup": true
   },
   "name": "Diffs",
   "description": "Read-only diff viewer and file renderer for agents.",
@@ -74,6 +74,10 @@
     "defaults.mode": {
       "label": "Default Output Mode",
       "help": "Tool default when mode is omitted. Use view for canvas/gateway viewer, file for PNG/PDF, or both."
+    },
+    "defaults.ttlSeconds": {
+      "label": "Default Artifact TTL",
+      "help": "Default lifetime in seconds for diff viewer and file artifacts. Maximum: 21600."
     },
     "security.allowRemoteViewer": {
       "label": "Allow Remote Viewer",
@@ -190,6 +194,12 @@
             "type": "string",
             "enum": ["view", "image", "file", "both"],
             "default": "both"
+          },
+          "ttlSeconds": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 21600,
+            "default": 1800
           }
         }
       },

--- a/extensions/diffs/src/config.test.ts
+++ b/extensions/diffs/src/config.test.ts
@@ -37,6 +37,7 @@ const FULL_DEFAULTS = {
   fileScale: 2.6,
   fileMaxWidth: 1280,
   mode: "file",
+  ttlSeconds: 21_600,
 } as const;
 
 function compileManifestConfigSchema() {
@@ -177,6 +178,28 @@ describe("resolveDiffsPluginDefaults", () => {
     });
   });
 
+  it("accepts plugin-wide artifact TTL defaults", () => {
+    expect(
+      resolveDiffsPluginDefaults({
+        defaults: {
+          ttlSeconds: 21_600,
+        },
+      }),
+    ).toMatchObject({
+      ttlSeconds: 21_600,
+    });
+
+    expect(
+      resolveDiffsPluginDefaults({
+        defaults: {
+          ttlSeconds: 99_999,
+        },
+      }),
+    ).toMatchObject({
+      ttlSeconds: 21_600,
+    });
+  });
+
   it("keeps loader-applied schema defaults from shadowing aliases and quality-derived defaults", () => {
     const validate = compileManifestConfigSchema();
 
@@ -250,6 +273,7 @@ describe("diffs plugin schema surfaces", () => {
         viewerBaseUrl: "https://example.com/openclaw/",
         defaults: {
           theme: "light",
+          ttlSeconds: 21_600,
         },
         security: {
           allowRemoteViewer: true,
@@ -274,6 +298,7 @@ describe("diffs plugin schema surfaces", () => {
           fileScale: 2,
           fileMaxWidth: 960,
           mode: "both",
+          ttlSeconds: 21_600,
         },
         security: {
           allowRemoteViewer: true,

--- a/extensions/diffs/src/config.ts
+++ b/extensions/diffs/src/config.ts
@@ -47,6 +47,7 @@ type DiffsPluginConfig = {
     /** @deprecated Use fileMaxWidth. */
     imageMaxWidth?: number;
     mode?: DiffMode;
+    ttlSeconds?: number;
   };
   security?: {
     allowRemoteViewer?: boolean;
@@ -89,6 +90,7 @@ export const DEFAULT_DIFFS_TOOL_DEFAULTS: DiffToolDefaults = {
   fileScale: DEFAULT_IMAGE_QUALITY_PROFILES.standard.scale,
   fileMaxWidth: DEFAULT_IMAGE_QUALITY_PROFILES.standard.maxWidth,
   mode: "both",
+  ttlSeconds: 1800,
 };
 
 type DiffsPluginSecurityConfig = {
@@ -168,6 +170,12 @@ const DiffsPluginJsonSchemaSource = z.strictObject({
         .optional()
         .describe("Deprecated alias for fileMaxWidth."),
       mode: z.enum(DIFF_MODES).default(DEFAULT_DIFFS_TOOL_DEFAULTS.mode).optional(),
+      ttlSeconds: z
+        .number()
+        .min(1)
+        .max(21_600)
+        .default(DEFAULT_DIFFS_TOOL_DEFAULTS.ttlSeconds)
+        .optional(),
     })
     .optional(),
   security: z
@@ -281,6 +289,7 @@ export function resolveDiffsPluginDefaults(config: unknown): DiffToolDefaults {
     fileScale: normalizeFileScale(fileScale, profile.scale),
     fileMaxWidth: normalizeFileMaxWidth(fileMaxWidth, profile.maxWidth),
     mode: normalizeMode(defaults.mode),
+    ttlSeconds: normalizeTtlSeconds(defaults.ttlSeconds),
   };
 }
 
@@ -377,6 +386,14 @@ function normalizeFileMaxWidth(fileMaxWidth: number | undefined, fallback: numbe
 
 function normalizeMode(mode?: DiffMode): DiffMode {
   return mode && DIFF_MODES.includes(mode) ? mode : DEFAULT_DIFFS_TOOL_DEFAULTS.mode;
+}
+
+function normalizeTtlSeconds(ttlSeconds?: number): number {
+  if (ttlSeconds === undefined || !Number.isFinite(ttlSeconds)) {
+    return DEFAULT_DIFFS_TOOL_DEFAULTS.ttlSeconds;
+  }
+  const rounded = Math.floor(ttlSeconds);
+  return Math.min(Math.max(rounded, 1), 21_600);
 }
 
 export function resolveDiffImageRenderOptions(params: {

--- a/extensions/diffs/src/tool.test.ts
+++ b/extensions/diffs/src/tool.test.ts
@@ -223,6 +223,35 @@ describe("diffs tool", () => {
     }
   });
 
+  it("uses default ttlSeconds when tool input omits ttlSeconds", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-02-27T16:00:00Z");
+    vi.setSystemTime(now);
+    try {
+      const screenshotter = createPngScreenshotter();
+      const tool = createToolWithScreenshotter(store, screenshotter, {
+        ...DEFAULT_DIFFS_TOOL_DEFAULTS,
+        ttlSeconds: 60,
+      });
+
+      const result = await tool.execute?.("tool-2c-default-ttl", {
+        before: "one\n",
+        after: "two\n",
+        mode: "file",
+      });
+      const filePath = (result?.details as Record<string, unknown>).filePath as string;
+      await expect(fs.stat(filePath)).resolves.toBeDefined();
+
+      vi.setSystemTime(new Date(now.getTime() + 61_000));
+      await store.cleanupExpired();
+      await expect(fs.stat(filePath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("accepts image* tool options for backward compatibility", async () => {
     const screenshotter = createPngScreenshotter({
       assertImage: (image) => {

--- a/extensions/diffs/src/tool.ts
+++ b/extensions/diffs/src/tool.ts
@@ -175,7 +175,7 @@ export function createDiffsTool(params: {
       const theme = normalizeTheme(toolParams.theme, params.defaults.theme);
       const layout = normalizeLayout(toolParams.layout, params.defaults.layout);
       const expandUnchanged = toolParams.expandUnchanged === true;
-      const ttlMs = normalizeTtlMs(toolParams.ttlSeconds);
+      const ttlMs = normalizeTtlMs(toolParams.ttlSeconds ?? params.defaults.ttlSeconds);
       const image = resolveDiffImageRenderOptions({
         defaults: params.defaults,
         fileFormat: normalizeOutputFormat(

--- a/extensions/diffs/src/types.ts
+++ b/extensions/diffs/src/types.ts
@@ -37,6 +37,7 @@ export type DiffFileDefaults = {
 export type DiffToolDefaults = DiffPresentationDefaults &
   DiffFileDefaults & {
     mode: DiffMode;
+    ttlSeconds: number;
   };
 
 type BeforeAfterDiffInput = {

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS = [
   "device-pair",
   "diagnostics-otel",
   "diagnostics-prometheus",
+  "diffs",
   "file-transfer",
   "google-meet",
   "llm-task",


### PR DESCRIPTION
## Summary
- Add `plugins.entries.diffs.config.defaults.ttlSeconds` as an official plugin-wide default for diff viewer and file artifact lifetime.
- Use the configured default when a `diffs` tool call omits per-call `ttlSeconds`, while keeping the existing 21600 second cap.
- Load the bundled `diffs` plugin at gateway startup so `/plugins/diffs/...` viewer and asset routes are registered before agents generate LAN viewer links.
- Document the default and add regression coverage so doctor/config validation does not quarantine LAN-viewer configs that set a longer TTL.

## Root Cause
The bundled `diffs` plugin already supported per-call `ttlSeconds`, but its strict plugin config schema did not accept `defaults.ttlSeconds`. Existing configs that used it for LAN-viewable, longer-lived viewer links were rejected as an additional property and could be quarantined by doctor.

The plugin also stayed lazy-loaded, so the agent tool could create viewer artifacts while the gateway HTTP route was not mounted. That produced valid-looking LAN URLs that returned the gateway's generic 404 until the plugin was explicitly enabled and loaded.

## Verification
- `pnpm test extensions/diffs/src/config.test.ts extensions/diffs/src/tool.test.ts src/plugins/bundled-plugin-metadata.test.ts`
- `pnpm build`
- `openclaw doctor`
- `openclaw gateway restart`
- `env OPENCLAW_UPDATE_IN_PROGRESS=1 openclaw health`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md docs/tools/diffs.md extensions/diffs/README.md extensions/diffs/openclaw.plugin.json extensions/diffs/src/config.ts extensions/diffs/src/tool.ts extensions/diffs/src/types.ts extensions/diffs/src/config.test.ts extensions/diffs/src/tool.test.ts src/plugins/bundled-plugin-metadata.test.ts`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed:** The diffs plugin accepts `plugins.entries.diffs.config.defaults.ttlSeconds`, uses the default when a tool call omits per-call `ttlSeconds`, and registers viewer/asset HTTP routes during gateway startup.
- **Real environment tested:** Real OpenClaw gateway process on a local development machine, with the diffs plugin enabled in gateway config. Host-specific addresses and generated viewer IDs are redacted.
- **Exact steps or command run after this patch:** Restarted the gateway with the patched diffs plugin, ran `openclaw doctor`, checked gateway health, fetched the diffs viewer asset over loopback and LAN routes, generated a real diff viewer URL, and fetched that viewer URL.
- **Evidence after fix:** Redacted terminal output from the live OpenClaw setup:

```text
$ openclaw doctor
Status: ok

$ openclaw gateway restart
Gateway restarted

$ env OPENCLAW_UPDATE_IN_PROGRESS=1 openclaw health
status: ok
plugins.diffs: enabled

$ curl -sSI http://127.0.0.1:<port>/plugins/diffs/assets/viewer.js | head -n 1
HTTP/1.1 200 OK

$ curl -sSI http://<lan-host>:<port>/plugins/diffs/assets/viewer.js | head -n 1
HTTP/1.1 200 OK

$ curl -sSI http://<lan-host>:<port>/plugins/diffs/view/<viewer-id>/<artifact-id> | head -n 1
HTTP/1.1 200 OK
```

- **Observed result after fix:** The real gateway stayed healthy after restart, the diffs plugin was active at startup, both loopback and LAN asset routes returned 200, and a generated real diff viewer route returned 200 without requiring a later manual plugin load.
- **What was not tested:** No additional gaps.
