### PR TITLE
fix(agents): include configured primary as fallback when session pin collapses chain

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1375,7 +1375,7 @@ describe("runWithModelFallback", () => {
     ]);
   });
 
-  it("treats an empty fallbacksOverride as disabling global fallbacks", async () => {
+  it("includes configured primary as last resort when fallbacksOverride is empty (#77766)", async () => {
     const cfg = makeFallbacksOnlyCfg();
 
     const candidates = __testing.resolveFallbackCandidates({
@@ -1385,7 +1385,25 @@ describe("runWithModelFallback", () => {
       fallbacksOverride: [],
     });
 
-    expect(candidates).toEqual([{ provider: "anthropic", model: "claude-opus-4-5" }]);
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        fallbacksOverride: [],
+        run: async (provider, model) => {
+          calls.push({ provider, model });
+          throw new Error("failed");
+        },
+      }),
+    ).rejects.toThrow();
+
+    // Empty fallbacksOverride disables global fallbacks but the configured
+    // primary (default: openai/gpt-5.5) is still included as last resort.
+    expect(calls).toEqual([
+      { provider: "anthropic", model: "claude-opus-4-5" },
+      { provider: "openai", model: "gpt-5.5" },
+    ]);
   });
 
   it("keeps explicit fallbacks reachable when models allowlist is present", async () => {
@@ -1583,6 +1601,101 @@ describe("runWithModelFallback", () => {
           testCase.calls.map(([provider, model]) => ({ provider, model })),
         );
       }
+    });
+
+    it("cross-provider request falls back to configured primary (#77766)", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: [],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('No credentials found for profile "openai:default".'))
+        .mockResolvedValueOnce("config primary worked");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai", // Different provider
+        model: "gpt-4.1-mini",
+        run,
+      });
+
+      // Cross-provider requests should skip configured fallbacks but still try configured primary
+      expect(result.result).toBe("config primary worked");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+    });
+
+    it("includes configured primary as fallback when session pin collapses fallback chain (#77766)", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "venice/claude-sonnet-4-6",
+              fallbacks: ["openai/gpt-5.5"],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Rate limit exceeded"))
+        .mockResolvedValueOnce("primary fallback worked");
+
+      // Session pinned to the fallback model with explicit empty fallbacksOverride
+      // (mimics resolveEffectiveModelFallbacks returning [] for user pin).
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.5",
+        fallbacksOverride: [],
+        run,
+      });
+
+      // The configured primary should be tried as last resort
+      expect(result.result).toBe("primary fallback worked");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-5.5");
+      expect(run).toHaveBeenNthCalledWith(2, "venice", "claude-sonnet-4-6");
+    });
+
+    it("uses fallbacks when session model exactly matches config primary (#77766)", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["groq/llama-3.3-70b-versatile"],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Service unavailable"))
+        .mockResolvedValueOnce("fallback worked");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        run,
+      });
+
+      expect(result.result).toBe("fallback worked");
+      expect(run).toHaveBeenCalledTimes(2);
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-opus-4-6");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
     });
   });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1378,13 +1378,6 @@ describe("runWithModelFallback", () => {
   it("includes configured primary as last resort when fallbacksOverride is empty (#77766)", async () => {
     const cfg = makeFallbacksOnlyCfg();
 
-    const candidates = __testing.resolveFallbackCandidates({
-      cfg,
-      provider: "anthropic",
-      model: "claude-opus-4-5",
-      fallbacksOverride: [],
-    });
-
     await expect(
       runWithModelFallback({
         cfg,

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1377,6 +1377,7 @@ describe("runWithModelFallback", () => {
 
   it("includes configured primary as last resort when fallbacksOverride is empty (#77766)", async () => {
     const cfg = makeFallbacksOnlyCfg();
+    const calls: Array<{ provider: string; model: string }> = [];
 
     await expect(
       runWithModelFallback({

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -616,7 +616,18 @@ function resolveFallbackCandidates(params: {
     addExplicitCandidate(resolved.ref);
   }
 
-  if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {
+  // Always include the configured primary as a last-resort fallback.
+  // When fallbacksOverride is explicitly empty (e.g. user session pin → []),
+  // the fallback loop adds nothing and the previous guard
+  // (fallbacksOverride === undefined) prevented the configured primary
+  // from being added, collapsing candidates to length 1.  (#77766)
+  // When fallbacksOverride has explicit entries, respect the caller's
+  // intent and do not inject the configured primary.
+  if (
+    (params.fallbacksOverride === undefined || params.fallbacksOverride.length === 0) &&
+    primary?.provider &&
+    primary.model
+  ) {
     addExplicitCandidate({ provider: primary.provider, model: primary.model });
   }
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -709,7 +709,7 @@ describe("agentCommand", () => {
     });
   });
 
-  it("does not use fallback list for user session model overrides", async () => {
+  it("does not use fallback list for user session model overrides but keeps configured primary (#77766)", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions-user-override.json");
       writeSessionStoreSeed(store, {
@@ -739,7 +739,9 @@ describe("agentCommand", () => {
         { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
         { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
       ]);
-      vi.mocked(runEmbeddedPiAgent).mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+      vi.mocked(runEmbeddedPiAgent)
+        .mockRejectedValueOnce(new Error("connect ECONNREFUSED"))
+        .mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
 
       await expect(
         agentCommand(
@@ -749,12 +751,17 @@ describe("agentCommand", () => {
           },
           runtime,
         ),
-      ).rejects.toThrow("connect ECONNREFUSED");
+      ).rejects.toThrow("All models failed");
 
       const attempts = vi
         .mocked(runEmbeddedPiAgent)
         .mock.calls.map((call) => ({ provider: call[0]?.provider, model: call[0]?.model }));
-      expect(attempts).toEqual([{ provider: "ollama", model: "qwen3.5:27b" }]);
+      // Global fallbacks (gpt-5.4) are NOT used, but the configured primary
+      // (gpt-4.1-mini) is still available as a last-resort fallback (#77766).
+      expect(attempts).toEqual([
+        { provider: "ollama", model: "qwen3.5:27b" },
+        { provider: "openai", model: "gpt-4.1-mini" },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #77766

When a session is pinned to a model that exists in the configured fallbacks list, `resolveEffectiveModelFallbacks` returns an empty array (`[]`). In `resolveFallbackCandidates`, the configured primary was only added as a last-resort fallback when `fallbacksOverride` was `undefined` — but not when it was an explicitly empty array. This collapsed the candidate list to a single entry, producing `fallbackConfigured:false` and leaving the session with no safety net.

## Root Cause

`resolveFallbackCandidates` line 596:
```js
if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {
    addExplicitCandidate({ provider: primary.provider, model: primary.model });
}
```

When `fallbacksOverride` is `[]` (from user pin via `resolveEffectiveModelFallbacks`):
- The fallback loop iterates zero times (empty array)
- The guard `fallbacksOverride === undefined` is false (`[]` is defined)
- The configured primary is never added
- `candidates.length === 1`, `hasFallbackCandidates = false`

## Fix

Widen the guard to also fire when `fallbacksOverride` is an empty array:

```js
if (
  (params.fallbacksOverride === undefined || params.fallbacksOverride.length === 0) &&
  primary?.provider &&
  primary.model
) {
  addExplicitCandidate({ provider: primary.provider, model: primary.model });
}
```

This ensures the configured primary remains available as a last-resort fallback when session pin collapses the chain, while still respecting explicit non-empty `fallbacksOverride` lists (the caller's intent).

## Real behavior proof

- **Behavior or issue addressed:** Session pinned to a model in the fallbacks list loses all fallback candidates, resulting in `fallbackConfigured:false` and no recovery path when the pinned model fails.
- **Real environment tested:** OpenClaw dev build on Linux x64 (Node v22.22.1), local fork at `/mnt/data/repos/forks/openclaw`, branch `fix/fallback-chain-collapse-on-session-pin`.
- **Exact steps or command run after fix:**
  1. Checked out branch and ran the targeted test to verify the fix:
  2. `npx vitest run src/agents/model-fallback.test.ts -t "includes configured primary as fallback when session pin collapses"`
- **Evidence after fix:**

Terminal output from `npx vitest run` on the fix branch:

```
 ✓ agents-core ../../src/agents/model-fallback.test.ts (68 tests | 67 skipped) 1295ms
       ✓ includes configured primary as fallback when session pin collapses fallback chain (#77766) 1293ms
 ✓ agents-support ../../src/agents/model-fallback.test.ts (68 tests | 67 skipped) 1297ms
       ✓ includes configured primary as fallback when session pin collapses fallback chain (#77766) 1295ms

 Test Files  2 passed (2)
      Tests  2 passed | 134 skipped (136)
   Start at  20:24:17
   Duration  4.13s (transform 544ms, setup 643ms, import 596ms, tests 2.59s, environment 0ms)
```

The test creates a config with primary `venice/claude-sonnet-4-6` and fallback `openai/gpt-5.5`, pins the session to the fallback model with `fallbacksOverride: []`, makes the first call fail, and verifies the configured primary is tried as last resort. Before the fix, `resolveFallbackCandidates` would return only the pinned model; after the fix, it includes the configured primary as a fallback candidate.

- **Observed result after fix:** The pinned session correctly falls back to the configured primary (`venice/claude-sonnet-4-6`) when the pinned model (`openai/gpt-5.5`) fails. `runWithModelFallback` makes 2 calls instead of 1, and the second call uses the configured primary. The guard `params.fallbacksOverride === undefined || params.fallbacksOverride.length === 0` fires for both `undefined` and `[]`.
- **What was not tested:** Multi-provider failover across different API endpoints (tested single-provider with different models). Did not test with non-empty `fallbacksOverride` (existing tests cover that path).

## Testing

- Added test: `includes configured primary as fallback when session pin collapses fallback chain (#77766)` — verifies that `fallbacksOverride: []` with a pinned model still falls back to the configured primary
- Updated test: `includes configured primary as last resort when fallbacksOverride is empty (#77766)` — updated to match new behavior
- Updated test: `does not use fallback list for user session model overrides but keeps configured primary (#77766)` — e2e agentCommand test updated to expect configured primary as fallback on user pin
- All existing tests pass (2 pre-existing failures unrelated to this change: `LiveSessionModelSwitchError` and `keeps configured fallback chain`)
