### PR TITLE
fix: avoid stalled Discord gateway registration

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -66,7 +66,10 @@ function assignGatewayClient(
 
 function hasGatewaySocketStarted(plugin: discordGateway.GatewayPlugin): boolean {
   const state = plugin as unknown as DiscordGatewayRegistrationState;
-  return state.ws != null || state.isConnecting === true;
+  // `isConnecting` without an active socket is stale bookkeeping, not a
+  // started gateway transport. Treating that as started skips
+  // super.registerClient(), leaving startup to wait for READY on nothing.
+  return state.ws != null;
 }
 
 type ResolveDiscordGatewayIntentsParams = {

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -733,7 +733,7 @@ describe("createDiscordGatewayPlugin", () => {
     await runCase((plugin) => {
       (plugin as { isConnecting: boolean }).isConnecting = true;
     });
-    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
+    expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes fallback gateway metadata on the next register attempt", async () => {


### PR DESCRIPTION
## Summary
- fix Discord gateway registration so stale `isConnecting=true` without an active socket does not suppress `super.registerClient(client)`
- keep the existing guard for an actual already-started gateway WebSocket
- update the regression test to cover the stale bookkeeping case from #78104

Fixes #78104.

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm test extensions/discord/src/monitor/provider.proxy.test.ts extensions/discord/src/monitor/gateway-plugin.test.ts extensions/discord/src/internal/gateway.test.ts extensions/discord/src/monitor/provider.lifecycle.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check --threads=1 extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/provider.proxy.test.ts`
