### PR TITLE
fix: surface silent turn error payloads

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -553,6 +553,25 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("keeps error payloads during silent turns", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      silentExpected: true,
+      payloads: [
+        {
+          text: "⚠️ Write failed: Memory flush writes are restricted to memory/2026-05-05.md",
+          isError: true,
+        },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      text: "⚠️ Write failed: Memory flush writes are restricted to memory/2026-05-05.md",
+      isError: true,
+    });
+  });
+
   it("keeps voice media payloads during silent turns", async () => {
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -91,6 +91,9 @@ async function normalizeSentMediaUrlsForDedupe(params: {
 }
 
 function shouldKeepPayloadDuringSilentTurn(payload: ReplyPayload): boolean {
+  if (payload.isError === true) {
+    return true;
+  }
   return payload.audioAsVoice === true && resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 


### PR DESCRIPTION
## Summary

Surfaces error payloads from silent/maintenance turns instead of filtering them away.

The memory-flush write guard was doing the right thing by rejecting writes outside the allowed memory file. The garbage part was downstream: the runner could convert the tool rejection into an `isError` payload, then `silentExpected` filtering dropped every non-voice payload. That makes a safety rail look like a hung agent.

## Changes

- Keep `isError` payloads during silent turns.
- Preserve existing suppression of ordinary silent text/media payloads.
- Add regression coverage for a restricted memory-flush write warning surviving silent-turn filtering.

## Testing

- `git diff --check fork/main...HEAD` — passed.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts -- --reporter=dot` — passed, 2 files, 73 tests.
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — passed.

Fixes #77821
