### PR TITLE
fix(browser): extend existing-session status probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: wait longer for existing-session Chrome MCP status and non-deep doctor probes so slow first attaches do not falsely report offline while keeping raw CDP status probes short. (#77473) Thanks @rubencu.
 - Exec approvals: keep `exec.approval.list` on the lightweight policy-summary path so listing pending approvals no longer loads the rich tree-sitter command explainer. (#76943) Thanks @rubencu.
 - Agents: surface concise default-visible warnings when `exec`/`bash` tool calls fail after the assistant claims success, while keeping raw stderr hidden unless verbose details are enabled. Fixes #60497. (#80003) Thanks @jbetala7.
 - CLI/agent: let `openclaw agent --model` use the backend/admin Gateway scope without cached device-token scopes silently downscoping the request. (#78837) Thanks @VACInc.

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -323,6 +323,12 @@ describe("browser client", () => {
         expect.stringMatching(/\/doctor\?profile=openclaw&deep=true$/),
       ]),
     );
+    const status = calls.find((c) => c.url.endsWith("/"));
+    expect(status?.init?.timeoutMs).toBe(7_500);
+    const doctor = calls.find((c) => c.url.endsWith("/doctor"));
+    expect(doctor?.init?.timeoutMs).toBe(7_500);
+    const deepDoctor = calls.find((c) => c.url.endsWith("/doctor?profile=openclaw&deep=true"));
+    expect(deepDoctor?.init?.timeoutMs).toBe(10_000);
     const open = calls.find((c) => c.url.endsWith("/tabs/open"));
     expect(open?.init?.method).toBe("POST");
 

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -11,6 +11,10 @@ import type { BrowserDoctorReport } from "./doctor.js";
 export type { BrowserStatus, BrowserTab, BrowserTransport } from "./client.types.js";
 export type { BrowserDoctorCheck, BrowserDoctorReport } from "./doctor.js";
 
+const BROWSER_STATUS_REQUEST_TIMEOUT_MS = 7_500;
+const BROWSER_DOCTOR_REQUEST_TIMEOUT_MS = 7_500;
+const BROWSER_DEEP_DOCTOR_REQUEST_TIMEOUT_MS = 10_000;
+
 export type ProfileStatus = {
   name: string;
   transport?: BrowserTransport;
@@ -71,7 +75,7 @@ export async function browserStatus(
     timeoutMs:
       typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
         ? Math.max(1, Math.floor(opts.timeoutMs))
-        : 1500,
+        : BROWSER_STATUS_REQUEST_TIMEOUT_MS,
   });
 }
 
@@ -88,7 +92,9 @@ export async function browserDoctor(
   }
   const q = params.size ? `?${params.toString()}` : "";
   return await fetchBrowserJson<BrowserDoctorReport>(withBaseUrl(baseUrl, `/doctor${q}`), {
-    timeoutMs: opts?.deep ? 10000 : 3000,
+    timeoutMs: opts?.deep
+      ? BROWSER_DEEP_DOCTOR_REQUEST_TIMEOUT_MS
+      : BROWSER_DOCTOR_REQUEST_TIMEOUT_MS,
   });
 }
 

--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -302,6 +302,7 @@ describe("basic browser routes", () => {
 
     expect(response.statusCode).toBe(200);
     expect(isTransportAvailable).toHaveBeenCalledTimes(1);
+    expect(isTransportAvailable).toHaveBeenCalledWith(5_000);
     expect(isHttpReachable).not.toHaveBeenCalled();
     expect(response.body).toMatchObject({
       cdpHttp: true,

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -17,6 +17,10 @@ import {
   toStringOrEmpty,
 } from "./utils.js";
 
+const STATUS_CDP_HTTP_TIMEOUT_MS = 300;
+const STATUS_CDP_TRANSPORT_TIMEOUT_MS = 600;
+const STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS = 5_000;
+
 function handleBrowserRouteError(res: BrowserResponse, err: unknown) {
   const mapped = toBrowserErrorResponse(err);
   if (mapped) {
@@ -72,10 +76,13 @@ async function buildBrowserStatus(req: BrowserRequest, ctx: BrowserRouteContext)
   const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
   const [cdpHttp, cdpReady] = capabilities.usesChromeMcp
     ? await (async () => {
-        const ready = await profileCtx.isTransportAvailable(600);
+        const ready = await profileCtx.isTransportAvailable(STATUS_CHROME_MCP_TRANSPORT_TIMEOUT_MS);
         return [ready, ready] as const;
       })()
-    : await Promise.all([profileCtx.isHttpReachable(300), profileCtx.isTransportAvailable(600)]);
+    : await Promise.all([
+        profileCtx.isHttpReachable(STATUS_CDP_HTTP_TIMEOUT_MS),
+        profileCtx.isTransportAvailable(STATUS_CDP_TRANSPORT_TIMEOUT_MS),
+      ]);
 
   const profileState = current.profiles.get(profileCtx.profile.name);
   let detectedBrowser: string | null = null;


### PR DESCRIPTION
## Summary

- Problem: Chrome MCP existing-session browser status used a 600ms server-side transport probe, so a real Chrome MCP attach could be reported as timed out during a slow first attach even though the browser endpoint became usable moments later.
- Why it matters: `openclaw browser --browser-profile <existing-session> status` and non-deep doctor are the first troubleshooting commands users run when attaching OpenClaw to an existing Chrome session.
- What changed: Chrome MCP status probes now get a 5s transport budget, the public status/doctor clients use 7.5s defaults, and focused tests lock those budgets in.
- What did NOT change (scope boundary): Raw CDP managed/remote status still uses the existing short 300ms HTTP and 600ms transport checks. Explicit caller-provided timeouts still win. No new config surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Existing-session Chrome MCP `status` could fail on the 600ms internal attach probe even when the real Chrome DevTools MCP server and browser endpoint became available after startup.
- Real environment tested: macOS local Gateway; Google Chrome `Chrome/147.0.7727.138` launched with CDP on `http://127.0.0.1:19492`; official Chrome DevTools MCP spawned as `npx -y chrome-devtools-mcp@latest`; OpenClaw browser profile `real-chrome-mcp` using `driver: "existing-session"` and `cdpUrl: "http://127.0.0.1:19492"`.
- Exact steps or command run after this patch: Started the PR-head Gateway with the real existing-session Chrome MCP profile, then ran `node scripts/run-node.mjs browser --json --url ws://127.0.0.1:19574 --token <redacted> --browser-profile real-chrome-mcp status` and `node scripts/run-node.mjs browser --json --url ws://127.0.0.1:19574 --token <redacted> --browser-profile real-chrome-mcp tabs`. The MCP command was a wrapper that sleeps 1.2s, then execs `npx -y chrome-devtools-mcp@latest "$@"`, so the test uses the real Chrome MCP package while reproducing a slow first attach.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
PR head 01a31b0e9d status output:
{
  "enabled": true,
  "profile": "real-chrome-mcp",
  "driver": "existing-session",
  "transport": "chrome-mcp",
  "running": true,
  "cdpReady": true,
  "cdpHttp": true,
  "detectedBrowser": "chrome",
  "detectedExecutablePath": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
  "attachOnly": true
}

PR head 01a31b0e9d tabs output:
{
  "tabs": [
    {
      "targetId": "1",
      "title": "",
      "url": "about:blank",
      "type": "page",
      "suggestedTargetId": "t1",
      "tabId": "t1"
    }
  ]
}

PR-head Gateway log excerpts:
[ws] ⇄ res ✓ browser.request 2640ms ...
[ws] ⇄ res ✓ browser.request 2476ms ...
```

- Observed result after fix: The patched Gateway waited long enough for the real Chrome DevTools MCP startup and attach path, then `status` reported the existing-session Chrome MCP profile as running and `tabs` returned the real Chrome `about:blank` page through Chrome MCP `list_pages`.
- What was not tested: Broad cross-platform/package validation is left to GitHub PR CI. I did not use a signed-in personal Chrome profile or a human-approved browser attach prompt; the live proof used an isolated temporary Chrome profile with CDP enabled.
- Before evidence (optional but encouraged): Same Chrome/CDP endpoint and same real `chrome-devtools-mcp@latest` wrapper on current `origin/main` (`48f51c1a51`) failed with `GatewayClientRequestError: Chrome MCP existing-session attach for profile "real-chrome-mcp" timed out after 600ms.` The base Gateway logged `[ws] ⇄ res ✗ browser.request 2853ms errorCode=INVALID_REQUEST errorMessage=Chrome MCP existing-session attach for profile "real-chrome-mcp" timed out after 600ms.`

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The browser route hard-coded a 600ms Chrome MCP transport probe for status, even though first Chrome MCP startup and attach can legitimately take longer.
- Missing detection / guardrail: Existing tests verified that Chrome MCP status performed one transport probe, but they did not assert the timeout budget or the public client defaults around it.
- Contributing context (if known): Existing-session Chrome MCP status is a readiness/troubleshooting path, but its internal timeout was shorter than the status/doctor client budget needed to observe a successful first attach.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/browser/src/browser/routes/basic.existing-session.test.ts`; `extensions/browser/src/browser/client.test.ts`
- Scenario the test should lock in: Chrome MCP status uses a 5s transport probe, public status and non-deep doctor use 7.5s defaults, deep doctor keeps its 10s default, and raw CDP status keeps the short existing budgets.
- Why this is the smallest reliable guardrail: It exercises the browser route/client boundary directly and locks the timeout contract without needing a live Chrome session in every test run.
- Existing test that already covers this (if any): The existing Chrome MCP status route test covered single-probe behavior but not the timeout value.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Existing-session Chrome MCP browser status and non-deep doctor are less likely to falsely report offline/timeout during a slow first attach handshake.
- No new config, env var, or CLI option.

## Diagram (if applicable)

```text
Before:
openclaw browser status -> Chrome MCP transport probe at 600ms -> timeout/offline on slow first attach

After:
openclaw browser status -> Chrome MCP transport probe at 5s -> client waits 7.5s -> running status can return
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local contributor worktree
- Model/provider: N/A
- Integration/channel (if any): Browser plugin, existing-session Chrome MCP profile
- Relevant config (redacted): `browser.profiles.real-chrome-mcp.driver="existing-session"`, `attachOnly=true`, `cdpUrl="http://127.0.0.1:19492"`, `mcpCommand` wrapper that sleeps 1.2s then execs `npx -y chrome-devtools-mcp@latest "$@"`.

### Steps

1. Launch Google Chrome with `--remote-debugging-port=19492` and a temporary user data directory.
2. Configure an OpenClaw browser profile for `driver: "existing-session"` and `cdpUrl: "http://127.0.0.1:19492"`.
3. On current `origin/main`, run `openclaw browser --browser-profile real-chrome-mcp status` through the Gateway and observe the 600ms attach timeout.
4. On this PR head, run the same `status` command and then `tabs` through the Gateway.

### Expected

- Status should wait long enough for a real Chrome DevTools MCP startup/attach and return the existing-session profile as running when attach succeeds.

### Actual

- Before this patch, the same real Chrome MCP setup timed out at 600ms.
- After this patch, status returned `running: true`, `transport: "chrome-mcp"`, `cdpReady: true`, and `cdpHttp: true`; `tabs` returned the live Chrome `about:blank` page.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local validation:

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/browser/src/browser/routes/basic.existing-session.test.ts extensions/browser/src/browser/client.test.ts` passed: 17 tests.
- `pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/client.ts extensions/browser/src/browser/client.test.ts extensions/browser/src/browser/routes/basic.ts extensions/browser/src/browser/routes/basic.existing-session.test.ts` passed.
- `git diff --check origin/main..HEAD` passed.
- `pnpm changed:lanes --json` reported only extension production/test lanes for the four browser files.
- `codex review --base origin/main` returned no actionable correctness issue.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Local live Gateway proof with real Google Chrome, real `chrome-devtools-mcp@latest`, status failure on `origin/main`, status success on this PR head, and `tabs` returning the live Chrome page through Chrome MCP.
- Edge cases checked: Raw CDP status probe budgets remain short; explicit caller `timeoutMs` values still override the public client defaults; deep doctor keeps the 10s default.
- What you did **not** verify: Signed-in personal browser state and human attach-prompt approval. Broad validation beyond the touched browser route/client surface is covered by GitHub PR CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Public status/doctor calls can wait longer before surfacing a timeout when the browser control service is reachable but Chrome MCP attach is slow.
  - Mitigation: The new defaults are still bounded, explicit `timeoutMs` overrides still win, and the longer budget applies only to the Chrome MCP existing-session status/doctor path rather than raw CDP status.
  - Timeout sizing: Chrome MCP status uses a 5s attach probe, while the public client waits 7.5s so it does not abort before the route can return. The longer wait is bounded by async request timeouts, not a lock: failed ephemeral status probes close their MCP client, and raw CDP status stays on the original 300ms/600ms fast path.
