### PR TITLE
fix: allow safe JSON media artifacts

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1746,7 +1746,7 @@ lives on the [Models FAQ](/help/faq-models).
     - The target channel supports outbound media and isn't blocked by allowlists.
     - The file is within the provider's size limits (images are resized to max 2048px).
     - `tools.fs.workspaceOnly=true` keeps local-path sends limited to workspace, temp/media-store, and sandbox-validated files.
-    - `tools.fs.workspaceOnly=false` lets `MEDIA:` send host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, and Office docs). Plain text and secret-like files are still blocked.
+    - `tools.fs.workspaceOnly=false` lets `MEDIA:` send host-local files the agent can already read, but only for media plus safe document types (images, audio, video, PDF, Office docs, CSV/Markdown text documents, and validated JSON artifacts). Sensitive JSON filenames such as `openclaw.json`, `credentials.json`, and `token.json`, plus secret-like JSON keys such as `apiKey`, `token`, `password`, and `privateKey`, are blocked. Arbitrary plain text and secret-like files are still blocked.
 
     See [Images](/nodes/images).
 

--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -19,7 +19,10 @@ directives; server-side media fetchers still enforce their own network guards.
 
 Local `MEDIA:` attachments can use absolute paths, workspace-relative paths, or
 home-relative `~/` paths. They still pass through the agent file-read policy and
-media type checks before delivery.
+media type checks before delivery. Host-local JSON files are treated as sendable
+artifacts only when they parse as JSON text and do not look like config/secret
+files (for example `openclaw.json`, `credentials.json`, or JSON with keys such
+as `apiKey`, `token`, `password`, or `privateKey`).
 
 Plain Markdown image syntax stays text by default. Channels that intentionally
 map Markdown image replies to media attachments opt in at their outbound

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -204,7 +204,9 @@ Local-path behavior follows the same file-read trust model as the agent:
 - If `tools.fs.workspaceOnly` is `true`, outbound `MEDIA:` local paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.
 - If `tools.fs.workspaceOnly` is `false`, outbound `MEDIA:` can use host-local files the agent is already allowed to read.
 - Local paths can be absolute, workspace-relative, or home-relative with `~/`.
-- Host-local sends still only allow media and safe document types (images, audio, video, PDF, and Office documents). Plain text and secret-like files are not treated as sendable media.
+- Host-local sends still only allow media and safe document types (images, audio, video, PDF, Office documents, CSV/Markdown text documents, and validated JSON artifacts).
+- JSON sends are intentionally narrow: the file must parse as JSON text, obvious sensitive JSON filenames such as `openclaw.json`, `credentials.json`, or `token.json` are blocked, and secret-like keys such as `apiKey`, `token`, `password`, or `privateKey` are blocked.
+- Arbitrary plain text and secret-like files are not treated as sendable media.
 
 That means generated images/files outside the workspace can now send when your fs policy already allows those reads, without reopening arbitrary host-text attachment exfiltration.
 

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -303,6 +303,73 @@ describe("loadWebMedia", () => {
     expect(result.contentType).toBe("text/markdown");
   });
 
+  it("allows host-read JSON artifact files", async () => {
+    const result = await loadDocumentWithHostRead(
+      "report.json",
+      JSON.stringify(
+        {
+          generatedAt: "2026-05-05T14:37:49.342Z",
+          familyClassification: {
+            kimi: { status: "selected", selectedRoutes: ["opencode-go/kimi-k2.6"] },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    expect(result.kind).toBe("document");
+    expect(result.contentType).toBe("application/json");
+    expect(result.fileName).toBe("report.json");
+  });
+
+  it.each(["openclaw.json", "openclaw.config.json", "credentials-report.json"])(
+    "rejects host-read risky JSON filename %s even when it is valid JSON",
+    async (fileName) => {
+      const configFile = path.join(fixtureRoot, fileName);
+      await fs.writeFile(configFile, JSON.stringify({ channels: { telegram: {} } }), "utf8");
+      await expect(
+        loadWebMedia(configFile, {
+          maxBytes: 1024 * 1024,
+          localRoots: "any",
+          readFile: async (filePath) => await fs.readFile(filePath),
+          hostReadCapability: true,
+        }),
+      ).rejects.toMatchObject({
+        code: "path-not-allowed",
+      });
+    },
+  );
+
+  it("rejects host-read JSON files with secret-like keys", async () => {
+    const jsonFile = path.join(fixtureRoot, "service-response.json");
+    await fs.writeFile(jsonFile, JSON.stringify({ ok: true, apiKey: "sk-test" }), "utf8");
+    await expect(
+      loadWebMedia(jsonFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "path-not-allowed",
+    });
+  });
+
+  it("rejects invalid host-read JSON files", async () => {
+    const jsonFile = path.join(fixtureRoot, "broken.json");
+    await fs.writeFile(jsonFile, "{not json", "utf8");
+    await expect(
+      loadWebMedia(jsonFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: "any",
+        readFile: async (filePath) => await fs.readFile(filePath),
+        hostReadCapability: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "path-not-allowed",
+    });
+  });
+
   it("rejects binary data disguised as a CSV file", async () => {
     const fakeCsv = path.join(fixtureRoot, "evil.csv");
     // Write ZIP magic bytes — file-type detects application/zip (not image, not CSV),

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -111,6 +111,53 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
 // Markdown, so host-read needs an explicit "this really decodes as text" fallback.
 const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
 const MB = 1024 * 1024;
+const HOST_READ_JSON_MAX_BYTES = 16 * MB;
+const HOST_READ_JSON_MIME = "application/json";
+const HOST_READ_JSON_BLOCKED_BASENAMES = new Set([
+  "auth.json",
+  "client_secret.json",
+  "credentials.json",
+  "openclaw.json",
+  "secret.json",
+  "secrets.json",
+  "service-account.json",
+  "service_account.json",
+  "token.json",
+  "tokens.json",
+]);
+const HOST_READ_JSON_BLOCKED_BASENAME_PATTERNS = [
+  /^\.openclaw\.json$/i,
+  /^openclaw(?:[-_.].*)?\.json$/i,
+  /^client[-_]?secret(?:[-_.].*)?\.json$/i,
+  /^.*credentials?(?:[-_.].*)?\.json$/i,
+  /^.*secrets?(?:[-_.].*)?\.json$/i,
+  /^.*service[-_]?account(?:[-_.].*)?\.json$/i,
+  /^.*tokens?(?:[-_.].*)?\.json$/i,
+];
+const HOST_READ_JSON_SENSITIVE_KEYS = new Set([
+  "accesstoken",
+  "apikey",
+  "auth",
+  "authorization",
+  "bearer",
+  "bottoken",
+  "clientsecret",
+  "cookie",
+  "credential",
+  "credentials",
+  "idtoken",
+  "passphrase",
+  "password",
+  "privatekey",
+  "refreshtoken",
+  "secret",
+  "session",
+  "sessionsecret",
+  "signingsecret",
+  "token",
+  "webhooksecret",
+]);
+const HOST_READ_JSON_MAX_SCANNED_KEYS = 50_000;
 
 function getTextStats(text: string): { printableRatio: number } {
   if (!text) {
@@ -193,6 +240,131 @@ function isValidatedHostReadText(buffer?: Buffer): boolean {
   return printableRatio > 0.95;
 }
 
+function normalizeJsonKeyForSecretCheck(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function isSensitiveJsonKey(key: string): boolean {
+  const normalized = normalizeJsonKeyForSecretCheck(key);
+  if (HOST_READ_JSON_SENSITIVE_KEYS.has(normalized)) {
+    return true;
+  }
+  if (normalized.endsWith("apikey") || normalized.endsWith("token")) {
+    return true;
+  }
+  return false;
+}
+
+function blockedHostReadJsonBasename(filePath?: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  const basename = path.basename(filePath).toLowerCase();
+  if (HOST_READ_JSON_BLOCKED_BASENAMES.has(basename)) {
+    return basename;
+  }
+  if (HOST_READ_JSON_BLOCKED_BASENAME_PATTERNS.some((pattern) => pattern.test(basename))) {
+    return basename;
+  }
+  return undefined;
+}
+
+function findSensitiveJsonKeyPath(value: unknown): string | undefined {
+  const stack: Array<{ path: string; value: unknown }> = [{ path: "$", value }];
+  let scannedKeys = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || current.value === null || typeof current.value !== "object") {
+      continue;
+    }
+    if (Array.isArray(current.value)) {
+      for (let index = current.value.length - 1; index >= 0; index -= 1) {
+        const child = current.value[index];
+        if (child !== null && typeof child === "object") {
+          stack.push({ path: `${current.path}[${index}]`, value: child });
+        }
+      }
+      continue;
+    }
+
+    for (const [key, child] of Object.entries(current.value as Record<string, unknown>)) {
+      scannedKeys += 1;
+      if (scannedKeys > HOST_READ_JSON_MAX_SCANNED_KEYS) {
+        return "<too-many-keys>";
+      }
+      const keyPath = `${current.path}.${key}`;
+      if (isSensitiveJsonKey(key)) {
+        return keyPath;
+      }
+      if (child !== null && typeof child === "object") {
+        stack.push({ path: keyPath, value: child });
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function assertHostReadJsonAllowed(params: {
+  sniffedContentType?: string;
+  filePath?: string;
+  buffer?: Buffer;
+}): void {
+  const blockedBasename = blockedHostReadJsonBasename(params.filePath);
+  if (blockedBasename) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      `Host-local JSON media sends block sensitive JSON filenames (got ${blockedBasename}).`,
+    );
+  }
+  const sniffedMime = normalizeMimeType(params.sniffedContentType);
+  if (sniffedMime && sniffedMime !== HOST_READ_JSON_MIME) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      `Host-local JSON media sends require plain JSON text without binary magic bytes (got ${sniffedMime}).`,
+    );
+  }
+  if (!params.buffer || !isValidatedHostReadText(params.buffer)) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      "Host-local JSON media sends require validated plain-text JSON documents.",
+    );
+  }
+  if (params.buffer.length > HOST_READ_JSON_MAX_BYTES) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      formatCapLimit("Host-local JSON document", HOST_READ_JSON_MAX_BYTES, params.buffer.length),
+    );
+  }
+
+  const decoded = decodeHostReadText(params.buffer);
+  if (decoded === undefined) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      "Host-local JSON media sends require decodable JSON text.",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded.charCodeAt(0) === 0xfeff ? decoded.slice(1) : decoded);
+  } catch {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      "Host-local JSON media sends require valid JSON syntax.",
+    );
+  }
+
+  const sensitiveKeyPath = findSensitiveJsonKeyPath(parsed);
+  if (sensitiveKeyPath) {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      `Host-local JSON media sends block secret-like JSON keys (first match: ${sensitiveKeyPath}).`,
+    );
+  }
+}
+
 function formatMb(bytes: number, digits = 2): string {
   return (bytes / MB).toFixed(digits);
 }
@@ -241,6 +413,14 @@ function assertHostReadMediaAllowed(params: {
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
+  if (declaredMime === HOST_READ_JSON_MIME) {
+    assertHostReadJsonAllowed({
+      sniffedContentType: params.sniffedContentType,
+      filePath: params.filePath,
+      buffer: params.buffer,
+    });
+    return;
+  }
   // For extension-declared plain-text aliases such as .csv/.md, trust only the
   // text validator path. Some opaque blobs can still produce bogus binary MIME
   // hits (for example BOM-prefixed 0xFF data sniffing as audio/mpeg), and
@@ -298,7 +478,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, CSV, Markdown, and safe JSON artifacts (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Summary

- allow host-local `.json` files to be sent as `MEDIA:` document artifacts when they parse as validated JSON text
- block risky JSON filenames such as `openclaw.json`, `openclaw.config.json`, credentials/secrets/token/service-account JSON files
- reject JSON artifacts with secret-like keys such as `apiKey`, `token`, `password`, and `privateKey`
- document the JSON artifact policy for local `MEDIA:` sends

Fixes #77702

## Testing

- `pnpm exec vitest run --config test/vitest/vitest.media.config.ts src/media/web-media.test.ts`
- `pnpm exec oxfmt --check src/media/web-media.ts src/media/web-media.test.ts docs/start/openclaw.md docs/help/faq.md docs/reference/rich-output-protocol.md`
- `pnpm exec oxlint src/media/web-media.ts src/media/web-media.test.ts`
- `pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc docs/start/openclaw.md docs/help/faq.md docs/reference/rich-output-protocol.md`
- `pnpm check:changed --base origin/main --head HEAD`
