### PR TITLE
feat(openrouter): add inbound audio STT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Providers/OpenRouter: add opt-in response caching params that send OpenRouter's `X-OpenRouter-Cache`, `X-OpenRouter-Cache-TTL`, and cache-clear headers only on verified OpenRouter routes. Thanks @vincentkoc.
 - Providers/OpenRouter: expand app-attribution categories so OpenClaw advertises coding, programming, writing, chat, and personal-agent usage on verified OpenRouter routes. Thanks @vincentkoc.
+- Providers/OpenRouter: add inbound audio STT support to media-understanding via OpenRouter's JSON `/audio/transcriptions` contract, including default audio model metadata and auto-selection priority. (#77463)
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Plugin SDK: add plugin-owned `SessionEntry` slot projection and scoped trusted-policy session extension reads. (#75609; replaces part of #73384/#74483) Thanks @100yenadmin.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: preserve every grouped child result when direct completion fallback has to bypass the requester-agent announce turn. Thanks @vincentkoc.
 - TTS/telephony: honor provider voice/model overrides in telephony synthesis providers so Google Meet agent speech logs match the backend that actually produced the audio. Thanks @vincentkoc.
 - Voice Call/realtime: bound the paced Twilio audio queue and close overloaded realtime streams before provider audio can pile up behind the websocket backpressure guard. Thanks @vincentkoc.
-- Docs: clarify that IRC uses raw TCP/TLS sockets outside operator-managed forward proxy routing, so direct IRC egress should be explicitly approved before enabling IRC. Thanks @jesse-merhi.
+- Docs: clarify that IRC uses raw TCP/TLS sockets outside operator-managed forward proxy routing, so direct IRC egress should be explicitly approved before enabling IRC. Thankjesse-merhi.
 - Gateway/performance: defer non-readiness sidecars until after the ready signal, avoid hot-path channel plugin barrel imports, and fast-path trusted bundled plugin metadata during Gateway startup.
 - Gateway/performance: avoid importing `jiti` on native-loadable plugin startup paths, so compiled bundled plugin surfaces do not pay source-transform loader cost unless fallback loading is actually needed.
 - Plugins/loader: preserve real compiled plugin module evaluation errors on the native fast path instead of treating every thrown `.js` module as a source-transform fallback miss. Thanks @vincentkoc.
@@ -41,7 +41,7 @@ Docs: https://docs.openclaw.ai
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Providers/OpenRouter: add opt-in response caching params that send OpenRouter's `X-OpenRouter-Cache`, `X-OpenRouter-Cache-TTL`, and cache-clear headers only on verified OpenRouter routes. Thanks @vincentkoc.
 - Providers/OpenRouter: expand app-attribution categories so OpenClaw advertises coding, programming, writing, chat, and personal-agent usage on verified OpenRouter routes. Thanks @vincentkoc.
-- Providers/OpenRouter: add inbound audio STT support to media-understanding via OpenRouter's JSON `/audio/transcriptions` contract, including default audio model metadata and auto-selection priority. (#77463)
+- Providers/OpenRouter: add inbound audio STT support to media-understanding via OpenRouter's JSON `/audio/transcriptions` contract, including default audio model metadata and auto-selection priority. Thanks @remdev
 - Plugins/runtime state: add `registerIfAbsent` for atomic keyed-store dedupe claims that return whether a plugin successfully claimed a key without overwriting an existing live value. Thanks @amknight.
 - Plugin SDK: add plugin-owned `SessionEntry` slot projection and scoped trusted-policy session extension reads. (#75609; replaces part of #73384/#74483) Thanks @100yenadmin.
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -192,7 +192,7 @@ If `tools.media.<capability>.enabled` is **not** set to `false` and you haven't 
 
     Bundled fallback order:
 
-    - Audio: OpenAI → Groq → xAI → Deepgram → Google → SenseAudio → ElevenLabs → Mistral
+    - Audio: OpenAI → Groq → xAI → Deepgram → OpenRouter → Google → SenseAudio → ElevenLabs → Mistral
     - Image: OpenAI → Anthropic → Google → MiniMax → MiniMax Portal → Z.AI
     - Video: Google → Qwen → Moonshot
 
@@ -237,7 +237,7 @@ If you set `capabilities`, the entry only runs for those media types. For shared
 - `openai`, `anthropic`, `minimax`: **image**
 - `minimax-portal`: **image**
 - `moonshot`: **image + video**
-- `openrouter`: **image**
+- `openrouter`: **image + audio**
 - `google` (Gemini API): **image + audio + video**
 - `qwen`: **image + video**
 - `mistral`: **audio**
@@ -254,7 +254,7 @@ For CLI entries, **set `capabilities` explicitly** to avoid surprising matches. 
 | Capability | Provider integration                                                                                                         | Notes                                                                                                                                                                                                                                   |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Image      | OpenAI, OpenAI Codex OAuth, Codex app-server, OpenRouter, Anthropic, Google, MiniMax, Moonshot, Qwen, Z.AI, config providers | Vendor plugins register image support; `openai-codex/*` uses OAuth provider plumbing; `codex/*` uses a bounded Codex app-server turn; MiniMax and MiniMax OAuth both use `MiniMax-VL-01`; image-capable config providers auto-register. |
-| Audio      | OpenAI, Groq, xAI, Deepgram, Google, SenseAudio, ElevenLabs, Mistral                                                         | Provider transcription (Whisper/Groq/xAI/Deepgram/Gemini/SenseAudio/Scribe/Voxtral).                                                                                                                                                    |
+| Audio      | OpenAI, Groq, xAI, Deepgram, OpenRouter, Google, SenseAudio, ElevenLabs, Mistral                                             | Provider transcription (Whisper/Groq/xAI/Deepgram/OpenRouter STT/Gemini/SenseAudio/Scribe/Voxtral).                                                                                                                                     |
 | Video      | Google, Qwen, Moonshot                                                                                                       | Provider video understanding via vendor plugins; Qwen video understanding uses the Standard DashScope endpoints.                                                                                                                        |
 
 <Note>

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -132,6 +132,29 @@ OpenRouter can also be used as a TTS provider through its OpenAI-compatible
 If `messages.tts.providers.openrouter.apiKey` is omitted, TTS reuses
 `models.providers.openrouter.apiKey`, then `OPENROUTER_API_KEY`.
 
+## Speech-to-text (inbound audio)
+
+OpenRouter can transcribe inbound voice/audio attachments through the shared
+`tools.media.audio` path using its STT endpoint (`/audio/transcriptions`).
+This applies to any channel plugin that forwards inbound voice/audio into
+media understanding preflight.
+
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [{ provider: "openrouter", model: "openai/whisper-large-v3-turbo" }],
+      },
+    },
+  },
+}
+```
+
+OpenClaw sends OpenRouter STT requests as JSON with base64 audio under
+`input_audio` (OpenRouter STT contract), not as multipart OpenAI form uploads.
+
 ## Authentication and headers
 
 OpenRouter uses a Bearer token with your API key under the hood.

--- a/docs/tools/media-overview.md
+++ b/docs/tools/media-overview.md
@@ -61,7 +61,7 @@ provider is configured.
 | MiniMax     |   ✓   |   ✓   |   ✓   |  ✓  |     |                |                     |
 | Mistral     |       |       |       |     |  ✓  |                |                     |
 | OpenAI      |   ✓   |   ✓   |       |  ✓  |  ✓  |       ✓        |          ✓          |
-| OpenRouter  |   ✓   |   ✓   |       |  ✓  |     |                |          ✓          |
+| OpenRouter  |   ✓   |   ✓   |       |  ✓  |  ✓  |                |          ✓          |
 | Qwen        |       |   ✓   |       |     |     |                |                     |
 | Runway      |       |   ✓   |       |     |     |                |                     |
 | SenseAudio  |       |       |       |     |  ✓  |                |                     |
@@ -96,7 +96,7 @@ original channel.
 
 ## Speech-to-text and Voice Call
 
-Deepgram, DeepInfra, ElevenLabs, Mistral, OpenAI, SenseAudio, and xAI can all transcribe
+Deepgram, DeepInfra, ElevenLabs, Mistral, OpenAI, OpenRouter, SenseAudio, and xAI can all transcribe
 inbound audio through the batch `tools.media.audio` path when configured.
 Channel plugins that preflight a voice note for mention gating or command
 parsing mark the transcribed attachment on the inbound context, so the shared

--- a/extensions/openrouter/media-understanding-provider.test.ts
+++ b/extensions/openrouter/media-understanding-provider.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  openrouterMediaUnderstandingProvider,
+  transcribeOpenRouterAudio,
+} from "./media-understanding-provider.js";
+
+const { assertOkOrThrowHttpErrorMock, postJsonRequestMock, resolveProviderHttpRequestConfigMock } =
+  vi.hoisted(() => ({
+    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+    postJsonRequestMock: vi.fn(),
+    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
+      allowPrivateNetwork: false,
+      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+      dispatcherPolicy: undefined,
+    })),
+  }));
+
+vi.mock("openclaw/plugin-sdk/provider-http", () => ({
+  assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
+  postJsonRequest: postJsonRequestMock,
+  requireTranscriptionText: (value: string | undefined, message: string) => {
+    const text = value?.trim();
+    if (!text) {
+      throw new Error(message);
+    }
+    return text;
+  },
+  resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
+}));
+
+describe("openrouter media understanding provider", () => {
+  afterEach(() => {
+    assertOkOrThrowHttpErrorMock.mockClear();
+    postJsonRequestMock.mockReset();
+    resolveProviderHttpRequestConfigMock.mockClear();
+  });
+
+  it("declares image and audio capabilities with defaults", () => {
+    expect(openrouterMediaUnderstandingProvider).toMatchObject({
+      id: "openrouter",
+      capabilities: ["image", "audio"],
+      defaultModels: {
+        image: "auto",
+        audio: "openai/whisper-large-v3-turbo",
+      },
+      autoPriority: { audio: 35 },
+    });
+    expect(openrouterMediaUnderstandingProvider.transcribeAudio).toBeTypeOf("function");
+  });
+
+  it("sends JSON STT payload to OpenRouter transcriptions endpoint", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "hello world" }), { status: 200 }),
+      release,
+    });
+
+    const result = await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.oga",
+      mime: "audio/ogg",
+      apiKey: "sk-openrouter",
+      timeoutMs: 12_000,
+      language: " en ",
+      fetchFn: fetch,
+    });
+
+    expect(result).toEqual({
+      text: "hello world",
+      model: "openai/whisper-large-v3-turbo",
+    });
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openrouter",
+        capability: "audio",
+      }),
+    );
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://openrouter.ai/api/v1/audio/transcriptions",
+        timeoutMs: 12_000,
+        body: {
+          model: "openai/whisper-large-v3-turbo",
+          input_audio: {
+            data: Buffer.from("audio-bytes").toString("base64"),
+            format: "ogg",
+          },
+          language: "en",
+        },
+      }),
+    );
+    const headers = postJsonRequestMock.mock.calls[0]?.[0]?.headers as Headers;
+    expect(headers.get("authorization")).toBe("Bearer sk-openrouter");
+    expect(headers.get("http-referer")).toBe("https://openclaw.ai");
+    expect(headers.get("x-openrouter-title")).toBe("OpenClaw");
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("accepts temperature via provider query options", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "ok" }), { status: 200 }),
+      release,
+    });
+
+    await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.webm",
+      apiKey: "sk-openrouter",
+      timeoutMs: 5_000,
+      query: { temperature: 0.2 },
+      fetchFn: fetch,
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          temperature: 0.2,
+        }),
+      }),
+    );
+  });
+
+  it("falls back to filename extension when mime is missing", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "ok" }), { status: 200 }),
+      release,
+    });
+
+    await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.opus",
+      apiKey: "sk-openrouter",
+      timeoutMs: 5_000,
+      fetchFn: fetch,
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          input_audio: expect.objectContaining({ format: "ogg" }),
+        }),
+      }),
+    );
+  });
+
+  it("throws when format cannot be resolved", async () => {
+    await expect(
+      transcribeOpenRouterAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.bin",
+        mime: "application/octet-stream",
+        apiKey: "sk-openrouter",
+        timeoutMs: 5_000,
+        fetchFn: fetch,
+      }),
+    ).rejects.toThrow("OpenRouter STT could not resolve audio format");
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when provider response omits text", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({}), { status: 200 }),
+      release,
+    });
+
+    await expect(
+      transcribeOpenRouterAudio({
+        buffer: Buffer.from("audio"),
+        fileName: "voice.mp3",
+        apiKey: "sk-openrouter",
+        timeoutMs: 5_000,
+        fetchFn: fetch,
+      }),
+    ).rejects.toThrow("OpenRouter transcription response missing text");
+  });
+});

--- a/extensions/openrouter/media-understanding-provider.test.ts
+++ b/extensions/openrouter/media-understanding-provider.test.ts
@@ -146,6 +146,31 @@ describe("openrouter media understanding provider", () => {
     );
   });
 
+  it("normalizes parameterized mime for extensionless filenames", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "ok" }), { status: 200 }),
+      release,
+    });
+
+    await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "media-1",
+      mime: " Audio/Ogg; codecs=opus ",
+      apiKey: "sk-openrouter",
+      timeoutMs: 5_000,
+      fetchFn: fetch,
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          input_audio: expect.objectContaining({ format: "ogg" }),
+        }),
+      }),
+    );
+  });
+
   it("throws when format cannot be resolved", async () => {
     await expect(
       transcribeOpenRouterAudio({

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -1,13 +1,161 @@
+import path from "node:path";
 import {
   describeImageWithModel,
   describeImagesWithModel,
+  type AudioTranscriptionRequest,
+  type AudioTranscriptionResult,
   type MediaUnderstandingProvider,
 } from "openclaw/plugin-sdk/media-understanding";
+import {
+  assertOkOrThrowHttpError,
+  postJsonRequest,
+  requireTranscriptionText,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
+
+const DEFAULT_OPENROUTER_AUDIO_TRANSCRIPTION_MODEL = "openai/whisper-large-v3-turbo";
+const SUPPORTED_AUDIO_FORMATS = new Set(["wav", "mp3", "flac", "m4a", "ogg", "webm", "aac"]);
+
+function resolveFormatFromMime(mime?: string): string | undefined {
+  const normalized = mime?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  switch (normalized) {
+    case "audio/wav":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/mpeg":
+    case "audio/mp3":
+      return "mp3";
+    case "audio/flac":
+      return "flac";
+    case "audio/mp4":
+    case "audio/x-m4a":
+      return "m4a";
+    case "audio/ogg":
+    case "audio/oga":
+      return "ogg";
+    case "audio/webm":
+      return "webm";
+    case "audio/aac":
+      return "aac";
+    default:
+      return undefined;
+  }
+}
+
+function resolveFormatFromFileName(fileName?: string): string | undefined {
+  const ext = path
+    .extname(fileName ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\./, "");
+  if (!ext) {
+    return undefined;
+  }
+  if (ext === "mpeg") {
+    return "mp3";
+  }
+  if (ext === "oga" || ext === "opus") {
+    return "ogg";
+  }
+  return SUPPORTED_AUDIO_FORMATS.has(ext) ? ext : undefined;
+}
+
+function resolveOpenRouterAudioFormat(params: { mime?: string; fileName?: string }): string {
+  const fromMime = resolveFormatFromMime(params.mime);
+  if (fromMime) {
+    return fromMime;
+  }
+  const fromFileName = resolveFormatFromFileName(params.fileName);
+  if (fromFileName) {
+    return fromFileName;
+  }
+  throw new Error(
+    `OpenRouter STT could not resolve audio format from mime "${params.mime ?? ""}" and file "${params.fileName ?? ""}"`,
+  );
+}
+
+type OpenRouterSttResponse = {
+  text?: string;
+};
+
+export async function transcribeOpenRouterAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const model = params.model?.trim() || DEFAULT_OPENROUTER_AUDIO_TRANSCRIPTION_MODEL;
+  const format = resolveOpenRouterAudioFormat({
+    mime: params.mime,
+    fileName: params.fileName,
+  });
+  const fetchFn = params.fetchFn ?? fetch;
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: OPENROUTER_BASE_URL,
+      headers: params.headers,
+      request: params.request,
+      defaultHeaders: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+      },
+      provider: "openrouter",
+      api: "openrouter-stt",
+      capability: "audio",
+      transport: "media-understanding",
+    });
+
+  const { response, release } = await postJsonRequest({
+    url: `${baseUrl}/audio/transcriptions`,
+    headers,
+    body: {
+      model,
+      input_audio: {
+        data: params.buffer.toString("base64"),
+        format,
+      },
+      ...(params.language?.trim() ? { language: params.language.trim() } : {}),
+      ...(typeof params.query?.temperature === "number"
+        ? { temperature: params.query.temperature }
+        : {}),
+    },
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+    allowPrivateNetwork,
+    dispatcherPolicy,
+    auditContext: "openrouter stt",
+  });
+
+  try {
+    await assertOkOrThrowHttpError(response, "OpenRouter audio transcription failed");
+    const payload = (await response.json()) as OpenRouterSttResponse;
+    return {
+      text: requireTranscriptionText(
+        payload.text,
+        "OpenRouter transcription response missing text",
+      ),
+      model,
+    };
+  } finally {
+    await release();
+  }
+}
 
 export const openrouterMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "openrouter",
-  capabilities: ["image"],
-  defaultModels: { image: "auto" },
+  capabilities: ["image", "audio"],
+  defaultModels: {
+    image: "auto",
+    audio: DEFAULT_OPENROUTER_AUDIO_TRANSCRIPTION_MODEL,
+  },
+  autoPriority: {
+    audio: 35,
+  },
   describeImage: describeImageWithModel,
   describeImages: describeImagesWithModel,
+  transcribeAudio: transcribeOpenRouterAudio,
 };

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -17,8 +17,18 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_OPENROUTER_AUDIO_TRANSCRIPTION_MODEL = "openai/whisper-large-v3-turbo";
 const SUPPORTED_AUDIO_FORMATS = new Set(["wav", "mp3", "flac", "m4a", "ogg", "webm", "aac"]);
 
-function resolveFormatFromMime(mime?: string): string | undefined {
+function normalizeMimeType(mime?: string): string | undefined {
   const normalized = mime?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  const [type] = normalized.split(";");
+  const clean = type?.trim();
+  return clean || undefined;
+}
+
+function resolveFormatFromMime(mime?: string): string | undefined {
+  const normalized = normalizeMimeType(mime);
   if (!normalized) {
     return undefined;
   }
@@ -32,10 +42,12 @@ function resolveFormatFromMime(mime?: string): string | undefined {
     case "audio/flac":
       return "flac";
     case "audio/mp4":
+    case "audio/m4a":
     case "audio/x-m4a":
       return "m4a";
     case "audio/ogg":
     case "audio/oga":
+    case "audio/opus":
       return "ogg";
     case "audio/webm":
       return "webm";

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -61,9 +61,13 @@
   },
   "mediaUnderstandingProviderMetadata": {
     "openrouter": {
-      "capabilities": ["image"],
+      "capabilities": ["image", "audio"],
       "defaultModels": {
-        "image": "auto"
+        "image": "auto",
+        "audio": "openai/whisper-large-v3-turbo"
+      },
+      "autoPriority": {
+        "audio": 35
       }
     }
   },

--- a/src/media-understanding/defaults.test.ts
+++ b/src/media-understanding/defaults.test.ts
@@ -64,7 +64,11 @@ const mediaMetadataPlugins = vi.hoisted(() => [
       },
       opencode: { capabilities: ["image"], defaultModels: { image: "gpt-5-nano" } },
       "opencode-go": { capabilities: ["image"], defaultModels: { image: "kimi-k2.6" } },
-      openrouter: { capabilities: ["image"], defaultModels: { image: "auto" } },
+      openrouter: {
+        capabilities: ["image", "audio"],
+        defaultModels: { image: "auto", audio: "openai/whisper-large-v3-turbo" },
+        autoPriority: { audio: 35 },
+      },
       qwen: { capabilities: ["video"], autoPriority: { video: 20 } },
       xai: { capabilities: ["audio"], autoPriority: { audio: 25 } },
       zai: { capabilities: ["image"], autoPriority: { image: 60 } },
@@ -108,6 +112,9 @@ describe("resolveDefaultMediaModel", () => {
     expect(resolveDefaultMediaModel({ providerId: "mistral", capability: "audio" })).toBe(
       "voxtral-mini-latest",
     );
+    expect(resolveDefaultMediaModel({ providerId: "openrouter", capability: "audio" })).toBe(
+      "openai/whisper-large-v3-turbo",
+    );
   });
 
   it("resolves bundled image defaults beyond the historical core set", () => {
@@ -137,6 +144,7 @@ describe("resolveAutoMediaKeyProviders", () => {
     expect(resolveAutoMediaKeyProviders({ capability: "audio" })).toEqual([
       "openai",
       "xai",
+      "openrouter",
       "google",
       "mistral",
     ]);


### PR DESCRIPTION
## Summary

- Problem: OpenRouter plugin exposed media-understanding only for images, so inbound voice/audio STT via shared `tools.media.audio` could not use OpenRouter.
- Why it matters: Channels that preflight voice/audio (including Telegram and others) could not route transcription through OpenRouter despite OpenRouter now supporting STT models and `/audio/transcriptions`.
- What changed: Added OpenRouter audio transcription support in the media-understanding provider using OpenRouter JSON STT contract (`input_audio` base64), expanded plugin metadata to `["image","audio"]`, added focused tests, and updated docs/matrices/fallback lists.
- What did NOT change (scope boundary): No channel-specific runtime rewrites, no core media pipeline redesign, no auth flow changes, no secret/config file commits.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A (feature addition).
- Missing detection / guardrail: N/A.
- Contributing context (if known): OpenRouter STT surface is newer than existing OpenRouter plugin media-understanding scope.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/openrouter/media-understanding-provider.test.ts` (new)
  - `src/media-understanding/defaults.test.ts` (updated metadata/fallback assertions)
  - `extensions/telegram/src/bot-message-context.body.test.ts` (focused channel-preflight safety check)
- Scenario the test should lock in:
  - OpenRouter STT request shape is JSON (`input_audio`) with correct headers/model/format and non-empty text handling.
  - OpenRouter appears in audio defaults/fallback ordering through provider metadata.
  - Existing channel preflight path remains stable.
- Why this is the smallest reliable guardrail:
  - Covers provider contract + default resolution + one representative channel preflight path without broad lane expansion.
- Existing test that already covers this (if any):
  - Existing extension/provider shard tests and media defaults tests were extended.
- If no new test is added, why not:
  - N/A (new tests added).

## User-visible / Behavior Changes

- OpenRouter can now transcribe inbound voice/audio via shared `tools.media.audio`.
- OpenRouter now appears as STT-capable in media docs/matrices.
- New OpenRouter STT docs/config example added.
- No required config migration; behavior is opt-in/auto-detect via existing media pipeline.

## Diagram (if applicable)

```text
Before:
[channel inbound voice/audio] -> [tools.media.audio runner] -> [OpenRouter skipped for audio]

After:
[channel inbound voice/audio] -> [tools.media.audio runner] -> [OpenRouter STT JSON /audio/transcriptions] -> [transcript]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Risk: New outbound request path to OpenRouter STT endpoint.
  - Mitigation: Uses existing provider HTTP policy helpers (`resolveProviderHttpRequestConfig`, guarded transport/policy handling), existing auth model, no secret persistence in repo.

## Repro + Verification

### Environment

- OS: macOS (darwin 25.3.0)
- Runtime/container: Node 22 + pnpm workspace tests
- Model/provider: OpenRouter (`openai/whisper-large-v3-turbo`)
- Integration/channel (if any): Shared media-understanding inbound audio path (channel-agnostic), plus focused Telegram preflight test
- Relevant config (redacted): `OPENROUTER_API_KEY` provided at runtime only for live smoke (not persisted)

### Steps

1. Run focused tests:
   - `pnpm test extensions/openrouter src/media-understanding/defaults.test.ts`
   - `pnpm test extensions/telegram/src/bot-message-context.body.test.ts`
2. Run formatting check on touched files:
   - `pnpm exec oxfmt --check --threads=1 <changed-files>`
3. Run live smoke against OpenRouter:
   - STT on a generated short English speech sample (and auto-detect language mode).
 4. Validate MIME edge case in focused tests:
 - extensions/openrouter/media-understanding-provider.test.ts covers parameterized MIME (Audio/Ogg; codecs=opus) with extensionless filename (media-1).

### Expected

- OpenRouter media provider exposes audio capability and sends valid JSON STT payload.
- Tests pass.
- Live transcript returns non-empty correct speech text.

### Actual

- All focused tests passed.
- Formatting/lints clean on touched files.
- Live OpenRouter STT smoke passed, including correct English transcript.
- MIME edge-case test passed: parameterized voice-note MIME with extensionless filename resolves to ogg and reaches /audio/transcriptions without format-resolution error.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Log snippets:

- `pnpm test extensions/openrouter src/media-understanding/defaults.test.ts`
  - `Test Files  8 passed`
  - `Tests  43 passed`
- `pnpm test extensions/telegram/src/bot-message-context.body.test.ts`
  - `Test Files  1 passed`
  - `Tests  6 passed`
- `pnpm exec oxfmt --check --threads=1 ...`
  - `All matched files use the correct format.`
- OpenRouter live STT smoke:
  - `OpenRouter live STT smoke passed`
  - `Transcript: OpenClaw Integration Test OK.`
- `pnpm test extensions/openrouter/media-understanding-provider.test.ts`
  - normalizes parameterized mime for extensionless filenames ✅

## Human Verification (required)

- Verified scenarios:
  - OpenRouter STT payload/headers/model selection behavior in unit tests.
  - Metadata-driven defaults/fallback inclusion for OpenRouter audio.
  - Real OpenRouter transcription on short English speech input.
- Edge cases checked:
  - Missing/unknown format handling path.
  - Empty-text response failure path.
  - Explicit/auto language handling on English speech.
- What you did **not** verify:
  - Full broad changed-lane suite in Testbox.
  - Multi-channel live matrix beyond focused Telegram preflight + direct OpenRouter live smoke.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk: Provider-side STT schema changes could break request compatibility.
  - Mitigation: Request shape is covered by focused provider tests and live smoke; uses explicit OpenRouter STT JSON contract.
- Risk: Incorrect MIME/extension mapping may degrade recognition on uncommon files.
  - Mitigation: Format resolver supports common audio MIME/ext combinations; unknown formats fail fast with explicit error.
- Risk: Fallback ordering assumptions could drift from metadata.
  - Mitigation: `src/media-understanding/defaults.test.ts` updated to assert OpenRouter audio defaults/order.
