### PR TITLE
fix: prevent duplicate generated media fallback sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/generated media: treat attachment-style message tool actions as completed chat sends, preventing duplicate fallback media posts when generated files were already uploaded.
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/OpenAI-compatible: send the assistant role SSE chunk as soon as streaming chat-completion headers are accepted, so cold agent setup cannot leave `/v1/chat/completions` clients with a bodyless 200 response until their idle timeout fires.

--- a/src/agents/pi-embedded-messaging.ts
+++ b/src/agents/pi-embedded-messaging.ts
@@ -2,6 +2,18 @@ import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 const CORE_MESSAGING_TOOLS = new Set(["sessions_send", "message"]);
+const MESSAGE_TOOL_SEND_ACTIONS = new Set([
+  "send",
+  "thread-reply",
+  "sendWithEffect",
+  "sendAttachment",
+  "upload-file",
+]);
+
+export function isMessageToolSendActionName(action: unknown): boolean {
+  const normalized = normalizeOptionalString(action) ?? "";
+  return MESSAGE_TOOL_SEND_ACTIONS.has(normalized);
+}
 
 // Provider docking: any plugin with `actions` opts into messaging tool handling.
 export function isMessagingTool(toolName: string): boolean {
@@ -21,7 +33,7 @@ export function isMessagingToolSendAction(
     return true;
   }
   if (toolName === "message") {
-    return action === "send" || action === "thread-reply";
+    return isMessageToolSendActionName(action);
   }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -941,6 +941,85 @@ describe("messaging tool media URL tracking", () => {
     ]);
   });
 
+  it("commits upload-file args as message delivery evidence", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-upload-file",
+      args: {
+        action: "upload-file",
+        channel: "discord",
+        to: "channel:123",
+        message: "track ready",
+        path: "/tmp/generated-song.mp3",
+      },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    expect(ctx.state.pendingMessagingMediaUrls.get("tool-upload-file")).toEqual([
+      "/tmp/generated-song.mp3",
+    ]);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-upload-file",
+      isError: false,
+      result: { ok: true },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/generated-song.mp3"]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([
+      expect.objectContaining({
+        provider: "discord",
+        to: "channel:123",
+        text: "track ready",
+        mediaUrls: ["/tmp/generated-song.mp3"],
+      }),
+    ]);
+    expect(ctx.state.pendingMessagingMediaUrls.has("tool-upload-file")).toBe(false);
+  });
+
+  it("commits sendAttachment args as message delivery evidence", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-send-attachment",
+      args: {
+        action: "sendAttachment",
+        provider: "discord",
+        to: "channel:123",
+        content: "track ready",
+        filePath: "/tmp/generated-song.mp3",
+      },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-send-attachment",
+      isError: false,
+      result: { ok: true },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/generated-song.mp3"]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([
+      expect.objectContaining({
+        provider: "discord",
+        to: "channel:123",
+        text: "track ready",
+        mediaUrls: ["/tmp/generated-song.mp3"],
+      }),
+    ]);
+  });
+
   it("trims messagingToolSentMediaUrls to 200 on commit (FIFO)", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.tools.extract.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.extract.test.ts
@@ -60,4 +60,58 @@ describe("extractMessagingToolSend", () => {
     expect(result?.provider).toBe("telegram");
     expect(result?.to).toBe("telegram:123");
   });
+
+  it("recognizes attachment-style message tool sends", () => {
+    const upload = extractMessagingToolSend("message", {
+      action: "upload-file",
+      channel: "discord",
+      to: "channel:123",
+      path: "/tmp/song.mp3",
+    });
+    const attachment = extractMessagingToolSend("message", {
+      action: "sendAttachment",
+      provider: "discord",
+      to: "channel:123",
+      filePath: "/tmp/song.mp3",
+    });
+    const effect = extractMessagingToolSend("message", {
+      action: "sendWithEffect",
+      provider: "discord",
+      to: "channel:123",
+      content: "done",
+    });
+
+    expect(upload).toMatchObject({
+      tool: "message",
+      provider: "discord",
+      to: "channel:123",
+    });
+    expect(attachment).toMatchObject({
+      tool: "message",
+      provider: "discord",
+      to: "channel:123",
+    });
+    expect(effect).toMatchObject({
+      tool: "message",
+      provider: "discord",
+      to: "channel:123",
+    });
+  });
+
+  it("keeps thread id evidence for thread replies", () => {
+    const result = extractMessagingToolSend("message", {
+      action: "thread-reply",
+      provider: "discord",
+      to: "channel:123",
+      threadId: "456",
+      content: "done",
+    });
+
+    expect(result).toMatchObject({
+      tool: "message",
+      provider: "discord",
+      to: "channel:123",
+      threadId: "456",
+    });
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -554,7 +554,9 @@ export function extractMessagingToolSend(
     const provider = providerId ?? normalizeOptionalLowercaseString(providerHint) ?? "message";
     const to = normalizeTargetForProvider(provider, toRaw);
     const threadId = normalizeOptionalString(args.threadId);
-    return to ? { tool: toolName, provider, accountId, to, threadId } : undefined;
+    return to
+      ? { tool: toolName, provider, accountId, to, ...(threadId ? { threadId } : {}) }
+      : undefined;
   }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { collectTextContentBlocks } from "./content-blocks.js";
+import { isMessageToolSendActionName } from "./pi-embedded-messaging.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -539,7 +540,7 @@ export function extractMessagingToolSend(
   const action = normalizeOptionalString(args.action) ?? "";
   const accountId = normalizeOptionalString(args.accountId);
   if (toolName === "message") {
-    if (action !== "send" && action !== "thread-reply") {
+    if (!isMessageToolSendActionName(action)) {
       return undefined;
     }
     const toRaw = resolveMessageToolTarget(args);
@@ -552,7 +553,8 @@ export function extractMessagingToolSend(
     const providerId = providerHint ? normalizeChannelId(providerHint) : null;
     const provider = providerId ?? normalizeOptionalLowercaseString(providerHint) ?? "message";
     const to = normalizeTargetForProvider(provider, toRaw);
-    return to ? { tool: toolName, provider, accountId, to } : undefined;
+    const threadId = normalizeOptionalString(args.threadId);
+    return to ? { tool: toolName, provider, accountId, to, threadId } : undefined;
   }
   const providerId = normalizeChannelId(toolName);
   if (!providerId) {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1271,6 +1271,58 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("does not fallback for generated media group completions when message tool evidence exists", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        didSendViaMessagingTool: false,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "slack",
+            accountId: "acct-1",
+            to: "channel:C123",
+            text: "The track is ready.",
+            mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      sessionId: "requester-session-channel",
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-media-message-tool-evidence",
+      sourceTool: "music_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "music_generation",
+          childSessionKey: "music_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "music generation task",
+          taskLabel: "night-drive synthwave",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 track.\nMEDIA:/tmp/generated-night-drive.mp3",
+          mediaUrls: ["/tmp/generated-night-drive.mp3"],
+          replyInstruction: "Deliver the generated music through the message tool.",
+        },
+      ],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        delivered: true,
+        path: "direct",
+      }),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not fallback while generated media announce-agent run is still pending", async () => {
     const callGateway = createGatewayMock({
       runId: "video_generate:task-123:ok",


### PR DESCRIPTION
## Summary

- Problem: generated media completions can double-post when the announce agent uploads the file through attachment-style `message` actions, because delivery evidence only counted `send` and `thread-reply`.
- Why it matters: routes that require the message tool, such as Discord group/channel completion announcements, saw a successful upload followed by the direct fallback sending the same media again.
- What changed: recognize `upload-file`, `sendAttachment`, and `sendWithEffect` as send-like `message` actions, share that recognition with target extraction, preserve thread ids, and add regression tests for media evidence commits.
- What did NOT change (scope boundary): no channel plugin behavior, media generation flow, or fallback delivery policy changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: duplicate generated-media fallback posts after an attachment-style message-tool upload.
- Real environment tested: local macOS checkout, focused agent/tool evidence tests.
- Exact steps or command run after this patch: `pnpm test src/agents/pi-embedded-subscribe.tools.extract.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- Evidence after fix: the new `upload-file` and `sendAttachment` tests commit `/tmp/generated-song.mp3` into `messagingToolSentMediaUrls` and `messagingToolSentTargets`, which is the evidence checked by generated-media fallback suppression.
- Observed result after fix: attachment-style message sends are treated as completed chat delivery evidence.
- What was not tested: live Discord media roundtrip; Testbox changed gate was attempted but remained queued, so it was stopped.
- Before evidence (optional but encouraged): code path previously only accepted `send` and `thread-reply` for the `message` tool.

## Root Cause (if applicable)

- Root cause: `isMessagingToolSendAction` and `extractMessagingToolSend` only recognized `message` actions `send` and `thread-reply`.
- Missing detection / guardrail: attachment-style send actions did not populate pending messaging targets/media, so successful uploads were invisible to fallback suppression.
- Contributing context (if known): generated-media completions rely on `hasGatewayAgentMessagingToolDelivery` before deciding whether to direct-send fallback media.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-subscribe.tools.extract.test.ts`, `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- Scenario the test should lock in: `upload-file` and `sendAttachment` actions record media delivery evidence after successful tool completion.
- Why this is the smallest reliable guardrail: it tests the shared evidence seam used by generated-media fallback suppression without needing a live channel upload.
- Existing test that already covers this (if any): existing `send` media evidence tests covered only text-send style actions.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Generated media should no longer be duplicated when the announce agent already uploaded the file through attachment-style message tool actions.

## Diagram (if applicable)

```text
Before:
message(upload-file) -> Discord upload succeeds -> no delivery evidence -> direct fallback sends media again

After:
message(upload-file) -> Discord upload succeeds -> delivery evidence recorded -> fallback suppressed
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Discord-style message action evidence
- Relevant config (redacted): N/A

### Steps

1. Run focused message-evidence tests.
2. Confirm `upload-file` and `sendAttachment` produce committed media delivery evidence.
3. Confirm core production/test type lanes pass.

### Expected

- Attachment-style message sends are treated as successful delivery evidence.

### Actual

- They are now committed to `messagingToolSentMediaUrls` and `messagingToolSentTargets` on success.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `upload-file` path media, `sendAttachment` filePath media, `sendWithEffect` target extraction, thread id preservation, existing `send` media evidence behavior.
- Edge cases checked: failed messaging tools still discard pending media; media URLs returned in tool result payloads still commit.
- What you did **not** verify: live Discord media generation roundtrip; Testbox `pnpm check:changed` stayed queued and was stopped.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: counting too many `message` actions as successful sends.
  - Mitigation: only known send-like actions from the message action spec are added, and evidence is committed only after successful tool completion.
