### PR TITLE
fix: strip symbol keys from fetch headers

### DIFF
--- a/src/infra/fetch.test.ts
+++ b/src/infra/fetch.test.ts
@@ -97,6 +97,34 @@ describe("wrapFetchWithAbortSignal", () => {
     expect(getSeenInit()).toMatchObject({ duplex: "half" });
   });
 
+  it("strips enumerable symbol keys from plain header dictionaries", async () => {
+    const { fetchImpl, getSeenInit } = createSeenInitFetch();
+    const wrapped = wrapFetchWithAbortSignal(fetchImpl);
+    const sensitiveHeaders = Symbol("sensitiveHeaders");
+    const headers = {
+      Authorization: "Bot token",
+      [sensitiveHeaders]: ["authorization"],
+    } as HeadersInit & { [sensitiveHeaders]: string[] };
+
+    await wrapped("https://example.com", { headers });
+
+    const seenHeaders = getSeenInit()?.headers as Record<PropertyKey, unknown>;
+    expect(seenHeaders).not.toBe(headers);
+    expect(seenHeaders.Authorization).toBe("Bot token");
+    expect(Object.getOwnPropertySymbols(seenHeaders)).toEqual([]);
+    expect(Object.getOwnPropertySymbols(headers)).toEqual([sensitiveHeaders]);
+  });
+
+  it("does not clone plain header dictionaries without enumerable symbol keys", async () => {
+    const { fetchImpl, getSeenInit } = createSeenInitFetch();
+    const wrapped = wrapFetchWithAbortSignal(fetchImpl);
+    const headers = { Authorization: "Bot token" };
+
+    await wrapped("https://example.com", { headers });
+
+    expect(getSeenInit()?.headers).toBe(headers);
+  });
+
   it("converts foreign abort signals to native controllers", async () => {
     const { fetchImpl, getSeenSignal } = createSeenSignalFetch();
     const wrapped = wrapFetchWithAbortSignal(fetchImpl);

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -33,13 +33,48 @@ function withDuplex(
     : ({ duplex: "half" as const } as RequestInitWithDuplex);
 }
 
+function hasEnumerableSymbolKeys(value: object): boolean {
+  return Object.getOwnPropertySymbols(value).some((symbol) =>
+    Object.prototype.propertyIsEnumerable.call(value, symbol),
+  );
+}
+
+function stripHeaderSymbolKeys(headers: HeadersInit | undefined): HeadersInit | undefined {
+  if (!headers || typeof headers !== "object") {
+    return headers;
+  }
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers;
+  }
+  if (Array.isArray(headers)) {
+    return headers;
+  }
+  if (!hasEnumerableSymbolKeys(headers)) {
+    return headers;
+  }
+
+  const nextHeaders: Record<string, string> = Object.create(null);
+  for (const [key, value] of Object.entries(headers)) {
+    nextHeaders[key] = value;
+  }
+  return nextHeaders;
+}
+
+function withoutHeaderSymbolKeys(init: RequestInit | undefined): RequestInit | undefined {
+  const headers = stripHeaderSymbolKeys(init?.headers);
+  if (headers === init?.headers) {
+    return init;
+  }
+  return { ...init, headers };
+}
+
 export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch {
   if ((fetchImpl as FetchWithAbortSignalMarker)[wrapFetchWithAbortSignalMarker]) {
     return fetchImpl;
   }
 
   const wrapped = ((input: RequestInfo | URL, init?: RequestInit) => {
-    const patchedInit = withDuplex(init, input);
+    const patchedInit = withoutHeaderSymbolKeys(withDuplex(init, input));
     const signal = patchedInit?.signal;
     if (!signal) {
       return fetchImpl(input, patchedInit);


### PR DESCRIPTION
## Summary

Fixes the fetch wrapper boundary so plain header dictionaries carrying enumerable symbol metadata are cloned with only string-keyed headers before being forwarded to native fetch/undici. This prevents Node 22's `Headers` constructor from crashing on symbol keys such as `Symbol(sensitiveHeaders)` while avoiding mutation of caller-owned header objects.

## Changes

- Sanitizes only plain-object `init.headers` values with enumerable symbol keys in `wrapFetchWithAbortSignal`.
- Preserves `Headers`, tuple-array headers, and plain header objects without symbol keys unchanged.
- Adds regression coverage for symbol-keyed header dictionaries and the pass-through case.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm vitest run src/infra/fetch.test.ts` — passed, 18 tests.
- `git diff --check` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — ran all gates through pairing account guard, then process was SIGKILLed at exit/final step; standalone `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-pairing-account-scope.mjs` passed immediately.

Fixes #77846
