### PR TITLE
fix(fireworks): pin Kimi thinking policy off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.
+- Providers/Fireworks: expose Kimi models as thinking-off-only and keep K2.5/K2.6 requests on `thinking: disabled`, so manual model switches do not send Fireworks-rejected `reasoning*` parameters. Refs #74289. Thanks @frankekn.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
 - Video generation: accept provider-specific aspect-ratio and resolution hints at the tool boundary, normalize `720P` to MiniMax's supported `768P`, and stop sending Google `generateAudio` on Gemini video requests so provider fallback can recover from model-specific parameter differences. Thanks @vincentkoc.
 - OpenAI/Google Meet: fail realtime voice connection attempts when the socket closes before `session.updated`, avoiding stuck Meet joins waiting on a bridge that never became ready. Thanks @vincentkoc.

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -18,6 +18,7 @@ import {
   FIREWORKS_K2_6_MAX_TOKENS,
   FIREWORKS_K2_6_MODEL_ID,
 } from "./provider-catalog.js";
+import { resolveThinkingProfile } from "./provider-policy-api.js";
 
 function createFireworksDefaultRuntimeModel(params: { reasoning: boolean }): ProviderRuntimeModel {
   return {
@@ -143,5 +144,43 @@ describe("fireworks provider plugin", () => {
       id: "accounts/fireworks/models/kimi-k2p6",
       reasoning: false,
     });
+  });
+
+  it("exposes off-only thinking policy for Fireworks Kimi models", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/routers/kimi-k2p5-turbo",
+      }),
+    ).toEqual({
+      levels: [{ id: "off" }],
+      defaultLevel: "off",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: FIREWORKS_K2_6_MODEL_ID,
+      }),
+    ).toEqual({
+      levels: [{ id: "off" }],
+      defaultLevel: "off",
+    });
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/qwen3.6-plus",
+      }),
+    ).toBeUndefined();
+    expect(resolveThinkingProfile({ modelId: FIREWORKS_K2_6_MODEL_ID })).toEqual({
+      levels: [{ id: "off" }],
+      defaultLevel: "off",
+    });
+    expect(
+      resolveThinkingProfile({
+        modelId: "accounts/fireworks/models/qwen3.6-plus",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/extensions/fireworks/index.ts
+++ b/extensions/fireworks/index.ts
@@ -16,6 +16,7 @@ import {
   FIREWORKS_DEFAULT_MODEL_ID,
 } from "./provider-catalog.js";
 import { wrapFireworksProviderStream } from "./stream.js";
+import { resolveFireworksThinkingProfile } from "./thinking-policy.js";
 
 const PROVIDER_ID = "fireworks";
 function resolveFireworksDynamicModel(ctx: ProviderResolveDynamicModelContext) {
@@ -77,6 +78,7 @@ export default defineSingleProviderPluginEntry({
     },
     ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
     wrapStreamFn: wrapFireworksProviderStream,
+    resolveThinkingProfile: ({ modelId }) => resolveFireworksThinkingProfile(modelId),
     resolveDynamicModel: (ctx) => resolveFireworksDynamicModel(ctx),
     isModernModelRef: () => true,
   },

--- a/extensions/fireworks/provider-policy-api.ts
+++ b/extensions/fireworks/provider-policy-api.ts
@@ -1,0 +1,8 @@
+import { resolveFireworksThinkingProfile } from "./thinking-policy.js";
+
+export function resolveThinkingProfile(params: {
+  provider?: string;
+  modelId: string;
+}): ReturnType<typeof resolveFireworksThinkingProfile> {
+  return resolveFireworksThinkingProfile(params.modelId);
+}

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -74,7 +74,7 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
   });
 
   it("strips reasoning fields when disabling Fireworks Kimi thinking", () => {
-    const payload = capturePayload({
+    const k2p5Payload = capturePayload({
       provider: "fireworks",
       api: "openai-completions",
       modelId: "accounts/fireworks/models/kimi-k2p5",
@@ -84,8 +84,19 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
         reasoningEffort: "low",
       },
     });
+    const k2p6Payload = capturePayload({
+      provider: "fireworks",
+      api: "openai-completions",
+      modelId: "accounts/fireworks/models/kimi-k2p6",
+      initialPayload: {
+        reasoning_effort: "low",
+        reasoning: { effort: "low" },
+        reasoningEffort: "low",
+      },
+    });
 
-    expect(payload).toEqual({ thinking: { type: "disabled" } });
+    expect(k2p5Payload).toEqual({ thinking: { type: "disabled" } });
+    expect(k2p6Payload).toEqual({ thinking: { type: "disabled" } });
   });
 
   it("passes sanitized payloads to caller onPayload hooks", () => {

--- a/extensions/fireworks/thinking-policy.ts
+++ b/extensions/fireworks/thinking-policy.ts
@@ -1,0 +1,17 @@
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import { isFireworksKimiModelId } from "./model-id.js";
+
+const FIREWORKS_KIMI_THINKING_PROFILE = {
+  levels: [{ id: "off" }],
+  defaultLevel: "off",
+} as const satisfies ProviderThinkingProfile;
+
+export function resolveFireworksThinkingProfile(
+  modelId: string,
+): ProviderThinkingProfile | undefined {
+  if (!isFireworksKimiModelId(modelId)) {
+    return undefined;
+  }
+
+  return FIREWORKS_KIMI_THINKING_PROFILE;
+}


### PR DESCRIPTION
## Summary
- add a Fireworks provider-owned thinking policy for Kimi models that exposes only `off`
- keep the public bundled provider policy artifact aligned with runtime provider behavior
- add K2.6 coverage proving rejected `reasoning*` request fields are stripped while `thinking: disabled` is preserved

Replacement for #74289. The live Fireworks behavior points to provider/model policy: Kimi accepts `thinking: { type: "disabled" }`, rejects `reasoning` / `reasoningEffort`, and rejects mixing `thinking` with `reasoning_effort`.

Refs #74289.

## Tests
- `pnpm test extensions/fireworks/index.test.ts extensions/fireworks/stream.test.ts`
- `pnpm format:check extensions/fireworks/index.ts extensions/fireworks/index.test.ts extensions/fireworks/provider-policy-api.ts extensions/fireworks/thinking-policy.ts extensions/fireworks/stream.test.ts`
- `pnpm check:changed`