### PR TITLE
fix(auto-reply): preserve reset inbound context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Native apps: advertise the Gateway protocol compatibility range so chat and node sessions can connect to v3 gateways after additive v4 client updates.
 - Gateway/agents: keep stale `sessions_send` ACP manager and `web_fetch` runtime chunks importable after package updates, preventing live gateways from breaking before restart. Fixes #78804. Thanks @Gomesy72.
 - Gateway/install: preserve service environment value-source metadata in `openclaw gateway install`, so systemd reinstall paths keep env-file-backed secrets out of inline unit metadata. Refs #77406, #77427. Thanks @stainlu and @brokemac79.
+- Auto-reply/reset: include inbound sender context in bare `/new` and `/reset` model prompts while keeping startup instructions out of transcript prompts, so agents see sender identity on the first reset turn. Fixes #77360. Thanks @srb11e.
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/auth: update successful model auth profile status with one locked store write, reducing post-model reply latency from duplicate `auth-profiles.json` saves. Thanks @mcaxtr.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1278,43 +1278,65 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.extraSystemPromptStatic).toBe("group:discord:channel:#ops");
   });
 
-  it("uses a non-empty transcript marker while keeping bare reset startup instructions out of visible transcript prompt", async () => {
-    await runPreparedReply(
-      baseParams({
-        ctx: {
-          Body: "/new",
-          RawBody: "/new",
-          CommandBody: "/new",
-          Provider: "webchat",
-          Surface: "webchat",
-          ChatType: "direct",
-        },
-        sessionCtx: {
-          Body: "",
-          BodyStripped: "",
-          Provider: "webchat",
-          Surface: "webchat",
-          ChatType: "direct",
-        },
-        command: {
-          surface: "webchat",
-          channel: "webchat",
-          isAuthorizedSender: true,
-          abortKey: "session-key",
-          ownerList: [],
-          senderIsOwner: true,
-          rawBodyNormalized: "/new",
-          commandBodyNormalized: "/new",
-        } as never,
-      }),
-    );
+  it.each([
+    ["/new", "new"],
+    ["/reset", "reset"],
+  ] as const)(
+    "keeps inbound sender context in the bare %s model prompt while hiding startup instructions from transcript prompt",
+    async (commandText, startupAction) => {
+      vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce(
+        [
+          "Conversation info (untrusted metadata):",
+          "Sender (untrusted metadata):",
+          "sender_id",
+          "telegram-user-1",
+        ].join("\n"),
+      );
 
-    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
-    expect(call?.commandBody).toContain("A new session was started via /new or /reset.");
-    expect(call?.followupRun.prompt).toContain("A new session was started via /new or /reset.");
-    expect(call?.transcriptCommandBody).toBe("[OpenClaw session new]");
-    expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw session new]");
-  });
+      await runPreparedReply(
+        baseParams({
+          ctx: {
+            Body: commandText,
+            RawBody: commandText,
+            CommandBody: commandText,
+            Provider: "webchat",
+            Surface: "webchat",
+            ChatType: "direct",
+          },
+          sessionCtx: {
+            Body: "",
+            BodyStripped: "",
+            Provider: "webchat",
+            Surface: "webchat",
+            ChatType: "direct",
+            SenderId: "telegram-user-1",
+            SenderName: "Ada Lovelace",
+          },
+          command: {
+            surface: "webchat",
+            channel: "webchat",
+            isAuthorizedSender: true,
+            abortKey: "session-key",
+            ownerList: [],
+            senderIsOwner: true,
+            rawBodyNormalized: commandText,
+            commandBodyNormalized: commandText,
+          } as never,
+        }),
+      );
+
+      const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+      expect(call?.commandBody).toContain("A new session was started via /new or /reset.");
+      expect(call?.commandBody).toContain("Conversation info (untrusted metadata):");
+      expect(call?.commandBody).toContain("Sender (untrusted metadata):");
+      expect(call?.commandBody).toContain("telegram-user-1");
+      expect(call?.followupRun.prompt).toContain("A new session was started via /new or /reset.");
+      expect(call?.followupRun.prompt).toContain("Sender (untrusted metadata):");
+      expect(call?.transcriptCommandBody).toBe(`[OpenClaw session ${startupAction}]`);
+      expect(call?.followupRun.transcriptPrompt).toBe(`[OpenClaw session ${startupAction}]`);
+      expect(call?.followupRun.transcriptPrompt).not.toContain("Sender (untrusted metadata):");
+    },
+  );
 
   it("keeps reset user notes visible while hiding startup instructions", async () => {
     await runPreparedReply(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -623,6 +623,7 @@ export async function runPreparedReply(
   );
   const baseBodyForPrompt = isBareSessionReset
     ? [
+        inboundUserContext,
         startupContextPrelude,
         baseBodyFinal,
         softResetTail


### PR DESCRIPTION
## Summary

- Problem: bare `/new` and `/reset` reset/bootstrap model prompts built `inboundUserContext` but omitted it from the prompt sent to the agent.
- Why it matters: agents that depend on sender identity could miss `Conversation info` / `Sender` metadata on the first reset turn and only regain it on the next message.
- What changed: the bare reset prompt now includes the existing user-role inbound context before startup context, and tests cover both `/new` and `/reset` while preserving the hidden transcript marker.
- What did NOT change (scope boundary): ordinary command acknowledgement behavior, trusted system metadata, transcript prompt hiding, and non-reset prompt composition are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #77360
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/auto-reply/reply/get-reply-run.ts` computed `inboundUserContext`, but the `isBareSessionReset` prompt branch only joined startup context, the reset prompt body, and optional soft-reset notes.
- Missing detection / guardrail: the existing bare `/new` test asserted startup prompt and transcript marker behavior, but did not assert that the model prompt retained inbound sender context.
- Contributing context (if known): sender metadata intentionally stays out of the trusted system prompt, so omitting the user-role block removed it entirely from bare reset/bootstrap turns.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply-run.media-only.test.ts`
- Scenario the test should lock in: bare `/new` and `/reset` include inbound sender context in `commandBody` / `followupRun.prompt` while keeping `followupRun.transcriptPrompt` on `[OpenClaw session new|reset]`.
- Why this is the smallest reliable guardrail: it exercises the prompt branch directly without needing live channel transport.
- Existing test that already covers this (if any): `src/auto-reply/reply/inbound-meta.test.ts` covers how the inbound user context is built, but not this reset branch inclusion.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Agents now see the same inbound sender context on bare reset/bootstrap model turns that they already see on ordinary model turns.

## Diagram (if applicable)

```text
Before:
/new or /reset -> reset prompt without sender context -> model starts without first-turn sender identity

After:
/new or /reset -> inbound sender context + reset prompt -> model starts with first-turn sender identity
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the model now receives existing inbound sender metadata on bare reset turns. This metadata is already sent on ordinary turns and remains in the user-role untrusted context, not the trusted system prompt.

## Repro + Verification

### Environment

- OS: local macOS dev worktree
- Runtime/container: Node 24.15.0 / pnpm
- Model/provider: N/A
- Integration/channel (if any): generic auto-reply prompt path
- Relevant config (redacted): default test config

### Steps

1. Send or simulate a bare `/new` or `/reset` that invokes the reset/bootstrap model prompt path.
2. Include sender metadata in the inbound session context.
3. Inspect the prompt passed to `runReplyAgent`.

### Expected

- The model prompt includes `Conversation info` / `Sender` inbound context.
- The transcript prompt remains the synthetic `[OpenClaw session new|reset]` marker and does not persist startup instructions or sender context.

### Actual

- Before this change, the bare reset branch omitted `inboundUserContext`, so sender context was absent from the model prompt.

## Real behavior proof

- Behavior or issue addressed: bare `/new` and `/reset` reset/bootstrap turns should include OpenClaw's existing inbound sender context in the model prompt while keeping sender metadata out of the stored transcript prompt.
- Real environment tested: local OpenClaw checkout at `5023482f48aeb42ff90d70012896245cec8481a2`, macOS host, Node 24.15.0, pnpm 10.33.2. The proof exercised the production inbound-context builder and asserted the current `get-reply-run.ts` bare-reset prompt branch includes `inboundUserContext` before startup context.
- Exact steps or command run after this patch: ran a `pnpm exec tsx -e` proof script that built a Telegram direct-message inbound context with sender id/name, verified the production bare-reset prompt branch contains `inboundUserContext`, composed the reset prompt with the production inbound metadata block, and checked the transcript marker remains sender-free.
- Evidence after fix:

```text
v24.15.0
bare_reset_branch_has_inbound_context=true
inbound_has_sender_block=true
prompt_has_sender_id=true
prompt_has_sender_name=true
prompt_has_reset_notice=true
transcript_prompt=[OpenClaw session reset]
transcript_has_sender_context=false
```

- Observed result after fix: the reset model prompt includes the untrusted sender block and sender id/name, while the transcript prompt remains `[OpenClaw session reset]` and does not contain sender context.
- What was not tested: live Telegram/Slack/Discord reset delivery; this proof stays on the direct auto-reply prompt-composition surface to avoid sending real messages or requiring provider credentials.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts`; `pnpm exec tsx -e '<temporary bare reset prompt proof>'`.
- Edge cases checked: whitespace sanity for touched files; transcript prompt remains sender-free.
- What you did **not** verify: live Telegram/Slack/Discord reset flow; this is covered by the direct prompt-composition proof rather than live transport.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: reset prompts get slightly longer.
  - Mitigation: this reuses the existing bounded inbound user context already used on ordinary turns and keeps the transcript prompt compact.
