### PR TITLE
fix(web_search): skip redundant provider re-resolution for external Brave plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: enforce allowlist `argPattern` argument restrictions on Linux and macOS as well as Windows, so an entry like `{ pattern: "python3", argPattern: "^safe\.py$" }` no longer silently relaxes to a path-only match on non-Windows hosts. (#75143) Thanks @eleqtrizit.
 - Agents/compaction: disable Pi auto-compaction whenever OpenClaw effectively owns safeguard compaction, including provider-backed safeguard mode, so Pi and OpenClaw no longer fight over long-session compaction. Fixes #73003. (#73839) Thanks @bradhallett.
 - Telegram/streaming: finalize text replies by stopping the edited stream message instead of sending a second answer bubble, so Telegram turns cannot duplicate the streamed final response. (#77947) Thanks @obviyus.
+- web_search/Brave: fix provider selection when Brave is installed as an external plugin and `tools.web.search.provider: "brave"` is explicitly configured — a redundant provider re-resolution at startup could race and return an empty list, causing a spurious `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` warning and treating the explicitly configured provider as absent. Fixes #77676. Thanks @openperf.
 
 ## 2026.5.3-1
 

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -234,7 +234,11 @@ export async function resolveRuntimeWebProviderSurface<
   ) {
     configuredBundledPluginId = undefined;
   }
-  if (params.rawProvider && !configuredBundledPluginId) {
+  if (
+    params.rawProvider &&
+    !configuredBundledPluginId &&
+    !allProviders.some((provider) => provider.id === params.rawProvider)
+  ) {
     const resolveManifestContractOwnerPluginId = await loadResolveManifestContractOwnerPluginId();
     configuredBundledPluginId = resolveManifestContractOwnerPluginId({
       contract: params.contract,

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -1564,4 +1564,94 @@ describe("runtime web tools resolution", () => {
     expect(resolveBundledWebFetchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
     expect(resolvePluginWebFetchProvidersMock).not.toHaveBeenCalled();
   });
+
+  describe("when brave is installed as an external plugin and explicitly configured", () => {
+    const externalBraveImpl = ({
+      value,
+      origin,
+    }: {
+      value: string;
+      origin?: string;
+    }): string | undefined => {
+      if (origin === "bundled" && value === "brave") {
+        return undefined;
+      }
+      return (
+        {
+          brave: "brave",
+          firecrawl: "firecrawl",
+          gemini: "google",
+          grok: "xai",
+          kimi: "moonshot",
+          perplexity: "perplexity",
+        } as Record<string, string | undefined>
+      )[value];
+    };
+
+    const defaultImpl = ({ value }: { value: string }): string | undefined =>
+      (
+        ({
+          brave: "brave",
+          firecrawl: "firecrawl",
+          gemini: "google",
+          grok: "xai",
+          kimi: "moonshot",
+          perplexity: "perplexity",
+        }) as Record<string, string | undefined>
+      )[value];
+
+    beforeEach(() => {
+      loadInstalledPluginIndexInstallRecordsSyncMock.mockReturnValue({
+        brave: { source: "npm", spec: "@openclaw/brave-search" },
+      });
+      resolveManifestContractOwnerPluginIdMock.mockImplementation(externalBraveImpl);
+    });
+
+    afterEach(() => {
+      resolveManifestContractOwnerPluginIdMock.mockImplementation(defaultImpl);
+    });
+
+    it("selects the configured provider without re-invoking provider discovery when found in the first pass", async () => {
+      resolvePluginWebSearchProvidersMock
+        .mockReturnValueOnce(buildTestWebSearchProviders())
+        .mockReturnValueOnce([]);
+
+      const { metadata, context } = await runRuntimeWebTools({
+        config: asConfig({
+          tools: {
+            web: {
+              search: {
+                provider: "brave",
+              },
+            },
+          },
+          plugins: {
+            entries: {
+              brave: {
+                config: {
+                  webSearch: {
+                    apiKey: "brave-api-key", // pragma: allowlist secret
+                  },
+                },
+              },
+            },
+          },
+        }),
+      });
+
+      expect(metadata.search.selectedProvider).toBe("brave");
+      expect(metadata.search.providerSource).toBe("configured");
+      expect(metadata.search.selectedProviderKeySource).toBe("config");
+      expect(context.warnings).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: "WEB_SEARCH_PROVIDER_INVALID_AUTODETECT" }),
+        ]),
+      );
+      expect(resolvePluginWebSearchProvidersMock).toHaveBeenCalledTimes(1);
+      expect(
+        resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock,
+      ).not.toHaveBeenCalled();
+      expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
### Summary

- **Problem**: When `tools.web.search.provider: "brave"` is explicitly configured and Brave is installed as an external (non-bundled) plugin via `openclaw plugins install`, the runtime emits a spurious `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` diagnostic at startup and records `providerSource` as `"none"` instead of `"configured"`. Downstream code that gates behavior on `providerSource === "configured"` therefore sees the explicitly configured provider as absent.

- **Root Cause**: `resolveRuntimeWebProviderSurface` in `src/secrets/runtime-web-tools.shared.ts` resolves the owning plugin for a configured provider via `resolveManifestContractOwnerPluginId({origin: "bundled"})`. For external plugins this lookup correctly returns `undefined`, so `configuredBundledPluginId` remains unset. A secondary resolution block then fires any time `rawProvider` is set and `configuredBundledPluginId` is still `undefined` — including the external-plugin case — and invokes `resolveProviders` a second time. That second call can race with an in-flight plugin registry load, returning an empty provider list. With an empty list the configured provider ID cannot be matched, `configuredProvider` becomes `undefined`, and the diagnostic is emitted. The secondary block was intended only for the case where a scoped-hint first pass had already missed the provider; it was not meant to fire when the first full-discovery pass had already found it.

- **Fix**: Guard the secondary resolution block with an additional condition: only enter it when the configured provider was not found in the first `resolveProviders` result. This preserves the intended recovery behavior — if the first scoped pass missed the provider, the block still widens the scope and retries — while eliminating the redundant and potentially destructive invocation for the external-plugin case where the provider is already present.

- **What changed**:
  - `src/secrets/runtime-web-tools.shared.ts`: added `&& !allProviders.some(provider => provider.id === params.rawProvider)` to the secondary resolution block's guard in `resolveRuntimeWebProviderSurface`.
  - `src/secrets/runtime-web-tools.test.ts`: added a regression test that simulates the exact failure path — external Brave install records, `resolveManifestContractOwnerPluginId` returning `undefined` for `origin: "bundled"`, the second discovery call returning an empty list — and asserts that `selectedProvider` is `"brave"`, `providerSource` is `"configured"`, no `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` warning is emitted, and provider discovery is invoked exactly once.
  - `CHANGELOG.md`: added entry under `## Unreleased`.

- **What did NOT change (scope boundary)**:
  - The `runWebSearch` execution path is not affected by this change and is out of scope.
  - The `origin: "bundled"` lookup inside the secondary block is unchanged; when the block legitimately fires (first pass missed the provider) its behavior is identical to before.
  - No changes to plugin loading, the active-registry contract, or any other web-tool surface.

---

### Reproduction

1. Install Brave as an external plugin: `openclaw plugins install @openclaw/brave-search`
2. Add to your OpenClaw config:
   ```yaml
   tools:
     web:
       search:
         provider: brave
   plugins:
     entries:
       brave:
         config:
           webSearch:
             apiKey: "sk-brave-..."
   ```
3. Start the gateway. A `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` warning appears in startup logs and `providerSource` reads as `"none"` despite the explicit provider configuration.

---

### Risk / Mitigation

- **Risk**: Low. The new guard is purely additive — it prevents the secondary `resolveProviders` call only when the first pass already returned the configured provider. All code paths that depend on the secondary block (scoped-hint recovery, where the first pass misses the provider) continue to enter it because the provider is absent from the first-pass result, making the new condition `false`.
- **Mitigation**: The regression test directly exercises the failure mode by returning an empty list on the second discovery call; the test fails without the fix and passes with it. All existing tests are unmodified and continue to pass.

---

### Change Type / Scope / Linked Issue

- **Type**: Bug fix
- **Scope**: `src/secrets/runtime-web-tools.shared.ts`, `src/secrets/runtime-web-tools.test.ts`, `CHANGELOG.md`
- **Linked issue**: Fixes #77676