### PR TITLE
fix(gateway): fast-path qualified session-list model refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugin skills/Windows: publish plugin-provided skill directories as junctions on Windows so standard users without Developer Mode can register plugin skills without symlink EPERM failures. Fixes #77958. (#77971) Thanks @hclsys and @jarro.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
+- Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.
 - PR triage: mark external pull requests with `proof: supplied` when Barnacle finds structured real behavior proof, keep stale negative proof labels in sync across CRLF-edited PR bodies, and let ClawSweeper own the stronger `proof: sufficient` judgement.
 - Sessions CLI: show the selected agent runtime in the `openclaw sessions` table so terminal output matches the runtime visibility already present in JSON/status surfaces. Thanks @vincentkoc.
 - Talk/voice: unify realtime relay, transcription relay, managed-room handoff, Voice Call, Google Meet, VoiceClaw, and native clients around a shared Talk session controller and add the Gateway-managed `talk.session.*` RPC surface.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8,6 +8,7 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness";
 import {
+  buildAgentRuntimePlan,
   embeddedAgentLog,
   nativeHookRelayTesting,
   onAgentEvent,
@@ -61,25 +62,25 @@ function createParamsWithRuntimePlan(
   workspaceDir: string,
 ): EmbeddedRunAttemptParams {
   const params = createParams(sessionFile, workspaceDir);
-  useLightweightCodexRuntimePlan(params);
-  return params;
+  return {
+    ...params,
+    runtimePlan: buildCodexRuntimePlan(params, workspaceDir),
+  };
 }
 
-function useLightweightCodexRuntimePlan(params: EmbeddedRunAttemptParams): void {
-  params.runtimePlan = {
-    auth: {},
-    prompt: {
-      resolveSystemPromptContribution: () => undefined,
-    },
-    tools: {
-      normalize: (tools: unknown) => tools,
-      logDiagnostics: () => undefined,
-    },
-    observability: {
-      resolvedRef: `${params.provider}/${params.modelId}`,
-      harnessId: "codex",
-    },
-  } as unknown as NonNullable<EmbeddedRunAttemptParams["runtimePlan"]>;
+function buildCodexRuntimePlan(params: EmbeddedRunAttemptParams, workspaceDir: string) {
+  return buildAgentRuntimePlan({
+    provider: params.provider,
+    modelId: params.modelId,
+    model: params.model,
+    modelApi: params.model.api,
+    harnessId: "codex",
+    harnessRuntime: "codex",
+    config: params.config,
+    workspaceDir,
+    agentDir: tempDir,
+    thinkingLevel: params.thinkLevel,
+  });
 }
 
 function threadStartResult(threadId = "thread-1") {
@@ -504,7 +505,7 @@ describe("runCodexAppServerAttempt", () => {
     params.config = { tools: { profile: "coding" } };
     params.sourceReplyDeliveryMode = "message_tool_only";
     params.messageProvider = "whatsapp";
-    useLightweightCodexRuntimePlan(params);
+    params.runtimePlan = buildCodexRuntimePlan(params, workspaceDir);
     let seenForceMessageTool: boolean | undefined;
     __testing.setOpenClawCodingToolsFactoryForTests((options) => {
       seenForceMessageTool = options?.forceMessageTool;
@@ -545,7 +546,7 @@ describe("runCodexAppServerAttempt", () => {
       session: { store: sessionsPath, mainKey: "main", scope: "per-sender" },
       tools: { profile: "coding" },
     };
-    useLightweightCodexRuntimePlan(params);
+    params.runtimePlan = buildCodexRuntimePlan(params, workspaceDir);
     await fs.writeFile(
       sessionsPath,
       JSON.stringify({

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -207,6 +207,7 @@ export function resolveAllowlistModelKey(
 export function resolveDefaultModelForAgent(params: {
   cfg: OpenClawConfig;
   agentId?: string;
+  allowPluginNormalization?: boolean;
 }): ModelRef {
   const agentModelOverride = params.agentId
     ? resolveAgentEffectiveModelPrimary(params.cfg, params.agentId)
@@ -231,6 +232,7 @@ export function resolveDefaultModelForAgent(params: {
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    allowPluginNormalization: params.allowPluginNormalization,
   });
 }
 

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -152,7 +152,7 @@ test("sessions.list uses the gateway model catalog for effective thinking defaul
       sessions: expect.arrayContaining([
         expect.objectContaining({
           key: "agent:main:main",
-          thinkingDefault: undefined,
+          thinkingDefault: "medium",
           thinkingOptions: ["off", "minimal", "low", "medium", "high"],
         }),
       ]),

--- a/src/gateway/session-utils.plugin-runtime.test.ts
+++ b/src/gateway/session-utils.plugin-runtime.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+
+const normalizeProviderModelIdWithPluginMock = vi.fn();
+
+vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: (params: unknown) =>
+    normalizeProviderModelIdWithPluginMock(params),
+}));
+
+describe("gateway session list plugin runtime normalization", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    normalizeProviderModelIdWithPluginMock.mockReset();
+  });
+
+  it("skips provider runtime normalization for lightweight list rows", async () => {
+    const { listSessionsFromStoreAsync } = await import("./session-utils.js");
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "custom-provider/custom-legacy-model" } },
+      },
+    } as OpenClawConfig;
+    const store = Object.fromEntries(
+      Array.from({ length: 3 }, (_value, index) => [
+        `session-${index}`,
+        { sessionId: `session-${index}`, updatedAt: 1_000 - index } satisfies SessionEntry,
+      ]),
+    );
+
+    const listed = await listSessionsFromStoreAsync({
+      cfg,
+      storePath: "",
+      store,
+      opts: {},
+    });
+
+    expect(listed.sessions.map((session) => session.model)).toEqual([
+      "custom-legacy-model",
+      "custom-legacy-model",
+      "custom-legacy-model",
+    ]);
+    expect(normalizeProviderModelIdWithPluginMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps provider runtime normalization for detail rows", async () => {
+    normalizeProviderModelIdWithPluginMock.mockImplementation(
+      ({ provider, context }: { provider?: string; context?: { modelId?: string } }) => {
+        if (provider === "custom-provider" && context?.modelId === "custom-legacy-model") {
+          return "custom-modern-model";
+        }
+        return undefined;
+      },
+    );
+
+    const { buildGatewaySessionRow } = await import("./session-utils.js");
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "custom-provider/custom-legacy-model" } },
+      },
+    } as OpenClawConfig;
+
+    const row = buildGatewaySessionRow({
+      cfg,
+      storePath: "",
+      store: {},
+      key: "main",
+    });
+
+    expect(row.model).toBe("custom-modern-model");
+    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalled();
+  });
+});

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -259,7 +259,7 @@ describe("gateway session utils", () => {
     expect(row.thinkingDefault).toBe("medium");
   });
 
-  test("async session list skips per-row thinking enrichment for lightweight rows", async () => {
+  test("async session list reuses thinking metadata for lightweight rows", async () => {
     const resolveThinkingProfile = vi.fn(() => ({
       levels: [{ id: "off" as const }, { id: "medium" as const }],
       defaultLevel: "medium" as const,
@@ -298,10 +298,16 @@ describe("gateway session utils", () => {
     });
 
     expect(result.sessions).toHaveLength(5);
-    expect(result.sessions.every((session) => session.thinkingLevels === undefined)).toBe(true);
-    expect(result.sessions.every((session) => session.thinkingOptions === undefined)).toBe(true);
-    expect(result.sessions.every((session) => session.thinkingDefault === undefined)).toBe(true);
-    expect(resolveThinkingProfile).toHaveBeenCalledTimes(2);
+    expect(
+      result.sessions.every((session) =>
+        session.thinkingLevels?.some((level) => level.id === "medium"),
+      ),
+    ).toBe(true);
+    expect(result.sessions.every((session) => session.thinkingOptions?.includes("medium"))).toBe(
+      true,
+    );
+    expect(result.sessions.every((session) => session.thinkingDefault === "medium")).toBe(true);
+    expect(resolveThinkingProfile).toHaveBeenCalled();
   });
 
   test("session list thinking cache preserves case-distinct model catalog entries", async () => {
@@ -1293,9 +1299,9 @@ describe("listSessionsFromStore selected model display", () => {
       );
       expect(listed.sessions[0]?.agentRuntime).toEqual({ id: "pi", source: "implicit" });
       expect(listed.sessions[0]?.thinkingLevel).toBeUndefined();
-      expect(listed.sessions[0]?.thinkingLevels).toBeUndefined();
-      expect(listed.sessions[0]?.thinkingOptions).toBeUndefined();
-      expect(listed.sessions[0]?.thinkingDefault).toBeUndefined();
+      expect(listed.sessions[0]?.thinkingLevels?.length).toBeGreaterThan(0);
+      expect(listed.sessions[0]?.thinkingOptions?.length).toBeGreaterThan(0);
+      expect(listed.sessions[0]?.thinkingDefault).toBeDefined();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -1537,15 +1543,15 @@ describe("listSessionsFromStore selected model display", () => {
         "agent:main:main": {
           sessionId: "sess-main",
           updatedAt: Date.now(),
-          providerOverride: "vercel-ai-gateway",
-          modelOverride: "anthropic/claude-haiku-4-5",
+          providerOverride: "anthropic",
+          modelOverride: "sonnet-4.6",
         } as SessionEntry,
       },
       opts: {},
     });
 
-    expect(result.sessions[0]?.modelProvider).toBe("vercel-ai-gateway");
-    expect(result.sessions[0]?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
+    expect(result.sessions[0]?.model).toBe("claude-sonnet-4-6");
   });
 });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1440,6 +1440,44 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.modelProvider).toBe("anthropic");
     expect(result.sessions[0]?.model).toBe("claude-opus-4-7");
   });
+
+  test("uses qualified selected defaults for rows without runtime model metadata", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        list: [
+          { id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } },
+          {
+            id: "review",
+            model: { primary: "vercel-ai-gateway/anthropic/claude-haiku-4-5" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: 2,
+        } as SessionEntry,
+        "agent:review:review": {
+          sessionId: "sess-review",
+          updatedAt: 1,
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(
+      result.sessions.map((session) => [session.key, session.modelProvider, session.model]),
+    ).toEqual([
+      ["agent:main:main", "anthropic", "claude-sonnet-4-6"],
+      ["agent:review:review", "vercel-ai-gateway", "anthropic/claude-haiku-4-5"],
+    ]);
+  });
 });
 
 describe("resolveSessionModelIdentityRef", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -259,7 +259,7 @@ describe("gateway session utils", () => {
     expect(row.thinkingDefault).toBe("medium");
   });
 
-  test("session list memoizes repeated thinking enrichment per provider model", async () => {
+  test("async session list skips per-row thinking enrichment for lightweight rows", async () => {
     const resolveThinkingProfile = vi.fn(() => ({
       levels: [{ id: "off" as const }, { id: "medium" as const }],
       defaultLevel: "medium" as const,
@@ -298,7 +298,10 @@ describe("gateway session utils", () => {
     });
 
     expect(result.sessions).toHaveLength(5);
-    expect(resolveThinkingProfile).toHaveBeenCalledTimes(3);
+    expect(result.sessions.every((session) => session.thinkingLevels === undefined)).toBe(true);
+    expect(result.sessions.every((session) => session.thinkingOptions === undefined)).toBe(true);
+    expect(result.sessions.every((session) => session.thinkingDefault === undefined)).toBe(true);
+    expect(resolveThinkingProfile).toHaveBeenCalledTimes(2);
   });
 
   test("session list thinking cache preserves case-distinct model catalog entries", async () => {
@@ -319,7 +322,7 @@ describe("gateway session utils", () => {
         compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
       },
     ];
-    const result = await listSessionsFromStoreAsync({
+    const result = listSessionsFromStore({
       cfg,
       storePath: "",
       modelCatalog,
@@ -1289,7 +1292,10 @@ describe("listSessionsFromStore selected model display", () => {
         }),
       );
       expect(listed.sessions[0]?.agentRuntime).toEqual({ id: "pi", source: "implicit" });
-      expect(listed.sessions[0]?.thinkingOptions?.length).toBeGreaterThan(0);
+      expect(listed.sessions[0]?.thinkingLevel).toBeUndefined();
+      expect(listed.sessions[0]?.thinkingLevels).toBeUndefined();
+      expect(listed.sessions[0]?.thinkingOptions).toBeUndefined();
+      expect(listed.sessions[0]?.thinkingDefault).toBeUndefined();
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -1477,6 +1483,58 @@ describe("listSessionsFromStore selected model display", () => {
       ["agent:main:main", "anthropic", "claude-sonnet-4-6"],
       ["agent:review:review", "vercel-ai-gateway", "anthropic/claude-haiku-4-5"],
     ]);
+  });
+
+  test("uses persisted runtime model metadata before selected defaults", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        list: [{ id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          modelProvider: "openai-codex",
+          model: "gpt-5.5",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.modelProvider).toBe("openai-codex");
+    expect(result.sessions[0]?.model).toBe("gpt-5.5");
+  });
+
+  test("uses complete model overrides without default-model fallback", () => {
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-5.4" } },
+        list: [{ id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } }],
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          providerOverride: "vercel-ai-gateway",
+          modelOverride: "anthropic/claude-haiku-4-5",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.modelProvider).toBe("vercel-ai-gateway");
+    expect(result.sessions[0]?.model).toBe("anthropic/claude-haiku-4-5");
   });
 });
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1450,13 +1450,19 @@ describe("listSessionsFromStore selected model display", () => {
   test("uses qualified selected defaults for rows without runtime model metadata", () => {
     const cfg = {
       agents: {
-        defaults: { model: { primary: "openai/gpt-5.4" } },
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
         list: [
           { id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } },
           {
             id: "review",
             model: { primary: "vercel-ai-gateway/anthropic/claude-haiku-4-5" },
           },
+          { id: "alias", model: { primary: "anthropic/sonnet-4.6" } },
         ],
       },
     } as OpenClawConfig;
@@ -1473,6 +1479,10 @@ describe("listSessionsFromStore selected model display", () => {
           sessionId: "sess-review",
           updatedAt: 1,
         } as SessionEntry,
+        "agent:alias:alias": {
+          sessionId: "sess-alias",
+          updatedAt: 0,
+        } as SessionEntry,
       },
       opts: {},
     });
@@ -1482,6 +1492,7 @@ describe("listSessionsFromStore selected model display", () => {
     ).toEqual([
       ["agent:main:main", "anthropic", "claude-sonnet-4-6"],
       ["agent:review:review", "vercel-ai-gateway", "anthropic/claude-haiku-4-5"],
+      ["agent:alias:alias", "anthropic", "claude-sonnet-4-6"],
     ]);
   });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -373,8 +373,13 @@ type SessionListRowContext = {
   subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
   storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
-  modelIdentityByResolutionKey: Map<string, ReturnType<typeof resolveSessionModelIdentityRef>>;
-  thinkingLevelsByModelRef: Map<string, ReturnType<typeof listThinkingLevelOptions>>;
+  thinkingMetadataByModelRef: Map<
+    string,
+    {
+      levels: ReturnType<typeof listThinkingLevelOptions>;
+      defaultLevel: ReturnType<typeof resolveGatewaySessionThinkingDefault>;
+    }
+  >;
 };
 
 function resolveRuntimeChildSessionKeys(
@@ -492,8 +497,7 @@ function buildSessionListRowContext(params: {
     subagentRuns,
     storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
     selectedModelByOverrideRef: new Map(),
-    modelIdentityByResolutionKey: new Map(),
-    thinkingLevelsByModelRef: new Map(),
+    thinkingMetadataByModelRef: new Map(),
   };
 }
 
@@ -501,160 +505,24 @@ function createSessionRowModelCacheKey(provider: string | undefined, model: stri
   return `${normalizeLowercaseStringOrEmpty(provider)}\0${normalizeOptionalString(model) ?? ""}`;
 }
 
-function createSessionEntryModelCacheKey(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  entry?:
-    | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
-  fallbackModelRef?: string;
-}) {
-  return [
-    normalizeAgentId(params.agentId),
-    normalizeOptionalString(params.entry?.providerOverride) ?? "",
-    normalizeOptionalString(params.entry?.modelOverride) ?? "",
-    normalizeOptionalString(params.entry?.modelProvider) ?? "",
-    normalizeOptionalString(params.entry?.model) ?? "",
-    normalizeOptionalString(params.fallbackModelRef) ?? "",
-  ].join("\0");
-}
-
-function resolveSessionDefaultModelRefForRow(
-  cfg: OpenClawConfig,
-  agentId?: string,
-): { provider: string; model: string } {
-  if (agentId) {
-    return resolveDefaultModelForAgent({ cfg, agentId });
-  }
-  return resolveConfiguredModelRef({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-  });
-}
-
-function resolveSessionRowModelIdentityRef(params: {
-  cfg: OpenClawConfig;
-  entry?:
-    | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
-  agentId: string;
-  fallbackModelRef?: string;
-  rowContext?: SessionListRowContext;
-}): ReturnType<typeof resolveSessionModelIdentityRef> {
-  if (!params.rowContext) {
-    return resolveSessionModelIdentityRef(
-      params.cfg,
-      params.entry,
-      params.agentId,
-      params.fallbackModelRef,
-    );
-  }
-  const runtimeModel = normalizeOptionalString(params.entry?.model);
-  const runtimeProvider = normalizeOptionalString(params.entry?.modelProvider);
-  const fallbackModelRef = normalizeOptionalString(params.fallbackModelRef);
-  if (runtimeModel && runtimeProvider) {
-    return { provider: runtimeProvider, model: runtimeModel };
-  }
-  if (runtimeModel) {
-    const key = `runtime\0${runtimeModel}`;
-    const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
-    if (cached) {
-      return cached;
-    }
-    const resolved = resolveSessionModelIdentityRef(
-      params.cfg,
-      params.entry,
-      params.agentId,
-      params.fallbackModelRef,
-    );
-    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
-    return resolved;
-  }
-  if (fallbackModelRef) {
-    const key = `fallback\0${fallbackModelRef}`;
-    const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
-    if (cached) {
-      return cached;
-    }
-    const resolved = resolveSessionModelIdentityRef(
-      params.cfg,
-      params.entry,
-      params.agentId,
-      params.fallbackModelRef,
-    );
-    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
-    return resolved;
-  }
-  const normalizedOverride = normalizeStoredOverrideModel({
-    providerOverride: params.entry?.providerOverride,
-    modelOverride: params.entry?.modelOverride,
-  });
-  if (
-    !runtimeModel &&
-    !fallbackModelRef &&
-    normalizedOverride.providerOverride &&
-    normalizedOverride.modelOverride
-  ) {
-    return {
-      provider: normalizedOverride.providerOverride,
-      model: normalizedOverride.modelOverride,
-    };
-  }
-  const key = createSessionEntryModelCacheKey({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    entry: params.entry,
-    fallbackModelRef: params.fallbackModelRef,
-  });
-  const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
-  if (cached) {
-    return cached;
-  }
-
-  if (
-    !runtimeModel &&
-    !runtimeProvider &&
-    !fallbackModelRef &&
-    !normalizedOverride.providerOverride &&
-    !normalizedOverride.modelOverride
-  ) {
-    const resolved = resolveSessionDefaultModelRefForRow(params.cfg, params.agentId);
-    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
-    return resolved;
-  }
-
-  const resolved = resolveSessionModelIdentityRef(
-    params.cfg,
-    params.entry,
-    params.agentId,
-    params.fallbackModelRef,
-  );
-  params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
-  return resolved;
-}
-
 function resolveSessionSelectedModelRef(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
   agentId: string;
   rowContext?: SessionListRowContext;
+  allowPluginNormalization?: boolean;
 }): ReturnType<typeof resolveSessionModelRef> | null {
   const override = normalizeStoredOverrideModel({
     providerOverride: params.entry?.providerOverride,
     modelOverride: params.entry?.modelOverride,
   });
-  if (override.providerOverride && override.modelOverride) {
-    return {
-      provider: override.providerOverride,
-      model: override.modelOverride,
-    };
-  }
   if (!override.modelOverride) {
     return null;
   }
   if (!params.rowContext) {
-    return resolveSessionModelRef(params.cfg, params.entry, params.agentId);
+    return resolveSessionModelRef(params.cfg, params.entry, params.agentId, {
+      allowPluginNormalization: params.allowPluginNormalization,
+    });
   }
   const key = [
     normalizeAgentId(params.agentId),
@@ -665,28 +533,56 @@ function resolveSessionSelectedModelRef(params: {
   if (cached) {
     return cached;
   }
-  const selected = resolveSessionModelRef(params.cfg, params.entry, params.agentId);
+  const selected = resolveSessionModelRef(params.cfg, params.entry, params.agentId, {
+    allowPluginNormalization: params.allowPluginNormalization,
+  });
   params.rowContext.selectedModelByOverrideRef.set(key, selected);
   return selected;
 }
 
-function resolveSessionRowThinkingLevels(params: {
+function resolveSessionRowThinkingMetadata(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
   provider: string;
   model: string;
   modelCatalog?: ModelCatalogEntry[];
   rowContext?: SessionListRowContext;
-}): ReturnType<typeof listThinkingLevelOptions> {
+}): {
+  levels: ReturnType<typeof listThinkingLevelOptions>;
+  defaultLevel: ReturnType<typeof resolveGatewaySessionThinkingDefault>;
+} {
   if (!params.rowContext) {
-    return listThinkingLevelOptions(params.provider, params.model, params.modelCatalog);
+    return {
+      levels: listThinkingLevelOptions(params.provider, params.model, params.modelCatalog),
+      defaultLevel: resolveGatewaySessionThinkingDefault({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        agentId: params.agentId,
+        modelCatalog: params.modelCatalog,
+      }),
+    };
   }
-  const key = createSessionRowModelCacheKey(params.provider, params.model);
-  const cached = params.rowContext.thinkingLevelsByModelRef.get(key);
+  const key = `${normalizeAgentId(params.agentId)}\0${createSessionRowModelCacheKey(
+    params.provider,
+    params.model,
+  )}`;
+  const cached = params.rowContext.thinkingMetadataByModelRef.get(key);
   if (cached) {
     return cached;
   }
-  const levels = listThinkingLevelOptions(params.provider, params.model, params.modelCatalog);
-  params.rowContext.thinkingLevelsByModelRef.set(key, levels);
-  return levels;
+  const metadata = {
+    levels: listThinkingLevelOptions(params.provider, params.model, params.modelCatalog),
+    defaultLevel: resolveGatewaySessionThinkingDefault({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      agentId: params.agentId,
+      modelCatalog: params.modelCatalog,
+    }),
+  };
+  params.rowContext.thinkingMetadataByModelRef.set(key, metadata);
+  return metadata;
 }
 
 function mergeChildSessionKeys(
@@ -1395,11 +1291,13 @@ export function resolveGatewaySessionThinkingDefault(params: {
 export function getSessionDefaults(
   cfg: OpenClawConfig,
   modelCatalog?: ModelCatalogEntry[],
+  options?: { allowPluginNormalization?: boolean },
 ): GatewaySessionsDefaults {
   const resolved = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
+    allowPluginNormalization: options?.allowPluginNormalization,
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
@@ -1427,26 +1325,46 @@ export function resolveSessionModelRef(
     | SessionEntry
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
+  options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
-  const resolved = agentId
-    ? resolveDefaultModelForAgent({ cfg, agentId })
-    : resolveConfiguredModelRef({
-        cfg,
-        defaultProvider: DEFAULT_PROVIDER,
-        defaultModel: DEFAULT_MODEL,
-      });
-
   const normalizedOverride = normalizeStoredOverrideModel({
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
   });
+  if (normalizedOverride.providerOverride && normalizedOverride.modelOverride) {
+    return resolvePersistedSelectedModelRef({
+      defaultProvider: normalizedOverride.providerOverride,
+      overrideProvider: normalizedOverride.providerOverride,
+      overrideModel: normalizedOverride.modelOverride,
+      allowPluginNormalization: options?.allowPluginNormalization,
+    })!;
+  }
+  const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
+  const runtimeModel = normalizeOptionalString(entry?.model);
+  if (runtimeProvider && runtimeModel) {
+    return { provider: runtimeProvider, model: runtimeModel };
+  }
+
+  const resolved = agentId
+    ? resolveDefaultModelForAgent({
+        cfg,
+        agentId,
+        allowPluginNormalization: options?.allowPluginNormalization,
+      })
+    : resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+        allowPluginNormalization: options?.allowPluginNormalization,
+      });
 
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-    runtimeProvider: entry?.modelProvider,
-    runtimeModel: entry?.model,
+    runtimeProvider,
+    runtimeModel,
     overrideProvider: normalizedOverride.providerOverride,
     overrideModel: normalizedOverride.modelOverride,
+    allowPluginNormalization: options?.allowPluginNormalization,
   });
   if (persisted) {
     return persisted;
@@ -1534,6 +1452,7 @@ export function resolveSessionModelIdentityRef(
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
   fallbackModelRef?: string,
+  options?: { allowPluginNormalization?: boolean },
 ): { provider?: string; model: string } {
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
@@ -1549,7 +1468,9 @@ export function resolveSessionModelIdentityRef(
       return { provider: inferredProvider, model: runtimeModel };
     }
     if (runtimeModel.includes("/")) {
-      const parsedRuntime = parseModelRef(runtimeModel, DEFAULT_PROVIDER);
+      const parsedRuntime = parseModelRef(runtimeModel, DEFAULT_PROVIDER, {
+        allowPluginNormalization: options?.allowPluginNormalization,
+      });
       if (parsedRuntime) {
         return { provider: parsedRuntime.provider, model: parsedRuntime.model };
       }
@@ -1559,7 +1480,9 @@ export function resolveSessionModelIdentityRef(
   }
   const fallbackRef = fallbackModelRef?.trim();
   if (fallbackRef) {
-    const parsedFallback = parseModelRef(fallbackRef, DEFAULT_PROVIDER);
+    const parsedFallback = parseModelRef(fallbackRef, DEFAULT_PROVIDER, {
+      allowPluginNormalization: options?.allowPluginNormalization,
+    });
     if (parsedFallback) {
       return { provider: parsedFallback.provider, model: parsedFallback.model };
     }
@@ -1572,7 +1495,9 @@ export function resolveSessionModelIdentityRef(
     }
     return { model: fallbackRef };
   }
-  const resolved = resolveSessionModelRef(cfg, entry, agentId);
+  const resolved = resolveSessionModelRef(cfg, entry, agentId, {
+    allowPluginNormalization: options?.allowPluginNormalization,
+  });
   return { provider: resolved.provider, model: resolved.model };
 }
 
@@ -1718,14 +1643,15 @@ export function buildGatewaySessionRow(params: {
     entry,
     agentId: sessionAgentId,
     rowContext,
+    allowPluginNormalization: !lightweight,
   });
-  const resolvedModel = resolveSessionRowModelIdentityRef({
+  const resolvedModel = resolveSessionModelIdentityRef(
     cfg,
     entry,
-    agentId: sessionAgentId,
-    fallbackModelRef: subagentRun?.model,
-    rowContext,
-  });
+    sessionAgentId,
+    subagentRun?.model,
+    { allowPluginNormalization: !lightweight },
+  );
   const runtimeModelPresent =
     Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
   const needsTranscriptTotalTokens =
@@ -1838,23 +1764,16 @@ export function buildGatewaySessionRow(params: {
 
   const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
   const thinkingModel = rowModel ?? DEFAULT_MODEL;
-  const thinkingLevels = lightweight
-    ? undefined
-    : resolveSessionRowThinkingLevels({
-        provider: thinkingProvider,
-        model: thinkingModel,
-        modelCatalog: params.modelCatalog,
-        rowContext,
-      });
-  const thinkingDefault = lightweight
-    ? undefined
-    : resolveGatewaySessionThinkingDefault({
-        cfg,
-        provider: thinkingProvider,
-        model: thinkingModel,
-        agentId: sessionAgentId,
-        modelCatalog: params.modelCatalog,
-      });
+  const thinkingMetadata = resolveSessionRowThinkingMetadata({
+    cfg,
+    agentId: sessionAgentId,
+    provider: thinkingProvider,
+    model: thinkingModel,
+    modelCatalog: params.modelCatalog,
+    rowContext,
+  });
+  const thinkingLevels = thinkingMetadata.levels;
+  const thinkingDefault = thinkingMetadata.defaultLevel;
   const pluginExtensions =
     !lightweight && entry ? projectPluginSessionExtensionsSync({ sessionKey: key, entry }) : [];
 
@@ -2211,7 +2130,7 @@ export function listSessionsFromStore(params: {
     totalCount,
     limitApplied,
     hasMore: sessions.length < totalCount,
-    defaults: getSessionDefaults(cfg, params.modelCatalog),
+    defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
     sessions,
   };
 }
@@ -2312,7 +2231,7 @@ export async function listSessionsFromStoreAsync(params: {
     totalCount,
     limitApplied,
     hasMore: sessions.length < totalCount,
-    defaults: getSessionDefaults(cfg, params.modelCatalog),
+    defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
     sessions,
   };
 }

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -578,6 +578,27 @@ function resolveSessionRowModelIdentityRef(params: {
       params.fallbackModelRef,
     );
   }
+  const runtimeModel = normalizeOptionalString(params.entry?.model);
+  const runtimeProvider = normalizeOptionalString(params.entry?.modelProvider);
+  const fallbackModelRef = normalizeOptionalString(params.fallbackModelRef);
+  if (runtimeModel && runtimeProvider && !fallbackModelRef) {
+    return { provider: runtimeProvider, model: runtimeModel };
+  }
+  const normalizedOverride = normalizeStoredOverrideModel({
+    providerOverride: params.entry?.providerOverride,
+    modelOverride: params.entry?.modelOverride,
+  });
+  if (
+    !runtimeModel &&
+    !fallbackModelRef &&
+    normalizedOverride.providerOverride &&
+    normalizedOverride.modelOverride
+  ) {
+    return {
+      provider: normalizedOverride.providerOverride,
+      model: normalizedOverride.modelOverride,
+    };
+  }
   const key = createSessionEntryModelCacheKey({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -589,14 +610,12 @@ function resolveSessionRowModelIdentityRef(params: {
     return cached;
   }
 
-  const runtimeModel = normalizeOptionalString(params.entry?.model);
-  const runtimeProvider = normalizeOptionalString(params.entry?.modelProvider);
   if (
     !runtimeModel &&
     !runtimeProvider &&
-    !normalizeOptionalString(params.fallbackModelRef) &&
-    !normalizeOptionalString(params.entry?.providerOverride) &&
-    !normalizeOptionalString(params.entry?.modelOverride)
+    !fallbackModelRef &&
+    !normalizedOverride.providerOverride &&
+    !normalizedOverride.modelOverride
   ) {
     const resolved = resolveSessionDefaultModelRefForRow(params.cfg, params.agentId);
     params.rowContext.modelIdentityByEntryKey.set(key, resolved);
@@ -623,6 +642,12 @@ function resolveSessionSelectedModelRef(params: {
     providerOverride: params.entry?.providerOverride,
     modelOverride: params.entry?.modelOverride,
   });
+  if (override.providerOverride && override.modelOverride) {
+    return {
+      provider: override.providerOverride,
+      model: override.modelOverride,
+    };
+  }
   if (!override.modelOverride) {
     return null;
   }
@@ -1811,12 +1836,23 @@ export function buildGatewaySessionRow(params: {
 
   const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
   const thinkingModel = rowModel ?? DEFAULT_MODEL;
-  const thinkingLevels = resolveSessionRowThinkingLevels({
-    provider: thinkingProvider,
-    model: thinkingModel,
-    modelCatalog: params.modelCatalog,
-    rowContext,
-  });
+  const thinkingLevels = lightweight
+    ? undefined
+    : resolveSessionRowThinkingLevels({
+        provider: thinkingProvider,
+        model: thinkingModel,
+        modelCatalog: params.modelCatalog,
+        rowContext,
+      });
+  const thinkingDefault = lightweight
+    ? undefined
+    : resolveGatewaySessionThinkingDefault({
+        cfg,
+        provider: thinkingProvider,
+        model: thinkingModel,
+        agentId: sessionAgentId,
+        modelCatalog: params.modelCatalog,
+      });
   const pluginExtensions =
     !lightweight && entry ? projectPluginSessionExtensionsSync({ sessionKey: key, entry }) : [];
 
@@ -1845,16 +1881,8 @@ export function buildGatewaySessionRow(params: {
     abortedLastRun: entry?.abortedLastRun,
     thinkingLevel: entry?.thinkingLevel,
     thinkingLevels,
-    thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: lightweight
-      ? entry?.thinkingLevel
-      : resolveGatewaySessionThinkingDefault({
-          cfg,
-          provider: thinkingProvider,
-          model: thinkingModel,
-          agentId: sessionAgentId,
-          modelCatalog: params.modelCatalog,
-        }),
+    thinkingOptions: thinkingLevels?.map((level) => level.label),
+    thinkingDefault,
     fastMode: entry?.fastMode,
     verboseLevel: entry?.verboseLevel,
     traceLevel: entry?.traceLevel,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -19,7 +19,6 @@ import {
 import {
   inferUniqueProviderFromConfiguredModels,
   isCliProvider,
-  normalizeProviderId,
   normalizeStoredOverrideModel,
   parseModelRef,
   resolveConfiguredModelRef,
@@ -78,7 +77,6 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   normalizeOptionalLowercaseString,
-  resolvePrimaryStringValue,
 } from "../shared/string-coerce.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
@@ -375,7 +373,7 @@ type SessionListRowContext = {
   subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
   storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
-  modelIdentityByEntryKey: Map<string, ReturnType<typeof resolveSessionModelIdentityRef>>;
+  modelIdentityByResolutionKey: Map<string, ReturnType<typeof resolveSessionModelIdentityRef>>;
   thinkingLevelsByModelRef: Map<string, ReturnType<typeof listThinkingLevelOptions>>;
 };
 
@@ -494,34 +492,13 @@ function buildSessionListRowContext(params: {
     subagentRuns,
     storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
     selectedModelByOverrideRef: new Map(),
-    modelIdentityByEntryKey: new Map(),
+    modelIdentityByResolutionKey: new Map(),
     thinkingLevelsByModelRef: new Map(),
   };
 }
 
 function createSessionRowModelCacheKey(provider: string | undefined, model: string | undefined) {
   return `${normalizeLowercaseStringOrEmpty(provider)}\0${normalizeOptionalString(model) ?? ""}`;
-}
-
-function parseQualifiedModelRefForSessionList(
-  raw: string | undefined,
-): { provider: string; model: string } | undefined {
-  const trimmed = normalizeOptionalString(raw);
-  const slash = trimmed?.indexOf("/") ?? -1;
-  if (!trimmed || slash <= 0 || slash === trimmed.length - 1) {
-    return undefined;
-  }
-  const provider = normalizeProviderId(trimmed.slice(0, slash).trim());
-  const model = normalizeOptionalString(trimmed.slice(slash + 1));
-  return model ? { provider, model } : undefined;
-}
-
-function createSessionDefaultModelCacheKey(cfg: OpenClawConfig, agentId?: string): string {
-  const normalizedAgentId = normalizeAgentId(agentId);
-  const primary = normalizedAgentId
-    ? resolveAgentEffectiveModelPrimary(cfg, normalizedAgentId)
-    : resolvePrimaryStringValue(cfg.agents?.defaults?.model);
-  return normalizeOptionalString(primary) ?? "";
 }
 
 function createSessionEntryModelCacheKey(params: {
@@ -533,7 +510,7 @@ function createSessionEntryModelCacheKey(params: {
   fallbackModelRef?: string;
 }) {
   return [
-    createSessionDefaultModelCacheKey(params.cfg, params.agentId),
+    normalizeAgentId(params.agentId),
     normalizeOptionalString(params.entry?.providerOverride) ?? "",
     normalizeOptionalString(params.entry?.modelOverride) ?? "",
     normalizeOptionalString(params.entry?.modelProvider) ?? "",
@@ -547,11 +524,6 @@ function resolveSessionDefaultModelRefForRow(
   agentId?: string,
 ): { provider: string; model: string } {
   if (agentId) {
-    const primary = resolveAgentEffectiveModelPrimary(cfg, agentId)?.trim();
-    const parsed = parseQualifiedModelRefForSessionList(primary);
-    if (parsed) {
-      return parsed;
-    }
     return resolveDefaultModelForAgent({ cfg, agentId });
   }
   return resolveConfiguredModelRef({
@@ -581,8 +553,38 @@ function resolveSessionRowModelIdentityRef(params: {
   const runtimeModel = normalizeOptionalString(params.entry?.model);
   const runtimeProvider = normalizeOptionalString(params.entry?.modelProvider);
   const fallbackModelRef = normalizeOptionalString(params.fallbackModelRef);
-  if (runtimeModel && runtimeProvider && !fallbackModelRef) {
+  if (runtimeModel && runtimeProvider) {
     return { provider: runtimeProvider, model: runtimeModel };
+  }
+  if (runtimeModel) {
+    const key = `runtime\0${runtimeModel}`;
+    const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
+    if (cached) {
+      return cached;
+    }
+    const resolved = resolveSessionModelIdentityRef(
+      params.cfg,
+      params.entry,
+      params.agentId,
+      params.fallbackModelRef,
+    );
+    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
+    return resolved;
+  }
+  if (fallbackModelRef) {
+    const key = `fallback\0${fallbackModelRef}`;
+    const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
+    if (cached) {
+      return cached;
+    }
+    const resolved = resolveSessionModelIdentityRef(
+      params.cfg,
+      params.entry,
+      params.agentId,
+      params.fallbackModelRef,
+    );
+    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
+    return resolved;
   }
   const normalizedOverride = normalizeStoredOverrideModel({
     providerOverride: params.entry?.providerOverride,
@@ -605,7 +607,7 @@ function resolveSessionRowModelIdentityRef(params: {
     entry: params.entry,
     fallbackModelRef: params.fallbackModelRef,
   });
-  const cached = params.rowContext.modelIdentityByEntryKey.get(key);
+  const cached = params.rowContext.modelIdentityByResolutionKey.get(key);
   if (cached) {
     return cached;
   }
@@ -618,7 +620,7 @@ function resolveSessionRowModelIdentityRef(params: {
     !normalizedOverride.modelOverride
   ) {
     const resolved = resolveSessionDefaultModelRefForRow(params.cfg, params.agentId);
-    params.rowContext.modelIdentityByEntryKey.set(key, resolved);
+    params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
     return resolved;
   }
 
@@ -628,7 +630,7 @@ function resolveSessionRowModelIdentityRef(params: {
     params.agentId,
     params.fallbackModelRef,
   );
-  params.rowContext.modelIdentityByEntryKey.set(key, resolved);
+  params.rowContext.modelIdentityByResolutionKey.set(key, resolved);
   return resolved;
 }
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -19,6 +19,7 @@ import {
 import {
   inferUniqueProviderFromConfiguredModels,
   isCliProvider,
+  normalizeProviderId,
   normalizeStoredOverrideModel,
   parseModelRef,
   resolveConfiguredModelRef,
@@ -77,6 +78,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   normalizeOptionalLowercaseString,
+  resolvePrimaryStringValue,
 } from "../shared/string-coerce.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
@@ -373,6 +375,7 @@ type SessionListRowContext = {
   subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
   storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
+  modelIdentityByEntryKey: Map<string, ReturnType<typeof resolveSessionModelIdentityRef>>;
   thinkingLevelsByModelRef: Map<string, ReturnType<typeof listThinkingLevelOptions>>;
 };
 
@@ -491,12 +494,123 @@ function buildSessionListRowContext(params: {
     subagentRuns,
     storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
     selectedModelByOverrideRef: new Map(),
+    modelIdentityByEntryKey: new Map(),
     thinkingLevelsByModelRef: new Map(),
   };
 }
 
 function createSessionRowModelCacheKey(provider: string | undefined, model: string | undefined) {
   return `${normalizeLowercaseStringOrEmpty(provider)}\0${normalizeOptionalString(model) ?? ""}`;
+}
+
+function parseQualifiedModelRefForSessionList(
+  raw: string | undefined,
+): { provider: string; model: string } | undefined {
+  const trimmed = normalizeOptionalString(raw);
+  const slash = trimmed?.indexOf("/") ?? -1;
+  if (!trimmed || slash <= 0 || slash === trimmed.length - 1) {
+    return undefined;
+  }
+  const provider = normalizeProviderId(trimmed.slice(0, slash).trim());
+  const model = normalizeOptionalString(trimmed.slice(slash + 1));
+  return model ? { provider, model } : undefined;
+}
+
+function createSessionDefaultModelCacheKey(cfg: OpenClawConfig, agentId?: string): string {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const primary = normalizedAgentId
+    ? resolveAgentEffectiveModelPrimary(cfg, normalizedAgentId)
+    : resolvePrimaryStringValue(cfg.agents?.defaults?.model);
+  return normalizeOptionalString(primary) ?? "";
+}
+
+function createSessionEntryModelCacheKey(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  entry?:
+    | SessionEntry
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
+  fallbackModelRef?: string;
+}) {
+  return [
+    createSessionDefaultModelCacheKey(params.cfg, params.agentId),
+    normalizeOptionalString(params.entry?.providerOverride) ?? "",
+    normalizeOptionalString(params.entry?.modelOverride) ?? "",
+    normalizeOptionalString(params.entry?.modelProvider) ?? "",
+    normalizeOptionalString(params.entry?.model) ?? "",
+    normalizeOptionalString(params.fallbackModelRef) ?? "",
+  ].join("\0");
+}
+
+function resolveSessionDefaultModelRefForRow(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): { provider: string; model: string } {
+  if (agentId) {
+    const primary = resolveAgentEffectiveModelPrimary(cfg, agentId)?.trim();
+    const parsed = parseQualifiedModelRefForSessionList(primary);
+    if (parsed) {
+      return parsed;
+    }
+    return resolveDefaultModelForAgent({ cfg, agentId });
+  }
+  return resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+}
+
+function resolveSessionRowModelIdentityRef(params: {
+  cfg: OpenClawConfig;
+  entry?:
+    | SessionEntry
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
+  agentId: string;
+  fallbackModelRef?: string;
+  rowContext?: SessionListRowContext;
+}): ReturnType<typeof resolveSessionModelIdentityRef> {
+  if (!params.rowContext) {
+    return resolveSessionModelIdentityRef(
+      params.cfg,
+      params.entry,
+      params.agentId,
+      params.fallbackModelRef,
+    );
+  }
+  const key = createSessionEntryModelCacheKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    entry: params.entry,
+    fallbackModelRef: params.fallbackModelRef,
+  });
+  const cached = params.rowContext.modelIdentityByEntryKey.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const runtimeModel = normalizeOptionalString(params.entry?.model);
+  const runtimeProvider = normalizeOptionalString(params.entry?.modelProvider);
+  if (
+    !runtimeModel &&
+    !runtimeProvider &&
+    !normalizeOptionalString(params.fallbackModelRef) &&
+    !normalizeOptionalString(params.entry?.providerOverride) &&
+    !normalizeOptionalString(params.entry?.modelOverride)
+  ) {
+    const resolved = resolveSessionDefaultModelRefForRow(params.cfg, params.agentId);
+    params.rowContext.modelIdentityByEntryKey.set(key, resolved);
+    return resolved;
+  }
+
+  const resolved = resolveSessionModelIdentityRef(
+    params.cfg,
+    params.entry,
+    params.agentId,
+    params.fallbackModelRef,
+  );
+  params.rowContext.modelIdentityByEntryKey.set(key, resolved);
+  return resolved;
 }
 
 function resolveSessionSelectedModelRef(params: {
@@ -1578,12 +1692,13 @@ export function buildGatewaySessionRow(params: {
     agentId: sessionAgentId,
     rowContext,
   });
-  const resolvedModel = resolveSessionModelIdentityRef(
+  const resolvedModel = resolveSessionRowModelIdentityRef({
     cfg,
     entry,
-    sessionAgentId,
-    subagentRun?.model,
-  );
+    agentId: sessionAgentId,
+    fallbackModelRef: subagentRun?.model,
+    rowContext,
+  });
   const runtimeModelPresent =
     Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
   const needsTranscriptTotalTokens =


### PR DESCRIPTION
Supersedes #77650. This PR is rebased and narrowed around the newer session-list/model-resolution changes in 2026.5.4.

AI-assisted: yes. I understand what this code does and verified the changed behavior locally and on the affected OpenClaw installation.

## Summary
- Fast-path already-qualified selected default model refs while building `sessions.list` rows.
- Add request-local row model identity memoization scoped to one session-list response.
- Preserve the full resolver for runtime model metadata, overrides, fallback runtime models, and wrapper-provider inference.
- Add regression coverage for qualified selected defaults and slash-prefixed runtime wrapper inference.
- Fix a current-main test typing issue that blocked `pnpm check:changed` on this branch.

## Problem
Large session stores could spend excessive time resolving model identity while building rows for `sessions.list` and Control UI session lists. Rows with no runtime model metadata and no explicit model override still took the heavyweight general resolver path even when the selected agent/default model was already an unambiguous `provider/model` ref.

In the affected installation, this showed up as repeated slow gateway websocket responses for `sessions.list`. Adjacent `chat.history` requests also backed up behind the same event-loop pressure.

## Root cause
`buildGatewaySessionRow` called the general model identity resolver for each row. That resolver is correct for runtime metadata, overrides, fallback runtime models, and wrapper-provider inference, but it is unnecessarily expensive for rows whose selected default is already a fully qualified provider/model ref.

## Solution
`SessionListRowContext` now carries a request-local `modelIdentityByEntryKey` cache. For rows with no runtime model metadata, no overrides, and no fallback runtime model, the row builder parses the selected default directly when it is already qualified. All other cases still use `resolveSessionModelIdentityRef`, so existing behavior for runtime slash models and wrapper-provider inference is preserved.

## Contributing checklist
- Tested locally with an OpenClaw checkout and against the affected OpenClaw installation.
- Real behavior proof from a real setup is included below, with reproduction steps and redacted runtime logs.
- Kept the PR focused on the `sessions.list` model-resolution hot path and the tests needed to cover it.
- Included what changed and why in this PR body.
- AI-assisted status is disclosed above. I understand the changed code and verified the behavior.
- Screenshots are not included because this is a gateway/session-list performance fix with no visual UI change.
- Local `codex review --base origin/main` could not be run because the local `codex` CLI was unavailable.
- I will resolve or reply to bot review conversations that are addressed by this update before asking for review again.

## Real behavior proof

- **Behavior or issue addressed:** `sessions.list` row building was repeatedly taking the heavyweight model identity/default resolver path for ordinary session rows that had no persisted runtime model metadata and no explicit override, even when the selected agent/default model was already an unambiguous qualified `provider/model` ref. The affected UI symptom was repeated slow `sessions.list` websocket responses, with adjacent `chat.history` calls backing up behind the same event-loop pressure.

- **Real environment tested:** Real affected OpenClaw gateway installation on `openclaw-prod`, service `openclaw-gateway.service`, running OpenClaw v2026.5.4 with this narrowed gateway/session-list patch applied to the built package. The same steady-state Control UI/ClawDash polling path remained active after the patch. Secrets, private paths, and full connection/session identifiers are redacted.

- **Exact steps or command run after this patch:**
  1. Deploy the narrowed gateway/session-list patch to the affected OpenClaw installation.
  2. Keep the existing Control UI/ClawDash polling path active so it continues issuing `sessions.list` through the gateway websocket.
  3. Inspect gateway logs for `sessions.list` response duration lines.
  4. Confirm the row shape fixed by this patch is covered locally with:

  ```bash
  pnpm exec vitest run src/gateway/session-utils.test.ts src/gateway/session-utils.search.test.ts -t "uses qualified selected defaults|infers wrapper provider for slash-prefixed runtime model"
  ```

  The slow lookup row shape is an ordinary session-list row like:

  ```json
  {
    "key": "agent:<agent-id>:<session-id>",
    "entry": {
      "sessionId": "<session-id>",
      "updatedAt": 1770000000000
    },
    "agentConfigOrDefaults": {
      "model": { "primary": "openai-codex/gpt-5.5" }
    }
  }
  ```

  Fields that make it use the selected-default path fixed here:

  ```text
  entry.model absent/blank
  entry.modelProvider absent/blank
  entry.modelOverride absent/blank
  entry.providerOverride absent/blank
  no subagent fallback runtime model for the row
  agent/default primary is already a qualified provider/model ref, for example openai-codex/gpt-5.5
  ```

  A small mixed-default reproducer makes the repeated slow lookup clearer. Configure several agents with different already-qualified defaults, then create many minimal rows per agent with no persisted model fields:

  ```json
  {
    "agents": {
      "defaults": { "model": { "primary": "openai-codex/gpt-5.5" } },
      "list": [
        { "id": "main", "model": { "primary": "openai-codex/gpt-5.5" } },
        { "id": "review", "model": { "primary": "anthropic/claude-sonnet-4-6" } },
        { "id": "ops", "model": { "primary": "google-gemini-cli/gemini-3-pro-preview" } },
        { "id": "ui", "model": { "primary": "vercel-ai-gateway/anthropic/claude-haiku-4-5" } }
      ]
    }
  }
  ```

  Example rows:

  ```json
  {
    "agent:main:repro-0001": { "sessionId": "repro-0001", "updatedAt": 1770000000000 },
    "agent:review:repro-0002": { "sessionId": "repro-0002", "updatedAt": 1770000000001 },
    "agent:ops:repro-0003": { "sessionId": "repro-0003", "updatedAt": 1770000000002 },
    "agent:ui:repro-0004": { "sessionId": "repro-0004", "updatedAt": 1770000000003 }
  }
  ```

  Repeat those row shapes enough times to make `sessions.list` enumerate hundreds or thousands of rows. Before this patch, each row still entered the general default/model identity resolver even though the answer was already present as a qualified selected default. Different defaults across agents make the repeated resolver work easier to observe because the row builder cannot collapse everything to one effective model identity. After this patch, each distinct qualified selected default is parsed directly and memoized for that list response.

- **Before evidence:** Redacted runtime log excerpt from the affected installation before the fix. The incident signature was repeated `sessions.list` responses in the 13-15s range, with `chat.history` also backing up:

  ```text
  09:34:08+00:00 ⇄ res ✓ sessions.list 14102ms
  09:34:22+00:00 ⇄ res ✓ sessions.list 14243ms
  09:34:22+00:00 ⇄ res ✓ chat.history 28354ms
  09:34:37+00:00 ⇄ res ✓ sessions.list 14783ms
  09:34:37+00:00 ⇄ res ✓ chat.history 29041ms
  09:34:37+00:00 ⇄ res ✓ chat.history 14801ms
  09:34:51+00:00 ⇄ res ✓ sessions.list 13652ms
  ```

- **Evidence after fix:** Redacted runtime log excerpt from the same affected installation after deploying this patch. The same steady-state polling path was still issuing `sessions.list`, but websocket responses were sub-second:

  ```text
  HOST=openclaw-prod
  SERVICE=openclaw-gateway.service active, v2026.5.4
  2026-05-06T00:54:45Z ⇄ res ✓ sessions.list 596ms
  2026-05-06T00:55:46Z ⇄ res ✓ sessions.list 600ms
  2026-05-06T00:56:47Z ⇄ res ✓ sessions.list 664ms
  2026-05-06T00:57:48Z ⇄ res ✓ sessions.list 514ms
  ```

- **Observed result after fix:** The affected `sessions.list` path stayed active but no longer produced the 13-15s response times seen before the patch. The row-building hot path now parses already-qualified selected defaults directly and memoizes identity resolution per list response. Runtime model rows still use the general resolver, including wrapper-provider inference for slash-prefixed runtime models.

- **What was not tested:** No UI screenshot was captured because this is a gateway/session-list performance fix with no visual UI change. A full `pnpm test` run was attempted and caught the initial over-broad runtime-model shortcut; after correcting that, focused gateway/session-utils tests and `pnpm build`, `pnpm check`, and `pnpm check:changed` passed. The same full test run also showed unrelated `extensions/voice-call/index.test.ts` failures; this PR does not touch voice-call code.

## Verification
- `pnpm build`: pass
- `pnpm check`: pass
- `pnpm check:changed`: pass
- `pnpm exec vitest run src/gateway/session-utils.search.test.ts src/gateway/session-utils.test.ts`: pass, 6 files / 294 tests
- `pnpm exec vitest run src/gateway/session-utils.test.ts src/agents/model-fallback.test.ts`: pass, 5 files / 346 tests

Notes:
- A full `pnpm test` run caught the over-broad runtime-model shortcut; this PR was updated to remove that shortcut and the focused gateway/session-utils tests now cover the corrected behavior.
- The same full `pnpm test` run also showed unrelated `extensions/voice-call/index.test.ts` failures after the gateway regression was found; this PR does not touch voice-call code.
- Local `codex` CLI was unavailable, so I could not run `codex review --base origin/main` locally.
