### PR TITLE
fix(discord): prevent false heartbeat ACK timeout on first interval tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/gateway: fix false heartbeat ACK timeout when the first heartbeat fires near the end of the random-delay window, causing intermittent gateway reconnect loops and "awaiting gateway readiness" hangs. Fixes #77668. Thanks @NikolaFC.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/extensions/discord/src/internal/gateway-lifecycle.test.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
 describe("GatewayHeartbeatTimers", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("does not false-timeout when first heartbeat fires near the end of the random-delay window", () => {

--- a/extensions/discord/src/internal/gateway-lifecycle.test.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
+
+describe("GatewayHeartbeatTimers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not false-timeout when first heartbeat fires near the end of the random-delay window", () => {
+    // This is the core bug: with the old setInterval approach, if random() ≈ 1.0
+    // the first heartbeat fires at ~intervalMs, and the first setInterval tick
+    // fires at intervalMs — before the ACK can arrive, causing a false timeout.
+    vi.useFakeTimers();
+
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+    const isAcked = vi.fn();
+
+    const timers = new GatewayHeartbeatTimers();
+
+    // random() = 0.95 → first heartbeat at 42750ms (of 45000ms interval)
+    timers.start({
+      intervalMs: 45_000,
+      isAcked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.95,
+    });
+
+    // isAcked starts as false (no heartbeat sent yet, so no ACK expected)
+    isAcked.mockReturnValue(false);
+
+    // Advance to just after the first heartbeat fires (42750ms)
+    vi.advanceTimersByTime(42_750);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    // With the OLD code (setInterval), the first interval tick at 45000ms would
+    // check isAcked() before the ACK has time to arrive, triggering false timeout.
+    //
+    // With the NEW code (recursive setTimeout), the next check is at
+    // 42750 + 45000 = 87750ms, giving plenty of time for the ACK.
+
+    // Advance to 45000ms — with old code, this would trigger false timeout
+    vi.advanceTimersByTime(2_250); // total: 45000ms
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    // Now simulate the ACK arriving (as it would in real usage)
+    isAcked.mockReturnValue(true);
+
+    // Advance to when the next heartbeat should fire (87750ms)
+    vi.advanceTimersByTime(42_750); // total: 87750ms
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    timers.stop();
+  });
+
+  it("fires ack timeout when heartbeat is genuinely not acked", () => {
+    vi.useFakeTimers();
+
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+    const isAcked = vi.fn().mockReturnValue(false);
+
+    const timers = new GatewayHeartbeatTimers();
+
+    // First heartbeat at 0ms (random = 0)
+    timers.start({
+      intervalMs: 45_000,
+      isAcked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0,
+    });
+
+    // First heartbeat fires immediately
+    vi.advanceTimersByTime(0);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+    // After full interval with no ACK → should timeout
+    vi.advanceTimersByTime(45_000);
+    expect(onAckTimeout).toHaveBeenCalledTimes(1);
+
+    timers.stop();
+  });
+
+  it("sends heartbeats at regular intervals after the initial random delay", () => {
+    vi.useFakeTimers();
+
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+    const isAcked = vi.fn().mockReturnValue(true);
+
+    const timers = new GatewayHeartbeatTimers();
+
+    timers.start({
+      intervalMs: 10_000,
+      isAcked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.5, // first heartbeat at 5000ms
+    });
+
+    // First heartbeat at 5000ms
+    vi.advanceTimersByTime(5_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+    // Second at 15000ms (5000 + 10000)
+    vi.advanceTimersByTime(10_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+
+    // Third at 25000ms
+    vi.advanceTimersByTime(10_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(3);
+
+    // No ack timeouts because isAcked returns true
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    timers.stop();
+  });
+
+  it("stop() cancels all pending timers", () => {
+    vi.useFakeTimers();
+
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+    const isAcked = vi.fn().mockReturnValue(true);
+
+    const timers = new GatewayHeartbeatTimers();
+
+    timers.start({
+      intervalMs: 10_000,
+      isAcked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.5,
+    });
+
+    timers.stop();
+
+    vi.advanceTimersByTime(100_000);
+    expect(onHeartbeat).not.toHaveBeenCalled();
+    expect(onAckTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/internal/gateway-lifecycle.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.ts
@@ -13,24 +13,46 @@ export class GatewayHeartbeatTimers {
   }): void {
     this.stop();
     const random = params.random ?? Math.random;
+
+    // Use recursive setTimeout instead of setInterval to prevent a race where
+    // the first heartbeat fires near the end of the random-delay window and the
+    // first setInterval tick fires before the ACK can arrive.
+    //
+    // With the old code:
+    //   - firstHeartbeatTimeout fires at T0 + intervalMs * random()
+    //   - heartbeatInterval first tick fires at T0 + intervalMs
+    //   - If random() ≈ 1.0, the heartbeat was JUST sent; isAcked() is still
+    //     false because the round-trip hasn't completed, triggering a false
+    //     "Gateway heartbeat ACK timeout" and a needless reconnect.
+    //
+    // With recursive setTimeout the ACK check always runs a full intervalMs
+    // AFTER the preceding heartbeat was sent, giving Discord enough time to
+    // respond regardless of when the initial random-delay heartbeat fired.
+    const scheduleNext = (): void => {
+      this.heartbeatInterval = setTimeout(() => {
+        if (!params.isAcked()) {
+          params.onAckTimeout();
+          return;
+        }
+        params.onHeartbeat();
+        scheduleNext();
+      }, params.intervalMs);
+      this.heartbeatInterval.unref?.();
+    };
+
     this.firstHeartbeatTimeout = setTimeout(
-      params.onHeartbeat,
+      () => {
+        params.onHeartbeat();
+        scheduleNext();
+      },
       Math.max(0, params.intervalMs * random()),
     );
     this.firstHeartbeatTimeout.unref?.();
-    this.heartbeatInterval = setInterval(() => {
-      if (!params.isAcked()) {
-        params.onAckTimeout();
-        return;
-      }
-      params.onHeartbeat();
-    }, params.intervalMs);
-    this.heartbeatInterval.unref?.();
   }
 
   stop(): void {
     if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
+      clearTimeout(this.heartbeatInterval);
       this.heartbeatInterval = undefined;
     }
     if (this.firstHeartbeatTimeout) {


### PR DESCRIPTION
## Problem

The Discord gateway hangs at "awaiting gateway readiness" intermittently (reported in #77668, also #52372, #53039, #68213).

After investigation, I found a race condition in `GatewayHeartbeatTimers.start()` (`extensions/discord/src/internal/gateway-lifecycle.ts`):

1. The first heartbeat uses a **random delay** (`intervalMs * random()`)
2. The ACK timeout check uses a **fixed interval** (`setInterval(..., intervalMs)`) that starts from `start()` time

When `random() ≈ 1.0`:
- First heartbeat fires at ~T0 + `intervalMs`
- First `setInterval` tick fires at T0 + `intervalMs`
- The ACK hasn't had time to arrive → false `"Gateway heartbeat ACK timeout"` → needless reconnect

This creates a reconnect loop that makes Discord appear to hang at "awaiting gateway readiness".

## Fix

Replace `setInterval` with recursive `setTimeout` so the ACK check always runs a full `intervalMs` AFTER the preceding heartbeat was sent:

```
Old:  setInterval(checkAckOrSend, intervalMs)   ← starts from T0
New:  setTimeout(checkAckThenScheduleNext, intervalMs)  ← starts from last heartbeat
```

## Real Behavior Proof

**Behavior or issue addressed:** Discord gateway heartbeat ACK timeout race condition causing false reconnect loop (#77668)

**Real environment tested:** OpenClaw 2026.5.5 (43dcdcd) on WSL2 Ubuntu 22.04, Node.js v22.22.0, Discord bot 1483184501986164748

**Exact steps or command run after this patch:**
1. `pnpm build` in hackable-src (commit 43dcdcd9)
2. Patched `~/.openclaw/npm/node_modules/@openclaw/discord/dist/provider-CnLt-Y4Z.js` with recursive setTimeout heartbeat logic
3. `systemctl --user restart openclaw-gateway`
4. Monitored `journalctl --user -u openclaw-gateway -f` for 2+ minutes

**Evidence after fix:**
```
19:32:32 [discord] client initialized as 1483184501986164748; awaiting gateway readiness
19:32:32 WebSocket OPEN event fired
19:32:33 message: op=0 t=READY           ← Discord connected
19:32:34 message: op=11 t=null           ← heartbeat ACK received
19:33:15 message: op=11 t=null           ← second heartbeat ACK, stable
```

**Observed result after fix:** Zero "heartbeat ACK timeout" log entries. Discord stays connected with regular heartbeat ACKs. Gateway running stable for 2+ minutes with no reconnect cycles. Previously would cycle through connect → false ACK timeout → reconnect indefinitely.

**What was not tested:** Long-running (24h+) stability; multi-guild load; Windows native environment.

## Tests

Added `gateway-lifecycle.test.ts` with 4 tests:
1. **No false timeout when random ≈ 1.0** — the core bug
2. **Genuine ACK timeout still fires** — when heartbeat is truly not acked
3. **Regular heartbeat intervals** — timing correctness
4. **stop() cancels all timers** — cleanup

All existing Discord gateway tests (20 in `gateway.test.ts`, 15 in `gateway-plugin.test.ts`) still pass.

## Related

- Fixes #77668
- Related to #53039 (registerClient race — already fixed in current code)
- Related to #68213 (heartbeat ACK as liveness signal — different approach)