### PR TITLE
fix: deliver command replies despite source suppression

### DIFF
--- a/src/auto-reply/reply/commands-core.send-policy.test.ts
+++ b/src/auto-reply/reply/commands-core.send-policy.test.ts
@@ -115,5 +115,9 @@ describe("handleCommands send policy", () => {
         replyToCurrent: false,
       },
     });
+    const { getReplyPayloadMetadata } = await import("../reply-payload.js");
+    expect(getReplyPayloadMetadata(result.reply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+    });
   });
 });

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,5 +1,6 @@
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
+import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import { maybeHandleResetCommand } from "./commands-reset.js";
 import type {
   CommandHandler,
@@ -22,11 +23,11 @@ function normalizeCommandHandlerResult(result: CommandHandlerResult): CommandHan
   }
   return {
     ...result,
-    reply: {
+    reply: markReplyPayloadForSourceSuppressionDelivery({
       ...result.reply,
       replyToId: undefined,
       replyToCurrent: false,
-    },
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary

Keeps text command replies visible even when group/channel source replies are configured as `message_tool` / message-tool-only.

The broken behavior was caused by treating command replies like normal assistant final replies. In groups, normal assistant replies may be source-suppressed so the model must use the message tool. Canned command replies are not model chatter; they are explicit command output. Suppressing them is just dropping the user's `/newsession` confirmation on the floor.

## Changes

- Mark normalized command handler replies with `deliverDespiteSourceReplySuppression` metadata.
- Preserve existing non-threaded command reply normalization.
- Preserve `sendPolicy: deny` as the hard delivery gate.
- Add regression coverage that command replies carry the source-suppression bypass metadata.

## Testing

- `git diff --check fork/main...HEAD` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/auto-reply/reply/source-reply-delivery-mode.test.ts src/auto-reply/reply/commands-core.send-policy.test.ts src/auto-reply/reply/dispatch-from-config.test.ts -- --reporter=dot` — passed, 3 files, 122 tests.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed.

Fixes #77260
