### PR TITLE
fix: reset telegram sticky fallback after recovery

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -827,6 +827,37 @@ describe("resolveTelegramFetch", () => {
     );
   });
 
+  it("returns to the default dispatcher after repeated sticky fallback successes", async () => {
+    undiciFetch
+      .mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"))
+      .mockResolvedValueOnce({ ok: true } as Response);
+    for (let i = 0; i < 5; i += 1) {
+      undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+    }
+    undiciFetch.mockResolvedValueOnce({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: true,
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/sendMessage");
+    for (let i = 0; i < 5; i += 1) {
+      await resolved("https://api.telegram.org/botx/sendChatAction");
+    }
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(undiciFetch).toHaveBeenCalledTimes(8);
+    const defaultDispatcher = getDispatcherFromUndiciCall(1);
+    const stickyDispatcher = getDispatcherFromUndiciCall(2);
+    expect(stickyDispatcher).toBe(getDispatcherFromUndiciCall(7));
+    expect(getDispatcherFromUndiciCall(8)).toBe(defaultDispatcher);
+    expect(loggerDebug).toHaveBeenCalledWith(
+      expect.stringContaining("resetting sticky dispatcher after 5 successful fallback requests"),
+    );
+  });
+
   it("escalates from IPv4 fallback to pinned Telegram IP and keeps it sticky", async () => {
     undiciFetch
       .mockRejectedValueOnce(buildFetchFallbackError("ETIMEDOUT"))

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -41,6 +41,7 @@ const TELEGRAM_DISPATCHER_KEEP_ALIVE_TIMEOUT_MS = 30_000;
 const TELEGRAM_DISPATCHER_KEEP_ALIVE_MAX_TIMEOUT_MS = 600_000;
 const TELEGRAM_DISPATCHER_CONNECTIONS_PER_ORIGIN = 10;
 const TELEGRAM_DISPATCHER_PIPELINING = 1;
+const TELEGRAM_STICKY_ATTEMPT_RESET_SUCCESS_THRESHOLD = 5;
 
 type TelegramAgentPoolOptions = {
   allowH2: false;
@@ -639,6 +640,28 @@ export function resolveTelegramTransport(
   });
 
   let stickyAttemptIndex = 0;
+  let consecutiveStickyAttemptSuccesses = 0;
+
+  const recordStickyAttemptSuccess = (attemptIndex: number): void => {
+    if (attemptIndex === 0 || attemptIndex !== stickyAttemptIndex) {
+      consecutiveStickyAttemptSuccesses = 0;
+      return;
+    }
+    consecutiveStickyAttemptSuccesses += 1;
+    if (consecutiveStickyAttemptSuccesses < TELEGRAM_STICKY_ATTEMPT_RESET_SUCCESS_THRESHOLD) {
+      return;
+    }
+    log.debug(
+      `telegram fetch fallback: resetting sticky dispatcher after ${consecutiveStickyAttemptSuccesses} successful fallback requests`,
+    );
+    stickyAttemptIndex = 0;
+    consecutiveStickyAttemptSuccesses = 0;
+  };
+
+  const resetStickyAttemptSuccesses = (): void => {
+    consecutiveStickyAttemptSuccesses = 0;
+  };
+
   const promoteStickyAttempt = (nextIndex: number, err: unknown, reason?: string): boolean => {
     if (nextIndex <= stickyAttemptIndex || nextIndex >= transportAttempts.length) {
       return false;
@@ -654,6 +677,7 @@ export function resolveTelegramTransport(
       }
     }
     stickyAttemptIndex = nextIndex;
+    resetStickyAttemptSuccesses();
     return true;
   };
 
@@ -669,6 +693,7 @@ export function resolveTelegramTransport(
         input,
         withDispatcherIfMissing(init, transportAttempts[startIndex].createDispatcher()),
       );
+      recordStickyAttemptSuccess(startIndex);
       captureHttpExchange({
         url: resolveRequestUrl(input),
         method: init?.method ?? "GET",
@@ -681,6 +706,7 @@ export function resolveTelegramTransport(
       return response;
     } catch (caught) {
       err = caught;
+      resetStickyAttemptSuccesses();
     }
 
     if (!shouldUseTelegramTransportFallback(err)) {
@@ -698,6 +724,7 @@ export function resolveTelegramTransport(
           input,
           withDispatcherIfMissing(init, nextAttempt.createDispatcher()),
         );
+        resetStickyAttemptSuccesses();
         captureHttpExchange({
           url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
@@ -710,6 +737,7 @@ export function resolveTelegramTransport(
         return response;
       } catch (caught) {
         err = caught;
+        resetStickyAttemptSuccesses();
         if (!shouldUseTelegramTransportFallback(err)) {
           throw err;
         }


### PR DESCRIPTION
## Summary

Resets Telegram's sticky fallback dispatcher after recovery.

`stickyAttemptIndex` was monotonic: after a transient default transport failure, Telegram could stay on the IPv4 or pinned fallback dispatcher forever. That is lazy failure-state handling. The fallback should be sticky long enough to survive a blip, not become a permanent process-lifetime downgrade.

## Changes

- Add an internal threshold of 5 successful requests that start on the current sticky fallback attempt.
- Reset `stickyAttemptIndex` back to the default dispatcher after that threshold.
- Reset the success counter on promotion, fallback success during promotion, or failure.
- Add regression coverage proving the transport returns to the original default dispatcher after sticky recovery.

## Testing

- `git diff --check fork/main...HEAD` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test extensions/telegram/src/fetch.test.ts extensions/telegram/src/polling-transport-state.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/send.test.ts -- --reporter=dot` — passed, 4 files, 155 tests.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed.

Fixes #77088
