### PR TITLE
fix: skip empty wiki pages during related refresh

### DIFF
--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -170,6 +170,39 @@ describe("compileMemoryWikiVault", () => {
     );
   });
 
+  it("leaves empty pages unchanged when refreshing related blocks", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+
+    const emptySourcePath = path.join(rootDir, "sources", "empty.md");
+    await fs.writeFile(emptySourcePath, "", "utf8");
+    const whitespaceSourcePath = path.join(rootDir, "sources", "whitespace.md");
+    await fs.writeFile(whitespaceSourcePath, " \n\t\n", "utf8");
+
+    await fs.writeFile(
+      path.join(rootDir, "entities", "beta.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.beta",
+          title: "Beta",
+          sourceIds: ["source.empty"],
+        },
+        body: "# Beta\n",
+      }),
+      "utf8",
+    );
+
+    const result = await compileMemoryWikiVault(config);
+
+    await expect(fs.readFile(emptySourcePath, "utf8")).resolves.toBe("");
+    await expect(fs.readFile(whitespaceSourcePath, "utf8")).resolves.toBe(" \n\t\n");
+    expect(result.updatedFiles).not.toContain(emptySourcePath);
+    expect(result.updatedFiles).not.toContain(whitespaceSourcePath);
+  });
+
   it("does not relate every page through a broad shared source", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -774,6 +774,9 @@ async function refreshPageRelatedBlocks(params: {
       continue;
     }
     const original = await fs.readFile(page.absolutePath, "utf8");
+    if (original.trim().length === 0) {
+      continue;
+    }
     const updated = withTrailingNewline(
       replaceManagedMarkdownBlock({
         original,


### PR DESCRIPTION
## Summary

Prevent memory wiki related-block refresh from rewriting zero-byte or whitespace-only pages into managed `## Related` stubs. Empty pages are now left unchanged so the refresh path does not turn transient empty reads into persistent 107-byte source-page stubs.

## Changes

- Skip related-block writes when the current page content is empty or whitespace-only.
- Add a regression test covering zero-byte and whitespace-only source pages during `compileMemoryWikiVault`.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs extensions/memory-wiki/src/compile.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

Fixes openclaw/openclaw#78121