### PR TITLE
fix(plugins): include json5 in memory runtime deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/startup: include resolved thinking and fast-mode defaults in the `agent model` startup log line, defaulting unset startup thinking to `medium` without mixing in reasoning visibility.
 - Gateway/watch: suppress sync-I/O trace output during `pnpm gateway:watch --benchmark` unless explicitly requested, so CPU profiling no longer floods the terminal with stack traces.
 - Gateway/watch: when benchmark sync-I/O tracing is explicitly enabled, tee trace blocks to the benchmark output log and filter them from the terminal pane while keeping normal Gateway logs visible.
+- Plugins/runtime-deps: include `json5` in the memory-core plugin runtime dependency set so packaged `memory_search` sandboxes can resolve generated OpenClaw runtime chunks that parse JSON5 config. Fixes #77461.
 - Agents/OpenAI: default direct OpenAI Responses models to the SSE transport instead of WebSocket auto-selection, preventing pi runtime chat turns from hanging on servers where the WebSocket path stalls while the OpenAI HTTP stream works. Thanks @vincentkoc.
 - Discord: prefer IPv4 for Discord REST and gateway WebSocket startup paths so IPv4-only networks no longer stall before Gateway READY and inbound message dispatch. Fixes #77398; refs #77526. Thanks @Beandon13.
 - Channels/plugins: key bundled package-state probes, env/config presence, and read-only command defaults by channel id instead of manifest plugin id, preserving setup and native-command detection for channel plugins whose package id differs from the channel alias. Thanks @vincentkoc.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -41,6 +41,7 @@ const bundledPluginIgnoredRuntimeDependencies = [
   "@tloncorp/tlon-skill",
   "@zed-industries/codex-acp",
   "jiti",
+  "json5",
   "linkedom",
   "openclaw",
   "pdfjs-dist",

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "dependencies": {
     "chokidar": "^5.0.0",
+    "json5": "^2.2.3",
     "typebox": "1.1.37"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,6 +924,9 @@ importers:
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       typebox:
         specifier: 1.1.37
         version: 1.1.37

--- a/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
+++ b/src/plugins/contracts/extension-runtime-dependencies.contract.test.ts
@@ -31,6 +31,11 @@ const INDIRECT_RUNTIME_DEPENDENCIES = new Map<string, Set<string>>([
     new Set(["apache-arrow"]),
   ],
   [
+    "extensions/memory-core",
+    // Packaged memory tools run through generated OpenClaw runtime chunks that parse JSON5 config.
+    new Set(["json5"]),
+  ],
+  [
     "extensions/tlon",
     // The Tlon plugin manifest exposes the bundled skill from this package path.
     new Set(["@tloncorp/tlon-skill"]),
@@ -215,6 +220,12 @@ describe("Discord dependency ownership", () => {
 });
 
 describe("extension runtime dependency manifests", () => {
+  it("keeps json5 in memory-core for packaged runtime config parsing", () => {
+    const manifest = readPackageManifest("extensions/memory-core/package.json");
+
+    expect(manifest.dependencies?.json5).toBeDefined();
+  });
+
   for (const manifestPath of listPackageManifests(EXTENSION_ROOT)) {
     const extensionDir = toPosixPath(path.dirname(manifestPath));
 


### PR DESCRIPTION
## Summary

- Adds `json5` to the `memory-core` plugin runtime dependency set so packaged `memory_search` sandboxes install the package needed by generated OpenClaw runtime chunks that parse JSON5 config.
- Keeps the dependency ownership explicit in the extension dependency contract, with a focused regression assertion for `memory-core`.
- Marks `json5` as an intentional bundled-plugin runtime-only dependency in Knip config so the static dependency gate agrees with the generated runtime chunk contract.
- Updates the lockfile and changelog for #77461.

Fixes #77461

## Verification

- `pnpm exec oxfmt --check --threads=1 config/knip.config.ts CHANGELOG.md src/plugins/contracts/extension-runtime-dependencies.contract.test.ts extensions/memory-core/package.json`
- `pnpm deadcode:dependencies`
- `pnpm test:serial src/plugins/contracts/extension-runtime-dependencies.contract.test.ts` — 358/358 passed
- `git diff --check origin/main...HEAD`
- Crabbox/Blacksmith `pnpm check:changed` passed after rebase on `tbx_01kqtmrv12cswz2e5cbxxdbm3p`: https://github.com/openclaw/openclaw/actions/runs/25348950845