### PR TITLE
Rate-limit bootstrap and device signature auth

### DIFF
--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -37,7 +37,9 @@ export interface RateLimitConfig {
 
 export const AUTH_RATE_LIMIT_SCOPE_DEFAULT = "default";
 export const AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET = "shared-secret";
+export const AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN = "bootstrap-token";
 export const AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN = "device-token";
+export const AUTH_RATE_LIMIT_SCOPE_DEVICE_SIGNATURE = "device-signature";
 export const AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH = "hook-auth";
 const BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX = "browser-origin:";
 

--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -19,6 +19,7 @@ import {
   sendRawConnectReq,
   startGatewayServer,
   TEST_OPERATOR_CLIENT,
+  testState,
   waitForWsClose,
   withGatewayServer,
   withRuntimeVersionEnv,
@@ -396,6 +397,53 @@ export function registerDefaultAuthTokenSuite(): void {
       );
       expect(connectRes.error?.details?.reason).toBe("device-signature");
       await new Promise<void>((resolve) => ws.once("close", () => resolve()));
+    });
+
+    test("rate-limits repeated invalid device signatures", async () => {
+      testState.gatewayAuth = {
+        mode: "token",
+        token: "secret",
+        rateLimit: { maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000, exemptLoopback: false },
+      };
+      await withGatewayServer(async ({ port: isolatedPort }) => {
+        const firstWs = await openWs(isolatedPort);
+        const firstNonce = await readConnectChallengeNonce(firstWs);
+        const { device: firstDevice } = await createSignedDevice({
+          token: "secret",
+          scopes: ["operator.admin"],
+          clientId: GATEWAY_CLIENT_NAMES.TEST,
+          clientMode: GATEWAY_CLIENT_MODES.TEST,
+          nonce: firstNonce,
+        });
+        const first = await sendRawConnectReq(firstWs, {
+          id: "c-invalid-device-signature-1",
+          token: "secret",
+          device: firstDevice,
+        });
+        expect(first.ok).toBe(false);
+        expect(first.error?.details?.code).toBe(
+          ConnectErrorDetailCodes.DEVICE_AUTH_SIGNATURE_INVALID,
+        );
+        firstWs.close();
+
+        const secondWs = await openWs(isolatedPort);
+        const secondNonce = await readConnectChallengeNonce(secondWs);
+        const { device: secondDevice } = await createSignedDevice({
+          token: "secret",
+          scopes: ["operator.admin"],
+          clientId: GATEWAY_CLIENT_NAMES.TEST,
+          clientMode: GATEWAY_CLIENT_MODES.TEST,
+          nonce: secondNonce,
+        });
+        const second = await sendRawConnectReq(secondWs, {
+          id: "c-invalid-device-signature-2",
+          token: "secret",
+          device: secondDevice,
+        });
+        expect(second.ok).toBe(false);
+        expect(second.error?.details?.code).toBe(ConnectErrorDetailCodes.AUTH_RATE_LIMITED);
+        secondWs.close();
+      });
     });
 
     test("sends connect challenge on open", async () => {

--- a/src/gateway/server/ws-connection/auth-context.test.ts
+++ b/src/gateway/server/ws-connection/auth-context.test.ts
@@ -9,6 +9,8 @@ type VerifyBootstrapTokenFn = Parameters<
 
 function createRateLimiter(params?: { allowed?: boolean; retryAfterMs?: number }): {
   limiter: AuthRateLimiter;
+  check: ReturnType<typeof vi.fn>;
+  recordFailure: ReturnType<typeof vi.fn>;
   reset: ReturnType<typeof vi.fn>;
 } {
   const allowed = params?.allowed ?? true;
@@ -22,6 +24,8 @@ function createRateLimiter(params?: { allowed?: boolean; retryAfterMs?: number }
       reset,
       recordFailure,
     } as unknown as AuthRateLimiter,
+    check,
+    recordFailure,
     reset,
   };
 }
@@ -141,11 +145,14 @@ describe("resolveConnectAuthDecision", () => {
   });
 
   it("accepts valid bootstrap tokens before device-token fallback", async () => {
+    const rateLimiter = createRateLimiter();
     const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({ ok: true }));
     const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));
     const decision = await resolveDeviceTokenDecision({
       verifyBootstrapToken,
       verifyDeviceToken,
+      rateLimiter: rateLimiter.limiter,
+      clientIp: "203.0.113.23",
       stateOverrides: {
         bootstrapTokenCandidate: "bootstrap-token",
         deviceTokenCandidate: "device-token",
@@ -154,10 +161,12 @@ describe("resolveConnectAuthDecision", () => {
     expect(decision.authOk).toBe(true);
     expect(decision.authMethod).toBe("bootstrap-token");
     expect(verifyBootstrapToken).toHaveBeenCalledOnce();
+    expect(rateLimiter.reset).toHaveBeenCalledWith("203.0.113.23", "bootstrap-token");
     expect(verifyDeviceToken).not.toHaveBeenCalled();
   });
 
   it("reports invalid bootstrap tokens when no device token fallback is available", async () => {
+    const rateLimiter = createRateLimiter();
     const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({
       ok: false,
       reason: "bootstrap_token_invalid",
@@ -166,6 +175,8 @@ describe("resolveConnectAuthDecision", () => {
     const decision = await resolveDeviceTokenDecision({
       verifyBootstrapToken,
       verifyDeviceToken,
+      rateLimiter: rateLimiter.limiter,
+      clientIp: "203.0.113.21",
       stateOverrides: {
         bootstrapTokenCandidate: "bootstrap-token",
         deviceTokenCandidate: undefined,
@@ -175,6 +186,31 @@ describe("resolveConnectAuthDecision", () => {
     expect(decision.authOk).toBe(false);
     expect(decision.authResult.reason).toBe("bootstrap_token_invalid");
     expect(verifyBootstrapToken).toHaveBeenCalledOnce();
+    expect(rateLimiter.check).toHaveBeenCalledWith("203.0.113.21", "bootstrap-token");
+    expect(rateLimiter.recordFailure).toHaveBeenCalledWith("203.0.113.21", "bootstrap-token");
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it("returns rate-limited auth result without verifying bootstrap token", async () => {
+    const rateLimiter = createRateLimiter({ allowed: false, retryAfterMs: 60_000 });
+    const verifyBootstrapToken = vi.fn<VerifyBootstrapTokenFn>(async () => ({ ok: true }));
+    const verifyDeviceToken = vi.fn<VerifyDeviceTokenFn>(async () => ({ ok: true }));
+    const decision = await resolveDeviceTokenDecision({
+      verifyBootstrapToken,
+      verifyDeviceToken,
+      rateLimiter: rateLimiter.limiter,
+      clientIp: "203.0.113.22",
+      stateOverrides: {
+        bootstrapTokenCandidate: "bootstrap-token",
+        deviceTokenCandidate: undefined,
+        deviceTokenCandidateSource: undefined,
+      },
+    });
+
+    expect(decision.authOk).toBe(false);
+    expect(decision.authResult.reason).toBe("rate_limited");
+    expect(decision.authResult.retryAfterMs).toBe(60_000);
+    expect(verifyBootstrapToken).not.toHaveBeenCalled();
     expect(verifyDeviceToken).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
 import {
+  AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN,
   AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
@@ -158,23 +159,42 @@ export async function resolveConnectAuthDecision(params: {
 
   const bootstrapTokenCandidate = params.state.bootstrapTokenCandidate;
   if (params.hasDeviceIdentity && params.deviceId && params.publicKey && bootstrapTokenCandidate) {
-    const tokenCheck = await params.verifyBootstrapToken({
-      deviceId: params.deviceId,
-      publicKey: params.publicKey,
-      token: bootstrapTokenCandidate,
-      role: params.role,
-      scopes: params.scopes,
-    });
-    if (tokenCheck.ok) {
-      // Prefer an explicit valid bootstrap token even when another auth path
-      // (for example tailscale serve header auth) already succeeded. QR pairing
-      // relies on the server classifying the handshake as bootstrap-token so the
-      // initial node pairing can be silently auto-approved and the bootstrap
-      // token can be revoked after approval.
-      authOk = true;
-      authMethod = "bootstrap-token";
-    } else if (!authOk) {
-      authResult = { ok: false, reason: tokenCheck.reason ?? "bootstrap_token_invalid" };
+    const bootstrapRateCheck = params.rateLimiter?.check(
+      params.clientIp,
+      AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN,
+    );
+    if (bootstrapRateCheck && !bootstrapRateCheck.allowed) {
+      if (!authOk) {
+        authResult = {
+          ok: false,
+          reason: "rate_limited",
+          rateLimited: true,
+          retryAfterMs: bootstrapRateCheck.retryAfterMs,
+        };
+      }
+    } else {
+      const tokenCheck = await params.verifyBootstrapToken({
+        deviceId: params.deviceId,
+        publicKey: params.publicKey,
+        token: bootstrapTokenCandidate,
+        role: params.role,
+        scopes: params.scopes,
+      });
+      if (tokenCheck.ok) {
+        // Prefer an explicit valid bootstrap token even when another auth path
+        // (for example tailscale serve header auth) already succeeded. QR pairing
+        // relies on the server classifying the handshake as bootstrap-token so the
+        // initial node pairing can be silently auto-approved and the bootstrap
+        // token can be revoked after approval.
+        authOk = true;
+        authMethod = "bootstrap-token";
+        params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN);
+      } else {
+        params.rateLimiter?.recordFailure(params.clientIp, AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN);
+        if (!authOk) {
+          authResult = { ok: false, reason: tokenCheck.reason ?? "bootstrap_token_invalid" };
+        }
+      }
     }
   }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -54,7 +54,10 @@ import {
   isWebchatClient,
 } from "../../../utils/message-channel.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
-import type { AuthRateLimiter } from "../../auth-rate-limit.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_DEVICE_SIGNATURE,
+  type AuthRateLimiter,
+} from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { hasForwardedRequestHeaders, isLocalDirectRequest } from "../../auth.js";
 import {
@@ -767,6 +770,32 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           }
           const rejectDeviceSignatureInvalid = () =>
             rejectDeviceAuthInvalid("device-signature", "device signature invalid");
+          const deviceSignatureRateCheck = authRateLimiter?.check(
+            browserRateLimitClientIp,
+            AUTH_RATE_LIMIT_SCOPE_DEVICE_SIGNATURE,
+          );
+          if (deviceSignatureRateCheck && !deviceSignatureRateCheck.allowed) {
+            setHandshakeState("failed");
+            setCloseCause("device-auth-invalid", {
+              reason: "device-signature-rate-limited",
+              client: connectParams.client.id,
+              deviceId: device.id,
+            });
+            send({
+              type: "res",
+              id: frame.id,
+              ok: false,
+              error: errorShape(ErrorCodes.INVALID_REQUEST, "device signature rate limited", {
+                details: {
+                  code: ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
+                  retryAfterMs: deviceSignatureRateCheck.retryAfterMs,
+                  reason: "device-signature-rate-limited",
+                },
+              }),
+            });
+            close(1008, "device signature rate limited");
+            return;
+          }
           const payloadVersion = resolveDeviceSignaturePayloadVersion({
             device,
             connectParams,
@@ -776,9 +805,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             nonce: providedNonce,
           });
           if (!payloadVersion) {
+            authRateLimiter?.recordFailure(
+              browserRateLimitClientIp,
+              AUTH_RATE_LIMIT_SCOPE_DEVICE_SIGNATURE,
+            );
             rejectDeviceSignatureInvalid();
             return;
           }
+          authRateLimiter?.reset(browserRateLimitClientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_SIGNATURE);
           deviceAuthPayloadVersion = payloadVersion;
           devicePublicKey = normalizeDevicePublicKeyBase64Url(device.publicKey);
           if (!devicePublicKey) {


### PR DESCRIPTION
## Summary
- add dedicated auth rate-limit scopes for `bootstrap-token` and `device-signature`
- check bootstrap-token lockout before serialized bootstrap token verification
- record bootstrap-token failures and reset on success
- check device-signature lockout before repeated signature verification work
- record device-signature failures and reset on success

Fixes #77980.

## Verification
- Local workflow batch verification passed before PR branch extraction.
- Targeted regressions cover bootstrap-token limiter behavior and repeated invalid device signatures.
