### PR TITLE
test(plugins): align kitchen sink prerelease canary version

### DIFF
--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -100,7 +100,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
         stateScenario: "empty",
       }),
     );
-    expect(script).toContain("npm:@openclaw/kitchen-sink@0.1.5");
+    expect(script).toContain("npm:@openclaw/kitchen-sink@0.2.5");
     expect(script).toContain("npm-pinned-conformance");
     expect(script).toContain("npm-pinned-adversarial");
     expect(script).toContain("npm:@openclaw/kitchen-sink@beta");


### PR DESCRIPTION
Summary:
- update the plugin prerelease test-plan assertion to match the current kitchen-sink Docker E2E default `npm:@openclaw/kitchen-sink@0.2.5`
- unblocks the current PR CI core-support-boundary shard, which is failing on main with the stale `0.1.5` expectation

Validation:
- `pnpm test test/scripts/plugin-prerelease-test-plan.test.ts`
- `pnpm exec oxlint test/scripts/plugin-prerelease-test-plan.test.ts`
- `pnpm exec oxfmt --check --threads=1 test/scripts/plugin-prerelease-test-plan.test.ts`

Notes:
- no changelog entry; test-only CI alignment
- no active rival PR found for the stale kitchen-sink version assertion