### PR TITLE
fix(media): allow aws-sdk auth for image runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Docs: https://docs.openclaw.ai
 - Media/Windows: open saved attachment temp files read/write before fsync so Windows WebChat and `chat.send` media offloads no longer fail with EPERM during durability flush. (#76593) Thanks @qq230849622-a11y.
 - Plugins/Windows: show a Git install hint when npm plugin installation fails with `spawn git ENOENT`, and document the WhatsApp plugin's Git-on-PATH requirement for Baileys/libsignal installs.
 - Media/images: keep HEIC/HEIF attachments fail-closed when optional Sharp conversion is unavailable instead of sending originals that still need conversion. Thanks @vincentkoc.
+- Media/images: allow Bedrock image understanding with `aws-sdk` auth to use the AWS credential chain instead of requiring a static API key. Thanks @Beandon13.
 - Control UI/chat: suppress `HEARTBEAT_OK` acknowledgement history, streams, deltas, and final events before they enter the transcript view, so repeated heartbeat no-op turns do not stack noisy bubbles. Thanks @BunsDev.
 - Control UI/Talk: make failed Talk startup errors dismissable and clear the stale Talk error state when dismissed, so missing realtime voice provider configuration does not leave a permanent chat banner. Fixes #77071. Thanks @ijoshdavis.
 - Control UI/Talk: stop and clear failed realtime Talk sessions when dismissing runtime error banners, so the next Talk click starts a fresh session instead of only stopping the stale one. Thanks @vincentkoc.

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -169,6 +169,69 @@ describe("describeImageWithModel", () => {
     expect(completeMock).not.toHaveBeenCalled();
   });
 
+  it("allows Bedrock image models to proceed without a static API key in aws-sdk mode", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "amazon-bedrock",
+        id: "anthropic.claude-opus-4-7",
+        input: ["text", "image"],
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      })),
+    });
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: undefined,
+      source: "aws-sdk default chain",
+      mode: "aws-sdk",
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "anthropic-messages",
+      provider: "amazon-bedrock",
+      model: "anthropic.claude-opus-4-7",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "bedrock ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {
+        models: {
+          providers: {
+            "amazon-bedrock": {
+              auth: "aws-sdk",
+              models: [],
+            },
+          },
+        },
+      },
+      agentDir: "/tmp/openclaw-agent",
+      provider: "amazon-bedrock",
+      model: "anthropic.claude-opus-4-7",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "bedrock ok",
+      model: "anthropic.claude-opus-4-7",
+    });
+    expect(requireApiKeyMock).not.toHaveBeenCalled();
+    expect(setRuntimeApiKeyMock).not.toHaveBeenCalled();
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "amazon-bedrock",
+        id: "anthropic.claude-opus-4-7",
+      }),
+      expect.objectContaining({
+        apiKey: undefined,
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("uses generic completion for non-canonical minimax-portal image models", async () => {
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -4,7 +4,7 @@ const hoisted = vi.hoisted(() => ({
   completeMock: vi.fn(),
   ensureOpenClawModelsJsonMock: vi.fn(async () => {}),
   getApiKeyForModelMock: vi.fn(async () => ({
-    apiKey: "oauth-test", // pragma: allowlist secret
+    apiKey: "oauth-test" as string | undefined, // pragma: allowlist secret
     source: "test",
     mode: "oauth",
   })),
@@ -199,6 +199,7 @@ describe("describeImageWithModel", () => {
           providers: {
             "amazon-bedrock": {
               auth: "aws-sdk",
+              baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
               models: [],
             },
           },
@@ -225,10 +226,10 @@ describe("describeImageWithModel", () => {
         provider: "amazon-bedrock",
         id: "anthropic.claude-opus-4-7",
       }),
+      expect.any(Object),
       expect.objectContaining({
         apiKey: undefined,
       }),
-      expect.any(Object),
     );
   });
 

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -391,9 +391,7 @@ async function describeImagesWithModelInternal(
 
   if (isMinimaxVlmModel(model.provider, model.id)) {
     if (!apiKey) {
-      throw new Error(
-        `No API key resolved for provider "${model.provider}" (auth mode: aws-sdk).`,
-      );
+      throw new Error(`No API key resolved for provider "${model.provider}" (auth mode: aws-sdk).`);
     }
     return await describeImagesWithMinimax({
       apiKey,

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -141,7 +141,7 @@ async function resolveImageRuntime(params: {
   profile?: string;
   preferredProfile?: string;
   authStore?: ImageDescriptionRequest["authStore"];
-}): Promise<{ apiKey: string; model: Model<Api> }> {
+}): Promise<{ apiKey?: string; model: Model<Api> }> {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
   const authStorage = discoverAuthStorage(params.agentDir);
@@ -209,8 +209,13 @@ async function resolveImageRuntime(params: {
     preferredProfile: params.preferredProfile,
     store: params.authStore,
   });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
-  authStorage.setRuntimeApiKey(model.provider, apiKey);
+  const apiKey =
+    apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
+      ? undefined
+      : requireApiKey(apiKeyInfo, model.provider);
+  if (apiKey !== undefined) {
+    authStorage.setRuntimeApiKey(model.provider, apiKey);
+  }
   return { apiKey, model };
 }
 
@@ -358,7 +363,7 @@ async function describeImagesWithModelInternal(
   const prompt = params.prompt ?? "Describe the image.";
   const startedAtMs = Date.now();
   const controller = new AbortController();
-  let apiKey: string;
+  let apiKey: string | undefined;
   let model: Model<Api> | undefined;
 
   try {
@@ -385,6 +390,11 @@ async function describeImagesWithModelInternal(
   }
 
   if (isMinimaxVlmModel(model.provider, model.id)) {
+    if (!apiKey) {
+      throw new Error(
+        `No API key resolved for provider "${model.provider}" (auth mode: aws-sdk).`,
+      );
+    }
     return await describeImagesWithMinimax({
       apiKey,
       modelId: model.id,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -47,6 +47,8 @@ export type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 type ResolveApiKeyForProvider = typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
 type RequireApiKey = typeof import("../agents/model-auth.js").requireApiKey;
 
+const AWS_SDK_CREDENTIALLESS_API_KEY = "__openclaw_aws_sdk_default_chain__";
+
 let cachedModelAuth: {
   resolveApiKeyForProvider: ResolveApiKeyForProvider;
   requireApiKey: RequireApiKey;
@@ -434,7 +436,9 @@ async function resolveProviderExecutionAuth(params: {
     agentDir: params.agentDir,
   });
   const primaryApiKey =
-    auth.mode === "aws-sdk" && !auth.apiKey ? undefined : requireApiKey(auth, params.providerId);
+    auth.mode === "aws-sdk" && !auth.apiKey
+      ? AWS_SDK_CREDENTIALLESS_API_KEY
+      : requireApiKey(auth, params.providerId);
   return {
     apiKeys: collectProviderApiKeysForExecution({
       provider: params.providerId,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -433,10 +433,12 @@ async function resolveProviderExecutionAuth(params: {
     preferredProfile: params.entry.preferredProfile,
     agentDir: params.agentDir,
   });
+  const primaryApiKey =
+    auth.mode === "aws-sdk" && !auth.apiKey ? undefined : requireApiKey(auth, params.providerId);
   return {
     apiKeys: collectProviderApiKeysForExecution({
       provider: params.providerId,
-      primaryApiKey: requireApiKey(auth, params.providerId),
+      primaryApiKey,
     }),
     providerConfig: params.cfg.models?.providers?.[params.providerId],
   };

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -5,14 +5,17 @@ import { withEnvAsync } from "../test-utils/env.js";
 import { runCapability } from "./runner.js";
 import { withVideoFixture } from "./runner.test-utils.js";
 
+let seenPrimaryApiKey: string | undefined;
+
 vi.mock("../media/channel-inbound-roots.js", () => ({
   resolveChannelInboundAttachmentRoots: () => undefined,
 }));
 
 vi.mock("../agents/api-key-rotation.js", () => ({
-  collectProviderApiKeysForExecution: ({ primaryApiKey }: { primaryApiKey?: string }) => [
-    primaryApiKey ?? "test-key",
-  ],
+  collectProviderApiKeysForExecution: ({ primaryApiKey }: { primaryApiKey?: string }) => {
+    seenPrimaryApiKey = primaryApiKey;
+    return [primaryApiKey ?? "test-key"];
+  },
   executeWithApiKeyRotation: async <T>({ execute }: { execute: (apiKey: string) => Promise<T> }) =>
     execute("test-key"),
 }));
@@ -23,6 +26,49 @@ vi.mock("../plugins/capability-provider-runtime.js", async () => {
 });
 
 describe("runCapability video provider wiring", () => {
+  it("keeps aws-sdk media auth running without a static API key", async () => {
+    seenPrimaryApiKey = undefined;
+    await withVideoFixture("openclaw-video-aws-sdk", async ({ ctx, media, cache }) => {
+      const result = await runCapability({
+        capability: "video",
+        cfg: {
+          models: {
+            providers: {
+              "amazon-bedrock": {
+                auth: "aws-sdk",
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              video: {
+                enabled: true,
+                models: [{ provider: "amazon-bedrock", model: "anthropic.claude-opus-4-7" }],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry: new Map([
+          [
+            "amazon-bedrock",
+            {
+              id: "amazon-bedrock",
+              capabilities: ["video"],
+              describeVideo: async () => ({ text: "video ok", model: "anthropic.claude-opus-4-7" }),
+            },
+          ],
+        ]),
+      });
+
+      expect(result.outputs[0]?.text).toBe("video ok");
+      expect(seenPrimaryApiKey).toBeUndefined();
+    });
+  });
+
   it("merges video baseUrl and headers with entry precedence", async () => {
     let seenBaseUrl: string | undefined;
     let seenHeaders: Record<string, string> | undefined;

--- a/src/media-understanding/runner.video.test.ts
+++ b/src/media-understanding/runner.video.test.ts
@@ -65,7 +65,7 @@ describe("runCapability video provider wiring", () => {
       });
 
       expect(result.outputs[0]?.text).toBe("video ok");
-      expect(seenPrimaryApiKey).toBeUndefined();
+      expect(seenPrimaryApiKey).toBe("__openclaw_aws_sdk_default_chain__");
     });
   });
 


### PR DESCRIPTION
Closes #77397\n\nAllows Bedrock image/runtime execution to proceed without a static API key when auth mode is "aws-sdk".\n\nChanges:\n- Allow aws-sdk auth to skip requireApiKey for Bedrock image runtime setup\n- Preserve runtime API key behavior only when a static key exists\n- Pass aws-sdk auth through media runner execution setup without forcing a static key\n- Add regression coverage for image and runner auth paths\n

## Real behavior proof
- Behavior or issue addressed: Bedrock media image/runtime auth with `auth: "aws-sdk"` no longer fails at OpenClaw's static API-key guard before the AWS SDK credential chain can run.
- Real environment tested: Local OpenClaw checkout from this PR branch on macOS, built through `pnpm openclaw` at head `2f2dd3832d361a8210a401d620de15b356125a33`; AWS credential values were not printed.
- Exact steps or command run after this patch:
  ```bash
  pnpm openclaw --version
  pnpm test src/media-understanding/image.test.ts src/media-understanding/runner.video.test.ts
  ```
- Evidence after fix:
  ```text
  OpenClaw 2026.5.4 (2f2dd38)

  ✓ media-understanding src/media-understanding/image.test.ts (15 tests)
  ✓ media-understanding src/media-understanding/runner.video.test.ts (3 tests)

  Test Files 2 passed (2)
  Tests 18 passed (18)
  ```
- Observed result after fix: The patched OpenClaw checkout builds and the Bedrock `aws-sdk` media-auth regression path reaches provider execution with the AWS SDK credential-chain sentinel instead of throwing the missing static API-key error.
- What was not tested: No live Bedrock network generation was run from this machine because complete AWS runtime credentials were not available in the environment.
