### PR TITLE
Add Telegram reliability and handoff commands

### DIFF
--- a/docs/channels/telegram-reliability-v1-runbook.md
+++ b/docs/channels/telegram-reliability-v1-runbook.md
@@ -1,0 +1,142 @@
+---
+summary: "Review, shadow-test, deploy, and roll back the Telegram Reliability v1 patch"
+read_when:
+  - Reviewing Telegram reliability changes
+  - Preparing a local build from a fork
+  - Investigating Telegram requests that were received but never answered
+title: "Telegram Reliability v1 Runbook"
+---
+
+This runbook describes the safe review and rollout path for Telegram Reliability v1.
+It is intentionally conservative: the patch improves observability and user-visible
+failure reporting, but it must not automatically replay Telegram requests or mutate
+gateway state.
+
+## Scope
+
+Telegram Reliability v1 covers four behaviors:
+
+1. Record lightweight Telegram inflight state for each dispatched request.
+2. Send explicit failure notices for timeout, provider/network, context, session-lock,
+   and delivery failure classes.
+3. Guard very long Telegram inputs when the current Telegram session is already large.
+4. On Telegram runtime startup, mark stale non-terminal inflight records as interrupted
+   and notify the original chat.
+
+The patch does not:
+
+- restart the gateway
+- retry or replay interrupted requests
+- cancel or clean tasks
+- change models, bindings, config, secrets, or sessions
+- call heavy task audit/show paths from Telegram hot code
+
+## Review Checklist
+
+Before building a package, reviewers should confirm:
+
+- Inflight records store only a short prompt preview and hash, not full user prompts.
+- Store writes are best-effort and do not block Telegram dispatch if they fail.
+- Startup interrupted notifications are bounded and do not rerun any action.
+- High-context input protection still allows short commands such as `/new`, `/handoff`,
+  `/resume`, `/compact`, `/status`, `/stop`, and `/abort`.
+- Failure notices are short and do not expose provider secrets or stack traces.
+- Tests cover completion, failure notification, long-input guard, and startup
+  interrupted notice.
+
+## Local Validation
+
+Run the narrow Telegram test set first:
+
+```bash
+corepack pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts \
+  extensions/telegram/src/bot-message-dispatch.test.ts \
+  extensions/telegram/src/bot.create-telegram-bot.test.ts
+```
+
+Then run formatting and type checks when the machine has enough headroom:
+
+```bash
+git diff --check
+corepack pnpm tsgo:extensions
+corepack pnpm tsgo:extensions:test
+```
+
+If the extension type checks time out locally, do not treat that alone as a production
+approval. Re-run them in CI or a less loaded environment.
+
+## Shadow Build
+
+Use a fork branch and build a package without replacing the currently installed
+OpenClaw package:
+
+```bash
+corepack pnpm install --frozen-lockfile
+corepack pnpm build
+corepack pnpm pack
+```
+
+Keep the generated tarball path and the git commit hash together. Do not overwrite
+the production global install until the package can answer basic local CLI checks.
+
+## Pre-Deployment Snapshot
+
+Before replacing a running installation, capture:
+
+```bash
+openclaw --version
+openclaw gateway status
+openclaw gateway probe --json
+openclaw channels status --json
+openclaw sessions --all-agents --active 1440 --json
+```
+
+Also record:
+
+- current npm package version and install path
+- current gateway PID and uptime
+- current Telegram session key and token count
+- current OpenClaw config backup path
+
+Do not print secrets in deployment notes.
+
+## Rollout
+
+Recommended rollout order:
+
+1. Stop the local test gateway, if any.
+2. Install the candidate package into a temporary or isolated Node prefix when possible.
+3. Run `openclaw --version` and a CLI smoke test from the candidate install.
+4. Start a test gateway with Telegram disabled or with a non-production account.
+5. Verify the gateway starts, probes, and stops cleanly.
+6. Only then consider replacing the production package.
+
+For a production Telegram account, the first live verification should be a short
+message such as `/status` or a one-line prompt. Do not paste long logs into the first
+test message.
+
+## Rollback
+
+Rollback must be simple and pre-decided:
+
+1. Stop the candidate gateway.
+2. Reinstall the previous known-good OpenClaw npm version or restore the previous
+   package directory.
+3. Restore the previous gateway service command if it was changed.
+4. Start the gateway.
+5. Verify `openclaw gateway probe --json` and `openclaw channels status --json`.
+
+The reliability inflight store is safe to leave in place during rollback. It is
+state-only telemetry and should not be required by the previous version.
+
+## Expected User-Facing Changes
+
+Users should see fewer silent Telegram failures:
+
+- A timeout should produce a short timeout notice.
+- A high-context long input should produce a handoff/new-session suggestion.
+- A gateway restart should produce an interrupted-request notice after Telegram
+  runtime startup.
+
+Users should not see automatic duplicate task execution.
+

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -40,6 +40,10 @@ import { tagTelegramNetworkError } from "./network-errors.js";
 import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import {
+  markStaleTelegramInflightInterrupted,
+  type TelegramInflightRecord,
+} from "./telegram-reliability-store.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
 
 export type { TelegramBotOptions } from "./bot.types.js";
@@ -152,6 +156,44 @@ function resolveTelegramClientTimeoutSeconds(params: {
     return configured;
   }
   return Math.max(configured, Math.max(1, Math.floor(minimum)));
+}
+
+const TELEGRAM_INTERRUPTED_NOTICE =
+  "A previous Telegram request was interrupted before completion, likely because the gateway restarted or the Telegram runtime was stopped. Please resend it or reply with a short continue instruction. I will not rerun it automatically.";
+
+function notifyInterruptedTelegramInflight(params: {
+  bot: TelegramBotInstance;
+  accountId: string;
+  telegramDeps: TelegramBotDeps;
+  runtime: RuntimeEnv;
+}): void {
+  let interrupted: TelegramInflightRecord[];
+  try {
+    interrupted = (
+      params.telegramDeps.markStaleTelegramInflightInterrupted ??
+      markStaleTelegramInflightInterrupted
+    )({
+      accountId: params.accountId,
+    });
+  } catch (err) {
+    params.runtime.error?.(
+      danger(`telegram reliability interrupted scan failed: ${formatErrorMessage(err)}`),
+    );
+    return;
+  }
+  for (const record of interrupted.slice(0, 5)) {
+    void params.bot.api
+      .sendMessage(record.chatId, TELEGRAM_INTERRUPTED_NOTICE, {
+        ...(record.thread?.scope === "forum" && typeof record.thread.id === "number"
+          ? { message_thread_id: record.thread.id }
+          : {}),
+      })
+      .catch((err: unknown) => {
+        params.runtime.error?.(
+          danger(`telegram reliability interrupted notice failed: ${formatErrorMessage(err)}`),
+        );
+      });
+  }
 }
 
 export function createTelegramBotCore(
@@ -332,6 +374,12 @@ export function createTelegramBotCore(
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
+  });
+  notifyInterruptedTelegramInflight({
+    bot,
+    accountId: account.accountId,
+    telegramDeps,
+    runtime,
   });
 
   const initialUpdateId =

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -15,6 +15,12 @@ import { createTelegramDraftStream } from "./draft-stream.js";
 import { resolveTelegramExecApproval } from "./exec-approval-resolver.js";
 import { editMessageTelegram } from "./send.js";
 import { wasSentByBot } from "./sent-message-cache.js";
+import {
+  markTelegramInflightCompleted,
+  markTelegramInflightDispatched,
+  markTelegramInflightFailed,
+  markStaleTelegramInflightInterrupted,
+} from "./telegram-reliability-store.js";
 
 export type TelegramBotDeps = {
   getRuntimeConfig: typeof getRuntimeConfig;
@@ -35,6 +41,10 @@ export type TelegramBotDeps = {
   emitInternalMessageSentHook?: typeof emitInternalMessageSentHook;
   editMessageTelegram?: typeof editMessageTelegram;
   createChannelReplyPipeline?: typeof createChannelReplyPipeline;
+  markTelegramInflightDispatched?: typeof markTelegramInflightDispatched;
+  markTelegramInflightCompleted?: typeof markTelegramInflightCompleted;
+  markTelegramInflightFailed?: typeof markTelegramInflightFailed;
+  markStaleTelegramInflightInterrupted?: typeof markStaleTelegramInflightInterrupted;
 };
 
 export const defaultTelegramBotDeps: TelegramBotDeps = {
@@ -91,5 +101,17 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   },
   get createChannelReplyPipeline() {
     return createChannelReplyPipeline;
+  },
+  get markTelegramInflightDispatched() {
+    return markTelegramInflightDispatched;
+  },
+  get markTelegramInflightCompleted() {
+    return markTelegramInflightCompleted;
+  },
+  get markTelegramInflightFailed() {
+    return markTelegramInflightFailed;
+  },
+  get markStaleTelegramInflightInterrupted() {
+    return markStaleTelegramInflightInterrupted;
   },
 };

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -54,6 +54,9 @@ const createChannelReplyPipeline = vi.hoisted(() =>
 );
 const wasSentByBot = vi.hoisted(() => vi.fn(() => false));
 const loadSessionStore = vi.hoisted(() => vi.fn());
+const markTelegramInflightDispatched = vi.hoisted(() => vi.fn(() => "inflight-1"));
+const markTelegramInflightCompleted = vi.hoisted(() => vi.fn());
+const markTelegramInflightFailed = vi.hoisted(() => vi.fn());
 const resolveStorePath = vi.hoisted(() => vi.fn(() => "/tmp/sessions.json"));
 const generateTopicLabel = vi.hoisted(() => vi.fn());
 const describeStickerImage = vi.hoisted(() => vi.fn(async () => null));
@@ -155,6 +158,12 @@ const telegramDepsForTest: TelegramBotDeps = {
   emitInternalMessageSentHook:
     emitInternalMessageSentHook as TelegramBotDeps["emitInternalMessageSentHook"],
   editMessageTelegram: editMessageTelegram as TelegramBotDeps["editMessageTelegram"],
+  markTelegramInflightDispatched:
+    markTelegramInflightDispatched as TelegramBotDeps["markTelegramInflightDispatched"],
+  markTelegramInflightCompleted:
+    markTelegramInflightCompleted as TelegramBotDeps["markTelegramInflightCompleted"],
+  markTelegramInflightFailed:
+    markTelegramInflightFailed as TelegramBotDeps["markTelegramInflightFailed"],
 };
 
 describe("dispatchTelegramMessage draft streaming", () => {
@@ -191,6 +200,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createChannelReplyPipeline.mockReset();
     wasSentByBot.mockReset();
     loadSessionStore.mockReset();
+    markTelegramInflightDispatched.mockReset();
+    markTelegramInflightCompleted.mockReset();
+    markTelegramInflightFailed.mockReset();
     resolveStorePath.mockReset();
     generateTopicLabel.mockReset();
     getAgentScopedMediaLocalRoots.mockClear();
@@ -237,6 +249,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       onModelSelected: () => undefined,
     });
     wasSentByBot.mockReturnValue(false);
+    markTelegramInflightDispatched.mockReturnValue("inflight-1");
     resolveStorePath.mockReturnValue("/tmp/sessions.json");
     loadSessionStore.mockReturnValue({});
     generateTopicLabel.mockResolvedValue("Topic label");
@@ -397,6 +410,118 @@ describe("dispatchTelegramMessage draft streaming", () => {
       ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
     });
   }
+
+  it("records Telegram inflight completion when a final reply is delivered", async () => {
+    loadSessionStore.mockReturnValue({
+      s1: { totalTokens: 42_000 },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          MessageSid: "456",
+          Body: "please do the work",
+          BodyForAgent: "please do the work",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    expect(markTelegramInflightDispatched).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        agentId: "default",
+        chatId: 123,
+        messageId: "456",
+        promptText: "please do the work",
+        sessionKey: "s1",
+        tokenRisk: "normal",
+        tokenTotal: 42_000,
+      }),
+    );
+    expect(markTelegramInflightCompleted).toHaveBeenCalledWith({
+      accountId: "default",
+      id: "inflight-1",
+    });
+    expect(markTelegramInflightFailed).not.toHaveBeenCalled();
+  });
+
+  it("records Telegram inflight failure and sends a timeout notice", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(
+      new Error("fetch timeout reached"),
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          MessageSid: "456",
+          Body: "please do the work",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    expect(markTelegramInflightFailed).toHaveBeenCalledWith({
+      accountId: "default",
+      id: "inflight-1",
+      errorKind: "timeout",
+      errorText: "fetch timeout reached",
+    });
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: expect.stringContaining("timed out"),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("guards long Telegram input when the session context is already high", async () => {
+    const longText = "large diagnostic report ".repeat(120);
+    loadSessionStore.mockReturnValue({
+      s1: { totalTokens: 170_000 },
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "s1",
+          MessageSid: "456",
+          Body: longText,
+          BodyForAgent: longText,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(markTelegramInflightDispatched).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenRisk: "high",
+        tokenTotal: 170_000,
+      }),
+    );
+    expect(markTelegramInflightFailed).toHaveBeenCalledWith({
+      accountId: "default",
+      id: "inflight-1",
+      errorKind: "context_overflow",
+      errorText: "Large Telegram input blocked before dispatch.",
+    });
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: expect.stringContaining("large context"),
+          }),
+        ],
+      }),
+    );
+  });
 
   it("streams drafts in private threads and forwards thread id", async () => {
     const draftStream = createDraftStream();
@@ -3214,7 +3339,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [
-          { text: "Something went wrong while processing your request. Please try again." },
+          {
+            text: "Something went wrong before a final Telegram reply could be delivered. Please try again.",
+          },
         ],
       }),
     );

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -88,6 +88,19 @@ import {
 } from "./reasoning-lane-coordinator.js";
 import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
+import {
+  buildTelegramFailureNotice,
+  classifyTelegramReliabilityError,
+  classifyTelegramTokenRisk,
+  shouldGuardTelegramLongInput,
+  type TelegramReliabilityErrorKind,
+  type TelegramTokenRisk,
+} from "./telegram-reliability.js";
+import {
+  markTelegramInflightCompleted,
+  markTelegramInflightDispatched,
+  markTelegramInflightFailed,
+} from "./telegram-reliability-store.js";
 
 export { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
 
@@ -215,6 +228,127 @@ function resolveTelegramReasoningLevel(params: {
     // Fall through to default.
   }
   return "off";
+}
+
+function resolveTelegramReliabilityText(ctxPayload: {
+  BodyForAgent?: string;
+  Body?: string;
+  RawBody?: string;
+  CommandBody?: string;
+}): string {
+  return (
+    ctxPayload.BodyForAgent ??
+    ctxPayload.Body ??
+    ctxPayload.RawBody ??
+    ctxPayload.CommandBody ??
+    ""
+  );
+}
+
+function resolveTelegramSessionTokenTotal(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  agentId: string;
+  telegramDeps: TelegramBotDeps;
+}): number | undefined {
+  const { cfg, sessionKey, agentId, telegramDeps } = params;
+  if (!sessionKey) {
+    return undefined;
+  }
+  try {
+    const storePath = telegramDeps.resolveStorePath(cfg.session?.store, { agentId });
+    const store = (telegramDeps.loadSessionStore ?? loadSessionStore)(storePath, {
+      skipCache: true,
+    });
+    const entry = resolveSessionStoreEntry({ store, sessionKey }).existing as
+      | { totalTokens?: unknown; contextTokens?: unknown }
+      | undefined;
+    const totalTokens = coerceFiniteNumber(entry?.totalTokens);
+    if (totalTokens !== undefined) {
+      return totalTokens;
+    }
+    return coerceFiniteNumber(entry?.contextTokens);
+  } catch (err) {
+    logVerbose(`telegram reliability: session token read failed: ${formatErrorMessage(err)}`);
+    return undefined;
+  }
+}
+
+function coerceFiniteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function markTelegramReliabilityDispatched(params: {
+  telegramDeps: TelegramBotDeps;
+  accountId?: string;
+  chatId: string | number;
+  messageId?: string | number;
+  thread?: { id?: string | number | null; scope?: string };
+  sessionKey?: string;
+  agentId?: string;
+  promptText?: string;
+  tokenTotal?: number;
+  tokenRisk?: TelegramTokenRisk;
+}): string | undefined {
+  try {
+    return (params.telegramDeps.markTelegramInflightDispatched ?? markTelegramInflightDispatched)({
+      accountId: params.accountId,
+      chatId: params.chatId,
+      messageId: params.messageId,
+      thread: params.thread,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      promptText: params.promptText,
+      tokenTotal: params.tokenTotal,
+      tokenRisk: params.tokenRisk,
+    });
+  } catch (err) {
+    logVerbose(`telegram reliability: inflight dispatch record failed: ${formatErrorMessage(err)}`);
+    return undefined;
+  }
+}
+
+function markTelegramReliabilityCompleted(params: {
+  telegramDeps: TelegramBotDeps;
+  accountId?: string;
+  inflightId?: string;
+}): void {
+  if (!params.inflightId) {
+    return;
+  }
+  try {
+    (params.telegramDeps.markTelegramInflightCompleted ?? markTelegramInflightCompleted)({
+      accountId: params.accountId,
+      id: params.inflightId,
+    });
+  } catch (err) {
+    logVerbose(`telegram reliability: inflight complete record failed: ${formatErrorMessage(err)}`);
+  }
+}
+
+function markTelegramReliabilityFailed(params: {
+  telegramDeps: TelegramBotDeps;
+  accountId?: string;
+  inflightId?: string;
+  errorKind: TelegramReliabilityErrorKind;
+  errorText?: string;
+}): void {
+  if (!params.inflightId) {
+    return;
+  }
+  try {
+    (params.telegramDeps.markTelegramInflightFailed ?? markTelegramInflightFailed)({
+      accountId: params.accountId,
+      id: params.inflightId,
+      errorKind: params.errorKind,
+      errorText: params.errorText,
+    });
+  } catch (err) {
+    logVerbose(`telegram reliability: inflight failed record failed: ${formatErrorMessage(err)}`);
+  }
 }
 
 const MAX_PROGRESS_MARKDOWN_TEXT_CHARS = 300;
@@ -669,6 +803,62 @@ export const dispatchTelegramMessage = async ({
   let hadErrorReplyFailureOrSkip = false;
   let isFirstTurnInSession = false;
   let dispatchError: unknown;
+  const reliabilityPromptText = resolveTelegramReliabilityText(ctxPayload);
+  const reliabilityTokenTotal = resolveTelegramSessionTokenTotal({
+    cfg,
+    sessionKey: ctxPayload.SessionKey,
+    agentId: route.agentId,
+    telegramDeps,
+  });
+  const reliabilityTokenRisk =
+    reliabilityTokenTotal === undefined
+      ? undefined
+      : classifyTelegramTokenRisk(reliabilityTokenTotal);
+  const inflightId = markTelegramReliabilityDispatched({
+    telegramDeps,
+    accountId: route.accountId,
+    chatId,
+    messageId: ctxPayload.MessageSid ?? msg.message_id,
+    thread: threadSpec,
+    sessionKey: ctxPayload.SessionKey,
+    agentId: route.agentId,
+    promptText: reliabilityPromptText,
+    tokenTotal: reliabilityTokenTotal,
+    tokenRisk: reliabilityTokenRisk,
+  });
+  const longInputGuard =
+    reliabilityTokenTotal === undefined
+      ? { guarded: false as const }
+      : shouldGuardTelegramLongInput({
+          totalTokens: reliabilityTokenTotal,
+          text: reliabilityPromptText,
+          commandSource: ctxPayload.CommandSource,
+        });
+  if (longInputGuard.guarded && longInputGuard.message) {
+    const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
+      replies: [{ text: longInputGuard.message }],
+      ...deliveryBaseOptions,
+      silent: false,
+      mediaLoader: telegramDeps.loadWebMedia,
+    });
+    markTelegramReliabilityFailed({
+      telegramDeps,
+      accountId: route.accountId,
+      inflightId,
+      errorKind: result.delivered ? "context_overflow" : "delivery_failure",
+      errorText: "Large Telegram input blocked before dispatch.",
+    });
+    if (statusReactionController) {
+      void finalizeTelegramStatusReaction({
+        outcome: "error",
+        hasFinalResponse: result.delivered,
+      }).catch((err: unknown) => {
+        logVerbose(`telegram: status reaction guard finalize failed: ${String(err)}`);
+      });
+    }
+    clearGroupHistory();
+    return;
+  }
 
   try {
     const sticker = ctxPayload.Sticker;
@@ -1169,6 +1359,11 @@ export const dispatchTelegramMessage = async ({
         },
       });
       if (!turnResult.dispatched) {
+        markTelegramReliabilityCompleted({
+          telegramDeps,
+          accountId: route.accountId,
+          inflightId,
+        });
         return;
       }
       ({ queuedFinal } = turnResult.dispatchResult);
@@ -1253,6 +1448,13 @@ export const dispatchTelegramMessage = async ({
     releaseAbortFence();
   }
   if (dispatchWasSuperseded) {
+    markTelegramReliabilityFailed({
+      telegramDeps,
+      accountId: route.accountId,
+      inflightId,
+      errorKind: "unknown",
+      errorText: "Dispatch superseded by a newer Telegram control message.",
+    });
     if (statusReactionController) {
       void finalizeTelegramStatusReaction({ outcome: "done", hasFinalResponse: true }).catch(
         (err: unknown) => {
@@ -1290,7 +1492,7 @@ export const dispatchTelegramMessage = async ({
       (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0))
   ) {
     const fallbackText = dispatchError
-      ? "Something went wrong while processing your request. Please try again."
+      ? buildTelegramFailureNotice(dispatchError)
       : EMPTY_RESPONSE_FALLBACK;
     const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
       replies: [{ text: fallbackText }],
@@ -1347,8 +1549,33 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (!hasFinalResponse) {
+    markTelegramReliabilityFailed({
+      telegramDeps,
+      accountId: route.accountId,
+      inflightId,
+      errorKind: dispatchError ? classifyTelegramReliabilityError(dispatchError) : "delivery_failure",
+      errorText: dispatchError ? formatErrorMessage(dispatchError) : "No final Telegram response.",
+    });
     clearGroupHistory();
     return;
+  }
+
+  if (dispatchError || sentFallback || hadErrorReplyFailureOrSkip) {
+    markTelegramReliabilityFailed({
+      telegramDeps,
+      accountId: route.accountId,
+      inflightId,
+      errorKind: dispatchError ? classifyTelegramReliabilityError(dispatchError) : "delivery_failure",
+      errorText: dispatchError
+        ? formatErrorMessage(dispatchError)
+        : "Telegram fallback or error reply path was used.",
+    });
+  } else {
+    markTelegramReliabilityCompleted({
+      telegramDeps,
+      accountId: route.accountId,
+      inflightId,
+    });
   }
 
   // Fire-and-forget: auto-rename DM topic on first message.

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -36,6 +36,11 @@ const { sessionStorePath } = vi.hoisted(() => ({
 const { loadWebMedia } = vi.hoisted((): { loadWebMedia: AnyMock } => ({
   loadWebMedia: vi.fn(),
 }));
+const { markStaleTelegramInflightInterrupted } = vi.hoisted(
+  (): { markStaleTelegramInflightInterrupted: AnyMock } => ({
+    markStaleTelegramInflightInterrupted: vi.fn(() => []),
+  }),
+);
 
 export function getLoadWebMediaMock(): AnyMock {
   return loadWebMedia;
@@ -301,6 +306,8 @@ export const setMyCommandsSpy: AnyAsyncMock = grammySpies.setMyCommandsSpy;
 export const getMeSpy: AnyAsyncMock = grammySpies.getMeSpy;
 export const getChatSpy: AnyAsyncMock = grammySpies.getChatSpy;
 export const sendMessageSpy: AnyAsyncMock = grammySpies.sendMessageSpy;
+export const markStaleTelegramInflightInterruptedSpy: AnyMock =
+  markStaleTelegramInflightInterrupted;
 export const sendAnimationSpy: AnyAsyncMock = grammySpies.sendAnimationSpy;
 export const sendPhotoSpy: AnyAsyncMock = grammySpies.sendPhotoSpy;
 export const getFileSpy: AnyAsyncMock = grammySpies.getFileSpy;
@@ -381,6 +388,8 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
   resolveExecApproval: resolveExecApprovalSpy as NonNullable<
     TelegramBotDeps["resolveExecApproval"]
   >,
+  markStaleTelegramInflightInterrupted:
+    markStaleTelegramInflightInterrupted as TelegramBotDeps["markStaleTelegramInflightInterrupted"],
 };
 
 vi.doMock("./bot.runtime.js", () => telegramBotRuntimeForTest);
@@ -521,6 +530,8 @@ beforeEach(() => {
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);
+  markStaleTelegramInflightInterrupted.mockReset();
+  markStaleTelegramInflightInterrupted.mockReturnValue([]);
   listSkillCommandsForAgents.mockReset();
   listSkillCommandsForAgents.mockReturnValue([]);
   buildModelsProviderData.mockReset();

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -19,6 +19,7 @@ const {
   getChatSpy,
   getLoadConfigMock,
   getLoadSessionStoreMock,
+  markStaleTelegramInflightInterruptedSpy,
   getOnHandler,
   getReadChannelAllowFromStoreMock,
   getUpsertChannelPairingRequestMock,
@@ -178,6 +179,31 @@ describe("createTelegramBot", () => {
     createTelegramBot({ token: "tok" });
     expect(throttlerSpy).toHaveBeenCalledTimes(1);
     expect(useSpy).toHaveBeenCalledWith("throttler");
+  });
+
+  it("notifies chats about interrupted inflight Telegram requests on startup", () => {
+    markStaleTelegramInflightInterruptedSpy.mockReturnValueOnce([
+      {
+        id: "inflight-1",
+        accountId: "default",
+        chatId: "123",
+        state: "interrupted",
+        receivedAt: "2026-05-05T12:00:00.000Z",
+        updatedAt: "2026-05-05T12:01:00.000Z",
+        thread: { scope: "forum", id: 99 },
+      },
+    ]);
+
+    createTelegramBot({ token: "tok" });
+
+    expect(markStaleTelegramInflightInterruptedSpy).toHaveBeenCalledWith({
+      accountId: "default",
+    });
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      "123",
+      expect.stringContaining("interrupted before completion"),
+      expect.objectContaining({ message_thread_id: 99 }),
+    );
   });
 
   it("logs middleware errors through grammY catch without rethrowing", () => {

--- a/extensions/telegram/src/telegram-reliability-store.ts
+++ b/extensions/telegram/src/telegram-reliability-store.ts
@@ -1,0 +1,272 @@
+import path from "node:path";
+import { loadJsonFile, saveJsonFile } from "openclaw/plugin-sdk/json-store";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import type { TelegramReliabilityErrorKind, TelegramTokenRisk } from "./telegram-reliability.js";
+
+const STORE_VERSION = 1;
+const MAX_RECORDS = 500;
+const TERMINAL_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type TelegramInflightState = "dispatched" | "completed" | "failed" | "interrupted";
+
+export type TelegramInflightRecord = {
+  id: string;
+  accountId: string;
+  chatId: string;
+  messageId?: string;
+  thread?: { id?: string | number | null; scope?: string };
+  sessionKey?: string;
+  agentId?: string;
+  state: TelegramInflightState;
+  receivedAt: string;
+  dispatchedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  interruptedAt?: string;
+  updatedAt: string;
+  promptPreview?: string;
+  promptHash?: string;
+  tokenTotal?: number;
+  tokenRisk?: TelegramTokenRisk;
+  errorKind?: TelegramReliabilityErrorKind;
+  errorText?: string;
+};
+
+type TelegramInflightStore = {
+  version: number;
+  records: Record<string, TelegramInflightRecord>;
+};
+
+export type MarkTelegramInflightDispatchedParams = {
+  accountId?: string;
+  chatId: string | number;
+  messageId?: string | number;
+  thread?: { id?: string | number | null; scope?: string };
+  sessionKey?: string;
+  agentId?: string;
+  receivedAt?: Date;
+  promptText?: string;
+  tokenTotal?: number;
+  tokenRisk?: TelegramTokenRisk;
+};
+
+export function resolveTelegramInflightId(params: {
+  accountId?: string;
+  chatId: string | number;
+  messageId?: string | number;
+  thread?: { id?: string | number | null; scope?: string };
+}): string {
+  return [
+    normalizeAccountId(params.accountId),
+    String(params.chatId),
+    params.thread?.scope ?? "chat",
+    params.thread?.id ?? "root",
+    params.messageId ?? "unknown",
+  ]
+    .map((part) => String(part).replace(/[^a-z0-9._:-]+/gi, "_"))
+    .join(":");
+}
+
+export function markTelegramInflightDispatched(
+  params: MarkTelegramInflightDispatchedParams,
+): string {
+  const accountId = normalizeAccountId(params.accountId);
+  const id = resolveTelegramInflightId({ ...params, accountId });
+  const store = loadStore(accountId);
+  const now = new Date();
+  const receivedAt = params.receivedAt ?? now;
+  const existing = store.records[id];
+  store.records[id] = {
+    ...existing,
+    id,
+    accountId,
+    chatId: String(params.chatId),
+    messageId: params.messageId == null ? undefined : String(params.messageId),
+    thread: params.thread,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    state: "dispatched",
+    receivedAt: existing?.receivedAt ?? receivedAt.toISOString(),
+    dispatchedAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    promptPreview: clipPromptPreview(params.promptText),
+    promptHash: hashText(params.promptText),
+    tokenTotal: params.tokenTotal,
+    tokenRisk: params.tokenRisk,
+    errorKind: undefined,
+    errorText: undefined,
+  };
+  saveStore(accountId, pruneStore(store));
+  return id;
+}
+
+export function markTelegramInflightCompleted(params: {
+  accountId?: string;
+  id: string;
+}): void {
+  updateTerminal(params.accountId, params.id, "completed");
+}
+
+export function markTelegramInflightFailed(params: {
+  accountId?: string;
+  id: string;
+  errorKind: TelegramReliabilityErrorKind;
+  errorText?: string;
+}): void {
+  const accountId = normalizeAccountId(params.accountId);
+  const store = loadStore(accountId);
+  const record = store.records[params.id];
+  if (!record) {
+    return;
+  }
+  const now = new Date().toISOString();
+  store.records[params.id] = {
+    ...record,
+    state: "failed",
+    failedAt: now,
+    updatedAt: now,
+    errorKind: params.errorKind,
+    errorText: clipErrorText(params.errorText),
+  };
+  saveStore(accountId, pruneStore(store));
+}
+
+export function markStaleTelegramInflightInterrupted(params: {
+  accountId?: string;
+  olderThanMs?: number;
+  recentWindowMs?: number;
+  now?: Date;
+}): TelegramInflightRecord[] {
+  const accountId = normalizeAccountId(params.accountId);
+  const store = loadStore(accountId);
+  const now = params.now ?? new Date();
+  const olderThanMs = params.olderThanMs ?? 60_000;
+  const recentWindowMs = params.recentWindowMs ?? 6 * 60 * 60 * 1000;
+  const interrupted: TelegramInflightRecord[] = [];
+  for (const [id, record] of Object.entries(store.records)) {
+    if (record.state !== "dispatched") {
+      continue;
+    }
+    const updatedAt = Date.parse(record.updatedAt);
+    if (!Number.isFinite(updatedAt)) {
+      continue;
+    }
+    const age = now.getTime() - updatedAt;
+    if (age < olderThanMs || age > recentWindowMs) {
+      continue;
+    }
+    const interruptedAt = now.toISOString();
+    const next = {
+      ...record,
+      state: "interrupted" as const,
+      interruptedAt,
+      updatedAt: interruptedAt,
+      errorKind: "unknown" as TelegramReliabilityErrorKind,
+      errorText: "Gateway restarted or Telegram runtime was interrupted before completion.",
+    };
+    store.records[id] = next;
+    interrupted.push(next);
+  }
+  if (interrupted.length > 0) {
+    saveStore(accountId, pruneStore(store));
+  }
+  return interrupted;
+}
+
+function updateTerminal(
+  accountIdInput: string | undefined,
+  id: string,
+  state: Extract<TelegramInflightState, "completed" | "failed" | "interrupted">,
+): void {
+  const accountId = normalizeAccountId(accountIdInput);
+  const store = loadStore(accountId);
+  const record = store.records[id];
+  if (!record) {
+    return;
+  }
+  const now = new Date().toISOString();
+  store.records[id] = {
+    ...record,
+    state,
+    completedAt: state === "completed" ? now : record.completedAt,
+    failedAt: state === "failed" ? now : record.failedAt,
+    interruptedAt: state === "interrupted" ? now : record.interruptedAt,
+    updatedAt: now,
+  };
+  saveStore(accountId, pruneStore(store));
+}
+
+function loadStore(accountId: string): TelegramInflightStore {
+  const loaded = loadJsonFile(storePath(accountId));
+  if (!loaded || typeof loaded !== "object") {
+    return emptyStore();
+  }
+  const store = loaded as Partial<TelegramInflightStore>;
+  if (store.version !== STORE_VERSION || !store.records || typeof store.records !== "object") {
+    return emptyStore();
+  }
+  return { version: STORE_VERSION, records: store.records };
+}
+
+function saveStore(accountId: string, store: TelegramInflightStore): void {
+  saveJsonFile(storePath(accountId), store);
+}
+
+function pruneStore(store: TelegramInflightStore): TelegramInflightStore {
+  const now = Date.now();
+  const entries = Object.entries(store.records)
+    .filter(([, record]) => {
+      if (record.state === "dispatched") {
+        return true;
+      }
+      const updatedAt = Date.parse(record.updatedAt);
+      return Number.isFinite(updatedAt) && now - updatedAt <= TERMINAL_TTL_MS;
+    })
+    .sort((a, b) => Date.parse(b[1].updatedAt) - Date.parse(a[1].updatedAt))
+    .slice(0, MAX_RECORDS);
+  return { version: STORE_VERSION, records: Object.fromEntries(entries) };
+}
+
+function emptyStore(): TelegramInflightStore {
+  return { version: STORE_VERSION, records: {} };
+}
+
+function storePath(accountId: string): string {
+  return path.join(resolveStateDir(), "telegram", `reliability-inflight-${accountId}.json`);
+}
+
+function normalizeAccountId(accountId?: string): string {
+  const trimmed = accountId?.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  return trimmed.replace(/[^a-z0-9._-]+/gi, "_");
+}
+
+function clipPromptPreview(text?: string): string | undefined {
+  const trimmed = text?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > 120 ? `${trimmed.slice(0, 117)}...` : trimmed;
+}
+
+function clipErrorText(text?: string): string | undefined {
+  const trimmed = text?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > 240 ? `${trimmed.slice(0, 237)}...` : trimmed;
+}
+
+function hashText(text?: string): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/extensions/telegram/src/telegram-reliability.ts
+++ b/extensions/telegram/src/telegram-reliability.ts
@@ -1,0 +1,100 @@
+export type TelegramReliabilityErrorKind =
+  | "timeout"
+  | "context_overflow"
+  | "session_lock"
+  | "provider_fetch"
+  | "delivery_failure"
+  | "unknown";
+
+export type TelegramTokenRisk = "normal" | "observe" | "handoff" | "high" | "new_session";
+
+export function classifyTelegramReliabilityError(error: unknown): TelegramReliabilityErrorKind {
+  const text = String(
+    error instanceof Error ? `${error.name}: ${error.message}` : error ?? "",
+  ).toLowerCase();
+  if (/\b(context|token).{0,24}(overflow|limit|too large)|maximum context/.test(text)) {
+    return "context_overflow";
+  }
+  if (/\b(session|conversation).{0,24}(lock|busy|locked)/.test(text)) {
+    return "session_lock";
+  }
+  if (/\b(fetch|network|econn|etimedout|eai_again|socket|provider|api)\b/.test(text)) {
+    return text.includes("timeout") || text.includes("timed out") ? "timeout" : "provider_fetch";
+  }
+  if (/\btimeout|timed out|abort(ed)?\b/.test(text)) {
+    return "timeout";
+  }
+  return "unknown";
+}
+
+export function classifyTelegramTokenRisk(totalTokens: number): TelegramTokenRisk {
+  if (totalTokens >= 200_000) {
+    return "new_session";
+  }
+  if (totalTokens >= 160_000) {
+    return "high";
+  }
+  if (totalTokens >= 120_000) {
+    return "handoff";
+  }
+  if (totalTokens >= 80_000) {
+    return "observe";
+  }
+  return "normal";
+}
+
+export function shouldGuardTelegramLongInput(params: {
+  totalTokens: number;
+  text: string;
+  commandSource?: string;
+}): { guarded: boolean; risk: TelegramTokenRisk; message?: string } {
+  const text = params.text.trim();
+  const risk = classifyTelegramTokenRisk(params.totalTokens);
+  if (!text) {
+    return { guarded: false, risk };
+  }
+  if (isReliabilitySafeCommand(text, params.commandSource)) {
+    return { guarded: false, risk };
+  }
+
+  const length = text.length;
+  const shouldGuard =
+    (risk === "new_session" && length >= 800) ||
+    (risk === "high" && length >= 2_000) ||
+    (risk === "handoff" && length >= 5_000);
+  if (!shouldGuard) {
+    return { guarded: false, risk };
+  }
+
+  return {
+    guarded: true,
+    risk,
+    message:
+      "This Telegram chat is already carrying a large context. I received the message, but I will not process this long input here because it may stall the gateway. Please run /handoff or /new first, then send a short summary or attach the long material through a background task.",
+  };
+}
+
+export function buildTelegramFailureNotice(error: unknown): string {
+  const kind = classifyTelegramReliabilityError(error);
+  if (kind === "timeout") {
+    return "The request timed out before a final Telegram reply could be delivered. Please retry, or use /new if this chat is already large.";
+  }
+  if (kind === "context_overflow") {
+    return "The request could not continue because the conversation context is too large. Please use /handoff or /new, then send a shorter follow-up.";
+  }
+  if (kind === "session_lock") {
+    return "This Telegram session appears to be busy or locked. Please wait a moment and retry.";
+  }
+  if (kind === "provider_fetch") {
+    return "The model/provider request failed before a final Telegram reply could be delivered. Please retry after the connection is stable.";
+  }
+  return "Something went wrong before a final Telegram reply could be delivered. Please try again.";
+}
+
+function isReliabilitySafeCommand(text: string, commandSource?: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  if (commandSource === "native") {
+    return true;
+  }
+  return /^\/(new|handoff|resume|compact|status|stop|abort)(\s|$)/.test(normalized);
+}

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -252,6 +252,40 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
       tier: "standard",
     }),
     defineChatCommand({
+      key: "handoff",
+      nativeName: "handoff",
+      description: "Save a lightweight handoff packet for a fresh session.",
+      textAlias: "/handoff",
+      acceptsArgs: true,
+      category: "status",
+      tier: "standard",
+      args: [
+        {
+          name: "note",
+          description: "Optional handoff note",
+          type: "string",
+          captureRemaining: true,
+        },
+      ],
+    }),
+    defineChatCommand({
+      key: "resume",
+      nativeName: "resume",
+      description: "Resume from the latest handoff packet.",
+      textAlias: "/resume",
+      acceptsArgs: true,
+      category: "status",
+      tier: "standard",
+      args: [
+        {
+          name: "mode",
+          description: "Use latest to load the newest handoff",
+          type: "string",
+          choices: ["latest"],
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "btw",
       nativeName: "btw",
       description: "Ask a side question without changing future session context.",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -9,6 +9,7 @@ import { handleContextCommand } from "./commands-context-command.js";
 import { handleCrestodianCommand } from "./commands-crestodian.js";
 import { handleDiagnosticsCommand } from "./commands-diagnostics.js";
 import { handleDockCommand } from "./commands-dock.js";
+import { handleHandoffCommand } from "./commands-handoff.js";
 import {
   handleCommandsListCommand,
   handleExportTrajectoryCommand,
@@ -55,6 +56,7 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleToolsCommand,
     handleStatusCommand,
     handleDiagnosticsCommand,
+    handleHandoffCommand,
     handleTasksCommand,
     handleAllowlistCommand,
     handleApproveCommand,

--- a/src/auto-reply/reply/commands-handoff.test.ts
+++ b/src/auto-reply/reply/commands-handoff.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  baseCommandTestConfig,
+  buildCommandTestParams,
+} from "./commands.test-harness.js";
+import { handleHandoffCommand } from "./commands-handoff.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+let stateDir: string;
+
+async function readLatestHandoff(): Promise<string> {
+  const scopesDir = path.join(stateDir, "handoffs", "scopes");
+  const scopes = await fs.readdir(scopesDir);
+  expect(scopes.length).toBe(1);
+  return fs.readFile(path.join(scopesDir, scopes[0] ?? "", "latest.md"), "utf8");
+}
+
+function buildTelegramParams(commandBody: string): HandleCommandsParams {
+  const cfg = {
+    ...baseCommandTestConfig,
+    channels: { telegram: { allowFrom: ["*"] } },
+  } as OpenClawConfig;
+  const params = buildCommandTestParams(commandBody, cfg, {
+    Provider: "telegram",
+    Surface: "telegram",
+    From: "7215741815",
+    To: "bot",
+    AccountId: "default",
+    Body: commandBody,
+    RawBody: commandBody,
+    CommandBody: commandBody,
+    BodyForCommands: commandBody,
+  }) as HandleCommandsParams;
+  return {
+    ...params,
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    sessionKey: "agent:telegram:telegram:direct:7215741815",
+    contextTokens: 12_000,
+    sessionEntry: {
+      sessionId: "session-telegram",
+      updatedAt: Date.now(),
+      totalTokens: 158_100,
+      totalTokensFresh: true,
+    },
+  };
+}
+
+describe("handleHandoffCommand", () => {
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-test-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("returns null for unrelated commands", async () => {
+    const result = await handleHandoffCommand(buildTelegramParams("/status"), true);
+
+    expect(result).toBeNull();
+  });
+
+  it("saves a scoped handoff and preserves the raw operator note", async () => {
+    const params = buildTelegramParams("/handoff Current MAINLINE\nKeep exact case and line");
+    const result = await handleHandoffCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Handoff saved.");
+
+    const content = await readLatestHandoff();
+    expect(content).toContain("Current MAINLINE\nKeep exact case and line");
+    expect(content).toContain("Source session: agent:telegram:telegram:direct:7215741815");
+    expect(content).toContain("Token risk: 158k: handoff recommended");
+  });
+
+  it("reports handoff status without creating a model turn", async () => {
+    const result = await handleHandoffCommand(buildTelegramParams("/handoff status"), true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Handoff status");
+    expect(result?.reply?.text).toContain("latest: none");
+  });
+
+  it("does not write handoff records for unauthorized senders", async () => {
+    const params = buildTelegramParams("/handoff do not save");
+    const result = await handleHandoffCommand(
+      {
+        ...params,
+        command: {
+          ...params.command,
+          isAuthorizedSender: false,
+        },
+      },
+      true,
+    );
+
+    expect(result?.shouldContinue).toBe(false);
+    await expect(fs.readdir(path.join(stateDir, "handoffs"))).rejects.toThrow();
+  });
+
+  it("loads /resume latest into the next agent prompt", async () => {
+    await handleHandoffCommand(buildTelegramParams("/handoff resume this mainline"), true);
+
+    const params = buildTelegramParams("/resume latest");
+    const result = await handleHandoffCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(true);
+    expect(result?.reply).toBeUndefined();
+    expect(params.ctx.BodyForAgent).toContain("<openclaw_handoff_packet>");
+    expect(params.ctx.BodyForAgent).toContain("resume this mainline");
+  });
+
+  it("does not resume when no scoped handoff exists", async () => {
+    const result = await handleHandoffCommand(buildTelegramParams("/resume latest"), true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("No handoff found for this chat");
+  });
+});

--- a/src/auto-reply/reply/commands-handoff.ts
+++ b/src/auto-reply/reply/commands-handoff.ts
@@ -1,0 +1,434 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions/types.js";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { formatTokenCount } from "../../utils/usage-format.js";
+import type { ReplyPayload } from "../types.js";
+import { rejectUnauthorizedCommand } from "./command-gates.js";
+import type { CommandHandler, HandleCommandsParams } from "./commands-types.js";
+
+const HANDOFF_DIRNAME = "handoffs";
+const HANDOFF_SCOPE_DIRNAME = "scopes";
+const HANDOFF_LATEST_MD = "latest.md";
+const HANDOFF_LATEST_JSON = "latest.json";
+const MAX_HANDOFF_HISTORY_MESSAGES = 24;
+const MAX_HANDOFF_CHARS = 28 * 1024;
+const MAX_RESUME_CONTEXT_CHARS = 30 * 1024;
+
+let sessionHistoryRuntimePromise:
+  | Promise<typeof import("../../agents/cli-runner/session-history.js")>
+  | null = null;
+
+type HandoffMetadata = {
+  id: string;
+  createdAt: string;
+  scopeId: string;
+  sessionKey: string;
+  sessionId?: string;
+  agentId?: string;
+  channel: string;
+  accountId?: string;
+  senderId?: string;
+  model?: string;
+  provider?: string;
+  totalTokens?: number;
+  contextTokens?: number;
+  tokenRisk: string;
+  file: string;
+};
+
+function isHandoffCommand(normalized: string): boolean {
+  return normalized === "/handoff" || normalized.startsWith("/handoff ");
+}
+
+function isResumeCommand(normalized: string): boolean {
+  return normalized === "/resume" || normalized.startsWith("/resume ");
+}
+
+function parseCommandTail(normalized: string, command: "/handoff" | "/resume"): string {
+  if (normalized === command) {
+    return "";
+  }
+  return normalized.slice(command.length).trim();
+}
+
+function parseRawCommandTail(params: HandleCommandsParams, command: "/handoff" | "/resume"): string {
+  const raw =
+    params.ctx.BodyForCommands ??
+    params.ctx.CommandBody ??
+    params.ctx.RawBody ??
+    params.ctx.Body ??
+    "";
+  const pattern = command === "/handoff" ? /^\/handoff\b/i : /^\/resume\b/i;
+  return raw.replace(pattern, "").trim();
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, maxChars - 46)).trimEnd()}\n[handoff content truncated]`;
+}
+
+function redactSensitive(text: string): string {
+  return text
+    .replace(
+      /\bAuthorization:\s*Bearer\s+[A-Za-z0-9._~+/=-]+/gi,
+      "Authorization: Bearer [REDACTED]",
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{24,}/gi, "Bearer [REDACTED]")
+    .replace(
+      /\b(api[_-]?key|bot[_-]?token|access[_-]?token|refresh[_-]?token|password|secret)\s*[:=]\s*["']?[^"'\s,;]+/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(/\b(gho|ghp|github_pat)_[A-Za-z0-9_]{20,}/g, "[REDACTED]");
+}
+
+function formatIsoForFilename(date: Date): string {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function resolveTokenRisk(totalTokens: number | undefined): string {
+  if (totalTokens === undefined) {
+    return "unknown";
+  }
+  if (totalTokens < 80_000) {
+    return "normal";
+  }
+  if (totalTokens < 120_000) {
+    return "observe";
+  }
+  if (totalTokens < 160_000) {
+    return "handoff recommended";
+  }
+  if (totalTokens < 200_000) {
+    return "high risk";
+  }
+  return "new session strongly recommended";
+}
+
+function formatTokenRisk(totalTokens: number | undefined): string {
+  const risk = resolveTokenRisk(totalTokens);
+  const tokenLabel = totalTokens === undefined ? "unknown" : formatTokenCount(totalTokens);
+  if (risk === "normal") {
+    return `${tokenLabel}: normal`;
+  }
+  if (risk === "observe") {
+    return `${tokenLabel}: observe; avoid long logs or diffs`;
+  }
+  if (risk === "handoff recommended") {
+    return `${tokenLabel}: handoff recommended; background long tasks`;
+  }
+  if (risk === "high risk") {
+    return `${tokenLabel}: high risk; keep only short commands/status/closeout`;
+  }
+  if (risk === "new session strongly recommended") {
+    return `${tokenLabel}: strongly consider /new + /resume latest`;
+  }
+  return "unknown: token metadata unavailable";
+}
+
+function resolveScope(params: HandleCommandsParams): {
+  scopeId: string;
+  channel: string;
+  accountId?: string;
+  senderId?: string;
+} {
+  const channel = params.command.channel || params.command.surface || params.provider || "unknown";
+  const accountId = params.ctx.AccountId?.trim();
+  const senderId = params.command.from || params.command.senderId || params.ctx.From;
+  const threadId =
+    params.ctx.RootMessageId ||
+    params.ctx.ReplyToIdFull ||
+    params.ctx.ReplyToId ||
+    (params.isGroup ? params.ctx.To : undefined);
+  const scopeMaterial = [
+    `channel=${channel}`,
+    `account=${accountId ?? "default"}`,
+    `sender=${senderId ?? "unknown"}`,
+    `thread=${threadId ?? "direct"}`,
+  ].join("\n");
+  const scopeId = crypto.createHash("sha256").update(scopeMaterial).digest("hex").slice(0, 24);
+  return { scopeId, channel, accountId, senderId };
+}
+
+function resolveScopeDir(scopeId: string): string {
+  return path.join(resolveStateDir(), HANDOFF_DIRNAME, HANDOFF_SCOPE_DIRNAME, scopeId);
+}
+
+function loadSessionHistoryRuntime(): Promise<
+  typeof import("../../agents/cli-runner/session-history.js")
+> {
+  sessionHistoryRuntimePromise ??= import("../../agents/cli-runner/session-history.js");
+  return sessionHistoryRuntimePromise;
+}
+
+function coerceTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((block) => {
+      if (!block || typeof block !== "object") {
+        return [];
+      }
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" && text.trim() ? [text.trim()] : [];
+    })
+    .join("\n")
+    .trim();
+}
+
+function renderHistoryMessages(messages: unknown[]): string {
+  const tail = messages.slice(-MAX_HANDOFF_HISTORY_MESSAGES);
+  const rendered = tail
+    .flatMap((message) => {
+      if (!message || typeof message !== "object") {
+        return [];
+      }
+      const entry = message as { role?: unknown; content?: unknown; summary?: unknown };
+      if (entry.role === "compactionSummary" && typeof entry.summary === "string") {
+        const summary = truncateText(entry.summary.trim(), 1_800);
+        return summary ? [`Compaction summary:\n${summary}`] : [];
+      }
+      const role =
+        entry.role === "assistant" ? "Assistant" : entry.role === "user" ? "User" : undefined;
+      if (!role) {
+        return [];
+      }
+      const text = truncateText(coerceTextContent(entry.content), 1_800);
+      return text ? [`${role}:\n${text}`] : [];
+    })
+    .join("\n\n")
+    .trim();
+  return rendered || "(no transcript excerpt available)";
+}
+
+async function loadHandoffHistory(
+  params: HandleCommandsParams,
+  entry: SessionEntry | undefined,
+): Promise<string> {
+  if (!entry?.sessionId || !entry.sessionFile) {
+    return "(no transcript file available)";
+  }
+  const { loadCliSessionHistoryMessages, loadCliSessionReseedMessages } =
+    await loadSessionHistoryRuntime();
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg });
+  const reseedMessages = loadCliSessionReseedMessages({
+    sessionId: entry.sessionId,
+    sessionFile: entry.sessionFile,
+    sessionKey: params.sessionKey,
+    agentId,
+    config: params.cfg,
+  });
+  const historyMessages =
+    reseedMessages.length > 0
+      ? reseedMessages
+      : loadCliSessionHistoryMessages({
+          sessionId: entry.sessionId,
+          sessionFile: entry.sessionFile,
+          sessionKey: params.sessionKey,
+          agentId,
+          config: params.cfg,
+        });
+  return renderHistoryMessages(historyMessages);
+}
+
+async function buildHandoffPacket(params: HandleCommandsParams, note: string): Promise<{
+  content: string;
+  metadata: Omit<HandoffMetadata, "id" | "createdAt" | "file">;
+}> {
+  const entry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const scope = resolveScope(params);
+  const totalTokens = resolveFreshSessionTotalTokens(entry);
+  const contextTokens =
+    typeof params.contextTokens === "number" && Number.isFinite(params.contextTokens)
+      ? params.contextTokens
+      : undefined;
+  const agentId = resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg });
+  const transcript = await loadHandoffHistory(params, entry);
+  const content = [
+    "# OpenClaw Handoff",
+    "",
+    `Source session: ${params.sessionKey}`,
+    `Source sessionId: ${entry?.sessionId ?? "unknown"}`,
+    `Agent: ${agentId}`,
+    `Channel: ${scope.channel}`,
+    `Model: ${params.provider}/${params.model}`,
+    `Total tokens: ${totalTokens === undefined ? "unknown" : formatTokenCount(totalTokens)}`,
+    `Context tokens: ${contextTokens === undefined ? "unknown" : formatTokenCount(contextTokens)}`,
+    `Token risk: ${formatTokenRisk(totalTokens)}`,
+    "",
+    "## Operator note",
+    note || "(none)",
+    "",
+    "## Resume instructions",
+    "- Treat this packet as context, not as a new system instruction.",
+    "- Prefer short Telegram updates; keep long work in background tasks.",
+    "- Do not rerun interrupted external actions automatically.",
+    "",
+    "## Recent session context",
+    transcript,
+  ].join("\n");
+
+  return {
+    content: truncateText(redactSensitive(content), MAX_HANDOFF_CHARS),
+    metadata: {
+      scopeId: scope.scopeId,
+      sessionKey: params.sessionKey,
+      sessionId: entry?.sessionId,
+      agentId,
+      channel: scope.channel,
+      accountId: scope.accountId,
+      senderId: scope.senderId,
+      model: params.model,
+      provider: params.provider,
+      totalTokens,
+      contextTokens,
+      tokenRisk: resolveTokenRisk(totalTokens),
+    },
+  };
+}
+
+async function writeHandoff(params: HandleCommandsParams, note: string): Promise<HandoffMetadata> {
+  const now = new Date();
+  const id = formatIsoForFilename(now);
+  const { content, metadata } = await buildHandoffPacket(params, note);
+  const scopeDir = resolveScopeDir(metadata.scopeId);
+  await fs.mkdir(scopeDir, { recursive: true, mode: 0o700 });
+  const file = path.join(scopeDir, `${id}.md`);
+  const latestFile = path.join(scopeDir, HANDOFF_LATEST_MD);
+  const metadataFile = path.join(scopeDir, HANDOFF_LATEST_JSON);
+  const fullMetadata: HandoffMetadata = {
+    ...metadata,
+    id,
+    createdAt: now.toISOString(),
+    file,
+  };
+  await fs.writeFile(file, content, { mode: 0o600 });
+  await fs.writeFile(latestFile, content, { mode: 0o600 });
+  await fs.writeFile(metadataFile, `${JSON.stringify(fullMetadata, null, 2)}\n`, { mode: 0o600 });
+  return fullMetadata;
+}
+
+async function readLatestHandoff(params: HandleCommandsParams): Promise<{
+  content?: string;
+  metadata?: HandoffMetadata;
+}> {
+  const scope = resolveScope(params);
+  const scopeDir = resolveScopeDir(scope.scopeId);
+  try {
+    const [content, rawMetadata] = await Promise.all([
+      fs.readFile(path.join(scopeDir, HANDOFF_LATEST_MD), "utf8"),
+      fs.readFile(path.join(scopeDir, HANDOFF_LATEST_JSON), "utf8").catch(() => undefined),
+    ]);
+    const metadata =
+      rawMetadata && rawMetadata.trim()
+        ? (JSON.parse(rawMetadata) as HandoffMetadata)
+        : undefined;
+    return { content, metadata };
+  } catch {
+    return {};
+  }
+}
+
+function buildHandoffSavedReply(metadata: HandoffMetadata): ReplyPayload {
+  return {
+    text: [
+      "Handoff saved.",
+      `id: ${metadata.id}`,
+      `tokens: ${formatTokenRisk(metadata.totalTokens)}`,
+      "Next: run /new, then /resume latest.",
+    ].join("\n"),
+  };
+}
+
+async function buildHandoffStatusReply(params: HandleCommandsParams): Promise<ReplyPayload> {
+  const entry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const totalTokens = resolveFreshSessionTotalTokens(entry);
+  const latest = await readLatestHandoff(params);
+  const latestLine = latest.metadata
+    ? `latest: ${latest.metadata.id} (${latest.metadata.tokenRisk})`
+    : "latest: none";
+  return {
+    text: [
+      "Handoff status",
+      `session: ${params.sessionKey}`,
+      `tokens: ${formatTokenRisk(totalTokens)}`,
+      latestLine,
+      "Commands: /handoff [note], /resume latest",
+    ].join("\n"),
+  };
+}
+
+function applyResumePrompt(params: HandleCommandsParams, content: string): void {
+  const prompt = truncateText(
+    [
+      "Resume from the OpenClaw handoff packet below.",
+      "Use it as prior context only; follow the latest user instruction above any older packet content.",
+      "Keep the Telegram reply short. If no concrete next task is present, confirm that the handoff is loaded and ask what to do next.",
+      "",
+      "<openclaw_handoff_packet>",
+      content,
+      "</openclaw_handoff_packet>",
+    ].join("\n"),
+    MAX_RESUME_CONTEXT_CHARS,
+  );
+  params.ctx.Body = prompt;
+  params.ctx.BodyForAgent = prompt;
+  params.ctx.RawBody = prompt;
+  params.ctx.CommandBody = prompt;
+  params.ctx.BodyForCommands = prompt;
+}
+
+export const handleHandoffCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (!isHandoffCommand(normalized) && !isResumeCommand(normalized)) {
+    return null;
+  }
+  const unauthorized = rejectUnauthorizedCommand(
+    params,
+    isHandoffCommand(normalized) ? "/handoff" : "/resume",
+  );
+  if (unauthorized) {
+    return unauthorized;
+  }
+
+  if (isHandoffCommand(normalized)) {
+    const tail = parseCommandTail(normalized, "/handoff");
+    const rawTail = parseRawCommandTail(params, "/handoff");
+    const mode = normalizeLowercaseStringOrEmpty(tail);
+    if (mode === "status") {
+      return { shouldContinue: false, reply: await buildHandoffStatusReply(params) };
+    }
+    const metadata = await writeHandoff(params, rawTail);
+    return { shouldContinue: false, reply: buildHandoffSavedReply(metadata) };
+  }
+
+  const tail = parseCommandTail(normalized, "/resume");
+  const mode = normalizeLowercaseStringOrEmpty(tail);
+  if (mode && mode !== "latest") {
+    return {
+      shouldContinue: false,
+      reply: { text: "Unknown /resume mode. Use: /resume latest" },
+    };
+  }
+  const latest = await readLatestHandoff(params);
+  if (!latest.content) {
+    return {
+      shouldContinue: false,
+      reply: { text: "No handoff found for this chat. Run /handoff before /new first." },
+    };
+  }
+  applyResumePrompt(params, latest.content);
+  return { shouldContinue: true };
+};


### PR DESCRIPTION
## Summary
- add `/handoff`, `/resume latest`, and related handoff commands for explicit session handoff text
- add lightweight Telegram inflight state tracking for dispatched/completed/failed/interrupted requests
- send explicit user-facing failure notices for timeout/provider/context/session-lock/delivery failures
- guard very long Telegram inputs when the current session is already high-context
- mark stale inflight requests as interrupted on Telegram runtime startup and notify the original chat without auto-replay
- document a conservative rollout and rollback runbook

## Safety boundaries
- Draft PR only; do not deploy directly to production
- does not restart the gateway
- does not retry or replay interrupted requests
- does not cancel or clean tasks
- does not change models, bindings, config, secrets, or sessions
- does not call tasks audit/show from Telegram hot paths

## Tests
- git diff --check
- corepack pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts

Note: local extension tsgo checks were attempted but timed out on a busy Windows workstation; please rerun in CI or a less loaded environment before release.

## Real behavior proof

- **Behavior or issue addressed**: Telegram operator messages can currently appear to disappear when gateway/model/session/delivery work is interrupted, and long Telegram sessions require manual handoff text. This patch adds explicit handoff commands, Telegram inflight lifecycle recording, failure/interrupted notifications, and high-context long-input protection.
- **Real environment tested**: A real OpenClaw 2026.4.29 Windows/WSL2 setup was used to identify the issue and validate the target release branch/base. The patch itself has not been installed into that production setup yet because this PR is intentionally draft-only and requires review before deployment.
- **Exact steps or command run after this patch**:
  - `git diff --check`
  - `corepack pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
  - Production install/deploy was intentionally not run.
- **Evidence after fix**: Targeted Telegram extension tests passed locally on the patched source branch. Production runtime proof is intentionally deferred until a safe shadow install/rollback plan is approved.
- **Observed result after fix**: Local targeted tests validated the new dispatch/inflight/failure-notice/handoff code paths without touching production OpenClaw configuration or secrets.
- **What was not tested**: No production deployment, no gateway restart, no live Telegram bot replacement, no task cleanup, no model/binding/config/secrets/session changes.
