### PR TITLE
fix(telegram): mirror outbound replies to session transcript

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-0dd4f5abaf72f0d6b3fe5777cbf16c7a8c8052eece17436dc0ac2809b0ea27de  plugin-sdk-api-baseline.json
-2c2170cf2f1193f7dbecdef3ccd1b601992407e3d99863d1aa13cb1817c238fd  plugin-sdk-api-baseline.jsonl
+c6a659fbfce4e1f0704316f4ed035505799b317798097aed69a8070daa3486fd  plugin-sdk-api-baseline.json
+c9765930bfcd092eaeee5acdd12cda1f06f93a043f368c223df5048b51ff9380  plugin-sdk-api-baseline.jsonl

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -661,6 +661,9 @@ export const dispatchTelegramMessage = async ({
     sessionKeyForInternalHooks: ctxPayload.SessionKey,
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
+    transcriptMirror: ctxPayload.SessionKey
+      ? { sessionKey: ctxPayload.SessionKey, agentId: route.agentId }
+      : undefined,
     token: opts.token,
     runtime,
     bot,
@@ -1370,6 +1373,7 @@ export const dispatchTelegramMessage = async ({
         ...deliveryBaseOptions,
         silent: false,
         mediaLoader: telegramDeps.loadWebMedia,
+        transcriptMirror: undefined,
       });
       sentFallback = result.delivered;
     }

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -1,4 +1,5 @@
 import { type Bot, GrammyError, InputFile } from "grammy";
+import { appendAssistantMessageToSessionTranscript } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { ReplyToMode } from "openclaw/plugin-sdk/config-types";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-types";
 import { fireAndForgetHook } from "openclaw/plugin-sdk/hook-runtime";
@@ -674,6 +675,10 @@ export async function deliverReplies(params: {
   policySessionKey?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
+  transcriptMirror?: {
+    sessionKey: string;
+    agentId?: string;
+  };
   token: string;
   runtime: RuntimeEnv;
   bot: Bot;
@@ -869,6 +874,14 @@ export async function deliverReplies(params: {
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
       });
+      if (params.transcriptMirror && progress.deliveredCount > deliveredCountBeforeReply) {
+        await appendAssistantMessageToSessionTranscript({
+          sessionKey: params.transcriptMirror.sessionKey,
+          agentId: params.transcriptMirror.agentId,
+          text: reply.text,
+          mediaUrls: mediaList,
+        });
+      }
     } catch (error) {
       emitMessageSentHooks({
         hookRunner,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -114,6 +114,7 @@ export {
   type SessionWriteLockAcquireTimeoutConfig,
 } from "../agents/session-write-lock.js";
 export { appendSessionTranscriptMessage } from "../config/sessions/transcript-append.js";
+export { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 export { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 export {
   isToolWrappedWithBeforeToolCallHook,


### PR DESCRIPTION
## Summary

  Telegram outbound assistant replies were never appended to the session
  transcript: the `.jsonl` file the `sessions.json` `sessionFile` field
  points at simply did not exist on disk. The session metadata side (token
  counts, `lastInteractionAt`) updated correctly, so this is silent — the
  agent has no record of what it just sent.

  Root cause: `extensions/telegram/src/bot/delivery.replies.ts::deliverReplies`
  dispatches via the Grammy SDK directly (`bot.api.sendMessage` /
  `sendPhoto` / etc.), bypassing `deliverOutboundPayloads` where the
  channel-mirror writer (`appendAssistantMessageToSessionTranscript`,
  introduced in #1031) actually runs. Telegram is one of the channels that
  never picked up that hook.

  This mirrors the same fix shape as #53607 (discord) and #75529 (bluebubbles),
  which patched the same gap for those channels. Addresses the missing-mirror
  behavior reported in #75991 for telegram + claude-cli runtime combinations.

  ## Changes

  - `extensions/telegram/src/bot/delivery.replies.ts`: add optional
    `transcriptMirror?: { sessionKey, agentId? }` param; after a successful
    delivery (and after `maybePinFirstDeliveredMessage`), call
    `appendAssistantMessageToSessionTranscript(...)` with `reply.text` +
    `mediaList`. Reuses the same helper `deliverOutboundPayloads` already
    calls so `delivery-mirror` entry shape, parentId DAG, and write-lock
    semantics stay identical to other channels.
  - `extensions/telegram/src/bot-message-dispatch.ts`: populate
    `transcriptMirror` in `deliveryBaseOptions` from
    `ctxPayload.SessionKey` + `route.agentId`. Silent NO_REPLY fallback
    explicitly opts out (`transcriptMirror: undefined`) so sentinels do
    not reach the transcript.
  - `src/plugin-sdk/agent-harness-runtime.ts`: re-export
    `appendAssistantMessageToSessionTranscript` so extension code can
    call it without reaching into core `src/`. The companion
    `transcript.runtime.ts` already exported the same function for
    internal consumers; adding it to the SDK boundary mirrors how
    `appendSessionTranscriptMessage` is already exposed alongside.
  - `docs/.generated/plugin-sdk-api-baseline.sha256`: regenerated via
    `pnpm plugin-sdk:api:gen` for the new SDK export.

  ## Verification

  Local (no Testbox):

  - `pnpm tsgo:core` ✅
  - `pnpm tsgo:extensions` ✅
  - `pnpm check:architecture` (import-cycles, madge, deprecated APIs, deprecated JSDoc) ✅
  - `pnpm test extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts` ✅ 159
  tests, 0 regressions
  - `pnpm build` ✅
  - `pnpm plugin-sdk:api:check` ✅ after regen
  - Empirical: with the running gateway rebuilt and restarted, sending a
    message through both telegram bots produced `<sessionFile>.jsonl` files
    for the first time, each containing one `model: "delivery-mirror"`
    assistant entry with the reply text. Before the fix the jsonl files
    were never created. `agent:main:hook:*` and `agent:main:main` sessions
    were unaffected.

  ## Risk / scope notes

  - New param is optional with a default-undefined branch; all 6 existing
    `deliverReplies` callers compile unchanged.
  - `bot-native-commands.ts` paths (3 additional `deliverReplies` callsites
    for inline-keyboard interactions) are intentionally not opted in here
    — happy to add in a follow-up if maintainers want them mirrored.
  - No webchat outbound change in this PR. Webchat appears to bypass
    `deliverOutboundPayloads` similarly; the email-inbox hook session
    shows the same symptom but via a different code path. Out of scope
    for this fix.
  - Inbound `user`-side append is not added: the channel-mirror system
    (the `appendAssistantMessageToSessionTranscript` family) appears to
    be assistant-only by design, and there is no public
    `appendUserMessage*` API to mirror to. If user-side mirroring is
    intended, that is a separate change.
