### PR TITLE
fix(agents): preserve media tools for alsoAllow policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tools/media: preserve implicit allow-all semantics from `tools.alsoAllow`-only policies when constructing built-in media generation tools, so configured image/video/music generation tools become live without forcing `tools.allow: ["*", ...]`. Fixes #77841. Thanks @trialanderrorstudios.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -13,6 +13,7 @@ import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot
 import { clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { __testing, createOpenClawTools } from "./openclaw-tools.js";
+import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "./tool-policy.js";
 import * as pdfModelConfigModule from "./tools/pdf-tool.model-config.js";
 
 function createAuthStore(providers: string[] = []): AuthProfileStore {
@@ -216,6 +217,43 @@ describe("optional media tool factory planning", () => {
       musicGenerate: true,
       pdf: true,
     });
+  });
+
+  it("preserves implicit allow-all from alsoAllow-only policy for built-in media factories", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+          videoGenerationModel: { primary: "video-owner/model" },
+          musicGenerationModel: { primary: "music-owner/model" },
+        },
+      },
+    };
+    const allowlistFromAlsoAllowOnlyPolicy = ["group:memory", DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY];
+    installSnapshot(config, []);
+
+    expect(
+      __testing.resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(),
+        toolAllowlist: allowlistFromAlsoAllowOnlyPolicy,
+      }),
+    ).toEqual({
+      imageGenerate: true,
+      videoGenerate: true,
+      musicGenerate: true,
+      pdf: false,
+    });
+
+    const toolNames = createOpenClawTools({
+      config,
+      authProfileStore: createAuthStore(),
+      pluginToolAllowlist: allowlistFromAlsoAllowOnlyPolicy,
+    }).map((tool) => tool.name);
+
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["image_generate", "video_generate", "music_generate"]),
+    );
   });
 
   it("skips tools that the resolved allowlist cannot expose", () => {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -23,6 +23,7 @@ import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "./tool-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -110,6 +111,21 @@ function mergeFactoryPolicyList(...lists: Array<string[] | undefined>): string[]
   return merged.length > 0 ? Array.from(new Set(merged)) : undefined;
 }
 
+function mergeBuiltInFactoryAllowlist(...lists: Array<string[] | undefined>): string[] | undefined {
+  const allowlist = mergeFactoryPolicyList(...lists);
+  if (
+    !allowlist?.some(
+      (entry) => typeof entry === "string" && entry.trim() === DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+    )
+  ) {
+    return allowlist;
+  }
+  const withoutDefaultPluginMarker = allowlist.filter(
+    (entry) => typeof entry !== "string" || entry.trim() !== DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+  );
+  return Array.from(new Set(["*", ...withoutDefaultPluginMarker]));
+}
+
 function resolveImageToolFactoryAvailable(params: {
   config?: OpenClawConfig;
   agentDir?: string;
@@ -181,7 +197,10 @@ function resolveOptionalMediaToolFactoryPlan(params: {
   toolDenylist?: string[];
 }): OptionalMediaToolFactoryPlan {
   const defaults = params.config?.agents?.defaults;
-  const toolAllowlist = mergeFactoryPolicyList(params.config?.tools?.allow, params.toolAllowlist);
+  const toolAllowlist = mergeBuiltInFactoryAllowlist(
+    params.config?.tools?.allow,
+    params.toolAllowlist,
+  );
   const toolDenylist = mergeFactoryPolicyList(params.config?.tools?.deny, params.toolDenylist);
   const allowImageGenerate = isToolAllowedByFactoryPolicy({
     toolName: "image_generate",


### PR DESCRIPTION
## Summary
- preserve implicit allow-all semantics from tools.alsoAllow-only policies when constructing built-in media generation tools
- keep the default-plugin discovery marker bounded to plugin loading while letting configured image/video/music generation tools become live
- add regression coverage for the issue path and a changelog entry

Fixes #77841.

## Real behavior proof

**Behavior or issue addressed:** `tools.alsoAllow` without `tools.allow` should preserve implicit allow-all semantics for built-in media generation tools. The fixed behavior is that configured `image_generate`, `music_generate`, and `video_generate` appear in `tools.effective` instead of staying catalog-only / Not Live.

**Real environment tested:** Real local OpenClaw Gateway started from this PR branch on macOS, `OpenClaw 2026.5.4 (0a3e57d)`, with an isolated config under `/private/tmp/openclaw-77841-proof-token/state`. The config used `tools.alsoAllow: ["group:memory"]`, explicit `agents.defaults.*GenerationModel` values, and enabled `openai`/`google` provider plugins.

**Exact steps or command run after this patch:** Started a real Gateway, created a real session over Gateway RPC, then called `tools.effective` for that session:

```text
OPENCLAW_STATE_DIR=/private/tmp/openclaw-77841-proof-token/state \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-77841-proof-token/state/openclaw.json \
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_NO_ONBOARD=1 \
node scripts/run-node.mjs gateway run --port 19041 --bind loopback --auth token --token proof-token --allow-unconfigured --ws-log compact

OPENCLAW_STATE_DIR=/private/tmp/openclaw-77841-proof-token/state \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-77841-proof-token/state/openclaw.json \
node scripts/run-node.mjs gateway call sessions.create \
--token proof-token \
--params '{"key":"main","agentId":"main","label":"77841 proof"}' \
--json --timeout 15000

OPENCLAW_STATE_DIR=/private/tmp/openclaw-77841-proof-token/state \
OPENCLAW_CONFIG_PATH=/private/tmp/openclaw-77841-proof-token/state/openclaw.json \
node scripts/run-node.mjs gateway call tools.effective \
--token proof-token \
--params '{"sessionKey":"agent:main:main"}' \
--json --timeout 15000
```

**Evidence after fix:** Terminal output from the real Gateway run:

```text
2026-05-05T09:58:20.462-04:00 [gateway] http server listening (10 plugins: acpx, bonjour, browser, device-pair, file-transfer, google, memory-core, openai, phone-control, talk-voice; 1.7s)
2026-05-05T09:58:20.668-04:00 [gateway] ready
```

Session creation output:

```json
{
  "ok": true,
  "key": "agent:main:main",
  "sessionId": "b21b9865-22b6-4e8d-affa-4202a3bf48b8",
  "runStarted": false
}
```

Relevant `tools.effective` excerpts from the live Gateway response:

```json
{
  "id": "image_generate",
  "label": "Image Generation",
  "source": "core"
}
```

```json
{
  "id": "music_generate",
  "label": "Music Generation",
  "source": "core"
}
```

```json
{
  "id": "video_generate",
  "label": "Video Generation",
  "source": "core"
}
```

**Observed result after fix:** `tools.effective` included all three configured media generation tools (`image_generate`, `music_generate`, and `video_generate`) as live built-in tools while the config still used `tools.alsoAllow: ["group:memory"]` without `tools.allow`.

**What was not tested:** I did not run a live provider media-generation request; this proof only verifies Gateway tool availability/effective inventory for the reported Not Live regression. Provider auth/readiness and actual image/video/music generation remain covered by their existing provider tests and runtime behavior.

## Tests
- pnpm test src/agents/openclaw-tools.media-factory-plan.test.ts
- pnpm test src/agents/openclaw-tools.media-factory-plan.test.ts src/agents/tool-policy.test.ts src/agents/tools-effective-inventory.test.ts src/gateway/tools-invoke-http.test.ts
- pnpm check:changed
