### PR TITLE
Cache plugin metadata snapshots briefly

### DIFF
--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -1,5 +1,10 @@
 let currentPluginMetadataSnapshot: unknown;
 let currentPluginMetadataSnapshotConfigFingerprint: string | undefined;
+const transientPluginMetadataSnapshotClearers = new Set<() => void>();
+
+export function registerTransientPluginMetadataSnapshotClearer(clearer: () => void): void {
+  transientPluginMetadataSnapshotClearers.add(clearer);
+}
 
 export function setCurrentPluginMetadataSnapshotState(
   snapshot: unknown,
@@ -12,6 +17,9 @@ export function setCurrentPluginMetadataSnapshotState(
 export function clearCurrentPluginMetadataSnapshotState(): void {
   currentPluginMetadataSnapshot = undefined;
   currentPluginMetadataSnapshotConfigFingerprint = undefined;
+  for (const clearer of transientPluginMetadataSnapshotClearers) {
+    clearer();
+  }
 }
 
 export function getCurrentPluginMetadataSnapshotState(): {

--- a/src/plugins/plugin-metadata-snapshot.cache.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.cache.test.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearCurrentPluginMetadataSnapshotState } from "./current-plugin-metadata-state.js";
+import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+
+const tempRoots: string[] = [];
+
+function createBundledPluginRoot(pluginId: string): { root: string; extensionsRoot: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-metadata-cache-"));
+  tempRoots.push(root);
+  const extensionsRoot = path.join(root, "extensions");
+  const pluginRoot = path.join(extensionsRoot, pluginId);
+  fs.mkdirSync(pluginRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginRoot, "openclaw.plugin.json"),
+    `${JSON.stringify(
+      {
+        id: pluginId,
+        configSchema: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  fs.writeFileSync(path.join(pluginRoot, "index.js"), "module.exports = { register() {} };\n");
+  return { root, extensionsRoot };
+}
+
+function createEnv(extensionsRoot: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    VITEST: "1",
+    OPENCLAW_BUNDLED_PLUGINS_DIR: extensionsRoot,
+    OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+  };
+}
+
+describe("loadPluginMetadataSnapshot cache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-05T00:00:00Z"));
+    clearCurrentPluginMetadataSnapshotState();
+  });
+
+  afterEach(() => {
+    clearCurrentPluginMetadataSnapshotState();
+    vi.useRealTimers();
+    for (const root of tempRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the same snapshot within the metadata cache ttl", () => {
+    const { extensionsRoot } = createBundledPluginRoot("metadata-cache-ttl");
+    const params = {
+      config: {},
+      env: createEnv(extensionsRoot),
+    };
+
+    const first = loadPluginMetadataSnapshot(params);
+    const second = loadPluginMetadataSnapshot(params);
+
+    expect(second).toBe(first);
+  });
+
+  it("refreshes snapshots after the metadata cache ttl", () => {
+    const { extensionsRoot } = createBundledPluginRoot("metadata-cache-expiry");
+    const params = {
+      config: {},
+      env: createEnv(extensionsRoot),
+    };
+
+    const first = loadPluginMetadataSnapshot(params);
+    vi.advanceTimersByTime(5_001);
+    const second = loadPluginMetadataSnapshot(params);
+
+    expect(second).not.toBe(first);
+  });
+
+  it("does not reuse cached snapshots across workspace scope", () => {
+    const { root, extensionsRoot } = createBundledPluginRoot("metadata-cache-scope");
+    const env = createEnv(extensionsRoot);
+
+    const first = loadPluginMetadataSnapshot({
+      config: {},
+      env,
+      workspaceDir: path.join(root, "workspace-a"),
+    });
+    const second = loadPluginMetadataSnapshot({
+      config: {},
+      env,
+      workspaceDir: path.join(root, "workspace-b"),
+    });
+
+    expect(second).not.toBe(first);
+  });
+
+  it("clears the metadata cache when the installed plugin index is persisted", () => {
+    const { root, extensionsRoot } = createBundledPluginRoot("metadata-cache-clear");
+    const stateDir = path.join(root, "state");
+    const params = {
+      config: {},
+      env: createEnv(extensionsRoot),
+      stateDir,
+    };
+
+    const first = loadPluginMetadataSnapshot(params);
+    writePersistedInstalledPluginIndexSync(first.index, { stateDir });
+    const second = loadPluginMetadataSnapshot(params);
+
+    expect(second).not.toBe(first);
+  });
+});

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { measureDiagnosticsTimelineSpanSync } from "../infra/diagnostics-timeline.js";
+import { registerTransientPluginMetadataSnapshotClearer } from "./current-plugin-metadata-state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
@@ -24,6 +25,68 @@ export type {
   PluginMetadataSnapshotOwnerMaps,
   PluginMetadataSnapshotRegistryDiagnostic,
 } from "./plugin-metadata-snapshot.types.js";
+
+const PLUGIN_METADATA_SNAPSHOT_CACHE_TTL_MS = 5_000;
+const MAX_PLUGIN_METADATA_SNAPSHOT_CACHE_ENTRIES = 16;
+
+const pluginMetadataSnapshotIndexIds = new WeakMap<InstalledPluginIndex, number>();
+let nextPluginMetadataSnapshotIndexId = 1;
+const pluginMetadataSnapshotCache = new Map<
+  string,
+  { cachedAtMs: number; snapshot: PluginMetadataSnapshot }
+>();
+
+function clearPluginMetadataSnapshotCache(): void {
+  pluginMetadataSnapshotCache.clear();
+}
+
+registerTransientPluginMetadataSnapshotClearer(clearPluginMetadataSnapshotCache);
+
+function resolvePluginMetadataSnapshotIndexCacheKey(
+  index: InstalledPluginIndex | undefined,
+): string {
+  if (!index) {
+    return "none";
+  }
+  const existing = pluginMetadataSnapshotIndexIds.get(index);
+  if (existing !== undefined) {
+    return String(existing);
+  }
+  const id = nextPluginMetadataSnapshotIndexId;
+  nextPluginMetadataSnapshotIndexId += 1;
+  pluginMetadataSnapshotIndexIds.set(index, id);
+  return String(id);
+}
+
+function resolvePluginMetadataSnapshotCacheKey(params: LoadPluginMetadataSnapshotParams): string {
+  return JSON.stringify({
+    configFingerprint: resolvePluginMetadataControlPlaneFingerprint({
+      config: params.config,
+      env: params.env,
+      index: params.index,
+      policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+      workspaceDir: params.workspaceDir,
+    }),
+    index: resolvePluginMetadataSnapshotIndexCacheKey(params.index),
+    preferPersisted: params.preferPersisted ?? null,
+    stateDir: params.stateDir ?? "",
+  });
+}
+
+function rememberPluginMetadataSnapshotCacheEntry(
+  key: string,
+  snapshot: PluginMetadataSnapshot,
+  now: number,
+): void {
+  pluginMetadataSnapshotCache.set(key, { cachedAtMs: now, snapshot });
+  if (pluginMetadataSnapshotCache.size <= MAX_PLUGIN_METADATA_SNAPSHOT_CACHE_ENTRIES) {
+    return;
+  }
+  const oldestKey = pluginMetadataSnapshotCache.keys().next().value;
+  if (oldestKey) {
+    pluginMetadataSnapshotCache.delete(oldestKey);
+  }
+}
 
 function resolvePluginMetadataControlPlaneFingerprint(
   params: Pick<LoadPluginMetadataSnapshotParams, "config" | "env" | "workspaceDir"> & {
@@ -173,7 +236,19 @@ export function listPluginOriginsFromMetadataSnapshot(
 export function loadPluginMetadataSnapshot(
   params: LoadPluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
-  return measureDiagnosticsTimelineSpanSync(
+  const cacheKey = resolvePluginMetadataSnapshotCacheKey(params);
+  const now = Date.now();
+  const cached = pluginMetadataSnapshotCache.get(cacheKey);
+  if (cached && now - cached.cachedAtMs < PLUGIN_METADATA_SNAPSHOT_CACHE_TTL_MS) {
+    pluginMetadataSnapshotCache.delete(cacheKey);
+    pluginMetadataSnapshotCache.set(cacheKey, cached);
+    return cached.snapshot;
+  }
+  if (cached) {
+    pluginMetadataSnapshotCache.delete(cacheKey);
+  }
+
+  const snapshot = measureDiagnosticsTimelineSpanSync(
     "plugins.metadata.scan",
     () => loadPluginMetadataSnapshotImpl(params),
     {
@@ -186,6 +261,8 @@ export function loadPluginMetadataSnapshot(
       },
     },
   );
+  rememberPluginMetadataSnapshotCacheEntry(cacheKey, snapshot, now);
+  return snapshot;
 }
 
 function loadPluginMetadataSnapshotImpl(


### PR DESCRIPTION
## Summary
- add a bounded short-TTL cache at `loadPluginMetadataSnapshot()`
- key cache entries by workspace/scope before synchronous manifest traversal
- clear transient snapshot cache through the existing current metadata lifecycle boundary
- add TTL, scope, and lifecycle regressions

Fixes #77983.

## Verification
- Local workflow batch verification passed before PR branch extraction.
- Targeted regression lives in `src/plugins/plugin-metadata-snapshot.cache.test.ts`.
