### PR TITLE
fix: keep Matrix room final replies automatic

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -402,6 +402,72 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
+  it("keeps automatic final replies for Matrix rooms when visibleReplies is unset", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: true,
+      counts: { final: 1, block: 0, tool: 0 },
+    }));
+    const { handler } = createMatrixHandlerTestHarness({
+      dispatchReplyFromConfig,
+      isDirectMessage: false,
+      roomsConfig: {
+        "!room:example.org": { requireMention: false },
+      },
+      getMemberDisplayName: async () => "sender",
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$room-auto-final",
+        body: "hello from matrix room",
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.objectContaining({
+          sourceReplyDeliveryMode: "automatic",
+        }),
+      }),
+    );
+  });
+
+  it("honors explicit Matrix room visibleReplies policy", async () => {
+    const dispatchReplyFromConfig = vi.fn(async () => ({
+      queuedFinal: false,
+      counts: { final: 0, block: 0, tool: 0 },
+    }));
+    const { handler } = createMatrixHandlerTestHarness({
+      cfg: {
+        messages: { groupChat: { visibleReplies: "message_tool" } },
+        channels: { matrix: { dm: { allowFrom: ["*"] } } },
+      },
+      dispatchReplyFromConfig,
+      isDirectMessage: false,
+      roomsConfig: {
+        "!room:example.org": { requireMention: false },
+      },
+      getMemberDisplayName: async () => "sender",
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$room-message-tool-final",
+        body: "hello from matrix room",
+      }),
+    );
+
+    expect(dispatchReplyFromConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyOptions: expect.not.objectContaining({
+          sourceReplyDeliveryMode: "automatic",
+        }),
+      }),
+    );
+  });
+
   it("drops room messages from configured Matrix bot accounts when allowBots is off", async () => {
     const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
       isDirectMessage: false,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1938,6 +1938,17 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           onReplyStart: typingCallbacks.onReplyStart,
           onIdle: typingCallbacks.onIdle,
         });
+      const messageVisibilityConfig = (
+        cfg as {
+          messages?: { groupChat?: { visibleReplies?: unknown }; visibleReplies?: unknown };
+        }
+      ).messages;
+      const sourceReplyDeliveryMode =
+        isRoom &&
+        messageVisibilityConfig?.groupChat?.visibleReplies === undefined &&
+        messageVisibilityConfig?.visibleReplies === undefined
+          ? "automatic"
+          : undefined;
       const pinnedMainDmOwner = isDirectMessage
         ? await (async () => {
             const livePinnedCfg = core.config.current() as CoreConfig;
@@ -2053,6 +2064,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                       dispatcher,
                       replyOptions: {
                         ...replyOptions,
+                        ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
                         skillFilter: roomConfig?.skills,
                         // Keep block streaming enabled when explicitly requested, even
                         // with draft previews on. The draft remains the live preview


### PR DESCRIPTION
## Summary

Fixes Matrix room replies being silently suppressed before `sendMessageMatrix` when `visibleReplies` is unset. Matrix room/channel dispatch now preserves automatic source replies by default, while explicit `messages.groupChat.visibleReplies` / `messages.visibleReplies` policy remains honored.

## Changes

- Set `sourceReplyDeliveryMode=automatic` for Matrix room/channel inbound dispatch only when visibleReplies config is unset.
- Add regression coverage for default Matrix room automatic final delivery and explicit message-tool policy preservation.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-matrix.config.ts extensions/matrix/src/matrix/monitor/handler.test.ts`
- `git diff --check`
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs`

Fixes openclaw/openclaw#78135