### PR TITLE
Clarify isolated Codex OAuth ownership in docs

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1094,6 +1094,15 @@ turn for that agent must be a Codex-supported OpenAI model.
 the gateway to clear stale native hook registrations. If `computer-use.list_apps`
 times out, restart Codex Computer Use or Codex Desktop and retry.
 
+**Codex backends fail with `401 token_revoked` or `refresh_token_reused`:**
+multiple isolated `CODEX_HOME` directories are sharing one OAuth token set and
+refreshing independently, so one backend's refresh invalidates the others. See
+the [App-server connection and policy](#app-server-connection-and-policy)
+section above for the OAuth ownership boundary, and the
+[isolated-OAuth ownership note in the OpenAI provider docs](/providers/openai#getting-started)
+for the safe setups: one `codex login` per isolated home, or one
+OpenClaw-managed shared profile that mirrors fresh credentials.
+
 ## Related
 
 - [Agent harness plugins](/plugins/sdk-agent-harness)

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -555,7 +555,15 @@ state. Codex's own skill loader reads `$CODEX_HOME/skills` and
 `$HOME/.agents/skills`, so both values are isolated for local app-server
 launches. That keeps Codex-native skills, plugins, config, accounts, and thread
 state scoped to the OpenClaw agent instead of leaking in from the operator's
-personal Codex CLI home.
+personal shell.
+
+This isolation also defines the OAuth ownership boundary. Treat each isolated
+`CODEX_HOME` as having exactly one refresh-token owner. Do not copy the same
+Codex OAuth token set into multiple isolated agent homes and let each backend
+refresh independently; Codex refresh tokens rotate, so one home can invalidate
+another and produce `401 token_revoked` or `refresh_token_reused`. Safe setups
+are either one login per isolated home or one OpenClaw-managed shared profile
+that refreshes once and then mirrors fresh credentials deliberately.
 
 OpenClaw plugins and OpenClaw skill snapshots still flow through OpenClaw's own
 plugin registry and skill loader. Personal Codex CLI assets do not. If you have

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -209,6 +209,17 @@ Choose your preferred auth method and follow the setup steps.
       </Step>
     </Steps>
 
+    <Note>
+    For native Codex runtime, keep one OAuth refresh owner per isolated Codex
+    home. OpenClaw's local app-server launches already isolate `CODEX_HOME` per
+    agent. Do not manually copy the same Codex OAuth token set into multiple
+    isolated agent homes unless you also provide one synchronized refresh owner.
+    Otherwise one backend can rotate the refresh token and the others will fail
+    later with `401 token_revoked` or `refresh_token_reused`. Safe setups are:
+    one `codex login` per isolated home, or one OpenClaw-managed shared profile
+    that owns refresh and mirrors the fresh credentials.
+    </Note>
+
     ### Route summary
 
     | Model ref | Runtime config | Route | Auth |

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -220,6 +220,31 @@ Choose your preferred auth method and follow the setup steps.
     that owns refresh and mirrors the fresh credentials.
     </Note>
 
+    The shared-profile setup looks like this in practice — one OpenClaw
+    `openai-codex` auth profile owns refresh, and every isolated agent reuses
+    that same profile id. OpenClaw refreshes the token once per rotation
+    window and then mirrors the fresh credentials into each isolated
+    `CODEX_HOME` deliberately, so no two agent homes race to refresh:
+
+    ```json5
+    {
+      // Sign in once: openclaw models auth login --provider openai-codex
+      // OpenClaw owns refresh for this single profile.
+      plugins: { entries: { codex: { enabled: true } } },
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          agentRuntime: { id: "codex" },
+          // Every agent points at the same OpenClaw-managed profile.
+          // OpenClaw mirrors the latest refreshed credentials into the
+          // isolated CODEX_HOME for each launch instead of letting the
+          // app-server backends refresh independently.
+          auth: { profile: "openai-codex:default" },
+        },
+      },
+    }
+    ```
+
     ### Route summary
 
     | Model ref | Runtime config | Route | Auth |


### PR DESCRIPTION
## Summary
- document the native Codex route as a model/runtime/auth chain instead of a token-copy shortcut
- add the missing OAuth refresh ownership rule for isolated `CODEX_HOME` directo...[truncated]