### PR TITLE
fix(update): stop dev updates after fetch failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,7 @@ Docs: https://docs.openclaw.ai
 - Ollama/thinking: expose the lightweight Ollama provider thinking profile through the public provider-policy artifact too, so reasoning-capable Ollama models such as `ollama/deepseek-v4-pro:cloud` keep `/think max` available even before the full plugin runtime activates. (#77617, fixes #77612) Thanks @rriggs and @yfge.
 - Codex/app-server: stabilize transcript mirror dedupe across re-mirrored turns so reordered snapshots no longer drop reasoning entries or duplicate the assistant reply. Refs #77012. (#77046) Thanks @openperf.
 - Agents/auth-profiles: do not record request-shape (`format`) rejections as auth-profile health failures, so a single per-session transcript-shape error (such as a prefill-strict 400 "conversation must end with a user message") no longer triggers a profile-wide cooldown that blocks every other healthy session sharing the same auth profile. Refs #77228. (#77280) Thanks @openperf.
+- CLI/update: stop dev-channel source updates immediately when `git fetch` fails, so tag conflicts cannot keep preflight, rebase, or build steps running against stale refs while the Gateway is still on the old runtime. (#77845) Thanks @obviyus.
 
 ## 2026.5.3-1
 

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -326,6 +326,28 @@ describe("runGatewayUpdate", () => {
     expect(calls.some((call) => call.includes("rebase"))).toBe(false);
   });
 
+  it.each([
+    { name: "upstream", options: {} },
+    { name: "target ref", options: { devTargetRef: "main" } },
+  ] as const)("stops dev update when fetch fails before resolving $name", async ({ options }) => {
+    await setupGitCheckout();
+    const fetchCommand = `git -C ${tempDir} fetch --all --prune --tags`;
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [fetchCommand]: {
+        code: 1,
+        stderr: "! [rejected] v2026.5.3 -> v2026.5.3 (would clobber existing tag)",
+      },
+    });
+
+    const result = await runWithRunner(runner, options);
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toBe("fetch-failed");
+    expect(calls).toContain(fetchCommand);
+    expect(calls.slice(calls.indexOf(fetchCommand) + 1)).toEqual([]);
+  });
+
   it("aborts rebase on failure", async () => {
     await setupGitCheckout();
     const { runner, calls } = createRunner({

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -737,11 +737,11 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       steps,
       durationMs: Date.now() - startedAt,
     });
-    const runGitCheckoutOrFail = async (name: string, argv: string[]) => {
-      const checkoutStep = await runStep(step(name, argv, gitRoot));
-      steps.push(checkoutStep);
-      if (checkoutStep.exitCode !== 0) {
-        return buildGitErrorResult("checkout-failed");
+    const runRequiredGitStep = async (name: string, argv: string[], reason: string) => {
+      const gitStep = await runStep(step(name, argv, gitRoot));
+      steps.push(gitStep);
+      if (gitStep.exitCode !== 0) {
+        return buildGitErrorResult(reason);
       }
       return null;
     };
@@ -770,22 +770,24 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
 
     if (channel === "dev") {
       if (needsCheckoutMain) {
-        const failure = await runGitCheckoutOrFail(`git checkout ${DEV_BRANCH}`, [
-          "git",
-          "-C",
-          gitRoot,
-          "checkout",
-          DEV_BRANCH,
-        ]);
+        const failure = await runRequiredGitStep(
+          `git checkout ${DEV_BRANCH}`,
+          ["git", "-C", gitRoot, "checkout", DEV_BRANCH],
+          "checkout-failed",
+        );
         if (failure) {
           return failure;
         }
       }
 
-      const fetchStep = await runStep(
-        step("git fetch", ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"], gitRoot),
+      const fetchFailure = await runRequiredGitStep(
+        "git fetch",
+        ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"],
+        "fetch-failed",
       );
-      steps.push(fetchStep);
+      if (fetchFailure) {
+        return fetchFailure;
+      }
       let preflightBaseSha: string | null = null;
       let candidates: string[] = [];
       if (devTargetRef) {
@@ -1091,14 +1093,11 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       }
 
       if (devTargetRef) {
-        const failure = await runGitCheckoutOrFail(`git checkout ${selectedSha}`, [
-          "git",
-          "-C",
-          gitRoot,
-          "checkout",
-          "--detach",
-          selectedSha,
-        ]);
+        const failure = await runRequiredGitStep(
+          `git checkout ${selectedSha}`,
+          ["git", "-C", gitRoot, "checkout", "--detach", selectedSha],
+          "checkout-failed",
+        );
         if (failure) {
           return failure;
         }
@@ -1133,20 +1132,13 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         }
       }
     } else {
-      const fetchStep = await runStep(
-        step("git fetch", ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"], gitRoot),
+      const fetchFailure = await runRequiredGitStep(
+        "git fetch",
+        ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"],
+        "fetch-failed",
       );
-      steps.push(fetchStep);
-      if (fetchStep.exitCode !== 0) {
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "fetch-failed",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
+      if (fetchFailure) {
+        return fetchFailure;
       }
 
       const tag = await resolveChannelTag(runCommand, gitRoot, timeoutMs, channel);
@@ -1162,14 +1154,11 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         };
       }
 
-      const failure = await runGitCheckoutOrFail(`git checkout ${tag}`, [
-        "git",
-        "-C",
-        gitRoot,
-        "checkout",
-        "--detach",
-        tag,
-      ]);
+      const failure = await runRequiredGitStep(
+        `git checkout ${tag}`,
+        ["git", "-C", gitRoot, "checkout", "--detach", tag],
+        "checkout-failed",
+      );
       if (failure) {
         return failure;
       }


### PR DESCRIPTION
## Summary
- make required git steps share one failure path in the source updater
- stop dev-channel updates immediately when `git fetch --all --prune --tags` fails
- cover both normal upstream and explicit dev target refs so stale refs cannot keep preflight/rebase moving

## Verification
- `pnpm test -- src/infra/update-runner.test.ts -t 'stops dev update when fetch fails'`
- `pnpm test -- src/infra/update-runner.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/update-runner.ts src/infra/update-runner.test.ts CHANGELOG.md`
- `git diff --check`
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
