### PR TITLE
fix(group-chat): default visibleReplies to automatic, not message_tool_only

### DIFF
--- a/src/auto-reply/reply/source-reply-delivery-mode.test.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.test.ts
@@ -20,12 +20,12 @@ const globalToolOnlyReplyConfig = {
 } as const satisfies OpenClawConfig;
 
 describe("resolveSourceReplyDeliveryMode", () => {
-  it("defaults groups and channels to message-tool-only delivery", () => {
+  it("defaults groups and channels to automatic delivery", () => {
     expect(resolveSourceReplyDeliveryMode({ cfg: emptyConfig, ctx: { ChatType: "channel" } })).toBe(
-      "message_tool_only",
+      "automatic",
     );
     expect(resolveSourceReplyDeliveryMode({ cfg: emptyConfig, ctx: { ChatType: "group" } })).toBe(
-      "message_tool_only",
+      "automatic",
     );
     expect(resolveSourceReplyDeliveryMode({ cfg: emptyConfig, ctx: { ChatType: "direct" } })).toBe(
       "automatic",
@@ -100,7 +100,7 @@ describe("resolveSourceReplyVisibilityPolicy", () => {
     });
   });
 
-  it("suppresses automatic source delivery for default group turns without suppressing typing", () => {
+  it("allows automatic source delivery for default group turns without suppressing typing", () => {
     expect(
       resolveSourceReplyVisibilityPolicy({
         cfg: emptyConfig,
@@ -108,14 +108,14 @@ describe("resolveSourceReplyVisibilityPolicy", () => {
         sendPolicy: "allow",
       }),
     ).toMatchObject({
-      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplyDeliveryMode: "automatic",
       sendPolicyDenied: false,
-      suppressAutomaticSourceDelivery: true,
-      suppressDelivery: true,
-      suppressHookUserDelivery: true,
+      suppressAutomaticSourceDelivery: false,
+      suppressDelivery: false,
+      suppressHookUserDelivery: false,
       suppressHookReplyLifecycle: false,
       suppressTyping: false,
-      deliverySuppressionReason: "sourceReplyDeliveryMode: message_tool_only",
+      deliverySuppressionReason: "",
     });
   });
 

--- a/src/auto-reply/reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.ts
@@ -23,7 +23,7 @@ export function resolveSourceReplyDeliveryMode(params: {
   if (chatType === "group" || chatType === "channel") {
     const configuredMode =
       params.cfg.messages?.groupChat?.visibleReplies ?? params.cfg.messages?.visibleReplies;
-    return configuredMode === "automatic" ? "automatic" : "message_tool_only";
+    return configuredMode === "message_tool" ? "message_tool_only" : "automatic";
   }
   return params.cfg.messages?.visibleReplies === "message_tool" ? "message_tool_only" : "automatic";
 }


### PR DESCRIPTION
## Summary

- `resolveSourceReplyDeliveryMode` had an inverted guard: it treated `"automatic"` as the only opt-in and silently mapped every **unconfigured** group/channel turn to `message_tool_only`
- Any install without `messages.groupChat.visibleReplies` explicitly set — the default for most users — had automatic replies suppressed in Discord guild channels, Telegram groups, and WhatsApp groups
- The bot appeared to receive and process messages normally; it just never posted a reply back to the channel, with no error logged

**Root cause** (`src/auto-reply/reply/source-reply-delivery-mode.ts` line 26):
```ts
// before (broken): undefined falls through to message_tool_only
return configuredMode === "automatic" ? "automatic" : "message_tool_only";

// after (fixed): only suppress when explicitly opted in
return configuredMode === "message_tool" ? "message_tool_only" : "automatic";
```

**Workaround for affected users on 5.4:**
```
openclaw config set messages.groupChat.visibleReplies automatic
```

## Test plan

- [ ] Updated unit tests in `source-reply-delivery-mode.test.ts` to assert `automatic` for unconfigured group/channel turns
- [ ] Existing tests covering explicit `"message_tool"` opt-in and `"automatic"` override are unchanged and still pass
- [ ] Verify Discord guild channel, Telegram group, and WhatsApp group replies restore without config changes on a clean install

🤖 Generated with [Claude Code](https://claude.ai/claude-code)