### PR TITLE
fix(agents): preload standalone plugin tool registry before resolve

### DIFF
--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -4,7 +4,7 @@ import {
   getRuntimeConfigSourceSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolvePluginTools } from "../plugins/tools.js";
+import { ensureStandalonePluginToolRegistryLoaded, resolvePluginTools } from "../plugins/tools.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { listProfilesForProvider } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -73,23 +73,27 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     return resolveApplicablePluginRuntimeConfig(params.resolvedConfig ?? params.options?.config);
   };
   const authProfileStore = params.options?.authProfileStore;
-  const pluginTools = resolvePluginTools({
+  const pluginToolInputs = {
     ...resolveOpenClawPluginToolInputs({
       options: params.options,
       resolvedConfig: params.resolvedConfig,
       runtimeConfig: resolveCurrentRuntimeConfig(),
       getRuntimeConfig: resolveCurrentRuntimeConfig,
     }),
-    existingToolNames: params.existingToolNames ?? new Set<string>(),
     toolAllowlist: params.options?.pluginToolAllowlist,
     toolDenylist: params.options?.pluginToolDenylist,
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,
     ...(authProfileStore
       ? {
-          hasAuthForProvider: (providerId) =>
+          hasAuthForProvider: (providerId: string) =>
             listProfilesForProvider(authProfileStore, providerId).length > 0,
         }
       : {}),
+  };
+  ensureStandalonePluginToolRegistryLoaded(pluginToolInputs);
+  const pluginTools = resolvePluginTools({
+    ...pluginToolInputs,
+    existingToolNames: params.existingToolNames ?? new Set<string>(),
   });
 
   return applyPluginToolDeliveryDefaults({


### PR DESCRIPTION
## Summary

`resolveOpenClawPluginToolsForOptions` in `src/agents/openclaw-plugin-tools.ts` was the only consumer of `resolvePluginTools` that did not first call `ensureStandalonePluginToolRegistryLoaded`. The gateway catalog (`tools-catalog.ts:98`) and MCP serve (`plugin-tools-serve.ts:45`) both preload the standalone registry before resolving tools.

Without the preload, when cached descriptor resolution satisfies all selected plugin IDs, `resolvePluginTools` returns early and the cold-load self-trigger never fires. The cached descriptor wrappers then fail at execution time with "plugin tool runtime unavailable".

## Changes

- Extract the shared context (`pluginToolInputs`) from the `resolvePluginTools` call
- Call `ensureStandalonePluginToolRegistryLoaded(pluginToolInputs)` before `resolvePluginTools`
- Pass `existingToolNames` only to `resolvePluginTools` (preload does not need it)
- Add explicit `providerId: string` type annotation (was inferred)

This makes the agent-path consumer symmetric with the other two consumers.

## Verification

- TypeScript compilation passes (0 diagnostics)
- Net change: +4 lines of logic, following the exact pattern of tools-catalog.ts and plugin-tools-serve.ts

Closes #77603
