### PR TITLE
Harden config backup restore permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,7 @@ Docs: https://docs.openclaw.ai
 - Codex/app-server: stabilize transcript mirror dedupe across re-mirrored turns so reordered snapshots no longer drop reasoning entries or duplicate the assistant reply. Refs #77012. (#77046) Thanks @openperf.
 - Agents/auth-profiles: do not record request-shape (`format`) rejections as auth-profile health failures, so a single per-session transcript-shape error (such as a prefill-strict 400 "conversation must end with a user message") no longer triggers a profile-wide cooldown that blocks every other healthy session sharing the same auth profile. Refs #77228. (#77280) Thanks @openperf.
 - CLI/update: stop dev-channel source updates immediately when `git fetch` fails, so tag conflicts cannot keep preflight, rebase, or build steps running against stale refs while the Gateway is still on the old runtime. (#77845) Thanks @obviyus.
+- Config/recovery: chmod restored `openclaw.json` back to owner-only (`0600`) after suspicious-read backup recovery on POSIX hosts, so a previously world-readable config mode cannot persist into a freshly restored credential-bearing config. (#77488) Thanks @drobison00.
 
 ## 2026.5.3-1
 

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -275,6 +275,22 @@ describe("config observe recovery", () => {
     });
   });
 
+  it("hardens async backup restores to owner-only config permissions", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withSuiteHome(async (home) => {
+      const { deps, configPath } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      await writeClobberedUpdateChannel(configPath);
+      await fsp.chmod(configPath, 0o644);
+
+      await recoverClobberedUpdateChannel({ deps, configPath });
+
+      expect((await fsp.stat(configPath)).mode & 0o777).toBe(0o600);
+    });
+  });
+
   it("auto-restores after a large size drop against last-good config", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath } = makeDeps(home);
@@ -453,6 +469,22 @@ describe("config observe recovery", () => {
       const observe = await readLastObserveEvent(auditPath);
       expect(observe?.backupHash).toBeTypeOf("string");
       expect(observe?.lastKnownGoodIno ?? null).toBeNull();
+    });
+  });
+
+  it("hardens sync backup restores to owner-only config permissions", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withSuiteHome(async (home) => {
+      const { deps, configPath } = makeDeps(home);
+      await seedConfigBackup(configPath, recoverableTelegramConfig);
+      await writeClobberedUpdateChannel(configPath);
+      await fsp.chmod(configPath, 0o644);
+
+      recoverClobberedUpdateChannelSync({ deps, configPath });
+
+      expect((await fsp.stat(configPath)).mode & 0o777).toBe(0o600);
     });
   });
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -640,6 +640,7 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
   let restoreError: unknown;
   try {
     await params.deps.fs.promises.copyFile(backupPath, params.configPath);
+    await params.deps.fs.promises.chmod?.(params.configPath, 0o600).catch(() => {});
     restoredFromBackup = true;
   } catch (error) {
     restoreError = error;
@@ -747,6 +748,9 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
   let restoreError: unknown;
   try {
     params.deps.fs.copyFileSync(backupPath, params.configPath);
+    try {
+      params.deps.fs.chmodSync?.(params.configPath, 0o600);
+    } catch {}
     restoredFromBackup = true;
   } catch (error) {
     restoreError = error;


### PR DESCRIPTION
# Harden config backup restore permissions

## Summary

- Problem: Suspicious-read config backup restore paths copied a backup over `openclaw.json` without forcing the final file mode back to owner-only permissions.
- Why it matters: `openclaw.json` can contain live tokens and API keys, so preserving a world-readable destination mode could expose credentials to other local users or processes.
- What changed: Added best-effort async and sync `chmod(..., 0o600)` calls after backup restore copies, plus regression tests for insecure destination modes.
- What did NOT change (scope boundary): Normal config writes, last-known-good recovery policy, audit record schema, CI, release, workflow, and infrastructure files were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #560
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The suspicious-read recovery helpers restored from `.bak` with `copyFile` / `copyFileSync` but did not normalize the destination mode afterward, so an existing broad destination mode could remain in place.
- Missing detection / guardrail: Existing recovery tests asserted restored content and audit records, but not the final file mode after restoring over an insecure destination.
- Contributing context (if known): Other config write and last-known-good restore paths already harden the destination mode.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/io.observe-recovery.test.ts`
- Scenario the test should lock in: Async and sync suspicious-read backup restores over an existing `0644` config leave `openclaw.json` at `0600`.
- Why this is the smallest reliable guardrail: The affected helpers are pure filesystem recovery helpers and can be exercised directly with the existing fixture setup.
- Existing test that already covers this (if any): Existing observe-recovery tests covered restore success and copy failures, but not file permissions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Restored `openclaw.json` files are best-effort hardened to owner-only permissions after suspicious-read backup recovery.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The change narrows local filesystem exposure for credential-bearing config restores by forcing owner-only permissions after recovery copy operations. The chmod is best-effort to avoid making restore unavailable on filesystems that cannot apply POSIX modes.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node v22.14.0, pnpm 10.33.2
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Test fixture config with token-like placeholder values only.

### Steps

1. Seed a recoverable config backup.
2. Replace the live config with a recoverable suspicious read state and chmod the live config to `0644`.
3. Run async and sync suspicious-read backup recovery.
4. Assert the final live config mode is `0600`.

### Expected

- Backup recovery restores the config content and leaves `openclaw.json` owner-readable/writable only.

### Actual

- `pnpm exec vitest run --config test/vitest/vitest.runtime-config.config.ts src/config/io.observe-recovery.test.ts` passed with 18 tests.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted test output:

```text
Test Files  1 passed (1)
Tests  18 passed (18)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Async and sync suspicious-read backup restore permission hardening through the targeted Vitest file.
- Edge cases checked: Restore copy failure tests still pass; chmod is best-effort and does not replace existing copy failure behavior.
- What you did **not** verify: Full repository test suite, Windows file-mode behavior, or live installed-package recovery.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Filesystems that do not support POSIX chmod may ignore or reject the permission update.
  - Mitigation: The chmod remains best-effort, matching adjacent config hardening paths.