### PR TITLE
fix(memory-core): preserve dreaming phase-signal history on transient I/O errors (#77881)

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1816,4 +1816,163 @@ describe("short-term promotion", () => {
       }),
     ).toEqual(expect.arrayContaining(["障害対応", "ルーター", "バックアップ", "路由器", "备份"]));
   });
+
+  describe("readPhaseSignalStore error classification (issue #77881)", () => {
+    it("rebuilds phase signals from empty when the store file does not exist (ENOENT)", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const phaseStorePath = resolveShortTermPhaseSignalStorePath(workspaceDir);
+        await fs.mkdir(path.dirname(phaseStorePath), { recursive: true });
+        await fs.rm(phaseStorePath, { force: true });
+
+        await writeDailyMemoryNote(workspaceDir, "2026-04-01", ["seed"]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "seed query",
+          results: [
+            {
+              path: "memory/2026-04-01.md",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet: "seed",
+              source: "memory",
+            },
+          ],
+        });
+
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+        const key = ranked[0]?.key;
+        expect(key).toBeTruthy();
+
+        await expect(
+          recordDreamingPhaseSignals({
+            workspaceDir,
+            phase: "light",
+            keys: [key!],
+          }),
+        ).resolves.toBeUndefined();
+
+        const written = JSON.parse(await fs.readFile(phaseStorePath, "utf-8")) as {
+          entries: Record<string, { lightHits: number }>;
+        };
+        expect(written.entries[key!]?.lightHits).toBe(1);
+      });
+    });
+
+    it("rebuilds phase signals from empty + warns on corrupt JSON, without throwing", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const phaseStorePath = resolveShortTermPhaseSignalStorePath(workspaceDir);
+        await fs.mkdir(path.dirname(phaseStorePath), { recursive: true });
+        await fs.writeFile(phaseStorePath, "{ this is not json", "utf-8");
+
+        await writeDailyMemoryNote(workspaceDir, "2026-04-02", ["corrupt"]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "corrupt query",
+          results: [
+            {
+              path: "memory/2026-04-02.md",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet: "corrupt",
+              source: "memory",
+            },
+          ],
+        });
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+        const key = ranked[0]?.key;
+        expect(key).toBeTruthy();
+
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+          await expect(
+            recordDreamingPhaseSignals({
+              workspaceDir,
+              phase: "rem",
+              keys: [key!],
+            }),
+          ).resolves.toBeUndefined();
+
+          const messages = warnSpy.mock.calls.map((c) => String(c[0] ?? ""));
+          expect(
+            messages.some((m) => m.includes("phase-signal store") && m.includes("corrupt JSON")),
+          ).toBe(true);
+        } finally {
+          warnSpy.mockRestore();
+        }
+
+        const written = JSON.parse(await fs.readFile(phaseStorePath, "utf-8")) as {
+          entries: Record<string, { remHits: number }>;
+        };
+        expect(written.entries[key!]?.remHits).toBe(1);
+      });
+    });
+
+    it("propagates non-ENOENT/non-Syntax I/O errors and preserves the on-disk store (no destructive empty-write)", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const phaseStorePath = resolveShortTermPhaseSignalStorePath(workspaceDir);
+        await fs.mkdir(path.dirname(phaseStorePath), { recursive: true });
+
+        await writeDailyMemoryNote(workspaceDir, "2026-04-03", ["protected"]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "protected query",
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet: "protected",
+              source: "memory",
+            },
+          ],
+        });
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+        const key = ranked[0]?.key;
+        expect(key).toBeTruthy();
+
+        // Seed real phase-signal data so we can detect destructive empty-write.
+        await recordDreamingPhaseSignals({ workspaceDir, phase: "light", keys: [key!] });
+        await recordDreamingPhaseSignals({ workspaceDir, phase: "rem", keys: [key!] });
+        const beforeDisk = await fs.readFile(phaseStorePath, "utf-8");
+        const beforeStore = JSON.parse(beforeDisk) as {
+          entries: Record<string, { lightHits: number; remHits: number }>;
+        };
+        expect(beforeStore.entries[key!]?.lightHits).toBe(1);
+        expect(beforeStore.entries[key!]?.remHits).toBe(1);
+
+        // Force a non-ENOENT, non-Syntax read error: replace the file with a
+        // directory of the same name so fs.readFile rejects with EISDIR. This
+        // is reliably reproducible cross-platform without relying on chmod.
+        await fs.unlink(phaseStorePath);
+        await fs.mkdir(phaseStorePath);
+
+        await expect(
+          recordDreamingPhaseSignals({ workspaceDir, phase: "light", keys: [key!] }),
+        ).rejects.toMatchObject({ code: "EISDIR" });
+
+        // The on-disk path must still be a directory — no destructive
+        // overwrite snuck through (would have left a JSON file behind).
+        const stat = await fs.stat(phaseStorePath);
+        expect(stat.isDirectory()).toBe(true);
+      });
+    });
+  });
 });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -834,10 +834,27 @@ async function readPhaseSignalStore(
     return normalizePhaseSignalStore(JSON.parse(raw) as unknown, nowIso);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
-    if (code === "ENOENT" || err instanceof SyntaxError) {
+    // ENOENT: no prior store on disk. Returning an empty store is safe — it
+    // mirrors the first-run case and preserves no destructible history.
+    if (code === "ENOENT") {
       return emptyPhaseSignalStore(nowIso);
     }
-    return emptyPhaseSignalStore(nowIso);
+    // SyntaxError: file exists but is corrupt JSON. The on-disk damage is
+    // already permanent; recover by rebuilding from empty so dreaming can make
+    // progress, but warn so operators can investigate.
+    if (err instanceof SyntaxError) {
+      console.warn(
+        `memory-core: phase-signal store at ${phaseSignalPath} is corrupt JSON; rebuilding from empty (${err.message}).`,
+      );
+      return emptyPhaseSignalStore(nowIso);
+    }
+    // EACCES, EIO, EBUSY, EMFILE, ENOSPC, etc.: transient or environmental I/O
+    // failure. Swallowing these and returning an empty store is destructive —
+    // the caller would then write the empty store back, permanently losing
+    // accumulated lightHits/remHits history. Re-throw so the caller's catch in
+    // dreaming.ts can increment failedWorkspaces and skip the destructive
+    // write-back.
+    throw err;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #77881. `readPhaseSignalStore` in `extensions/memory-core/src/short-term-promotion.ts` previously caught **every** error and returned an empty store. The caller (`recordDreamingPhaseSignals`, line ~1151) then mutates that empty store with the current cycle's hits and writes it back via `writePhaseSignalStore` — silently destroying every previously accumulated `lightHits`/`remHits` count on a transient I/O failure (EACCES, EIO, EBUSY, EMFILE, ENOSPC, antivirus lock, etc.).

This patch classifies errors at the read boundary:

| Error class | New behavior | Rationale |
| --- | --- | --- |
| `ENOENT` | return empty store | first run, nothing to lose |
| `SyntaxError` | warn + return empty store | corrupt JSON; on-disk damage already permanent, recovery is the only forward path |
| any other I/O error | **re-throw** | caller's `try { … } catch { failedWorkspaces++ }` in `dreaming.ts:551–665` handles it and skips the destructive `writePhaseSignalStore` |

This restores symmetry with the sibling `readStore` function in the same file (which already throws on non-ENOENT). The bug was a one-line regression: a fall-through `return emptyPhaseSignalStore(nowIso)` after the conditional return path.

## Behavior contract (mathematical guarantee)

Let `Φ` be the on-disk phase-signal store and `Φ'` the result of one `recordDreamingPhaseSignals` cycle. For any read error `e` thrown inside the lock body:

- `e.code = "ENOENT"`     ⇒ `Φ' = update(∅, current_cycle)` and previous `Φ` did not exist (no loss).
- `e instanceof SyntaxError` ⇒ `Φ' = update(∅, current_cycle)` and `Φ` was already unrecoverable JSON (loss already on-disk; bounded).
- otherwise               ⇒ `Φ' = Φ` (untouched on disk), error propagates, `failedWorkspaces++`.

The previous behavior was: **for every `e` ≠ ENOENT and ≠ SyntaxError**, `Φ' = update(∅, current_cycle)` even though `Φ` was healthy — destroying all prior `lightHits/remHits` history that the dreaming pipeline depends on for promotion gating.

## Real behavior proof

3 new tests in `extensions/memory-core/src/short-term-promotion.test.ts`:

1. **ENOENT path** — no prior file ⇒ `recordDreamingPhaseSignals` resolves, file written with `lightHits: 1`. Locks in the existing-correct branch.
2. **SyntaxError path** — pre-write garbage JSON ⇒ resolves with a `console.warn` mentioning `phase-signal store … corrupt JSON`. Validates graceful corrupt-JSON recovery.
3. **EISDIR path** (the regression site) — pre-populate phase signals via the public API, replace the JSON file with a directory of the same name (reliably reproducible cross-platform; no chmod), call `recordDreamingPhaseSignals` ⇒ rejects with `code: "EISDIR"`, and `phase-signals.json` is **still a directory** on disk. The destructive empty-write did not occur.

```
$ pnpm test extensions/memory-core/src/short-term-promotion.test.ts
Test Files  1 passed (1)
     Tests  47 passed (47)
```

The 3 new tests are scoped to `describe("readPhaseSignalStore error classification (issue #77881)")` so reviewers can locate them quickly.

## Risk

- **Surface**: one private function (`readPhaseSignalStore`) with three call sites all inside `withShortTermLock` — the lock is released cleanly via the helper's existing `finally` (line 726), so re-throwing does not leak locks.
- **Semantics**: ENOENT and SyntaxError paths are unchanged. Only the previously-silent error class becomes loud.
- **Caller compatibility**: `dreaming.ts:551–665` already wraps `runDreamingSweepPhases` (and downstream phase-signal writes) in a per-workspace `try/catch` that increments `failedWorkspaces`. No new caller plumbing needed.

## Why this matters

The dreaming pipeline's promotion gates (`PHASE_SIGNAL_LIGHT_BOOST_MAX`, `PHASE_SIGNAL_REM_BOOST_MAX`, the consolidation component) all depend on accumulated phase-signal history. A single antivirus lock or transient EIO during a cron-driven dream cycle was enough to wipe weeks of consolidation signal silently — the user would only notice that promotions stopped happening, with no error in the logs and no entry in the `failed=` count. After this patch, the failure is loud, accounted for, and non-destructive.

Closes #77881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
