### PR TITLE
fix(ollama): sanitize exec tool schema

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -17,6 +17,7 @@ import {
   buildAssistantMessage,
   parseNdjsonStream,
   resolveOllamaBaseUrlForRun,
+  sanitizeOllamaToolParameters,
 } from "./stream.js";
 
 type GuardedFetchCall = {
@@ -30,6 +31,49 @@ type GuardedFetchCall = {
 
 afterEach(() => {
   fetchWithSsrFGuardMock.mockReset();
+});
+
+
+describe("sanitizeOllamaToolParameters", () => {
+  it("removes approval-routing exec properties from Ollama tool schemas", () => {
+    const result = sanitizeOllamaToolParameters("exec", {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        workdir: { type: "string" },
+        timeout: { type: "number" },
+        host: { type: "string" },
+        node: { type: "string" },
+        elevated: { type: "boolean" },
+        security: { type: "string" },
+        ask: { type: "string" },
+      },
+      required: ["command", "host", "node"],
+    });
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        workdir: { type: "string" },
+        timeout: { type: "number" },
+      },
+      required: ["command"],
+    });
+  });
+
+  it("leaves non-exec tool schemas unchanged", () => {
+    const parameters = {
+      type: "object",
+      properties: {
+        host: { type: "string" },
+        query: { type: "string" },
+      },
+      required: ["query"],
+    };
+
+    expect(sanitizeOllamaToolParameters("search", parameters)).toBe(parameters);
+  });
 });
 
 describe("buildOllamaChatRequest", () => {
@@ -1789,6 +1833,76 @@ describe("createOllamaStreamFn", () => {
           hostnameAllowlist: ["127.0.0.1"],
           allowPrivateNetwork: true,
         });
+      },
+    );
+  });
+
+  it("sanitizes exec tool schemas before sending them to Ollama", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "qwen3:32b",
+              api: "ollama",
+              provider: "custom-ollama",
+              contextWindow: 131072,
+            } as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+              tools: [
+                {
+                  name: "exec",
+                  description: "Run a command",
+                  parameters: {
+                    type: "object",
+                    properties: {
+                      command: { type: "string" },
+                      workdir: { type: "string" },
+                      timeout: { type: "number" },
+                      host: { type: "string" },
+                      node: { type: "string" },
+                      elevated: { type: "boolean" },
+                      security: { type: "string" },
+                      ask: { type: "string" },
+                    },
+                    required: ["command", "host"],
+                  },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        await collectStreamEvents(stream);
+        const requestInit = getGuardedFetchCall(fetchMock).init ?? {};
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+
+        const requestBody = JSON.parse(requestInit.body) as {
+          tools?: Array<{
+            function: { parameters: { properties?: Record<string, unknown>; required?: string[] } };
+          }>;
+        };
+        const execParameters = requestBody.tools?.[0]?.function.parameters;
+        expect(execParameters?.properties).toMatchObject({
+          command: { type: "string" },
+          workdir: { type: "string" },
+          timeout: { type: "number" },
+        });
+        expect(execParameters?.properties).not.toHaveProperty("host");
+        expect(execParameters?.properties).not.toHaveProperty("node");
+        expect(execParameters?.properties).not.toHaveProperty("elevated");
+        expect(execParameters?.properties).not.toHaveProperty("security");
+        expect(execParameters?.properties).not.toHaveProperty("ask");
+        expect(execParameters?.required).toEqual(["command"]);
       },
     );
   });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -740,6 +740,14 @@ function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefi
   return undefined;
 }
 
+const OLLAMA_EXEC_SCHEMA_BLOCKED_PROPERTIES = new Set([
+  "host",
+  "node",
+  "elevated",
+  "security",
+  "ask",
+]);
+
 function normalizeOllamaToolSchema(schema: unknown, isRoot = false): Record<string, unknown> {
   if (!isRecord(schema)) {
     return {
@@ -784,6 +792,36 @@ function normalizeOllamaToolSchema(schema: unknown, isRoot = false): Record<stri
     normalized.properties = {};
   }
   return normalized;
+}
+
+export function sanitizeOllamaToolParameters(
+  toolName: string,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  if (toolName !== "exec") {
+    return parameters;
+  }
+
+  const sanitized = { ...parameters };
+  const properties = isRecord(parameters.properties)
+    ? { ...(parameters.properties as Record<string, unknown>) }
+    : undefined;
+
+  if (properties) {
+    for (const propertyName of OLLAMA_EXEC_SCHEMA_BLOCKED_PROPERTIES) {
+      delete properties[propertyName];
+    }
+    sanitized.properties = properties;
+  }
+
+  if (Array.isArray(parameters.required)) {
+    sanitized.required = parameters.required.filter(
+      (value): value is string =>
+        typeof value === "string" && !OLLAMA_EXEC_SCHEMA_BLOCKED_PROPERTIES.has(value),
+    );
+  }
+
+  return sanitized;
 }
 
 type OllamaToolCallNameOptions = {
@@ -925,7 +963,10 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
       function: {
         name: tool.name,
         description: typeof tool.description === "string" ? tool.description : "",
-        parameters: normalizeOllamaToolSchema(tool.parameters, true),
+        parameters: sanitizeOllamaToolParameters(
+          tool.name,
+          normalizeOllamaToolSchema(tool.parameters, true),
+        ),
       },
     });
   }


### PR DESCRIPTION
## Summary
- strip approval-routing exec fields from Ollama tool schemas (`host`, `node`, `elevated`, `security`, `ask`)
- preserve ordinary exec fields such as `command`, `workdir`, and `timeout`
- leave non-exec tool schemas unchanged

## Why
Local Ollama models can otherwise select host/node execution overrides when calling `exec`, which can route simple local commands into approval-required node execution and fail with `SYSTEM_RUN_DENIED`.

## Tests
- `pnpm vitest run extensions/ollama/src/stream-runtime.test.ts`
