### PR TITLE
fix(sessions): stabilize spawned session visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,7 @@ Docs: https://docs.openclaw.ai
 - Plugin tools: honor explicit tool denylists while selecting plugin tool runtimes, so denied plugin tools are not materialized for direct command or gateway surfaces before later policy filtering. Thanks @vincentkoc.
 - Plugin tools: filter factory-returned tools by manifest per-tool optional policy, so optional sibling tools from a shared runtime factory stay hidden unless explicitly allowed. Thanks @vincentkoc.
 - Agents/transcripts: retry context-overflow compaction from the current transcript only after the inbound user turn was actually persisted, and keep WebChat agent-run live delivery from writing duplicate Pi-managed assistant turns. Fixes #76424. (#77033)
+- Agents/sessions: keep spawned cross-agent fleet sessions visible under default tree-scoped session tools and prevent constrained Control UI session lists from briefly showing rows that current filters cannot keep.
 - Agents/bootstrap: keep pending `BOOTSTRAP.md` and bootstrap truncation notices in system-prompt Project Context instead of copying setup text or raw warning diagnostics into WebChat user/runtime context. Fixes #76946.
 - Gateway/install: keep `.env`-managed values in the macOS LaunchAgent env file while still tracking `OPENCLAW_SERVICE_MANAGED_ENV_KEYS`, so regenerated services do not boot without managed auth/provider keys. Fixes #75374.
 - Gateway/restart: verify listener PIDs by argv when `lsof` reports only the Node process name, so stale gateway cleanup can find macOS `cnode` listeners. Fixes #70664.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1380,6 +1380,44 @@ describe("session_status tool", () => {
     );
   });
 
+  it("allows cross-agent spawned session_status under tree visibility without agent-to-agent access", async () => {
+    const childKey = "agent:ops:subagent:worker";
+    resetSessionStore({
+      "agent:main:main": {
+        sessionId: "s-main",
+        updatedAt: 10,
+      },
+      [childKey]: {
+        sessionId: "s-child",
+        updatedAt: 20,
+        spawnedBy: "agent:main:main",
+      },
+    });
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        sessions: { visibility: "tree" },
+        agentToAgent: { enabled: false },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {},
+        },
+      },
+    };
+    mockSpawnedSessionList((spawnedBy) =>
+      spawnedBy === "agent:main:main" ? [{ key: childKey }] : [],
+    );
+
+    const tool = getSessionStatusTool("agent:main:main");
+    const result = await tool.execute("call-cross-agent-child", { sessionKey: childKey });
+
+    const details = result.details as { ok?: boolean; sessionKey?: string };
+    expect(details.ok).toBe(true);
+    expect(details.sessionKey).toBe(childKey);
+  });
+
   it("blocks unsandboxed same-agent session_status outside self visibility", async () => {
     resetSessionStore({
       "agent:main:main": {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -401,11 +401,13 @@ export function createSessionStatusTool(opts?: {
 
       if (requestedKeyRaw.startsWith("agent:") && !isSemanticCurrentRequest) {
         const requestedAgentId = resolveAgentIdFromSessionKey(requestedKeyRaw);
-        ensureAgentAccess(requestedAgentId);
-        const access = visibilityGuard.check(
-          normalizeVisibilityTargetSessionKey(requestedKeyRaw, requestedAgentId),
+        const visibilityTarget = normalizeVisibilityTargetSessionKey(
+          requestedKeyRaw,
+          requestedAgentId,
         );
+        const access = visibilityGuard.check(visibilityTarget);
         if (!access.allowed) {
+          ensureAgentAccess(requestedAgentId);
           throw new Error(access.error);
         }
       }
@@ -453,11 +455,17 @@ export function createSessionStatusTool(opts?: {
           if (!visibleSession.ok) {
             throw new Error("Session status visibility is restricted to the current session tree.");
           }
-          // If resolution points at another agent, enforce A2A policy before switching stores.
-          ensureAgentAccess(resolveAgentIdFromSessionKey(visibleSession.key));
+          const visibleAgentId = resolveAgentIdFromSessionKey(visibleSession.key);
+          const visibleAccess = visibilityGuard.check(
+            normalizeVisibilityTargetSessionKey(visibleSession.key, visibleAgentId),
+          );
+          if (!visibleAccess.allowed) {
+            ensureAgentAccess(visibleAgentId);
+            throw new Error(visibleAccess.error);
+          }
           resolvedViaSessionId = true;
           requestedKeyRaw = visibleSession.key;
-          agentId = resolveAgentIdFromSessionKey(visibleSession.key);
+          agentId = visibleAgentId;
           storePath = resolveStorePath(cfg.session?.store, { agentId });
           store = loadSessionStore(storePath);
           storeScopedRequesterKey = resolveStoreScopedRequesterKey({

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -1,14 +1,28 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   createAgentToAgentPolicy,
   createSessionVisibilityGuard,
+  listSpawnedSessionKeys,
   resolveEffectiveSessionToolsVisibility,
   resolveSandboxSessionToolsVisibility,
   resolveSessionToolsVisibility,
 } from "../../plugin-sdk/session-visibility.js";
 import { resolveSandboxedSessionToolContext } from "./sessions-access.js";
 import { __testing as sessionsResolutionTesting } from "./sessions-resolution.js";
+
+const loggerMocks = vi.hoisted(() => ({
+  logDebug: vi.fn(),
+}));
+
+vi.mock("../../logger.js", () => ({
+  logDebug: loggerMocks.logDebug,
+}));
+
+beforeEach(() => {
+  loggerMocks.logDebug.mockReset();
+  sessionsResolutionTesting.setDepsForTest();
+});
 
 describe("resolveSessionToolsVisibility", () => {
   it("defaults to tree when unset or invalid", () => {
@@ -109,6 +123,23 @@ describe("createAgentToAgentPolicy", () => {
 });
 
 describe("createSessionVisibilityGuard", () => {
+  it("logs and fails closed when spawned key listing fails", async () => {
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async () => {
+        throw new Error("gateway unavailable");
+      }) as never,
+    });
+
+    const keys = await listSpawnedSessionKeys({
+      requesterSessionKey: "agent:main:main",
+    });
+
+    expect(keys.size).toBe(0);
+    expect(loggerMocks.logDebug).toHaveBeenCalledWith(
+      "sessions: failed to list spawned session keys for agent:main:main: gateway unavailable",
+    );
+  });
+
   it("does not block exact same-agent spawned targets that fall past the spawned list cap", async () => {
     sessionsResolutionTesting.setDepsForTest({
       callGateway: vi.fn(async (request: { method?: string; params?: { key?: string } }) => {
@@ -141,6 +172,36 @@ describe("createSessionVisibilityGuard", () => {
     sessionsResolutionTesting.setDepsForTest();
   });
 
+  it("allows cross-agent spawned targets under tree visibility without broad agent-to-agent access", async () => {
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async (request: { method?: string }) => {
+        if (request.method === "sessions.list") {
+          return {
+            sessions: [{ key: "agent:ops:subagent:worker-1" }],
+          };
+        }
+        return {};
+      }) as never,
+    });
+
+    const guard = await createSessionVisibilityGuard({
+      action: "list",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:ops:subagent:worker-1")).toEqual({ allowed: true });
+    expect(guard.check("agent:ops:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session list visibility is restricted to the current session tree (tools.sessions.visibility=tree).",
+    });
+
+    sessionsResolutionTesting.setDepsForTest();
+  });
+
   it("blocks cross-agent send when agent-to-agent is disabled", async () => {
     const guard = await createSessionVisibilityGuard({
       action: "send",
@@ -154,6 +215,24 @@ describe("createSessionVisibilityGuard", () => {
       status: "forbidden",
       error:
         "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+    });
+  });
+
+  it("explains non-spawned cross-agent targets under same-agent visibility", async () => {
+    const guard = await createSessionVisibilityGuard({
+      action: "send",
+      requesterSessionKey: "agent:main:main",
+      visibility: "agent",
+      a2aPolicy: createAgentToAgentPolicy({
+        tools: { agentToAgent: { enabled: true, allow: ["*"] } },
+      } as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:ops:main")).toEqual({
+      allowed: false,
+      status: "forbidden",
+      error:
+        "Session send visibility is restricted for non-spawned cross-agent sessions. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access.",
     });
   });
 

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.js";
+import type { SessionToolsVisibility } from "../../plugin-sdk/session-visibility.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
 
@@ -14,7 +15,7 @@ type SessionsToolTestConfig = {
   session: { scope: "per-sender"; mainKey: string };
   tools: {
     agentToAgent: { enabled: boolean };
-    sessions?: { visibility: "all" | "own" };
+    sessions?: { visibility: SessionToolsVisibility };
   };
 };
 
@@ -417,13 +418,20 @@ describe("resolveAnnounceTarget", () => {
 describe("sessions_list gating", () => {
   beforeEach(() => {
     callGatewayMock.mockClear();
-    callGatewayMock.mockResolvedValue({
-      path: "/tmp/sessions.json",
-      sessions: [
-        { key: "agent:main:main", kind: "direct" },
-        { key: "agent:other:main", kind: "direct" },
-      ],
-    });
+    callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        if (request.method === "sessions.list" && request.params?.spawnedBy) {
+          return { path: "/tmp/sessions.json", sessions: [] };
+        }
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            { key: "agent:main:main", kind: "direct" },
+            { key: "agent:other:main", kind: "direct" },
+          ],
+        };
+      },
+    );
   });
 
   it("filters out other agents when tools.agentToAgent.enabled is false", async () => {
@@ -432,6 +440,47 @@ describe("sessions_list gating", () => {
     expect(result.details).toMatchObject({
       count: 1,
       sessions: [{ key: MAIN_AGENT_SESSION_KEY }],
+    });
+  });
+
+  it("keeps cross-agent spawned children visible in tree-scoped sessions_list", async () => {
+    const crossAgentChild = "agent:ops:subagent:worker";
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(
+      async (request: { method?: string; params?: Record<string, unknown> }) => {
+        if (request.method === "sessions.list" && request.params?.spawnedBy) {
+          return {
+            path: "(multiple)",
+            sessions: [{ key: crossAgentChild, kind: "direct" }],
+          };
+        }
+        if (request.method === "sessions.list") {
+          return {
+            path: "(multiple)",
+            sessions: [
+              { key: MAIN_AGENT_SESSION_KEY, kind: "direct" },
+              { key: crossAgentChild, kind: "direct", spawnedBy: MAIN_AGENT_SESSION_KEY },
+              { key: "agent:ops:main", kind: "direct" },
+            ],
+          };
+        }
+        return {};
+      },
+    );
+
+    const tool = createMainSessionsListTool();
+    const result = await tool.execute("call1", {});
+
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "sessions.list",
+        params: expect.objectContaining({ agentId: undefined }),
+      }),
+    );
+    expect(result.details).toMatchObject({
+      count: 2,
+      sessions: [{ key: MAIN_AGENT_SESSION_KEY }, { key: crossAgentChild }],
     });
   });
 

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -204,6 +204,83 @@ test("sessions.list marks sessions with active abortable runs", async () => {
   );
 });
 
+test("sessions.list reflects session store changes across repeated calls", async () => {
+  await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", { updatedAt: 10 }),
+    },
+  });
+
+  const { ws } = await openClient();
+  const params = { includeGlobal: true, includeUnknown: true };
+  const first = await rpcReq<{
+    sessions: Array<{ key: string }>;
+  }>(ws, "sessions.list", params);
+
+  expect(first.ok).toBe(true);
+  expect(first.payload?.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-main", { updatedAt: 10 }),
+      "dashboard:new": sessionStoreEntry("sess-new", { updatedAt: 20 }),
+    },
+  });
+
+  const second = await rpcReq<{
+    sessions?: Array<{ key: string }>;
+  }>(ws, "sessions.list", params);
+
+  expect(second.ok).toBe(true);
+  expect(second.payload?.sessions?.map((session) => session.key)).toEqual([
+    "agent:main:dashboard:new",
+    "agent:main:main",
+  ]);
+  ws.close();
+});
+
+test("sessions.list spawnedBy filter sees cross-agent children without agentId", async () => {
+  const { dir } = await createSessionStoreDir();
+  const storeTemplate = path.join(dir, "agents", "{agentId}", "sessions", "sessions.json");
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = { store: storeTemplate };
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "ops" }] };
+  const now = Date.now();
+
+  await writeSessionStore({
+    storePath: storeTemplate.replace("{agentId}", "main"),
+    agentId: "main",
+    entries: {
+      main: sessionStoreEntry("sess-main", { updatedAt: now }),
+    },
+  });
+  await writeSessionStore({
+    storePath: storeTemplate.replace("{agentId}", "ops"),
+    agentId: "ops",
+    entries: {
+      "subagent:worker": sessionStoreEntry("sess-ops-worker", {
+        updatedAt: now + 1,
+        spawnedBy: "agent:main:main",
+      }),
+    },
+  });
+
+  const { ws } = await openClient();
+  const listed = await rpcReq<{
+    sessions?: Array<{ key: string; spawnedBy?: string }>;
+  }>(ws, "sessions.list", { spawnedBy: "agent:main:main" });
+
+  expect(listed.ok).toBe(true);
+  expect(listed.payload?.sessions).toEqual([
+    expect.objectContaining({
+      key: "agent:ops:subagent:worker",
+      spawnedBy: "agent:main:main",
+    }),
+  ]);
+  ws.close();
+});
+
 test("sessions.list yields before responding during bulk transcript hydration", async () => {
   const { dir } = await createSessionStoreDir();
   const entries: Record<string, ReturnType<typeof sessionStoreEntry>> = {};

--- a/src/plugin-sdk/session-visibility.ts
+++ b/src/plugin-sdk/session-visibility.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway as defaultCallGateway } from "../gateway/call.js";
+import { logDebug } from "../logger.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -52,7 +53,11 @@ export async function listSpawnedSessionKeys(params: {
     const sessions = Array.isArray(list?.sessions) ? list.sessions : [];
     const keys = sessions.map((entry) => normalizeOptionalString(entry?.key) ?? "").filter(Boolean);
     return new Set(keys);
-  } catch {
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logDebug(
+      `sessions: failed to list spawned session keys for ${params.requesterSessionKey}: ${message}`,
+    );
     return new Set();
   }
 }
@@ -165,15 +170,15 @@ function a2aDeniedMessage(action: SessionAccessAction): string {
 
 function crossVisibilityMessage(action: SessionAccessAction): string {
   if (action === "history") {
-    return "Session history visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
+    return "Session history visibility is restricted for non-spawned cross-agent sessions. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access.";
   }
   if (action === "send") {
-    return "Session send visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
+    return "Session send visibility is restricted for non-spawned cross-agent sessions. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access.";
   }
   if (action === "status") {
-    return "Session status visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
+    return "Session status visibility is restricted for non-spawned cross-agent sessions. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access.";
   }
-  return "Session list visibility is restricted. Set tools.sessions.visibility=all to allow cross-agent access.";
+  return "Session list visibility is restricted for non-spawned cross-agent sessions. Set tools.sessions.visibility=all and tools.agentToAgent.enabled=true to allow cross-agent access.";
 }
 
 function selfVisibilityMessage(action: SessionAccessAction): string {
@@ -196,6 +201,20 @@ export function createSessionVisibilityChecker(params: {
 
   const check = (targetSessionKey: string): SessionAccessResult => {
     const targetAgentId = resolveAgentIdFromSessionKey(targetSessionKey);
+    const isCurrentSession = targetSessionKey === params.requesterSessionKey;
+    const isSpawnedSession = spawnedKeys?.has(targetSessionKey) === true;
+
+    if (params.visibility === "tree") {
+      if (isCurrentSession || isSpawnedSession) {
+        return { allowed: true };
+      }
+      return {
+        allowed: false,
+        status: "forbidden",
+        error: treeVisibilityMessage(params.action),
+      };
+    }
+
     const isCrossAgent = targetAgentId !== requesterAgentId;
     if (isCrossAgent) {
       if (params.visibility !== "all") {
@@ -222,23 +241,11 @@ export function createSessionVisibilityChecker(params: {
       return { allowed: true };
     }
 
-    if (params.visibility === "self" && targetSessionKey !== params.requesterSessionKey) {
+    if (params.visibility === "self" && !isCurrentSession) {
       return {
         allowed: false,
         status: "forbidden",
         error: selfVisibilityMessage(params.action),
-      };
-    }
-
-    if (
-      params.visibility === "tree" &&
-      targetSessionKey !== params.requesterSessionKey &&
-      !spawnedKeys?.has(targetSessionKey)
-    ) {
-      return {
-        allowed: false,
-        status: "forbidden",
-        error: treeVisibilityMessage(params.action),
       };
     }
 

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -194,7 +194,7 @@ describe("handleGatewayEvent sessions.changed", () => {
     expect(loadSessionsMock).not.toHaveBeenCalled();
   });
 
-  it("does not reload sessions when a message-phase event cannot patch local state", () => {
+  it("reloads sessions when a message-phase event cannot patch local state", () => {
     loadSessionsMock.mockReset();
     applySessionsChangedEventMock.mockReset().mockReturnValue({ applied: false });
     const host = createHost();
@@ -206,7 +206,9 @@ describe("handleGatewayEvent sessions.changed", () => {
       seq: 1,
     });
 
-    expect(loadSessionsMock).not.toHaveBeenCalled();
+    expect(applySessionsChangedEventMock).toHaveBeenCalledTimes(1);
+    expect(loadSessionsMock).toHaveBeenCalledTimes(1);
+    expect(loadSessionsMock).toHaveBeenCalledWith(host);
   });
 
   it("does not reload sessions for chat lifecycle events", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -758,7 +758,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
 
   if (evt.event === "sessions.changed") {
     const result = applySessionsChangedEvent(host as unknown as SessionsState, evt.payload);
-    if (result.applied || isChatTurnSessionChangedPayload(evt.payload)) {
+    if (result.applied) {
       return;
     }
     void loadSessions(host as unknown as SessionsState);

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -802,4 +802,31 @@ describe("applySessionsChangedEvent", () => {
       updatedAt: 2,
     });
   });
+
+  it("does not locally insert websocket rows into a limited sessions.list result", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`unexpected method: ${method}`);
+      }
+      return {
+        ts: 1,
+        path: "(multiple)",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:current", kind: "direct", updatedAt: 10 }],
+      };
+    });
+    const state = createState(request);
+
+    await loadSessions(state, { activeMinutes: 10, limit: 1 });
+    const applied = applySessionsChangedEvent(state, {
+      sessionKey: "agent:main:new",
+      ts: 2,
+      kind: "direct",
+      updatedAt: Date.now(),
+    });
+
+    expect(applied).toEqual({ applied: false });
+    expect(state.sessionsResult?.sessions.map((row) => row.key)).toEqual(["agent:main:current"]);
+  });
 });

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -56,7 +56,16 @@ type SessionsLoadControl = {
   ownsStateLoading: boolean;
 };
 
+type EffectiveSessionsListParams = {
+  includeGlobal: boolean;
+  includeUnknown: boolean;
+  showArchived: boolean;
+  activeMinutes: number;
+  limit: number;
+};
+
 const sessionsLoadControls = new WeakMap<object, SessionsLoadControl>();
+const sessionsListParamsByState = new WeakMap<object, EffectiveSessionsListParams>();
 
 const SESSION_EVENT_ROW_FIELDS = [
   "abortedLastRun",
@@ -155,6 +164,52 @@ function projectSessionsResultForAvailability(
 
 function compareSessionRowsByUpdatedAt(a: GatewaySessionRow, b: GatewaySessionRow): number {
   return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+}
+
+function resolveEffectiveSessionsListParams(
+  state: SessionsState,
+  overrides?: LoadSessionsOverrides,
+): EffectiveSessionsListParams {
+  const showArchived = overrides?.showArchived ?? state.sessionsShowArchived;
+  return {
+    includeGlobal: overrides?.includeGlobal ?? state.sessionsIncludeGlobal,
+    includeUnknown: overrides?.includeUnknown ?? state.sessionsIncludeUnknown,
+    showArchived,
+    activeMinutes: showArchived
+      ? 0
+      : (overrides?.activeMinutes ?? toNumber(state.sessionsFilterActive, 0)),
+    limit: overrides?.limit ?? toNumber(state.sessionsFilterLimit, 0),
+  };
+}
+
+function getActiveSessionsListParams(state: SessionsState): EffectiveSessionsListParams {
+  return (
+    sessionsListParamsByState.get(state as object) ?? resolveEffectiveSessionsListParams(state)
+  );
+}
+
+function canInsertSessionChangedRow(state: SessionsState, row: GatewaySessionRow): boolean {
+  const params = getActiveSessionsListParams(state);
+  if (!params.includeGlobal && (row.key === "global" || row.kind === "global")) {
+    return false;
+  }
+  if (!params.includeUnknown && (row.key === "unknown" || row.kind === "unknown")) {
+    return false;
+  }
+  if (!params.showArchived && row.archived === true) {
+    return false;
+  }
+  if (params.limit > 0) {
+    return false;
+  }
+  if (params.activeMinutes > 0) {
+    const updatedAt =
+      typeof row.updatedAt === "number" && Number.isFinite(row.updatedAt) ? row.updatedAt : 0;
+    if (updatedAt < Date.now() - params.activeMinutes * 60_000) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function checkpointSummarySignature(
@@ -345,6 +400,9 @@ export function applySessionsChangedEvent(
     existingIndex >= 0
       ? previousRows.map((row, index) => (index === existingIndex ? nextRow : row))
       : [nextRow, ...previousRows];
+  if (existingIndex < 0 && !canInsertSessionChangedRow(state, nextRow)) {
+    return { applied: false };
+  }
   const sessions = nextRows.toSorted(compareSessionRowsByUpdatedAt);
   const eventTs = typeof payload.ts === "number" && Number.isFinite(payload.ts) ? payload.ts : null;
   state.sessionsResult = {
@@ -419,13 +477,8 @@ async function loadSessionsOnce(
     const previousRows = new Map(
       (state.sessionsResult?.sessions ?? []).map((row) => [row.key, row] as const),
     );
-    const includeGlobal = overrides?.includeGlobal ?? state.sessionsIncludeGlobal;
-    const includeUnknown = overrides?.includeUnknown ?? state.sessionsIncludeUnknown;
-    const showArchived = overrides?.showArchived ?? state.sessionsShowArchived;
-    const activeMinutes = showArchived
-      ? 0
-      : (overrides?.activeMinutes ?? toNumber(state.sessionsFilterActive, 0));
-    const limit = overrides?.limit ?? toNumber(state.sessionsFilterLimit, 0);
+    const effectiveParams = resolveEffectiveSessionsListParams(state, overrides);
+    const { includeGlobal, includeUnknown, showArchived, activeMinutes, limit } = effectiveParams;
     const params: Record<string, unknown> = {
       includeGlobal,
       includeUnknown,
@@ -440,6 +493,7 @@ async function loadSessionsOnce(
     if (res) {
       state.sessionsResult = projectSessionsResultForAvailability(res, { showArchived });
       const nextKeys = new Set(state.sessionsResult.sessions.map((row) => row.key));
+      sessionsListParamsByState.set(state as object, effectiveParams);
       for (const key of Object.keys(state.sessionsCheckpointItemsByKey)) {
         if (!nextKeys.has(key)) {
           invalidateCheckpointCacheForKey(state, key);


### PR DESCRIPTION
Summary

- Keep spawned cross-agent fleet sessions visible under default tree-scoped session tools without granting broad agent-to-agent access.
- Make spawned-session listing failures observable in debug logs while preserving fail-closed behavior.
- Prevent constrained Control UI session lists from briefly showing websocket rows that the active list filters cannot keep, while preserving upstream archived-session filtering.
- Add gateway, agent-tool, session_status, and Control UI regressions for the session visibility and list-refresh paths.

Verification

- pnpm test -- src/agents/tools/sessions-access.test.ts src/agents/tools/sessions.test.ts src/agents/openclaw-tools.session-status.test.ts src/gateway/server.sessions.list-changed.test.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/app-gateway.sessions.node.test.ts -- --reporter=verbose
- pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/openclaw-tools.session-status.test.ts src/agents/tools/session-status-tool.ts src/agents/tools/sessions-access.test.ts src/agents/tools/sessions.test.ts src/gateway/server.sessions.list-changed.test.ts src/plugin-sdk/session-visibility.ts ui/src/ui/app-gateway.sessions.node.test.ts ui/src/ui/app-gateway.ts ui/src/ui/controllers/sessions.test.ts ui/src/ui/controllers/sessions.ts
- git diff --check

Notes

- Replaces the relevant session-visibility fix from the closed cache-focused PR #62164 on top of current upstream/main.
