### PR TITLE
fix(doctor): discover load-path plugin contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: disable Pi auto-compaction whenever OpenClaw effectively owns safeguard compaction, including provider-backed safeguard mode, so Pi and OpenClaw no longer fight over long-session compaction. Fixes #73003. (#73839) Thanks @bradhallett.
 - Telegram/streaming: finalize text replies by stopping the edited stream message instead of sending a second answer bubble, so Telegram turns cannot duplicate the streamed final response. (#77947) Thanks @obviyus.
 - web_search/Brave: fix provider selection when Brave is installed as an external plugin and `tools.web.search.provider: "brave"` is explicitly configured — a redundant provider re-resolution at startup could race and return an empty list, causing a spurious `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` warning and treating the explicitly configured provider as absent. Fixes #77676. Thanks @openperf.
+- Doctor/plugins: discover doctor contracts from load-path channel plugins during `openclaw doctor --fix`, so plugin-owned legacy config repair runs before validation. (#77477) Thanks @jalehman.
 
 ## 2026.5.3-1
 

--- a/extensions/googlechat/src/channel.deps.runtime.ts
+++ b/extensions/googlechat/src/channel.deps.runtime.ts
@@ -9,6 +9,7 @@ export {
   PAIRING_APPROVED_MESSAGE,
   resolveChannelMediaMaxBytes,
   type ChannelMessageActionAdapter,
+  type ChannelMessageActionName,
   type ChannelStatusIssue,
   type OpenClawConfig,
 } from "../runtime-api.js";

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -735,7 +735,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           const includeDisabled = Boolean(params.includeDisabled);
           let offset = 0;
           let result: unknown;
-          do {
+          for (;;) {
             result = await callGateway("cron.list", gatewayOpts, {
               includeDisabled,
               agentId: listAgentId,
@@ -749,7 +749,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               break;
             }
             offset = nextOffset;
-          } while (true);
+          }
           return jsonResult(
             selfRemoveOnlyJobId ? filterCronListResultToJobId(result, selfRemoveOnlyJobId) : result,
           );

--- a/src/channels/plugins/legacy-config.test.ts
+++ b/src/channels/plugins/legacy-config.test.ts
@@ -85,12 +85,13 @@ describe("collectChannelLegacyConfigRules", () => {
       },
     ]);
 
-    const rules = collectChannelLegacyConfigRules({
+    const config = {
       channels: {
         slack: {},
         "custom-chat": {},
       },
-    });
+    };
+    const rules = collectChannelLegacyConfigRules(config);
 
     expect(rules).toEqual([
       {
@@ -103,6 +104,7 @@ describe("collectChannelLegacyConfigRules", () => {
       },
     ]);
     expect(listPluginDoctorLegacyConfigRulesMock).toHaveBeenCalledWith({
+      config,
       pluginIds: ["custom-chat"],
     });
   });

--- a/src/channels/plugins/legacy-config.ts
+++ b/src/channels/plugins/legacy-config.ts
@@ -1,4 +1,5 @@
 import type { LegacyConfigRule } from "../../config/legacy.shared.js";
+import type { OpenClawConfig } from "../../config/types.js";
 import { listPluginDoctorLegacyConfigRules } from "../../plugins/doctor-contract-registry.js";
 import { getBootstrapChannelPlugin } from "./bootstrap-registry.js";
 import { loadBundledChannelDoctorContractApi } from "./doctor-contract-api.js";
@@ -101,7 +102,12 @@ export function collectChannelLegacyConfigRules(
     unresolvedChannelIds.push(channelId);
   }
   if (unresolvedChannelIds.length > 0) {
-    rules.push(...listPluginDoctorLegacyConfigRules({ pluginIds: unresolvedChannelIds }));
+    rules.push(
+      ...listPluginDoctorLegacyConfigRules({
+        config: raw as OpenClawConfig,
+        pluginIds: unresolvedChannelIds,
+      }),
+    );
   }
 
   const seen = new Set<string>();

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -121,9 +121,10 @@ export function resolveConfiguredDoctorSessionStateRoute(params: {
 }
 
 function resolvePluginDoctorSessionRouteStateOwners(params: {
+  cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): DoctorSessionRouteStateOwner[] {
-  return listPluginDoctorSessionRouteStateOwners({ env: params.env });
+  return listPluginDoctorSessionRouteStateOwners({ config: params.cfg, env: params.env });
 }
 
 function entryMayContainPluginSessionRouteState(entry: SessionEntry): boolean {
@@ -460,7 +461,7 @@ export async function runPluginSessionStateDoctorRepairs(params: {
   if (!storeMayContainPluginSessionRouteState(params.store)) {
     return;
   }
-  const owners = resolvePluginDoctorSessionRouteStateOwners({ env: params.env });
+  const owners = resolvePluginDoctorSessionRouteStateOwners({ cfg: params.cfg, env: params.env });
   if (owners.length === 0) {
     return;
   }

--- a/src/commands/doctor/shared/channel-legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/channel-legacy-config-migrate.test.ts
@@ -1,12 +1,18 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const applyPluginDoctorCompatibilityMigrations = vi.hoisted(() => vi.fn());
+const { applyPluginDoctorCompatibilityMigrations, collectRelevantDoctorPluginIds } = vi.hoisted(
+  () => ({
+    applyPluginDoctorCompatibilityMigrations: vi.fn(),
+    collectRelevantDoctorPluginIds: vi.fn(),
+  }),
+);
 const loadBundledChannelDoctorContractApi = vi.hoisted(() => vi.fn());
 const getBootstrapChannelPlugin = vi.hoisted(() => vi.fn());
 
 vi.mock("../../../plugins/doctor-contract-registry.js", () => ({
   applyPluginDoctorCompatibilityMigrations: (...args: unknown[]) =>
     applyPluginDoctorCompatibilityMigrations(...args),
+  collectRelevantDoctorPluginIds: (...args: unknown[]) => collectRelevantDoctorPluginIds(...args),
 }));
 
 vi.mock("../../../channels/plugins/doctor-contract-api.js", () => ({
@@ -30,12 +36,14 @@ beforeAll(async () => {
 
 beforeEach(() => {
   applyPluginDoctorCompatibilityMigrations.mockReset();
+  collectRelevantDoctorPluginIds.mockReset();
   loadBundledChannelDoctorContractApi.mockReset();
   getBootstrapChannelPlugin.mockReset();
 });
 
 describe("bundled channel legacy config migrations", () => {
   it("prefers bundled channel doctor contract normalizers before plugin registry fallback", () => {
+    collectRelevantDoctorPluginIds.mockReturnValueOnce([]);
     loadBundledChannelDoctorContractApi.mockImplementation((channelId: string) =>
       channelId === "slack"
         ? {
@@ -82,6 +90,7 @@ describe("bundled channel legacy config migrations", () => {
   });
 
   it("normalizes legacy private-network aliases exposed through bundled contract surfaces", () => {
+    collectRelevantDoctorPluginIds.mockReturnValueOnce(["mattermost"]);
     loadBundledChannelDoctorContractApi.mockReturnValue(undefined);
     getBootstrapChannelPlugin.mockReturnValue(undefined);
     applyPluginDoctorCompatibilityMigrations.mockReturnValueOnce({
@@ -121,6 +130,7 @@ describe("bundled channel legacy config migrations", () => {
     });
 
     expect(applyPluginDoctorCompatibilityMigrations).toHaveBeenCalledWith(expect.any(Object), {
+      config: expect.any(Object),
       pluginIds: ["mattermost"],
     });
 
@@ -146,5 +156,43 @@ describe("bundled channel legacy config migrations", () => {
         "Moved channels.mattermost.accounts.work.allowPrivateNetwork → channels.mattermost.accounts.work.network.dangerouslyAllowPrivateNetwork (false).",
       ]),
     );
+  });
+
+  it("applies plugin doctor normalizers for configured non-channel plugin entries", () => {
+    collectRelevantDoctorPluginIds.mockReturnValueOnce(["lossless-claw"]);
+    applyPluginDoctorCompatibilityMigrations.mockReturnValueOnce({
+      config: {
+        plugins: {
+          entries: {
+            "lossless-claw": {
+              llm: {
+                allowModelOverride: true,
+                allowedModels: ["openai-codex/gpt-5.4-mini"],
+              },
+            },
+          },
+        },
+      },
+      changes: ["Configured plugins.entries.lossless-claw.llm.allowedModels."],
+    });
+
+    const config = {
+      plugins: {
+        entries: {
+          "lossless-claw": {
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+            },
+          },
+        },
+      },
+    };
+    const result = applyChannelDoctorCompatibilityMigrations(config);
+
+    expect(applyPluginDoctorCompatibilityMigrations).toHaveBeenCalledWith(expect.any(Object), {
+      config,
+      pluginIds: ["lossless-claw"],
+    });
+    expect(result.changes).toEqual(["Configured plugins.entries.lossless-claw.llm.allowedModels."]);
   });
 });

--- a/src/commands/doctor/shared/channel-legacy-config-migrate.ts
+++ b/src/commands/doctor/shared/channel-legacy-config-migrate.ts
@@ -1,7 +1,10 @@
 import { getBootstrapChannelPlugin } from "../../../channels/plugins/bootstrap-registry.js";
 import { loadBundledChannelDoctorContractApi } from "../../../channels/plugins/doctor-contract-api.js";
 import type { OpenClawConfig } from "../../../config/types.js";
-import { applyPluginDoctorCompatibilityMigrations } from "../../../plugins/doctor-contract-registry.js";
+import {
+  applyPluginDoctorCompatibilityMigrations,
+  collectRelevantDoctorPluginIds,
+} from "../../../plugins/doctor-contract-registry.js";
 import { isRecord } from "./legacy-config-record-shared.js";
 
 type ChannelDoctorCompatibilityMutation = {
@@ -34,6 +37,21 @@ function resolveBundledChannelCompatibilityNormalizer(
   return getBootstrapChannelPlugin(channelId)?.doctor?.normalizeCompatibilityConfig;
 }
 
+function collectPluginDoctorCompatibilityIds(params: {
+  raw: unknown;
+  unresolvedChannelIds: readonly string[];
+}): string[] {
+  const unresolvedChannelIds = new Set(params.unresolvedChannelIds);
+  return [
+    ...new Set([
+      ...params.unresolvedChannelIds,
+      ...collectRelevantDoctorPluginIds(params.raw).filter(
+        (pluginId) => !unresolvedChannelIds.has(pluginId),
+      ),
+    ]),
+  ].toSorted();
+}
+
 export function applyChannelDoctorCompatibilityMigrations(cfg: Record<string, unknown>): {
   next: Record<string, unknown>;
   changes: string[];
@@ -56,9 +74,11 @@ export function applyChannelDoctorCompatibilityMigrations(cfg: Record<string, un
     changes.push(...mutation.changes);
   }
 
-  if (unresolvedChannelIds.length > 0) {
+  const pluginIds = collectPluginDoctorCompatibilityIds({ raw: cfg, unresolvedChannelIds });
+  if (pluginIds.length > 0) {
     const compat = applyPluginDoctorCompatibilityMigrations(nextCfg, {
-      pluginIds: unresolvedChannelIds,
+      config: cfg as OpenClawConfig,
+      pluginIds,
     });
     nextCfg = compat.config;
     changes.push(...compat.changes);

--- a/src/commands/doctor/shared/legacy-config-issues.ts
+++ b/src/commands/doctor/shared/legacy-config-issues.ts
@@ -1,7 +1,7 @@
 import { collectChannelLegacyConfigRules } from "../../../channels/plugins/legacy-config.js";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { LegacyConfigRule } from "../../../config/legacy.shared.js";
-import type { LegacyConfigIssue } from "../../../config/types.js";
+import type { LegacyConfigIssue, OpenClawConfig } from "../../../config/types.js";
 import {
   collectRelevantDoctorPluginIds,
   collectRelevantDoctorPluginIdsForTouchedPaths,
@@ -32,7 +32,7 @@ function collectPluginLegacyConfigRules(
   if (pluginIds.length === 0) {
     return [];
   }
-  return listPluginDoctorLegacyConfigRules({ pluginIds });
+  return listPluginDoctorLegacyConfigRules({ config: raw as OpenClawConfig, pluginIds });
 }
 
 export function findDoctorLegacyConfigIssues(

--- a/src/plugin-sdk/fetch-auth.test.ts
+++ b/src/plugin-sdk/fetch-auth.test.ts
@@ -125,7 +125,8 @@ describe("fetchWithBearerAuthScopeFallback", () => {
       enumerable: false,
     });
     const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
-      new Headers(init?.headers);
+      const normalizedHeaders = new Headers(init?.headers);
+      expect(normalizedHeaders.get("accept")).toBe("application/json");
       return fetchFn.mock.calls.length === 1
         ? new Response("unauthorized", { status: 401 })
         : new Response("ok", { status: 200 });

--- a/src/plugins/doctor-contract-registry.load-paths.test.ts
+++ b/src/plugins/doctor-contract-registry.load-paths.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findLegacyConfigIssues } from "../config/legacy.js";
+import type { OpenClawConfig } from "../config/types.js";
+import {
+  applyPluginDoctorCompatibilityMigrations,
+  clearPluginDoctorContractRegistryCache,
+  listPluginDoctorLegacyConfigRules,
+} from "./doctor-contract-registry.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(
+    path.join(fs.realpathSync(os.tmpdir()), "openclaw-doctor-contract-load-paths-"),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeHermeticDoctorEnv(stateDir: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: stateDir,
+    OPENCLAW_HOME: stateDir,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+  };
+}
+
+function writeDoctorPlugin(pluginRoot: string, pluginId: string): void {
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: pluginId,
+        name: "Load Path Doctor",
+        version: "0.0.0-test",
+        configSchema: {},
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(pluginRoot, "index.cjs"), "module.exports = {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(pluginRoot, "doctor-contract-api.cjs"),
+    `
+const pluginId = ${JSON.stringify(pluginId)};
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+module.exports = {
+  legacyConfigRules: [
+    {
+      path: ["plugins", "entries", pluginId, "config", "summaryModel"],
+      message: "load-path doctor contract warning",
+    },
+  ],
+  normalizeCompatibilityConfig({ cfg }) {
+    const root = isRecord(cfg) ? { ...cfg } : {};
+    const plugins = isRecord(root.plugins) ? { ...root.plugins } : {};
+    const entries = isRecord(plugins.entries) ? { ...plugins.entries } : {};
+    const entry = isRecord(entries[pluginId]) ? { ...entries[pluginId] } : {};
+    const llm = isRecord(entry.llm) ? { ...entry.llm } : {};
+    const allowedModels = Array.isArray(llm.allowedModels) ? [...llm.allowedModels] : [];
+    if (!allowedModels.includes("openai-codex/gpt-5.4-mini")) {
+      allowedModels.push("openai-codex/gpt-5.4-mini");
+    }
+    root.plugins = plugins;
+    plugins.entries = entries;
+    entries[pluginId] = entry;
+    entry.llm = {
+      ...llm,
+      allowModelOverride: true,
+      allowedModels,
+    };
+    return {
+      config: root,
+      changes: ["configured load-path doctor contract LLM policy"],
+    };
+  },
+};
+`,
+    "utf8",
+  );
+}
+
+function createDoctorPluginConfig(pluginRoot: string, pluginId: string): OpenClawConfig {
+  return {
+    plugins: {
+      load: { paths: [pluginRoot] },
+      entries: {
+        [pluginId]: {
+          enabled: true,
+          config: {
+            summaryModel: "gpt-5.4-mini",
+          },
+        },
+      },
+    },
+  };
+}
+
+function readPluginLlmPolicy(config: OpenClawConfig, pluginId: string): Record<string, unknown> {
+  const entry = config.plugins?.entries?.[pluginId] as { llm?: unknown } | undefined;
+  return entry?.llm && typeof entry.llm === "object" && !Array.isArray(entry.llm)
+    ? (entry.llm as Record<string, unknown>)
+    : {};
+}
+
+beforeEach(() => {
+  clearPluginDoctorContractRegistryCache();
+});
+
+afterEach(() => {
+  clearPluginDoctorContractRegistryCache();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("doctor contract registry load-path plugins", () => {
+  it("discovers doctor warning rules from plugins.load.paths", () => {
+    const stateDir = makeTempDir();
+    const pluginRoot = makeTempDir();
+    const pluginId = "load-path-doctor";
+    writeDoctorPlugin(pluginRoot, pluginId);
+    const config = createDoctorPluginConfig(pluginRoot, pluginId);
+
+    const rules = listPluginDoctorLegacyConfigRules({
+      config,
+      env: makeHermeticDoctorEnv(stateDir),
+      pluginIds: [pluginId],
+    });
+    expect(rules).toEqual([
+      {
+        path: ["plugins", "entries", pluginId, "config", "summaryModel"],
+        message: "load-path doctor contract warning",
+      },
+    ]);
+    expect(findLegacyConfigIssues(config, config, rules)).toEqual([
+      {
+        path: `plugins.entries.${pluginId}.config.summaryModel`,
+        message: "load-path doctor contract warning",
+      },
+    ]);
+  });
+
+  it("applies compatibility normalizers from plugins.load.paths", () => {
+    const stateDir = makeTempDir();
+    const pluginRoot = makeTempDir();
+    const pluginId = "load-path-doctor";
+    writeDoctorPlugin(pluginRoot, pluginId);
+    const config = createDoctorPluginConfig(pluginRoot, pluginId);
+
+    const result = applyPluginDoctorCompatibilityMigrations(config, {
+      config,
+      env: makeHermeticDoctorEnv(stateDir),
+      pluginIds: [pluginId],
+    });
+    const llm = readPluginLlmPolicy(result.config, pluginId);
+
+    expect(result.changes).toEqual(["configured load-path doctor contract LLM policy"]);
+    expect(llm).toMatchObject({
+      allowModelOverride: true,
+      allowedModels: ["openai-codex/gpt-5.4-mini"],
+    });
+    expect(llm).not.toHaveProperty("allowAgentIdOverride");
+  });
+});

--- a/src/plugins/doctor-contract-registry.load-paths.test.ts
+++ b/src/plugins/doctor-contract-registry.load-paths.test.ts
@@ -8,6 +8,7 @@ import {
   applyPluginDoctorCompatibilityMigrations,
   clearPluginDoctorContractRegistryCache,
   listPluginDoctorLegacyConfigRules,
+  listPluginDoctorSessionRouteStateOwners,
 } from "./doctor-contract-registry.js";
 
 const tempDirs: string[] = [];
@@ -87,6 +88,43 @@ module.exports = {
       changes: ["configured load-path doctor contract LLM policy"],
     };
   },
+};
+`,
+    "utf8",
+  );
+}
+
+function writeDoctorSessionOwnerPlugin(pluginRoot: string, pluginId: string): void {
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: pluginId,
+        name: "Load Path Session Owner",
+        version: "0.0.0-test",
+        configSchema: {},
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  fs.writeFileSync(path.join(pluginRoot, "index.cjs"), "module.exports = {};\n", "utf8");
+  fs.writeFileSync(
+    path.join(pluginRoot, "doctor-contract-api.cjs"),
+    `
+module.exports = {
+  sessionRouteStateOwners: [
+    {
+      id: "load-path-session-owner",
+      label: "Load Path Session Owner",
+      providerIds: ["load-path-provider"],
+      runtimeIds: ["load-path-runtime"],
+      cliSessionKeys: ["load-path-cli"],
+      authProfilePrefixes: ["load-path:"],
+    },
+  ],
 };
 `,
     "utf8",
@@ -174,5 +212,29 @@ describe("doctor contract registry load-path plugins", () => {
       allowedModels: ["openai-codex/gpt-5.4-mini"],
     });
     expect(llm).not.toHaveProperty("allowAgentIdOverride");
+  });
+
+  it("discovers session route-state owners from plugins.load.paths", () => {
+    const stateDir = makeTempDir();
+    const pluginRoot = makeTempDir();
+    const pluginId = "load-path-session-owner";
+    writeDoctorSessionOwnerPlugin(pluginRoot, pluginId);
+    const config = createDoctorPluginConfig(pluginRoot, pluginId);
+
+    expect(
+      listPluginDoctorSessionRouteStateOwners({
+        config,
+        env: makeHermeticDoctorEnv(stateDir),
+      }),
+    ).toEqual([
+      {
+        id: "load-path-session-owner",
+        label: "Load Path Session Owner",
+        providerIds: ["load-path-provider"],
+        runtimeIds: ["load-path-runtime"],
+        cliSessionKeys: ["load-path-cli"],
+        authProfilePrefixes: ["load-path:"],
+      },
+    ]);
   });
 });

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -214,6 +214,48 @@ describe("doctor-contract-registry module loader", () => {
     ]);
   });
 
+  it("passes active config to manifest registry discovery", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(
+      path.join(pluginRoot, "doctor-contract-api.cjs"),
+      "module.exports = { legacyConfigRules: [{ path: ['plugins', 'entries', 'load-path-doctor', 'config', 'summaryModel'], message: 'load path contract' }] };\n",
+      "utf-8",
+    );
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "load-path-doctor", rootDir: pluginRoot }],
+      diagnostics: [],
+    });
+    const config = {
+      plugins: {
+        load: { paths: [pluginRoot] },
+        entries: {
+          "load-path-doctor": {
+            config: {
+              summaryModel: "openai-codex/gpt-5.4-mini",
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      listPluginDoctorLegacyConfigRules({
+        config,
+        workspaceDir: "/workspace",
+        env: {},
+        pluginIds: ["load-path-doctor"],
+      }),
+    ).toEqual([
+      {
+        path: ["plugins", "entries", "load-path-doctor", "config", "summaryModel"],
+        message: "load path contract",
+      },
+    ]);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({ config }),
+    );
+  });
+
   it("reads doctor contracts from the current manifest registry on each call", () => {
     const firstRoot = makeTempDir();
     const secondRoot = makeTempDir();

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -255,6 +255,7 @@ function loadPluginDoctorContractEntry(
 }
 
 function resolvePluginDoctorContracts(params?: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
@@ -265,6 +266,7 @@ function resolvePluginDoctorContracts(params?: {
   }
 
   const manifestRegistry = loadPluginManifestRegistryForPluginRegistry({
+    config: params?.config,
     workspaceDir: params?.workspaceDir,
     env,
     includeDisabled: true,
@@ -295,6 +297,7 @@ export function clearPluginDoctorContractRegistryCache(): void {
 }
 
 export function listPluginDoctorLegacyConfigRules(params?: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];
@@ -321,6 +324,7 @@ export function listPluginDoctorSessionRouteStateOwners(params?: {
 export function applyPluginDoctorCompatibilityMigrations(
   cfg: OpenClawConfig,
   params?: {
+    config?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
     pluginIds?: readonly string[];

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -306,6 +306,7 @@ export function listPluginDoctorLegacyConfigRules(params?: {
 }
 
 export function listPluginDoctorSessionRouteStateOwners(params?: {
+  config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   pluginIds?: readonly string[];

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -20,6 +20,7 @@ function makeTempDir() {
 function createHermeticEnv(rootDir: string): NodeJS.ProcessEnv {
   return {
     OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(rootDir, "bundled"),
+    OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
     OPENCLAW_VERSION: "2026.4.26",
     VITEST: "true",
   };


### PR DESCRIPTION
## Summary

Fixes OpenClaw doctor so plugin doctor contract sidecars are discovered for explicit filesystem plugins loaded via `plugins.load.paths`.

This matters for plugins like Lossless Claw during local/checkout-based development: the runtime can load the plugin successfully, but `openclaw doctor` previously built its doctor-contract registry from the installed/persisted plugin registry without the active config, so load-path plugins were invisible to doctor.

## What changed

- Pass active config into plugin doctor contract discovery so `plugins.load.paths` plugins are included.
- Pass active config through doctor warning collection.
- Extend `doctor --fix` compatibility migration collection so configured plugin entries, not just channel ids, can contribute plugin doctor normalizers.
- Add focused coverage for load-path plugin doctor sidecars and non-channel plugin fix paths.

## Validation

```bash
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.load-paths.test.ts src/channels/plugins/legacy-config.ts src/commands/doctor/shared/legacy-config-issues.ts src/commands/doctor/shared/channel-legacy-config-migrate.ts src/commands/doctor/shared/channel-legacy-config-migrate.test.ts
# Passed

pnpm test src/plugins/doctor-contract-registry.test.ts src/plugins/doctor-contract-registry.load-paths.test.ts src/commands/doctor/shared/channel-legacy-config-migrate.test.ts -- --reporter=verbose
# Passed: 12 tests across 3 files

pnpm build
# Passed
```

Manual combined-branch validation with Lossless PR #600:

- `pnpm openclaw doctor` now shows Lossless warnings for `summaryModel` and `fallbackProviders` requiring `plugins.entries.lossless-claw.llm.allowModelOverride` / `allowedModels`.
- A temp-config `doctor --fix` run adds `allowModelOverride: true` and the configured `allowedModels`, without adding `allowAgentIdOverride`.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw doctor` / `openclaw doctor --fix` now discovers doctor contract sidecars from explicit `plugins.load.paths` plugins. This lets load-path plugins such as `lossless-claw` surface legacy config warnings and lets `doctor --fix` apply plugin-owned normalizers before validation, instead of only considering unresolved channel ids.

- **Real environment tested:** Josh’s local OpenClaw checkout on macOS, using the real OpenClaw CLI and real configured Lossless plugin entry. The destructive fix path was tested against a copied temp config so Josh’s real config was not modified.

- **Exact steps or command run after this patch:**
  ```bash
  pnpm openclaw doctor | rg -i "lossless|allowModelOverride|allowedModels|summaryModel|fallbackProviders"

  OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" pnpm openclaw doctor --fix --non-interactive

  node -e '<inspect temp copied config>'
  ```

- **Evidence after fix:**
  ```text
  Plain `pnpm openclaw doctor` reported Lossless warnings for `summaryModel` / `fallbackProviders`.

  Temp copied-config `doctor --fix --non-interactive` applied the Lossless fix.

  Inspecting the copied config after the fix showed:
  - allowModelOverride: true
  - allowedModels includes openai-codex/gpt-5.4-mini
  - allowedModels includes minimax/MiniMax-M2.7
  - allowAgentIdOverride absent
  ```

- **Observed result after fix:** The load-path Lossless doctor contract was discovered from the configured plugin entry, read-only doctor showed the expected Lossless warnings, and `doctor --fix --non-interactive` updated the copied config with the expected Lossless `llm` policy.

- **What was not tested:** The fix path was intentionally run against a copied temp config, not Josh’s real live config. Full local `pnpm test` later failed because `vitest.unit-fast.config.ts` hit the no-output watchdog twice; focused tests, `pnpm build`, and `pnpm check` passed.
