### PR TITLE
Fix plugin shared state across repeated register calls

### DIFF
--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -47,6 +47,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerCodexAppServerExtensionFactory() {},
     registerAgentToolResultMiddleware() {},
     registerDetachedTaskRuntime() {},
+    getSharedState: () => Object.create(null),
     registerSessionExtension() {},
     enqueueNextTurnInjection: async (injection) => ({
       enqueued: false,

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -65,6 +65,7 @@ export type BuildPluginApiParams = {
       | "clearRunContext"
       | "registerSessionSchedulerJob"
       | "registerDetachedTaskRuntime"
+      | "getSharedState"
       | "registerMemoryCapability"
       | "registerMemoryPromptSection"
       | "registerMemoryPromptSupplement"
@@ -139,6 +140,7 @@ const noopClearRunContext: OpenClawPluginApi["clearRunContext"] = () => {};
 const noopRegisterSessionSchedulerJob: OpenClawPluginApi["registerSessionSchedulerJob"] = () =>
   undefined;
 const noopRegisterDetachedTaskRuntime: OpenClawPluginApi["registerDetachedTaskRuntime"] = () => {};
+const noopGetSharedState: OpenClawPluginApi["getSharedState"] = () => Object.create(null);
 const noopRegisterMemoryCapability: OpenClawPluginApi["registerMemoryCapability"] = () => {};
 const noopRegisterMemoryPromptSection: OpenClawPluginApi["registerMemoryPromptSection"] = () => {};
 const noopRegisterMemoryPromptSupplement: OpenClawPluginApi["registerMemoryPromptSupplement"] =
@@ -229,6 +231,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
       handlers.registerSessionSchedulerJob ?? noopRegisterSessionSchedulerJob,
     registerDetachedTaskRuntime:
       handlers.registerDetachedTaskRuntime ?? noopRegisterDetachedTaskRuntime,
+    getSharedState: handlers.getSharedState ?? noopGetSharedState,
     registerMemoryCapability: handlers.registerMemoryCapability ?? noopRegisterMemoryCapability,
     registerMemoryPromptSection:
       handlers.registerMemoryPromptSection ?? noopRegisterMemoryPromptSection,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1869,6 +1869,47 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(registry.plugins).toEqual([]);
   });
 
+  it("shares plugin state across repeated register calls", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "shared-register-state",
+      filename: "shared-register-state.cjs",
+      body: `module.exports = {
+        id: "shared-register-state",
+        register(api) {
+          const state = api.getSharedState();
+          state.registerCalls = Number(state.registerCalls || 0) + 1;
+          api.on("before_prompt_build", () => ({
+            appendSystemContext: "registerCalls:" + state.registerCalls,
+          }));
+        },
+      };`,
+    });
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["shared-register-state"],
+        },
+      },
+    };
+
+    const active = loadOpenClawPlugins({ ...options, cache: false });
+    loadOpenClawPlugins({
+      ...options,
+      cache: false,
+      activate: false,
+      onlyPluginIds: ["shared-register-state"],
+    });
+
+    const result = await createHookRunner(active).runBeforePromptBuild(
+      { prompt: "test", messages: [] },
+      {},
+    );
+    expect(result?.appendSystemContext).toBe("registerCalls:2");
+  });
+
   it("skips discovery and manifest registry loading entirely when onlyPluginIds is an explicit empty array", async () => {
     useNoBundledPlugins();
     const allowed = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -127,6 +127,7 @@ import type {
 import { withPluginRuntimePluginIdScope } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { normalizeSessionEntrySlotKey } from "./session-entry-slot-keys.js";
+import { getPluginSharedState } from "./shared-state.js";
 import { defaultSlotIdForKey, hasKind } from "./slots.js";
 import {
   findUndeclaredPluginToolNames,
@@ -2469,6 +2470,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                 });
               },
               registerSessionSchedulerJob: (job) => registerSessionSchedulerJob(record, job),
+              getSharedState: () => getPluginSharedState(record.id),
               registerMemoryCapability: (capability) => {
                 if (!hasKind(record.kind, "memory")) {
                   throwRegistrationError("only memory plugins can register a memory capability");

--- a/src/plugins/shared-state.ts
+++ b/src/plugins/shared-state.ts
@@ -1,0 +1,27 @@
+const PLUGIN_SHARED_STATE_KEY = Symbol.for("openclaw.plugins.sharedState.v1");
+
+type PluginSharedState = Record<string, unknown>;
+
+type GlobalStore = typeof globalThis & {
+  [PLUGIN_SHARED_STATE_KEY]?: Map<string, PluginSharedState>;
+};
+
+function resolvePluginSharedStateMap(): Map<string, PluginSharedState> {
+  const store = globalThis as GlobalStore;
+  let states = store[PLUGIN_SHARED_STATE_KEY];
+  if (!states) {
+    states = new Map<string, PluginSharedState>();
+    store[PLUGIN_SHARED_STATE_KEY] = states;
+  }
+  return states;
+}
+
+export function getPluginSharedState(pluginId: string): PluginSharedState {
+  const states = resolvePluginSharedStateMap();
+  let state = states.get(pluginId);
+  if (!state) {
+    state = Object.create(null) as PluginSharedState;
+    states.set(pluginId, state);
+  }
+  return state;
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2528,6 +2528,14 @@ export type OpenClawPluginApi = {
   registerDetachedTaskRuntime: (
     runtime: import("./runtime/runtime-tasks.types.js").DetachedTaskLifecycleRuntime,
   ) => void;
+  /**
+   * Return the plugin's process-local shared state object.
+   *
+   * Plugin entrypoints may be registered more than once for discovery, scoped
+   * runtime loads, and tool materialization. Store ephemeral coordination state
+   * here instead of relying on closure variables inside one `register(api)` call.
+   */
+  getSharedState: () => Record<string, unknown>;
   /** Register the active memory capability for this memory plugin (exclusive slot). */
   registerMemoryCapability: (
     capability: import("./memory-state.js").MemoryPluginCapability,


### PR DESCRIPTION
Fixes #77822.

## Summary
- add a plugin-id-scoped process-local shared state store
- expose it as `api.getSharedState()` so repeated `register(api)` instances can coordinate explicitly
- add a regression test covering state shared across repeated register calls

## Verification
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" ./node_modules/.bin/vitest run --config /tmp/vitest-issue-77822.config.ts` (182 tests passed)
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
