### PR TITLE
fix(auth): block remote node OAuth writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/auth: block OAuth login on remote node hosts before writing credentials to the local node store, so gateway-backed installs do not consume refresh tokens without syncing them to the gateway. Fixes #42291. (#42381) Thanks @MaheshBhushan and @vincentkoc.
 - Codex plugin: mirror the experimental upstream app-server protocol and format generated TypeScript before drift checks, keeping OpenClaw's `experimentalApi` bridge compatible with latest Codex while preserving formatter gates.
 - Telegram/media: derive no-caption inbound media placeholders from saved MIME metadata instead of the Telegram `photo` shape, so non-image and mixed attachments no longer reach the model as `<media:image>`. Fixes #69793. Thanks @aspalagin.
 - Agents/cache: keep per-turn runtime context out of ordinary chat system prompts while still delivering hidden current-turn context, restoring prompt-cache reuse on chat continuations. Fixes #77431. Thanks @Udjin79.

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   logConfigUpdated: vi.fn(),
   openUrl: vi.fn(),
   isRemoteEnvironment: vi.fn(() => false),
+  loadNodeHostConfig: vi.fn<() => Promise<Record<string, unknown> | null>>(async () => null),
   loadAuthProfileStoreForRuntime: vi.fn(),
   listProfilesForProvider: vi.fn(),
   promoteAuthProfileInOrder: vi.fn(),
@@ -117,6 +118,10 @@ vi.mock("../onboard-helpers.js", () => ({
 
 vi.mock("../oauth-env.js", () => ({
   isRemoteEnvironment: mocks.isRemoteEnvironment,
+}));
+
+vi.mock("../../node-host/config.js", () => ({
+  loadNodeHostConfig: mocks.loadNodeHostConfig,
 }));
 
 vi.mock("../../plugins/provider-oauth-flow.js", () => ({
@@ -287,6 +292,7 @@ describe("modelsAuthLoginCommand", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.resolveDefaultAgentWorkspaceDir.mockReturnValue("/tmp/openclaw/workspace");
     mocks.isRemoteEnvironment.mockReturnValue(false);
+    mocks.loadNodeHostConfig.mockResolvedValue(null);
     mocks.loadValidConfigOrThrow.mockImplementation(async () => currentConfig);
     mocks.updateConfig.mockImplementation(
       async (mutator: (cfg: OpenClawConfig) => OpenClawConfig) => {
@@ -412,6 +418,28 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Tip: Codex-capable models can use native Codex web search. Enable it with openclaw configure --section web (recommended mode: cached). Docs: https://docs.openclaw.ai/tools/web",
     );
+  });
+
+  it("blocks OAuth login on a remote node host before writing local credentials", async () => {
+    const runtime = createRuntime();
+    mocks.loadNodeHostConfig.mockResolvedValue({
+      version: 1,
+      nodeId: "node-1",
+      token: "node-token",
+      gateway: {
+        host: "10.30.10.20",
+        port: 18789,
+      },
+    });
+
+    await expect(modelsAuthLoginCommand({ provider: "openai-codex" }, runtime)).rejects.toThrow(
+      "configured as a remote node host",
+    );
+
+    expect(mocks.loadValidConfigOrThrow).not.toHaveBeenCalled();
+    expect(runProviderAuth).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
   it("uses the requested agent store for provider auth login", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -25,6 +25,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadNodeHostConfig } from "../../node-host/config.js";
 import {
   applyProviderAuthConfigPatch,
   applyDefaultModel,
@@ -606,10 +607,29 @@ function maybeLogOpenAICodexNativeSearchTip(runtime: RuntimeEnv, providerId: str
     "Tip: Codex-capable models can use native Codex web search. Enable it with openclaw configure --section web (recommended mode: cached). Docs: https://docs.openclaw.ai/tools/web",
   );
 }
+
+function isLoopbackHost(host: string | undefined): boolean {
+  const normalized = normalizeOptionalString(host)?.toLowerCase();
+  return (
+    !normalized || normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1"
+  );
+}
+
+async function assertCanWriteOAuthProfileLocally(): Promise<void> {
+  const nodeHostConfig = await loadNodeHostConfig();
+  if (!nodeHostConfig?.token || isLoopbackHost(nodeHostConfig.gateway?.host)) {
+    return;
+  }
+  throw new Error(
+    "This machine is configured as a remote node host. `openclaw models auth login` would write OAuth credentials to this node, not the gateway. Run this command on the gateway host instead.",
+  );
+}
+
 export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: RuntimeEnv) {
   if (!process.stdin.isTTY) {
     throw new Error("models auth login requires an interactive TTY.");
   }
+  await assertCanWriteOAuthProfileLocally();
 
   const { config, agentDir, workspaceDir, providers } = await resolveModelsAuthContext({
     requestedProvider: opts.provider,


### PR DESCRIPTION
Summary
- Detect remote node-host configs before running `openclaw models auth login`.
- Block OAuth login when the node host points at a non-loopback gateway, avoiding refresh-token writes to the node-local auth store.
- Fixes #42291; supersedes #42381.

Verification
- pnpm test:serial src/commands/models/auth.test.ts
- pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/commands/models/auth.ts src/commands/models/auth.test.ts
- Blacksmith Testbox tbx_01kqtqd24p8tq79bb90vsrnq19: pnpm check:changed exit 0
