### PR TITLE
[codex] fix subagent gateway backend auth

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -248,10 +248,19 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "agent",
+        mode: "backend",
+        clientName: "gateway-client",
         params: expect.objectContaining({
           sessionKey: childSessionKey,
           cleanupBundleMcpOnRunEnd: true,
         }),
+      }),
+    );
+    expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.patch",
+        mode: "backend",
+        clientName: "gateway-client",
       }),
     );
   });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -41,6 +41,10 @@ import {
   splitModelRef,
 } from "./subagent-spawn-plan.js";
 import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../gateway/protocol/client-info.js";
+import {
   ADMIN_SCOPE,
   AGENT_LANE_SUBAGENT,
   DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
@@ -192,9 +196,14 @@ async function callSubagentGateway(
   // Only admin-only methods are pinned to ADMIN_SCOPE; other methods (e.g.
   // "agent" → write) keep their least-privilege scope so that the gateway does
   // not treat the caller as owner (senderIsOwner) and expose owner-only tools.
+  //
+  // Backend RPC calls must identify as "gateway-client" in BACKEND mode to avoid
+  // requiring device identity when authenticating with shared credentials on loopback.
   const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
   return await subagentSpawnDeps.callGateway({
     ...params,
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
     ...(scopes != null ? { scopes } : {}),
   });
 }


### PR DESCRIPTION
## Summary

- fix subagent gateway calls being rejected with close 1008 on loopback shared-auth
- set `mode: BACKEND` + `clientName: gateway-client` on all `callSubagentGateway` RPCs
- add regression assertions for both `agent` and `sessions.patch` gateway calls

## Root Cause

`callSubagentGateway` defaulted `mode` and `clientName` to their CLI equivalents.
The gateway skips device-identity checks only when **all four** conditions hold:

```
mode === "backend"
clientName === "gateway-client"
hasSharedAuth          (token or password present)
isLoopbackGatewayUrl   (localhost / 127.x / ::1)
```

(`src/gateway/call.ts` → `shouldOmitDeviceIdentityForGatewayCall`)

With CLI defaults, the device-identity check ran, found no device file in the
subagent environment, and the connection was rejected before the handshake
completed.

## What Changed

- `src/agents/subagent-spawn.ts`: `callSubagentGateway` now always passes
  `mode: GATEWAY_CLIENT_MODES.BACKEND` and `clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT`
- least-privilege scope logic is unchanged: admin-only methods still pin
  `ADMIN_SCOPE`; non-admin methods keep their write-tier scope so
  `senderIsOwner` is not triggered
- `src/agents/subagent-spawn.test.ts`: regression assertions added for both
  `method: "agent"` and `method: "sessions.patch"` calls

## Verification

Focused test (run before landing):
```
pnpm test src/agents/subagent-spawn.test.ts
```

- reviewed `src/gateway/call.ts` `shouldOmitDeviceIdentityForGatewayCall` — all four bypass conditions are now satisfied
- scope-upgrade close(1008) fix (#59428) and this fix are siblings; this closes the device-identity rejection on the same path