### PR TITLE
Avoid duplicate status inspection work

### DIFF
--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -222,13 +222,16 @@ describe("scanStatus", () => {
     expect(mocks.getMemorySearchManager).not.toHaveBeenCalled();
   });
 
-  it("keeps default text status off plugin compatibility and memory scans", async () => {
-    configureScanStatus({ memoryConfigured: true });
+  it("keeps default text status off plugin compatibility, memory, and channel-summary scans", async () => {
+    configureScanStatus({ hasConfiguredChannels: true, memoryConfigured: true });
 
     await scanStatus({ json: false }, {} as never);
 
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
     expect(mocks.getMemorySearchManager).not.toHaveBeenCalled();
+    expect(mocks.getStatusSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ includeChannelSummary: false }),
+    );
   });
 
   it("inspects memory backend when memory search is explicitly configured", async () => {

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -86,6 +86,7 @@ export async function scanStatus(
         channelIssues: overview.channelIssues,
         channels: overview.channels,
         pluginCompatibility,
+        summary: { includeChannelSummary: false },
       });
       progress.tick();
 

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -61,42 +61,50 @@ vi.mock("../infra/system-events.js", () => ({
   peekSystemEvents: vi.fn(() => []),
 }));
 
-vi.mock("../tasks/task-registry.maintenance.js", () => ({
+const taskMaintenanceMocks = vi.hoisted(() => ({
   configureTaskRegistryMaintenance: vi.fn(),
-  getInspectableTaskRegistrySummary: vi.fn(() => ({
-    total: 0,
-    active: 0,
-    terminal: 0,
-    failures: 0,
-    byStatus: {
-      queued: 0,
-      running: 0,
-      succeeded: 0,
-      failed: 0,
-      timed_out: 0,
-      cancelled: 0,
-      lost: 0,
+  getInspectableTaskRegistryInspectionSummary: vi.fn(() => ({
+    tasks: {
+      total: 0,
+      active: 0,
+      terminal: 0,
+      failures: 0,
+      byStatus: {
+        queued: 0,
+        running: 0,
+        succeeded: 0,
+        failed: 0,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 0,
+      },
+      byRuntime: {
+        subagent: 0,
+        acp: 0,
+        cli: 0,
+        cron: 0,
+      },
     },
-    byRuntime: {
-      subagent: 0,
-      acp: 0,
-      cli: 0,
-      cron: 0,
+    taskAudit: {
+      total: 1,
+      warnings: 1,
+      errors: 0,
+      byCode: {
+        stale_queued: 0,
+        stale_running: 0,
+        lost: 0,
+        delivery_failed: 1,
+        missing_cleanup: 0,
+        inconsistent_timestamps: 0,
+      },
     },
   })),
-  getInspectableTaskAuditSummary: vi.fn(() => ({
-    total: 1,
-    warnings: 1,
-    errors: 0,
-    byCode: {
-      stale_queued: 0,
-      stale_running: 0,
-      lost: 0,
-      delivery_failed: 1,
-      missing_cleanup: 0,
-      inconsistent_timestamps: 0,
-    },
-  })),
+}));
+
+vi.mock("../tasks/task-registry.maintenance.js", () => ({
+  configureTaskRegistryMaintenance: taskMaintenanceMocks.configureTaskRegistryMaintenance,
+  getInspectableTaskRegistryInspectionSummary:
+    taskMaintenanceMocks.getInspectableTaskRegistryInspectionSummary,
 }));
 
 vi.mock("../routing/session-key.js", () => ({
@@ -174,5 +182,11 @@ describe("getStatusSummary", () => {
     expect(vi.mocked(statusSummaryRuntime.resolveContextTokensForModel)).toHaveBeenCalledWith(
       expect.objectContaining({ allowAsyncLoad: false }),
     );
+  });
+
+  it("uses one task-registry inspection pass for status task and audit summaries", async () => {
+    await getStatusSummary({ includeChannelSummary: false });
+
+    expect(taskMaintenanceMocks.getInspectableTaskRegistryInspectionSummary).toHaveBeenCalledOnce();
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -150,8 +150,7 @@ export async function getStatusSummary(
   taskMaintenanceModule.configureTaskRegistryMaintenance({
     cronStorePath: resolveCronStorePath(cfg.cron?.store),
   });
-  const tasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
-  const taskAudit = taskMaintenanceModule.getInspectableTaskAuditSummary();
+  const { tasks, taskAudit } = taskMaintenanceModule.getInspectableTaskRegistryInspectionSummary();
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -887,13 +887,23 @@ export function getInspectableActiveTaskRestartBlockers(): ActiveTaskRestartBloc
   return blockers;
 }
 
+export function getInspectableTaskRegistryInspectionSummary(): {
+  tasks: TaskRegistrySummary;
+  taskAudit: TaskAuditSummary;
+} {
+  const inspectableTasks = reconcileInspectableTasks();
+  return {
+    tasks: summarizeTaskRecords(inspectableTasks),
+    taskAudit: summarizeTaskAuditFindings(listTaskAuditFindings({ tasks: inspectableTasks })),
+  };
+}
+
 export function getInspectableTaskRegistrySummary(): TaskRegistrySummary {
-  return summarizeTaskRecords(reconcileInspectableTasks());
+  return getInspectableTaskRegistryInspectionSummary().tasks;
 }
 
 export function getInspectableTaskAuditSummary(): TaskAuditSummary {
-  const tasks = reconcileInspectableTasks();
-  return summarizeTaskAuditFindings(listTaskAuditFindings({ tasks }));
+  return getInspectableTaskRegistryInspectionSummary().taskAudit;
 }
 
 export function reconcileTaskLookupToken(token: string): TaskRecord | undefined {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -49,6 +49,7 @@ import {
 } from "./task-registry.js";
 import {
   getInspectableTaskAuditSummary,
+  getInspectableTaskRegistryInspectionSummary,
   previewTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
   reconcileInspectableTasks,
@@ -2411,6 +2412,43 @@ describe("task-registry", () => {
           inconsistent_timestamps: 0,
         },
       });
+    });
+  });
+
+  it("builds inspectable task registry and audit summaries from one reconciliation pass", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+      const listTaskRecords = vi.fn(() => [
+        {
+          taskId: "task-combined-summary",
+          runtime: "acp" as const,
+          requesterSessionKey: "agent:main:main",
+          ownerKey: "agent:main:main",
+          scopeKind: "session" as const,
+          runId: "run-combined-summary",
+          task: "Hung task",
+          status: "running" as const,
+          deliveryStatus: "pending" as const,
+          notifyPolicy: "done_only" as const,
+          createdAt: now - 50 * 60_000,
+          startedAt: now - 40 * 60_000,
+          lastEventAt: now - 40 * 60_000,
+        },
+      ]);
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks: new Map(),
+        snapshotTasks: [],
+        listTaskRecords,
+      });
+
+      const summary = getInspectableTaskRegistryInspectionSummary();
+
+      expect(listTaskRecords).toHaveBeenCalledOnce();
+      expect(summary.tasks.active).toBe(1);
+      expect(summary.taskAudit.errors).toBe(1);
+      expect(summary.taskAudit.byCode.stale_running).toBe(1);
     });
   });
 


### PR DESCRIPTION
Fixes #77995.

## Summary
- combine task registry/audit status inspection into one reconciliation pass
- keep plain text `openclaw status` from building an unused channel summary
- preserve `status --all`, JSON fast path, and explicit gateway status behavior

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/commands/status.scan.test.ts src/commands/status.summary.test.ts src/tasks/task-registry.test.ts --maxWorkers=1`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`