### PR TITLE
Fix private LAN mobile pairing auth policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iOS/Gateway pairing: allow private LAN, link-local, and `.local` `ws://` setup/manual connections while keeping Tailscale/public plaintext blocked, and prefer explicit gateway passwords over stale bootstrap tokens in Swift and TypeScript clients. Fixes #47887. Thanks @BunsDev.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- iOS/Gateway pairing: allow private LAN, link-local, and `.local` `ws://` setup/manual connections while keeping Tailscale/public plaintext blocked, and prefer explicit gateway passwords over stale bootstrap tokens in Swift and TypeScript clients. Fixes #47887. Thanks @BunsDev.
+- iOS/Android/Gateway pairing: allow private LAN, link-local, and `.local` `ws://` setup/manual connections while keeping Tailscale/public plaintext blocked, and prefer explicit gateway passwords over stale bootstrap tokens in Swift and TypeScript clients. Fixes #47887. Thanks @BunsDev.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
@@ -63,6 +63,7 @@ internal fun isPrivateLanGatewayHost(
   }
   if (host.isEmpty()) return false
   if (isLoopbackGatewayHost(host, allowEmulatorBridgeAlias = allowEmulatorBridgeAlias)) return true
+  if (host.endsWith(".local")) return true
 
   parseIpv4Address(host)?.let { ipv4 ->
     val first = ipv4[0].toInt() and 0xff

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -525,9 +525,11 @@ class GatewaySession(
     }
 
     private fun shouldPersistBootstrapHandoffTokens(authSource: GatewayConnectAuthSource): Boolean {
-      if (authSource != GatewayConnectAuthSource.BOOTSTRAP_TOKEN) return false
-      if (isLoopbackGatewayHost(endpoint.host)) return true
-      return tls != null
+      return shouldPersistBootstrapHandoffTokensForEndpoint(
+        usedBootstrapAuth = authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN,
+        endpoint = endpoint,
+        tls = tls,
+      )
     }
 
     private fun filteredBootstrapHandoffScopes(
@@ -1072,6 +1074,16 @@ class GatewaySession(
     }
     return tls?.expectedFingerprint?.trim()?.isNotEmpty() == true
   }
+}
+
+internal fun shouldPersistBootstrapHandoffTokensForEndpoint(
+  usedBootstrapAuth: Boolean,
+  endpoint: GatewayEndpoint,
+  tls: GatewayTlsParams?,
+): Boolean {
+  if (!usedBootstrapAuth) return false
+  if (isPrivateLanGatewayHost(endpoint.host)) return true
+  return tls != null
 }
 
 internal fun buildGatewayWebSocketUrl(

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -8,7 +8,7 @@ import ai.openclaw.app.gateway.GatewayClientInfo
 import ai.openclaw.app.gateway.GatewayConnectOptions
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayTlsParams
-import ai.openclaw.app.gateway.isLoopbackGatewayHost
+import ai.openclaw.app.gateway.isPrivateLanGatewayHost
 import android.os.Build
 
 class ConnectionManager(
@@ -34,7 +34,7 @@ class ConnectionManager(
       val stableId = endpoint.stableId
       val stored = storedFingerprint?.trim().takeIf { !it.isNullOrEmpty() }
       val isManual = stableId.startsWith("manual|")
-      val cleartextAllowedHost = isLoopbackGatewayHost(endpoint.host)
+      val cleartextAllowedHost = isPrivateLanGatewayHost(endpoint.host)
 
       if (isManual) {
         if (!manualTlsEnabled && cleartextAllowedHost) return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -1,6 +1,6 @@
 package ai.openclaw.app.ui
 
-import ai.openclaw.app.gateway.isLoopbackGatewayHost
+import ai.openclaw.app.gateway.isPrivateLanGatewayHost
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -56,9 +56,9 @@ internal data class GatewayScannedSetupCodeResult(
 
 private val gatewaySetupJson = Json { ignoreUnknownKeys = true }
 private const val remoteGatewaySecurityRule =
-  "Tailscale and public mobile nodes require wss:// or Tailscale Serve. ws:// is allowed only for localhost and the Android emulator."
+  "Tailscale and public mobile nodes require wss:// or Tailscale Serve. ws:// is allowed only for localhost, private LAN or link-local addresses, .local hosts, and the Android emulator."
 private const val remoteGatewaySecurityFix =
-  "Use localhost/the Android emulator, or enable Tailscale Serve / expose a wss:// gateway URL."
+  "Use localhost, a private LAN/.local route, the Android emulator, or enable Tailscale Serve / expose a wss:// gateway URL."
 
 internal fun resolveGatewayConnectConfig(
   useSetupCode: Boolean,
@@ -149,7 +149,7 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
       "wss", "https" -> true
       else -> true
     }
-  if (!tls && !isLoopbackGatewayHost(host)) {
+  if (!tls && !isPrivateLanGatewayHost(host)) {
     return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INSECURE_REMOTE_URL)
   }
   val defaultPort =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -51,7 +51,7 @@ internal fun buildGatewayDiagnosticsReport(
     Please:
     - pick one route only: same machine, same LAN, Tailscale, or public URL
     - classify this as pairing/auth, TLS trust, wrong advertised route, wrong address/port, or gateway down
-    - remember: Tailscale/public mobile routes require wss:// or Tailscale Serve; ws:// is loopback-only
+    - remember: Tailscale/public mobile routes require wss:// or Tailscale Serve; ws:// is only for loopback, private LAN, link-local, .local, and emulator routes
     - quote the exact app status/error below
     - tell me whether `openclaw devices list` should show a pending pairing request
     - if more signal is needed, ask for `openclaw qr --json`, `openclaw devices list`, and `openclaw nodes status`

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -21,7 +21,9 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -328,6 +330,22 @@ class GatewaySessionInvokeTest {
         shutdownHarness(harness, server)
       }
     }
+
+  @Test
+  fun bootstrapHandoffPersistenceTrustsPrivateLanCleartextEndpoints() {
+    assertTrue(shouldPersistBootstrapHandoffTokenForHost("192.168.1.25"))
+    assertTrue(shouldPersistBootstrapHandoffTokenForHost("openclaw.local"))
+    assertTrue(shouldPersistBootstrapHandoffTokenForHost("fd00::1"))
+    assertFalse(shouldPersistBootstrapHandoffTokenForHost("100.64.1.25"))
+    assertFalse(shouldPersistBootstrapHandoffTokenForHost("gateway.example.com"))
+    assertFalse(
+      shouldPersistBootstrapHandoffTokensForEndpoint(
+        usedBootstrapAuth = false,
+        endpoint = testEndpoint("192.168.1.25"),
+        tls = null,
+      ),
+    )
+  }
 
   @Test
   fun nonBootstrapConnect_ignoresAdditionalBootstrapDeviceTokens() =
@@ -701,6 +719,22 @@ class GatewaySessionInvokeTest {
       tls = null,
     )
   }
+
+  private fun testEndpoint(host: String): GatewayEndpoint =
+    GatewayEndpoint(
+      stableId = "manual|${host.lowercase()}|18789",
+      name = host,
+      host = host,
+      port = 18789,
+      tlsEnabled = false,
+    )
+
+  private fun shouldPersistBootstrapHandoffTokenForHost(host: String): Boolean =
+    shouldPersistBootstrapHandoffTokensForEndpoint(
+      usedBootstrapAuth = true,
+      endpoint = testEndpoint(host),
+      tls = null,
+    )
 
   private suspend fun awaitConnectedOrThrow(
     connected: CompletableDeferred<Unit>,

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -108,7 +108,7 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_manualPrivateLanForcesTlsWhenToggleIsOff() {
+  fun resolveTlsParamsForEndpoint_manualPrivateLanCanStayCleartextWhenToggleIsOff() {
     val endpoint = GatewayEndpoint.manual(host = "192.168.1.20", port = 18789)
 
     val params =
@@ -118,9 +118,7 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
+    assertNull(params)
   }
 
   @Test
@@ -148,7 +146,7 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsStillRequiresTls() {
+  fun resolveTlsParamsForEndpoint_discoveryPrivateLanWithoutHintsCanStayCleartext() {
     val endpoint =
       GatewayEndpoint(
         stableId = "_openclaw-gw._tcp.|local.|Test",
@@ -166,9 +164,7 @@ class ConnectionManagerTest {
         manualTlsEnabled = false,
       )
 
-    assertEquals(true, params?.required)
-    assertNull(params?.expectedFingerprint)
-    assertEquals(false, params?.allowTOFU)
+    assertNull(params)
   }
 
   @Test
@@ -244,11 +240,37 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun isPrivateLanGatewayHost_acceptsLanIpsButRejectsMdnsAndTailnetHosts() {
+  fun isPrivateLanGatewayHost_acceptsLanMdnsAndRejectsTailnetHosts() {
     assertTrue(isPrivateLanGatewayHost("192.168.1.20"))
-    assertFalse(isPrivateLanGatewayHost("gateway.local"))
+    assertTrue(isPrivateLanGatewayHost("169.254.1.20"))
+    assertTrue(isPrivateLanGatewayHost("fd00::1"))
+    assertTrue(isPrivateLanGatewayHost("fe80::1%25wlan0"))
+    assertTrue(isPrivateLanGatewayHost("gateway.local"))
     assertFalse(isPrivateLanGatewayHost("100.64.0.9"))
     assertFalse(isPrivateLanGatewayHost("gateway.tailnet.ts.net"))
+    assertFalse(isPrivateLanGatewayHost("gateway.example"))
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_discoveryMdnsWithoutHintsCanStayCleartext() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "gateway.local",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -99,16 +99,33 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointRejectsPrivateLanCleartextWsUrls() {
+  fun parseGatewayEndpointAllowsPrivateLanCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://192.168.1.20:18789")
-    assertNull(parsed)
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "192.168.1.20",
+        port = 18789,
+        tls = false,
+        displayUrl = "http://192.168.1.20:18789",
+      ),
+      parsed,
+    )
   }
 
   @Test
-  fun parseGatewayEndpointRejectsMdnsCleartextWsUrls() {
+  fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://gateway.local:18789")
 
-    assertNull(parsed)
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.local",
+        port = 18789,
+        tls = false,
+        displayUrl = "http://gateway.local:18789",
+      ),
+      parsed,
+    )
   }
 
   @Test
@@ -146,9 +163,13 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointRejectsLinkLocalIpv6ZoneCleartextWsUrls() {
+  fun parseGatewayEndpointAllowsLinkLocalIpv6ZoneCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://[fe80::1%25eth0]")
-    assertNull(parsed)
+
+    assertEquals("fe80::1%25eth0", parsed?.host)
+    assertEquals(18789, parsed?.port)
+    assertEquals(false, parsed?.tls)
+    assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
   }
 
   @Test
@@ -250,6 +271,26 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun resolveScannedSetupCodeAcceptsPrivateLanCleartextGateway() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://192.168.1.20:18789","bootstrapToken":"bootstrap-1"}""")
+
+    val resolved = resolveScannedSetupCode(setupCode)
+
+    assertEquals(setupCode, resolved)
+  }
+
+  @Test
+  fun resolveScannedSetupCodeAcceptsMdnsCleartextGateway() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://gateway.local:18789","bootstrapToken":"bootstrap-1"}""")
+
+    val resolved = resolveScannedSetupCode(setupCode)
+
+    assertEquals(setupCode, resolved)
+  }
+
+  @Test
   fun resolveScannedSetupCodeResultFlagsInsecureRemoteGateway() {
     val setupCode =
       encodeSetupCode("""{"url":"ws://attacker.example:18789","bootstrapToken":"bootstrap-1"}""")
@@ -269,10 +310,14 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointResultFlagsInsecureLanCleartextGateway() {
+  fun parseGatewayEndpointResultAllowsLanAndFlagsInsecureTailnetCleartextGateway() {
     val parsed = parseGatewayEndpointResult("ws://192.168.1.20:18789")
-    assertNull(parsed.config)
-    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, parsed.error)
+    assertEquals("192.168.1.20", parsed.config?.host)
+    assertEquals(false, parsed.config?.tls)
+
+    val tailnet = parseGatewayEndpointResult("ws://100.64.0.9:18789")
+    assertNull(tailnet.config)
+    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, tailnet.error)
   }
 
   @Test
@@ -413,7 +458,7 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun resolveGatewayConnectConfigRejectsPrivateLanManualCleartextEndpoint() {
+  fun resolveGatewayConnectConfigAcceptsPrivateLanManualCleartextEndpoint() {
     val resolved =
       resolveGatewayConnectConfig(
         useSetupCode = false,
@@ -429,7 +474,9 @@ class GatewayConfigResolverTest {
         fallbackPassword = "",
       )
 
-    assertNull(resolved)
+    assertEquals("192.168.31.100", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
   }
 
   @Test

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Maintenance update for the current OpenClaw development release.
 
-- Gateway pairing now supports scanning QR codes from Settings and accepts full copied setup-code messages while keeping non-loopback `ws://` setup links blocked.
+- Gateway pairing now supports scanning QR codes from Settings and accepts full copied setup-code messages, private LAN/link-local/`.local` `ws://` setup links, and explicit passwords over stale bootstrap tokens while keeping Tailscale/public plaintext blocked.
 
 ## 2026.5.3 - 2026-05-03
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -689,58 +689,13 @@ final class GatewayConnectionController {
     }
 
     private func shouldRequireTLS(host: String) -> Bool {
-        !Self.isLoopbackHost(host)
+        !LoopbackHost.isPlaintextGatewayHost(host)
     }
 
     private func shouldForceTLS(host: String) -> Bool {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if trimmed.isEmpty { return false }
         return trimmed.hasSuffix(".ts.net") || trimmed.hasSuffix(".ts.net.")
-    }
-
-    private static func isLoopbackHost(_ rawHost: String) -> Bool {
-        var host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !host.isEmpty else { return false }
-
-        if host.hasPrefix("[") && host.hasSuffix("]") {
-            host.removeFirst()
-            host.removeLast()
-        }
-        if host.hasSuffix(".") {
-            host.removeLast()
-        }
-        if let zoneIndex = host.firstIndex(of: "%") {
-            host = String(host[..<zoneIndex])
-        }
-        if host.isEmpty { return false }
-
-        if host == "localhost" || host == "0.0.0.0" || host == "::" {
-            return true
-        }
-        return Self.isLoopbackIPv4(host) || Self.isLoopbackIPv6(host)
-    }
-
-    private static func isLoopbackIPv4(_ host: String) -> Bool {
-        var addr = in_addr()
-        let parsed = host.withCString { inet_pton(AF_INET, $0, &addr) == 1 }
-        guard parsed else { return false }
-        let value = UInt32(bigEndian: addr.s_addr)
-        let firstOctet = UInt8((value >> 24) & 0xFF)
-        return firstOctet == 127
-    }
-
-    private static func isLoopbackIPv6(_ host: String) -> Bool {
-        var addr = in6_addr()
-        let parsed = host.withCString { inet_pton(AF_INET6, $0, &addr) == 1 }
-        guard parsed else { return false }
-        return withUnsafeBytes(of: &addr) { rawBytes in
-            let bytes = rawBytes.bindMemory(to: UInt8.self)
-            let isV6Loopback = bytes[0..<15].allSatisfy { $0 == 0 } && bytes[15] == 1
-            if isV6Loopback { return true }
-
-            let isMappedV4 = bytes[0..<10].allSatisfy { $0 == 0 } && bytes[10] == 0xFF && bytes[11] == 0xFF
-            return isMappedV4 && bytes[12] == 127
-        }
     }
 
     private func manualStableID(host: String, port: Int) -> String {

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import SwiftUI
 
 struct GatewayOnboardingView: View {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -107,8 +107,9 @@ import Testing
         let controller = makeController()
 
         #expect(controller._test_resolveManualUseTLS(host: "gateway.example.com", useTLS: false) == true)
-        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == true)
         #expect(controller._test_resolveManualUseTLS(host: "127.attacker.example", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "device.sample.ts.net", useTLS: false) == true)
+        #expect(controller._test_resolveManualUseTLS(host: "100.64.0.9", useTLS: false) == true)
 
         #expect(controller._test_resolveManualUseTLS(host: "localhost", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "127.0.0.1", useTLS: false) == false)
@@ -116,6 +117,13 @@ import Testing
         #expect(controller._test_resolveManualUseTLS(host: "[::1]", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "::ffff:127.0.0.1", useTLS: false) == false)
         #expect(controller._test_resolveManualUseTLS(host: "0.0.0.0", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "openclaw.local.", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "192.168.1.20", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "10.0.0.5", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "172.16.0.5", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "169.254.1.2", useTLS: false) == false)
+        #expect(controller._test_resolveManualUseTLS(host: "fd00::1", useTLS: false) == false)
     }
 
     @Test @MainActor func manualDefaultPortUses443OnlyForTailnetTLSHosts() async {

--- a/apps/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/apps/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,3 +1,3 @@
 Maintenance update for the current OpenClaw development release.
 
-- Gateway pairing now supports scanning QR codes from Settings and accepts full copied setup-code messages while keeping non-loopback `ws://` setup links blocked.
+- Gateway pairing now supports scanning QR codes from Settings and accepts full copied setup-code messages, private LAN/link-local/`.local` `ws://` setup links, and explicit passwords over stale bootstrap tokens while keeping Tailscale/public plaintext blocked.

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -57,7 +57,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         {
             return link
         }
-        return fromGatewayURLString(
+        return self.fromGatewayURLString(
             trimmed,
             bootstrapToken: nil,
             token: nil,
@@ -89,7 +89,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         {
             return link
         }
-        for candidate in setupCodeCandidates(in: trimmed) where candidate != trimmed {
+        for candidate in self.setupCodeCandidates(in: trimmed) where candidate != trimmed {
             if let data = decodeBase64Url(candidate),
                let link = decodeSetupPayload(from: data)
             {
@@ -104,7 +104,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
         if let urlString = payload.url?.trimmingCharacters(in: .whitespacesAndNewlines),
            !urlString.isEmpty
         {
-            return fromGatewayURLString(
+            return self.fromGatewayURLString(
                 urlString,
                 bootstrapToken: payload.bootstrapToken,
                 token: payload.token,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -116,7 +116,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
             return nil
         }
         let tls = payload.tls ?? true
-        if !tls, !LoopbackHost.isLoopbackHost(host) {
+        if !tls, !LoopbackHost.isPlaintextGatewayHost(host) {
             return nil
         }
         return GatewayConnectDeepLink(
@@ -143,7 +143,7 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
             return nil
         }
         let tls = scheme == "wss" || scheme == "https"
-        if !tls, !LoopbackHost.isLoopbackHost(hostname) {
+        if !tls, !LoopbackHost.isPlaintextGatewayHost(hostname) {
             return nil
         }
         return GatewayConnectDeepLink(
@@ -254,7 +254,7 @@ public enum DeepLinkParser {
             }
             let port = query["port"].flatMap { Int($0) } ?? 18789
             let tls = (query["tls"] as NSString?)?.boolValue ?? false
-            if !tls, !LoopbackHost.isLoopbackHost(hostParam) {
+            if !tls, !LoopbackHost.isPlaintextGatewayHost(hostParam) {
                 return nil
             }
             return .gateway(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -522,16 +522,17 @@ public actor GatewayChannelActor {
             (includeDeviceIdentity && explicitPassword == nil && explicitBootstrapToken == nil
                 ? storedToken
                 : nil)
-        let authBootstrapToken = authToken == nil ? explicitBootstrapToken : nil
+        let authBootstrapToken =
+            authToken == nil && explicitPassword == nil ? explicitBootstrapToken : nil
         let authDeviceToken = shouldUseDeviceRetryToken ? storedToken : nil
         let authSource: GatewayAuthSource = if authDeviceToken != nil || (explicitToken == nil && authToken != nil) {
             .deviceToken
         } else if authToken != nil {
             .sharedToken
-        } else if authBootstrapToken != nil {
-            .bootstrapToken
         } else if explicitPassword != nil {
             .password
+        } else if authBootstrapToken != nil {
+            .bootstrapToken
         } else {
             .none
         }
@@ -551,7 +552,7 @@ public actor GatewayChannelActor {
         if scheme == "wss" {
             return true
         }
-        if let host = self.url.host, LoopbackHost.isLoopback(host) {
+        if let host = self.url.host, LoopbackHost.isPlaintextGatewayHost(host) {
             return true
         }
         return false

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/LoopbackHost.swift
@@ -53,6 +53,29 @@ public enum LoopbackHost {
         return self.isLocalNetworkIPv4(ipv4)
     }
 
+    public static func isPlaintextGatewayHost(_ rawHost: String) -> Bool {
+        var host = rawHost
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+        if host.hasSuffix(".") {
+            host.removeLast()
+        }
+        if let zoneIndex = host.firstIndex(of: "%") {
+            host = String(host[..<zoneIndex])
+        }
+        guard !host.isEmpty else { return false }
+        if self.isLoopbackHost(host) { return true }
+        if host.hasSuffix(".local") { return true }
+        if let ipv4 = self.parseIPv4(host) {
+            return self.isPrivateLanOrLinkLocalIPv4(ipv4)
+        }
+        if let ipv6 = IPv6Address(host) {
+            return self.isPrivateLanOrLinkLocalIPv6(ipv6)
+        }
+        return false
+    }
+
     static func parseIPv4(_ host: String) -> (UInt8, UInt8, UInt8, UInt8)? {
         let parts = host.split(separator: ".", omittingEmptySubsequences: false)
         guard parts.count == 4 else { return nil }
@@ -76,5 +99,26 @@ public enum LoopbackHost {
         // Tailscale: 100.64.0.0/10
         if a == 100, (64...127).contains(Int(b)) { return true }
         return false
+    }
+
+    static func isPrivateLanOrLinkLocalIPv4(_ ip: (UInt8, UInt8, UInt8, UInt8)) -> Bool {
+        let (a, b, _, _) = ip
+        if a == 10 { return true }
+        if a == 172, (16...31).contains(Int(b)) { return true }
+        if a == 192, b == 168 { return true }
+        if a == 169, b == 254 { return true }
+        return false
+    }
+
+    static func isPrivateLanOrLinkLocalIPv6(_ ip: IPv6Address) -> Bool {
+        let bytes = Array(ip.rawValue)
+        let isMappedV4 =
+            bytes[0..<10].allSatisfy { $0 == 0 } && bytes[10] == 0xFF && bytes[11] == 0xFF
+        if isMappedV4 {
+            return self.isPrivateLanOrLinkLocalIPv4((bytes[12], bytes[13], bytes[14], bytes[15]))
+        }
+        let isUniqueLocal = (bytes[0] & 0xFE) == 0xFC
+        let isLinkLocal = bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80
+        return isUniqueLocal || isLinkLocal
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift
@@ -37,6 +37,20 @@ private func setupCode(from payload: String) -> String {
                     password: nil)))
     }
 
+    @Test func gatewayDeepLinkAllowsPrivateLanWs() {
+        let url = URL(
+            string: "openclaw://gateway?host=192.168.1.20&port=18789&tls=0&token=abc")!
+        #expect(
+            DeepLinkParser.parse(url) == .gateway(
+                .init(
+                    host: "192.168.1.20",
+                    port: 18789,
+                    tls: false,
+                    bootstrapToken: nil,
+                    token: "abc",
+                    password: nil)))
+    }
+
     @Test func setupCodeRejectsInsecureNonLoopbackWs() {
         let payload = #"{"url":"ws://attacker.example:18789","bootstrapToken":"tok"}"#
         #expect(GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload)) == nil)
@@ -52,6 +66,30 @@ private func setupCode(from payload: String) -> String {
         #expect(
             GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload)) == .init(
                 host: "127.0.0.1",
+                port: 18789,
+                tls: false,
+                bootstrapToken: "tok",
+                token: nil,
+                password: nil))
+    }
+
+    @Test func setupCodeAllowsPrivateLanWs() {
+        let payload = #"{"url":"ws://192.168.1.20:18789","bootstrapToken":"tok"}"#
+        #expect(
+            GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload)) == .init(
+                host: "192.168.1.20",
+                port: 18789,
+                tls: false,
+                bootstrapToken: "tok",
+                token: nil,
+                password: nil))
+    }
+
+    @Test func setupCodeAllowsMdnsHostPayload() {
+        let payload = #"{"host":"openclaw.local","port":18789,"tls":false,"bootstrapToken":"tok"}"#
+        #expect(
+            GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload)) == .init(
+                host: "openclaw.local",
                 port: 18789,
                 tls: false,
                 bootstrapToken: "tok",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -250,6 +250,43 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func explicitPasswordSuppressesBootstrapTokenAuth() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: URL(string: "ws://127.0.0.1:18789")!,
+            token: nil,
+            bootstrapToken: "stale-bootstrap-token",
+            password: "shared-password",
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let auth = try #require(session.latestTask()?.latestConnectAuth())
+        #expect(auth["password"] as? String == "shared-password")
+        #expect(auth["bootstrapToken"] == nil)
+        #expect(auth["token"] == nil)
+        #expect(auth["deviceToken"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
     func bootstrapHelloStoresAdditionalDeviceTokens() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -324,6 +361,60 @@ struct GatewayNodeSessionTests {
             "operator.talk.secrets",
             "operator.write",
         ])
+
+        await gateway.disconnect()
+    }
+
+    @Test
+    func privateLanBootstrapHelloStoresDeviceTokens() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        let session = FakeGatewayWebSocketSession(helloAuth: [
+            "deviceToken": "lan-node-token",
+            "role": "node",
+            "scopes": [],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        try await gateway.connect(
+            url: URL(string: "ws://192.168.1.20:18789")!,
+            token: nil,
+            bootstrapToken: "fresh-bootstrap-token",
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
+        #expect(nodeEntry.token == "lan-node-token")
+        #expect(nodeEntry.scopes == [])
 
         await gateway.disconnect()
     }

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -134,12 +134,12 @@ That bootstrap token carries the built-in pairing bootstrap profile:
 
 Treat the setup code like a password while it is valid.
 
-For Tailscale, public, or other non-loopback mobile pairing, use Tailscale
-Serve/Funnel or another `wss://` Gateway URL. Direct non-loopback `ws://` setup
-URLs are rejected before QR/setup-code issuance. Plaintext `ws://` setup codes
-are limited to loopback URLs; private-network `ws://` clients still require the explicit
-`OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` break-glass described in the remote
-Gateway guide.
+For Tailscale or public mobile pairing, use Tailscale Serve/Funnel or another
+`wss://` Gateway URL. Raw tailnet and public `ws://` setup URLs are rejected
+before QR/setup-code issuance. Plaintext `ws://` setup codes are accepted only
+for loopback, private LAN IPs, link-local IPs, and `.local` hosts; this narrow
+mobile pairing path does not require the generic
+`OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` client break-glass.
 
 ### Approve a node device
 

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -38,7 +38,7 @@ openclaw qr --url wss://gateway.example/ws
 - In the built-in node/operator bootstrap flow, the primary node token still lands with `scopes: []`.
 - If bootstrap handoff also issues an operator token, it stays bounded to the bootstrap allowlist: `operator.approvals`, `operator.read`, `operator.talk.secrets`, `operator.write`.
 - Bootstrap scope checks are role-prefixed. That operator allowlist only satisfies operator requests; non-operator roles still need scopes under their own role prefix.
-- Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Private LAN `ws://` remains supported, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
+- Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Loopback, private LAN IPs, link-local IPs, and `.local` `ws://` remain supported, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
 - With `--remote`, OpenClaw requires either `gateway.remote.url` or
   `gateway.tailscale.mode=serve|funnel`.
 - With `--remote`, if effectively active remote credentials are configured as SecretRefs and you do not pass `--token` or `--password`, the command resolves them from the active gateway snapshot. If gateway is unavailable, the command fails fast.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -453,6 +453,9 @@ See [Inferred commitments](/concepts/commitments).
   equivalent, and browser private-network config such as
   `browser.ssrfPolicy.dangerouslyAllowPrivateNetwork` does not affect Gateway
   WebSocket clients.
+- Mobile setup-code/manual pairing separately allows plaintext `ws://` for
+  loopback, private LAN IPs, link-local IPs, and `.local` hosts. Tailscale and
+  public mobile routes still need `wss://`, Tailscale Serve/Funnel, or a tunnel.
 - `gateway.remote.token` / `.password` are remote-client credential fields. They do not configure gateway auth by themselves.
 - `gateway.push.apns.relay.baseUrl`: base HTTPS URL for the external APNs relay used by official/TestFlight iOS builds after they publish relay-backed registrations to the gateway. This URL must match the relay URL compiled into the iOS build.
 - `gateway.push.apns.relay.timeoutMs`: gateway-to-relay send timeout in milliseconds. Defaults to `10000`.

--- a/docs/gateway/discovery.md
+++ b/docs/gateway/discovery.md
@@ -114,7 +114,7 @@ For mobile node pairing, discovery hints do not relax transport security on tail
 
 - iOS/Android still require a secure first-time tailnet/public connect path (`wss://` or Tailscale Serve/Funnel).
 - A discovered raw tailnet IP is a routing hint, not permission to use plaintext remote `ws://`.
-- Private LAN direct-connect `ws://` remains supported.
+- Private LAN, link-local, and `.local` direct-connect `ws://` remains supported.
 - If you want the simplest Tailscale path for mobile nodes, use Tailscale Serve so discovery and the setup code both resolve to the same secure MagicDNS endpoint.
 
 ### 3) Manual / SSH target

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -615,14 +615,15 @@ rather than the pre-handshake defaults.
     then an explicit `deviceToken`, then a stored per-device token (keyed by
     `deviceId` + `role`).
   - `auth.bootstrapToken` is sent only when none of the above resolved an
-    `auth.token`. A shared token or any resolved device token suppresses it.
+    `auth.token` and no explicit password is set. A shared token, any resolved
+    device token, or an explicit password suppresses it.
   - Auto-promotion of a stored device token on the one-shot
     `AUTH_TOKEN_MISMATCH` retry is gated to **trusted endpoints only** —
     loopback, or `wss://` with a pinned `tlsFingerprint`. Public `wss://`
     without pinning does not qualify.
 - Additional `hello-ok.auth.deviceTokens` entries are bootstrap handoff tokens.
   Persist them only when the connect used bootstrap auth on a trusted transport
-  such as `wss://` or loopback/local pairing.
+  such as `wss://`, loopback, or private-LAN/link-local/`.local` mobile pairing.
 - If a client supplies an **explicit** `deviceToken` or explicit `scopes`, that
   caller-requested scope set remains authoritative; cached scopes are only
   reused when the client is reusing the stored per-device token.

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -144,6 +144,10 @@ Short version: **keep the Gateway loopback-only** unless you’re sure you need 
   set `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` on the client process as
   break-glass. There is no `openclaw.json` equivalent; this must be process
   environment for the client making the WebSocket connection.
+- Mobile setup-code/manual pairing has a narrower built-in exception for
+  loopback, private LAN IPs, link-local IPs, and `.local` hosts. Tailscale and
+  public mobile routes still require `wss://`, Tailscale Serve, Funnel, or a
+  tunnel.
 - **Non-loopback binds** (`lan`/`tailnet`/`custom`, or `auto` when loopback is unavailable) must use gateway auth: token, password, or an identity-aware reverse proxy with `gateway.auth.mode: "trusted-proxy"`.
 - `gateway.remote.token` / `.password` are client credential sources. They do **not** configure server auth by themselves.
 - Local call paths can use `gateway.remote.*` as fallback only when `gateway.auth.*` is unset.

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -870,10 +870,10 @@ Plaintext `ws://` is loopback-only by default. For trusted private-network
 paths, set `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` on the client process as
 break-glass. This is intentionally process environment only, not an
 `openclaw.json` config key.
-Mobile pairing and Android manual or scanned gateway routes are stricter:
-cleartext is accepted for loopback, but private-LAN, link-local, `.local`, and
-dotless hostnames must use TLS unless you explicitly opt into the trusted
-private-network cleartext path.
+Mobile setup-code/manual pairing has a narrower built-in cleartext exception:
+loopback, private LAN IPs, link-local IPs, and `.local` hosts may use `ws://`.
+Raw Tailscale and public mobile routes still require `wss://`, Tailscale
+Serve/Funnel, or a tunnel.
 
 Local device pairing:
 

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -222,6 +222,7 @@ See [Bonjour](/gateway/bonjour) for the CoreDNS example.
 ### Manual host/port
 
 In Settings, enable **Manual Host** and enter the gateway host + port (default `18789`).
+Manual `ws://` is allowed for loopback, private LAN IPs, link-local IPs, and `.local` hosts. Tailscale and public routes should use `wss://`, Tailscale Serve/Funnel, or a tunnel.
 
 ## Canvas + A2UI
 

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -742,7 +742,7 @@ describe("device-pair /pair default setup code", () => {
     expect(text).toContain("Gateway: ws://127.0.0.1:18789");
   });
 
-  it("rejects private LAN cleartext setup urls before issuing setup codes", async () => {
+  it("allows private LAN cleartext setup urls", async () => {
     const command = registerPairCommand({
       pluginConfig: {
         publicUrl: "ws://192.168.1.20:18789",
@@ -756,11 +756,30 @@ describe("device-pair /pair default setup code", () => {
         gatewayClientScopes: ["operator.write", "operator.pairing"],
       }),
     );
+    const text = requireText(result);
 
-    expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
-    expect(requireText(result)).toContain(
-      "Mobile pairing over non-loopback networks requires a secure gateway URL",
+    expect(pluginApiMocks.issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+    expect(text).toContain("Gateway: ws://192.168.1.20:18789");
+  });
+
+  it("allows mdns cleartext setup urls", async () => {
+    const command = registerPairCommand({
+      pluginConfig: {
+        publicUrl: "ws://openclaw.local:18789",
+      },
+    });
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "",
+        commandBody: "/pair",
+        gatewayClientScopes: ["operator.write", "operator.pairing"],
+      }),
     );
+    const text = requireText(result);
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+    expect(text).toContain("Gateway: ws://openclaw.local:18789");
   });
 
   it("rejects public cleartext setup urls before issuing setup codes", async () => {
@@ -780,7 +799,7 @@ describe("device-pair /pair default setup code", () => {
 
     expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
     expect(requireText(result)).toContain(
-      "Mobile pairing over non-loopback networks requires a secure gateway URL",
+      "Tailscale and public mobile pairing require a secure gateway URL",
     );
   });
 

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -175,11 +175,11 @@ function parseNormalizedGatewayUrl(raw: string): string | null {
 function describeSecureMobilePairingFix(source?: string): string {
   const sourceNote = source ? ` Resolved source: ${source}.` : "";
   return (
-    "Mobile pairing over non-loopback networks requires a secure gateway URL (wss://) or Tailscale Serve/Funnel." +
+    "Tailscale and public mobile pairing require a secure gateway URL (wss://) or Tailscale Serve/Funnel." +
     sourceNote +
-    " Fix: prefer gateway.tailscale.mode=serve, or set " +
+    " Fix: use a private LAN IP address, prefer gateway.tailscale.mode=serve, or set " +
     "gateway.remote.url / plugins.entries.device-pair.config.publicUrl to a wss:// URL. " +
-    "ws:// setup codes are only valid for localhost/loopback or the Android emulator."
+    "ws:// setup codes are only valid for localhost/loopback, private LAN IP addresses, .local hosts, or the Android emulator."
   );
 }
 
@@ -256,6 +256,23 @@ function isPrivateIPv4(address: string): boolean {
   return false;
 }
 
+function isLinkLocalIPv4(address: string): boolean {
+  const octets = parseIPv4Octets(address);
+  if (!octets) {
+    return false;
+  }
+  const [a, b] = octets;
+  return a === 169 && b === 254;
+}
+
+function isPrivateOrLinkLocalIPv6(address: string): boolean {
+  const normalized = normalizeHostForIpCheck(address);
+  return (
+    normalized.includes(":") &&
+    (normalized.startsWith("fe80:") || normalized.startsWith("fc") || normalized.startsWith("fd"))
+  );
+}
+
 function isTailnetIPv4(address: string): boolean {
   const octets = parseIPv4Octets(address);
   if (!octets) {
@@ -267,7 +284,14 @@ function isTailnetIPv4(address: string): boolean {
 
 function isMobilePairingCleartextAllowedHost(host: string): boolean {
   const normalized = normalizeHostForIpCheck(host);
-  return isLoopbackHost(normalized) || normalized === "10.0.2.2";
+  return (
+    isLoopbackHost(normalized) ||
+    normalized === "10.0.2.2" ||
+    normalized.endsWith(".local") ||
+    isPrivateIPv4(normalized) ||
+    isLinkLocalIPv4(normalized) ||
+    isPrivateOrLinkLocalIPv6(normalized)
+  );
 }
 
 function validateMobilePairingUrl(url: string, source?: string): string | null {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -2235,6 +2235,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordSessionState(evt);
               return;
             case "session.long_running":
+            case "session.recovery.completed":
+            case "session.recovery.requested":
             case "session.stalled":
               return;
             case "session.stuck":

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import {
   DEFAULT_ACCOUNT_ID,
-  normalizeE164,
   pathExists,
   splitSetupEntries,
   type DmPolicy,

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -247,6 +247,20 @@ describe("registerQrCli", () => {
     expectLoggedSetupCode("ws://192.168.1.8:18789");
   });
 
+  it("allows mdns cleartext setup urls", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "openclaw.local",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+
+    await runQr(["--setup-code-only"]);
+
+    expectLoggedSetupCode("ws://openclaw.local:18789");
+  });
+
   it("allows android emulator cleartext override urls", async () => {
     loadConfig.mockReturnValue({
       gateway: {

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -800,6 +800,28 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it("uses explicit shared password instead of bootstrap token", () => {
+    loadDeviceAuthTokenMock.mockReturnValue(undefined);
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      bootstrapToken: "stale-bootstrap-token",
+      password: "shared-password", // pragma: allowlist secret
+    });
+
+    client.start();
+    const ws = getLatestWs();
+    ws.emitOpen();
+    emitConnectChallenge(ws);
+
+    expect(connectFrameFrom(ws)).toMatchObject({
+      password: "shared-password", // pragma: allowlist secret
+    });
+    expect(connectFrameFrom(ws).bootstrapToken).toBeUndefined();
+    expect(connectFrameFrom(ws).token).toBeUndefined();
+    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
+    client.stop();
+  });
+
   it("uses stored device token scopes when shared token is not provided", () => {
     loadDeviceAuthTokenMock.mockReturnValue({
       token: "stored-device-token",

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -796,7 +796,9 @@ export class GatewayClient {
     // no explicit shared token is present.
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;
     const authBootstrapToken =
-      !explicitGatewayToken && !resolvedDeviceToken ? explicitBootstrapToken : undefined;
+      !explicitGatewayToken && !resolvedDeviceToken && !authPassword
+        ? explicitBootstrapToken
+        : undefined;
     return {
       authToken,
       authBootstrapToken,

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -482,6 +482,21 @@ describe("pairing setup code", () => {
         urlSource: "gateway.bind=custom",
       },
     },
+    {
+      name: "allows mdns cleartext setup urls",
+      config: {
+        gateway: {
+          bind: "custom",
+          customBindHost: "openclaw.local",
+          auth: { mode: "token", token: "tok_123" },
+        },
+      } satisfies ResolveSetupConfig,
+      expected: {
+        authLabel: "token",
+        url: "ws://openclaw.local:18789",
+        urlSource: "gateway.bind=custom",
+      },
+    },
   ] as const)("$name", async ({ config, options, expected }) => {
     await expectResolvedSetupSuccessCase({
       config,
@@ -501,17 +516,6 @@ describe("pairing setup code", () => {
         },
       } satisfies ResolveSetupConfig,
       expectedError: "Tailscale and public mobile pairing require a secure gateway URL",
-    },
-    {
-      name: "rejects mdns hostname cleartext setup urls",
-      config: {
-        gateway: {
-          bind: "custom",
-          customBindHost: "gateway.local",
-          auth: { mode: "token", token: "tok_123" },
-        },
-      } satisfies ResolveSetupConfig,
-      expectedError: "private LAN IP address",
     },
     {
       name: "rejects tailnet bind remote ws setup urls for mobile pairing",

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -76,8 +76,13 @@ function describeSecureMobilePairingFix(source?: string): string {
     sourceNote +
     " Fix: use a private LAN IP address, prefer gateway.tailscale.mode=serve, or set " +
     "gateway.remote.url / plugins.entries.device-pair.config.publicUrl to a wss:// URL. " +
-    "ws:// is only valid for localhost, private LAN IP addresses, or the Android emulator."
+    "ws:// is only valid for localhost, private LAN IP addresses, .local hosts, or the Android emulator."
   );
+}
+
+function isMdnsHost(host: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(host).replace(/\.+$/, "");
+  return normalized.endsWith(".local");
 }
 
 function isPrivateLanIpHost(host: string): boolean {
@@ -102,7 +107,9 @@ function isPrivateLanIpHost(host: string): boolean {
 }
 
 function isMobilePairingCleartextAllowedHost(host: string): boolean {
-  return isLoopbackHost(host) || host === "10.0.2.2" || isPrivateLanIpHost(host);
+  return (
+    isLoopbackHost(host) || host === "10.0.2.2" || isPrivateLanIpHost(host) || isMdnsHost(host)
+  );
 }
 
 function validateMobilePairingUrl(url: string, source?: string): string | null {


### PR DESCRIPTION
## Summary

Fixes the private-LAN mobile pairing policy for #47887 without opening public or tailnet plaintext routes.

- allows `ws://` setup/manual endpoints only for loopback, private LAN, link-local, ULA, and `.local` hosts across iOS setup/manual paths, Android setup/manual paths, the setup-code generator, and the device-pair plugin
- keeps public and Tailscale/tailnet cleartext endpoints rejected; those still require `wss://` or a tunnel/Serve/Funnel path
- makes explicit password auth suppress stale bootstrap-token auth in Swift and TypeScript gateway clients
- persists Android bootstrap handoff tokens for the same private/local cleartext endpoints that Android setup/manual pairing accepts, while keeping public/tailnet cleartext persistence rejected
- adds mixed-auth, private-LAN, `.local`, public, tailnet, and Android session persistence coverage for the changed clients and setup-code paths
- includes a small iOS onboarding compile fix so the setup-code parser symbol is imported where the onboarding flow uses it

## Verification

- `pnpm test src/gateway/client.test.ts extensions/device-pair/index.test.ts src/pairing/setup-code.test.ts src/cli/qr-cli.test.ts` passed locally
- `swift test --package-path apps/shared/OpenClawKit --filter 'DeepLinksSecurityTests|GatewayNodeSessionTests'` passed locally at `77b48f43b1` with 26 tests
- Android targeted Testbox proof passed at `fbd0c6afdb`: `cd apps/android && ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest.bootstrapHandoffPersistenceTrustsPrivateLanCleartextEndpoints --tests ai.openclaw.app.ui.GatewayConfigResolverTest --tests ai.openclaw.app.node.ConnectionManagerTest`
- `pnpm check:changed` passed in Testbox at `fbd0c6afdb`
- live proof is still pending: no Android `adb`/emulator is available locally, connected iOS devices are unavailable, and the iOS simulator app target still fails before launch on unrelated `apps/ios/Sources/Settings/SettingsTab.swift` issues (SwiftFormat drift on the branch state; after a local formatting experiment, Swift type-check timeout at line 423). The formatting experiment was reverted and is not part of this PR.

Fixes #47887.