### PR TITLE
fix(ollama): expose resolveThinkingProfile in provider-policy surface

### DIFF
--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -38,3 +38,19 @@ export function normalizeConfig({
 
   return next;
 }
+
+export function resolveThinkingProfile({
+  reasoning,
+}: {
+  provider: string;
+  modelId: string;
+  reasoning?: boolean;
+}) {
+  if (reasoning !== true) {
+    return { levels: [{ id: "off" }], defaultLevel: "off" };
+  }
+  return {
+    levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+    defaultLevel: "off",
+  };
+}


### PR DESCRIPTION
## Summary

The Ollama plugin is startup-lazy (`activation.onStartup: false`). When `/think max` is issued for a reasoning model like `deepseek-v4-pro:cloud`, the thinking resolver in `src/auto-reply/thinking.ts` falls through to the bundled provider-policy surface. That surface (`extensions/ollama/provider-policy-api.ts`) only exports `normalizeConfig` — it does not export `resolveThinkingProfile`, so the resolver defaults to the base profile which only offers off/minimal/low/medium/high (no `max`).

## Changes

- Add `resolveThinkingProfile` export to `extensions/ollama/provider-policy-api.ts` with the same level set (`off`, `low`, `medium`, `high`, `max`) used by the runtime registration at `index.ts:252-258`.
- Follows the same pattern as `extensions/deepseek/provider-policy-api.ts:100-104`.

## Verification

- TypeScript compilation passes (0 diagnostics)
- New export only; existing `normalizeConfig` behavior unchanged
- Logic mirrors the full runtime registration

Closes #77612
