### PR TITLE
docs(changelog): credit group config migration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Doctor/config: restore legacy group chat config migrations for `routing.allowFrom`, `routing.groupChat.*`, and `channels.telegram.requireMention` so upgrades keep WhatsApp, Telegram, and iMessage group mention gates and history settings instead of leaving configs invalid or silently blocked.
+- Doctor/config: restore legacy group chat config migrations for `routing.allowFrom`, `routing.groupChat.*`, and `channels.telegram.requireMention` so upgrades keep WhatsApp, Telegram, and iMessage group mention gates and history settings instead of leaving configs invalid or silently blocked. Thanks @scoootscooob.
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.


### PR DESCRIPTION
Summary:
- Credit @scoootscooob for the group config drift migration fix that landed in #77465.

Verification:
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md`
- `git diff --check`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts -- --reporter=verbose`