### PR TITLE
fix(channels): preserve channel aliases in plugin probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/OpenAI: default direct OpenAI Responses models to the SSE transport instead of WebSocket auto-selection, preventing pi runtime chat turns from hanging on servers where the WebSocket path stalls while the OpenAI HTTP stream works. Thanks @vincentkoc.
+- Channels/plugins: key bundled package-state probes by channel id instead of manifest plugin id, preserving configured-state and persisted-auth detection for channel plugins whose package id differs from the channel alias. Thanks @vincentkoc.
 - Docker: prune package-excluded plugin dist directories from runtime images unless the build explicitly opts that plugin in, so official external plugins such as Feishu stay install-on-demand instead of shipping partial metadata without compiled runtime output. Fixes #77424. Thanks @vincentkoc.
 - Model switching: include the exact additive allowlist repair command when `/model ... --runtime ...` targets a blocked model, and make Telegram's model picker say that it changes only the session model while leaving the runtime unchanged. Thanks @vincentkoc.
 - Doctor/config: keep active `auth.profiles` metadata intact when `doctor --fix` strips stale secret fields from configs, repairing legacy `<provider>:default` API-key profile metadata when model fallbacks or explicit `model@profile` refs still depend on it. Fixes #77400.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/OpenAI: default direct OpenAI Responses models to the SSE transport instead of WebSocket auto-selection, preventing pi runtime chat turns from hanging on servers where the WebSocket path stalls while the OpenAI HTTP stream works. Thanks @vincentkoc.
-- Channels/plugins: key bundled package-state probes by channel id instead of manifest plugin id, preserving configured-state and persisted-auth detection for channel plugins whose package id differs from the channel alias. Thanks @vincentkoc.
+- Channels/plugins: key bundled package-state probes, env/config presence, and read-only command defaults by channel id instead of manifest plugin id, preserving setup and native-command detection for channel plugins whose package id differs from the channel alias. Thanks @vincentkoc.
 - Docker: prune package-excluded plugin dist directories from runtime images unless the build explicitly opts that plugin in, so official external plugins such as Feishu stay install-on-demand instead of shipping partial metadata without compiled runtime output. Fixes #77424. Thanks @vincentkoc.
 - Model switching: include the exact additive allowlist repair command when `/model ... --runtime ...` targets a blocked model, and make Telegram's model picker say that it changes only the session model while leaving the runtime unchanged. Thanks @vincentkoc.
 - Doctor/config: keep active `auth.profiles` metadata intact when `doctor --fix` strips stale secret fields from configs, repairing legacy `<provider>:default` API-key profile metadata when model fallbacks or explicit `model@profile` refs still depend on it. Fixes #77400.

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -9,7 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasNonEmptyString } from "../infra/outbound/channel-target.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { isRecord } from "../utils.js";
-import { listBundledChannelPluginIds } from "./plugins/bundled-ids.js";
+import { listBundledChannelIds } from "./plugins/bundled-ids.js";
 
 const IGNORED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
 
@@ -121,7 +121,7 @@ export function listPotentialConfiguredChannelPresenceSignals(
     signals.push({ channelId, source });
   };
   const configuredChannelIds = new Set<string>();
-  const channelIds = options.channelIds ?? listBundledChannelPluginIds(env);
+  const channelIds = options.channelIds ?? listBundledChannelIds(env);
   const channelEnvPrefixes = listChannelEnvPrefixes(channelIds);
   const channels = isRecord(cfg.channels) ? cfg.channels : null;
   if (channels) {
@@ -165,7 +165,7 @@ function hasEnvConfiguredChannel(
   env: NodeJS.ProcessEnv,
   options: ChannelPresenceOptions = {},
 ): boolean {
-  const channelIds = options.channelIds ?? listBundledChannelPluginIds(env);
+  const channelIds = options.channelIds ?? listBundledChannelIds(env);
   const channelEnvPrefixes = listChannelEnvPrefixes(channelIds);
   for (const [key, value] of Object.entries(env)) {
     if (!hasNonEmptyString(value)) {

--- a/src/channels/plugins/bundled-ids.ts
+++ b/src/channels/plugins/bundled-ids.ts
@@ -10,6 +10,20 @@ export function listBundledChannelPluginIdsForRoot(
     .toSorted((left, right) => left.localeCompare(right));
 }
 
+export function listBundledChannelIdsForRoot(
+  _packageRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return listChannelCatalogEntries({ origin: "bundled", env })
+    .map((entry) => entry.channel.id)
+    .filter((channelId): channelId is string => Boolean(channelId))
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
 export function listBundledChannelPluginIds(env: NodeJS.ProcessEnv = process.env): string[] {
   return listBundledChannelPluginIdsForRoot(resolveBundledChannelRootScope(env).cacheKey, env);
+}
+
+export function listBundledChannelIds(env: NodeJS.ProcessEnv = process.env): string[] {
+  return listBundledChannelIdsForRoot(resolveBundledChannelRootScope(env).cacheKey, env);
 }

--- a/src/channels/plugins/bundled-root-caches.test.ts
+++ b/src/channels/plugins/bundled-root-caches.test.ts
@@ -62,10 +62,10 @@ describe("bundled root-aware plugin lookups", () => {
       listChannelCatalogEntries: (params?: { env?: NodeJS.ProcessEnv }) => {
         const activeRoot = params?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR;
         if (activeRoot === rootA.pluginsDir) {
-          return [{ pluginId: "alpha" }];
+          return [{ pluginId: "alpha", channel: { id: "alpha-chat" } }];
         }
         if (activeRoot === rootB.pluginsDir) {
-          return [{ pluginId: "beta" }];
+          return [{ pluginId: "beta", channel: { id: "beta-chat" } }];
         }
         return [];
       },
@@ -78,9 +78,11 @@ describe("bundled root-aware plugin lookups", () => {
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootA.pluginsDir;
     expect(bundledIds.listBundledChannelPluginIds()).toEqual(["alpha"]);
+    expect(bundledIds.listBundledChannelIds()).toEqual(["alpha-chat"]);
 
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = rootB.pluginsDir;
     expect(bundledIds.listBundledChannelPluginIds()).toEqual(["beta"]);
+    expect(bundledIds.listBundledChannelIds()).toEqual(["beta-chat"]);
   });
 
   it("reads bootstrap plugins from the active bundled root without re-importing", async () => {

--- a/src/channels/plugins/package-state-probes.test.ts
+++ b/src/channels/plugins/package-state-probes.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginChannelCatalogEntry } from "../../plugins/channel-catalog-registry.js";
+import {
+  hasBundledChannelPackageState,
+  listBundledChannelIdsForPackageState,
+} from "./package-state-probes.js";
+
+const listChannelCatalogEntriesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../plugins/channel-catalog-registry.js", () => ({
+  listChannelCatalogEntries: listChannelCatalogEntriesMock,
+}));
+
+function makeBundledChannelCatalogEntry(params: {
+  pluginId: string;
+  channelId: string;
+}): PluginChannelCatalogEntry {
+  return {
+    pluginId: params.pluginId,
+    origin: "bundled",
+    rootDir: "/tmp/openclaw-channel-plugin",
+    channel: {
+      id: params.channelId,
+      configuredState: {
+        env: {
+          allOf: ["ALIAS_CHAT_TOKEN"],
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  listChannelCatalogEntriesMock.mockReset();
+});
+
+describe("channel package-state probes", () => {
+  it("uses channel ids when manifest plugin ids differ", () => {
+    listChannelCatalogEntriesMock.mockReturnValue([
+      makeBundledChannelCatalogEntry({
+        pluginId: "vendor-alias-chat-plugin",
+        channelId: "alias-chat",
+      }),
+    ]);
+
+    expect(listBundledChannelIdsForPackageState("configuredState")).toEqual(["alias-chat"]);
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "configuredState",
+        channelId: "alias-chat",
+        cfg: {},
+        env: { ALIAS_CHAT_TOKEN: "token" },
+      }),
+    ).toBe(true);
+    expect(
+      hasBundledChannelPackageState({
+        metadataKey: "configuredState",
+        channelId: "vendor-alias-chat-plugin",
+        cfg: {},
+        env: { ALIAS_CHAT_TOKEN: "token" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/channels/plugins/package-state-probes.ts
+++ b/src/channels/plugins/package-state-probes.ts
@@ -137,10 +137,16 @@ function resolveChannelPackageStateChecker(params: {
   }
 }
 
+function resolvePackageStateChannelId(entry: PluginChannelCatalogEntry): string | undefined {
+  return normalizeOptionalString(entry.channel.id);
+}
+
 export function listBundledChannelIdsForPackageState(
   metadataKey: ChannelPackageStateMetadataKey,
 ): string[] {
-  return listChannelPackageStateCatalog(metadataKey).map((entry) => entry.pluginId);
+  return listChannelPackageStateCatalog(metadataKey)
+    .map((entry) => resolvePackageStateChannelId(entry))
+    .filter((channelId): channelId is string => Boolean(channelId));
 }
 
 export function hasBundledChannelPackageState(params: {
@@ -149,8 +155,9 @@ export function hasBundledChannelPackageState(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): boolean {
+  const requestedChannelId = normalizeOptionalString(params.channelId);
   const entry = listChannelPackageStateCatalog(params.metadataKey).find(
-    (candidate) => candidate.pluginId === params.channelId,
+    (candidate) => resolvePackageStateChannelId(candidate) === requestedChannelId,
   );
   if (!entry) {
     return false;

--- a/src/channels/plugins/read-only-command-defaults.test.ts
+++ b/src/channels/plugins/read-only-command-defaults.test.ts
@@ -65,4 +65,43 @@ describe("resolveReadOnlyChannelCommandDefaults", () => {
       workspaceDir: "/workspace",
     });
   });
+
+  it("resolves command defaults for manifest channel aliases", () => {
+    loadPluginMetadataSnapshot.mockReturnValue({
+      index: {
+        plugins: [
+          {
+            pluginId: "vendor-demo-plugin",
+            origin: "global",
+            enabled: true,
+            enabledByDefault: true,
+          },
+        ],
+      },
+      plugins: [
+        {
+          id: "vendor-demo-plugin",
+          origin: "global",
+          channels: ["demo"],
+          channelConfigs: {
+            demo: {
+              commands: {
+                nativeCommandsAutoEnabled: true,
+                nativeSkillsAutoEnabled: false,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(
+      resolveReadOnlyChannelCommandDefaults("demo", {
+        config: {},
+      }),
+    ).toEqual({
+      nativeCommandsAutoEnabled: true,
+      nativeSkillsAutoEnabled: false,
+    });
+  });
 });

--- a/src/channels/plugins/read-only-command-defaults.ts
+++ b/src/channels/plugins/read-only-command-defaults.ts
@@ -74,12 +74,6 @@ export function resolveReadOnlyChannelCommandDefaults(
     if (!record.channels.includes(normalizedChannelId)) {
       continue;
     }
-    if (
-      record.id !== normalizedChannelId &&
-      record.channelCatalogMeta?.id !== normalizedChannelId
-    ) {
-      continue;
-    }
     if (!isInstalledPluginEnabled(snapshot.index, record.id, options.config)) {
       continue;
     }
@@ -92,9 +86,11 @@ export function resolveReadOnlyChannelCommandDefaults(
       !Array.isArray(channelConfigValue)
         ? (channelConfigValue as ManifestChannelConfigRecord)
         : undefined;
-    const commands = normalizeChannelCommandDefaults(
-      channelConfig?.commands ?? record.channelCatalogMeta?.commands,
-    );
+    const catalogCommands =
+      record.channelCatalogMeta?.id === normalizedChannelId
+        ? record.channelCatalogMeta.commands
+        : undefined;
+    const commands = normalizeChannelCommandDefaults(channelConfig?.commands ?? catalogCommands);
     if (commands) {
       return commands;
     }


### PR DESCRIPTION
Summary
- key bundled package-state probes by channel id instead of manifest plugin id
- make env/config presence use bundled channel ids, preserving env-only detection for alias-owned channel plugins
- let read-only command defaults use manifest channel claims when plugin id differs from channel id

Verification
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/channels/config-presence.ts src/channels/plugins/bundled-ids.ts src/channels/plugins/bundled-root-caches.test.ts src/channels/plugins/package-state-probes.ts src/channels/plugins/package-state-probes.test.ts src/channels/plugins/read-only-command-defaults.ts src/channels/plugins/read-only-command-defaults.test.ts`
- `pnpm test:serial src/channels/plugins/package-state-probes.test.ts src/channels/plugins/configured-state.test.ts src/channels/plugins/persisted-auth-state.test.ts src/channels/plugins/read-only-command-defaults.test.ts src/channels/plugins/bundled-root-caches.test.ts src/channels/config-presence.test.ts`
- Crabbox/Blacksmith `pnpm check:changed`: https://github.com/openclaw/openclaw/actions/runs/25346897582 (`tbx_01kqthj1a1kp7wtp87sbf2x49t`, exit 0)

Follow-up to https://github.com/openclaw/openclaw/pull/77487.
