### PR TITLE
fix(active-memory): only include memory_recall in toolsAllow when registered

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1084,7 +1084,10 @@ describe("active-memory plugin", () => {
     expect(runParams?.prompt).toContain(
       "If memory_recall is unavailable, use memory_search and memory_get.",
     );
-    expect(runParams?.toolsAllow).toEqual(["memory_recall", "memory_search", "memory_get"]);
+    // memory_recall is only included when a plugin registers it (e.g. memory-lancedb).
+    // In test environments with no plugin registry, it should be absent.
+    expect(runParams?.toolsAllow).toEqual(expect.arrayContaining(["memory_search", "memory_get"]));
+    expect(runParams?.toolsAllow).not.toContain("memory_recall");
     expect(runParams?.allowGatewaySubagentBinding).toBe(true);
     expect(runParams?.prompt).toContain(
       "When searching for preference or habit recall, use a permissive recall limit or memory_search threshold before deciding that no useful memory exists.",

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -23,6 +23,7 @@ import {
   updateSessionStore,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { getPluginRegistryState } from "../../src/plugins/runtime-state.js";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_AGENT_ID = "main";
@@ -2300,6 +2301,25 @@ function getModelRef(
   return undefined;
 }
 
+/**
+ * Build the toolsAllow list for the recall sub-agent.
+ *
+ * `memory_recall` is only registered when the `memory-lancedb` plugin (or
+ * another plugin that provides the tool) is active. Including it when it is
+ * absent causes the embedded-runner allowlist resolver to throw
+ * "No callable tools remain" and wipe the session context (#77506).
+ */
+function resolveRecallToolsAllow(): string[] {
+  const base = ["memory_search", "memory_get"];
+  const registeredToolNames = new Set(
+    getPluginRegistryState()?.activeRegistry?.tools.map((t) => t.name) ?? [],
+  );
+  if (registeredToolNames.has("memory_recall")) {
+    base.unshift("memory_recall");
+  }
+  return base;
+}
+
 async function runRecallSubagent(params: {
   api: OpenClawPluginApi;
   config: ResolvedActiveRecallPluginConfig;
@@ -2394,7 +2414,7 @@ async function runRecallSubagent(params: {
       timeoutMs: embeddedTimeoutMs,
       runId: subagentSessionId,
       trigger: "manual",
-      toolsAllow: ["memory_recall", "memory_search", "memory_get"],
+      toolsAllow: resolveRecallToolsAllow(),
       disableMessageTool: true,
       allowGatewaySubagentBinding: true,
       bootstrapContextMode: "lightweight",


### PR DESCRIPTION
## Problem

Closes #77506

The `active-memory` recall sub-agent hardcodes `toolsAllow: ["memory_recall", "memory_search", "memory_get"]`. However, `memory_recall` is only registered when `memory-lancedb` (or another plugin providing that tool) is active.

When `memory-lancedb` is absent, the embedded-runner allowlist resolver throws:

```
Error: No callable tools remain after resolving explicit tool allowlist
(tools.allow: *, lobster; runtime toolsAllow: memory_recall, memory_search, memory_get);
no registered tools matched.
```

This kills the sub-agent on every conversational turn, causing the main session to lose context (history wipe).

## Fix

Add `resolveRecallToolsAllow()` which checks the active plugin registry at call time and only includes `memory_recall` when a plugin has actually registered it. Falls back to `["memory_search", "memory_get"]` otherwise — matching the existing fallback documented in the prompt itself (`"If memory_recall is unavailable, use memory_search and memory_get."`).

## Changes

- `extensions/active-memory/index.ts`: `resolveRecallToolsAllow()` helper + import of `getPluginRegistryState`
- `extensions/active-memory/index.test.ts`: updated assertion to expect `memory_recall` absent when registry has no matching plugin

## Behaviour

| Scenario | toolsAllow result |
|---|---|
| `memory-lancedb` active | `["memory_recall", "memory_search", "memory_get"]` |
| `memory-lancedb` absent | `["memory_search", "memory_get"]` |

No change in behaviour for users who have `memory-lancedb` installed. Fixes the session wipe for users who don't.