### PR TITLE
fix(core): avoid session export filename collisions

### DIFF
--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const hoisted = await vi.hoisted(async () => {
@@ -119,6 +120,10 @@ function makeParams(): HandleCommandsParams {
 }
 
 describe("buildExportSessionReply", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.resolveDefaultSessionStorePathMock.mockReturnValue("/tmp/target-store/sessions.json");
@@ -229,6 +234,32 @@ describe("buildExportSessionReply", () => {
       ).toString("base64"),
     );
     expect(html).toContain('const base64 = document.getElementById("session-data").textContent;');
+  });
+
+  it("suffixes colliding default export filenames instead of overwriting", async () => {
+    const { buildExportSessionReply } = await import("./commands-export-session.js");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-05T10:11:12.345Z"));
+    const collision = Object.assign(new Error("exists"), { code: "EEXIST" });
+    hoisted.writeFileMock.mockRejectedValueOnce(collision).mockResolvedValueOnce(undefined);
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    const expectedBase = path.join(
+      "/tmp/workspace",
+      "openclaw-session-session--2026-05-05T10-11-12.html",
+    );
+    const expectedSuffix = path.join(
+      "/tmp/workspace",
+      "openclaw-session-session--2026-05-05T10-11-12-2.html",
+    );
+    expect(hoisted.writeFileMock.mock.calls[0]?.[0]).toBe(expectedBase);
+    expect(hoisted.writeFileMock.mock.calls[0]?.[2]).toMatchObject({
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    expect(hoisted.writeFileMock.mock.calls[1]?.[0]).toBe(expectedSuffix);
+    expect(reply.text).toContain("📄 File: openclaw-session-session--2026-05-05T10-11-12-2.html");
   });
 
   it("preserves replacement text with dollar sequences", async () => {

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -131,6 +131,28 @@ async function fileExists(pathName: string): Promise<boolean> {
   }
 }
 
+function addCollisionSuffix(filePath: string, suffix: number): string {
+  const ext = path.extname(filePath);
+  const baseName = path.basename(filePath, ext);
+  return path.join(path.dirname(filePath), `${baseName}-${suffix}${ext}`);
+}
+
+async function writeNewDefaultExportFile(filePath: string, html: string): Promise<string> {
+  for (let suffix = 1; suffix <= 100; suffix++) {
+    const candidate = suffix === 1 ? filePath : addCollisionSuffix(filePath, suffix);
+    try {
+      await fsp.writeFile(candidate, html, { encoding: "utf-8", flag: "wx" });
+      return candidate;
+    } catch (error) {
+      if (typeof error === "object" && error && "code" in error && error.code === "EEXIST") {
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`Could not find an unused export filename near ${filePath}`);
+}
+
 async function readSessionDataFromTranscript(sessionFile: string): Promise<{
   header: SessionHeader | null;
   entries: PiSessionEntry[];
@@ -193,7 +215,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   // 6. Determine output path
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const defaultFileName = `openclaw-session-${entry.sessionId.slice(0, 8)}-${timestamp}.html`;
-  const outputPath = args.outputPath
+  let outputPath = args.outputPath
     ? path.resolve(
         args.outputPath.startsWith("~")
           ? args.outputPath.replace("~", process.env.HOME ?? "")
@@ -206,7 +228,11 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   await fsp.mkdir(outputDir, { recursive: true });
 
   // 7. Write file
-  await fsp.writeFile(outputPath, html, "utf-8");
+  if (args.outputPath) {
+    await fsp.writeFile(outputPath, html, "utf-8");
+  } else {
+    outputPath = await writeNewDefaultExportFile(outputPath, html);
+  }
 
   const relativePath = path.relative(params.workspaceDir, outputPath);
   const displayPath = relativePath.startsWith("..") ? outputPath : relativePath;


### PR DESCRIPTION
## Summary

- Problem: default `/export-session` filenames only include seconds, so two exports for the same session in the same second can target the same HTML file.
- Why it matters: the second default export can silently replace the first export.
- What changed: default exports now use exclusive writes and retry with `-2`, `-3`, etc. when a generated name already exists.
- What did NOT change (scope boundary): explicit user-provided output paths keep the existing overwrite behavior; trajectory exports were not touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #77749
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: repeated default `/export-session` calls can collide on the same generated filename.
- Real environment tested: local OpenClaw source checkout on macOS, Node v25.9.0.
- Exact steps or command run after this patch: `pnpm test:serial src/auto-reply/reply/commands-export-session.test.ts`.
- Evidence after fix: regression test forces an `EEXIST` on the first generated default path and verifies the second write uses the `-2.html` suffix.
- Observed result after fix: test passes, and the reply reports the suffixed export path.
- What was not tested: live chat command execution against a running Gateway.
- Before evidence: code path previously called `writeFile(outputPath, html, "utf-8")` on the default path.

## Root Cause (if applicable)

- Root cause: default export filenames used second-precision timestamps and plain overwrite writes.
- Missing detection / guardrail: no regression covered same-second default export collisions.
- Contributing context (if known): same filename-collision class as the session-memory default filename fix in #77749.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-export-session.test.ts`
- Scenario the test should lock in: default export retries with a numeric suffix when the generated path already exists.
- Why this is the smallest reliable guardrail: it exercises the command reply writer directly without needing a live channel.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Default `/export-session` calls no longer overwrite an existing same-second generated export; they create a suffixed file instead.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v25.9.0, pnpm
- Model/provider: N/A
- Integration/channel (if any): slash command export path
- Relevant config (redacted): N/A

### Steps

1. Force the generated default export path to collide with `EEXIST`.
2. Run the `/export-session` reply builder.
3. Check the write path and returned display path.

### Expected

- The second default path uses a numeric suffix and preserves the previous export.

### Actual

- The test writes `openclaw-session-session--2026-05-05T10-11-12-2.html` after the base name collides.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted regression, targeted formatter, changed gate.
- Edge cases checked: default path collision; explicit output path remains unchanged by the new helper.
- What you did **not** verify: live Gateway command flow.

Verification run:

- `pnpm test:serial src/auto-reply/reply/commands-export-session.test.ts` passed.
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/commands-export-session.ts src/auto-reply/reply/commands-export-session.test.ts` passed.
- `git diff --check` passed.
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed` passed. Blacksmith Testbox `tbx_01kqvm10vbc8pfxh53acyppf5n` stayed queued, so it was stopped and the explicit local escape hatch was used.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: hidden callers may expect default exports to overwrite.
  - Mitigation: explicit output paths still overwrite; only generated default filenames become collision-safe.
