### PR TITLE
Harden Windows command wrapper resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ Docs: https://docs.openclaw.ai
 - QQBot: preserve the framework command authorization decision when converting framework command contexts into engine slash command contexts, so downstream slash handlers see `commandAuthorized` matching the channel's resolved `isAuthorizedSender` instead of a hardcoded `true`. (#77453) Thanks @drobison00.
 - Security/Windows: block `LOCALAPPDATA` from workspace `.env` and resolve Windows update-flow portable Git path prepends from the trusted process-local `LOCALAPPDATA` only, so workspace-supplied values cannot redirect `git` discovery during `openclaw update`. (#77470) Thanks @drobison00.
 - Browser/SSRF: enforce the existing current-tab URL navigation policy before tab-scoped debug, export, and read routes (console, page errors, network requests, trace start/stop, response body, screenshot, snapshot, storage, etc.) collect from an already-selected tab, so blocked tabs return a policy error instead of being read first and redacted only at response time. (#75731) Thanks @eleqtrizit.
+- Security/Windows: route the `.cmd`/`.bat` process wrapper through the shared Windows install-root resolver instead of `process.env.ComSpec`, so workspace dotenv-blocked `SystemRoot`/`WINDIR` overrides and unsafe values like UNC paths or path-lists cannot redirect `cmd.exe` selection on Windows. (#77472) Thanks @drobison00.
 
 ## 2026.5.3-1
 

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -9,6 +9,7 @@ import {
   decodeWindowsOutputBuffer,
   resolveWindowsConsoleEncoding,
 } from "../infra/windows-encoding.js";
+import { getWindowsInstallRoots } from "../infra/windows-install-roots.js";
 import { logDebug, logError } from "../logger.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveCommandStdio } from "./spawn-utils.js";
@@ -49,13 +50,7 @@ function resolveTrustedWindowsCmdExe(): string {
   if (process.platform !== "win32") {
     return "cmd.exe";
   }
-  for (const key of ["SystemRoot", "SYSTEMROOT", "windir", "WINDIR"] as const) {
-    const systemRoot = process.env[key]?.trim();
-    if (systemRoot && path.win32.isAbsolute(systemRoot)) {
-      return path.win32.join(systemRoot, "System32", "cmd.exe");
-    }
-  }
-  return "cmd.exe";
+  return path.win32.join(getWindowsInstallRoots().systemRoot, "System32", "cmd.exe");
 }
 
 /**

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -45,6 +45,19 @@ function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string
   return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
 }
 
+function resolveTrustedWindowsCmdExe(): string {
+  if (process.platform !== "win32") {
+    return "cmd.exe";
+  }
+  for (const key of ["SystemRoot", "SYSTEMROOT", "windir", "WINDIR"] as const) {
+    const systemRoot = process.env[key]?.trim();
+    if (systemRoot && path.win32.isAbsolute(systemRoot)) {
+      return path.win32.join(systemRoot, "System32", "cmd.exe");
+    }
+  }
+  return "cmd.exe";
+}
+
 /**
  * On Windows, Node 18.20.2+ (CVE-2024-27980) rejects spawning .cmd/.bat directly
  * without shell, causing EINVAL. Resolve npm/npx to node + cli script so we
@@ -107,7 +120,7 @@ function resolveChildProcessInvocation(params: {
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
 
   return {
-    command: useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
+    command: useCmdWrapper ? resolveTrustedWindowsCmdExe() : resolvedCommand,
     args: useCmdWrapper
       ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
       : finalArgv.slice(1),

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -3,6 +3,10 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetWindowsInstallRootsForTests,
+  getWindowsInstallRoots,
+} from "../infra/windows-install-roots.js";
 
 const { spawnMock, spawnSyncMock, execFileMock, execFilePromisifyMock } = vi.hoisted(() => {
   const execFilePromisifyMock = vi.fn();
@@ -101,11 +105,8 @@ function expectCmdWrappedInvocation(params: {
   expect(params.captured[2].windowsVerbatimArguments).toBe(true);
 }
 
-function expectedTrustedCmdExe(systemRoot?: string): string {
-  if (systemRoot && path.win32.isAbsolute(systemRoot)) {
-    return path.win32.join(systemRoot, "System32", "cmd.exe");
-  }
-  return "cmd.exe";
+function expectedTrustedCmdExe(): string {
+  return path.win32.join(getWindowsInstallRoots().systemRoot, "System32", "cmd.exe");
 }
 
 async function expectShimmedWindowsCommandWithoutExitCodeSucceeds(params?: { killed?: boolean }) {
@@ -134,6 +135,7 @@ describe("windows command wrapper behavior", () => {
   });
 
   beforeEach(() => {
+    _resetWindowsInstallRootsForTests();
     spawnMock.mockReset();
     spawnSyncMock.mockReset();
     spawnSyncMock.mockReturnValue({ stdout: "Active code page: 936", stderr: "" });
@@ -164,7 +166,7 @@ describe("windows command wrapper behavior", () => {
 
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
+    const expectedComSpec = expectedTrustedCmdExe();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -214,9 +216,53 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("rejects unsafe Windows root values when selecting the command wrapper", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const previousSystemRoot = process.env.SystemRoot;
+    const previousWindir = process.env.windir;
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      for (const unsafeRoot of [
+        "\\\\evil\\share",
+        "C:\\Windows;C:\\evil",
+        "\\Windows",
+        "relative\\path",
+      ]) {
+        _resetWindowsInstallRootsForTests();
+        process.env.SystemRoot = unsafeRoot;
+        delete process.env.windir;
+        spawnMock.mockClear();
+
+        const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
+        expect(result.code).toBe(0);
+        const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+        expectCmdWrappedInvocation({
+          captured,
+          expectedComSpec: path.win32.join("C:\\Windows", "System32", "cmd.exe"),
+        });
+      }
+    } finally {
+      if (previousSystemRoot === undefined) {
+        delete process.env.SystemRoot;
+      } else {
+        process.env.SystemRoot = previousSystemRoot;
+      }
+      if (previousWindir === undefined) {
+        delete process.env.windir;
+      } else {
+        process.env.windir = previousWindir;
+      }
+      platformSpy.mockRestore();
+    }
+  });
+
   it("wraps corepack.cmd via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
+    const expectedComSpec = expectedTrustedCmdExe();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -284,7 +330,7 @@ describe("windows command wrapper behavior", () => {
   it("falls back to npm.cmd when npm-cli.js is unavailable", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
+    const expectedComSpec = expectedTrustedCmdExe();
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -338,7 +384,7 @@ describe("windows command wrapper behavior", () => {
 
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
+    const expectedComSpec = expectedTrustedCmdExe();
 
     execFileMock.mockImplementation(
       (

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -101,6 +101,13 @@ function expectCmdWrappedInvocation(params: {
   expect(params.captured[2].windowsVerbatimArguments).toBe(true);
 }
 
+function expectedTrustedCmdExe(systemRoot?: string): string {
+  if (systemRoot && path.win32.isAbsolute(systemRoot)) {
+    return path.win32.join(systemRoot, "System32", "cmd.exe");
+  }
+  return "cmd.exe";
+}
+
 async function expectShimmedWindowsCommandWithoutExitCodeSucceeds(params?: { killed?: boolean }) {
   const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
   const child = createMockChild({
@@ -157,7 +164,7 @@ describe("windows command wrapper behavior", () => {
 
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -173,9 +180,43 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("ignores ComSpec when selecting the Windows command wrapper", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const previousComSpec = process.env.ComSpec;
+    const previousSystemRoot = process.env.SystemRoot;
+    process.env.ComSpec = "C:\\workspace\\evil\\cmd.exe";
+    process.env.SystemRoot = "C:\\Windows";
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      expectCmdWrappedInvocation({
+        captured,
+        expectedComSpec: path.win32.join("C:\\Windows", "System32", "cmd.exe"),
+      });
+    } finally {
+      if (previousComSpec === undefined) {
+        delete process.env.ComSpec;
+      } else {
+        process.env.ComSpec = previousComSpec;
+      }
+      if (previousSystemRoot === undefined) {
+        delete process.env.SystemRoot;
+      } else {
+        process.env.SystemRoot = previousSystemRoot;
+      }
+      platformSpy.mockRestore();
+    }
+  });
+
   it("wraps corepack.cmd via cmd.exe in runCommandWithTimeout", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -243,7 +284,7 @@ describe("windows command wrapper behavior", () => {
   it("falls back to npm.cmd when npm-cli.js is unavailable", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -297,7 +338,7 @@ describe("windows command wrapper behavior", () => {
 
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+    const expectedComSpec = expectedTrustedCmdExe(process.env.SystemRoot);
 
     execFileMock.mockImplementation(
       (

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -222,7 +222,7 @@ describe("windows command wrapper behavior", () => {
   it("rejects unsafe Windows root values when selecting the command wrapper", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const previousSystemRoot = process.env.SystemRoot;
-    const previousWindir = process.env.windir;
+    const previousWindir = process.env.WINDIR;
 
     spawnMock.mockImplementation(
       (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
@@ -236,8 +236,12 @@ describe("windows command wrapper behavior", () => {
         "relative\\path",
       ]) {
         _resetWindowsInstallRootsForTests({ queryRegistryValue: () => null });
+        // Set every install-root env source to the unsafe value so the
+        // resolver rejects each one and falls through to the safe default.
+        // Deleting WINDIR here is unreliable on real Windows runners, so
+        // overwrite it with the same rejected payload.
         process.env.SystemRoot = unsafeRoot;
-        delete process.env.windir;
+        process.env.WINDIR = unsafeRoot;
         spawnMock.mockClear();
 
         const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
@@ -255,9 +259,9 @@ describe("windows command wrapper behavior", () => {
         process.env.SystemRoot = previousSystemRoot;
       }
       if (previousWindir === undefined) {
-        delete process.env.windir;
+        delete process.env.WINDIR;
       } else {
-        process.env.windir = previousWindir;
+        process.env.WINDIR = previousWindir;
       }
       platformSpy.mockRestore();
     }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -135,7 +135,10 @@ describe("windows command wrapper behavior", () => {
   });
 
   beforeEach(() => {
-    _resetWindowsInstallRootsForTests();
+    // Stub the registry probe so install-root resolution is fully driven by
+    // process.env in tests; on real Windows runners the registry returns the
+    // canonical SystemRoot and would shadow the test's env setup.
+    _resetWindowsInstallRootsForTests({ queryRegistryValue: () => null });
     spawnMock.mockReset();
     spawnSyncMock.mockReset();
     spawnSyncMock.mockReturnValue({ stdout: "Active code page: 936", stderr: "" });
@@ -232,7 +235,7 @@ describe("windows command wrapper behavior", () => {
         "\\Windows",
         "relative\\path",
       ]) {
-        _resetWindowsInstallRootsForTests();
+        _resetWindowsInstallRootsForTests({ queryRegistryValue: () => null });
         process.env.SystemRoot = unsafeRoot;
         delete process.env.windir;
         spawnMock.mockClear();


### PR DESCRIPTION
# Harden Windows command wrapper resolution

## Summary

- Problem: Windows `.cmd` and `.bat` shim launches selected their command interpreter from `ComSpec`.
- Why it matters: A workspace-provided environment value could redirect update or install-related shim execution through an untrusted interpreter.
- What changed: `.cmd` and `.bat` wrapper launches now derive `cmd.exe` from an absolute Windows root environment value already blocked from workspace dotenv loading, with a `cmd.exe` fallback.
- What did NOT change (scope boundary): No changes to dotenv loading, command argument escaping, CI, release, or automation files.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #542
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Windows process wrapper used `ComSpec` to select the interpreter for `.cmd` and `.bat` shims.
- Missing detection / guardrail: Existing process-wrapper tests asserted wrapper behavior but did not assert that an attacker-controlled `ComSpec` value is ignored.
- Contributing context (if known): Workspace dotenv loading already blocks Windows shell trust-root variables on current `main`, but the process wrapper still read `ComSpec` directly.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/process/exec.windows.test.ts`
- Scenario the test should lock in: A malicious `ComSpec` value does not control the executable used to wrap a Windows `.cmd` shim.
- Why this is the smallest reliable guardrail: The behavior is isolated in the process wrapper and can be verified through the existing mocked Windows spawn tests.
- Existing test that already covers this (if any): `src/infra/dotenv.test.ts` covers blocking these keys from workspace dotenv loading.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Windows `.cmd` and `.bat` shim execution no longer honors `ComSpec` when selecting the wrapper executable.

## Diagram (if applicable)

```text
Before:
[Windows shim launch] -> [read ComSpec] -> [wrapper executable]

After:
[Windows shim launch] -> [derive cmd.exe from Windows root] -> [wrapper executable]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: Command wrapper selection is narrowed so `.cmd` and `.bat` launches do not trust `ComSpec`; existing argument escaping and shell-disabled execution are unchanged.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node v22.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Focused local Vitest run through `scripts/test-projects.mjs`

### Steps

1. Set a mocked Windows platform in `src/process/exec.windows.test.ts`.
2. Set `process.env.ComSpec` to an untrusted path and `process.env.SystemRoot` to `C:\Windows`.
3. Launch a shim-backed command through `runCommandWithTimeout(["pnpm", "--version"], ...)`.

### Expected

- The spawn executable is `C:\Windows\System32\cmd.exe`, not the `ComSpec` value.

### Actual

- The focused tests passed with the new assertion.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`node scripts/test-projects.mjs src/process/exec.windows.test.ts src/infra/dotenv.test.ts` passed 2 Vitest shards: 29 process tests and 15 dotenv tests.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused Windows process-wrapper tests and workspace dotenv tests through the repo test-project runner.
- Edge cases checked: `ComSpec` set to an untrusted path, `SystemRoot` set to an absolute Windows root, existing fallback wrapper tests for pnpm/corepack/npm shims.
- What you did **not** verify: Native execution on a Windows host.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Systems with no absolute Windows root environment value fall back to `cmd.exe`.
  - Mitigation: The fallback preserves prior availability while the common Windows `SystemRoot` path avoids `ComSpec` control.