### PR TITLE
Use trusted Windows browser helper root

### DIFF
--- a/src/infra/browser-open.test.ts
+++ b/src/infra/browser-open.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveBrowserOpenCommand } from "./browser-open.js";
+import { _resetWindowsInstallRootsForTests } from "./windows-install-roots.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  _resetWindowsInstallRootsForTests();
+});
+
+describe("resolveBrowserOpenCommand", () => {
+  it("does not resolve Windows browser launching through a relative SystemRoot", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("SystemRoot", ".\\fake-root");
+    vi.stubEnv("windir", ".\\fake-windir");
+    _resetWindowsInstallRootsForTests({ queryRegistryValue: () => null });
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    const rundll32 = path.win32.join("C:\\Windows", "System32", "rundll32.exe");
+    expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
+    expect(resolved.command).toBe(rundll32);
+  });
+
+  it("prefers the registry-backed Windows system root over process env", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    vi.stubEnv("SystemRoot", "C:\\PoisonedWindows");
+    _resetWindowsInstallRootsForTests({
+      queryRegistryValue: (key, valueName) => {
+        if (
+          key === "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion" &&
+          valueName === "SystemRoot"
+        ) {
+          return "D:\\Windows";
+        }
+        return null;
+      },
+    });
+
+    const resolved = await resolveBrowserOpenCommand();
+
+    const rundll32 = path.win32.join("D:\\Windows", "System32", "rundll32.exe");
+    expect(resolved.argv).toEqual([rundll32, "url.dll,FileProtocolHandler"]);
+    expect(resolved.command).toBe(rundll32);
+  });
+});

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { detectBinary } from "./detect-binary.js";
+import { getWindowsInstallRoots } from "./windows-install-roots.js";
 import { isWSL } from "./wsl.js";
 
 type BrowserOpenCommand = {
@@ -23,7 +24,7 @@ function shouldSkipBrowserOpenInTests(): boolean {
 }
 
 function resolveWindowsRundll32Path(): string {
-  const systemRoot = process.env.SystemRoot?.trim() || process.env.windir?.trim() || "C:\\Windows";
+  const { systemRoot } = getWindowsInstallRoots();
   return path.win32.join(systemRoot, "System32", "rundll32.exe");
 }
 


### PR DESCRIPTION
# Use trusted Windows browser helper root

## Summary

- Problem: The Windows browser-launch helper built its `rundll32.exe` path directly from `SystemRoot` or `windir`.
- Why it matters: Polluted process environment values could steer URL-opening flows toward an unintended executable.
- What changed: Browser launching now uses the existing validated Windows install-root resolver, and regression tests cover relative and registry-backed root selection.
- What did NOT change (scope boundary): No browser URL handling, dotenv loading, CI, workflow, release, or automation behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related NVIDIA-dev/openclaw-tracking#543
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveWindowsRundll32Path()` read `process.env.SystemRoot` and `process.env.windir` directly instead of using the existing validated Windows install-root resolver.
- Missing detection / guardrail: Browser-open coverage did not assert that relative or polluted Windows root values are ignored for helper executable selection.
- Contributing context (if known): Workspace dotenv loading already blocks these environment keys on current `main`, but the browser helper still had a direct environment lookup.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/browser-open.test.ts`
- Scenario the test should lock in: Windows browser helper resolution ignores relative environment roots and prefers registry-backed Windows install roots over process env values.
- Why this is the smallest reliable guardrail: The bug is in local command-path resolution, so a focused unit test can validate the resolver output without launching a browser.
- Existing test that already covers this (if any): `src/infra/dotenv.test.ts` covers workspace dotenv blocking for `SystemRoot` and `windir`, but not browser helper path selection.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Windows URL-opening flows now resolve `rundll32.exe` through validated Windows install-root discovery instead of direct `SystemRoot` / `windir` environment values.

## Diagram (if applicable)

```text
Before:
[open URL on Windows] -> [read SystemRoot/windir directly] -> [launch derived rundll32.exe]

After:
[open URL on Windows] -> [resolve validated Windows install root] -> [launch system rundll32.exe]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The browser-launch executable selection now uses validated Windows install-root resolution, reducing exposure to polluted environment values.

## Repro + Verification

### Environment

- OS: Linux 11a9332f228e 6.8.0-110-generic x86_64
- Runtime/container: Node v22.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): Windows browser-open helper
- Relevant config (redacted): N/A

### Steps

1. On Windows helper resolution, set `SystemRoot` to a relative path such as `.\fake-root`.
2. Resolve the browser-open command.
3. Check the selected helper executable path.

### Expected

- The helper resolves to a validated Windows install root such as `C:\Windows\System32\rundll32.exe` or a registry-backed system root.

### Actual

- Before this patch, the helper derived `rundll32.exe` directly from the environment value. After this patch, the new regression test resolves through the validated root helper.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/browser-open.test.ts src/infra/dotenv.test.ts`

Result: 2 test files passed, 31 tests passed.

## Human Verification (required)

- Verified scenarios: Relative `SystemRoot` / `windir` values fall back to the default Windows root; registry-backed system root wins over a polluted process env root; existing workspace dotenv blocking coverage still passes.
- Edge cases checked: Relative root values, registry-preferred root values.
- What you did **not** verify: Real browser launching on a Windows host.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Windows systems with unusual install roots could resolve differently than before.
  - Mitigation: The resolver already checks registry-backed Windows install roots before falling back to validated environment roots and defaults.