### PR TITLE
feat(discord): VC-02 — TTS response hook for voice-message channels

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -22,6 +22,7 @@ import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import { logDebug } from "openclaw/plugin-sdk/text-runtime";
+import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import {
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordSlug,
@@ -34,7 +35,6 @@ import {
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
-import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import {
   formatDiscordUserTag,
   resolveDiscordSystemLocation,
@@ -782,15 +782,18 @@ export async function preflightDiscordMessage(
 
   // Only authorized guild senders should reach the expensive transcription path.
   const { resolveDiscordPreflightAudioMentionContext } = await loadPreflightAudioRuntime();
-  const { hasTypedText, transcript: preflightTranscript } =
-    await resolveDiscordPreflightAudioMentionContext({
-      message,
-      isDirectMessage,
-      shouldRequireMention,
-      mentionRegexes,
-      cfg: params.cfg,
-      abortSignal: params.abortSignal,
-    });
+  const {
+    hasAudioAttachment,
+    hasTypedText,
+    transcript: preflightTranscript,
+  } = await resolveDiscordPreflightAudioMentionContext({
+    message,
+    isDirectMessage,
+    shouldRequireMention,
+    mentionRegexes,
+    cfg: params.cfg,
+    abortSignal: params.abortSignal,
+  });
   if (isPreflightAborted(params.abortSignal)) {
     return null;
   }
@@ -1018,5 +1021,6 @@ export async function preflightDiscordMessage(
     historyEntry,
     threadBindings: params.threadBindings,
     discordRestFetch: params.discordRestFetch,
+    hasAudioAttachment,
   };
 }

--- a/extensions/discord/src/monitor/message-handler.preflight.types.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.types.ts
@@ -91,6 +91,12 @@ export type DiscordMessagePreflightContext = DiscordMessagePreflightSharedFields
   historyEntry?: HistoryEntry;
   threadBindings: DiscordThreadBindingLookup;
   discordRestFetch?: typeof fetch;
+  /**
+   * True when the inbound message contained at least one audio attachment.
+   * Set by the preflight audio pass; used by VC-02 to decide whether to
+   * deliver the response as a Discord voice message.
+   */
+  hasAudioAttachment: boolean;
 };
 
 export type DiscordMessagePreflightParams = DiscordMessagePreflightSharedFields & {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -67,6 +67,7 @@ import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
   DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
 } from "./timeouts.js";
+import { tryDeliverTtsReply, VOICE_REPLY_CHANNEL_IDS } from "./tts-response.js";
 import { sendTyping } from "./typing.js";
 
 function sleep(ms: number): Promise<void> {
@@ -142,6 +143,7 @@ export async function processDiscordMessage(
     commandAuthorized,
     discordRestFetch,
     abortSignal,
+    hasAudioAttachment,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
     return;
@@ -789,6 +791,34 @@ export async function processDiscordMessage(
         if (isFinal) {
           notifyFinalReplyStart();
         }
+
+        // VC-02: TTS voice reply — attempt to send the final text reply as a
+        // Discord voice message when the inbound message was audio and the
+        // channel is in the configured voice-reply list.
+        if (
+          isFinal &&
+          hasAudioAttachment &&
+          !payload.isError &&
+          !payload.isReasoning &&
+          payload.text &&
+          !resolveSendableOutboundReplyParts(payload).hasMedia &&
+          VOICE_REPLY_CHANNEL_IDS.has(messageChannelId)
+        ) {
+          const ttsResult = await tryDeliverTtsReply({
+            text: payload.text,
+            channelId: messageChannelId,
+            replyToMessageId: replyToId,
+            rest: client.rest as RequestClient,
+            token,
+          });
+          if (ttsResult.sentAsVoice) {
+            replyReference.markSent();
+            observer?.onFinalReplyDelivered?.();
+            return;
+          }
+          // TTS failed or fell back — fall through to standard text delivery below.
+        }
+
         await deliverDiscordReply({
           cfg,
           replies: [payload],

--- a/extensions/discord/src/monitor/tts-response.ts
+++ b/extensions/discord/src/monitor/tts-response.ts
@@ -1,0 +1,188 @@
+/**
+ * TTS Response Hook — VC-02
+ *
+ * When an agent response is triggered by an inbound voice message on one of the
+ * configured "voice reply" channels, this module converts the text reply to speech
+ * via OpenAI TTS (model: tts-1, voice: onyx) and sends it as a Discord voice message.
+ *
+ * Long-response policy:
+ *   If the response exceeds MAX_TTS_WORDS words we fall back to plain text.
+ *   Rationale: TTS latency scales with length, Discord voice messages have no
+ *   seek bar, and very long audio clips are a poor UX for conversational replies.
+ *   The threshold (500 words) keeps voice replies comfortable to listen to while
+ *   still handling typical conversational responses.  Anything longer is sent as
+ *   regular text so the user gets the answer without waiting.
+ *
+ * Fallback contract:
+ *   Any error — TTS API, ffmpeg conversion, Discord upload — logs a warning and
+ *   returns `{ sentAsVoice: false }` so the caller falls back to plain text.
+ *   The response is never silently dropped.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { RequestClient } from "@buape/carbon";
+import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { createDiscordRetryRunner } from "../retry.js";
+import {
+  ensureOggOpus,
+  getVoiceMessageMetadata,
+  sendDiscordVoiceMessage,
+} from "../voice-message.js";
+
+/** Channels that should receive voice replies when the inbound message was audio. */
+export const VOICE_REPLY_CHANNEL_IDS = new Set(["1490438088080490506", "1490437981780312064"]);
+
+/**
+ * Maximum word count before falling back to plain text.
+ * At ~130 wpm, 500 words ≈ 3.8 minutes — already at the upper edge of comfortable.
+ */
+const MAX_TTS_WORDS = 500;
+
+/** OpenAI TTS timeout in ms — generous to accommodate long-ish responses. */
+const TTS_TIMEOUT_MS = 60_000;
+
+const OPENAI_TTS_BASE_URL = "https://api.openai.com/v1";
+
+function countWords(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function resolveOpenAIApiKey(): string | undefined {
+  return process.env.OPENAI_API_KEY?.trim() || undefined;
+}
+
+/**
+ * Call the OpenAI TTS API and return the raw MP3 buffer.
+ * Self-contained: does not depend on the openai extension package.
+ */
+async function callOpenAITts(params: {
+  text: string;
+  apiKey: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
+  try {
+    const response = await fetch(`${OPENAI_TTS_BASE_URL}/audio/speech`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "tts-1",
+        input: params.text,
+        voice: "onyx",
+        response_format: "mp3",
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      throw new Error(
+        `OpenAI TTS API error (${response.status})${detail ? `: ${detail.slice(0, 200)}` : ""}`,
+      );
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export type TtsReplyResult = { sentAsVoice: true } | { sentAsVoice: false; reason: string };
+
+/**
+ * Attempt to deliver `text` as a Discord voice message.
+ *
+ * Returns `{ sentAsVoice: true }` on success.
+ * Returns `{ sentAsVoice: false, reason }` on any failure or when the fallback
+ * policy applies (too long, no API key, non-voice channel).
+ */
+export async function tryDeliverTtsReply(params: {
+  text: string;
+  channelId: string;
+  replyToMessageId: string | undefined;
+  rest: RequestClient;
+  token: string;
+}): Promise<TtsReplyResult> {
+  const { text, channelId, replyToMessageId, rest, token } = params;
+
+  // Gate: only for configured voice-reply channels.
+  if (!VOICE_REPLY_CHANNEL_IDS.has(channelId)) {
+    return { sentAsVoice: false, reason: "channel not in voice-reply list" };
+  }
+
+  // Gate: word-count fallback.
+  const wordCount = countWords(text);
+  if (wordCount > MAX_TTS_WORDS) {
+    logVerbose(
+      `discord tts-response: response too long (${wordCount} words > ${MAX_TTS_WORDS}), falling back to text`,
+    );
+    return { sentAsVoice: false, reason: "response exceeds max word count" };
+  }
+
+  const apiKey = resolveOpenAIApiKey();
+  if (!apiKey) {
+    logVerbose("discord tts-response: OPENAI_API_KEY not set, falling back to text");
+    return { sentAsVoice: false, reason: "OPENAI_API_KEY not configured" };
+  }
+
+  let mp3Path: string | null = null;
+  let oggPath: string | null = null;
+  let oggCleanup = false;
+
+  try {
+    // 1. Call OpenAI TTS → MP3 buffer.
+    logVerbose(`discord tts-response: synthesising ${wordCount} words via tts-1/onyx`);
+    const mp3Buffer = await callOpenAITts({ text, apiKey, timeoutMs: TTS_TIMEOUT_MS });
+
+    // 2. Write MP3 to a temp file so ffmpeg can consume it.
+    const tempDir = resolvePreferredOpenClawTmpDir();
+    mp3Path = path.join(tempDir, `tts-${crypto.randomUUID()}.mp3`);
+    await fs.writeFile(mp3Path, mp3Buffer, { mode: 0o600 });
+
+    // 3. Convert MP3 → OGG/Opus at 48 kHz (Discord voice message requirement).
+    const ogg = await ensureOggOpus(mp3Path);
+    oggPath = ogg.path;
+    oggCleanup = ogg.cleanup;
+
+    // 4. Gather waveform + duration metadata.
+    const metadata = await getVoiceMessageMetadata(oggPath);
+
+    // 5. Read OGG bytes.
+    const audioBuffer = await fs.readFile(oggPath);
+
+    // 6. Build a retry runner for the upload calls.
+    const request = createDiscordRetryRunner({});
+
+    // 7. Send the Discord voice message.
+    await sendDiscordVoiceMessage(
+      rest,
+      channelId,
+      audioBuffer,
+      metadata,
+      replyToMessageId,
+      request,
+      /* silent */ false,
+      token,
+    );
+
+    logVerbose(`discord tts-response: voice reply sent to channel ${channelId}`);
+    return { sentAsVoice: true };
+  } catch (err) {
+    logVerbose(`discord tts-response: failed, falling back to text: ${String(err)}`);
+    return { sentAsVoice: false, reason: String(err) };
+  } finally {
+    // Best-effort temp file cleanup.
+    await unlinkIfExists(mp3Path).catch(() => undefined);
+    if (oggCleanup) {
+      await unlinkIfExists(oggPath).catch(() => undefined);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds TTS response hook (`tts-response.ts`) that intercepts final agent replies on designated voice-message channels and delivers them as Discord voice messages via OpenAI TTS (model: `tts-1`, voice: `onyx`)
- Threads the `hasAudioAttachment` flag from the preflight audio pass into `DiscordMessagePreflightContext` so the process pipeline can detect voice-origin messages
- Fallback to plain text on any TTS/conversion/upload error; responses are never silently dropped
- Responses >500 words fall back to plain text (TTS latency + no seek bar makes long audio a poor UX)

## Files changed

| File | Change |
|------|--------|
| `extensions/discord/src/monitor/tts-response.ts` | New — self-contained TTS fetch, MP3→OGG/Opus conversion, Discord voice message upload, word-count gate, error fallback |
| `extensions/discord/src/monitor/message-handler.preflight.types.ts` | Adds `hasAudioAttachment: boolean` to `DiscordMessagePreflightContext` |
| `extensions/discord/src/monitor/message-handler.preflight.ts` | Destructures `hasAudioAttachment` from preflight audio result; passes it in returned context |
| `extensions/discord/src/monitor/message-handler.process.ts` | Hooks `tryDeliverTtsReply` into final-reply delivery; falls through to `deliverDiscordReply` on failure |

## Config required

Set `OPENAI_API_KEY` in the environment (already present for other OpenAI features).

No new config keys needed. Target channel IDs hardcoded in `tts-response.ts`:
- `1490438088080490506`
- `1490437981780312064`

## Coordination with VC-01

This branch is independent of `vc-01-stt-wiring`. The only overlapping files are `message-handler.preflight.ts` and `message-handler.preflight.types.ts` — changes are additive and will merge cleanly.

## Test plan

- [ ] Send a Discord voice message in channel `1490438088080490506` or `1490437981780312064`; confirm the agent responds with a voice message
- [ ] Send a voice message whose transcript generates a >500 word response; confirm plain text fallback
- [ ] Test with `OPENAI_API_KEY` unset; confirm plain text fallback, no dropped responses
- [ ] Verify text messages in those channels still get text replies
- [ ] Verify voice messages in other channels still get text replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)