### PR TITLE
fix: cache plugin registry snapshot loads

### DIFF
--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -3,12 +3,18 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
-import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
+import {
+  loadPluginRegistrySnapshotWithMetadata,
+  PLUGIN_REGISTRY_SNAPSHOT_CACHE_TTL_MS,
+  resetPluginRegistrySnapshotCacheForTest,
+} from "./plugin-registry-snapshot.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
+  resetPluginRegistrySnapshotCacheForTest();
   vi.restoreAllMocks();
   cleanupTrackedTempDirs(tempDirs);
 });
@@ -231,6 +237,62 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
 
     expect(result.source).toBe("persisted");
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("coalesces repeated registry snapshot loads for a short TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-05T00:00:00.000Z"));
+    const tempRoot = makeTempDir();
+    const rootDir = path.join(tempRoot, "workspace");
+    const stateDir = path.join(tempRoot, "state");
+    const env = { ...createHermeticEnv(tempRoot), OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" };
+    const config = {
+      plugins: {
+        load: { paths: [rootDir] },
+      },
+    };
+    writePackagePlugin(rootDir);
+    const index = loadInstalledPluginIndex({ config, env });
+    writePersistedInstalledPluginIndexSync(index, { stateDir });
+
+    const first = loadPluginRegistrySnapshotWithMetadata({
+      config,
+      env,
+      stateDir,
+    });
+    expect(first.source).toBe("persisted");
+
+    fs.writeFileSync(
+      path.join(rootDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "demo",
+        name: "Demo",
+        description: "changed within cache ttl",
+        configSchema: { type: "object" },
+      }),
+      "utf8",
+    );
+
+    const cached = loadPluginRegistrySnapshotWithMetadata({
+      config,
+      env,
+      stateDir,
+    });
+    expect(cached).toBe(first);
+    expect(cached.source).toBe("persisted");
+
+    vi.advanceTimersByTime(PLUGIN_REGISTRY_SNAPSHOT_CACHE_TTL_MS + 1);
+
+    const refreshed = loadPluginRegistrySnapshotWithMetadata({
+      config,
+      env,
+      stateDir,
+    });
+    expect(refreshed).not.toBe(first);
+    expect(refreshed.source).toBe("derived");
+    expect(refreshed.diagnostics).toContainEqual(
+      expect.objectContaining({ code: "persisted-registry-stale-source" }),
+    );
   });
 
   it("detects same-size same-mtime manifest replacements", () => {

--- a/src/plugins/plugin-registry-snapshot.ts
+++ b/src/plugins/plugin-registry-snapshot.ts
@@ -48,6 +48,19 @@ export type PluginRegistrySnapshotResult = {
 };
 
 export const DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV = "OPENCLAW_DISABLE_PERSISTED_PLUGIN_REGISTRY";
+export const PLUGIN_REGISTRY_SNAPSHOT_CACHE_TTL_MS = 1_000;
+
+type CachedPluginRegistrySnapshotResult = {
+  key: string;
+  result: PluginRegistrySnapshotResult;
+  expiresAt: number;
+};
+
+let cachedPluginRegistrySnapshotResult: CachedPluginRegistrySnapshotResult | null = null;
+
+export function resetPluginRegistrySnapshotCacheForTest(): void {
+  cachedPluginRegistrySnapshotResult = null;
+}
 
 function formatDeprecatedPersistedRegistryDisableWarning(): string {
   return `${DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV} is a deprecated break-glass compatibility switch; use \`openclaw plugins registry --refresh\` or \`openclaw doctor --fix\` to repair registry state.`;
@@ -191,6 +204,26 @@ function hasRecoveredInstallRecordsMissingFromPersistedIndex(
   );
 }
 
+function resolvePluginRegistrySnapshotCacheKey(
+  params: LoadPluginRegistryParams,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (params.index || params.installRecords) {
+    return null;
+  }
+  return JSON.stringify({
+    stateDir: params.stateDir ?? env.OPENCLAW_STATE_DIR ?? null,
+    filePath: params.filePath ?? null,
+    pluginIndexFilePath: params.pluginIndexFilePath ?? null,
+    preferPersisted: params.preferPersisted ?? null,
+    disabled: hasEnvFlag(env, DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV),
+    bundledPluginsDir: env.OPENCLAW_BUNDLED_PLUGINS_DIR ?? null,
+    bundledDisabled: env.OPENCLAW_DISABLE_BUNDLED_PLUGINS ?? null,
+    version: env.OPENCLAW_VERSION ?? null,
+    policyHash: params.config ? resolveInstalledPluginIndexPolicyHash(params.config) : null,
+  });
+}
+
 export function loadPluginRegistrySnapshotWithMetadata(
   params: LoadPluginRegistryParams = {},
 ): PluginRegistrySnapshotResult {
@@ -203,6 +236,16 @@ export function loadPluginRegistrySnapshotWithMetadata(
   }
 
   const env = params.env ?? process.env;
+  const cacheKey = resolvePluginRegistrySnapshotCacheKey(params, env);
+  const now = Date.now();
+  if (
+    cacheKey &&
+    cachedPluginRegistrySnapshotResult &&
+    cachedPluginRegistrySnapshotResult.key === cacheKey &&
+    cachedPluginRegistrySnapshotResult.expiresAt > now
+  ) {
+    return cachedPluginRegistrySnapshotResult.result;
+  }
   const diagnostics: PluginRegistrySnapshotDiagnostic[] = [];
   const disabledByCaller = params.preferPersisted === false;
   const disabledByEnv = hasEnvFlag(env, DISABLE_PERSISTED_PLUGIN_REGISTRY_ENV);
@@ -256,11 +299,19 @@ export function loadPluginRegistrySnapshotWithMetadata(
             "Persisted plugin registry is missing recoverable managed npm plugins; using derived plugin index. Run `openclaw plugins registry --refresh` to update the persisted registry.",
         });
       } else {
-        return {
+        const result = {
           snapshot: persistedIndex,
           source: "persisted",
           diagnostics,
-        };
+        } satisfies PluginRegistrySnapshotResult;
+        if (cacheKey) {
+          cachedPluginRegistrySnapshotResult = {
+            key: cacheKey,
+            result,
+            expiresAt: now + PLUGIN_REGISTRY_SNAPSHOT_CACHE_TTL_MS,
+          };
+        }
+        return result;
       }
     } else if (persistedReadsEnabled) {
       diagnostics.push({
@@ -279,7 +330,7 @@ export function loadPluginRegistrySnapshotWithMetadata(
     });
   }
 
-  return {
+  const result = {
     snapshot: loadInstalledPluginIndex({
       ...params,
       ...(persistedInstallRecordReadsEnabled
@@ -288,7 +339,15 @@ export function loadPluginRegistrySnapshotWithMetadata(
     }),
     source: "derived",
     diagnostics,
-  };
+  } satisfies PluginRegistrySnapshotResult;
+  if (cacheKey) {
+    cachedPluginRegistrySnapshotResult = {
+      key: cacheKey,
+      result,
+      expiresAt: now + PLUGIN_REGISTRY_SNAPSHOT_CACHE_TTL_MS,
+    };
+  }
+  return result;
 }
 
 function resolveSnapshot(params: LoadPluginRegistryParams = {}): PluginRegistrySnapshot {
@@ -324,5 +383,6 @@ export function inspectPluginRegistry(
 export function refreshPluginRegistry(
   params: RefreshInstalledPluginIndexParams & InstalledPluginIndexStoreOptions,
 ): Promise<PluginRegistrySnapshot> {
+  cachedPluginRegistrySnapshotResult = null;
   return refreshPersistedInstalledPluginIndex(params);
 }


### PR DESCRIPTION
Fixes #78100.

## Summary
- add a 1s process-local TTL cache for equivalent `loadPluginRegistrySnapshotWithMetadata` calls
- key the cache by state/index paths, persisted-read mode, relevant plugin env flags, bundled dir/version, and policy hash
- keep explicit caller-provided `index` / `installRecords` exact by bypassing the cache
- clear the cache before `refreshPluginRegistry`

## Tests
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/plugin-registry-snapshot.test.ts`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm exec oxfmt --check src/plugins/plugin-registry-snapshot.ts src/plugins/plugin-registry-snapshot.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

## Notes
The cache deliberately permits at most a short stale window for implicit registry loads. Explicit data paths and registry refresh remain uncached/invalidating.
