### PR TITLE
Fix Bedrock aws-sdk auth refresh after shared credential rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Bedrock: refresh aws-sdk runtime auth after token expiry by returning a fresh synthetic runtime token from `prepareRuntimeAuth`, so `ExpiredTokenException` enters the existing auth-error refresh path. Fixes #77551. Thanks @Beandon13.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -540,6 +540,21 @@ describe("amazon-bedrock provider plugin", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("preserves the caller-provided apiKey when authMode is api-key", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+    const context = buildBedrockRuntimeAuthContext({
+      apiKey: "literal-key",
+      authMode: "api-key",
+    });
+
+    const result = await provider.prepareRuntimeAuth?.(context);
+
+    // No synthetic runtime token is returned for api-key mode; the auth
+    // controller therefore keeps using the original apiKey unchanged.
+    expect(result).toBeUndefined();
+    expect(context.apiKey).toBe("literal-key");
+  });
+
   describe("guardrail config schema", () => {
     it("defines discovery and guardrail objects with the expected shape", () => {
       const pluginJson = JSON.parse(

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -11,6 +11,7 @@ import { resetBedrockDiscoveryCacheForTest } from "./discovery.js";
 import amazonBedrockPlugin from "./index.js";
 import {
   resetBedrockAppProfileCacheEligibilityForTest,
+  resetBedrockAwsSdkRuntimeAuthEpochForTest,
   setBedrockAppProfileControlPlaneForTest,
 } from "./register.sync.runtime.js";
 
@@ -92,6 +93,9 @@ vi.mock("@aws-sdk/client-bedrock", () => {
 });
 
 type RegisteredProviderPlugin = Awaited<ReturnType<typeof registerSingleProviderPlugin>>;
+type BedrockRuntimeAuthContext = Parameters<
+  NonNullable<RegisteredProviderPlugin["prepareRuntimeAuth"]>
+>[0];
 
 /** Register the amazon-bedrock plugin with an optional pluginConfig override. */
 async function registerWithConfig(
@@ -141,6 +145,8 @@ const ANTHROPIC_MODEL_DESCRIPTOR = {
   provider: "amazon-bedrock",
   id: ANTHROPIC_MODEL,
 } as never;
+
+const BEDROCK_RUNTIME_AUTH_SENTINEL = "__aws_sdk_auth__";
 
 const APP_INFERENCE_PROFILE_ARN =
   "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-claude-profile";
@@ -207,6 +213,38 @@ function runtimePluginConfig(config?: Record<string, unknown>): OpenClawConfig {
   } as OpenClawConfig;
 }
 
+function buildBedrockRuntimeAuthContext(
+  overrides: Partial<BedrockRuntimeAuthContext> = {},
+): BedrockRuntimeAuthContext {
+  const modelId = overrides.modelId ?? "us.anthropic.claude-sonnet-4-6-v1:0";
+  return {
+    provider: "amazon-bedrock",
+    modelId,
+    model:
+      overrides.model ??
+      ({
+        id: modelId,
+        name: "Claude Sonnet 4.6",
+        provider: "amazon-bedrock",
+        api: "bedrock-converse-stream",
+        baseUrl: "https://bedrock-runtime.us-west-2.amazonaws.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 8_192,
+      } as BedrockRuntimeAuthContext["model"]),
+    apiKey: BEDROCK_RUNTIME_AUTH_SENTINEL,
+    authMode: "aws-sdk",
+    profileId: "amazon-bedrock:default",
+    agentDir: "/tmp/agent",
+    workspaceDir: "/tmp/workspace",
+    env: process.env,
+    config: runtimePluginConfig(),
+    ...overrides,
+  };
+}
+
 describe("amazon-bedrock provider plugin", () => {
   beforeEach(() => {
     foundationModelResults.length = 0;
@@ -216,6 +254,7 @@ describe("amazon-bedrock provider plugin", () => {
     sendBedrockCommand.mockClear();
     resetBedrockDiscoveryCacheForTest();
     resetBedrockAppProfileCacheEligibilityForTest();
+    resetBedrockAwsSdkRuntimeAuthEpochForTest();
     setBedrockAppProfileControlPlaneForTest((region) => ({
       async getInferenceProfile(input) {
         class GetInferenceProfileCommand {
@@ -475,6 +514,30 @@ describe("amazon-bedrock provider plugin", () => {
           'ValidationException: The model returned the following errors: {"type":"error","error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."}}',
       } as never),
     ).toBe("format");
+  });
+
+  it("returns a fresh runtime auth token for Bedrock aws-sdk auth refreshes", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    const first = await provider.prepareRuntimeAuth?.(buildBedrockRuntimeAuthContext());
+    const second = await provider.prepareRuntimeAuth?.(buildBedrockRuntimeAuthContext());
+
+    expect(first).toMatchObject({
+      apiKey: `${BEDROCK_RUNTIME_AUTH_SENTINEL}:1`,
+    });
+    expect(second).toMatchObject({
+      apiKey: `${BEDROCK_RUNTIME_AUTH_SENTINEL}:2`,
+    });
+  });
+
+  it("skips Bedrock runtime auth token synthesis for non aws-sdk auth modes", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    await expect(
+      provider.prepareRuntimeAuth?.(
+        buildBedrockRuntimeAuthContext({ apiKey: "literal-key", authMode: "api-key" }),
+      ),
+    ).resolves.toBeUndefined();
   });
 
   describe("guardrail config schema", () => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -33,6 +33,18 @@ type AmazonBedrockPluginConfig = {
   guardrail?: GuardrailConfig;
 };
 
+const BEDROCK_AWS_SDK_RUNTIME_AUTH_SENTINEL = "__aws_sdk_auth__";
+let bedrockAwsSdkRuntimeAuthEpoch = 0;
+
+function nextBedrockAwsSdkRuntimeAuthToken(): string {
+  bedrockAwsSdkRuntimeAuthEpoch += 1;
+  return `${BEDROCK_AWS_SDK_RUNTIME_AUTH_SENTINEL}:${bedrockAwsSdkRuntimeAuthEpoch}`;
+}
+
+export function resetBedrockAwsSdkRuntimeAuthEpochForTest(): void {
+  bedrockAwsSdkRuntimeAuthEpoch = 0;
+}
+
 function createGuardrailWrapStreamFn(
   innerWrapStreamFn: (ctx: { modelId: string; streamFn?: StreamFn }) => StreamFn | null | undefined,
   guardrailConfig: GuardrailConfig,
@@ -456,6 +468,19 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
       },
     },
     resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
+    prepareRuntimeAuth: async ({ authMode }) => {
+      if (authMode !== "aws-sdk") {
+        return undefined;
+      }
+      // Shared credentials written by Midway/STS helpers often omit expiration,
+      // so the AWS SDK can memoize a stale provider instance until the process
+      // rebuilds the Bedrock client. Returning a fresh runtime auth token on each
+      // auth negotiation forces pi-ai/OpenClaw to recreate the authenticated
+      // client after auth failures without changing the public AWS SDK contract.
+      return {
+        apiKey: nextBedrockAwsSdkRuntimeAuthToken(),
+      };
+    },
     ...anthropicByModelReplayHooks,
     wrapStreamFn: ({ modelId, config, model, streamFn, thinkingLevel }) => {
       const currentGuardrail = resolveCurrentPluginConfig(config)?.guardrail;

--- a/src/agents/pi-embedded-runner/run/auth-controller.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.test.ts
@@ -471,6 +471,45 @@ describe("createEmbeddedRunAuthController", () => {
       }
     });
 
+    it("refreshes aws-sdk runtime auth on auth errors when the provider returns a runtime token", async () => {
+      const harness = createMutableAuthControllerHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+
+      mocks.getApiKeyForModel.mockResolvedValue({
+        apiKey: undefined,
+        mode: "aws-sdk",
+        source: "aws-sdk default chain",
+      });
+      mocks.prepareProviderRuntimeAuth
+        .mockResolvedValueOnce({
+          apiKey: "__aws_sdk_auth__:1",
+        })
+        .mockResolvedValueOnce({
+          apiKey: "__aws_sdk_auth__:2",
+        });
+
+      const controller = createMutableEmbeddedRunAuthController({
+        harness,
+        setRuntimeApiKey,
+        profileCandidates: [undefined as unknown as string],
+      });
+
+      await controller.initializeAuthProfile();
+      await expect(
+        controller.maybeRefreshRuntimeAuthForAuthError(
+          "ExpiredTokenException: The security token included in the request is expired",
+          false,
+        ),
+      ).resolves.toBe(true);
+
+      expect(setRuntimeApiKey).toHaveBeenNthCalledWith(1, "custom-openai", "__aws_sdk_auth__:1");
+      expect(setRuntimeApiKey).toHaveBeenNthCalledWith(2, "custom-openai", "__aws_sdk_auth__:2");
+      expect(harness.runtimeAuthState).toMatchObject({
+        sourceApiKey: "__aws_sdk_auth__",
+        authMode: "aws-sdk",
+      });
+    });
+
     it("injects sentinel when prepareProviderRuntimeAuth throws", async () => {
       const harness = createMutableAuthControllerHarness();
       const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();


### PR DESCRIPTION
## Summary
- keep Bedrock `aws-sdk` auth on the runtime-auth path by synthesizing a fresh runtime token for each auth negotiation
- preserve a refreshable auth state so `ExpiredTokenException` can trigger the existing auth-error refresh flow
- add regression coverage for the auth controller and the Bedrock provider hook

## Testing
- `pnpm test src/agents/pi-embedded-runner/run/auth-controller.test.ts extensions/amazon-bedrock/index.test.ts extensions/amazon-bedrock/embedding-provider.test.ts`
- `pnpm test extensions/amazon-bedrock`
- `pnpm check:changed`

Closes #77551
