### PR TITLE
fix(status): honor selected usage auth profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status/usage: prefer the session-selected OAuth profile when resolving provider usage summaries, so `/status` matches the active model auth profile instead of falling back to the provider default. Fixes #58498. (#59208) Thanks @luoxiao6645 and @vincentkoc.
 - Codex plugin: mirror the experimental upstream app-server protocol and format generated TypeScript before drift checks, keeping OpenClaw's `experimentalApi` bridge compatible with latest Codex while preserving formatter gates.
 - Telegram/media: derive no-caption inbound media placeholders from saved MIME metadata instead of the Telegram `photo` shape, so non-image and mixed attachments no longer reach the model as `<media:image>`. Fixes #69793. Thanks @aspalagin.
 - Agents/cache: keep per-turn runtime context out of ordinary chat system prompts while still delivering hidden current-turn context, restoring prompt-cache reuse on chat continuations. Fixes #77431. Thanks @Udjin79.

--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -187,6 +187,12 @@ const providerRuntimeMocks = vi.hoisted(() => ({
       }
 
       if (params.provider === "minimax") {
+        const portalAuth = await params.context.resolveOAuthToken({ provider: "minimax-portal" });
+        if (portalAuth?.token) {
+          return portalAuth.accountId
+            ? { token: portalAuth.token, accountId: portalAuth.accountId }
+            : { token: portalAuth.token };
+        }
         const token = resolveToken({
           providerIds: ["minimax"],
           envDirect: [
@@ -691,6 +697,84 @@ describe("resolveProviderAuths key normalization", () => {
         env: buildSuiteEnv(home),
       });
       expect(auths).toEqual([{ provider: "anthropic", token: "anthropic-token" }]);
+    });
+  });
+
+  it("prefers the requested OAuth profile when resolving provider usage auth", async () => {
+    await withSuiteHome(async (home) => {
+      await writeAuthProfiles(home, {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          token: "default-token",
+        },
+        "anthropic:work": {
+          type: "token",
+          provider: "anthropic",
+          token: "work-token",
+        },
+      });
+      await writeProfileOrder(home, "anthropic", ["anthropic:default"]);
+
+      const auths = await resolveProviderAuths({
+        providers: ["anthropic"],
+        agentDir: agentDirForHome(home),
+        config: {},
+        env: buildSuiteEnv(home),
+        preferredProfileIds: { anthropic: "anthropic:work" },
+      });
+      expect(auths).toEqual([{ provider: "anthropic", token: "work-token" }]);
+    });
+  });
+
+  it("ignores a preferred usage profile id owned by another provider", async () => {
+    await withSuiteHome(async (home) => {
+      await writeAuthProfiles(home, {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          token: "anthropic-token",
+        },
+        "zai:work": {
+          type: "token",
+          provider: "zai",
+          token: "wrong-provider-token",
+        },
+      });
+      await writeProfileOrder(home, "anthropic", ["anthropic:default"]);
+
+      const auths = await resolveProviderAuths({
+        providers: ["anthropic"],
+        agentDir: agentDirForHome(home),
+        config: {},
+        env: buildSuiteEnv(home),
+        preferredProfileIds: { anthropic: "zai:work" },
+      });
+      expect(auths).toEqual([{ provider: "anthropic", token: "anthropic-token" }]);
+    });
+  });
+
+  it("preserves preferred profile ids across provider override usage lookups", async () => {
+    await withSuiteHome(async (home) => {
+      await writeAuthProfiles(home, {
+        "minimax-portal:work": {
+          type: "oauth",
+          provider: "minimax-portal",
+          token: "portal-token",
+          accountId: "portal-account",
+        },
+      });
+
+      const auths = await resolveProviderAuths({
+        providers: ["minimax"],
+        agentDir: agentDirForHome(home),
+        config: {},
+        env: buildSuiteEnv(home),
+        preferredProfileIds: { minimax: "minimax-portal:work" },
+      });
+      expect(auths).toEqual([
+        { provider: "minimax", token: "portal-token", accountId: "portal-account" },
+      ]);
     });
   });
 

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -207,17 +207,27 @@ function resolveUsageCredentialProviderIds(params: {
 async function resolveOAuthToken(params: {
   state: UsageAuthState;
   provider: string;
+  preferredProfileId?: string;
 }): Promise<ProviderAuth | null> {
   if (!params.state.allowAuthProfileStore) {
     return null;
   }
   const store = resolveUsageAuthStore(params.state);
+  const preferredProfileId = params.preferredProfileId?.trim();
+  const preferredProfile = preferredProfileId ? store.profiles[preferredProfileId] : undefined;
+  const normalizedProvider = normalizeProviderId(params.provider);
   const order = resolveAuthProfileOrder({
     cfg: params.state.cfg,
     store,
     provider: params.provider,
   });
-  const deduped = dedupeProfileIds(order);
+  const deduped = dedupeProfileIds(
+    preferredProfileId &&
+      preferredProfile &&
+      normalizeProviderId(preferredProfile.provider) === normalizedProvider
+      ? [preferredProfileId, ...order]
+      : order,
+  );
 
   for (const profileId of deduped) {
     const cred = store.profiles[profileId];
@@ -255,6 +265,7 @@ async function resolveOAuthToken(params: {
 async function resolveProviderUsageAuthViaPlugin(params: {
   state: UsageAuthState;
   provider: UsageProviderId;
+  preferredProfileId?: string;
 }): Promise<ProviderAuth | null> {
   const resolved = await resolveProviderUsageAuthWithPlugin({
     provider: params.provider,
@@ -275,6 +286,7 @@ async function resolveProviderUsageAuthViaPlugin(params: {
         const auth = await resolveOAuthToken({
           state: params.state,
           provider: options?.provider ?? params.provider,
+          preferredProfileId: params.preferredProfileId,
         });
         return auth
           ? {
@@ -298,10 +310,12 @@ async function resolveProviderUsageAuthViaPlugin(params: {
 async function resolveProviderUsageAuthFallback(params: {
   state: UsageAuthState;
   provider: UsageProviderId;
+  preferredProfileId?: string;
 }): Promise<ProviderAuth | null> {
   const oauthToken = await resolveOAuthToken({
     state: params.state,
     provider: params.provider,
+    preferredProfileId: params.preferredProfileId,
   });
   if (oauthToken) {
     return oauthToken;
@@ -356,6 +370,7 @@ export async function resolveProviderAuths(params: {
   agentDir?: string;
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  preferredProfileIds?: Partial<Record<UsageProviderId, string | undefined>>;
   skipPluginAuthWithoutCredentialSource?: boolean;
 }): Promise<ProviderAuth[]> {
   if (params.auth) {
@@ -413,6 +428,7 @@ export async function resolveProviderAuths(params: {
       const pluginAuth = await resolveProviderUsageAuthViaPlugin({
         state,
         provider,
+        preferredProfileId: params.preferredProfileIds?.[provider],
       });
       if (pluginAuth) {
         auths.push(pluginAuth);
@@ -422,6 +438,7 @@ export async function resolveProviderAuths(params: {
     const fallbackAuth = await resolveProviderUsageAuthFallback({
       state,
       provider,
+      preferredProfileId: params.preferredProfileIds?.[provider],
     });
     if (fallbackAuth) {
       auths.push(fallbackAuth);

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -40,6 +40,7 @@ type UsageSummaryOptions = {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   fetch?: typeof fetch;
+  preferredProfileIds?: Partial<Record<UsageProviderId, string | undefined>>;
   skipPluginAuthWithoutCredentialSource?: boolean;
 };
 
@@ -97,6 +98,7 @@ export async function loadProviderUsageSummary(
     agentDir: opts.agentDir,
     config,
     env,
+    preferredProfileIds: opts.preferredProfileIds,
     skipPluginAuthWithoutCredentialSource: opts.skipPluginAuthWithoutCredentialSource,
   });
   if (auths.length === 0) {

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -251,6 +251,9 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
           timeoutMs: usageSummaryTimeoutMs,
           providers: [currentUsageProvider],
           agentDir: statusAgentDir,
+          preferredProfileIds: sessionEntry?.authProfileOverride
+            ? { [currentUsageProvider]: sessionEntry.authProfileOverride }
+            : undefined,
         }),
         new Promise<never>((_, reject) => {
           usageTimeout = setTimeout(


### PR DESCRIPTION
Summary
- Pass the session-selected auth profile into provider usage summary auth resolution.
- Preserve that preferred profile across plugin provider override lookups while rejecting cross-provider profile ids.
- Fixes #58498; supersedes #59208.

Verification
- pnpm test:serial src/infra/provider-usage.auth.normalizes-keys.test.ts
- pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/status/status-text.ts src/infra/provider-usage.auth.ts src/infra/provider-usage.load.ts src/infra/provider-usage.auth.normalizes-keys.test.ts
- Blacksmith Testbox tbx_01kqtq78y3apm0ct84bgrx5eqq: pnpm check:changed exit 0
