### PR TITLE
fix(auth): preserve legacy Codex OAuth profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Auth/OpenAI Codex: normalize legacy OAuth profile field aliases and explain stale auth profile mode overrides, so older Codex OAuth accounts do not get masked as missing API keys. Fixes #47964. (#75030) Thanks @liaoandi and @vincentkoc.
 - Plugins/migration: emit catalog-backed install hints when `plugins.entries` or `plugins.allow` references an official external plugin that is not installed, so upgraded configs point operators to `openclaw plugins install <spec>` instead of telling them to remove valid plugin config. (#77483) Thanks @hclsys.
 - Dependencies: refresh runtime and provider packages including Pi 0.73.0, ACPX adapters, OpenAI, Anthropic, Slack, and TypeScript native preview, while keeping the Bedrock runtime installer override pinned below the Windows ARM Node 24 npm resolver failure.
 - Agents/performance: pass the resolved workspace through BTW, compaction, embedded-run model generation, and PDF model setup so explicit agent-dir model refreshes can reuse the current workspace-scoped plugin metadata snapshot instead of falling back to cold plugin metadata scans. (#77519, #77532)

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -11,6 +11,7 @@ import {
   saveAuthProfileStore,
 } from "./auth-profiles/store.js";
 import type { AuthProfileCredential } from "./auth-profiles/types.js";
+import { resolvePiCredentialMapFromStore } from "./pi-auth-credentials.js";
 
 const resolveExternalAuthProfilesWithPluginsMock = vi.hoisted(() =>
   vi.fn<() => ProviderExternalAuthProfile[]>(() => []),
@@ -124,6 +125,16 @@ describe("ensureAuthProfileStore", () => {
     return profile;
   }
 
+  function expectOAuthProfile(
+    profile: AuthProfileCredential,
+  ): Extract<AuthProfileCredential, { type: "oauth" }> {
+    expect(profile.type).toBe("oauth");
+    if (profile.type !== "oauth") {
+      throw new Error(`Expected oauth profile, got ${profile.type}`);
+    }
+    return profile;
+  }
+
   it("migrates legacy auth.json and deletes it (PR #368)", () => {
     const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-profiles-"));
     try {
@@ -163,6 +174,42 @@ describe("ensureAuthProfileStore", () => {
     } finally {
       fs.rmSync(agentDir, { recursive: true, force: true });
     }
+  });
+
+  it("normalizes legacy OpenAI Codex OAuth field aliases on load", () => {
+    withTempAgentDir("openclaw-auth-codex-legacy-aliases-", (agentDir) => {
+      const expires = Date.now() + 60_000;
+      writeAuthProfileStore(agentDir, {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access_token: "legacy-access-token",
+          refreshToken: "legacy-refresh-token",
+          expires_at: String(expires),
+          account_id: "acct_legacy",
+        },
+      });
+
+      const profile = expectOAuthProfile(loadAuthProfile(agentDir, "openai-codex:default"));
+
+      expect(profile.access).toBe("legacy-access-token");
+      expect(profile.refresh).toBe("legacy-refresh-token");
+      expect(profile.expires).toBe(expires);
+      expect(profile.accountId).toBe("acct_legacy");
+      expect(
+        resolvePiCredentialMapFromStore({
+          version: AUTH_STORE_VERSION,
+          profiles: { "openai-codex:default": profile },
+        }),
+      ).toEqual({
+        "openai-codex": {
+          type: "oauth",
+          access: "legacy-access-token",
+          refresh: "legacy-refresh-token",
+          expires,
+        },
+      });
+    });
   });
 
   it("merges main auth profiles into agent store and keeps agent overrides", () => {

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -49,7 +49,55 @@ function normalizeSecretBackedField(params: {
   delete params.entry[params.valueField];
 }
 
-function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<AuthProfileCredential> {
+function normalizeStringFieldAlias(
+  entry: Record<string, unknown>,
+  canonicalField: string,
+  aliases: string[],
+): void {
+  if (canonicalField in entry) {
+    return;
+  }
+  for (const alias of aliases) {
+    const value = entry[alias];
+    if (typeof value === "string") {
+      entry[canonicalField] = value;
+      return;
+    }
+  }
+}
+
+function normalizeNumberFieldAlias(
+  entry: Record<string, unknown>,
+  canonicalField: string,
+  aliases: string[],
+): void {
+  if (canonicalField in entry) {
+    return;
+  }
+  for (const alias of aliases) {
+    const value = entry[alias];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      entry[canonicalField] = value;
+      return;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        entry[canonicalField] = parsed;
+        return;
+      }
+    }
+  }
+}
+
+function normalizeLegacyOpenAiCodexOAuthAliases(entry: Record<string, unknown>): void {
+  normalizeStringFieldAlias(entry, "access", ["access_token", "accessToken"]);
+  normalizeStringFieldAlias(entry, "refresh", ["refresh_token", "refreshToken"]);
+  normalizeNumberFieldAlias(entry, "expires", ["expires_at", "expiresAt"]);
+  normalizeStringFieldAlias(entry, "accountId", ["account_id", "accountID"]);
+}
+
+function normalizeRawCredentialEntry(raw: Record<string, unknown>): Record<string, unknown> {
   const entry = { ...raw } as Record<string, unknown>;
   if (!("type" in entry) && typeof entry["mode"] === "string") {
     entry["type"] = entry["mode"];
@@ -59,7 +107,7 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });
   normalizeSecretBackedField({ entry, valueField: "token", refField: "tokenRef" });
-  return entry as Partial<AuthProfileCredential>;
+  return entry;
 }
 
 function parseCredentialEntry(
@@ -70,12 +118,16 @@ function parseCredentialEntry(
     return { ok: false, reason: "non_object" };
   }
   const typed = normalizeRawCredentialEntry(raw as Record<string, unknown>);
-  if (!AUTH_PROFILE_TYPES.has(typed.type as AuthProfileCredential["type"])) {
+  const type = typed.type;
+  if (!AUTH_PROFILE_TYPES.has(type as AuthProfileCredential["type"])) {
     return { ok: false, reason: "invalid_type" };
   }
   const provider = typed.provider ?? fallbackProvider;
   if (typeof provider !== "string" || provider.trim().length === 0) {
     return { ok: false, reason: "missing_provider" };
+  }
+  if (type === "oauth" && normalizeProviderId(provider) === "openai-codex") {
+    normalizeLegacyOpenAiCodexOAuthAliases(typed);
   }
   return {
     ok: true,

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -104,6 +104,9 @@ vi.mock("./provider-auth-aliases.js", () => ({
     if (normalized === "bedrock" || normalized === "aws-bedrock") {
       return "amazon-bedrock";
     }
+    if (normalized === "codex-cli") {
+      return "openai-codex";
+    }
     return normalized;
   },
 }));
@@ -375,6 +378,97 @@ describe("getApiKeyForModel", () => {
         expect(apiKey.apiKey).toBe(oauthFixture.access);
       },
     );
+  });
+
+  it("explains when stale config mode masks a stored Codex OAuth profile", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          ...oauthFixture,
+        },
+      },
+    };
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "api_key",
+          },
+        },
+      },
+    };
+
+    let error: unknown = null;
+    try {
+      await resolveApiKeyForProvider({
+        provider: "openai-codex",
+        cfg,
+        store,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    const message = String(error);
+    expect(message).toContain('No API key found for provider "openai-codex".');
+    expect(message).toContain(
+      'Auth profile "openai-codex:default" for provider "openai-codex" exists as oauth',
+    );
+    expect(message).toContain(
+      'auth.profiles.openai-codex:default.mode is "api_key", so it is skipped',
+    );
+    expect(message).toContain('Update that config mode to "oauth"');
+    expect(message).not.toContain(oauthFixture.access);
+    expect(message).not.toContain(oauthFixture.refresh);
+  });
+
+  it("uses provider auth aliases when explaining stale config mode mismatches", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          ...oauthFixture,
+        },
+      },
+    };
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "codex-cli",
+            mode: "api_key",
+          },
+        },
+      },
+    };
+
+    let error: unknown = null;
+    try {
+      await resolveApiKeyForProvider({
+        provider: "codex-cli",
+        cfg,
+        store,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    const message = String(error);
+    expect(message).toContain('No API key found for provider "codex-cli".');
+    expect(message).toContain(
+      'Auth profile "openai-codex:default" for provider "codex-cli" exists as oauth',
+    );
+    expect(message).toContain(
+      'auth.profiles.openai-codex:default.mode is "api_key", so it is skipped',
+    );
+    expect(message).not.toContain(oauthFixture.access);
+    expect(message).not.toContain(oauthFixture.refresh);
   });
 
   it("suggests openai-codex when only Codex OAuth is configured", async () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -43,6 +43,7 @@ import {
   type ResolvedProviderAuth,
 } from "./model-auth-runtime-shared.js";
 import { normalizeProviderId } from "./model-selection.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 export {
   ensureAuthProfileStore,
@@ -232,6 +233,59 @@ function resolveProviderAuthOverride(
     return auth;
   }
   return undefined;
+}
+
+function isConfigProfileModeCompatible(params: {
+  configuredMode: string | undefined;
+  storedType: string | undefined;
+}): boolean {
+  if (!params.configuredMode || !params.storedType) {
+    return true;
+  }
+  if (params.configuredMode === params.storedType) {
+    return true;
+  }
+  return params.configuredMode === "oauth" && params.storedType === "token";
+}
+
+function buildAuthProfileModeMismatchHint(params: {
+  cfg: OpenClawConfig | undefined;
+  store: AuthProfileStore;
+  provider: string;
+}): string | null {
+  const profiles = params.cfg?.auth?.profiles;
+  if (!profiles) {
+    return null;
+  }
+  const providerAuthKey = resolveProviderIdForAuth(params.provider, { config: params.cfg });
+  for (const [profileId, profileConfig] of Object.entries(profiles)) {
+    if (
+      resolveProviderIdForAuth(profileConfig.provider, { config: params.cfg }) !== providerAuthKey
+    ) {
+      continue;
+    }
+    const credential = params.store.profiles[profileId];
+    if (
+      !credential ||
+      resolveProviderIdForAuth(credential.provider, { config: params.cfg }) !== providerAuthKey
+    ) {
+      continue;
+    }
+    if (
+      isConfigProfileModeCompatible({
+        configuredMode: profileConfig.mode,
+        storedType: credential.type,
+      })
+    ) {
+      continue;
+    }
+    return [
+      `Auth profile "${profileId}" for provider "${params.provider}" exists as ${credential.type}`,
+      `but auth.profiles.${profileId}.mode is "${profileConfig.mode}", so it is skipped.`,
+      `Update that config mode to "${credential.type}" or remove the stale auth.profiles override.`,
+    ].join(" ");
+  }
+  return null;
 }
 
 function isLocalBaseUrl(baseUrl: string): boolean {
@@ -729,12 +783,20 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const authProfileModeMismatchHint = buildAuthProfileModeMismatchHint({
+    cfg,
+    store,
+    provider,
+  });
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
+      authProfileModeMismatchHint,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy only portable static auth profiles from the main agentDir.`,
-    ].join(" "),
+    ]
+      .filter(Boolean)
+      .join(" "),
   );
 }
 


### PR DESCRIPTION
Summary
- Normalize legacy OpenAI Codex OAuth auth-profile field aliases when loading persisted profiles.
- Add a stale config-mode mismatch hint when an existing OAuth profile is masked by an api_key override.
- Fixes #47964; carries forward #75030.

Verification
- pnpm test:serial src/agents/auth-profiles.ensureauthprofilestore.test.ts src/agents/model-auth.profiles.test.ts
- pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/auth-profiles.ensureauthprofilestore.test.ts src/agents/auth-profiles/persisted.ts src/agents/model-auth.profiles.test.ts src/agents/model-auth.ts
- Blacksmith Testbox tbx_01kqtq78yd6v7s6pg19e0cshs8: pnpm check:changed exit 0
