### PR TITLE
fix(doctor): surface GH_CONFIG_DIR hint when gh auth lives at a different HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Cron: keep long manual cron runs active in the task registry until completion, preventing transient `lost` markers before durable recovery reconciles. Fixes #78233. (#78243) Thanks @Feelw00.
+- Doctor/GitHub CLI: surface a `GH_CONFIG_DIR` hint when the GitHub skill is usable but `gh` auth lives under a different operator HOME than the agent process, without warning for disabled or filtered skills. Fixes #78063. (#78095) Thanks @tmimmanuel.
 - Gateway: clear speculative node wake state when APNs registration is missing, preventing unregistered or mistyped node IDs from retaining wake throttle entries. Fixes #68847. (#68848) Thanks @Feelw00.
 - Auto-reply: keep late follow-up queue drain finalizers from deleting a replacement queue registered after `/stop`, preventing immediate follow-up messages from being orphaned. Fixes #68838. (#68839) Thanks @Feelw00.
 - Feishu: make manual App ID/App Secret setup the default channel-binding path while keeping QR scan-to-create as an optional best-effort flow, and document the manual fallback for domestic Feishu mobile clients that do not react to the QR code. Fixes #80591. Thanks @wei-wei-zhao.

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -63,6 +63,25 @@ gh auth login
 gh auth status
 ```
 
+### When the gateway HOME differs from the operator HOME
+
+OpenClaw agent shells often run with a different `HOME` than the user that ran
+`gh auth login` (per-agent codex homes, systemd `User=` services, sudo). `gh`
+looks up its config under `$GH_CONFIG_DIR`, then `$XDG_CONFIG_HOME/gh`, then
+`$HOME/.config/gh`, so the agent shell can report `not logged into any GitHub
+hosts` even when the operator login is intact.
+
+To point the gateway at the canonical `gh` config, set `GH_CONFIG_DIR` on the
+service environment, e.g.
+
+```bash
+# Gateway service env file (example: ~/.openclaw/gateway.systemd.env)
+GH_CONFIG_DIR=/path/to/operator/.config/gh
+```
+
+then restart the gateway. `openclaw doctor` warns when it detects an authenticated
+`hosts.yml` outside the agent process's effective `gh` config dir.
+
 ## Common Commands
 
 ### Pull Requests

--- a/src/agents/skills/gh-config-discovery.test.ts
+++ b/src/agents/skills/gh-config-discovery.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectGhConfigDirMismatch,
+  formatGhConfigDirMismatchHint,
+  type GhConfigDirMismatch,
+  type GhConfigDiscoveryInput,
+} from "./gh-config-discovery.js";
+
+function makeInput(overrides: Partial<GhConfigDiscoveryInput>): GhConfigDiscoveryInput {
+  return {
+    platform: "linux",
+    env: {},
+    fileExists: () => false,
+    ...overrides,
+  };
+}
+
+function fileSet(...paths: readonly string[]): (absolutePath: string) => boolean {
+  const set = new Set(paths);
+  return (absolutePath) => set.has(absolutePath);
+}
+
+describe("detectGhConfigDirMismatch", () => {
+  it("returns 'explicit-gh-config-dir-set' when GH_CONFIG_DIR is already set", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home", GH_CONFIG_DIR: "/etc/openclaw/gh" },
+      }),
+    );
+    expect(result).toEqual({ kind: "explicit-gh-config-dir-set", ghConfigDir: "/etc/openclaw/gh" });
+  });
+
+  it("returns 'no-process-home' when HOME and XDG and APPDATA are missing", () => {
+    const result = detectGhConfigDirMismatch(makeInput({ env: {} }));
+    expect(result).toEqual({ kind: "no-process-home" });
+  });
+
+  it("returns 'auth-discoverable' when the effective config dir already has hosts.yml", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home" },
+        fileExists: fileSet("/agent/home/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "/agent/home/.config/gh",
+    });
+  });
+
+  it("flags a mismatch when /root/.config/gh has hosts.yml but the agent HOME does not", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/root/.openclaw/agents/main/agent/codex-home/home" },
+        fileExists: fileSet("/root/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "mismatch",
+      effectiveConfigDir: "/root/.openclaw/agents/main/agent/codex-home/home/.config/gh",
+      alternateConfigDir: "/root/.config/gh",
+      alternateHostsFile: "/root/.config/gh/hosts.yml",
+      alternateHomeHint: "/root",
+      suggestedEnvValue: "/root/.config/gh",
+    });
+  });
+
+  it("uses SUDO_USER home as a candidate when set", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/var/lib/openclaw/agent", SUDO_USER: "alice" },
+        fileExists: fileSet("/home/alice/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "mismatch",
+      alternateConfigDir: "/home/alice/.config/gh",
+      alternateHomeHint: "/home/alice",
+    });
+  });
+
+  it("uses USER home as a fallback candidate when SUDO_USER is missing", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/var/lib/openclaw/agent", USER: "ops" },
+        fileExists: fileSet("/home/ops/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "mismatch",
+      alternateConfigDir: "/home/ops/.config/gh",
+      alternateHomeHint: "/home/ops",
+    });
+  });
+
+  it("ignores USER=root since /root is already part of the default candidate set", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home", USER: "root" },
+        fileExists: fileSet("/root/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result.kind).toBe("mismatch");
+  });
+
+  it("returns 'no-known-auth' when no candidate has hosts.yml", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home" },
+        fileExists: () => false,
+      }),
+    );
+    expect(result).toEqual({
+      kind: "no-known-auth",
+      effectiveConfigDir: "/agent/home/.config/gh",
+    });
+  });
+
+  it("does not flag a mismatch when the agent HOME equals the operator HOME", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/root" },
+        fileExists: fileSet("/root/.config/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "/root/.config/gh",
+    });
+  });
+
+  it("respects XDG_CONFIG_HOME for the effective config dir on Linux", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home", XDG_CONFIG_HOME: "/agent/xdg" },
+        fileExists: fileSet("/agent/xdg/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "/agent/xdg/gh",
+    });
+  });
+
+  it("uses HOME/.config/gh on darwin (matches gh's documented macOS lookup)", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        platform: "darwin",
+        env: { HOME: "/Users/agent" },
+        fileExists: fileSet("/Users/operator/.config/gh/hosts.yml"),
+        candidateOperatorHomes: ["/Users/operator"],
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "mismatch",
+      effectiveConfigDir: "/Users/agent/.config/gh",
+      alternateConfigDir: "/Users/operator/.config/gh",
+      alternateHomeHint: "/Users/operator",
+    });
+  });
+
+  it("uses APPDATA/GitHub CLI on win32", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        platform: "win32",
+        env: { APPDATA: "C:\\Users\\agent\\AppData\\Roaming" },
+        fileExists: fileSet("C:\\Users\\agent\\AppData\\Roaming\\GitHub CLI\\hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "C:\\Users\\agent\\AppData\\Roaming\\GitHub CLI",
+    });
+  });
+
+  it("respects an explicit candidateOperatorHomes list", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        env: { HOME: "/agent/home" },
+        fileExists: fileSet("/srv/automation/.config/gh/hosts.yml"),
+        candidateOperatorHomes: ["/srv/automation"],
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "mismatch",
+      alternateConfigDir: "/srv/automation/.config/gh",
+      alternateHomeHint: "/srv/automation",
+    });
+  });
+});
+
+describe("formatGhConfigDirMismatchHint", () => {
+  it("formats the mismatch into operator-actionable lines", () => {
+    const mismatch: GhConfigDirMismatch = {
+      effectiveConfigDir: "/agent/home/.config/gh",
+      alternateConfigDir: "/root/.config/gh",
+      alternateHostsFile: "/root/.config/gh/hosts.yml",
+      alternateHomeHint: "/root",
+      suggestedEnvValue: "/root/.config/gh",
+    };
+    expect(formatGhConfigDirMismatchHint(mismatch)).toEqual([
+      "GitHub CLI auth was found at a different HOME than the one this OpenClaw process uses.",
+      "  Process gh config dir: /agent/home/.config/gh",
+      "  Authenticated config:  /root/.config/gh (contains hosts.yml)",
+      "  Authenticated HOME:    /root",
+      "  Fix: set GH_CONFIG_DIR=/root/.config/gh on the OpenClaw service environment, then restart the gateway.",
+    ]);
+  });
+
+  it("omits the home hint line when the alternate has no associated HOME", () => {
+    const mismatch: GhConfigDirMismatch = {
+      effectiveConfigDir: "/agent/home/.config/gh",
+      alternateConfigDir: "/srv/automation/.config/gh",
+      alternateHostsFile: "/srv/automation/.config/gh/hosts.yml",
+      suggestedEnvValue: "/srv/automation/.config/gh",
+    };
+    const lines = formatGhConfigDirMismatchHint(mismatch);
+    expect(lines.some((line) => line.includes("Authenticated HOME"))).toBe(false);
+    expect(lines).toContain(
+      "  Fix: set GH_CONFIG_DIR=/srv/automation/.config/gh on the OpenClaw service environment, then restart the gateway.",
+    );
+  });
+});

--- a/src/agents/skills/gh-config-discovery.test.ts
+++ b/src/agents/skills/gh-config-discovery.test.ts
@@ -142,6 +142,20 @@ describe("detectGhConfigDirMismatch", () => {
     });
   });
 
+  it("respects XDG_CONFIG_HOME before HOME on darwin", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        platform: "darwin",
+        env: { HOME: "/Users/agent", XDG_CONFIG_HOME: "/Users/agent/Library/XDG" },
+        fileExists: fileSet("/Users/agent/Library/XDG/gh/hosts.yml"),
+      }),
+    );
+    expect(result).toEqual({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "/Users/agent/Library/XDG/gh",
+    });
+  });
+
   it("uses HOME/.config/gh on darwin (matches gh's documented macOS lookup)", () => {
     const result = detectGhConfigDirMismatch(
       makeInput({
@@ -170,6 +184,37 @@ describe("detectGhConfigDirMismatch", () => {
     expect(result).toMatchObject({
       kind: "auth-discoverable",
       effectiveConfigDir: "C:\\Users\\agent\\AppData\\Roaming\\GitHub CLI",
+    });
+  });
+
+  it("respects XDG_CONFIG_HOME before APPDATA on win32", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        platform: "win32",
+        env: {
+          XDG_CONFIG_HOME: "C:\\Users\\agent\\XDG",
+          APPDATA: "C:\\Users\\agent\\AppData\\Roaming",
+        },
+        fileExists: fileSet("C:\\Users\\agent\\XDG\\gh\\hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "C:\\Users\\agent\\XDG\\gh",
+    });
+  });
+
+  it("falls back to HOME/.config/gh on win32 when APPDATA and USERPROFILE are missing", () => {
+    const result = detectGhConfigDirMismatch(
+      makeInput({
+        platform: "win32",
+        env: { HOME: "C:\\Users\\agent" },
+        fileExists: fileSet("C:\\Users\\agent\\.config\\gh\\hosts.yml"),
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "auth-discoverable",
+      effectiveConfigDir: "C:\\Users\\agent\\.config\\gh",
     });
   });
 

--- a/src/agents/skills/gh-config-discovery.ts
+++ b/src/agents/skills/gh-config-discovery.ts
@@ -1,0 +1,187 @@
+import { posix as posixPath, win32 as win32Path } from "node:path";
+
+function pathFor(platform: NodeJS.Platform) {
+  return platform === "win32" ? win32Path : posixPath;
+}
+
+// Detects the case where `gh` is authenticated under one HOME but the current
+// OpenClaw process is running with a different HOME (e.g. the per-agent
+// codex-home, a systemd service home, or a sudo'd shell). Without GH_CONFIG_DIR
+// the gh CLI looks at $XDG_CONFIG_HOME/gh or $HOME/.config/gh and reports
+// "not logged in", even though the operator HOME has a valid hosts.yml.
+// See https://github.com/openclaw/openclaw/issues/78063.
+
+export type GhConfigDiscoveryEnv = {
+  HOME?: string;
+  XDG_CONFIG_HOME?: string;
+  GH_CONFIG_DIR?: string;
+  APPDATA?: string;
+  SUDO_USER?: string;
+  USER?: string;
+  USERPROFILE?: string;
+};
+
+export type GhConfigDiscoveryInput = {
+  platform: NodeJS.Platform;
+  env: GhConfigDiscoveryEnv;
+  fileExists: (absolutePath: string) => boolean;
+  // Optional: well-known operator-home guesses to consider when looking for an
+  // alternate gh config dir. Defaults to a small Linux/macOS set; tests pass an
+  // explicit list to keep behavior deterministic.
+  candidateOperatorHomes?: readonly string[];
+};
+
+export type GhConfigDirMismatch = {
+  // The directory `gh` would actually consult given the current process env.
+  effectiveConfigDir: string;
+  // The directory that contains the operator's real `hosts.yml`.
+  alternateConfigDir: string;
+  // Absolute path to the alternate hosts.yml that the current process won't see.
+  alternateHostsFile: string;
+  // The HOME-like path the alternate dir was derived from, if known.
+  alternateHomeHint?: string;
+  // Suggested env value the operator should set on the OpenClaw service to
+  // surface the alternate config to the agent shell.
+  suggestedEnvValue: string;
+};
+
+export type GhConfigDiscoveryResult =
+  | { kind: "no-gh-binary" }
+  | { kind: "explicit-gh-config-dir-set"; ghConfigDir: string }
+  | { kind: "no-process-home" }
+  | { kind: "auth-discoverable"; effectiveConfigDir: string }
+  | { kind: "no-known-auth"; effectiveConfigDir: string }
+  | ({ kind: "mismatch" } & GhConfigDirMismatch);
+
+const HOSTS_FILE = "hosts.yml";
+
+// gh config-dir lookup order, matching the documented behavior of `gh
+// help environment` for each platform. macOS uses Library/Application Support,
+// Windows uses %AppData%\GitHub CLI, Linux/other uses XDG_CONFIG_HOME or
+// $HOME/.config/gh.
+function resolveEffectiveGhConfigDir(input: GhConfigDiscoveryInput): string | undefined {
+  const env = input.env;
+  if (env.GH_CONFIG_DIR && env.GH_CONFIG_DIR.trim()) {
+    return env.GH_CONFIG_DIR.trim();
+  }
+  if (input.platform === "win32") {
+    const appData = env.APPDATA?.trim();
+    if (appData) {
+      return pathFor(input.platform).join(appData, "GitHub CLI");
+    }
+    const profile = env.USERPROFILE?.trim();
+    if (profile) {
+      return pathFor(input.platform).join(profile, "AppData", "Roaming", "GitHub CLI");
+    }
+    return undefined;
+  }
+  if (input.platform === "darwin") {
+    const home = env.HOME?.trim();
+    if (!home) {
+      return undefined;
+    }
+    return pathFor(input.platform).join(home, ".config", "gh");
+  }
+  // Linux and POSIX-like default
+  const xdg = env.XDG_CONFIG_HOME?.trim();
+  if (xdg) {
+    return pathFor(input.platform).join(xdg, "gh");
+  }
+  const home = env.HOME?.trim();
+  if (!home) {
+    return undefined;
+  }
+  return pathFor(input.platform).join(home, ".config", "gh");
+}
+
+function defaultCandidateOperatorHomes(input: GhConfigDiscoveryInput): string[] {
+  const env = input.env;
+  const homes = new Set<string>();
+  // Common operator HOME on Linux servers running gateway as root.
+  if (input.platform !== "win32") {
+    homes.add("/root");
+  }
+  // sudo invocation: the original shell user's home is exposed through SUDO_USER.
+  if (env.SUDO_USER?.trim()) {
+    const sudoUser = env.SUDO_USER.trim();
+    homes.add(pathFor(input.platform).join("/home", sudoUser));
+    if (input.platform === "darwin") {
+      homes.add(pathFor(input.platform).join("/Users", sudoUser));
+    }
+  }
+  // USER fallback: works when HOME has been redirected but the login user is
+  // still on the env (e.g. systemd User= with PassEnvironment=USER).
+  if (env.USER?.trim()) {
+    const user = env.USER.trim();
+    if (user !== "root") {
+      if (input.platform === "darwin") {
+        homes.add(pathFor(input.platform).join("/Users", user));
+      } else if (input.platform !== "win32") {
+        homes.add(pathFor(input.platform).join("/home", user));
+      }
+    }
+  }
+  // Drop the current process HOME from the candidate set; we want directories
+  // that are NOT what gh would already consult.
+  const processHome = env.HOME?.trim();
+  if (processHome) {
+    homes.delete(processHome);
+  }
+  return [...homes];
+}
+
+function ghConfigDirForHome(home: string, platform: NodeJS.Platform): string {
+  // Linux and macOS both put gh's config under <HOME>/.config/gh. Windows is
+  // not a realistic mismatch case for the bug this helper detects; we still
+  // return the POSIX-layout directory so the hint points at a sensible path.
+  return pathFor(platform).join(home, ".config", "gh");
+}
+
+export function detectGhConfigDirMismatch(input: GhConfigDiscoveryInput): GhConfigDiscoveryResult {
+  const env = input.env;
+  if (env.GH_CONFIG_DIR && env.GH_CONFIG_DIR.trim()) {
+    return { kind: "explicit-gh-config-dir-set", ghConfigDir: env.GH_CONFIG_DIR.trim() };
+  }
+  const effective = resolveEffectiveGhConfigDir(input);
+  if (!effective) {
+    return { kind: "no-process-home" };
+  }
+  const effectiveHosts = pathFor(input.platform).join(effective, HOSTS_FILE);
+  if (input.fileExists(effectiveHosts)) {
+    return { kind: "auth-discoverable", effectiveConfigDir: effective };
+  }
+  const candidates = input.candidateOperatorHomes ?? defaultCandidateOperatorHomes(input);
+  for (const home of candidates) {
+    const candidateDir = ghConfigDirForHome(home, input.platform);
+    if (candidateDir === effective) {
+      continue;
+    }
+    const candidateHosts = pathFor(input.platform).join(candidateDir, HOSTS_FILE);
+    if (input.fileExists(candidateHosts)) {
+      return {
+        kind: "mismatch",
+        effectiveConfigDir: effective,
+        alternateConfigDir: candidateDir,
+        alternateHostsFile: candidateHosts,
+        alternateHomeHint: home,
+        suggestedEnvValue: candidateDir,
+      };
+    }
+  }
+  return { kind: "no-known-auth", effectiveConfigDir: effective };
+}
+
+export function formatGhConfigDirMismatchHint(mismatch: GhConfigDirMismatch): string[] {
+  const lines: string[] = [
+    "GitHub CLI auth was found at a different HOME than the one this OpenClaw process uses.",
+    `  Process gh config dir: ${mismatch.effectiveConfigDir}`,
+    `  Authenticated config:  ${mismatch.alternateConfigDir} (contains ${HOSTS_FILE})`,
+  ];
+  if (mismatch.alternateHomeHint) {
+    lines.push(`  Authenticated HOME:    ${mismatch.alternateHomeHint}`);
+  }
+  lines.push(
+    `  Fix: set GH_CONFIG_DIR=${mismatch.suggestedEnvValue} on the OpenClaw service environment, then restart the gateway.`,
+  );
+  return lines;
+}

--- a/src/agents/skills/gh-config-discovery.ts
+++ b/src/agents/skills/gh-config-discovery.ts
@@ -55,14 +55,15 @@ export type GhConfigDiscoveryResult =
 
 const HOSTS_FILE = "hosts.yml";
 
-// gh config-dir lookup order, matching the documented behavior of `gh
-// help environment` for each platform. macOS uses Library/Application Support,
-// Windows uses %AppData%\GitHub CLI, Linux/other uses XDG_CONFIG_HOME or
-// $HOME/.config/gh.
+// gh config-dir lookup order, matching `gh help environment`.
 function resolveEffectiveGhConfigDir(input: GhConfigDiscoveryInput): string | undefined {
   const env = input.env;
   if (env.GH_CONFIG_DIR && env.GH_CONFIG_DIR.trim()) {
     return env.GH_CONFIG_DIR.trim();
+  }
+  const xdg = env.XDG_CONFIG_HOME?.trim();
+  if (xdg) {
+    return pathFor(input.platform).join(xdg, "gh");
   }
   if (input.platform === "win32") {
     const appData = env.APPDATA?.trim();
@@ -73,19 +74,6 @@ function resolveEffectiveGhConfigDir(input: GhConfigDiscoveryInput): string | un
     if (profile) {
       return pathFor(input.platform).join(profile, "AppData", "Roaming", "GitHub CLI");
     }
-    return undefined;
-  }
-  if (input.platform === "darwin") {
-    const home = env.HOME?.trim();
-    if (!home) {
-      return undefined;
-    }
-    return pathFor(input.platform).join(home, ".config", "gh");
-  }
-  // Linux and POSIX-like default
-  const xdg = env.XDG_CONFIG_HOME?.trim();
-  if (xdg) {
-    return pathFor(input.platform).join(xdg, "gh");
   }
   const home = env.HOME?.trim();
   if (!home) {

--- a/src/commands/doctor-skills.test.ts
+++ b/src/commands/doctor-skills.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
+import type { GhConfigDiscoveryInput } from "../agents/skills/gh-config-discovery.js";
 import { createEmptyInstallChecks } from "../cli/requirements-test-fixtures.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   collectUnavailableAgentSkills,
+  describeGhConfigDirHintFromDiscovery,
   disableUnavailableSkillsInConfig,
   formatUnavailableSkillDoctorLines,
 } from "./doctor-skills.js";
@@ -85,6 +87,67 @@ describe("doctor skills", () => {
     expect(lines.join("\n")).toContain("places: bins: goplaces; env: GOOGLE_MAPS_API_KEY");
     expect(lines.join("\n")).toContain("install option: Install goplaces (brew)");
     expect(lines.join("\n")).toContain("openclaw doctor --fix");
+  });
+
+  it("surfaces a GH_CONFIG_DIR hint when the github skill is eligible but auth lives at a different HOME", () => {
+    const githubSkill = createSkill({
+      name: "github",
+      skillKey: "github",
+      eligible: true,
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    });
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/root/.openclaw/agents/main/agent/codex-home/home" },
+      fileExists: (p) => p === "/root/.config/gh/hosts.yml",
+    };
+
+    const lines = describeGhConfigDirHintFromDiscovery([githubSkill], discovery);
+
+    expect(lines.some((line) => line.includes("/root/.config/gh"))).toBe(true);
+    expect(lines.join("\n")).toContain("GH_CONFIG_DIR=/root/.config/gh");
+  });
+
+  it("does not surface the GH_CONFIG_DIR hint when the github skill is missing the gh binary", () => {
+    const githubSkill = createSkill({
+      name: "github",
+      skillKey: "github",
+      eligible: false,
+      missing: { bins: ["gh"], anyBins: [], env: [], config: [], os: [] },
+    });
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/agent/home" },
+      fileExists: (p) => p === "/root/.config/gh/hosts.yml",
+    };
+
+    expect(describeGhConfigDirHintFromDiscovery([githubSkill], discovery)).toEqual([]);
+  });
+
+  it("does not surface the GH_CONFIG_DIR hint when GH_CONFIG_DIR is already set", () => {
+    const githubSkill = createSkill({
+      name: "github",
+      skillKey: "github",
+      eligible: true,
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    });
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/agent/home", GH_CONFIG_DIR: "/etc/openclaw/gh" },
+      fileExists: () => true,
+    };
+
+    expect(describeGhConfigDirHintFromDiscovery([githubSkill], discovery)).toEqual([]);
+  });
+
+  it("does not surface the GH_CONFIG_DIR hint when the github skill is not present in the report", () => {
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/agent/home" },
+      fileExists: (p) => p === "/root/.config/gh/hosts.yml",
+    };
+
+    expect(describeGhConfigDirHintFromDiscovery([], discovery)).toEqual([]);
   });
 
   it("disables unavailable skills through skills.entries without dropping existing config", () => {

--- a/src/commands/doctor-skills.test.ts
+++ b/src/commands/doctor-skills.test.ts
@@ -124,6 +124,40 @@ describe("doctor skills", () => {
     expect(describeGhConfigDirHintFromDiscovery([githubSkill], discovery)).toEqual([]);
   });
 
+  it("does not surface the GH_CONFIG_DIR hint when the github skill is disabled", () => {
+    const githubSkill = createSkill({
+      name: "github",
+      skillKey: "github",
+      eligible: false,
+      disabled: true,
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    });
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/agent/home" },
+      fileExists: (p) => p === "/root/.config/gh/hosts.yml",
+    };
+
+    expect(describeGhConfigDirHintFromDiscovery([githubSkill], discovery)).toEqual([]);
+  });
+
+  it("does not surface the GH_CONFIG_DIR hint when the github skill is filtered out for the agent", () => {
+    const githubSkill = createSkill({
+      name: "github",
+      skillKey: "github",
+      eligible: true,
+      blockedByAgentFilter: true,
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+    });
+    const discovery: GhConfigDiscoveryInput = {
+      platform: "linux",
+      env: { HOME: "/agent/home" },
+      fileExists: (p) => p === "/root/.config/gh/hosts.yml",
+    };
+
+    expect(describeGhConfigDirHintFromDiscovery([githubSkill], discovery)).toEqual([]);
+  });
+
   it("does not surface the GH_CONFIG_DIR hint when GH_CONFIG_DIR is already set", () => {
     const githubSkill = createSkill({
       name: "github",

--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -1,6 +1,13 @@
+import { existsSync } from "node:fs";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
+import {
+  detectGhConfigDirMismatch,
+  formatGhConfigDirMismatchHint,
+  type GhConfigDiscoveryInput,
+  type GhConfigDiscoveryResult,
+} from "../agents/skills/gh-config-discovery.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { note } from "../terminal/note.js";
@@ -41,6 +48,38 @@ function formatInstallHints(skill: SkillStatusEntry): string[] {
     return [];
   }
   return skill.install.slice(0, 2).map((entry) => `  install option: ${entry.label}`);
+}
+
+function defaultGhConfigDiscoveryInput(): GhConfigDiscoveryInput {
+  return {
+    platform: process.platform,
+    env: process.env as GhConfigDiscoveryInput["env"],
+    fileExists: (absolutePath) => existsSync(absolutePath),
+  };
+}
+
+export function describeGhConfigDirHint(skills: SkillStatusEntry[]): string[] {
+  return describeGhConfigDirHintFromDiscovery(skills, defaultGhConfigDiscoveryInput());
+}
+
+export function describeGhConfigDirHintFromDiscovery(
+  skills: SkillStatusEntry[],
+  discoveryInput: GhConfigDiscoveryInput,
+): string[] {
+  const githubSkill = skills.find((skill) => skill.name === "github");
+  if (!githubSkill) {
+    return [];
+  }
+  // The github skill only requires the `gh` binary; if it is not installed we
+  // do not surface a config-dir hint (the bin install hint covers it).
+  if (githubSkill.missing.bins.includes("gh")) {
+    return [];
+  }
+  const result: GhConfigDiscoveryResult = detectGhConfigDirMismatch(discoveryInput);
+  if (result.kind !== "mismatch") {
+    return [];
+  }
+  return formatGhConfigDirMismatchHint(result);
 }
 
 export function formatUnavailableSkillDoctorLines(skills: SkillStatusEntry[]): string[] {
@@ -91,6 +130,10 @@ export async function maybeRepairSkillReadiness(params: {
     config: params.cfg,
     agentId,
   });
+  const githubHint = describeGhConfigDirHint(report.skills);
+  if (githubHint.length > 0) {
+    note(githubHint.join("\n"), "GitHub CLI");
+  }
   const unavailable = collectUnavailableAgentSkills(report);
   if (unavailable.length === 0) {
     return params.cfg;

--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -70,9 +70,12 @@ export function describeGhConfigDirHintFromDiscovery(
   if (!githubSkill) {
     return [];
   }
-  // The github skill only requires the `gh` binary; if it is not installed we
-  // do not surface a config-dir hint (the bin install hint covers it).
-  if (githubSkill.missing.bins.includes("gh")) {
+  if (
+    !githubSkill.eligible ||
+    githubSkill.blockedByAgentFilter ||
+    githubSkill.disabled ||
+    githubSkill.blockedByAllowlist
+  ) {
     return [];
   }
   const result: GhConfigDiscoveryResult = detectGhConfigDirMismatch(discoveryInput);


### PR DESCRIPTION
## Summary

- Problem: When an OpenClaw agent shell runs with a different `HOME` than the user that ran `gh auth login` (per-agent codex homes, systemd `User=` services, sudo'd shells), `gh` looks up its config under `$XDG_CONFIG_HOME/gh` or `$HOME/.config/gh` and reports `not logged into any GitHub hosts`, even though the operator HOME has a valid `hosts.yml`. Issue #78063 reports the symptom: `HOME=/root/.openclaw/agents/main/agent/codex-home/home gh auth status` returns "not logged in" while `gh` is fully authenticated under `/root/.config/gh`.
- Why it matters: The user-facing symptom looks like the GitHub skill is broken; operators try `GH_TOKEN` / `GITHUB_TOKEN` rabbit holes when the real fix is to set `GH_CONFIG_DIR=/root/.config/gh` (or equivalent) on the gateway service environment.
- What changed: New pure helper `detectGhConfigDirMismatch` in `src/agents/skills/gh-config-discovery.ts` that takes process env + a `fileExists` probe and reports either `auth-discoverable`, `no-known-auth`, `explicit-gh-config-dir-set`, or `mismatch` with the alternate config dir, hosts file, and a suggested `GH_CONFIG_DIR` value. `src/commands/doctor-skills.ts` now calls the helper from the doctor skills health flow when the `github` skill is reported and the `gh` binary is present, printing a "GitHub CLI" note with the operator-actionable fix before any unavailable-skill repair prompt. `skills/github/SKILL.md` gains a troubleshooting subsection documenting `GH_CONFIG_DIR` for service/agent environments.
- What did NOT change (scope boundary): No core credential migration; OpenClaw does not copy or move `gh` auth between homes. No new config option added; we read existing process env. The requirement engine is unchanged. No changes to `gh` itself or its skill metadata other than docs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78063
- Related #65958 (GitHub skill needs OpenClaw restart after CLI install; restart guidance unclear)
- Related #75169 (docs(github): clarify restart after gh setup)
- Related #53628 (`${XDG_CONFIG_HOME}` not processed when installing a skill)
- Related #257 (per-session GitHub authentication setup guide)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `gh` resolves its config dir as `$GH_CONFIG_DIR` -> `$XDG_CONFIG_HOME/gh` -> `$HOME/.config/gh` (Linux/macOS) or `$AppData/GitHub CLI` (Windows). When OpenClaw spawns an agent shell with `HOME` redirected to a per-agent codex home, the `gh` lookup misses the operator's authenticated config. The previous doctor flow only checked whether the `gh` binary was on `PATH` and never inspected config-dir layout, so the GitHub skill looked ready while runtime calls failed.
- Missing detection / guardrail: No code path on main correlated the running process's effective `gh` config dir against well-known operator homes that might hold a `hosts.yml`.
- Contributing context (if known): Per-agent codex homes are a documented isolation feature (`docs/plugins/codex-harness.md`), and several adjacent issues (#65958, #75169, #53628) already point at gh-skill setup gaps. This PR closes the specific HOME-mismatch case without changing the isolation model.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/skills/gh-config-discovery.test.ts` (new, 13 cases for the pure helper) and `src/commands/doctor-skills.test.ts` (4 new cases covering `describeGhConfigDirHintFromDiscovery`).
- Scenario the test should lock in: A reproduction of the issue's `HOME=/root/.openclaw/agents/main/agent/codex-home/home` setup yields a `mismatch` result whose `suggestedEnvValue` equals `/root/.config/gh`, and the formatted hint contains `GH_CONFIG_DIR=/root/.config/gh`. SUDO_USER and USER fallbacks resolve to the right candidate dirs. `GH_CONFIG_DIR` already set, missing `gh` binary, missing `github` skill, and aligned HOME all correctly suppress the hint. Linux, macOS, and Windows path layouts are exercised.
- Why this is the smallest reliable guardrail: The mismatch decision is a pure function of process env + filesystem state; covering it as a pure helper test keeps coverage deterministic without mocking the doctor flow. The doctor wiring tests cover the skill-presence and `gh`-binary preconditions.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw doctor` now prints a "GitHub CLI" note when it detects an authenticated `hosts.yml` outside the agent process's effective `gh` config dir, including the suggested `GH_CONFIG_DIR` env value. No new config keys; no changes to existing skill behavior. The GitHub skill docs gain a troubleshooting subsection.

## Diagram (if applicable)

```text
Before:
  agent shell HOME=/root/.openclaw/agents/main/agent/codex-home/home
  gh -> $HOME/.config/gh -> not present -> "not logged in"
  doctor -> gh binary on PATH? yes -> github skill reported as ready

After:
  agent shell HOME=/root/.openclaw/agents/main/agent/codex-home/home
  gh -> same lookup, still misses
  doctor -> finds /root/.config/gh/hosts.yml at a candidate operator HOME
        -> prints "GitHub CLI" note:
             Process gh config dir: /root/.openclaw/agents/main/agent/codex-home/home/.config/gh
             Authenticated config:  /root/.config/gh (contains hosts.yml)
             Authenticated HOME:    /root
             Fix: set GH_CONFIG_DIR=/root/.config/gh on the OpenClaw service environment, then restart the gateway.
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` (helper reads HOME/USER/SUDO_USER/APPDATA from process env and probes `hosts.yml` existence; never reads token contents)
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu workstation, Linux 6.8.0-110-generic
- Runtime/container: Node 22.22.0 via nvm, pnpm 10.33.2
- Model/provider: N/A (skill diagnostic)
- Integration/channel (if any): GitHub skill (`gh` CLI)
- Relevant config (redacted): N/A

### Steps

1. Check out the branch on top of `upstream/main`.
2. Run the bot-prescribed acceptance tests: `pnpm test src/commands/doctor-skills.test.ts src/agents/skills-status.test.ts` (plus the new `src/agents/skills/gh-config-discovery.test.ts`).
3. Run `pnpm tsgo:core` and `pnpm tsgo:core:test`.
4. Reproduce the issue scenario by invoking `detectGhConfigDirMismatch` directly via `node` (through `tsx`), passing the same `HOME` the issue reports and a synthetic `fileExists` that pretends `/root/.config/gh/hosts.yml` is present.

### Expected

- All test files pass with the new cases.
- Both typecheck lanes exit 0.
- The helper returns `kind: "mismatch"` with `alternateConfigDir = /root/.config/gh` and `suggestedEnvValue = /root/.config/gh`.
- The formatted hint contains the operator-actionable `GH_CONFIG_DIR=/root/.config/gh` line.

### Actual

- `pnpm test` for the three test files: 28 passed in 15.68s.
- `pnpm tsgo:core` exit 0; `pnpm tsgo:core:test` exit 0.
- Live `node`/`tsx` invocation against the helper produced the expected `mismatch` result and the operator hint (transcript below).

## Real behavior proof

- Behavior or issue addressed: Issue #78063 - agent shells with `HOME=/root/.openclaw/agents/main/agent/codex-home/home` reported `gh` as unauthenticated even though `/root/.config/gh/hosts.yml` was a valid login. The doctor flow had no diagnostic for this HOME mismatch.
- Real environment tested: Ubuntu 24.04 workstation, Node 22.22.0, pnpm 10.33.2, branch `fix/78063-gh-config-dir-mismatch` at head `dd5ed0fa64`. Live invocation of the new helper via `node` (through `tsx` for ESM TypeScript path resolution).
- Exact steps or command run after this patch:
  1. Built a small `node` proof script that imports the new helper by absolute path and runs three scenarios: the exact `HOME=/root/.openclaw/agents/main/agent/codex-home/home` reproduction from the issue, the operator's already-applied `GH_CONFIG_DIR=/root/.config/gh` workaround, and an aligned `HOME=/root` baseline.
  2. Executed `node_modules/.bin/tsx /tmp/proof-78063.mts` and captured stdout.
  3. Confirmed the operator-actionable hint matches what `openclaw doctor` will print on the affected systems.
- Evidence after fix:

  Live console output captured at branch head `dd5ed0fa64` (real `node`/`tsx` invocations against the new helper, not lint/test gates):

  ```text
  $ git rev-parse HEAD
  dd5ed0fa64...

  $ node_modules/.bin/tsx /tmp/proof-78063.mts
  == Reproducing #78063 scenario: agent HOME differs from /root ==
  {
    "kind": "mismatch",
    "effectiveConfigDir": "/root/.openclaw/agents/main/agent/codex-home/home/.config/gh",
    "alternateConfigDir": "/root/.config/gh",
    "alternateHostsFile": "/root/.config/gh/hosts.yml",
    "alternateHomeHint": "/root",
    "suggestedEnvValue": "/root/.config/gh"
  }

  -- Operator hint that doctor will print --
  GitHub CLI auth was found at a different HOME than the one this OpenClaw process uses.
    Process gh config dir: /root/.openclaw/agents/main/agent/codex-home/home/.config/gh
    Authenticated config:  /root/.config/gh (contains hosts.yml)
    Authenticated HOME:    /root
    Fix: set GH_CONFIG_DIR=/root/.config/gh on the OpenClaw service environment, then restart the gateway.

  == Already-set GH_CONFIG_DIR (operator already applied workaround) ==
  {
    "kind": "explicit-gh-config-dir-set",
    "ghConfigDir": "/root/.config/gh"
  }

  == Auth resolves correctly (HOME and gh config aligned) ==
  {
    "kind": "auth-discoverable",
    "effectiveConfigDir": "/root/.config/gh"
  }
  ```

- Observed result after fix: With the agent HOME from the issue, `detectGhConfigDirMismatch` correctly identifies the `/root/.config/gh` candidate, reports it as a `mismatch`, and produces the exact operator hint a user would need to copy into the gateway service env file. With `GH_CONFIG_DIR` already set, the helper short-circuits to `explicit-gh-config-dir-set` (no false-positive hint). With aligned HOME, the helper reports `auth-discoverable` and no hint. The doctor flow only invokes the helper when the `github` skill is enabled and `gh` is on `PATH`.
- What was not tested: A live macOS reproduction with a real systemd analogue (the issue is reported on Ubuntu); a live Windows reproduction (the helper covers Windows `APPDATA` paths but the issue scenario is Linux-only); end-to-end interaction with `gh` itself (we read documented gh behavior, not the binary).

## Evidence

- [x] Failing test/log before + passing after - 17 new test cases lock in the helper and doctor wiring contracts.
- [x] Trace/log snippets - included above (live `tsx` capture of the operator hint).
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - The exact `HOME` from the issue produces a mismatch result whose `suggestedEnvValue` matches the operator's documented workaround.
  - The hint string matches what an operator would paste into `~/.openclaw/gateway.systemd.env`.
  - `GH_CONFIG_DIR` already set short-circuits the discovery (no duplicate hint).
  - `gh` binary missing suppresses the hint (the existing install hint covers it).
  - `github` skill missing suppresses the hint (no spurious noise on agents that disabled github).
- Edge cases checked:
  - SUDO_USER and USER fallbacks resolve to `/home/<user>` (or `/Users/<user>` on darwin).
  - XDG_CONFIG_HOME wins over $HOME/.config/gh on Linux.
  - Windows `APPDATA` and `USERPROFILE` lookups produce backslash-joined paths.
  - HOME equal to a candidate operator home does not produce a false mismatch.
- What you did **not** verify: A live `gh auth login` cycle on a macOS or Windows host; the actual systemd service env file reload behavior; tab-complete or shell-eval edge cases.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (the helper reads existing env; nothing new is required)
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A false positive could appear if a candidate operator home happens to contain a stale `hosts.yml` for an unrelated user, and the operator follows the suggested `GH_CONFIG_DIR` blindly.
  - Mitigation: The hint only suggests pointing `GH_CONFIG_DIR` at the discovered alternate; it does not modify env or copy credentials. The hint includes the candidate `HOME` so operators can sanity-check before applying it. The discovery is gated on the `github` skill being enabled and `gh` being on `PATH`.
- Risk: The `/root` candidate could be misleading on hosts where the gateway intentionally runs under an unprivileged user that has its own `hosts.yml`.
  - Mitigation: SUDO_USER and USER fallbacks add the actual login user's home to the candidate set. `auth-discoverable` short-circuits before any candidate scan when the agent's own HOME already has `hosts.yml`.