### PR TITLE
fix: schedule discord heartbeat checks after sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.
 - Control UI/Sessions: make the compaction count a compact `N Checkpoint(s)` disclosure and show expanded session-level details with modern checkpoint history cards across responsive table layouts. Thanks @BunsDev.
 - Control UI/performance: keep chat and channel tabs responsive while history payloads and channel probes are slow, label partial channel status, and record slow chat/config render timings in the event log. Thanks @BunsDev.
 - Control UI/sessions: fire the documented `/new` command and lifecycle hooks only for explicit Control UI session creation, restoring session-memory and custom hook capture without changing SDK parent-session creates. Fixes #76957. Thanks @BunsDev.

--- a/extensions/discord/src/internal/gateway-lifecycle.test.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
+
+describe("GatewayHeartbeatTimers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("does not false-timeout when the first heartbeat fires near the interval boundary", () => {
+    vi.useFakeTimers();
+
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+    const isAcked = vi.fn().mockReturnValue(false);
+    const timers = new GatewayHeartbeatTimers();
+
+    timers.start({
+      intervalMs: 45_000,
+      isAcked,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.95,
+    });
+
+    vi.advanceTimersByTime(42_750);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2_250);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    isAcked.mockReturnValue(true);
+    vi.advanceTimersByTime(42_750);
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    timers.stop();
+  });
+
+  it("fires an ACK timeout when a heartbeat is genuinely not acknowledged", () => {
+    vi.useFakeTimers();
+
+    const timers = new GatewayHeartbeatTimers();
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+
+    timers.start({
+      intervalMs: 45_000,
+      isAcked: () => false,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0,
+    });
+
+    vi.advanceTimersByTime(0);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(45_000);
+    expect(onAckTimeout).toHaveBeenCalledTimes(1);
+
+    timers.stop();
+  });
+
+  it("sends heartbeats at regular intervals after the initial random delay", () => {
+    vi.useFakeTimers();
+
+    const timers = new GatewayHeartbeatTimers();
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+
+    timers.start({
+      intervalMs: 10_000,
+      isAcked: () => true,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.5,
+    });
+
+    vi.advanceTimersByTime(5_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(10_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(3);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    timers.stop();
+  });
+
+  it("stop cancels all pending timers", () => {
+    vi.useFakeTimers();
+
+    const timers = new GatewayHeartbeatTimers();
+    const onHeartbeat = vi.fn();
+    const onAckTimeout = vi.fn();
+
+    timers.start({
+      intervalMs: 10_000,
+      isAcked: () => true,
+      onAckTimeout,
+      onHeartbeat,
+      random: () => 0.5,
+    });
+
+    timers.stop();
+    vi.advanceTimersByTime(100_000);
+
+    expect(onHeartbeat).not.toHaveBeenCalled();
+    expect(onAckTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/internal/gateway-lifecycle.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.ts
@@ -4,6 +4,24 @@ export class GatewayHeartbeatTimers {
   heartbeatInterval?: GatewayTimer;
   firstHeartbeatTimeout?: GatewayTimer;
 
+  private scheduleHeartbeatCycle(params: {
+    intervalMs: number;
+    isAcked: () => boolean;
+    onAckTimeout: () => void;
+    onHeartbeat: () => void;
+  }): void {
+    this.heartbeatInterval = setTimeout(() => {
+      this.heartbeatInterval = undefined;
+      if (!params.isAcked()) {
+        params.onAckTimeout();
+        return;
+      }
+      params.onHeartbeat();
+      this.scheduleHeartbeatCycle(params);
+    }, params.intervalMs);
+    this.heartbeatInterval.unref?.();
+  }
+
   start(params: {
     intervalMs: number;
     isAcked: () => boolean;
@@ -14,18 +32,14 @@ export class GatewayHeartbeatTimers {
     this.stop();
     const random = params.random ?? Math.random;
     this.firstHeartbeatTimeout = setTimeout(
-      params.onHeartbeat,
+      () => {
+        this.firstHeartbeatTimeout = undefined;
+        params.onHeartbeat();
+        this.scheduleHeartbeatCycle(params);
+      },
       Math.max(0, params.intervalMs * random()),
     );
     this.firstHeartbeatTimeout.unref?.();
-    this.heartbeatInterval = setInterval(() => {
-      if (!params.isAcked()) {
-        params.onAckTimeout();
-        return;
-      }
-      params.onHeartbeat();
-    }, params.intervalMs);
-    this.heartbeatInterval.unref?.();
   }
 
   stop(): void {

--- a/extensions/discord/src/internal/gateway-lifecycle.ts
+++ b/extensions/discord/src/internal/gateway-lifecycle.ts
@@ -44,7 +44,7 @@ export class GatewayHeartbeatTimers {
 
   stop(): void {
     if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
+      clearTimeout(this.heartbeatInterval);
       this.heartbeatInterval = undefined;
     }
     if (this.firstHeartbeatTimeout) {

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -10,6 +10,7 @@ import {
 } from "discord-api-types/v10";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sharedGatewayIdentifyLimiter } from "./gateway-identify-limiter.js";
+import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
 import { GatewayPlugin } from "./gateway.js";
 
 function attachOpenSocket(gateway: GatewayPlugin) {
@@ -66,6 +67,66 @@ type GatewaySessionState = {
 function gatewaySessionState(gateway: GatewayPlugin): GatewaySessionState {
   return gateway as unknown as GatewaySessionState;
 }
+
+describe("GatewayHeartbeatTimers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("checks heartbeat ACK one full interval after the actual heartbeat send", async () => {
+    vi.useFakeTimers();
+    const timers = new GatewayHeartbeatTimers();
+    let acked = true;
+    const onHeartbeat = vi.fn(() => {
+      acked = false;
+    });
+    const onAckTimeout = vi.fn();
+
+    timers.start({
+      intervalMs: 1_000,
+      isAcked: () => acked,
+      onHeartbeat,
+      onAckTimeout,
+      random: () => 0.9,
+    });
+
+    await vi.advanceTimersByTimeAsync(900);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(onAckTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onAckTimeout).toHaveBeenCalledTimes(1);
+    timers.stop();
+  });
+
+  it("schedules the next heartbeat after an ACKed heartbeat cycle", async () => {
+    vi.useFakeTimers();
+    const timers = new GatewayHeartbeatTimers();
+    let acked = true;
+    const onHeartbeat = vi.fn(() => {
+      acked = false;
+    });
+
+    timers.start({
+      intervalMs: 1_000,
+      isAcked: () => acked,
+      onHeartbeat,
+      onAckTimeout: vi.fn(),
+      random: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    acked = true;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onHeartbeat).toHaveBeenCalledTimes(2);
+    timers.stop();
+  });
+});
 
 describe("GatewayPlugin", () => {
   afterEach(() => {

--- a/extensions/discord/src/internal/gateway.test.ts
+++ b/extensions/discord/src/internal/gateway.test.ts
@@ -10,7 +10,6 @@ import {
 } from "discord-api-types/v10";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sharedGatewayIdentifyLimiter } from "./gateway-identify-limiter.js";
-import { GatewayHeartbeatTimers } from "./gateway-lifecycle.js";
 import { GatewayPlugin } from "./gateway.js";
 
 function attachOpenSocket(gateway: GatewayPlugin) {
@@ -67,66 +66,6 @@ type GatewaySessionState = {
 function gatewaySessionState(gateway: GatewayPlugin): GatewaySessionState {
   return gateway as unknown as GatewaySessionState;
 }
-
-describe("GatewayHeartbeatTimers", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("checks heartbeat ACK one full interval after the actual heartbeat send", async () => {
-    vi.useFakeTimers();
-    const timers = new GatewayHeartbeatTimers();
-    let acked = true;
-    const onHeartbeat = vi.fn(() => {
-      acked = false;
-    });
-    const onAckTimeout = vi.fn();
-
-    timers.start({
-      intervalMs: 1_000,
-      isAcked: () => acked,
-      onHeartbeat,
-      onAckTimeout,
-      random: () => 0.9,
-    });
-
-    await vi.advanceTimersByTimeAsync(900);
-    expect(onHeartbeat).toHaveBeenCalledTimes(1);
-    expect(onAckTimeout).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(999);
-    expect(onAckTimeout).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(onAckTimeout).toHaveBeenCalledTimes(1);
-    timers.stop();
-  });
-
-  it("schedules the next heartbeat after an ACKed heartbeat cycle", async () => {
-    vi.useFakeTimers();
-    const timers = new GatewayHeartbeatTimers();
-    let acked = true;
-    const onHeartbeat = vi.fn(() => {
-      acked = false;
-    });
-
-    timers.start({
-      intervalMs: 1_000,
-      isAcked: () => acked,
-      onHeartbeat,
-      onAckTimeout: vi.fn(),
-      random: () => 0,
-    });
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(onHeartbeat).toHaveBeenCalledTimes(1);
-    acked = true;
-
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(onHeartbeat).toHaveBeenCalledTimes(2);
-    timers.stop();
-  });
-});
 
 describe("GatewayPlugin", () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes the Discord gateway heartbeat scheduler so ACK timeout checks are measured from the actual heartbeat send time, not from the HELLO-time fixed interval.

The previous scheduler randomized the first heartbeat but started a fixed interval immediately. If the first heartbeat fired late in that interval — or the event loop was delayed — the next interval tick could check `lastHeartbeatAck` too soon after the send and trigger a false `Gateway heartbeat ACK timeout`/reconnect cycle while the Discord channel was still awaiting readiness.

## Changes

- Replace the fixed heartbeat interval with a chained timeout cycle.
- Keep randomized first heartbeat behavior.
- After each heartbeat send, schedule the ACK check one full heartbeat interval later.
- If ACKed, send the next heartbeat and schedule the next check from that send.
- Keep reconnect cleanup clearing both first-heartbeat and heartbeat-cycle timers.
- Add dedicated regression coverage for late randomized first heartbeat, genuine ACK timeout, ACKed heartbeat cycles, and timer cleanup.
- Add a changelog entry crediting both contributors.

## Real Behavior Proof

**Behavior or issue addressed:** Discord gateway heartbeat ACK timeout race causing false reconnect loops and intermittent `awaiting gateway readiness` hangs (#77668).

**Real environment tested:** OpenClaw 2026.5.5 from commit `43dcdcd9` on WSL2 Ubuntu 22.04, Node.js v22.22.0, Discord bot runtime.

**Exact steps or command run after this patch:**
1. `pnpm build` in the OpenClaw source checkout.
2. Patched the installed `@openclaw/discord` runtime bundle with the recursive timeout heartbeat logic.
3. `systemctl --user restart openclaw-gateway`.
4. Monitored `journalctl --user -u openclaw-gateway -f` for 2+ minutes.

**Evidence after fix:** Runtime log excerpt from the real Discord gateway run:
```text
19:32:32 [discord] client initialized as 1483184501986164748; awaiting gateway readiness
19:32:32 WebSocket OPEN event fired
19:32:33 message: op=0 t=READY
19:32:34 message: op=11 t=null
19:33:15 message: op=11 t=null
```

**Observed result after fix:** Zero `Gateway heartbeat ACK timeout` entries; Discord reached READY and stayed connected with repeated heartbeat ACKs instead of reconnecting.

**What was not tested:** Long-running 24h+ stability, multi-guild load, and Windows native runtime were not covered by this after-fix run. The original #77668 reporter offered to rerun 5 macOS launchd restart cycles once this lands.

## Testing

- `pnpm exec oxfmt --write --threads=1 CHANGELOG.md extensions/discord/src/internal/gateway-lifecycle.ts extensions/discord/src/internal/gateway-lifecycle.test.ts extensions/discord/src/internal/gateway.test.ts` — passed.
- `pnpm test extensions/discord/src/internal/gateway-lifecycle.test.ts extensions/discord/src/internal/gateway.test.ts` — passed, 2 files / 24 tests.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/discord/src/internal/gateway-lifecycle.ts extensions/discord/src/internal/gateway-lifecycle.test.ts extensions/discord/src/internal/gateway.test.ts` — passed.
- `git diff --check` — passed.

Fixes #77668
Supersedes #77956
