### PR TITLE
fix(plugins): explain source-only package diagnostics (#77835)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/diagnostics: make source-only TypeScript package warnings actionable by explaining that missing compiled runtime output is a publisher packaging issue and pointing users to update/reinstall or disable/uninstall the plugin. Fixes #77835. Thanks @googlerest.
 - TUI: skip the generic CLI respawn wrapper for interactive launches, exit cleanly on terminal loss, and refuse to restore heartbeat sessions as the remembered chat session, preventing stale heartbeat history and orphaned `openclaw-tui` processes on first boot. Thanks @vincentkoc.
 - Doctor/sessions: move heartbeat-poisoned default main session store entries to recovery keys and clear stale TUI restore pointers, so `doctor --fix` can repair instances already stuck on `agent:main:main` heartbeat history. Thanks @vincentkoc.
 - Agents/context engines: keep hidden OpenClaw runtime-context custom messages out of context-engine assemble, afterTurn, and ingest hooks so transcript reconstruction plugins only see conversation messages. Thanks @vincentkoc.

--- a/docs/channels/wechat.md
+++ b/docs/channels/wechat.md
@@ -149,6 +149,11 @@ openclaw plugins install "@tencent-weixin/openclaw-weixin" --force
 openclaw gateway restart
 ```
 
+If startup reports that the installed plugin package `requires compiled runtime
+output for TypeScript entry`, the npm package was published without the compiled
+JavaScript runtime files OpenClaw needs. Update/reinstall after the plugin
+publisher ships a fixed package, or temporarily disable/uninstall the plugin.
+
 Temporary disable:
 
 ```bash

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -164,6 +164,12 @@ Packaged installs must ship that JavaScript runtime output. The TypeScript
 source fallback is for source checkouts and local development paths, not for
 npm packages installed into OpenClaw's managed plugin root.
 
+If a managed package warning says it `requires compiled runtime output for
+TypeScript entry ...`, the package was published without the JavaScript files
+OpenClaw needs at runtime. That is a plugin packaging issue, not a local config
+problem. Update or reinstall the plugin after the publisher republishes compiled
+JavaScript, or disable/uninstall that plugin until a fixed package is available.
+
 Use `openclaw.runtimeExtensions` when published runtime files do not live at the
 same paths as the source entries. When present, `runtimeExtensions` must contain
 exactly one entry for every `extensions` entry. Mismatched lists fail install and

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -163,7 +163,7 @@ describe("loadConfigForInstall", () => {
           {
             path: "plugins",
             message:
-              "plugin: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, index.js, index.mjs, index.cjs",
+              "plugin: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, index.js, index.mjs, index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.",
           },
         ],
       }),

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -769,7 +769,9 @@ describe("discoverOpenClawPlugins", () => {
           entry.level === "warn" &&
           entry.pluginId === "source-only-pack" &&
           entry.message.includes("requires compiled runtime output") &&
-          entry.message.includes("./dist/index.js"),
+          entry.message.includes("./dist/index.js") &&
+          entry.message.includes("plugin packaging issue") &&
+          entry.message.includes("disable/uninstall the plugin"),
       ),
     ).toBe(true);
   });

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -949,6 +949,8 @@ describe("installPluginFromArchive", () => {
       expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.INVALID_OPENCLAW_EXTENSIONS);
       expect(result.error).toContain("requires compiled runtime output");
       expect(result.error).toContain("./dist/index.js");
+      expect(result.error).toContain("plugin packaging issue");
+      expect(result.error).toContain("disable/uninstall the plugin");
     }
   });
 

--- a/src/plugins/package-entry-resolution.ts
+++ b/src/plugins/package-entry-resolution.ts
@@ -87,7 +87,7 @@ function missingCompiledRuntimeEntryMessage(params: {
   entry: string;
   candidates: readonly string[];
 }): string {
-  return `${params.label} requires compiled runtime output for TypeScript entry ${params.entry}: expected ${params.candidates.join(", ")}`;
+  return `${params.label} requires compiled runtime output for TypeScript entry ${params.entry}: expected ${params.candidates.join(", ")}. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.`;
 }
 
 async function validatePackageExtensionEntry(params: {


### PR DESCRIPTION
## Summary

Fixes #77835.

Source-only TypeScript package diagnostics currently say an installed plugin package requires compiled runtime output, but they do not tell operators what action is available. For packages such as `@tencent-weixin/openclaw-weixin@2.3.1`, the missing compiled JS is a publisher packaging issue rather than a local config problem.

This PR makes that diagnostic actionable by telling users to update/reinstall after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. It also documents the same recovery path in the general plugin docs and WeChat troubleshooting page.

## Changes

- `src/plugins/package-entry-resolution.ts`: extend the missing compiled runtime output diagnostic with user action and scope.
- `src/plugins/discovery.test.ts`: assert startup/discovery warnings include the actionable guidance.
- `src/plugins/install.test.ts`: assert install-time rejection includes the same guidance.
- `src/cli/plugins-install-config.test.ts`: keep official reinstall recovery tolerant of the new longer diagnostic.
- `docs/tools/plugin.md` and `docs/channels/wechat.md`: document the publisher-package fix path.

## Scout audit

- Audit A (existing helper): reused existing `missingCompiledRuntimeEntryMessage`; no new classifier/predicate added.
- Audit B (shared callers): one shared diagnostic helper, contract preserved; message text becomes more actionable without changing severity or control flow.
- Audit C (broader rival): no fresh open PR found for #77835 or the exact source-only compiled-output diagnostic.

## Real behavior proof

- **Behavior or issue addressed**: Operators who hit a source-only TypeScript managed plugin package now receive an actionable diagnostic explaining the missing compiled output is a plugin packaging issue and giving update/reinstall or disable/uninstall recovery steps.
- **Real environment tested**: Local OpenClaw checkout on branch `fix/77835-plugin-source-only-actionable-diagnostic`, based on `origin/main` `0c977cd687`; repository plugin discovery/install and CLI install-config test shards.
- **Exact steps or command run after this patch**:
  - `pnpm test src/plugins/discovery.test.ts src/plugins/install.test.ts src/cli/plugins-install-config.test.ts src/cli/plugins-cli.install.test.ts`
  - `pnpm exec oxlint CHANGELOG.md src/plugins/package-entry-resolution.ts src/plugins/discovery.test.ts src/plugins/install.test.ts src/cli/plugins-install-config.test.ts src/cli/plugins-cli.install.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/plugins/package-entry-resolution.ts src/plugins/discovery.test.ts src/plugins/install.test.ts src/cli/plugins-install-config.test.ts src/cli/plugins-cli.install.test.ts docs/tools/plugin.md docs/channels/wechat.md CHANGELOG.md`
  - `pnpm check:changed`
- **Evidence after fix**: Terminal output from after-patch runs:

```text
Test Files  2 passed (2)
Tests  89 passed (89)
Test Files  2 passed (2)
Tests  150 passed (150)
[test] passed 2 Vitest shards in 9.84s

Found 0 warnings and 0 errors.
All matched files use the correct format.
pnpm check:changed exited 0.
```

- **Observed result after fix**: Discovery/install diagnostics now include `plugin packaging issue` and `disable/uninstall the plugin`; all focused plugin/CLI tests and changed-file guardrails passed.
- **What was not tested**: Did not install the broken `@tencent-weixin/openclaw-weixin@2.3.1` package in a live Gateway; verification used repository package discovery/install coverage and docs checks.
### Additional real behavior proof after maintainer-bot review

After the initial review requested real plugin output, I reproduced the source-only package shape against this branch with actual plugin install and discovery code paths:

```bash
node --import tsx --input-type=module <<'NODE'
# creates a temp plugin package with openclaw.extensions=["./src/index.ts"]
# and no compiled JS, then runs installPluginFromDir() and discoverOpenClawPlugins()
NODE
```

Observed after-fix output:

```text
scenario=install-source-only-package
install.ok=false
install.error=package install requires compiled runtime output for TypeScript entry ./src/index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./src/index.js, ./src/index.mjs, ./src/index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.
scenario=discover-managed-source-only-package
candidates=<none>
warn:source-only-pack:installed plugin package requires compiled runtime output for TypeScript entry src/index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, src/index.js, src/index.mjs, src/index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.
```
