### PR TITLE
fix(plugins): fall back from invalid beta plugin packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/status: label Linux managed gateway services as `systemd user`, making status output explicit about the user-service scope instead of implying a system-level unit. Thanks @vincentkoc.
 - Plugins/install: remove the previous managed plugin directory when a reinstall switches sources, so stale ClawHub and npm copies no longer keep duplicate plugin ids in discovery after the new install wins. Thanks @vincentkoc.
 - Plugins/install: let official plugin reinstall recovery repair source-only installed runtime shadows, so `openclaw plugins install npm:@openclaw/discord --force` can replace the bad package instead of stopping at stale config validation. Thanks @vincentkoc.
+- Plugins/update: when the OpenClaw beta channel probes an npm plugin `@beta` tag that ships TypeScript-only runtime entries without compiled output, fall back to the saved default spec instead of breaking plugin update. Thanks @vincentkoc.
 - Plugins/commands: allow the official ClawHub Codex plugin package to keep reserved `/codex` command ownership, matching the existing npm-managed Codex package behavior. Thanks @vincentkoc.
 - Auth/OpenAI Codex: rewrite invalidated per-agent Codex auth-order and session profile overrides toward a healthy relogin profile, so revoked OAuth accounts do not stay pinned after signing in again. Thanks @BunsDev.
 - Plugins/commands: scope QQBot framework slash commands to the QQBot channel so `/bot-*` command handlers and native specs do not leak onto unrelated chat surfaces. Thanks @vincentkoc.

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -25,6 +25,7 @@ vi.mock("./install.js", () => ({
   resolvePluginInstallDir: (pluginId: string, extensionsDir = "/tmp") =>
     `${extensionsDir}/${pluginId}`,
   PLUGIN_INSTALL_ERROR_CODE: {
+    INVALID_OPENCLAW_EXTENSIONS: "invalid_openclaw_extensions",
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   },
 }));
@@ -1285,6 +1286,58 @@ describe("updateNpmInstalledPlugins", () => {
       }),
     );
     expect(warnMessages).toEqual([expect.stringContaining("has no beta npm release")]);
+    expectCodexAppServerInstallState({
+      result,
+      spec: "openclaw-codex-app-server",
+      version: "0.2.6",
+      resolvedSpec: "openclaw-codex-app-server@0.2.6",
+    });
+  });
+
+  it("falls back to the default npm spec when the beta package is not runtime-installable", async () => {
+    installPluginFromNpmSpecMock
+      .mockResolvedValueOnce({
+        ok: false,
+        code: "invalid_openclaw_extensions",
+        error:
+          "openclaw-codex-app-server@beta requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs",
+      })
+      .mockResolvedValueOnce(
+        createSuccessfulNpmUpdateResult({
+          pluginId: "openclaw-codex-app-server",
+          targetDir: "/tmp/openclaw-codex-app-server",
+          version: "0.2.6",
+          npmResolution: {
+            name: "openclaw-codex-app-server",
+            version: "0.2.6",
+            resolvedSpec: "openclaw-codex-app-server@0.2.6",
+          },
+        }),
+      );
+
+    const warnMessages: string[] = [];
+    const result = await updateNpmInstalledPlugins({
+      config: createCodexAppServerInstallConfig({
+        spec: "openclaw-codex-app-server",
+      }),
+      pluginIds: ["openclaw-codex-app-server"],
+      updateChannel: "beta",
+      logger: { warn: (msg) => warnMessages.push(msg) },
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        spec: "openclaw-codex-app-server@beta",
+      }),
+    );
+    expect(installPluginFromNpmSpecMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        spec: "openclaw-codex-app-server",
+      }),
+    );
+    expect(warnMessages).toEqual([expect.stringContaining("is not runtime-installable")]);
     expectCodexAppServerInstallState({
       result,
       spec: "openclaw-codex-app-server",

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -1056,7 +1056,7 @@ export async function updateNpmInstalledPlugins(params: {
         logger.warn?.(
           formatBetaNpmFallbackWarning({
             pluginId,
-            attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+            attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec!,
             fallbackSpec: npmSpecs.fallbackSpec,
             result: probe,
           }),
@@ -1242,7 +1242,7 @@ export async function updateNpmInstalledPlugins(params: {
       logger.warn?.(
         formatBetaNpmFallbackWarning({
           pluginId,
-          attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+          attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec!,
           fallbackSpec: npmSpecs.fallbackSpec,
           result,
         }),

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -435,9 +435,30 @@ function shouldFallbackBetaNpmUpdate(result: { ok: false; code?: string; error: 
   if (result.code === PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND) {
     return true;
   }
+  if (
+    result.code === PLUGIN_INSTALL_ERROR_CODE.INVALID_OPENCLAW_EXTENSIONS &&
+    result.error.includes("requires compiled runtime output for TypeScript entry")
+  ) {
+    return true;
+  }
   return /\b(ETARGET|notarget)\b|No matching version found|dist-tag|tag .*not found/i.test(
     result.error,
   );
+}
+
+function formatBetaNpmFallbackWarning(params: {
+  pluginId: string;
+  attemptedSpec: string;
+  fallbackSpec: string;
+  result: { code?: string; error: string };
+}): string {
+  if (
+    params.result.code === PLUGIN_INSTALL_ERROR_CODE.INVALID_OPENCLAW_EXTENSIONS &&
+    params.result.error.includes("requires compiled runtime output for TypeScript entry")
+  ) {
+    return `Plugin "${params.pluginId}" beta npm release for ${params.attemptedSpec} is not runtime-installable; falling back to ${params.fallbackSpec}.`;
+  }
+  return `Plugin "${params.pluginId}" has no beta npm release for ${params.attemptedSpec}; falling back to ${params.fallbackSpec}.`;
 }
 
 function isDefaultNpmSpecForBetaUpdate(spec: string): { name: string } | null {
@@ -1033,7 +1054,12 @@ export async function updateNpmInstalledPlugins(params: {
         shouldFallbackBetaNpmUpdate(probe)
       ) {
         logger.warn?.(
-          `Plugin "${pluginId}" has no beta npm release for ${npmSpecs.fallbackLabel ?? effectiveSpec}; falling back to ${npmSpecs.fallbackSpec}.`,
+          formatBetaNpmFallbackWarning({
+            pluginId,
+            attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+            fallbackSpec: npmSpecs.fallbackSpec,
+            result: probe,
+          }),
         );
         probe = await installPluginFromNpmSpec({
           spec: npmSpecs.fallbackSpec,
@@ -1214,7 +1240,12 @@ export async function updateNpmInstalledPlugins(params: {
       shouldFallbackBetaNpmUpdate(result)
     ) {
       logger.warn?.(
-        `Plugin "${pluginId}" has no beta npm release for ${npmSpecs.fallbackLabel ?? effectiveSpec}; falling back to ${npmSpecs.fallbackSpec}.`,
+        formatBetaNpmFallbackWarning({
+          pluginId,
+          attemptedSpec: npmSpecs.fallbackLabel ?? effectiveSpec,
+          fallbackSpec: npmSpecs.fallbackSpec,
+          result,
+        }),
       );
       result = await installPluginFromNpmSpec({
         spec: npmSpecs.fallbackSpec,


### PR DESCRIPTION
## Summary
- treat OpenClaw beta-channel npm plugin probes that resolve to TypeScript-only runtime entries without compiled output as non-installable beta packages
- fall back from the opportunistic `@beta` spec to the recorded/default npm spec instead of failing plugin update
- keep explicit plugin pins/tags untouched; this only applies to default specs on the OpenClaw beta update channel

## Verification
- `pnpm exec oxfmt --write --threads=1 src/plugins/update.ts`
- `git diff --check`
- `pnpm test:serial src/plugins/update.test.ts -- --reporter=verbose` passed: 60 tests
- `OPENCLAW_TESTBOX=1 pnpm testbox:run --id tbx_01kqt7cqza22e8s4ddpba01j3x -- "pnpm check:changed"` passed

## Notes
- Related to https://github.com/openclaw/openclaw/pull/77282: that PR fixes stale package overlay/runtime aliasing; this PR handles the separate case where an npm plugin's `@beta` tag exists but is not runtime-installable.
