### PR TITLE
build: harden runtime deps fingerprint on Windows

### DIFF
--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -431,20 +431,23 @@ function appendDirectoryFingerprint(hash, rootDir, currentDir = rootDir) {
   for (const entry of entries) {
     const fullPath = path.join(currentDir, entry.name);
     const relativePath = path.relative(rootDir, fullPath).replace(/\\/g, "/");
-    if (entry.isSymbolicLink()) {
+    // On Windows, some pnpm-materialized files can look symlink-like at the
+    // Dirent layer even when lstat reports a regular file. Re-check the path
+    // before calling readlink so runtime fingerprinting stays stable.
+    const entryStats = fs.lstatSync(fullPath);
+    if (entryStats.isSymbolicLink()) {
       hash.update(`symlink:${relativePath}->${fs.readlinkSync(fullPath).replace(/\\/g, "/")}\n`);
       continue;
     }
-    if (entry.isDirectory()) {
+    if (entryStats.isDirectory()) {
       hash.update(`dir:${relativePath}\n`);
       appendDirectoryFingerprint(hash, rootDir, fullPath);
       continue;
     }
-    if (!entry.isFile()) {
+    if (!entryStats.isFile()) {
       continue;
     }
-    const stat = fs.statSync(fullPath);
-    hash.update(`file:${relativePath}:${stat.size}\n`);
+    hash.update(`file:${relativePath}:${entryStats.size}\n`);
     hash.update(fs.readFileSync(fullPath));
   }
 }

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectRuntimeDependencyInstallManifest,
   collectRuntimeDependencyInstallSpecs,
@@ -9,6 +9,10 @@ import {
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("stageBundledPluginRuntimeDeps", () => {
   function createBundledPluginFixture(params: {
@@ -280,6 +284,70 @@ describe("stageBundledPluginRuntimeDeps", () => {
     expect(
       fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
     ).toBe("module.exports = 'second';\n");
+  });
+
+  it("ignores dirent symlink false positives for runtime fingerprinting", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const directDir = path.join(repoRoot, "node_modules", "direct");
+    const packageJsonPath = path.join(directDir, "package.json");
+    fs.mkdirSync(directDir, { recursive: true });
+    fs.writeFileSync(
+      packageJsonPath,
+      '{ "name": "direct", "version": "1.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(directDir, "index.js"), "module.exports = 'runtime';\n", "utf8");
+
+    const originalReaddirSync = fs.readdirSync.bind(fs);
+    const readlinkSpy = vi.spyOn(fs, "readlinkSync");
+
+    vi.spyOn(fs, "readdirSync").mockImplementation(
+      ((targetPath: Parameters<typeof fs.readdirSync>[0], options?: unknown) => {
+        if (
+          String(targetPath) === directDir &&
+          typeof options === "object" &&
+          options !== null &&
+          "withFileTypes" in options &&
+          (options as { withFileTypes?: boolean }).withFileTypes === true
+        ) {
+          const makeDirent = (
+            name: string,
+            kind: "file" | "directory" | "symlink",
+          ): fs.Dirent<string> =>
+            ({
+              name,
+              isBlockDevice: () => false,
+              isCharacterDevice: () => false,
+              isDirectory: () => kind === "directory",
+              isFIFO: () => false,
+              isFile: () => kind === "file",
+              isSocket: () => false,
+              isSymbolicLink: () => kind === "symlink",
+            }) as fs.Dirent<string>;
+          return [
+            makeDirent("index.js", "file"),
+            makeDirent("package.json", "symlink"),
+          ] as ReturnType<typeof fs.readdirSync>;
+        }
+        return originalReaddirSync(
+          targetPath,
+          options as Parameters<typeof fs.readdirSync>[1],
+        ) as ReturnType<typeof fs.readdirSync>;
+      }) as typeof fs.readdirSync,
+    );
+
+    expect(() => stageBundledPluginRuntimeDeps({ cwd: repoRoot })).not.toThrow();
+    expect(readlinkSpy).not.toHaveBeenCalledWith(packageJsonPath);
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
+    ).toBe("module.exports = 'runtime';\n");
   });
 
   it("refuses to replace a symlinked plugin node_modules directory", () => {


### PR DESCRIPTION
﻿## Summary

- Problem: runtime dependency fingerprinting trusted `Dirent.isSymbolicLink()` before checking the actual filesystem entry.
- Why it matters: on Windows, pnpm-materialized files can be reported as symlink-like at the Dirent layer, causing `readlinkSync()` to throw while staging bundled plugin runtime deps.
- What changed: re-check each path with `lstatSync()` before symlink/file/directory handling and use that stat for file size fingerprinting.
- What did NOT change (scope boundary): no dependency resolution, install, package manifest, or runtime output behavior beyond avoiding the false-positive readlink path.

## Change Type (select all)

- [x] Bug fix
- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the fingerprint walker used `fs.readdirSync(..., { withFileTypes: true })` Dirent classification as the source of truth, then called `readlinkSync()` for entries reported as symbolic links.
- Missing detection / guardrail: there was no regression test for a Dirent symlink false positive where `lstat()` reports a regular file.
- Contributing context (if known): Windows + pnpm dependency trees can surface this mismatch while staging bundled plugin runtime dependencies.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: Unit test
- Target test or file: `test/scripts/stage-bundled-plugin-runtime-deps.test.ts`
- Scenario the test should lock in: a Dirent reports `package.json` as a symlink but `lstat()` reports it as a normal file, so staging should not call `readlinkSync()` for that path.
- Why this is the smallest reliable guardrail: it isolates the filesystem classification mismatch without depending on a specific pnpm install layout.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node 22 / local checkout
- Model/provider: N/A
- Integration/channel (if any): bundled plugin runtime dependency staging
- Relevant config (redacted): N/A

### Steps

1. Run the focused regression test.
2. Run the whole touched test file.
3. Check the diff for whitespace errors.

### Expected

- The focused regression passes and no whitespace errors are reported.

### Actual

- Focused regression passed.
- `git diff --check origin/main...HEAD` passed.
- The full touched test file runs 24 passing tests, including the new regression, but 5 existing symlink-security tests are blocked on this Windows shell because `fs.symlinkSync(...)` returns `EPERM: operation not permitted` before assertions run.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: `pnpm exec vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/stage-bundled-plugin-runtime-deps.test.ts -t "ignores dirent symlink false positives"`; `git diff --check origin/main...HEAD`.
- Edge cases checked: `readlinkSync()` is not called for the false-positive package file, and staging still copies the runtime dependency file.
- What you did **not** verify: full file green on Windows, because existing symlink tests need symlink privileges and fail with `EPERM` in this shell.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
