### PR TITLE
fix: recover Slack channel restart after stop timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 - Update/restart: probe managed Gateway restarts with the service environment and add a Docker product lane that exercises candidate-owned `openclaw update --yes --json` restarts, so SecretRef-backed local gateway auth cannot regress behind mocked restart checks. Thanks @vincentkoc.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
+- Slack: keep health-monitor recovery stops from poisoning manual-stop state after channel stop timeouts, allowing Socket Mode accounts to reconnect after event-loop stalls instead of staying dead until Gateway restart. Fixes #77651. Thanks @Gusty3055.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.
 - Control UI/chat: suppress `HEARTBEAT_OK` acknowledgement history, streams, deltas, and final events before they enter the transcript view, so repeated heartbeat no-op turns do not stack noisy bubbles. Thanks @BunsDev.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -131,7 +131,7 @@ async function expectRestartedChannel(
   accountId = "default",
 ) {
   const monitor = await startAndRunCheck(manager);
-  expect(manager.stopChannel).toHaveBeenCalledWith(channel, accountId);
+  expect(manager.stopChannel).toHaveBeenCalledWith(channel, accountId, { manual: false });
   expect(manager.startChannel).toHaveBeenCalledWith(channel, accountId);
   monitor.stop();
 }
@@ -286,9 +286,9 @@ describe("channel-health-monitor", () => {
       },
     );
     const monitor = await startAndRunCheck(manager);
-    expect(manager.stopChannel).toHaveBeenCalledWith("discord", "default");
+    expect(manager.stopChannel).toHaveBeenCalledWith("discord", "default", { manual: false });
     expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
-    expect(manager.stopChannel).not.toHaveBeenCalledWith("discord", "quiet");
+    expect(manager.stopChannel).not.toHaveBeenCalledWith("discord", "quiet", { manual: false });
     expect(manager.startChannel).not.toHaveBeenCalledWith("discord", "quiet");
     monitor.stop();
   });
@@ -308,7 +308,7 @@ describe("channel-health-monitor", () => {
       },
     });
     const monitor = await startAndRunCheck(manager);
-    expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default");
+    expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default", { manual: false });
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("whatsapp", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
     monitor.stop();
@@ -613,7 +613,7 @@ describe("channel-health-monitor", () => {
       const monitor = await startAndRunCheck(manager, {
         staleEventThresholdMs: customThreshold,
       });
-      expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
+      expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default", { manual: false });
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
     });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -163,7 +163,9 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           try {
             if (status.running) {
-              await channelManager.stopChannel(channelId as ChannelId, accountId);
+              await channelManager.stopChannel(channelId as ChannelId, accountId, {
+                manual: false,
+              });
             }
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -367,6 +367,47 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(2);
   });
 
+  it("lets manual stops cancel recovery backoff after recovery stop times out", async () => {
+    const releaseFirstTask = createDeferred();
+    const startAccount = vi.fn(
+      async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => {}, { once: true });
+          void releaseFirstTask.promise.then(resolve);
+        }),
+    );
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    releaseFirstTask.resolve();
+    await waitForMicrotaskCondition(
+      () => hoisted.sleepWithAbort.mock.calls.length > 0,
+      "expected recovery restart backoff to be scheduled",
+    );
+    expect(hoisted.sleepWithAbort).toHaveBeenCalledWith(10, expect.any(AbortSignal));
+
+    await manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(false);
+    expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(true);
+  });
+
   it("marks enabled/configured when account descriptors omit them", () => {
     installTestRegistry(
       createTestPlugin({

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -329,6 +329,44 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toContain("channel stop timed out");
   });
 
+  it("does not poison auto-restart state when recovery stop times out", async () => {
+    const releaseFirstTask = createDeferred();
+    const startAccount = vi.fn(
+      async ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => {}, { once: true });
+          void releaseFirstTask.promise.then(resolve);
+        }),
+    );
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, { manual: false });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(true);
+    expect(account?.lastError).toContain("channel stop timed out");
+    expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+
+    releaseFirstTask.resolve();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushMicrotasks();
+
+    expect(startAccount).toHaveBeenCalledTimes(2);
+  });
+
   it("marks enabled/configured when account descriptors omit them", () => {
     installTestRegistry(
       createTestPlugin({

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -573,8 +573,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 restartPending: true,
                 reconnectAttempts: attempt,
               });
+              const recoveryRestartSleepAbort = recoveryStopTimedOut.has(rKey)
+                ? new AbortController()
+                : undefined;
+              if (recoveryRestartSleepAbort) {
+                store.aborts.set(id, recoveryRestartSleepAbort);
+              }
               try {
-                const restartSleepAbort = recoveryStopTimedOut.has(rKey) ? undefined : abort.signal;
+                const restartSleepAbort = recoveryRestartSleepAbort?.signal ?? abort.signal;
                 await sleepWithAbort(delayMs, restartSleepAbort);
                 if (manuallyStopped.has(rKey)) {
                   recoveryStopTimedOut.delete(rKey);
@@ -584,7 +590,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 if (store.tasks.get(id) === trackedPromise) {
                   store.tasks.delete(id);
                 }
-                if (store.aborts.get(id) === abort) {
+                if (store.aborts.get(id) === (recoveryRestartSleepAbort ?? abort)) {
                   store.aborts.delete(id);
                 }
                 await startChannelInternal(channelId, id, {
@@ -593,6 +599,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 });
               } catch {
                 // abort or startup failure — next crash will retry
+              } finally {
+                if (recoveryRestartSleepAbort) {
+                  recoveryStopTimedOut.delete(rKey);
+                  if (store.aborts.get(id) === recoveryRestartSleepAbort) {
+                    store.aborts.delete(id);
+                  }
+                }
               }
             })
             .finally(() => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -188,11 +188,15 @@ type StartChannelOptions = {
   preserveManualStop?: boolean;
 };
 
+type StopChannelOptions = {
+  manual?: boolean;
+};
+
 export type ChannelManager = {
   getRuntimeSnapshot: () => ChannelRuntimeSnapshot;
   startChannels: () => Promise<void>;
   startChannel: (channel: ChannelId, accountId?: string) => Promise<void>;
-  stopChannel: (channel: ChannelId, accountId?: string) => Promise<void>;
+  stopChannel: (channel: ChannelId, accountId?: string, opts?: StopChannelOptions) => Promise<void>;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
@@ -216,6 +220,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const restartAttempts = new Map<string, number>();
   // Tracks accounts that were manually stopped so we don't auto-restart them.
   const manuallyStopped = new Set<string>();
+  const recoveryStopTimedOut = new Set<string>();
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
   const ensureChannelLog = (channelId: ChannelId): SubsystemLogger => {
@@ -569,10 +574,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 reconnectAttempts: attempt,
               });
               try {
-                await sleepWithAbort(delayMs, abort.signal);
+                const restartSleepAbort = recoveryStopTimedOut.has(rKey) ? undefined : abort.signal;
+                await sleepWithAbort(delayMs, restartSleepAbort);
                 if (manuallyStopped.has(rKey)) {
+                  recoveryStopTimedOut.delete(rKey);
                   return;
                 }
+                recoveryStopTimedOut.delete(rKey);
                 if (store.tasks.get(id) === trackedPromise) {
                   store.tasks.delete(id);
                 }
@@ -630,7 +638,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
     await startChannelInternal(channelId, accountId);
   };
 
-  const stopChannel = async (channelId: ChannelId, accountId?: string) => {
+  const stopChannel = async (
+    channelId: ChannelId,
+    accountId?: string,
+    opts: StopChannelOptions = {},
+  ) => {
+    const manual = opts.manual ?? true;
     const plugin = getChannelPlugin(channelId);
     const store = getStore(channelId);
     // Fast path: nothing running and no explicit plugin shutdown hook to run.
@@ -656,7 +669,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         if (!abort && !task && !plugin?.gateway?.stopAccount) {
           return;
         }
-        manuallyStopped.add(restartKey(channelId, id));
+        const rKey = restartKey(channelId, id);
+        if (manual) {
+          manuallyStopped.add(rKey);
+        }
         abort?.abort();
         const log = ensureChannelLog(channelId);
         const runtime = ensureChannelRuntime(channelId);
@@ -683,12 +699,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           );
           setRuntime(channelId, id, {
             accountId: id,
-            running: true,
-            restartPending: false,
+            running: manual,
+            restartPending: !manual,
             lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
           });
+          if (!manual) {
+            recoveryStopTimedOut.add(rKey);
+          }
           return;
         }
+        recoveryStopTimedOut.delete(rKey);
         store.aborts.delete(id);
         store.tasks.delete(id);
         setRuntime(channelId, id, {


### PR DESCRIPTION
## Summary

- Treat channel health-monitor restarts as recovery stops, not manual stops, so a timed-out stop does not poison future auto-reconnect state.
- Preserve manual-stop timeout behavior for user-initiated stops while marking recovery stop timeouts as restart-pending.
- Add regression coverage for the timed-out recovery stop path and the manual-stop-during-recovery-backoff path.
- Update the changelog.

Fixes #77651.

## Real behavior proof

- **Behavior or issue addressed**: A recovery restart that times out while stopping a stuck channel task should remain eligible for auto-restart when the old task finally settles, while later manual stops should still cancel recovery backoff.
- **Real environment tested**: Local OpenClaw checkout on macOS, running the actual gateway `createChannelManager` implementation through Node/tsx with a temporary channel plugin installed in the runtime registry.
- **Exact steps or command run after this patch**: From repo root, ran a `node --import tsx --input-type=module` runtime harness that imports `src/gateway/server-channels.ts`, starts a channel account whose first task ignores abort until explicitly released, calls `stopChannel('discord', 'default', { manual: false })`, immediately requests `startChannel`, releases the old task, waits for the manager's real auto-restart path, then performs a manual cleanup stop.
- **Evidence after fix**: Terminal output from the local runtime harness:

```text
after start: startCalls=1
[recovery-proof] [default] channel stop exceeded 5000ms after abort; continuing shutdown
after recovery stop timeout: elapsedMs=5023 running=false restartPending=true manuallyStopped=false lastError=channel stop timed out after 5000ms
after immediate restart request while old task is stuck: startCalls=1
[recovery-proof] [default] auto-restart attempt 1/10 in 5s
after old task settled: startCalls=2 running=true restartPending=false reconnectAttempts=1 lastError=null
events=startAccount(default) #1 | first task received abort but stays stuck until release | first task settled after simulated stuck stop | startAccount(default) #2
cleanup manual stop: running=false restartPending=false manuallyStopped=true
```

- **Observed result after fix**: The recovery stop timed out without setting the account as manually stopped, the immediate restart request did not double-start while the old task was still stuck, and after the old task settled the manager auto-restarted the account (`startCalls=2`, `running=true`, `lastError=null`). A later manual stop left `restartPending=false` and `manuallyStopped=true`.
- **What was not tested**: Live Slack credentials/socket reconnection. The proof uses the real gateway channel manager and a temporary local channel plugin to reproduce the stuck-task lifecycle deterministically.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/gateway/server-channels.ts src/gateway/server-channels.test.ts src/gateway/channel-health-monitor.ts src/gateway/channel-health-monitor.test.ts`
- `git diff --check HEAD~2..HEAD`
- `pnpm changed:lanes --json`
- `pnpm test src/gateway/server-channels.test.ts src/gateway/channel-health-monitor.test.ts`
- Local Node/tsx runtime harness output copied in `Real behavior proof` above.

## Notes

- `pnpm changed:lanes --json` selected broad lanes after the rebase because the branch had been rewritten on top of current `main`; the touched-surface checks above are the local targeted proof for this PR.
- Testbox/Crabbox broad validation was not run from this environment because neither `blacksmith` nor `crabbox` is installed here.
