### PR TITLE
feat: add configurable trajectory flush timeout for reasoning traces

### DIFF
--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -35,6 +35,7 @@ import type { PluginsConfig } from "./types.plugins.js";
 import type { SecretsConfig } from "./types.secrets.js";
 import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
+import type { TrajectoryConfig } from "./types.trajectory.js";
 import type { ProxyConfig } from "./zod-schema.proxy.js";
 
 export type SurfaceConfigEntry = {
@@ -116,6 +117,7 @@ export type OpenClawConfig = {
   nodeHost?: NodeHostConfig;
   agents?: AgentsConfig;
   tools?: ToolsConfig;
+  trajectory?: TrajectoryConfig;
   bindings?: AgentBinding[];
   broadcast?: BroadcastConfig;
   audio?: AudioConfig;

--- a/src/config/types.trajectory.ts
+++ b/src/config/types.trajectory.ts
@@ -1,0 +1,10 @@
+export type TrajectoryConfig = {
+  /**
+   * Interval (ms) for periodic flush of trajectory events to storage.
+   * When set, the trajectory recorder will flush buffered events to disk
+   * at this interval, in addition to explicit flushes at turn/session boundaries.
+   *
+   * @default undefined (no periodic flush)
+   */
+  flushTimeoutMs?: number;
+};

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -40,6 +40,31 @@ type TrajectoryRuntimeInit = {
   writer?: QueuedFileWriter;
 };
 
+/**
+ * Resolve the trajectory flush timeout (ms) from config or env.
+ * Reads, in order:
+ *  1. cfg.trajectory.flushTimeoutMs (openclaw.json)
+ *  2. env.OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS
+ *  3. undefined (no periodic flush)
+ */
+function resolveFlushTimeoutMs(
+  cfg?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): number | undefined {
+  const cfgValue = cfg?.trajectory?.flushTimeoutMs;
+  if (typeof cfgValue === "number" && cfgValue > 0) {
+    return cfgValue;
+  }
+  const envValue = env?.OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS?.trim();
+  if (envValue) {
+    const parsed = parseInt(envValue, 10);
+    if (!isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
 type TrajectoryRuntimeRecorder = {
   enabled: true;
   filePath: string;
@@ -272,6 +297,32 @@ export function createTrajectoryRuntimeRecorder(
   let droppedEventBytes = 0;
   let captureStopped = false;
 
+  // Periodic flush timer (configurable via cfg or env).
+  const flushTimeoutMs = resolveFlushTimeoutMs(params.cfg, env);
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastFlushTime = Date.now();
+
+  const scheduleFlush = () => {
+    if (flushTimer || flushTimeoutMs === undefined) {
+      return;
+    }
+    flushTimer = setTimeout(async () => {
+      flushTimer = null;
+      await writer.flush();
+      lastFlushTime = Date.now();
+    }, flushTimeoutMs);
+  };
+
+  const cancelFlushTimer = () => {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+  };
+
+  // Initial schedule.
+  scheduleFlush();
+
   const writeBoundedLine = (line: string, options: { reserveSentinel: boolean }): boolean => {
     const jsonlLine = `${line}\n`;
     const lineBytes = Buffer.byteLength(jsonlLine, "utf8");
@@ -338,8 +389,17 @@ export function createTrajectoryRuntimeRecorder(
         return;
       }
       writeBoundedLine(line, { reserveSentinel: true });
+
+      // Reschedule periodic flush on new events.
+      if (flushTimeoutMs !== undefined) {
+        cancelFlushTimer();
+        scheduleFlush();
+      }
     },
     flush: async () => {
+      // Cancel any pending periodic flush.
+      cancelFlushTimer();
+
       if (droppedEvents > 0) {
         const line = buildEventLine("trace.truncated", {
           reason: "trajectory-runtime-file-size-limit",
@@ -357,6 +417,10 @@ export function createTrajectoryRuntimeRecorder(
       if (!params.writer) {
         writers.delete(filePath);
       }
+
+      // Reschedule periodic flush if enabled.
+      lastFlushTime = Date.now();
+      scheduleFlush();
     },
   };
 }


### PR DESCRIPTION
Duplicate of existing trajectory flush timeout work (see #77373). Closing.