### PR TITLE
feat(skills): add post-update-awareness skill [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Skills: add bundled `post-update-awareness` skill so agents can read the CHANGELOG entry for a newly-installed OpenClaw version, distill new tools/breaking changes/optional-native-dep notices for the user, probe known-flaky optional deps (`sharp`, `ffmpeg-static`, `node-pty`), and surface a single brief "OpenClaw updated to vX — here's what changed for you" message via the active channel. Persists the last-known version in agent state so the surface fires once per version bump rather than on every heartbeat.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.
 - Control UI/cron: make the New Job sidebar collapsible so the jobs list can reclaim space while keeping the form one click away. Thanks @BunsDev.

--- a/skills/post-update-awareness/SKILL.md
+++ b/skills/post-update-awareness/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: post-update-awareness
+description: "After an OpenClaw version change, read the CHANGELOG entry for the new version and surface the user-relevant changes — new tools, breaking changes, and optional native dependencies that may need verification (sharp, ffmpeg, etc.). Runs once per detected version bump. Use when the gateway has just been updated or the agent notices its known version has changed since last run."
+user-invocable: true
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["node"] }
+      }
+  }
+---
+
+# Post-Update Awareness
+
+When OpenClaw is updated, the agent should not be the last to know. This skill reads the project CHANGELOG for the new version, distills what changed for the user, and surfaces it once.
+
+## When to use
+
+Run this skill when **any** of the following is true:
+
+1. The gateway log reports a successful version change (e.g. `openclaw -V` differs from the value the agent has on file).
+2. A first-class update flow finishes (`openclaw update`, `openclaw plugins update`, package-manager update).
+3. The user mentions an update they just performed and asks "what changed?" — even without a heartbeat trigger.
+4. Heartbeat / `update-guard` script reports `GUARD_RECOVERED` or `GUARD_OK` after a version bump.
+
+Do **not** run on every heartbeat. Run **once per detected version change** and persist the new version so subsequent heartbeats stay quiet.
+
+## Scope and non-goals
+
+This skill **only**:
+
+- Reads existing CHANGELOG content
+- Reports it to the user
+- Optionally probes for known-flaky optional native deps mentioned in the entry
+
+This skill **does not**:
+
+- Apply updates (`openclaw update` already handles that)
+- Modify configuration (config drift is a separate concern; surface only)
+- Install missing dependencies without explicit user confirmation
+- Roll back versions (per the existing "no auto-rollback" convention; surface and let the user decide)
+
+## Workflow (follow in order)
+
+### 1) Detect a version change
+
+Compare the current installed version against the agent's last-known version.
+
+- Current: `openclaw -V` (output like `OpenClaw 2026.5.3-1 (2eae30e)`)
+- Last-known: a small JSON file the skill maintains, e.g. `~/.openclaw/state/post-update-awareness.json` with `{ "lastKnownVersion": "2026.5.2", "lastSurfacedAt": "2026-05-04T13:15:00Z" }`
+
+If the file does not exist, treat the current version as the initial baseline, write it, and exit silently. (No CHANGELOG dump on first run — only on actual transitions.)
+
+If `currentVersion === lastKnownVersion`, exit silently.
+
+If `currentVersion !== lastKnownVersion`, continue.
+
+### 2) Fetch the CHANGELOG entry
+
+Try, in order:
+
+1. **Local** — read the bundled CHANGELOG if available at the install root (e.g. `/opt/homebrew/lib/node_modules/openclaw/CHANGELOG.md` on macOS Homebrew, or platform-equivalent).
+2. **Remote** — `curl -sL https://raw.githubusercontent.com/openclaw/openclaw/main/CHANGELOG.md` if the local copy is missing or older than the installed version.
+
+Extract only the section for the new version (between `## <newVersion>` and the next `## ` heading). Do not dump the whole file.
+
+If neither source is available, surface a short note ("OpenClaw was updated to vX, but I couldn't read the CHANGELOG to summarize what changed.") and exit. Do not invent.
+
+### 3) Distill the entry into 3 buckets
+
+Read the version's CHANGELOG section and group items into:
+
+- **🆕 New for you** — new tools, new commands, new channels, new capabilities the agent could benefit from. Filter ruthlessly to what an end-user agent actually touches; skip internal refactor lines, build-system changes, and CI plumbing.
+- **⚠️ Breaking or removed** — anything that could change current behavior: removed config keys, renamed CLI commands, deprecated features, security tightenings that may block previously-accepted input.
+- **🔧 May need attention** — optional native dependencies mentioned (`sharp`, `ffmpeg`, `libvips`, etc.), peer-dep notes, post-install scripts, and config-format migrations.
+
+Keep each bucket tight: 1–4 bullets max. If a bucket has nothing relevant, omit it entirely.
+
+### 4) Probe known-flaky optional deps (best effort)
+
+If the CHANGELOG's "May need attention" bucket mentions a known-flaky native module, do a non-blocking probe:
+
+```bash
+node -e "require('<dep>'); process.exit(0)" 2>/dev/null
+```
+
+Report missing deps in the surfaced summary as `❌ sharp (image processing) — not installed` so the user knows to fix. Do not auto-install.
+
+Known list (extend as the project evolves):
+
+- `sharp` — image attachment optimization
+- `ffmpeg-static` / system `ffmpeg` — audio/video transcoding
+- `node-pty` — terminal/PTY tools
+
+### 5) Surface to the user
+
+Send **one** brief message via the active channel. Format:
+
+```
+OpenClaw updated to <newVersion> (was <oldVersion>).
+
+🆕 New for you:
+- <bullet>
+- <bullet>
+
+⚠️ Breaking or removed:
+- <bullet>
+
+🔧 May need attention:
+- ❌ sharp (image processing) — not installed; run: <install command>
+
+Full notes: https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md
+```
+
+Hard cap: keep the whole message under ~15 lines. If a section is empty, drop it. If everything is quiet, send: `OpenClaw updated to <newVersion>. Nothing in the changelog requires action on my end.`
+
+### 6) Persist new state
+
+Write the new version + surfaced timestamp to the state file. Subsequent heartbeats compare against this and stay silent unless the version changes again.
+
+## Voice
+
+This is an operational notice, not a marketing email. Keep it terse, factual, and skip celebratory language.
+
+- ✅ "OpenClaw updated to 2026.5.3-1. New: agent can now use the `talk` realtime voice tool. Watch: optional `sharp` is not installed; some image replies will fall back to original-size send."
+- ❌ "🎉 Exciting news! OpenClaw has been upgraded with brand-new features..."
+
+## Failure modes
+
+- **CHANGELOG section missing for the new version** — fall back to a one-line "OpenClaw updated to vX. No detailed notes available yet; see GitHub Releases for raw notes." Do not hallucinate content.
+- **No internet, no local copy** — same as above.
+- **State file write fails** — log the error to today's memory file; surface still happens; next run will re-surface (acceptable noise vs silent miss).
+
+## Why this exists
+
+OpenClaw releases are well-documented in `CHANGELOG.md` and per-version GitHub Releases, but the running agent has no built-in mechanism to *consume* that information after an update. Real-world consequence: when an update introduces a new optional dependency requirement (e.g. `sharp` for image optimization), the user discovers it only when an unrelated workflow fails — typically in front of someone they care about.
+
+This skill closes that loop. The CHANGELOG is the source of truth; this skill is the agent reading it on the user's behalf.


### PR DESCRIPTION
## Summary

Adds a bundled `post-update-awareness` skill so the running agent can read the CHANGELOG entry for a newly-installed OpenClaw version and surface what changed to the user — once, briefly, via the active channel.

The skill:
- Detects a version change between the current install (`openclaw -V`) and a small JSON state file the skill maintains
- Reads the relevant CHANGELOG section (local install copy first, GitHub raw fallback)
- Distills it into three buckets: 🆕 new for the user, ⚠️ breaking or removed, 🔧 may need attention
- Probes known-flaky optional native deps (`sharp`, `ffmpeg-static`, `node-pty`) when the changelog mentions them
- Sends one brief message via the active channel and persists the new version so subsequent heartbeats stay quiet

## Why

OpenClaw releases are already well-documented in `CHANGELOG.md` and per-version GitHub Releases, but the running agent has no built-in mechanism to *consume* that information after an update. The real-world failure mode: when an update introduces a new optional dependency requirement (e.g. `sharp` for image attachment optimization), the user discovers it only when an unrelated workflow fails — typically the moment they post an image into a chat and the agent replies with a stack trace instead of useful output.

I hit exactly this pattern today on a 2026.5.2 → 2026.5.3-1 update on a personal-agent install. The CHANGELOG already mentioned `sharp` graceful-fallback work (#77081 for Telegram), but the running agent had no way to surface "by the way, sharp is missing on your install" until something tried to use it. This skill closes that loop using the existing CHANGELOG as the source of truth — no new release-process work required.

## Scope and non-goals

Intentionally narrow:

- **Reads** existing CHANGELOG content, surfaces it, probes known-flaky optional deps non-destructively
- **Does not** apply updates (`openclaw update` already handles that), modify configuration, install missing dependencies without explicit user confirmation, or roll back versions

The skill complements existing update flows rather than replacing them.

## Files

- `skills/post-update-awareness/SKILL.md` — the new skill
- `CHANGELOG.md` — single bullet under `Unreleased > Changes`

No code changes, no plugin internals touched, no CODEOWNERS-protected paths edited.

## Verification

This is a documentation-only skill PR (no TypeScript, no test surfaces). I have not run `pnpm check:changed` or `codex review --base origin/main` locally because the change is `SKILL.md` text plus one CHANGELOG bullet. I'm happy to run either if a maintainer wants the proof; just point me at the relevant lane.

What I did verify:

- Skill frontmatter format matches the existing `skills/gh-issues/SKILL.md` convention (top-level `name`, `description`, `user-invocable`, then `metadata` block with the `openclaw` key)
- Skill folder layout matches the simple `skills/<name>/SKILL.md` pattern used by 50+ existing stock skills (e.g. `healthcheck`, `clawhub`)
- CHANGELOG entry placed under the existing `## Unreleased > ### Changes` section, sentence-cased and ending with a period, matching the surrounding style

## AI-assisted

- [x] Marked: drafted with Claude Sonnet 4.5
- [x] Testing degree: lightly tested — skill text was reviewed against existing stock skills for tone/structure; no live OpenClaw integration test yet (the skill describes the workflow rather than executing code, so the integration surface is at runtime when an agent loads and follows it)
- [x] I understand what the skill instructs the agent to do
- [x] I will resolve / reply to any bot review conversations after addressing them

## Open questions for maintainers

1. **State file location.** I suggested `~/.openclaw/state/post-update-awareness.json` for the last-known-version cache. If there's an existing per-skill state convention I missed, happy to adjust.
2. **Known-flaky deps list.** The skill ships with `sharp`, `ffmpeg-static`, `node-pty`. Anything else worth adding upfront?
3. **Surface channel.** The skill says "active channel" — for a heartbeat-triggered run on a multi-channel agent, is there a preferred convention (DM only? primary channel only?) I should encode rather than leaving to the agent's judgment?
