### PR TITLE
fix(plugins): sync official plugin installs during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/sessions: show each session's agent runtime in the Sessions table and allow filtering by runtime labels, matching the Agents panel runtime wording. Thanks @vincentkoc.
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Gateway/status: avoid marking fast repeated health/status samples as event-loop degraded from CPU/utilization alone until the Gateway has accumulated a sustained sampling window. Thanks @shakkernerd.
-- Plugins/update: keep installed official npm plugins such as Codex, Discord, and WhatsApp synced during host updates even when disabled or previously exact-pinned, while preserving third-party plugin pins. Thanks @vincentkoc.
+- Plugins/update: keep installed official npm and ClawHub plugins such as Codex, Discord, WhatsApp, and diagnostics plugins synced during host updates even when disabled or previously exact-pinned, while preserving third-party plugin pins. Thanks @vincentkoc.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/HTTP: avoid loading managed outgoing-image media handlers for unrelated requests, so disabled OpenAI-compatible routes return 404 without waiting on lazy media sidecars. Thanks @vincentkoc.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/sessions: show each session's agent runtime in the Sessions table and allow filtering by runtime labels, matching the Agents panel runtime wording. Thanks @vincentkoc.
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Gateway/status: avoid marking fast repeated health/status samples as event-loop degraded from CPU/utilization alone until the Gateway has accumulated a sustained sampling window. Thanks @shakkernerd.
+- Plugins/update: keep installed official npm plugins such as Codex, Discord, and WhatsApp synced during host updates even when disabled or previously exact-pinned, while preserving third-party plugin pins. Thanks @vincentkoc.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/HTTP: avoid loading managed outgoing-image media handlers for unrelated requests, so disabled OpenAI-compatible routes return 404 without waiting on lazy media sidecars. Thanks @vincentkoc.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2439,14 +2439,14 @@ describe("update-cli", () => {
       | OpenClawConfig
       | undefined;
     const updateCall = vi.mocked(updateNpmInstalledPlugins).mock.calls[0]?.[0] as
-      | { skipDisabledPlugins?: boolean; syncOfficialNpmPluginInstalls?: boolean }
+      | { skipDisabledPlugins?: boolean; syncOfficialPluginInstalls?: boolean }
       | undefined;
     expect(syncConfig?.plugins?.installs).toEqual(pluginInstallRecords);
     expect(syncConfig?.update?.channel).toBe("beta");
     expect(syncConfig?.gateway?.auth).toBeUndefined();
     expect(syncConfig?.plugins?.entries).toBeUndefined();
     expect(updateCall?.skipDisabledPlugins).toBe(true);
-    expect(updateCall?.syncOfficialNpmPluginInstalls).toBe(true);
+    expect(updateCall?.syncOfficialPluginInstalls).toBe(true);
   });
 
   it("persists channel and runs post-update work after switching from package to git", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2439,13 +2439,14 @@ describe("update-cli", () => {
       | OpenClawConfig
       | undefined;
     const updateCall = vi.mocked(updateNpmInstalledPlugins).mock.calls[0]?.[0] as
-      | { skipDisabledPlugins?: boolean }
+      | { skipDisabledPlugins?: boolean; syncOfficialNpmPluginInstalls?: boolean }
       | undefined;
     expect(syncConfig?.plugins?.installs).toEqual(pluginInstallRecords);
     expect(syncConfig?.update?.channel).toBe("beta");
     expect(syncConfig?.gateway?.auth).toBeUndefined();
     expect(syncConfig?.plugins?.entries).toBeUndefined();
     expect(updateCall?.skipDisabledPlugins).toBe(true);
+    expect(updateCall?.syncOfficialNpmPluginInstalls).toBe(true);
   });
 
   it("persists channel and runs post-update work after switching from package to git", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -168,6 +168,8 @@ vi.mock("../utils.js", async (importOriginal) => {
 });
 
 vi.mock("../plugins/update.js", () => ({
+  resolveTrustedSourceLinkedOfficialClawHubSpec: vi.fn(() => undefined),
+  resolveTrustedSourceLinkedOfficialNpmSpec: vi.fn(() => undefined),
   syncPluginsForUpdateChannel: (...args: unknown[]) => syncPluginsForUpdateChannel(...args),
   updateNpmInstalledPlugins: (...args: unknown[]) => updateNpmInstalledPlugins(...args),
 }));

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -262,7 +262,7 @@ describe("collectMissingPluginInstallPayloads", () => {
         collectMissingPluginInstallPayloads({
           env: { HOME: tmpDir } as NodeJS.ProcessEnv,
           skipDisabledPlugins: true,
-          syncOfficialNpmPluginInstalls: true,
+          syncOfficialPluginInstalls: true,
           config: {
             plugins: {
               entries: {
@@ -285,6 +285,44 @@ describe("collectMissingPluginInstallPayloads", () => {
       ).resolves.toEqual([
         {
           pluginId: "codex",
+          installPath: missingDir,
+          reason: "missing-package-dir",
+        },
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps disabled trusted official ClawHub records eligible for payload repair when requested", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const missingDir = path.join(tmpDir, "state", "clawhub", "diagnostics-otel");
+    try {
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          skipDisabledPlugins: true,
+          syncOfficialPluginInstalls: true,
+          config: {
+            plugins: {
+              entries: {
+                "diagnostics-otel": {
+                  enabled: false,
+                },
+              },
+            },
+          },
+          records: {
+            "diagnostics-otel": {
+              source: "clawhub",
+              spec: "clawhub:@openclaw/diagnostics-otel@2026.5.3",
+              installPath: missingDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([
+        {
+          pluginId: "diagnostics-otel",
           installPath: missingDir,
           reason: "missing-package-dir",
         },

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -253,6 +253,46 @@ describe("collectMissingPluginInstallPayloads", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("keeps disabled trusted official npm records eligible for payload repair when requested", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const missingDir = path.join(tmpDir, "state", "npm", "node_modules", "@openclaw", "codex");
+    try {
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          skipDisabledPlugins: true,
+          syncOfficialNpmPluginInstalls: true,
+          config: {
+            plugins: {
+              entries: {
+                codex: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+          records: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@2026.5.3",
+              resolvedName: "@openclaw/codex",
+              resolvedSpec: "@openclaw/codex@2026.5.3",
+              installPath: missingDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([
+        {
+          pluginId: "codex",
+          installPath: missingDir,
+          reason: "missing-package-dir",
+        },
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("shouldUseLegacyProcessRestartAfterUpdate", () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -58,6 +58,7 @@ import {
   withPluginInstallRecords,
 } from "../../plugins/installed-plugin-index-records.js";
 import {
+  resolveTrustedSourceLinkedOfficialNpmSpec,
   syncPluginsForUpdateChannel,
   updateNpmInstalledPlugins,
   type PluginUpdateIntegrityDriftParams,
@@ -190,6 +191,7 @@ export async function collectMissingPluginInstallPayloads(params: {
   records: Record<string, PluginInstallRecord>;
   config?: OpenClawConfig;
   skipDisabledPlugins?: boolean;
+  syncOfficialNpmPluginInstalls?: boolean;
   env?: NodeJS.ProcessEnv;
 }): Promise<MissingPluginInstallPayload[]> {
   const env = params.env ?? process.env;
@@ -204,6 +206,9 @@ export async function collectMissingPluginInstallPayloads(params: {
     if (!isTrackedPackageInstallRecord(record)) {
       continue;
     }
+    const officialNpmSpec = params.syncOfficialNpmPluginInstalls
+      ? resolveTrustedSourceLinkedOfficialNpmSpec({ pluginId, record })
+      : undefined;
     if (normalizedPluginConfig && params.config) {
       const enableState = resolveEffectiveEnableState({
         id: pluginId,
@@ -211,7 +216,7 @@ export async function collectMissingPluginInstallPayloads(params: {
         config: normalizedPluginConfig,
         rootConfig: params.config,
       });
-      if (!enableState.enabled) {
+      if (!enableState.enabled && !officialNpmSpec) {
         continue;
       }
     }
@@ -1168,6 +1173,7 @@ async function updatePluginsAfterCoreUpdate(params: {
       records,
       config: pluginConfig,
       skipDisabledPlugins: true,
+      syncOfficialNpmPluginInstalls: true,
     });
     if (missing.length === 0) {
       return [];
@@ -1188,6 +1194,21 @@ async function updatePluginsAfterCoreUpdate(params: {
         defaultRuntime.log(theme.warn(warning.message));
       }
     }
+    const repairResult = await updateNpmInstalledPlugins({
+      config: pluginConfig,
+      pluginIds: missingIds,
+      timeoutMs: params.timeoutMs,
+      updateChannel: params.channel,
+      skipDisabledPlugins: true,
+      syncOfficialNpmPluginInstalls: true,
+      disableOnFailure: true,
+      logger: pluginLogger,
+      onIntegrityDrift: onPluginIntegrityDrift,
+    });
+    pluginConfig = repairResult.config;
+    pluginsChanged ||= repairResult.changed;
+    npmPluginsChanged ||= repairResult.changed;
+    pluginUpdateOutcomes.push(...repairResult.outcomes);
     return missingIds;
   };
 
@@ -1199,6 +1220,8 @@ async function updatePluginsAfterCoreUpdate(params: {
     updateChannel: params.channel,
     skipIds: new Set([...syncResult.summary.switchedToNpm, ...missingPayloadIds]),
     skipDisabledPlugins: true,
+    syncOfficialNpmPluginInstalls: true,
+    disableOnFailure: true,
     logger: pluginLogger,
     onIntegrityDrift: onPluginIntegrityDrift,
   });
@@ -1217,6 +1240,7 @@ async function updatePluginsAfterCoreUpdate(params: {
     records: pluginConfig.plugins?.installs ?? {},
     config: pluginConfig,
     skipDisabledPlugins: true,
+    syncOfficialNpmPluginInstalls: true,
   });
   pluginUpdateOutcomes.push(
     ...remainingMissingPayloads

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -58,6 +58,7 @@ import {
   withPluginInstallRecords,
 } from "../../plugins/installed-plugin-index-records.js";
 import {
+  resolveTrustedSourceLinkedOfficialClawHubSpec,
   resolveTrustedSourceLinkedOfficialNpmSpec,
   syncPluginsForUpdateChannel,
   updateNpmInstalledPlugins,
@@ -191,7 +192,7 @@ export async function collectMissingPluginInstallPayloads(params: {
   records: Record<string, PluginInstallRecord>;
   config?: OpenClawConfig;
   skipDisabledPlugins?: boolean;
-  syncOfficialNpmPluginInstalls?: boolean;
+  syncOfficialPluginInstalls?: boolean;
   env?: NodeJS.ProcessEnv;
 }): Promise<MissingPluginInstallPayload[]> {
   const env = params.env ?? process.env;
@@ -206,8 +207,11 @@ export async function collectMissingPluginInstallPayloads(params: {
     if (!isTrackedPackageInstallRecord(record)) {
       continue;
     }
-    const officialNpmSpec = params.syncOfficialNpmPluginInstalls
+    const officialNpmSpec = params.syncOfficialPluginInstalls
       ? resolveTrustedSourceLinkedOfficialNpmSpec({ pluginId, record })
+      : undefined;
+    const officialClawHubSpec = params.syncOfficialPluginInstalls
+      ? resolveTrustedSourceLinkedOfficialClawHubSpec({ pluginId, record })
       : undefined;
     if (normalizedPluginConfig && params.config) {
       const enableState = resolveEffectiveEnableState({
@@ -216,7 +220,7 @@ export async function collectMissingPluginInstallPayloads(params: {
         config: normalizedPluginConfig,
         rootConfig: params.config,
       });
-      if (!enableState.enabled && !officialNpmSpec) {
+      if (!enableState.enabled && !officialNpmSpec && !officialClawHubSpec) {
         continue;
       }
     }
@@ -1173,7 +1177,7 @@ async function updatePluginsAfterCoreUpdate(params: {
       records,
       config: pluginConfig,
       skipDisabledPlugins: true,
-      syncOfficialNpmPluginInstalls: true,
+      syncOfficialPluginInstalls: true,
     });
     if (missing.length === 0) {
       return [];
@@ -1200,7 +1204,7 @@ async function updatePluginsAfterCoreUpdate(params: {
       timeoutMs: params.timeoutMs,
       updateChannel: params.channel,
       skipDisabledPlugins: true,
-      syncOfficialNpmPluginInstalls: true,
+      syncOfficialPluginInstalls: true,
       disableOnFailure: true,
       logger: pluginLogger,
       onIntegrityDrift: onPluginIntegrityDrift,
@@ -1220,7 +1224,7 @@ async function updatePluginsAfterCoreUpdate(params: {
     updateChannel: params.channel,
     skipIds: new Set([...syncResult.summary.switchedToNpm, ...missingPayloadIds]),
     skipDisabledPlugins: true,
-    syncOfficialNpmPluginInstalls: true,
+    syncOfficialPluginInstalls: true,
     disableOnFailure: true,
     logger: pluginLogger,
     onIntegrityDrift: onPluginIntegrityDrift,
@@ -1240,7 +1244,7 @@ async function updatePluginsAfterCoreUpdate(params: {
     records: pluginConfig.plugins?.installs ?? {},
     config: pluginConfig,
     skipDisabledPlugins: true,
-    syncOfficialNpmPluginInstalls: true,
+    syncOfficialPluginInstalls: true,
   });
   pluginUpdateOutcomes.push(
     ...remainingMissingPayloads

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1111,6 +1111,115 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it("updates disabled trusted official npm installs from the channel spec when requested", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@openclaw/codex",
+      version: "2026.5.3",
+    });
+    mockNpmViewMetadata({
+      name: "@openclaw/codex",
+      version: "2026.5.4",
+      integrity: "sha512-next",
+      shasum: "next",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "codex",
+        targetDir: installPath,
+        version: "2026.5.4",
+        npmResolution: {
+          name: "@openclaw/codex",
+          version: "2026.5.4",
+          resolvedSpec: "@openclaw/codex@2026.5.4",
+        },
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          entries: {
+            codex: {
+              enabled: false,
+              config: { preserved: true },
+            },
+          },
+          installs: {
+            codex: {
+              source: "npm",
+              spec: "@openclaw/codex@2026.5.3",
+              installPath,
+              resolvedName: "@openclaw/codex",
+              resolvedVersion: "2026.5.3",
+              resolvedSpec: "@openclaw/codex@2026.5.3",
+            },
+          },
+        },
+      },
+      skipDisabledPlugins: true,
+      syncOfficialNpmPluginInstalls: true,
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@openclaw/codex",
+        expectedPluginId: "codex",
+        trustedSourceLinkedOfficialInstall: true,
+      }),
+    );
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.entries?.codex).toEqual({
+      enabled: false,
+      config: { preserved: true },
+    });
+    expect(result.config.plugins?.installs?.codex).toMatchObject({
+      source: "npm",
+      spec: "@openclaw/codex",
+      version: "2026.5.4",
+      resolvedName: "@openclaw/codex",
+      resolvedVersion: "2026.5.4",
+      resolvedSpec: "@openclaw/codex@2026.5.4",
+    });
+    expect(result.outcomes[0]).toMatchObject({
+      pluginId: "codex",
+      status: "updated",
+      currentVersion: "2026.5.3",
+      nextVersion: "2026.5.4",
+    });
+  });
+
+  it("keeps third-party exact pinned npm specs pinned during official install sync", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@acme/demo",
+      version: "1.2.3",
+    });
+    installPluginFromNpmSpecMock.mockResolvedValue(
+      createSuccessfulNpmUpdateResult({
+        pluginId: "demo",
+        targetDir: installPath,
+        version: "1.2.3",
+      }),
+    );
+
+    await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "demo",
+        spec: "@acme/demo@1.2.3",
+        installPath,
+      }),
+      pluginIds: ["demo"],
+      dryRun: true,
+      syncOfficialNpmPluginInstalls: true,
+    });
+
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@acme/demo@1.2.3",
+        expectedPluginId: "demo",
+      }),
+    );
+  });
+
   it("keeps enabled tracked plugin update failures fatal when disabled skipping is enabled", async () => {
     installPluginFromNpmSpecMock.mockResolvedValue({
       ok: false,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1149,15 +1149,12 @@ describe("updateNpmInstalledPlugins", () => {
               source: "npm",
               spec: "@openclaw/codex@2026.5.3",
               installPath,
-              resolvedName: "@openclaw/codex",
-              resolvedVersion: "2026.5.3",
-              resolvedSpec: "@openclaw/codex@2026.5.3",
             },
           },
         },
       },
       skipDisabledPlugins: true,
-      syncOfficialNpmPluginInstalls: true,
+      syncOfficialPluginInstalls: true,
     });
 
     expect(installPluginFromNpmSpecMock).toHaveBeenCalledWith(
@@ -1209,7 +1206,7 @@ describe("updateNpmInstalledPlugins", () => {
       }),
       pluginIds: ["demo"],
       dryRun: true,
-      syncOfficialNpmPluginInstalls: true,
+      syncOfficialPluginInstalls: true,
     });
 
     expect(installPluginFromNpmSpecMock).toHaveBeenCalledWith(
@@ -1218,6 +1215,101 @@ describe("updateNpmInstalledPlugins", () => {
         expectedPluginId: "demo",
       }),
     );
+  });
+
+  it("updates disabled trusted official ClawHub installs through the catalog spec", async () => {
+    installPluginFromClawHubMock.mockResolvedValue(
+      createSuccessfulClawHubUpdateResult({
+        pluginId: "diagnostics-otel",
+        targetDir: "/tmp/diagnostics-otel",
+        version: "2026.5.4",
+        clawhubPackage: "@openclaw/diagnostics-otel",
+      }),
+    );
+
+    const config = createClawHubInstallConfig({
+      pluginId: "diagnostics-otel",
+      installPath: "/tmp/diagnostics-otel",
+      clawhubUrl: "https://clawhub.ai",
+      clawhubPackage: "@openclaw/diagnostics-otel",
+      clawhubFamily: "code-plugin",
+      clawhubChannel: "official",
+      spec: "clawhub:@openclaw/diagnostics-otel@2026.5.3",
+    });
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        ...config,
+        plugins: {
+          ...config.plugins,
+          entries: {
+            "diagnostics-otel": {
+              enabled: false,
+              config: { preserved: true },
+            },
+          },
+        },
+      },
+      skipDisabledPlugins: true,
+      syncOfficialPluginInstalls: true,
+    });
+
+    expect(installPluginFromClawHubMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "clawhub:@openclaw/diagnostics-otel",
+        expectedPluginId: "diagnostics-otel",
+      }),
+    );
+    expect(result.config.plugins?.installs?.["diagnostics-otel"]).toMatchObject({
+      source: "clawhub",
+      spec: "clawhub:@openclaw/diagnostics-otel",
+      version: "2026.5.4",
+      clawhubPackage: "@openclaw/diagnostics-otel",
+      clawhubChannel: "official",
+    });
+    expect(result.config.plugins?.entries?.["diagnostics-otel"]).toEqual({
+      enabled: false,
+      config: { preserved: true },
+    });
+  });
+
+  it("updates bare trusted official ClawHub installs through the catalog spec", async () => {
+    installPluginFromClawHubMock.mockResolvedValue(
+      createSuccessfulClawHubUpdateResult({
+        pluginId: "diagnostics-prometheus",
+        targetDir: "/tmp/diagnostics-prometheus",
+        version: "2026.5.4",
+        clawhubPackage: "@openclaw/diagnostics-prometheus",
+      }),
+    );
+
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            "diagnostics-prometheus": {
+              source: "clawhub",
+              spec: "clawhub:@openclaw/diagnostics-prometheus@2026.5.3",
+              installPath: "/tmp/diagnostics-prometheus",
+            },
+          },
+        },
+      },
+      syncOfficialPluginInstalls: true,
+    });
+
+    expect(installPluginFromClawHubMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "clawhub:@openclaw/diagnostics-prometheus",
+        expectedPluginId: "diagnostics-prometheus",
+      }),
+    );
+    expect(result.config.plugins?.installs?.["diagnostics-prometheus"]).toMatchObject({
+      source: "clawhub",
+      spec: "clawhub:@openclaw/diagnostics-prometheus",
+      version: "2026.5.4",
+      clawhubPackage: "@openclaw/diagnostics-prometheus",
+      clawhubChannel: "official",
+    });
   });
 
   it("keeps enabled tracked plugin update failures fatal when disabled skipping is enabled", async () => {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -467,31 +467,39 @@ function resolveNpmSpecPackageName(spec: string | undefined): string | undefined
   return spec ? parseRegistryNpmSpec(spec)?.name : undefined;
 }
 
-function isTrustedSourceLinkedOfficialNpmUpdate(params: {
+export function resolveTrustedSourceLinkedOfficialNpmSpec(params: {
   pluginId: string;
-  spec: string | undefined;
   record: PluginInstallRecord;
-}): boolean {
+}): string | undefined {
   if (params.record.source !== "npm") {
-    return false;
+    return undefined;
   }
   const entry = getOfficialExternalPluginCatalogEntry(params.pluginId);
   if (!entry) {
-    return false;
+    return undefined;
   }
-  const officialPackageName = resolveNpmSpecPackageName(
-    resolveOfficialExternalPluginInstall(entry)?.npmSpec,
-  );
-  const requestedPackageName = resolveNpmSpecPackageName(params.spec);
-  if (!officialPackageName || requestedPackageName !== officialPackageName) {
-    return false;
+  const officialSpec = resolveOfficialExternalPluginInstall(entry)?.npmSpec;
+  const officialPackageName = resolveNpmSpecPackageName(officialSpec);
+  if (!officialSpec || !officialPackageName) {
+    return undefined;
   }
   const recordedPackageNames = [
     params.record.resolvedName,
     resolveNpmSpecPackageName(params.record.spec),
     resolveNpmSpecPackageName(params.record.resolvedSpec),
   ].filter((value): value is string => Boolean(value));
-  return recordedPackageNames.includes(officialPackageName);
+  return recordedPackageNames.includes(officialPackageName) ? officialSpec : undefined;
+}
+
+function isTrustedSourceLinkedOfficialNpmUpdate(params: {
+  pluginId: string;
+  spec: string | undefined;
+  record: PluginInstallRecord;
+}): boolean {
+  const officialSpec = resolveTrustedSourceLinkedOfficialNpmSpec(params);
+  const officialPackageName = resolveNpmSpecPackageName(officialSpec);
+  const requestedPackageName = resolveNpmSpecPackageName(params.spec);
+  return Boolean(officialPackageName && requestedPackageName === officialPackageName);
 }
 
 function isTrustedSourceLinkedOfficialBridgeNpmInstall(params: {
@@ -542,6 +550,7 @@ function isBridgeClawHubInstall(params: {
 function resolveNpmUpdateSpecs(params: {
   record: PluginInstallRecord;
   specOverride?: string;
+  officialSpecOverride?: string;
   updateChannel?: UpdateChannel;
 }): {
   installSpec?: string;
@@ -549,7 +558,7 @@ function resolveNpmUpdateSpecs(params: {
   fallbackSpec?: string;
   fallbackLabel?: string;
 } {
-  const recordSpec = params.specOverride ?? params.record.spec;
+  const recordSpec = params.specOverride ?? params.officialSpecOverride ?? params.record.spec;
   if (!recordSpec) {
     return {};
   }
@@ -726,6 +735,7 @@ export async function updateNpmInstalledPlugins(params: {
   pluginIds?: string[];
   skipIds?: Set<string>;
   skipDisabledPlugins?: boolean;
+  syncOfficialNpmPluginInstalls?: boolean;
   disableOnFailure?: boolean;
   timeoutMs?: number;
   dryRun?: boolean;
@@ -787,6 +797,10 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
+    const officialNpmSpec = params.syncOfficialNpmPluginInstalls
+      ? resolveTrustedSourceLinkedOfficialNpmSpec({ pluginId, record })
+      : undefined;
+
     if (normalizedPluginConfig) {
       const enableState = resolveEffectiveEnableState({
         id: pluginId,
@@ -794,7 +808,7 @@ export async function updateNpmInstalledPlugins(params: {
         config: normalizedPluginConfig,
         rootConfig: params.config,
       });
-      if (!enableState.enabled) {
+      if (!enableState.enabled && !officialNpmSpec) {
         outcomes.push({
           pluginId,
           status: "skipped",
@@ -823,6 +837,7 @@ export async function updateNpmInstalledPlugins(params: {
         ? resolveNpmUpdateSpecs({
             record,
             specOverride: params.specOverrides?.[pluginId],
+            officialSpecOverride: officialNpmSpec,
             updateChannel: params.updateChannel,
           })
         : undefined;

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -467,6 +467,10 @@ function resolveNpmSpecPackageName(spec: string | undefined): string | undefined
   return spec ? parseRegistryNpmSpec(spec)?.name : undefined;
 }
 
+function resolveClawHubSpecPackageName(spec: string | undefined): string | undefined {
+  return spec ? parseClawHubPluginSpec(spec)?.name : undefined;
+}
+
 export function resolveTrustedSourceLinkedOfficialNpmSpec(params: {
   pluginId: string;
   record: PluginInstallRecord;
@@ -487,6 +491,29 @@ export function resolveTrustedSourceLinkedOfficialNpmSpec(params: {
     params.record.resolvedName,
     resolveNpmSpecPackageName(params.record.spec),
     resolveNpmSpecPackageName(params.record.resolvedSpec),
+  ].filter((value): value is string => Boolean(value));
+  return recordedPackageNames.includes(officialPackageName) ? officialSpec : undefined;
+}
+
+export function resolveTrustedSourceLinkedOfficialClawHubSpec(params: {
+  pluginId: string;
+  record: PluginInstallRecord;
+}): string | undefined {
+  if (params.record.source !== "clawhub") {
+    return undefined;
+  }
+  const entry = getOfficialExternalPluginCatalogEntry(params.pluginId);
+  if (!entry) {
+    return undefined;
+  }
+  const officialSpec = resolveOfficialExternalPluginInstall(entry)?.clawhubSpec;
+  const officialPackageName = resolveClawHubSpecPackageName(officialSpec);
+  if (!officialSpec || !officialPackageName) {
+    return undefined;
+  }
+  const recordedPackageNames = [
+    params.record.clawhubPackage,
+    resolveClawHubSpecPackageName(params.record.spec),
   ].filter((value): value is string => Boolean(value));
   return recordedPackageNames.includes(officialPackageName) ? officialSpec : undefined;
 }
@@ -576,6 +603,7 @@ function resolveNpmUpdateSpecs(params: {
 
 function resolveClawHubUpdateSpecs(params: {
   record: PluginInstallRecord;
+  officialSpecOverride?: string;
   updateChannel?: UpdateChannel;
 }): {
   installSpec?: string;
@@ -583,10 +611,11 @@ function resolveClawHubUpdateSpecs(params: {
   fallbackSpec?: string;
   fallbackLabel?: string;
 } {
-  if (!params.record.clawhubPackage) {
+  if (!params.officialSpecOverride && !params.record.clawhubPackage) {
     return {};
   }
-  const recordSpec = params.record.spec ?? `clawhub:${params.record.clawhubPackage}`;
+  const recordSpec =
+    params.officialSpecOverride ?? params.record.spec ?? `clawhub:${params.record.clawhubPackage}`;
   return resolveClawHubInstallSpecsForUpdateChannel({
     spec: recordSpec,
     updateChannel: params.updateChannel,
@@ -735,7 +764,7 @@ export async function updateNpmInstalledPlugins(params: {
   pluginIds?: string[];
   skipIds?: Set<string>;
   skipDisabledPlugins?: boolean;
-  syncOfficialNpmPluginInstalls?: boolean;
+  syncOfficialPluginInstalls?: boolean;
   disableOnFailure?: boolean;
   timeoutMs?: number;
   dryRun?: boolean;
@@ -797,8 +826,11 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    const officialNpmSpec = params.syncOfficialNpmPluginInstalls
+    const officialNpmSpec = params.syncOfficialPluginInstalls
       ? resolveTrustedSourceLinkedOfficialNpmSpec({ pluginId, record })
+      : undefined;
+    const officialClawHubSpec = params.syncOfficialPluginInstalls
+      ? resolveTrustedSourceLinkedOfficialClawHubSpec({ pluginId, record })
       : undefined;
 
     if (normalizedPluginConfig) {
@@ -808,7 +840,7 @@ export async function updateNpmInstalledPlugins(params: {
         config: normalizedPluginConfig,
         rootConfig: params.config,
       });
-      if (!enableState.enabled && !officialNpmSpec) {
+      if (!enableState.enabled && !officialNpmSpec && !officialClawHubSpec) {
         outcomes.push({
           pluginId,
           status: "skipped",
@@ -845,6 +877,7 @@ export async function updateNpmInstalledPlugins(params: {
       record.source === "clawhub"
         ? resolveClawHubUpdateSpecs({
             record,
+            officialSpecOverride: officialClawHubSpec,
             updateChannel: params.updateChannel,
           })
         : undefined;
@@ -892,7 +925,7 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    if (record.source === "clawhub" && !record.clawhubPackage) {
+    if (record.source === "clawhub" && !record.clawhubPackage && !officialClawHubSpec) {
       outcomes.push({
         pluginId,
         status: "skipped",


### PR DESCRIPTION
## Summary

- Problem: installed official plugins can shadow the bundled/current host plugin after `openclaw update`, especially when install records are disabled or exact-pinned to an older version.
- Why it matters: the host can update to a new OpenClaw version while an official plugin entry still points at `~/.openclaw/npm/node_modules/...` or a ClawHub-managed payload from an older release, so users keep running stale integration code.
- What changed: host post-update sync now treats trusted catalog-backed official npm and ClawHub installs as update-eligible even when disabled, and floats official exact pins back to the catalog/channel spec.
- What did NOT change: third-party exact npm/ClawHub pins still stay pinned; user-requested plugin updates outside the host update path keep their current behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: operator report from beta/stable update testing
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw update` left official plugin installs stale while the host package advanced.
- Real environment tested: operator Linux hosts running OpenClaw 2026.5.4/2026.5.4-beta.*.
- Exact steps or command run after this patch: targeted regression tests model the stale official npm and ClawHub install records observed on hosts, including disabled/exact-pinned `@openclaw/codex@2026.5.3` and bare/managed ClawHub diagnostics records.
- Evidence after fix: `src/plugins/update.test.ts` asserts npm and ClawHub records use the catalog spec, preserve disabled entries, and record the new version; `src/cli/update-cli/update-command.test.ts` asserts disabled official npm and bare ClawHub payloads remain repair-eligible.
- Observed result after fix: official catalog-backed npm and ClawHub installs are synced during host update; third-party exact pins are left alone.
- What was not tested: a live published package update after this exact patch. Local targeted Vitest was blocked by another worktree's heavy-check lock, and Blacksmith Testbox stayed queued.
- Before evidence: operator plugin lists showed OpenClaw 2026.5.4 with Codex/Discord/WhatsApp install records still loaded from `~/.openclaw/npm/node_modules/...` at older versions such as 2026.5.3.

## Root Cause (if applicable)

- Root cause: post-update plugin sync used the stored install record as the source of truth. Disabled plugin entries were skipped, and exact npm/ClawHub specs remained exact, so official plugins could stay pinned after the host moved forward.
- Missing detection / guardrail: coverage did not exercise disabled official npm or ClawHub install records during the host post-update path.
- Contributing context: official plugin installs can be catalog-backed and trusted even when they live in the user npm plugin root or a ClawHub-managed install record.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/update.test.ts`, `src/cli/update-cli/update-command.test.ts`, `src/cli/update-cli.test.ts`.
- Scenario the test should lock in: disabled or bare exact-pinned official npm/ClawHub records still update through the catalog spec during host post-update, while third-party exact pins remain pinned.
- Why this is the smallest reliable guardrail: it locks the update selection/spec logic directly without requiring live npm or ClawHub publication state.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw update` will now keep installed official npm and ClawHub plugins synced with the selected update channel during host updates, including disabled catalog-backed records. Third-party exact pins are unchanged.

## Diagram (if applicable)

```text
Before:
openclaw update -> host package updates -> disabled/exact-pinned official plugin skipped -> stale plugin shadows current host

After:
openclaw update -> host package updates -> trusted official install resolves via catalog spec -> plugin payload refreshed
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No new call type; host update already updates installed npm/ClawHub plugins.
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree, operator Linux host reports
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): official npm and ClawHub plugins, especially Codex/Discord/WhatsApp and diagnostics plugins
- Relevant config (redacted): stale `plugins.installs` records with `source: "npm"` or `source: "clawhub"` and exact specs like `@openclaw/codex@2026.5.3` or `clawhub:@openclaw/diagnostics-otel@2026.5.3`

### Steps

1. Create a config with disabled or bare official install records exact-pinned to an older OpenClaw package version.
2. Run the host post-update plugin sync path with official plugin install sync enabled.
3. Confirm the update uses the catalog spec and not the stale exact pin.

### Expected

- Official catalog-backed npm and ClawHub installs are eligible for host update sync and repair.
- Exact-pinned third-party npm/ClawHub installs remain exact-pinned.

### Actual

- Verified by static checks and targeted regression code. Targeted Vitest execution was blocked by environment queue/lock, not by a test failure.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `git diff --check`
  - `pnpm exec oxfmt --check --threads=1 src/plugins/update.ts src/plugins/update.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts src/cli/update-cli.test.ts CHANGELOG.md`
  - `pnpm changed:lanes --json`
  - `codex review --base origin/main` before the follow-up ClawHub widening found no correctness issue in the npm path.
- Edge cases checked in regression coverage: disabled official npm record, bare exact-pinned official npm record, managed exact-pinned official ClawHub record, bare exact-pinned official ClawHub record, missing disabled official payload repair, third-party exact pin preservation.
- What you did **not** verify: live published package update with this branch; local targeted Vitest was blocked by heavy-check lock pid 4509 in `pr-76452-archive-fixes`; Testbox `tbx_01kqwzb6hh45wkw6s1157qjex4` stayed queued and was stopped.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: official npm/ClawHub packages with intentionally old exact pins now float during host update.
  - Mitigation: only trusted catalog-backed official installs opt into this path; third-party exact pins are preserved.
