### PR TITLE
fix(gateway/plugins): pass workspaceDir to setCurrentPluginMetadataSnapshot to restore cache hit rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/plugins: pass `workspaceDir` to `setCurrentPluginMetadataSnapshot` at startup and on hot-reload so the cached snapshot's fingerprint matches the `workspaceDir` that readers (`model-catalog.ts`, `models-config.ts`, `tools.ts`) supply on every dispatch. The mismatch caused 100% cache misses and a 192-statSync sweep per RPC on multi-agent deployments, saturating the gateway event loop. Fixes #77519. Thanks @hclsys.
 - Plugins/active-memory: skip session-store channel entries that contain `:` when resolving the recall subagent's channel, so QQ c2c agent IDs (e.g. `c2c:10D4F7C2…`) and other scoped conversation IDs do not reach bundled-plugin `dirName` validation and crash the recall run. The same guard already applied to explicit `channelId` params (#76704); this extends it to store-derived channels. (#77396) Thanks @hclsys.
 - Models/auth: add `openclaw models auth list [--provider <id>] [--json]` so users can inspect saved per-agent auth profiles without dumping secrets or hitting the old “too many arguments” path. Thanks @vincentkoc.
 - Control UI/header: show the active agent name in dashboard breadcrumbs without adding the current session key, keeping non-chat views oriented without crowding the topbar.

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -662,7 +662,10 @@ export async function startGatewayServer(
     baseMethods,
     runtimePluginsLoaded,
   } = pluginBootstrap;
-  setCurrentPluginMetadataSnapshot(pluginLookUpTable, { config: gatewayPluginConfigAtStart });
+  setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
+    config: gatewayPluginConfigAtStart,
+    workspaceDir: defaultWorkspaceDir,
+  });
   if (pluginLookUpTable) {
     const metrics = pluginLookUpTable.metrics;
     startupTrace.detail("plugins.lookup-table", [
@@ -1185,7 +1188,10 @@ export async function startGatewayServer(
         }
       }
       await params.beforeReplace(channelsToStopBeforeReplace);
-      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, { config: params.nextConfig });
+      setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
+        config: params.nextConfig,
+        workspaceDir: defaultWorkspaceDir,
+      });
       const loaded = prepareGatewayPluginLoad({
         cfg: params.nextConfig,
         workspaceDir: defaultWorkspaceDir,


### PR DESCRIPTION
## Summary

Both `setCurrentPluginMetadataSnapshot` call sites in `server.impl.ts` omit `workspaceDir`. Readers (`model-catalog.ts`, `models-config.ts`, `tools.ts`) always pass `workspaceDir = resolveAgentWorkspaceDir(cfg, agentId)` — a concrete path like `~/.openclaw/agents/<id>`. The fingerprint check inside `getCurrentPluginMetadataSnapshot` (lines 79-86) then never matches, so the cached snapshot is rejected on every call and `loadPluginMetadataSnapshot` runs a full 192-statSync sweep per dispatch.

## Root cause (two lines)

`server.impl.ts:665` (startup) and `:1188` (hot-reload) call:
```ts
setCurrentPluginMetadataSnapshot(pluginLookUpTable, { config: gatewayPluginConfigAtStart });
//                                                    ↑ workspaceDir missing
```

`defaultWorkspaceDir` is destructured from `pluginBootstrap` at the same scope — it was just never forwarded.

## Fix

```ts
// startup (line 665):
setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
  config: gatewayPluginConfigAtStart,
  workspaceDir: defaultWorkspaceDir,   // ← add
});

// hot-reload (line 1188):
setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
  config: params.nextConfig,
  workspaceDir: defaultWorkspaceDir,   // ← add
});
```

## Impact of the bug

From the reporter's strace (multi-agent + webchat polling `sessions.list` every ~1s):

| Metric | Before fix | After rollback to 4.27 |
|--------|------------|----------------------|
| `sessions.list` RPC latency | **156 seconds** | 99-155 ms |
| syscalls/5s | **67,201** (mostly statx) | 671 |
| `eventLoopDelayMaxMs` | **30,000+ ms** | baseline |

## Validation

- `vitest run src/plugins/setup-registry.runtime.test.ts` — 4/4 pass (existing coverage already tests the getter/setter round-trip with concrete workspaceDir)
- `oxlint -f unix src/gateway/server.impl.ts` — clean
- `defaultWorkspaceDir` is in scope at both call sites (destructured from `pluginBootstrap` at line 658)

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- No new network calls

## Scope Boundary

- 2 lines changed in `server.impl.ts` + CHANGELOG
- Does not change `setCurrentPluginMetadataSnapshot` API or reader contract

Fixes #77519.