### PR TITLE
feat(skills): add Higgsfield skills

### DIFF
--- a/skills/higgsfield/generate/SKILL.md
+++ b/skills/higgsfield/generate/SKILL.md
@@ -8,6 +8,14 @@ description: |
   higgsfield-soul-id when the user wants their own face in generated output.
   Use higgsfield-product-photoshoot for professional product photography.
 allowed-tools: Bash
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["higgsfield"] },
+        "homepage": "https://higgsfield.ai",
+      },
+  }
 ---
 
 # Higgsfield Generate
@@ -16,12 +24,9 @@ Submit jobs to any Higgsfield model. Wraps the `higgsfield` CLI. Covers generic 
 
 ## Step 0 — Bootstrap
 
-Before any other command, make sure the CLI is installed and authenticated:
+Before any other command, make sure the CLI is already installed and authenticated:
 
-1. If `higgsfield` is not on `$PATH`, install it:
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
-   ```
+1. If `higgsfield` is not on `$PATH`, stop and ask the user to install the official Higgsfield CLI manually. Do not run remote installer scripts from this skill.
 2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive, opens a browser) and wait for them to confirm before continuing.
 
 Skip both checks if `higgsfield account status` already prints account info.

--- a/skills/higgsfield/generate/SKILL.md
+++ b/skills/higgsfield/generate/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: higgsfield-generate
+description: |
+  Generate images and videos via Higgsfield AI models and Marketing Studio.
+  Use for text-to-image, image-to-image, image-to-video, photo edits, stylized
+  artwork, short clips, branded ad videos, UGC-style product demos, avatar or
+  product showcase videos, and imported product workflows. Chain with
+  higgsfield-soul-id when the user wants their own face in generated output.
+  Use higgsfield-product-photoshoot for professional product photography.
+allowed-tools: Bash
+---
+
+# Higgsfield Generate
+
+Submit jobs to any Higgsfield model. Wraps the `higgsfield` CLI. Covers generic image/video gen and Marketing Studio (branded ads, avatars, products).
+
+## Step 0 — Bootstrap
+
+Before any other command, make sure the CLI is installed and authenticated:
+
+1. If `higgsfield` is not on `$PATH`, install it:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
+   ```
+2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive, opens a browser) and wait for them to confirm before continuing.
+
+Skip both checks if `higgsfield account status` already prints account info.
+
+## UX Rules
+
+1. Be concise. No raw IDs, no JSON dumps in chat. Print result URL when ready.
+2. No internal jargon. Don't narrate "calling higgsfield cost", "polling job".
+3. Detect the user's language from the first message and reply in it. Technical args (`--aspect_ratio 16:9`) stay English.
+4. Don't batch-ask. Pick a sane default model and ask one thing at a time only if genuinely missing.
+5. Don't pre-estimate cost. Just submit unless the user asks.
+6. Pass `--wait` to `generate create` so the command blocks until done and prints the result URL itself. Avoid the two-step `create` → `wait` pattern.
+
+## Workflow — generic generation
+
+1. **Pick a model.** Practical defaults from production use:
+
+   **Image:**
+   - Brand product visual (Pinterest pin, lifestyle, hero banner, ad pack, virtual try-on) → use `higgsfield-product-photoshoot` instead. NOT this skill.
+   - Branded ad image with avatar + product (Marketing Studio shape) → Marketing Studio Image (see Marketing Studio below)
+   - Aesthetic UGC / fashion editorial / lifestyle character → Soul 2.0
+   - Cinematic still frame → Soul Cinema
+   - Highly characterful creative persona (text-only, distinctive) → Soul Cast
+   - Locations / environments / no-people scenes → Soul Location (best in class)
+   - Vector illustrations OR face edit + complex scene swap → Seedream 4.5
+   - Soul Character (reference id from `higgsfield-soul-id`) → Soul 2.0 for stills, Soul Cinema for cinematic
+   - Fast and cheap iteration → Z Image
+   - Character or cartoon-style work → Nano Banana 2; step up to Nano Banana Pro on hard cases
+   - **Default for everything else → GPT Image 2.** Graphic design, UI, banners, typography, and high-fidelity general generation.
+
+   **Video:**
+   - All advertising / commercial / branded ad video → Marketing Studio (see Marketing Studio below)
+   - **Default all-purpose serious video (multi-shot, consistent identity, motion-heavy) → Seedance 2.0.** SOTA.
+   - Single-plane scene without strong dynamics, cheaper than Seedance 2.0 → Kling 3.0
+   - Cheap clean shot without cuts → Seedance 1.5 Pro
+   - Cinema-grade highest fidelity → Cinema Studio Video 3.0
+   - Cheap with strong physics, no audio needed → Minimax Hailuo
+   - Fast batch / volume → Veo 3.1 Lite
+
+   For the actual `--model` ID to pass to `higgsfield generate create`, run `higgsfield model list --json | jq` to map display names to IDs. See `references/model-catalog.md` for the full table.
+
+2. **Pass media inputs straight to flags.** Media flags accept a local file path **or** a UUID. CLI auto-uploads paths and auto-detects job vs upload for UUIDs. No need to pre-upload. Each model declares accepted roles (`image`, `start_image`, `end_image`, `video`, `audio`) — see `references/media-inputs.md`.
+3. **Validate quickly.** If unsure of params, run `higgsfield model get <jst> --json` once and pass only what's needed. Use schema defaults otherwise. The server returns `adjustments` for non-fatal coercions (e.g. `aspect_ratio=99:99` → closest match) and a structured error for invalid declared-param values.
+4. **Submit and wait in one shot.** `higgsfield generate create <jst> --prompt "..." [media flags] [param flags] --wait`. Blocks until terminal status and prints the result URL on stdout. Tunables: `--wait-timeout 20m` (default 10m), `--wait-interval 5s` (default 3s).
+5. **Deliver.** Send the URL plus a one-line summary (model, duration if video).
+
+To inspect or rerun later, `higgsfield generate list --json` and `higgsfield generate get <id> --json` work for retrospection. `higgsfield generate wait <id>` is still available if you ever need to rejoin a job started without `--wait`.
+
+## Media flags
+
+| Flag | Use for | Models that accept it |
+|---|---|---|
+| `--image <path-or-id>` | reference image | most image models, `seedance_2_0`, `veo3`, `marketing_studio_video` |
+| `--start-image <path-or-id>` | first frame for image-to-video transitions | `kling3_0`, `kling2_6`, `veo3_1`, `seedance_2_0`, `marketing_studio_video` |
+| `--end-image <path-or-id>` | last frame for transitions | `kling3_0`, `seedance_2_0`, `marketing_studio_video` |
+| `--video <path-or-id>` | reference video | `seedance_2_0` |
+| `--audio <path-or-id>` | reference audio (lipsync, soundtrack match) | `seedance_2_0` (use this, NOT `--generate-audio`) |
+
+Each flag accepts either a local file path (auto-uploaded) or a UUID (upload id from `higgsfield upload create`, or a previous job id). Each model declares its own role set via `MEDIA_ROLES`. See `references/media-inputs.md` for the full table.
+
+## Common params
+
+Flags pass through to model schema. Use `higgsfield model get <jst>` to discover.
+
+```bash
+higgsfield generate create gpt_image_2 --prompt "neon city at dusk" --aspect_ratio 16:9 --resolution 2k --wait
+higgsfield generate create nano_banana_2 --prompt "anime character concept, expressive pose" --image ./ref.png --wait
+higgsfield generate create seedance_2_0 --prompt "camera dollies in" --start-image ./first.png --duration 8 --wait
+higgsfield generate create text2image_soul_v2 --prompt "..." --soul-id <soul_ref_id> --wait
+```
+
+For machine-readable output (chained pipelines, agent context), add `--json`. With `--wait --json` you get the final job object array. Without `--wait`, you get the job IDs.
+
+Stdin prompt: `echo "..." | higgsfield generate create z_image --wait`.
+
+## Marketing Studio
+
+Branded image/video gen: avatars + products + ad-style modes. Use models `marketing_studio_video` and `marketing_studio_image`.
+
+### Concepts
+
+- **Avatar** — presenter face. Curated `preset` (browse `higgsfield marketing-studio avatars list`) or `custom` (uploaded photos via `higgsfield marketing-studio avatars create`).
+- **Product** — brand item with title + reference images. Imported from URL (`higgsfield marketing-studio products fetch --url ...`) or created from uploaded images (`higgsfield marketing-studio products create`).
+- **Webproduct** — App Store / web page version. Auto-routes when fetching App Store URLs.
+
+### UX rules (additional)
+
+- One question per phase. Don't ask product+avatar+mode upfront.
+
+### Workflow — quick ad video
+
+1. **Get product.**
+   - URL → `higgsfield marketing-studio products fetch --url <url> --wait` (polls until import done)
+   - Local images → `higgsfield upload create <photo>...` then `higgsfield marketing-studio products create --title "..." --image <id>...`
+   Capture product id.
+2. **Pick avatar.**
+   - Default: `higgsfield marketing-studio avatars list` and pick a preset matching the brand voice.
+   - Custom: `higgsfield marketing-studio avatars create --name "..." --image <upload_id>`.
+3. **Pick mode.** Default `ugc`. Other slugs (canonical from MCP): `tutorial`, `ugc_unboxing`, `hyper_motion`, `product_review`, `tv_spot`, `wild_card`, `ugc_virtual_try_on`, `virtual_try_on`. See `references/marketing-modes.md`.
+4. **Generate (one-shot).**
+   ```bash
+   higgsfield generate create marketing_studio_video \
+     --prompt "..." \
+     --avatars '[{"id":"<avatar_id>","type":"preset"}]' \
+     --product_ids '[<product_id>]' \
+     --mode ugc \
+     --duration 15 \
+     --resolution 720p \
+     --aspect_ratio 9:16 \
+     --wait
+   ```
+   Resolution is `480p` or `720p`. Aspect ratio is one of `auto`/`21:9`/`16:9`/`4:3`/`1:1`/`3:4`/`9:16`. `--generate-audio true` is supported here (unlike `seedance_2_0`). `--wait` blocks until done; bump `--wait-timeout 30m` for longer ad runs.
+5. **Deliver.** URL + one-line summary (mode, duration).
+
+### Click-to-Ad shortcut (URL-driven)
+
+When the user gives a product URL and wants a marketing video in one go:
+
+```bash
+# 1. Trigger fetch (returns the product id and starts background scrape)
+higgsfield marketing-studio products fetch --url https://shop.example.com/sneakers --wait
+
+# 2. Generate the marketing video against the same URL — backend reuses the entity
+higgsfield generate create marketing_studio_video \
+  --url https://shop.example.com/sneakers \
+  --mode ugc \
+  --duration 15 \
+  --aspect_ratio 9:16 \
+  --wait
+```
+
+Backend dedupes by URL, so repeated runs reuse the existing entity instead of re-fetching.
+
+### Workflow — marketing image
+
+Same as above but use `marketing_studio_image` model:
+
+```bash
+higgsfield generate create marketing_studio_image \
+  --prompt "..." \
+  --aspect_ratio 1:1 \
+  --resolution 2k \
+  --wait
+```
+
+## Errors
+
+- `Missing required params: prompt` → user gave no prompt; ask for it.
+- `Invalid values: aspect_ratio=99:99 (allowed: ...)` → bad enum; pick from allowed.
+- `Unknown params: foo` → schema doesn't accept that flag; check `higgsfield model get <jst>`.
+- `Session expired` → `higgsfield auth login`.
+
+See `references/troubleshooting.md` for more.
+
+## Reference docs
+
+Load on demand:
+
+- `references/model-catalog.md` — picking the right model for the task
+- `references/prompt-engineering.md` — writing prompts that work
+- `references/media-inputs.md` — image/video reference flows
+- `references/troubleshooting.md` — common errors and fixes
+- `references/marketing-avatars.md` — preset vs custom avatars
+- `references/marketing-products.md` — URL fetch vs manual product create
+- `references/marketing-modes.md` — every Marketing Studio mode

--- a/skills/higgsfield/generate/references/marketing-avatars.md
+++ b/skills/higgsfield/generate/references/marketing-avatars.md
@@ -1,0 +1,40 @@
+# Avatars
+
+## Preset vs Custom
+
+| | Preset | Custom |
+|---|---|---|
+| Source | Curated by Higgsfield | User-uploaded |
+| Cost | None for selection | Cost of upload |
+| Diversity | Limited but professional | Unlimited |
+| Use when | Generic ad, fast turnaround | Brand-specific face, founder, employee |
+
+## Listing presets
+
+```bash
+higgsfield marketing-studio avatars list
+higgsfield marketing-studio avatars list --json | jq '.[] | select(.gender=="female")'
+```
+
+Filter by `name`, `gender`, etc. on the JSON output.
+
+## Creating a custom avatar
+
+```bash
+ID=$(higgsfield upload create founder.png)
+URL=$(higgsfield upload create founder.png --json | jq -r .url)   # if you need cloudfront URL
+higgsfield marketing-studio avatars create --name "Founder" --image $ID --image-url $URL
+```
+
+`--image-url` is the cloudfront URL from the upload. Required by the API.
+
+## Passing to video
+
+```bash
+higgsfield generate create marketing_studio_video \
+  --avatars '[{"id":"<avatar_id>","type":"preset"}]' \
+  ... \
+  --wait
+```
+
+`type` is `preset` for curated, `custom` for user-created.

--- a/skills/higgsfield/generate/references/marketing-modes.md
+++ b/skills/higgsfield/generate/references/marketing-modes.md
@@ -1,0 +1,49 @@
+# Marketing Studio Modes
+
+Canonical mode values for `marketing_studio_video` `--mode`. Mirrored from the MCP server (`fnf-mcp-server/src/provider/fnf-client/generation/marketing-studio-video.ts`). All slugs below are accepted by the API.
+
+| `--mode` slug | Human-readable label | Best for |
+|---|---|---|
+| `ugc` | UGC | Default. Casual, organic-feel content from a presenter. |
+| `tutorial` | Tutorial | "Here's how to use this." Tutorial / explainer. |
+| `ugc_unboxing` | Unboxing | "Just got this in the mail." Unboxing reveal. |
+| `hyper_motion` | Hyper Motion | Clean product highlight, polished. |
+| `product_review` | Product Review | Presenter giving an opinion on the product. |
+| `tv_spot` | TV Spot | Broadcast-style commercial. Higher production. |
+| `wild_card` | Wild Card | Experimental, model picks the vibe. |
+| `ugc_virtual_try_on` | UGC Virtual Try On | Person trying on clothing/accessories — UGC vibe. |
+| `virtual_try_on` | Pro Virtual Try On | Same but more polished, model-driven. |
+
+**Default when the user doesn't specify:** `ugc`.
+
+## Picking flow
+
+- "Looks like a real person filmed on phone" → `ugc` family (`ugc`, `ugc_unboxing`, `ugc_virtual_try_on`, `tutorial`)
+- "Polished broadcast commercial" → `tv_spot`
+- "Show the product itself, less presenter" → `hyper_motion`
+- "Presenter giving an opinion" → `product_review`
+- "Try clothing on someone" → `virtual_try_on` (polished) or `ugc_virtual_try_on` (organic feel)
+- "Surprise me / something different" → `wild_card`
+
+## Other parameters
+
+For `marketing_studio_video`, the API accepts:
+
+- `aspect_ratio`: `auto`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, `9:16` (default `16:9`).
+- `duration`: integer ≥ 4 seconds. No fixed cap; check `higgsfield model get marketing_studio_video` for the current upper bound.
+- `resolution`: `480p` or `720p` (default `720p`).
+- `generate_audio`: boolean (default `false`). Generates audio for the video.
+- `avatars`: array of `{id, type}` where `type` is `preset` or `custom`. See `marketing-avatars.md`.
+- `product_ids`: array of product UUIDs (from `higgsfield marketing-studio products fetch` or `create`). See `marketing-products.md`.
+- `medias`: optional reference images with role `image`, `start_image`, or `end_image`.
+- `feature: "click_to_ad"`: when generating from a single landing-page URL (Click-to-Ad flow).
+- `product: { id?, url? }`: alternative single-product reference; the URL flow auto-fetches.
+
+## URL-driven Click-to-Ad shortcut
+
+For `marketing_studio_video` driven by a product URL (no manual product create / fetch), the MCP-side flow is:
+
+1. Call `higgsfield marketing-studio products fetch --url <url> --wait` (or use `show_marketing_studio` widget action `fetch`).
+2. Call `higgsfield generate create marketing_studio_video --url <same url>` — the backend looks up / reuses the entity and submits.
+
+Repeated fetches for the same URL dedupe — the backend reuses any existing non-failed entity.

--- a/skills/higgsfield/generate/references/marketing-products.md
+++ b/skills/higgsfield/generate/references/marketing-products.md
@@ -1,0 +1,56 @@
+# Products
+
+Two ways to register a product: URL fetch (auto-imports title, description, images) or manual (provide your own).
+
+## URL fetch (default)
+
+```bash
+ID=$(higgsfield marketing-studio products fetch --url https://shop.example.com/sneakers --wait --json | jq -r .id)
+```
+
+`--wait` polls until `status` is `completed` or `failed`. Default timeout 90s.
+
+If `failed`, check `fail_reason` — usually invalid URL or scrape blocked.
+
+App Store URLs auto-route to `webproducts` (different endpoint). Use:
+
+```bash
+higgsfield marketing-studio webproducts fetch --url https://apps.apple.com/... --wait
+```
+
+## Manual
+
+When the user has product photos and details:
+
+```bash
+A=$(higgsfield upload create shoe1.png)
+B=$(higgsfield upload create shoe2.png)
+higgsfield marketing-studio products create \
+  --title "AeroRun Pro" \
+  --description "Lightweight running shoe" \
+  --image $A --image $B
+```
+
+Returns the product entity directly (no polling needed).
+
+## Manual webproduct
+
+For App Store / web pages without URL fetch:
+
+```bash
+higgsfield marketing-studio webproducts create \
+  --url "https://example.com" \
+  --title "MyApp" \
+  --subtitle "Productivity for teams" \
+  --description "..." \
+  --favicon-url "https://example.com/favicon.png" \
+  --desktop "https://cdn/screenshot1.png" \
+  --mobile "https://cdn/mobile-screenshot.png"
+```
+
+## Listing
+
+```bash
+higgsfield marketing-studio products list
+higgsfield marketing-studio webproducts list
+```

--- a/skills/higgsfield/generate/references/media-inputs.md
+++ b/skills/higgsfield/generate/references/media-inputs.md
@@ -1,0 +1,88 @@
+# Media Inputs
+
+How to pass reference images, videos, and audio. Mirrored from MCP server media-handling logic.
+
+## Path or UUID — both work
+
+Each media flag accepts either a local file path or a UUID. The CLI auto-uploads paths before submission and auto-detects whether a UUID is an upload id (from `higgsfield upload create`) or a previous job id.
+
+```bash
+# Local path — CLI uploads automatically
+higgsfield generate create nano_banana_2 --prompt "stylize in watercolor" --image ./photo.png --wait
+
+# Upload id (from higgsfield upload create)
+higgsfield generate create nano_banana_2 --prompt "..." --image <upload_id> --wait
+
+# Job id from a previous generation
+higgsfield generate create seedance_2_0 --prompt "anim" --start-image <previous_job_id> --wait
+```
+
+Type auto-detected from extension:
+
+- Image: `png`, `jpg`/`jpeg`, `webp`, `gif`
+- Video: `mp4`, `mov`, `webm`
+- Audio: `mp3`, `wav`, `m4a`, `ogg`
+
+## Roles by model family
+
+Each model declares a closed set of accepted roles via `MEDIA_ROLES`. Pass the right role; the CLI rejects unknown ones locally before submission.
+
+| Model | Accepted roles | Notes |
+|---|---|---|
+| Most image models (`nano_banana_2`, `flux_2`, `seedream_v4_5`, `gpt_image_2`, …) | `image` | 1+ references, often up to 8. |
+| `seedance_2_0` | `image`, `start_image`, `end_image`, `video`, `audio` | Audio is via `medias` (role `audio`), NOT via `--generate-audio`. |
+| `kling3_0` | `start_image`, `end_image` | Image-to-video with optional last-frame transition. |
+| `kling2_6` | `start_image` | Single frame anchor. |
+| `veo3_1` | `start_image` | Max 1 reference. |
+| `veo3` | `image` | Single image-to-video. |
+| `marketing_studio_video` | `image`, `start_image`, `end_image` | Plus `avatars`, `product_ids`, `assets` as separate fields. |
+| `z_image`, `soul_cast`, `soul_location` | (none) | Text-only. Reject media inputs. |
+
+For simple image-to-video on a video model that only declares `image` (e.g. `veo3`), plain `--image` is auto-remapped to `start_image` by the CLI when unambiguous. When in doubt:
+
+```bash
+higgsfield model get <model_id>   # shows the accepted media roles for this model
+```
+
+## Multiple images
+
+Most image models accept multiple references — repeat the `--image` flag:
+
+```bash
+higgsfield generate create nano_banana_2 --prompt "..." \
+  --image ./a.png --image ./b.png --image <upload_id> \
+  --wait
+```
+
+Single-reference video models (`veo3`, `veo3_1`, `kling2_6`) reject extra images — the CLI errors locally before submission with `Model accepts only one image reference`.
+
+## Audio reference (Seedance)
+
+`seedance_2_0` is the one model that takes an audio reference for lipsync / soundtrack matching. Pass via `medias` with role `audio`:
+
+```bash
+higgsfield generate create seedance_2_0 \
+  --prompt "person speaking" \
+  --start-image ./headshot.png \
+  --audio ./voice.mp3 \
+  --duration 8 \
+  --wait
+```
+
+**Do NOT pass `--generate-audio` to `seedance_2_0`** — the model schema doesn't declare it. Use the audio media role instead.
+
+## Schema mismatches
+
+The CLI returns specific error messages for known shape mismatches:
+
+- `Model accepts only --image (no roles)` — the model uses the legacy `input_images` shape, not `medias` with roles. Drop role-prefixed flags and use plain `--image`.
+- `Model does not accept media inputs` — the model is text-only (`z_image`, `soul_location`, `soul_cast`, `wan2_6` for some configs). Drop all media flags.
+- `Unknown media role "<role>"` — the role isn't in this model's `MEDIA_ROLES`. Run `higgsfield model get <model>` and check `medias[].roles`.
+
+## Seeing what a model accepts
+
+```bash
+higgsfield model get <model_id> --json | jq '{aspect_ratios, durations, parameters, medias}'
+```
+
+Returns the full schema: aspect ratios (closed enum or open), durations (closed list or `min/max` range), parameters (with descriptions and defaults), and media roles per slot.

--- a/skills/higgsfield/generate/references/model-catalog.md
+++ b/skills/higgsfield/generate/references/model-catalog.md
@@ -1,0 +1,140 @@
+# Model Catalog
+
+The full lineup of generation models available through Higgsfield. Each entry has its own sweet spot — pick the one that matches your brief. For the actual `--model` ID to pass to `higgsfield generate create`, run `higgsfield model list --json` and look up by display name.
+
+Preferred defaults for examples and quick-start guidance in this repo:
+- **Images:** `gpt_image_2` (general/high-fidelity) and `nano_banana_2` (character/cartoon).
+- **Video:** `seedance_2_0` (all-purpose serious video).
+
+---
+
+## Image models
+
+| Model | Provider | What it's for |
+|---|---|---|
+| Nano Banana 2 | Google | **Fast everyday default for character work.** Edits, general generation, character / cartoon / animated-style outputs. The reach-for-this model when the brief calls for character or cartoon-style image generation. |
+| Nano Banana Pro | Google | **Top-tier Nano Banana.** Same canvas as Nano Banana 2 with extra fidelity and accuracy on harder briefs. Pick when 2 isn't getting there. |
+| Nano Banana | Google | Reliable, budget-friendly entry in the Nano Banana family — picks up the same realistic look at a lighter price point. |
+| Higgsfield Soul 2.0 | Higgsfield | **Aesthetic UGC, fashion editorial, character generation.** When the brief leans editorial, lifestyle, or "looks like a magazine cover". Soul-aware (accepts a Soul Character reference). |
+| Soul Cinema | Higgsfield | **Cinematic stills, film-grade lighting.** The pick when the user asks for "cinematic" or wants concept-art mood. |
+| Soul Cast | Higgsfield | **Distinctive, characterful personas.** When the brief calls for a creative, expressive character rather than photoreal default. Text-only (no reference image). |
+| Soul Location | Higgsfield | **Best-in-class environments and locations.** Unmatched for pure scene and place generation without a person in frame. |
+| Seedream 4.5 | Bytedance | **Vector illustrations and complex scene edits with faces.** When the brief is a face-anchored photo edit into a complex new scene (more than an outfit change), without heavy filters. |
+| Seedream 5.0 Lite | Bytedance | Same Seedream lineage as 4.5 with faster turnaround for visual-reasoning and instruction-based edits. |
+| Z Image | Tongyi-MAI | **Fastest in the catalog.** Built for speed, drafts, and LoRA-driven stylization. The pick when the brief is "fast and cheap, let me iterate". |
+| Flux 2.0 | Black Forest Labs | Precise prompt adherence with multiple variants (pro, flex, max). A strong creative alternative when the user wants a different look from the Banana family. |
+| Flux Kontext Max | Black Forest Labs | **Context-aware editing and style transfer.** Strong for anime, stylized looks, typography remix — when defaults feel too generic. |
+| Kling O1 Image | Kling | Versatile photorealistic image generation with broad aspect-ratio support. |
+| GPT Image 1.5 | OpenAI | Earlier-generation OpenAI image model with editing and text-rendering capabilities. |
+| GPT Image 2 | OpenAI | **Default high-fidelity image generation.** Graphic design, UI, banners, typography, and any brief with on-image text. Used by `higgsfield-product-photoshoot` under the hood. |
+| Grok Imagine | xAI | Expressive, high-contrast, bold creative outputs. Worth trying for anime and stylized looks. |
+| Cinema Studio Image 2.5 | Higgsfield | Cinematic still frames up to 4K, dramatic film look. |
+| Marketing Studio Image | Higgsfield | **Branded image ads.** Retrieval-augmented over the user's avatars and products — runs inside the Marketing Studio flow. |
+| Auto | Higgsfield | **Smart routing layer.** Picks the best image model from the prompt automatically. Use when the user's intent is open and you don't want to commit to a specific model. |
+
+## Video models
+
+| Model | Provider | What it's for |
+|---|---|---|
+| Seedance 2.0 | Bytedance | **SOTA all-purpose video.** Crisp, consistent identity, multi-shot capable. The default for any serious motion / cinematic / production brief. |
+| Kling 3.0 | Kling | **Cheaper Seedance 2.0 substitute** for single-plane scenes that don't need heavy motion. Multi-shot, audio sync, motion transfer. |
+| Seedance 1.5 Pro | Bytedance | A budget-friendly Seedance for clean single-take shots. |
+| Marketing Studio | Higgsfield | **All advertising and commercial video** — UGC, unboxing, TV spot, product showcase. The default whenever the brief is "make an ad". See `marketing-modes.md`. |
+| Cinema Studio Video 3.0 | Higgsfield | **Top-tier cinema-grade execution.** The pick for film-look briefs at the highest fidelity. |
+| Veo 3.1 Lite | Google | **Fast and cost-effective Veo.** Built for batch and volume work. |
+| Google Veo 3.1 | Google | Ultra-realistic, top-tier cinematic quality. Quality tiers basic/high/ultra. Format set is constrained — verify accepted aspect ratio and duration before submitting. |
+| Google Veo 3 | Google | Reliable cinematic with broad creative range and audio support. |
+| Minimax Hailuo | Hailuo | **Cheap with strong physics.** Solid budget pick when natural-physics motion matters; no audio in current variants. |
+| Wan 2.7 | Wan | Synchronized audio with character-consistent video. The newer Wan release. |
+| Wan 2.6 | Wan | Open-weight, stylized, experimental creative. Cheap option when the brief is intentionally artistic. |
+| Kling 2.6 | Kling | Cinematic motion with advanced physics — earlier Kling release alongside 3.0. |
+| Grok Imagine (video) | xAI | Text and image-to-video with audio support. Worth trying for stylized creative briefs. |
+| Cinema Studio Video | Higgsfield | Cinematic compositions with dramatic mood. Use Cinema Studio Video 3.0 as the modern default. |
+| Cinema Studio Video v2 | Higgsfield | Refined cinematic camera and color with genre control. Use Cinema Studio Video 3.0 as the modern default. |
+
+---
+
+## Picking flow
+
+Practical defaults from production use. Match by intent, not surface keyword. When two could apply, the higher entry wins.
+
+### Image — pick this default
+
+1. **Brand product visual (Pinterest pin, lifestyle, hero banner, ad pack, virtual try-on, restyle)** → use `higgsfield-product-photoshoot` instead. NOT this skill.
+2. **Branded ad image with presenter avatar + product (Marketing Studio shape with RAG over user assets)** → Marketing Studio Image.
+3. **Aesthetic UGC / fashion editorial / lifestyle character** → Soul 2.0.
+4. **Cinematic still frame** → Soul Cinema.
+5. **Highly characterful, creative character (text-only, distinctive persona, no reference photo)** → Soul Cast.
+6. **Locations / environments / no-people scenes** → Soul Location. Best in class — nothing else matches.
+7. **Vector illustrations OR face edit + complex scene swap (more than outfit change, no heavy filters)** → Seedream 4.5. Seedream 5.0 Lite for the same niche but faster.
+8. **Soul Character (reference id from `higgsfield-soul-id`)** → Soul 2.0 for stills; Soul Cinema for cinematic vibe.
+9. **Anime / stylized / non-default look where defaults feel flat** → Flux Kontext Max or Grok Imagine. Worth trying.
+10. **Character or cartoon-style work** → Nano Banana 2; step up to Nano Banana Pro on hard cases.
+11. **Fast and cheap iteration / drafts / LoRA work** → Z Image.
+12. **Default for everything else** → GPT Image 2. High-fidelity general generation, graphic design, UI, banners, anything with on-image text.
+13. **Intent-only request, no preference, want auto-routing** → Auto.
+
+### Video — pick this default
+
+1. **All advertising / commercial video (UGC, unboxing, TV spot, product showcase, branded ad)** → Marketing Studio. See `marketing-modes.md`.
+2. **Default all-purpose serious video (multi-shot, consistent identity, motion-heavy, production work)** → Seedance 2.0. SOTA.
+3. **Single-plane scene without strong dynamics, cheaper** → Kling 3.0. Substitute for Seedance 2.0 when motion isn't critical.
+4. **Cheap clean shot without cuts** → Seedance 1.5 Pro.
+5. **Image-to-video with explicit first frame** → Kling 3.0 with a start frame, or Seedance 2.0 with a start frame for higher motion.
+6. **Cinema-grade execution (highest fidelity, film look)** → Cinema Studio Video 3.0.
+7. **Cheap with strong physics, audio not needed** → Minimax Hailuo.
+8. **Fast batch / volume** → Veo 3.1 Lite.
+9. **Veo-format-bound work (specific aspect / duration set Veo accepts)** → Veo 3.1; Veo 3 is slightly behind.
+10. **Stylized / animation-style edit-driven work** → Wan 2.7.
+11. **Stylized cheap experimental** → Wan 2.6.
+12. **Anime / bold-style outputs where defaults feel flat** → Grok Imagine (video). Worth trying.
+
+### Things to keep in mind
+
+- **Don't invent model names.** Run `higgsfield model list` if you're unsure — submitting an unknown model returns `unknown model "..."`.
+- **Audio reference for Seedance 2.0** comes through the media inputs with role `audio`, not via a separate `generate_audio` flag.
+- **Text-only models reject reference images.** Z Image, Soul Cast, Soul Location, and some Wan configs are text-only; pass no media flags to them.
+- **Route branded product visuals through `higgsfield-product-photoshoot`** — its prompt enhancer adds 10 mode-specific templates on top of GPT Image 2. Direct GPT Image 2 generation here is the right call for everything that isn't a product photoshoot.
+- **For cinema video, prefer Cinema Studio Video 3.0** as the modern default; reach for the earlier Cinema Studio Video variants only when the user names them.
+- **When the user names a specific model, use it.** The defaults above cover the common intents — the rest of the catalog exists for users who know what they want.
+
+---
+
+## Media role conventions
+
+Each model accepts a fixed set of media roles. When unsure, run `higgsfield model get <model>` and inspect the `medias[].roles` field.
+
+| Model | Accepted media roles |
+|---|---|
+| Seedance 2.0 | `image`, `start_image`, `end_image`, `video`, `audio` |
+| Kling 3.0 | `start_image`, `end_image` |
+| Kling 2.6 | `start_image` |
+| Veo 3.1 | `start_image` (max 1) |
+| Veo 3 | `image` (max 1) |
+| Marketing Studio (video) | `image`, `start_image`, `end_image` |
+| Most image models | `image` (1+) |
+| Z Image, Soul Cast, Soul Location | (no media — text-only) |
+
+For simple image-to-video, the `start_image` role is what you want. For pure video models that only declare `image`, the `image` flag is auto-remapped to `start_image` by the CLI.
+
+## Aspect ratios and durations
+
+These are model-specific. The CLI clamps unsupported values to the nearest allowed one (with a `Note: adjustments applied` warning) when the model declares a closed set. When in doubt:
+
+```bash
+higgsfield model get <model>
+```
+
+Common patterns:
+
+- **Seedance 2.0** image: `auto`, `21:9`, `16:9`, `4:3`, `1:1`, `3:4`, `9:16`. Duration 4–15s.
+- **Kling 3.0**: `16:9`, `9:16`, `1:1`. Duration 3–15s. Modes `pro`/`std`.
+- **Veo 3.1**: `16:9` or `9:16`. Duration `4`, `6`, or `8` only. Quality `basic`/`high`/`ultra`.
+- **Marketing Studio (video)**: `auto`/`21:9`/`16:9`/`4:3`/`1:1`/`3:4`/`9:16`. Resolution `480p` or `720p`.
+
+## When you submit an unknown value
+
+The CLI reports two kinds of feedback:
+
+- **Adjustments** — a non-fatal coercion. E.g. you passed `aspect_ratio=99:99` and the model accepts a closed set; the CLI picks the closest match and continues. The adjustments map is included in the response.
+- **Validation error** — a fatal mismatch. E.g. an unknown declared parameter, or a media role the model doesn't accept. The CLI returns an error and does not submit.

--- a/skills/higgsfield/generate/references/prompt-engineering.md
+++ b/skills/higgsfield/generate/references/prompt-engineering.md
@@ -1,0 +1,47 @@
+# Prompt Engineering
+
+## Basics
+
+Higgsfield models reward concrete, sensory prompts.
+
+- **Subject + setting + style**: "a red fox curled in a snowy pine forest, golden hour, cinematic"
+- **Camera**: lens (35mm, 85mm), angle (low, overhead), motion (dolly in, tracking shot)
+- **Lighting**: rim light, neon glow, moody backlight
+- **Style/medium**: oil painting, watercolor, photograph, anime, 3D render
+
+Keep it under ~200 tokens. Models distort with very long prompts.
+
+## Image-to-image
+
+When passing `--image`, the prompt should describe what changes, not redescribe the input.
+
+Bad: "a man with brown hair in a leather jacket holding coffee, made into anime"
+Good: "transform into anime style, vibrant colors, soft cel shading"
+
+## Image-to-video
+
+`--start-image` anchors the first frame. Prompt describes motion.
+
+- Verbs: zooms in, dollies left, sweeping pan, slow push, fast whip
+- Subject motion: "the dancer spins", "smoke rises slowly"
+- Don't redescribe the static frame — model already has it.
+
+## Negative phrasing
+
+Most models don't expose a `negative_prompt`. Phrase positively:
+- Instead of "no blur" → "tack sharp"
+- Instead of "no people" → "uninhabited landscape"
+
+## Aspect ratio guidance
+
+- `16:9` — landscape, cinematic
+- `9:16` — vertical, social
+- `1:1` — square, profile / icon
+- `4:3`, `3:4`, `21:9` — model-dependent, check `higgsfield model get <jst>`
+
+## Safety
+
+Models reject prompts with `nsfw` or `ip_detected` terminal status. Avoid:
+- Real public figures
+- Sexual content
+- Trademarks / branded characters

--- a/skills/higgsfield/generate/references/troubleshooting.md
+++ b/skills/higgsfield/generate/references/troubleshooting.md
@@ -1,0 +1,31 @@
+# Troubleshooting
+
+## Authentication
+
+- `Session expired.` → `higgsfield auth login`
+- `Stored credentials are for ... but current environment ...` → `higgsfield auth login` for the current API URL.
+- `Not authenticated.` → first `higgsfield auth login`.
+
+## Validation
+
+- `Missing required params: prompt` — user gave no prompt. Ask.
+- `Invalid values: <param>=<v> (allowed: ...)` — pick from allowed enum.
+- `Unknown params: <name>` — schema doesn't accept this flag. Run `higgsfield model get <jst>` and check.
+
+## Job lifecycle
+
+- `Job ended with status "failed"` — server-side failure. Often prompt content / safety. Try rephrasing.
+- `nsfw` / `ip_detected` — content policy. Rephrase.
+- `Timeout after 10m` — model is slow today. Bump `--timeout 30m` or retry.
+
+## Rate limits
+
+`Higgsfield API error (HTTP 429)` — too many requests. Back off.
+
+## CloudFlare / DataDome
+
+If `Failed to decode response. Body: <html>...captcha-delivery...` appears, the server's anti-bot fired. Wait 30s and retry. If persistent, ping the team.
+
+## Cost
+
+`higgsfield generate cost <jst> ...` returns credit estimate without submitting. Useful when the user asks "how much will this cost?".

--- a/skills/higgsfield/marketplace-cards/SKILL.md
+++ b/skills/higgsfield/marketplace-cards/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: higgsfield-marketplace-cards
+description: |
+  Generate marketplace product image cards through Higgsfield: compliant
+  main image, secondary product images, and A+ style content modules. Use when
+  the user asks for marketplace listing images, product detail cards,
+  secondary product images, product infographics, lifestyle listing shots,
+  A+ style content, marketplace image sets, or sales-ready product visuals.
+  Backend owns marketplace compliance references and prompt templates; this skill
+  only routes user intent to the CLI.
+  NOT for generic brand product photography without marketplace/listing context
+  (use higgsfield-product-photoshoot), video generation or UGC ads (use
+  higgsfield-generate), or Soul Character training (use higgsfield-soul-id).
+allowed-tools: Bash
+---
+
+# Marketplace Cards
+
+Create marketplace-ready product visuals with `higgsfield marketplace-cards create`.
+The CLI first calls the backend enhancer, where marketplace rules and templates are kept private, then creates `nano_banana_2` jobs and prints result URLs.
+
+## Bootstrap
+
+1. If `higgsfield` is not on `$PATH`, install it by running the official installer with Bash: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`.
+2. If `higgsfield account status` fails with authentication errors, ask the user to run `higgsfield auth login`.
+
+## UX Rules
+
+1. Respond in the user's language.
+2. Ask at most one concise confirmation question before running.
+3. Prefer a product image. If the user provides only text or a URL, proceed only when the product details are clear.
+4. Do not write final image-generation prompts yourself. Backend enhancement owns that.
+5. Final answer should contain only the ready image URLs and short labels.
+
+## Scope Selection
+
+Use `--scope` when the user asks for a common bundle:
+
+| Scope | Creates |
+|---|---|
+| `main` | 1 marketplace main image |
+| `product-images` | main image + 5 secondary images |
+| `aplus` | main image + 7 A+ modules |
+| `full-set` | main image + 5 secondary images + 7 A+ modules |
+
+Use repeated `--asset` only for custom subsets:
+
+- `main_image`
+- `infographic`
+- `multi_angle`
+- `detail_shot`
+- `lifestyle`
+- `whats_in_box`
+- `aplus_hero_banner`
+- `aplus_pain_points`
+- `aplus_features`
+- `aplus_ingredients`
+- `aplus_efficacy`
+- `aplus_how_to_use`
+- `aplus_endorsement`
+
+## Command
+
+Build and run one `higgsfield marketplace-cards create` command from the user's request.
+
+For common bundles, use `--scope <main|product-images|aplus|full-set>`, `--prompt "<short product and listing intent>"`, optional repeated `--image <path-or-upload-id>`, and optional context flags: `--product_context`, `--brand_context`, `--category`, `--visual_style`.
+
+Examples to mirror when choosing arguments:
+
+- Product images: `higgsfield marketplace-cards create --scope product-images --prompt "sparkling peach lemonade can for marketplace listing" --image ./can.png --category "beverage"`
+- Full set: `higgsfield marketplace-cards create --scope full-set --prompt "premium skincare serum, clean clinical marketplace visual system" --image ./serum.jpg --brand_context "minimal white and sage palette"`
+- Custom subset: repeat `--asset`, for example `--asset main_image --asset infographic --asset lifestyle`.
+- Existing completed main image job: use `--main-job <completed_main_job_id>` with the requested secondary or A+ `--asset` values.
+
+## Delivery
+
+Print URLs with labels:
+
+```text
+Marketplace cards ready:
+- Main image: https://...
+- Infographic: https://...
+- Lifestyle: https://...
+```
+
+Avoid JSON, job IDs, internal model names, or enhanced prompt text unless the user explicitly asks.

--- a/skills/higgsfield/marketplace-cards/SKILL.md
+++ b/skills/higgsfield/marketplace-cards/SKILL.md
@@ -12,6 +12,14 @@ description: |
   (use higgsfield-product-photoshoot), video generation or UGC ads (use
   higgsfield-generate), or Soul Character training (use higgsfield-soul-id).
 allowed-tools: Bash
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["higgsfield"] },
+        "homepage": "https://higgsfield.ai",
+      },
+  }
 ---
 
 # Marketplace Cards
@@ -21,7 +29,7 @@ The CLI first calls the backend enhancer, where marketplace rules and templates 
 
 ## Bootstrap
 
-1. If `higgsfield` is not on `$PATH`, install it by running the official installer with Bash: `curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh`.
+1. If `higgsfield` is not on `$PATH`, stop and ask the user to install the official Higgsfield CLI manually. Do not run remote installer scripts from this skill.
 2. If `higgsfield account status` fails with authentication errors, ask the user to run `higgsfield auth login`.
 
 ## UX Rules

--- a/skills/higgsfield/product-photoshoot/SKILL.md
+++ b/skills/higgsfield/product-photoshoot/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: higgsfield-product-photoshoot
+description: |
+  Generate brand-quality product images through Higgsfield prompt enhancement
+  on gpt_image_2. Use for studio shots, lifestyle scenes, website heroes,
+  Pinterest pins, carousels, Meta ad creatives, virtual model try-ons, closeups
+  with hands, levitating products, splash shots, CGI-style concepts, seasonal
+  restyles, and other product or brand visuals. Use higgsfield-generate for
+  generic image or video generation and higgsfield-soul-id for Soul training.
+allowed-tools: Bash
+---
+
+# Product Photoshoot
+
+Brand-image generation via the `higgsfield product-photoshoot create` command. The CLI calls a backend prompt enhancer that holds mode-specific photography vocabulary and structural templates, then submits to `gpt_image_2` and returns image URLs.
+
+## Step 0 — Bootstrap
+
+Before any other command:
+
+1. If `higgsfield` is not on `$PATH`, install it:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
+   ```
+2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive) and wait for confirmation.
+
+## UX Rules
+
+1. Be concise. Print only image URLs in the final reply.
+2. Detect language, respond in it. Mode names and CLI flags stay English.
+3. Ask at most 4 short questions before submitting. Use labeled options, never open-ended.
+4. Skip questions whose answer is obvious from context (uploaded image, prior turn, brand memory).
+5. Never write the gpt_image_2 prompt yourself — backend assembles it.
+6. Polling is silent. Wait until URLs are ready, then deliver.
+
+## Modes
+
+| Mode | When user wants… |
+|---|---|
+| `product_shot` | Product on neutral / studio / catalog background |
+| `lifestyle_scene` | Product in real-world environment, hands, action, atmosphere |
+| `closeup_product_with_person` | Tight crop with hands / partial face — beauty application, holding, demonstrating |
+| `moodboard_pin` | Vertical 2:3 Pinterest-native aesthetic, moodboard feel |
+| `hero_banner` | Wide-format website / email / campaign header |
+| `social_carousel` | 3–10 connected slides for IG / LinkedIn / Facebook |
+| `ad_creative_pack` | Coordinated pack of static ad variants for Meta / TikTok / Pinterest / Google Ads |
+| `virtual_model_tryout` | Product worn or used by an AI-rendered model |
+| `conceptual_product` | Surreal / CGI-style / levitating / splash / sculptural product |
+| `restyle` | Transform an existing image's aesthetic, mood, or seasonal context |
+
+## Mode selection
+
+Pick by intent, not surface keyword. When two modes could apply, prefer the more specific one.
+
+- product + neutral / clean / white / studio / catalog / Shopify → `product_shot`
+- product + scene / in use / kitchen / outdoor / cafe / gym → `lifestyle_scene`
+- hands holding / face with product / beauty application / demonstrating → `closeup_product_with_person`
+- Pinterest, pin, vertical pin → `moodboard_pin`
+- hero, banner, website header, landing page, email header, wide format → `hero_banner`
+- carousel, slide post, multi-slide, swipeable → `social_carousel`
+- ads, ad pack, paid social, Meta / TikTok / Pinterest ads → `ad_creative_pack`
+- model wearing, virtual try-on, on body, fashion shoot, lookbook → `virtual_model_tryout`
+- levitating, floating, splash, frozen motion, surreal, CGI, sculptural → `conceptual_product`
+- modify EXISTING image's aesthetic, mood, season — without changing subject → `restyle`
+
+Tie-breakers:
+- "Pinterest pin of my product on a kitchen counter" → `moodboard_pin` (Pinterest is the platform)
+- "Hero banner showing my product in use" → `hero_banner` (banner format wins)
+- "Carousel of my product in different scenes" → `social_carousel` (multi-slide wins)
+- "Closeup of person applying my serum" → `closeup_product_with_person` (specific genre wins)
+
+## Pre-generation interview
+
+Ask 3–4 short questions before submitting. Always labeled options, never open-ended. Skip a question whose answer is obvious from context.
+
+### Type A — uploaded a product photo, "make me images / photoshoots"
+
+1. How many? `[1 / 3 / 5]`
+2. What style/mood? `[Clean studio / Lifestyle / Conceptual / With a model / Other]`
+3. Where will you use them? `[Shopify / Instagram / Pinterest / Paid ads / Website hero]`
+4. Brand colors to match? (skip if obvious)
+
+### Type B — uploaded a product photo, named a use case
+
+E.g. "make ads for my product", "make a Pinterest pin", "make a hero banner". Mode is obvious. Ask only the gaps:
+
+1. How many? (if multi-output mode)
+2. What's the offer / mood / hook?
+3. Anything in particular to emphasize?
+
+### Type C — text only, no product photo
+
+1. Can you upload a product photo? (preferred — much higher fidelity)
+2. If not, describe the product — category, packaging, color, distinctive features.
+3. What style? (same options as Type A)
+4. Where will you use it?
+
+### Type D — uploaded existing image, "redo / change vibe / different version"
+
+→ `restyle`
+
+1. What aesthetic? `[Clean girl / Cottagecore / Quiet luxury / Dark academia / Y2K / Other]`
+2. Seasonal context? `[Christmas / Valentine's / Halloween / Black Friday / None]`
+3. What to preserve, what to change? (only if ambiguous)
+
+### Type E — model wearing a product (fashion, accessories)
+
+→ `virtual_model_tryout`
+
+1. Model archetype? (suggest 2–3 based on brand audience)
+2. Environment? `[Studio clean / Outdoor natural / Street style / Editorial / Home cozy]`
+3. Framing? `[Full body / Three-quarter / Waist up / Closeup on product area]`
+
+### Type F — vague request, unclear subject
+
+E.g. "make me something cool for my brand".
+
+1. What product or topic?
+2. Goal? `[Sell on a marketplace / Build awareness / Run paid ads / Update website]`
+3. Upload a reference image?
+
+After answers → return to the relevant Type A–E.
+
+## Generation
+
+Single command. Backend assembles the final prompt and submits to `gpt_image_2`. URLs print on stdout.
+
+```bash
+higgsfield product-photoshoot create \
+  --mode <mode> \
+  --prompt "<short user-intent description from interview answers>" \
+  [--image <path-or-upload-id>]... \
+  [--count <1-10>] \
+  [--aspect_ratio <override>]
+```
+
+Examples:
+
+```bash
+higgsfield product-photoshoot create \
+  --mode lifestyle_scene \
+  --prompt "bottle of cold-brew on a sunlit kitchen counter, IG feed" \
+  --image bottle.jpg \
+  --count 3
+```
+
+```bash
+higgsfield product-photoshoot create \
+  --mode moodboard_pin \
+  --prompt "vertical pin for my candle brand, cottagecore mood" \
+  --image candle.jpg
+```
+
+```bash
+higgsfield product-photoshoot create \
+  --mode restyle \
+  --prompt "Christmas version, quiet-luxury aesthetic" \
+  --image existing-shot.jpg
+```
+
+## Image inputs
+
+`--image` accepts a local file path (auto-uploaded) OR an existing upload UUID. Repeat the flag for multiple references.
+
+## Multi-variant
+
+`--count 3` returns 3 distinct image URLs. Backend asks the enhancer to vary preset, lighting, angle, and palette across variants — they will not be paraphrased copies of one another.
+
+For `social_carousel` and `ad_creative_pack`, count = number of slides / variants in the pack. Backend locks the visual system across all slides automatically.
+
+## Aspect ratio
+
+Backend picks a sensible default per mode. Override with `--aspect_ratio` only if the user explicitly asks for a different one. Allowed values: `1:1`, `4:5`, `5:4`, `3:4`, `4:3`, `2:3`, `3:2`, `9:16`, `16:9`.
+
+## Resolution
+
+Use `2k` for every product-photoshoot job.
+
+## Delivering results
+
+Print the image URLs as a short bulleted list. No JSON, no IDs, no internal model names, no enhanced prompt text. If a job failed, mention it briefly with the failure status.
+
+```
+3 lifestyle shots ready:
+- https://cdn.higgsfield.ai/.../job_abc.jpg
+- https://cdn.higgsfield.ai/.../job_def.jpg
+- https://cdn.higgsfield.ai/.../job_ghi.jpg
+```
+
+## What this skill does NOT do
+
+- Does not write gpt_image_2 prompts directly. Backend owns prompt assembly.
+- Does not auto-pick a different image-gen model. Always `gpt_image_2`.
+- Does not replace `higgsfield-generate` Marketing Studio for branded video / avatar workflows.
+- Does not replace `higgsfield-generate` for raw text-to-image without a product or brand context.
+
+## Common mistakes to avoid
+
+- Asking more than 4 interview questions in a single message.
+- Picking the wrong mode (e.g. `product_shot` when the user wants a Pinterest pin).
+- Calling `higgsfield generate create gpt_image_2 --prompt ...` directly instead of `higgsfield product-photoshoot create` — bypasses the prompt enhancer and produces noticeably worse output.
+- Pasting the assembled prompt back to the user — they want the URLs.
+- Using a `--mode` value not in the table above.

--- a/skills/higgsfield/product-photoshoot/SKILL.md
+++ b/skills/higgsfield/product-photoshoot/SKILL.md
@@ -8,6 +8,14 @@ description: |
   restyles, and other product or brand visuals. Use higgsfield-generate for
   generic image or video generation and higgsfield-soul-id for Soul training.
 allowed-tools: Bash
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["higgsfield"] },
+        "homepage": "https://higgsfield.ai",
+      },
+  }
 ---
 
 # Product Photoshoot
@@ -18,10 +26,7 @@ Brand-image generation via the `higgsfield product-photoshoot create` command. T
 
 Before any other command:
 
-1. If `higgsfield` is not on `$PATH`, install it:
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
-   ```
+1. If `higgsfield` is not on `$PATH`, stop and ask the user to install the official Higgsfield CLI manually. Do not run remote installer scripts from this skill.
 2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive) and wait for confirmation.
 
 ## UX Rules

--- a/skills/higgsfield/soul-id/SKILL.md
+++ b/skills/higgsfield/soul-id/SKILL.md
@@ -12,6 +12,14 @@ description: |
   NOT for: one-shot face swaps (use higgsfield-generate with --image),
   named-character / non-photo avatars (use higgsfield-generate with prompt).
 allowed-tools: Bash
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["higgsfield"] },
+        "homepage": "https://higgsfield.ai",
+      },
+  }
 ---
 
 # Higgsfield Soul Character
@@ -22,10 +30,7 @@ Train a face-faithful identity model. Reusable across all Soul-powered generatio
 
 Before any other command:
 
-1. If `higgsfield` is not on `$PATH`, install it:
-   ```bash
-   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
-   ```
+1. If `higgsfield` is not on `$PATH`, stop and ask the user to install the official Higgsfield CLI manually. Do not run remote installer scripts from this skill.
 2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive) and wait for confirmation.
 3. Soul training requires a paid plan (Basic+). If `higgsfield account status` shows free plan, tell the user before submitting.
 

--- a/skills/higgsfield/soul-id/SKILL.md
+++ b/skills/higgsfield/soul-id/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: higgsfield-soul-id
+description: |
+  Train a Soul Character, a personalized model on a person's face that
+  Higgsfield uses for identity-faithful image and video generation.
+  Use when: "create my Soul", "train my face", "make my digital twin",
+  "build me an avatar", "learn my appearance", "create a character of me",
+  "set up identity for video", "I want my face in generated images".
+  Chain: train Soul once, get reference_id, then use in
+  higgsfield-generate via --soul-id with models like
+  `text2image_soul_v2` or `soul_cinema_studio`.
+  NOT for: one-shot face swaps (use higgsfield-generate with --image),
+  named-character / non-photo avatars (use higgsfield-generate with prompt).
+allowed-tools: Bash
+---
+
+# Higgsfield Soul Character
+
+Train a face-faithful identity model. Reusable across all Soul-powered generations.
+
+## Step 0 — Bootstrap
+
+Before any other command:
+
+1. If `higgsfield` is not on `$PATH`, install it:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/higgsfield-ai/cli/main/install.sh | sh
+   ```
+2. If `higgsfield account status` fails with `Session expired` / `Not authenticated`, ask the user to run `higgsfield auth login` (interactive) and wait for confirmation.
+3. Soul training requires a paid plan (Basic+). If `higgsfield account status` shows free plan, tell the user before submitting.
+
+## UX Rules
+
+1. Be concise. No raw IDs in chat. Just say "Soul ready" with a name reference.
+2. Detect language and respond in it. CLI flags stay English.
+3. Ask for the smallest set of inputs: name + photos. Pick a sensible model variant.
+4. Polling is silent — training takes minutes. Don't repeat status updates.
+
+## Workflow
+
+1. **Get name.** One word, used for later reference. Ask if missing.
+2. **Get photos.** 5–20 face photos, varied angles and lighting. Local paths or already-uploaded IDs both work — `--image` accepts either.
+3. **Pick variant.**
+   - `--soul-2` — for image generation (default)
+   - `--soul-cinematic` — for cinematic / video work
+   Choose based on user's stated downstream use. Default to `--soul-2`.
+4. **Submit.**
+   ```bash
+   higgsfield soul-id create --name "<name>" --soul-2 --image ./photo1.png --image ./photo2.png ...
+   higgsfield soul-id create --name "<name>" --soul-2 --image <upload_id> --image <upload_id> ...
+   ```
+   CLI auto-uploads paths. Captures returned reference id.
+5. **Wait.** `higgsfield soul-id wait <id>`. Silent. Default timeout 30m.
+6. **Deliver.** "Soul `<name>` ready. Use in generate with `--soul-id <id>`."
+
+## Use the Soul
+
+Once trained, pass to `higgsfield-generate`:
+
+```bash
+higgsfield generate create text2image_soul_v2 --prompt "..." --soul-id <ref_id> --wait
+higgsfield generate create soul_cinema_studio --prompt "..." --soul-id <ref_id> --wait
+```
+
+## Listing existing Souls
+
+```bash
+higgsfield soul-id list                   # all references
+higgsfield soul-id get <id>               # one by id
+```
+
+## Errors
+
+- `Minimum Basic plan required` — user is on free plan; tell them.
+- `Training failed` — check photos quality (5+ unique faces, well-lit).
+- `Session expired` → `higgsfield auth login`.
+
+## Reference docs
+
+- `references/photo-guide.md` — what photos work best
+- `references/troubleshooting.md` — common training failures

--- a/skills/higgsfield/soul-id/references/photo-guide.md
+++ b/skills/higgsfield/soul-id/references/photo-guide.md
@@ -1,0 +1,37 @@
+# Photo Guide
+
+What to upload for Soul training.
+
+## Quantity
+
+- Minimum 5, maximum 20.
+- 8–12 is the sweet spot.
+
+## Content
+
+- Clear face, eyes visible.
+- Single person per photo.
+- No heavy filters, no sunglasses.
+
+## Variety
+
+Higher variety = better identity capture.
+
+- Multiple angles: front, 3/4 left, 3/4 right, slight up/down.
+- Different lighting: indoor, outdoor, soft, harsh.
+- Different expressions: neutral, smiling, talking.
+- Different distances: head shot, head-and-shoulders, full body.
+
+## Quality
+
+- Sharp, in-focus.
+- Resolution ≥ 1024×1024 ideal.
+- JPEG or PNG.
+
+## Avoid
+
+- Group photos.
+- Heavy makeup not normally worn.
+- Costumes / cosplay.
+- Hats covering the face.
+- Same pose repeated.

--- a/skills/higgsfield/soul-id/references/troubleshooting.md
+++ b/skills/higgsfield/soul-id/references/troubleshooting.md
@@ -1,0 +1,24 @@
+# Soul Troubleshooting
+
+## `Minimum Basic plan required`
+
+Soul training needs a paid plan. Tell the user to upgrade.
+
+## `Training failed`
+
+Common causes:
+
+- Too few photos (<5) or too uniform.
+- Heavy occlusion (sunglasses, hats).
+- Group photos confusing identity.
+- Upload type mismatch (must be image uploads, not video).
+
+Action: ask user to swap in better photos, retrain.
+
+## `Session expired`
+
+`higgsfield auth login`.
+
+## Slow training
+
+Default timeout is 30m. If still in progress: `higgsfield soul-id wait <id> --timeout 60m`.


### PR DESCRIPTION
## Summary

Adds bundled Higgsfield skills for generation, product photoshoots, marketplace cards, and Soul ID workflows.

## Changes

- Adds `higgsfield-generate`.
- Adds `higgsfield-product-photoshoot`.
- Adds `higgsfield-marketplace-cards`.
- Adds `higgsfield-soul-id`.
- Adds supporting Higgsfield reference docs.
- Removes the mutable `curl | sh` auto-install bootstrap from the bundled skill instructions.
- Gates the skills with `metadata.openclaw.requires.bins = ["higgsfield"]`.

## Real behavior proof

- Behavior or issue addressed: Adds bundled Higgsfield skills and, after review, removes the mutable remote installer bootstrap so the skills require an already installed Higgsfield CLI instead of running `curl | sh`.
- Real environment tested: macOS, local OpenClaw checkout at `/Users/arss/openclaw`, authenticated Higgsfield CLI, account details redacted.
- Exact steps or command run after this patch:
  ```bash
  cd /Users/arss/openclaw
  rg -n 'curl -fsSL|install\.sh|\| sh' skills/higgsfield
  for d in skills/higgsfield/*; do python3 skills/skill-creator/scripts/quick_validate.py "$d"; done
  command -v higgsfield
  higgsfield account status
  higgsfield generate create z_image --prompt "small OpenClaw Higgsfield proof image: clean blue ceramic cup on a white table" --wait
  ```
- Evidence after fix:
  ```text
  $ rg -n 'curl -fsSL|install\.sh|\| sh' skills/higgsfield
  <no matches>

  $ for d in skills/higgsfield/*; do python3 skills/skill-creator/scripts/quick_validate.py "$d"; done
  Skill is valid!
  Skill is valid!
  Skill is valid!
  Skill is valid!

  $ command -v higgsfield
  /usr/local/bin/higgsfield

  $ higgsfield account status
  <redacted>@higgsfield.ai — team plan, credits redacted

  $ higgsfield generate create z_image --prompt "small OpenClaw Higgsfield proof image: clean blue ceramic cup on a white table" --wait
  https://d8j0ntlcm91z4.cloudfront.net/user_3BrjzfgW6X7l4VwsUlfFuUzWdUD/hf_20260505_203059_6d9aeaaf-910d-4355-9a2e-8caaa2e6cfd5.png
  ```
- Observed result after fix: The Higgsfield CLI was available, all four Higgsfield skill files validated, no `curl | sh` installer bootstrap remained, and a real Higgsfield generation command completed with a generated image URL.
- What was not tested: Marketplace cards, product photoshoot, and Soul ID live workflows were not run in this proof.
