### PR TITLE
fix: avoid duplicate media completion fallback

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1271,6 +1271,48 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("does not fallback while generated media announce-agent run is still pending", async () => {
+    const callGateway = createGatewayMock({
+      runId: "video_generate:task-123:ok",
+      status: "accepted",
+      acceptedAt: Date.now(),
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      sessionId: "requester-session-channel",
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-media-pending",
+      sourceTool: "video_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "video_generation",
+          childSessionKey: "video_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "video generation task",
+          taskLabel: "lobster trailer",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 video.\nMEDIA:/tmp/lobster-trailer.mp4",
+          mediaUrls: ["/tmp/lobster-trailer.mp4"],
+          replyInstruction: "Deliver the generated video through the message tool.",
+        },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        delivered: true,
+        path: "direct",
+      }),
+    );
+    expect(callGateway).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("uses a direct channel fallback when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -689,6 +689,14 @@ function hasGatewayAgentMessagingToolDelivery(response: unknown): boolean {
   return Boolean(result && hasMessagingToolDeliveryEvidence(result));
 }
 
+function isGatewayAgentRunPending(response: unknown): boolean {
+  if (!response || typeof response !== "object") {
+    return false;
+  }
+  const status = (response as { status?: unknown }).status;
+  return status === "accepted" || status === "in_flight" || status === "started";
+}
+
 function inferCompletionChatType(params: {
   requesterSessionKey: string;
   targetRequesterSessionKey: string;
@@ -1047,7 +1055,11 @@ async function sendSubagentAnnounceDirectly(params: {
       throw err;
     }
 
-    if (shouldSendCompletionFallback(directAnnounceResponse, completionFallbackText)) {
+    const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
+    if (
+      !directAnnounceStillPending &&
+      shouldSendCompletionFallback(directAnnounceResponse, completionFallbackText)
+    ) {
       const didFallback = await sendCompletionFallback({
         cfg,
         channel: deliveryTarget.channel,
@@ -1066,6 +1078,13 @@ async function sendSubagentAnnounceDirectly(params: {
           path: resolveCompletionFallbackPath(deliveryTarget.threadId),
         };
       }
+    }
+
+    if (directAnnounceStillPending) {
+      return {
+        delivered: true,
+        path: "direct",
+      };
     }
 
     if (


### PR DESCRIPTION
## Summary
- treat pending announce-agent gateway responses as delivered/pending instead of fallback-worthy
- prevent generated media completions from sending a raw fallback while the announce agent is still running
- add regression coverage for pending media announce responses

## Test
- pnpm test src/agents/subagent-announce-delivery.test.ts