### PR TITLE
fix(cli): route diagnostics to stderr in agent --json mode

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -10,6 +10,7 @@ import type { agentCommand as AgentCommand } from "./agent.js";
 const loadConfig = vi.hoisted(() => vi.fn());
 const callGateway = vi.hoisted(() => vi.fn());
 const agentCommand = vi.hoisted(() => vi.fn());
+const routeLogsToStderr = vi.hoisted(() => vi.fn());
 
 const runtime: RuntimeEnv = {
   log: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock("../gateway/call.js", () => ({
   randomIdempotencyKey: () => "idem-1",
 }));
 vi.mock("./agent.js", () => ({ agentCommand }));
+vi.mock("../logging/console.js", () => ({ routeLogsToStderr }));
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -151,6 +153,39 @@ describe("agentCliCommand", () => {
       expect(agentCommand.mock.calls[0]?.[0]).not.toMatchObject({
         cleanupBundleMcpOnRunEnd: true,
       });
+    });
+  });
+
+  it("routes logs to stderr when --json is set (gateway path)", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", json: true }, runtime);
+
+      expect(routeLogsToStderr).toHaveBeenCalled();
+      expect(callGateway).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("routes logs to stderr when --json is set (embedded fallback)", async () => {
+    await withTempStore(async () => {
+      callGateway.mockRejectedValue(new Error("gateway not connected"));
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", json: true }, runtime);
+
+      expect(routeLogsToStderr).toHaveBeenCalled();
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not route logs to stderr without --json", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(routeLogsToStderr).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -7,6 +7,7 @@ import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
+import { routeLogsToStderr } from "../logging/console.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -178,6 +179,16 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
 }
 
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
+  // Defensively route all diagnostics to stderr when --json is active so stdout
+  // stays clean for the JSON envelope.  The preaction hook already calls
+  // routeLogsToStderr() when it detects JSON output mode, but plugin lifecycle
+  // logs forwarded from the gateway or emitted during embedded fallback can
+  // slip through if the flag was not yet set or was restored by an intermediate
+  // loader.  Setting it here gives the JSON-output contract a single owner at
+  // the command boundary.  See #71319.
+  if (opts.json) {
+    routeLogsToStderr();
+  }
   const localOpts = {
     ...opts,
     agentId: opts.agent,


### PR DESCRIPTION
## Summary

- Fixes `openclaw agent --json` leaking plugin lifecycle logs into stdout, breaking JSON consumers/piping
- Calls `routeLogsToStderr()` defensively at the `agentCliCommand` boundary when `--json` is active, before gateway or embedded fallback execution starts
- Adds regression tests covering gateway path, embedded fallback path, and the no-`--json` baseline

Closes #71319

## Test plan

- [x] `pnpm test src/commands/agent-via-gateway.test.ts` — 8/8 pass (5 existing + 3 new)
- [x] `pnpm test:changed` — 162 files, 1005 tests pass
- [ ] Manual: `openclaw agent --json --message "hi" 1>/tmp/out 2>/tmp/err && cat /tmp/out` — stdout should contain only JSON, no `[plugins]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)