### PR TITLE
fix(discord): show reasoning text in progress drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.
 - Agents/media: avoid direct generated-media completion fallback while the announce-agent run is still pending, so async video and music completions do not duplicate raw media messages. (#77754)

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -82,6 +82,8 @@ export function createDiscordDraftPreviewController(params: {
     });
   let previewToolProgressSuppressed = false;
   let previewToolProgressLines: string[] = [];
+  let reasoningProgressRawText = "";
+  let lastReasoningProgressLine: string | undefined;
   const progressSeed = `${params.accountId}:${params.deliverChannelId}`;
 
   const renderProgressDraft = async (options?: { flush?: boolean }) => {
@@ -116,6 +118,8 @@ export function createDiscordDraftPreviewController(params: {
     draftChunker?.reset();
     previewToolProgressSuppressed = false;
     previewToolProgressLines = [];
+    reasoningProgressRawText = "";
+    lastReasoningProgressLine = undefined;
   };
 
   const forceNewMessageIfNeeded = () => {
@@ -163,8 +167,11 @@ export function createDiscordDraftPreviewController(params: {
         return;
       }
       const normalized = line?.replace(/\s+/g, " ").trim();
+      if (!normalized) {
+        return;
+      }
       if (discordStreamMode !== "progress") {
-        if (!previewToolProgressEnabled || previewToolProgressSuppressed || !normalized) {
+        if (!previewToolProgressEnabled || previewToolProgressSuppressed) {
           return;
         }
         const previous = previewToolProgressLines.at(-1);
@@ -193,6 +200,36 @@ export function createDiscordDraftPreviewController(params: {
             -resolveChannelProgressDraftMaxLines(params.discordConfig),
           );
         }
+      }
+      const alreadyStarted = progressDraftGate.hasStarted;
+      await progressDraftGate.noteWork();
+      if (alreadyStarted && progressDraftGate.hasStarted) {
+        await renderProgressDraft();
+      }
+    },
+    async pushReasoningProgress(text?: string) {
+      if (!draftStream || discordStreamMode !== "progress" || !text) {
+        return;
+      }
+      reasoningProgressRawText += text;
+      const normalized = normalizeReasoningProgressLine(reasoningProgressRawText);
+      if (!normalized) {
+        return;
+      }
+      if (previewToolProgressEnabled && !previewToolProgressSuppressed) {
+        const priorIndex =
+          lastReasoningProgressLine === undefined
+            ? -1
+            : previewToolProgressLines.lastIndexOf(lastReasoningProgressLine);
+        if (priorIndex >= 0) {
+          previewToolProgressLines = [...previewToolProgressLines];
+          previewToolProgressLines[priorIndex] = normalized;
+        } else {
+          previewToolProgressLines = [...previewToolProgressLines, normalized].slice(
+            -resolveChannelProgressDraftMaxLines(params.discordConfig),
+          );
+        }
+        lastReasoningProgressLine = normalized;
       }
       const alreadyStarted = progressDraftGate.hasStarted;
       await progressDraftGate.noteWork();
@@ -328,4 +365,11 @@ export function createDiscordDraftPreviewController(params: {
       }
     },
   };
+}
+
+function normalizeReasoningProgressLine(text: string): string {
+  return text
+    .replace(/^\s*(?:>\s*)?Reasoning:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -211,7 +211,7 @@ export function createDiscordDraftPreviewController(params: {
       if (!draftStream || discordStreamMode !== "progress" || !text) {
         return;
       }
-      reasoningProgressRawText += text;
+      reasoningProgressRawText = mergeReasoningProgressText(reasoningProgressRawText, text);
       const normalized = normalizeReasoningProgressLine(reasoningProgressRawText);
       if (!normalized) {
         return;
@@ -372,4 +372,23 @@ function normalizeReasoningProgressLine(text: string): string {
     .replace(/^\s*(?:>\s*)?Reasoning:\s*/i, "")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function mergeReasoningProgressText(current: string, incoming: string): string {
+  if (!current) {
+    return incoming;
+  }
+  const normalizedCurrent = normalizeReasoningProgressLine(current);
+  const normalizedIncoming = normalizeReasoningProgressLine(incoming);
+  if (!normalizedIncoming || normalizedIncoming === normalizedCurrent) {
+    return current;
+  }
+  if (isReasoningSnapshotText(incoming) || normalizedIncoming.startsWith(normalizedCurrent)) {
+    return incoming;
+  }
+  return `${current}${incoming}`;
+}
+
+function isReasoningSnapshotText(text: string): boolean {
+  return /^\s*(?:>\s*)?Reasoning:\s*/i.test(text);
 }

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -96,7 +96,7 @@ type DispatchInboundParams = {
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {
-    onReasoningStream?: (payload: { text?: string }) => Promise<void> | void;
+    onReasoningStream?: (payload?: { text?: string }) => Promise<void> | void;
     onReasoningEnd?: () => Promise<void> | void;
     onToolStart?: (payload: {
       name?: string;
@@ -1648,6 +1648,39 @@ describe("processDiscordMessage draft streaming", () => {
       "Clawing...\n🛠️ Exec\n• Reading the event projector",
     );
     expect(draftStream.update).not.toHaveBeenCalledWith(expect.stringContaining("Reasoning"));
+  });
+
+  it("replaces reasoning snapshots instead of appending duplicates", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_Checking files_" });
+      await params?.replyOptions?.onReasoningStream?.({
+        text: "Reasoning:\n_Checking files and tests_",
+      });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Clawing...",
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Clawing...\n🛠️ Exec\n• _Checking files and tests_",
+    );
+    expect(draftStream.update).not.toHaveBeenCalledWith(
+      expect.stringContaining("_Checking files_Reasoning:"),
+    );
   });
 
   it("keeps Discord progress lines across assistant boundaries", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -96,7 +96,7 @@ type DispatchInboundParams = {
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {
-    onReasoningStream?: () => Promise<void> | void;
+    onReasoningStream?: (payload: { text?: string }) => Promise<void> | void;
     onReasoningEnd?: () => Promise<void> | void;
     onToolStart?: (payload: {
       name?: string;
@@ -105,6 +105,7 @@ type DispatchInboundParams = {
       detailMode?: "explain" | "raw";
     }) => Promise<void> | void;
     onItemEvent?: (payload: {
+      kind?: string;
       progressText?: string;
       summary?: string;
       title?: string;
@@ -1614,6 +1615,39 @@ describe("processDiscordMessage draft streaming", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(draftStream.update).toHaveBeenCalledWith("Shelling\n🛠️ Exec\n• done");
+  });
+
+  it("shows reasoning text instead of a bare Reasoning progress line", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onItemEvent?.({
+        kind: "analysis",
+        title: "Reasoning",
+      });
+      await params?.replyOptions?.onReasoningStream?.({ text: "Reading " });
+      await params?.replyOptions?.onReasoningStream?.({ text: "the event projector" });
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: {
+            label: "Clawing...",
+          },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalledWith(
+      "Clawing...\n🛠️ Exec\n• Reading the event projector",
+    );
+    expect(draftStream.update).not.toHaveBeenCalledWith(expect.stringContaining("Reasoning"));
   });
 
   it("keeps Discord progress lines across assistant boundaries", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -660,8 +660,9 @@ export async function processDiscordMessage(
                 onModelSelected,
                 suppressDefaultToolProgressMessages:
                   draftPreview.suppressDefaultToolProgressMessages ? true : undefined,
-                onReasoningStream: async () => {
+                onReasoningStream: async (payload) => {
                   await statusReactions.setThinking();
+                  await draftPreview.pushReasoningProgress(payload?.text);
                 },
                 onToolStart: async (payload) => {
                   if (isProcessAborted(abortSignal)) {

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -337,6 +337,21 @@ describe("channel-streaming", () => {
         },
       ),
     ).toBe("🛠️ Exec");
+    expect(
+      formatChannelProgressDraftLine({
+        event: "item",
+        itemKind: "analysis",
+        title: "Reasoning",
+      }),
+    ).toBeUndefined();
+    expect(
+      formatChannelProgressDraftLine({
+        event: "item",
+        itemKind: "analysis",
+        title: "Reasoning",
+        progressText: "Reading the code path",
+      }),
+    ).toBe("Reading the code path");
   });
 
   it("starts progress drafts after five seconds or a second work event", async () => {

--- a/src/plugin-sdk/channel-streaming.ts
+++ b/src/plugin-sdk/channel-streaming.ts
@@ -275,6 +275,17 @@ function isCommandProgressItem(input: Extract<ChannelProgressDraftLineInput, { e
   return itemKind === "command" || isCommandToolName(input.name);
 }
 
+function isEmptyReasoningProgressItem(
+  input: Extract<ChannelProgressDraftLineInput, { event: "item" }>,
+  meta: string | undefined,
+): boolean {
+  return (
+    !meta &&
+    normalizeOptionalLowercaseString(input.itemKind) === "analysis" &&
+    normalizeOptionalLowercaseString(input.title) === "reasoning"
+  );
+}
+
 function patchMetas(input: Extract<ChannelProgressDraftLineInput, { event: "patch" }>): string[] {
   const fileMetas = [...(input.added ?? []), ...(input.modified ?? []), ...(input.deleted ?? [])];
   return compactStrings([input.summary, ...fileMetas, input.title]);
@@ -346,6 +357,9 @@ export function buildChannelProgressDraftLine(
         (options?.commandText === "status" && isCommandProgressItem(input)
           ? undefined
           : input.progressText);
+      if (isEmptyReasoningProgressItem(input, meta)) {
+        return undefined;
+      }
       if (name) {
         return buildNamedProgressLine(input.event, name, [meta], options, {
           status: input.status,

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -18,11 +18,16 @@ import {
 
 describe("usage-format", () => {
   const originalAgentDir = process.env.OPENCLAW_AGENT_DIR;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  let stateDir: string;
   let agentDir: string;
 
   beforeEach(async () => {
-    agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-format-"));
-    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-usage-format-"));
+    agentDir = path.join(stateDir, "agents", "main", "agent");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    delete process.env.OPENCLAW_AGENT_DIR;
+    await fs.mkdir(agentDir, { recursive: true });
     __resetUsageFormatCachesForTest();
     __resetGatewayModelPricingCacheForTest();
   });
@@ -33,9 +38,14 @@ describe("usage-format", () => {
     } else {
       process.env.OPENCLAW_AGENT_DIR = originalAgentDir;
     }
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
     __resetUsageFormatCachesForTest();
     __resetGatewayModelPricingCacheForTest();
-    await fs.rm(agentDir, { recursive: true, force: true });
+    await fs.rm(stateDir, { recursive: true, force: true });
   });
 
   it("formats token counts", () => {


### PR DESCRIPTION
## Summary

- Problem: Discord `streaming.mode: "progress"` could show a bare `Reasoning` lifecycle line while the useful reasoning text was only routed to status reactions.
- Why it matters: inline progress drafts should show what the agent is working through, not a placeholder label.
- What changed: Discord progress drafts now accumulate reasoning stream text into a single editable progress line, and the shared formatter suppresses empty reasoning analysis placeholders.
- What did NOT change: final reply text, hidden reasoning storage, channel config shape, and non-Discord progress behavior.

## Change Type

- [x] Bug fix
- [x] Docs

## Scope

- [x] Integrations
- [x] API / contracts
- [x] UI / DX

## Root Cause

- Root cause: Codex app-server reasoning deltas reached `onReasoningStream`, but Discord's handler only used that callback for thinking reactions; the progress draft also consumed the generic item lifecycle event, so the draft rendered the item title `Reasoning` without the streamed text.
- Missing detection / guardrail: no regression covered reasoning deltas in Discord progress draft mode.

## Regression Test Plan

- Coverage level that should have caught this: seam / integration test.
- Target test or file: `extensions/discord/src/monitor/message-handler.process.test.ts`; shared guard in `src/plugin-sdk/channel-streaming.test.ts`.
- Scenario the test locks in: reasoning stream deltas render as progress text and bare `Reasoning` item events are suppressed.
- Why this is the smallest reliable guardrail: it exercises the Discord reply-options callbacks and the shared progress formatter without needing a live Discord bot.

## User-visible / Behavior Changes

Discord progress drafts now show the live reasoning text instead of only `Reasoning` when inline progress updates are enabled.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node/pnpm repo test wrapper
- Integration/channel: Discord progress draft streaming
- Relevant config: `channels.discord.streaming.mode = "progress"`

### Steps

1. Simulate Discord progress mode.
2. Emit an empty reasoning item event.
3. Emit reasoning stream deltas.

### Expected

- Progress draft shows the reasoning text.
- Progress draft does not show a bare `Reasoning` line.

### Actual

- After this patch, the regression test observes `Clawing...\n🛠️ Exec\n• Reading the event projector` and no `Reasoning` placeholder update.

## Evidence

- [x] Passing focused tests:
  - `pnpm test src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/plugin-sdk/channel-streaming.ts src/plugin-sdk/channel-streaming.test.ts extensions/discord/src/monitor/message-handler.draft-preview.ts extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts`
  - `git diff --check`

## Human Verification

- Verified scenarios: shared formatter suppression; Discord progress draft reasoning text accumulation; old no-payload reasoning callback compatibility.
- Edge cases checked: empty reasoning item event, split reasoning deltas, command progress still present.
- What I did not verify: live Discord bot run. Attempted Testbox `pnpm check:changed`, but it remained queued; stopped the box cleanly.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: reasoning deltas could create noisy progress edits.
  - Mitigation: they update one existing progress line and remain bounded by existing progress draft line compaction.
