### PR TITLE
[AI-assisted] fix: throw on registerTool without contracts.tools instead of silent failure

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2976,7 +2976,9 @@ module.exports = { id: "throws-after-import", register() {} };`,
       expect.arrayContaining([
         expect.objectContaining({
           pluginId: "undeclared-tool-owner",
-          message: "plugin must declare contracts.tools before registering agent tools",
+          message: expect.stringContaining(
+            "must declare contracts.tools before registering agent tools",
+          ),
         }),
       ]),
     );
@@ -3018,7 +3020,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
       expect.arrayContaining([
         expect.objectContaining({
           pluginId: "wrong-tool-owner",
-          message: "plugin must declare contracts.tools for: runtime_tool",
+          message: expect.stringContaining("must declare contracts.tools for: runtime_tool"),
         }),
       ]),
     );

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -532,7 +532,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         source: record.source,
         message: "plugin must declare contracts.tools before registering agent tools",
       });
-      return;
+      throw new Error(
+        `plugin ${record.id} must declare contracts.tools before registering agent tools`,
+      );
     }
     const names = [...(opts?.names ?? []), ...(opts?.name ? [opts.name] : [])];
     const optional = opts?.optional === true;
@@ -555,7 +557,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         source: record.source,
         message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
       });
-      return;
+      throw new Error(
+        `plugin ${record.id} must declare contracts.tools for: ${undeclared.join(", ")}`,
+      );
     }
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
@@ -1774,7 +1778,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         source: record.source,
         message: `plugin must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
       });
-      return;
+      throw new Error(
+        `plugin ${record.id} must declare contracts.tools for tool metadata: ${undeclared.join(", ")}`,
+      );
     }
     // Uniqueness is scoped to (pluginId + toolName): different plugins may each
     // register metadata under the same toolName for their own tools, but a given


### PR DESCRIPTION
## Root Cause

`api.registerTool()` in `src/plugins/registry.ts` silently pushes a diagnostic and returns when the plugin manifest does not declare `contracts.tools`. The plugin's own code receives no error or warning — the only signal is a gateway-level diagnostic log (`plugin must declare contracts.tools before registering agent tools`) that most plugin developers never see.

This was introduced as part of the manifest-first tool contract enforcement (2026.5.2) but the enforcement path chose a non-throwing diagnostic instead of an error, making it impossible for plugins to detect the failed registration.

## Fix

Replace the silent `return` with a `throw new Error(...)` in three guard paths within `registerTool` and `registerToolMetadata`:

1. **No `contracts.tools` declared at all** — throws immediately with the plugin ID and a clear message.
2. **Tool names not in the declared contract** — throws with the list of undeclared tool names.
3. **Tool metadata for undeclared tools** — throws with the undeclared tool names.

The loader's existing try/catch around `register(api)` catches the error and records it as a plugin load failure with a diagnostic, so the plugin is properly marked as failed and the error is surfaced in logs.

## Regression Test Plan

- Existing tests in `src/plugins/loader.test.ts` ("rejects plugin tool registration without manifest tool ownership" and "rejects plugin tool names outside the manifest tool contract") updated to match the new error message format.
- All 123 tests in `loader.test.ts` pass.
- The throw does not change the external contract: `registerTool` return type remains `void`, and the loader already handles thrown errors from plugin `register()` calls.

## Security Impact

None. This change makes a silent failure loud — it does not alter any security boundary or access control.

Closes #77800