### PR TITLE
fix(ui): show session runtime in sessions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/generated media: treat attachment-style message tool actions as completed chat sends, preventing duplicate fallback media posts when generated files were already uploaded.
+- Control UI/sessions: show each session's agent runtime in the Sessions table and allow filtering by runtime labels, matching the Agents panel runtime wording. Thanks @vincentkoc.
 - Discord/streaming: show live reasoning text in progress drafts instead of a bare `Reasoning` status line.
 - Doctor/status: warn when `OPENCLAW_GATEWAY_TOKEN` would shadow a different active `gateway.auth.token` source for local CLI commands, while avoiding false positives when config points at the same env token. Fixes #74271. Thanks @yelog.
 - Gateway/HTTP: avoid loading managed outgoing-image media handlers for unrelated requests, so disabled OpenAI-compatible routes return 404 without waiting on lazy media sidecars. Thanks @vincentkoc.

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -367,6 +367,41 @@ describe("sessions view", () => {
     expect(badge?.textContent?.trim()).toBe("cron");
   });
 
+  it("renders and filters the session runtime", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildMultiResult([
+            {
+              key: "agent:main:claude",
+              kind: "direct",
+              updatedAt: 20,
+              agentRuntime: { id: "claude-cli", fallback: "none", source: "agent" },
+            },
+            {
+              key: "agent:main:pi",
+              kind: "direct",
+              updatedAt: 10,
+              agentRuntime: { id: "pi", source: "implicit" },
+            },
+          ]),
+        ),
+        searchQuery: "fallback none",
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(
+      Array.from(container.querySelectorAll("thead th")).map((cell) => cell.textContent?.trim()),
+    ).toContain("Runtime");
+    expect(container.querySelector(".session-runtime-cell")?.textContent?.trim()).toBe(
+      "claude-cli (fallback none)",
+    );
+    expect(container.textContent).not.toContain("agent:main:pi");
+  });
+
   it("keeps raw keys for inherited identity object properties", async () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -13,6 +13,7 @@ import type {
   SessionCompactionCheckpoint,
   SessionsListResult,
 } from "../types.ts";
+import { resolveAgentRuntimeLabel } from "./agents-utils.ts";
 
 export type SessionsProps = {
   loading: boolean;
@@ -178,7 +179,14 @@ function filterRows(
     const label = normalizeLowercaseStringOrEmpty(row.label);
     const kind = normalizeLowercaseStringOrEmpty(row.kind);
     const displayName = normalizeLowercaseStringOrEmpty(row.displayName);
-    if (key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q)) {
+    const runtime = normalizeLowercaseStringOrEmpty(resolveAgentRuntimeLabel(row.agentRuntime));
+    if (
+      key.includes(q) ||
+      label.includes(q) ||
+      kind.includes(q) ||
+      displayName.includes(q) ||
+      runtime.includes(q)
+    ) {
       return true;
     }
     const keyParts = parseSessionKeyParts(row.key);
@@ -543,6 +551,7 @@ export function renderSessions(props: SessionsProps) {
                 ${sortHeader("key", t("sessionsView.key"), "data-table-key-col")}
                 <th>${t("sessionsView.label")}</th>
                 ${sortHeader("kind", t("sessionsView.kind"))}
+                <th>${t("agents.context.runtime")}</th>
                 ${sortHeader("updated", t("sessionsView.updated"))}
                 ${sortHeader("tokens", t("sessionsView.tokens"))}
                 <th>${t("sessionsView.compaction")}</th>
@@ -556,7 +565,7 @@ export function renderSessions(props: SessionsProps) {
               ${paginated.length === 0
                 ? html`
                     <tr>
-                      <td colspan="11" class="data-table-empty-cell">
+                      <td colspan="12" class="data-table-empty-cell">
                         ${emptyBecauseFiltered
                           ? html`
                               <div class="data-table-empty-state" role="status" aria-live="polite">
@@ -748,6 +757,9 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
       <td>
         <span class="data-table-badge ${badgeClass}">${row.kind}</span>
       </td>
+      <td class="session-runtime-cell">
+        <span class="mono">${resolveAgentRuntimeLabel(row.agentRuntime)}</span>
+      </td>
       <td>${updated}</td>
       <td class="session-token-cell">${formatSessionTokens(row)}</td>
       <td>
@@ -858,7 +870,7 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
     ...(isExpanded && hasCheckpoints
       ? [
           html`<tr id=${detailsId} class="session-checkpoint-details-row">
-            <td colspan="11" style="padding: 0;">
+            <td colspan="12" style="padding: 0;">
               <div
                 style="padding: 14px 16px; border-top: 1px solid var(--border); background: var(--surface-2, rgba(127, 127, 127, 0.05));"
               >


### PR DESCRIPTION
## Summary

- Problem: Control UI Sessions table omitted the per-session agent runtime even though `sessions.list` rows already carry `agentRuntime`.
- Why it matters: users could see runtime/harness selection in `/status`, `openclaw status`, `openclaw sessions`, and Agents, but not the browser Sessions view.
- What changed: add a Runtime column, reuse the Agents runtime label formatter, make runtime labels searchable, and cover the behavior in `sessions.test.ts`.
- What did NOT change (scope boundary): no Gateway RPC shape or session persistence changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #77776
- Related #78056
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Sessions table rendered key/kind/model-control metadata but never projected the existing `GatewaySessionRow.agentRuntime` field.
- Missing detection / guardrail: the sessions view test did not assert runtime visibility or runtime filtering.
- Contributing context (if known): runtime visibility was added to nearby status surfaces first, leaving the browser Sessions table behind.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/sessions.test.ts`
- Scenario the test should lock in: a session row with `agentRuntime: { id: "claude-cli", fallback: "none" }` renders `Runtime` and can be found by runtime label text.
- Why this is the smallest reliable guardrail: this is a pure table projection/filtering gap in the Lit render function.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The Control UI Sessions table now includes a Runtime column and runtime text participates in the existing session search.

## Diagram (if applicable)

```text
Before:
sessions.list row -> Sessions table -> runtime hidden

After:
sessions.list row -> Sessions table -> Runtime column + searchable runtime label
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS maintainer worktree
- Runtime/container: Node/pnpm local; Blacksmith Testbox attempted
- Model/provider: N/A
- Integration/channel (if any): Control UI Sessions view
- Relevant config (redacted): N/A

### Steps

1. Render `renderSessions` with a `GatewaySessionRow.agentRuntime` value.
2. Search for runtime fallback label text.
3. Run the changed gate for the touched UI/core lanes.

### Expected

- Runtime label is visible in the table.
- Runtime label text participates in filtering.
- Targeted and changed-lane checks pass.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification run:

```bash
pnpm test:serial ui/src/ui/views/sessions.test.ts -- --reporter=verbose
pnpm exec oxfmt --check --threads=1 ui/src/ui/views/sessions.ts ui/src/ui/views/sessions.test.ts
git diff --check
OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed
```

Targeted sessions test passed: 1 file, 18 tests. `pnpm check:changed` passed with lanes `core`, `coreTests`, and `docs`.

Testbox note: claimed `tbx_01kqx2gkvr06h7pgcghvwck8m8`, but `pnpm check:changed` stayed queued, so the claimed box was stopped and the documented throttled local fallback was used.

## Human Verification (required)

- Verified scenarios: Runtime column render, fallback label formatting, runtime text filtering, empty/checkpoint table colspan adjustment through the focused sessions view suite.
- Edge cases checked: implicit `pi` row is filtered out when searching for `fallback none`.
- What you did **not** verify: live browser screenshot against a running Gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the Sessions table gets one column wider.
  - Mitigation: keep the cell compact and reuse the existing monospace runtime label.
