### PR TITLE
fix(feishu): pass local file roots for media attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: pass local file root permissions to the media dispatcher so channel bots can send local file attachments instead of returning local file paths.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
 - Update/restart: probe managed Gateway restarts with the service environment and add a Docker product lane that exercises candidate-owned `openclaw update --yes --json` restarts, so SecretRef-backed local gateway auth cannot regress behind mocked restart checks. Thanks @vincentkoc.
 - Webhooks/Gmail/Windows: resolve `gcloud`, `gog`, and `tailscale` PATH/PATHEXT shims before setup and watcher spawns, using the Windows-safe `.cmd` wrapper for long-lived `gog serve` processes. (#74881, fixes #54470) Thanks @Angfr95.

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -659,6 +659,22 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("passes mediaLocalRoots from info.mediaAccess to media attachments", async () => {
+    const { options } = createDispatcherHarness();
+    await options.deliver(
+      { mediaUrl: "file:///local/path/a.png" },
+      { kind: "final", mediaAccess: { localRoots: ["/local/path"] } },
+    );
+
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrl: "file:///local/path/a.png",
+        mediaLocalRoots: ["/local/path"],
+      }),
+    );
+  });
+
   it("passes audioAsVoice to media attachments", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver(

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -442,7 +442,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
   };
 
-  const sendMediaReplies = async (payload: ReplyPayload, options?: { fallbackText?: string }) => {
+  const sendMediaReplies = async (
+    payload: ReplyPayload,
+    options?: { fallbackText?: string },
+    mediaLocalRoots?: readonly string[],
+  ) => {
     const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
     let sentFallbackText = false;
     await sendMediaWithLeadingCaption({
@@ -456,6 +460,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
           accountId,
+          mediaLocalRoots,
           ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
         });
         if (result?.voiceIntentDegradedToFile && options?.fallbackText && !sentFallbackText) {
@@ -592,7 +597,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             // Send media even when streaming handled the text
             if (hasMedia) {
-              await sendMediaReplies(payload);
+              await sendMediaReplies(payload, undefined, info?.mediaAccess?.localRoots);
             }
             return;
           }
@@ -642,6 +647,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           await sendMediaReplies(
             payload,
             hasVoiceMedia && hasText ? { fallbackText: text } : undefined,
+            info?.mediaAccess?.localRoots,
           );
         }
       },


### PR DESCRIPTION
## Summary

- **Problem**: Feishu channel was unable to dispatch local file attachments. Instead of uploading and sending the actual file, it would only return the local `file://` path as plain text because the `mediaLocalRoots` authorization parameter was not being passed to the media sender.
- **Why it matters**: This prevented Feishu bots from successfully sharing local assets (like generated images or local logs) even when authorized by the OpenClaw core.
- **What changed**: 
  - Updated `sendMediaReplies` in `extensions/feishu/src/reply-dispatcher.ts` to accept an optional `mediaLocalRoots` whitelist.
  - Wired the `deliver` logic to extract `mediaAccess.localRoots` from the dispatcher context and pass it down to the Feishu media client.
  - Added a regression test case to ensure the authorized roots are correctly propagated.
- **What did NOT change**: The core Feishu client authentication and the general message delivery pipeline remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs (Changelog updated)
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Feishu)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to the reported issue where Feishu media dispatch returns only file paths.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: Local media files were sent as text paths.
- **Real environment tested**: Local Mac environment.
- **Exact steps or command run after this patch**: `pnpm test extensions/feishu`
- **Evidence after fix**: 
  ```bash
  ✓ |extension-feishu| extensions/feishu/src/reply-dispatcher.test.ts (114 tests)
  Test Files  61 passed (61)
  Tests  721 passed (721)
  ```
- **Observed result after fix**: The new test case `passes mediaLocalRoots from info.mediaAccess to media attachments` passed, confirming that the dispatcher now correctly forwards the local file access whitelist.

## Root Cause (if applicable)

- **Root cause**: The Feishu `reply-dispatcher` was missing the plumbing to receive and forward the `mediaLocalRoots` parameter provided by the OpenClaw core dispatcher context.
- **Missing detection / guardrail**: Existing unit tests for media delivery did not assert the presence of `mediaLocalRoots` in the mock calls.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this**:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `extensions/feishu/src/reply-dispatcher.test.ts`
- **Scenario the test should lock in**: Verify that `sendMediaFeishu` receives `mediaLocalRoots` when the dispatcher is provided with local access permissions in the `info` object.
- **Why this is the smallest reliable guardrail**: It directly tests the interface boundary between the dispatcher and the media client.

## User-visible / Behavior Changes

Feishu bots can now successfully upload and send local files if the session has been granted local media access.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) - Allows the plugin to utilize the local file access permissions granted by the core.
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`) - It only enables the use of existing authorized scopes.

## Repro + Verification

### Environment

- OS: macOS
- Integration/channel: Feishu

### Steps

1. Configure a Feishu bot.
2. Trigger a reply that includes a local `file://` path in the media payload.
3. Ensure the dispatcher is initialized with `mediaAccess.localRoots`.

### Expected

- The Feishu bot uploads the file and sends it as a media attachment.

### Actual (Before Fix)

- The Feishu bot sends the string `"file:///path/to/file"` as a text message.

## Evidence

- [x] Trace/log snippets: `721 tests passed` (pnpm test)

## Human Verification (required)

- **Verified scenarios**: Verified the code change correctly maps `info.mediaAccess.localRoots` to the `sendMediaFeishu` call.
- **Edge cases checked**: Verified that it handles cases where `mediaAccess` or `localRoots` is undefined (using optional chaining).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)