### PR TITLE
Ignore unsupported proxy schemes for env dispatcher

### DIFF
--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -114,17 +114,22 @@ describe("resolveEnvHttpProxyAgentOptions", () => {
       },
     },
     {
-      name: "uses ALL_PROXY for both protocols",
-      env: { ALL_PROXY: "socks5://all-proxy.test:1080" } as NodeJS.ProcessEnv,
+      name: "uses HTTP ALL_PROXY for both protocols",
+      env: { ALL_PROXY: "http://all-proxy.test:1080" } as NodeJS.ProcessEnv,
       expected: {
-        httpProxy: "socks5://all-proxy.test:1080",
-        httpsProxy: "socks5://all-proxy.test:1080",
+        httpProxy: "http://all-proxy.test:1080",
+        httpsProxy: "http://all-proxy.test:1080",
       },
+    },
+    {
+      name: "ignores unsupported SOCKS ALL_PROXY for EnvHttpProxyAgent",
+      env: { ALL_PROXY: "socks5://all-proxy.test:1080" } as NodeJS.ProcessEnv,
+      expected: undefined,
     },
     {
       name: "lets protocol-specific proxy override ALL_PROXY",
       env: {
-        ALL_PROXY: "socks5://all-proxy.test:1080",
+        ALL_PROXY: "http://all-proxy.test:1080",
         HTTP_PROXY: "http://http-proxy.test:8080",
         HTTPS_PROXY: "http://https-proxy.test:8443",
       } as NodeJS.ProcessEnv,
@@ -137,7 +142,7 @@ describe("resolveEnvHttpProxyAgentOptions", () => {
       name: "treats empty lower-case all_proxy as authoritative over upper-case ALL_PROXY",
       env: {
         all_proxy: "",
-        ALL_PROXY: "socks5://upper-all-proxy.test:1080",
+        ALL_PROXY: "http://upper-all-proxy.test:1080",
       } as NodeJS.ProcessEnv,
       expected: undefined,
     },

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -25,6 +25,22 @@ function normalizeProxyEnvValue(value: string | undefined): string | null | unde
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function isHttpProxyUrl(value: string | undefined): value is string {
+  if (!value) {
+    return false;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEnvHttpProxyAgentUrl(value: string | undefined): string | undefined {
+  return isHttpProxyUrl(value) ? value : undefined;
+}
+
 export type EnvHttpProxyAgentProxyOptions = {
   httpProxy?: string;
   httpsProxy?: string;
@@ -76,9 +92,10 @@ function resolveEnvAllProxyUrl(env: NodeJS.ProcessEnv): string | undefined {
 export function resolveEnvHttpProxyAgentOptions(
   env: NodeJS.ProcessEnv = process.env,
 ): EnvHttpProxyAgentProxyOptions | undefined {
-  const allProxy = resolveEnvAllProxyUrl(env);
-  const httpProxy = resolveEnvHttpProxyUrl("http", env) ?? allProxy;
-  const httpsProxy = resolveEnvHttpProxyUrl("https", env) ?? httpProxy;
+  const allProxy = normalizeEnvHttpProxyAgentUrl(resolveEnvAllProxyUrl(env));
+  const httpProxy = normalizeEnvHttpProxyAgentUrl(resolveEnvHttpProxyUrl("http", env)) ?? allProxy;
+  const httpsProxy =
+    normalizeEnvHttpProxyAgentUrl(resolveEnvHttpProxyUrl("https", env)) ?? httpProxy;
   const options: EnvHttpProxyAgentProxyOptions = {
     ...(httpProxy ? { httpProxy } : {}),
     ...(httpsProxy ? { httpsProxy } : {}),

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -241,11 +241,11 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
     expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
   });
 
-  it("installs EnvHttpProxyAgent with explicit ALL_PROXY fallback options", () => {
+  it("installs EnvHttpProxyAgent with explicit HTTP ALL_PROXY fallback options", () => {
     vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue({
-      httpProxy: "socks5://proxy.test:1080",
-      httpsProxy: "socks5://proxy.test:1080",
+      httpProxy: "http://proxy.test:1080",
+      httpsProxy: "http://proxy.test:1080",
     });
 
     ensureGlobalUndiciEnvProxyDispatcher();
@@ -254,8 +254,8 @@ describe("ensureGlobalUndiciEnvProxyDispatcher", () => {
     const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
     expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options).toEqual({
-      httpProxy: "socks5://proxy.test:1080",
-      httpsProxy: "socks5://proxy.test:1080",
+      httpProxy: "http://proxy.test:1080",
+      httpsProxy: "http://proxy.test:1080",
     });
   });
 


### PR DESCRIPTION
Fixes #78007.

## Summary
- restrict EnvHttpProxyAgent options to HTTP(S) proxy URLs
- ignore unsupported schemes such as `socks5:` for the gateway/global Undici HTTP proxy dispatcher
- preserve HTTP `ALL_PROXY` fallback behavior

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/infra/net/proxy-env.test.ts src/infra/net/undici-global-dispatcher.test.ts --maxWorkers=1`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`