### PR TITLE
fix(agents): prevent reasoning stream feedback loop for MiniMax models

### DIFF
--- a/src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts
@@ -74,7 +74,7 @@ describe("createMinimaxThinkingDisabledWrapper", () => {
     ).toBeUndefined();
   });
 
-  it("preserves an already-set thinking value", () => {
+  it("overrides an already-set thinking value for minimax (#77625)", () => {
     let capturedThinking: unknown = undefined;
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {
@@ -91,6 +91,31 @@ describe("createMinimaxThinkingDisabledWrapper", () => {
         api: "anthropic-messages",
         provider: "minimax",
         id: "MiniMax-M2.7",
+      } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(capturedThinking).toEqual({ type: "disabled" });
+  });
+
+  it("does not override thinking for non-minimax providers", () => {
+    let capturedThinking: unknown = undefined;
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        thinking: { type: "enabled", budget_tokens: 1024 },
+      };
+      options?.onPayload?.(payload, _model);
+      capturedThinking = payload.thinking;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createMinimaxThinkingDisabledWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
       } as Model<"anthropic-messages">,
       { messages: [] } as Context,
       {},

--- a/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
@@ -49,6 +49,10 @@ export function createMinimaxFastModeWrapper(
  * provider cannot process this format and leaks the reasoning text as visible
  * content. Disable thinking in the outgoing payload so MiniMax does not produce
  * reasoning_content deltas during streaming.
+ *
+ * This MUST override any previously-set thinking value (e.g. from
+ * reasoningDefault:"stream") because MiniMax cannot emit thinking blocks in a
+ * format the runtime can safely replay without creating a feedback loop (#77625).
  */
 export function createMinimaxThinkingDisabledWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -63,11 +67,7 @@ export function createMinimaxThinkingDisabledWrapper(baseStreamFn: StreamFn | un
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
-          // Only inject if thinking is not already explicitly set.
-          // This preserves any intentional override from other wrappers.
-          if (payloadObj.thinking === undefined) {
-            payloadObj.thinking = { type: "disabled" };
-          }
+          payloadObj.thinking = { type: "disabled" };
         }
         return originalOnPayload?.(payload, model);
       },

--- a/src/plugins/provider-replay-helpers.test.ts
+++ b/src/plugins/provider-replay-helpers.test.ts
@@ -178,6 +178,32 @@ describe("provider replay helpers", () => {
     });
   });
 
+  it("drops reasoning from history for non-Claude models on anthropic-messages (#77625)", () => {
+    const minimaxPolicy = buildHybridAnthropicOrOpenAIReplayPolicy(
+      {
+        provider: "minimax",
+        modelApi: "anthropic-messages",
+        modelId: "MiniMax-M2.7",
+      } as never,
+      { anthropicModelDropThinkingBlocks: true },
+    );
+    expect(minimaxPolicy).toMatchObject({
+      validateAnthropicTurns: true,
+      dropReasoningFromHistory: true,
+    });
+
+    // Claude models should NOT get dropReasoningFromHistory
+    const claudePolicy = buildHybridAnthropicOrOpenAIReplayPolicy(
+      {
+        provider: "minimax",
+        modelApi: "anthropic-messages",
+        modelId: "claude-sonnet-4-6",
+      } as never,
+      { anthropicModelDropThinkingBlocks: true },
+    );
+    expect(claudePolicy).not.toHaveProperty("dropReasoningFromHistory");
+  });
+
   it("builds Gemini replay helpers and tagged reasoning mode", () => {
     expect(buildGoogleGeminiReplayPolicy()).toMatchObject({
       validateGeminiTurns: true,

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -127,12 +127,18 @@ export function buildHybridAnthropicOrOpenAIReplayPolicy(
 ): ProviderReplayPolicy | undefined {
   if (ctx.modelApi === "anthropic-messages" || ctx.modelApi === "bedrock-converse-stream") {
     const isClaude = normalizeLowercaseStringOrEmpty(ctx.modelId).includes("claude");
-    return buildStrictAnthropicReplayPolicy({
-      dropThinkingBlocks:
-        options.anthropicModelDropThinkingBlocks &&
-        isClaude &&
-        !shouldPreserveThinkingBlocks(ctx.modelId),
-    });
+    return {
+      ...buildStrictAnthropicReplayPolicy({
+        dropThinkingBlocks:
+          options.anthropicModelDropThinkingBlocks &&
+          isClaude &&
+          !shouldPreserveThinkingBlocks(ctx.modelId),
+      }),
+      // Non-Claude models on the Anthropic-messages API (e.g. MiniMax) cannot
+      // produce replayable thinking blocks. Strip leaked reasoning from history
+      // to prevent feedback loops when reasoningDefault is "stream" (#77625).
+      ...(!isClaude ? { dropReasoningFromHistory: true } : {}),
+    };
   }
 
   return buildOpenAICompatibleReplayPolicy(ctx.modelApi, { modelId: ctx.modelId });


### PR DESCRIPTION
## Summary

Fixes #77625 — `reasoningDefault=stream` causes infinite reasoning recursion with MiniMax-M2.7.

Two interacting issues created a feedback loop where the model's own streamed reasoning content was replayed as context on subsequent turns:

- **MiniMax thinking-disabled wrapper bypassed**: The wrapper at `src/agents/pi-embedded-runner/minimax-stream-wrappers.ts` only injected `thinking: { type: "disabled" }` when `payloadObj.thinking === undefined`. When `reasoningDefault: "stream"` pre-set the thinking payload to enabled, the guard was skipped, allowing MiniMax to emit `reasoning_content` in an incompatible format that leaked as visible content.

- **Reasoning not stripped from replay history**: The hybrid Anthropic/OpenAI replay policy in `src/plugins/provider-replay-helpers.ts` did not set `dropReasoningFromHistory: true` for non-Claude models, so leaked reasoning content persisted in the session transcript and was replayed on every subsequent turn.

### Changes

- `minimax-stream-wrappers.ts`: Unconditionally override thinking to disabled for MiniMax anthropic-messages models, regardless of prior payload state
- `provider-replay-helpers.ts`: Add `dropReasoningFromHistory: true` to the strict Anthropic replay policy for non-Claude models on the anthropic-messages API

## Verification

- [x] `pnpm test src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts` — 7 tests pass
- [x] `pnpm test src/plugins/provider-replay-helpers.test.ts` — 13 tests pass
- [x] `pnpm test extensions/minimax` — 106 tests pass
- [x] `pnpm test src/agents/models-config.preserves-explicit-reasoning-override.test.ts` — 2 tests pass
- [x] `pnpm test src/plugins/provider-model-shared.test.ts` — passes
- [x] `pnpm test src/agents/pi-embedded-runner/thinking.ts` — 27 tests pass
- [ ] Live verification with MiniMax-M2.7 + `reasoningDefault: "stream"` (needs credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)