### PR TITLE
fix(runtime): avoid no-proxy undici fetch side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 - TUI: skip the generic CLI respawn wrapper for interactive launches, exit cleanly on terminal loss, and refuse to restore heartbeat sessions as the remembered chat session, preventing stale heartbeat history and orphaned `openclaw-tui` processes on first boot. Thanks @vincentkoc.
 - Doctor/sessions: move heartbeat-poisoned default main session store entries to recovery keys and clear stale TUI restore pointers, so `doctor --fix` can repair instances already stuck on `agent:main:main` heartbeat history. Thanks @vincentkoc.
 - Agents/context engines: keep hidden OpenClaw runtime-context custom messages out of context-engine assemble, afterTurn, and ingest hooks so transcript reconstruction plugins only see conversation messages. Thanks @vincentkoc.
+- Network/runtime: avoid importing Undici's package dispatcher during no-proxy timeout bootstrap so external channel plugin fetch requests with explicit Content-Length keep working. Fixes #78007. Thanks @shakkernerd.
 - Gateway/shutdown: cancel delayed post-ready maintenance during close and suppress maintenance/cron startup after quick restarts, preventing orphaned background timers. Thanks @vincentkoc.
 - Agents/generated media: treat attachment-style message tool actions as completed chat sends, preventing duplicate fallback media posts when generated files were already uploaded.
 - Control UI/sessions: show each session's agent runtime in the Sessions table and allow filtering by runtime labels, matching the Agents panel runtime wording. Thanks @vincentkoc.

--- a/src/agents/pi-embedded-runner/run/attempt-http-runtime.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-http-runtime.ts
@@ -1,14 +1,14 @@
 import {
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+  ensureGlobalUndiciDispatcherStreamTimeouts,
   ensureGlobalUndiciEnvProxyDispatcher,
-  ensureGlobalUndiciStreamTimeouts,
 } from "../../../infra/net/undici-global-dispatcher.js";
 
 export function configureEmbeddedAttemptHttpRuntime(params: { timeoutMs: number }): void {
   // Proxy bootstrap must happen before timeout tuning so the timeouts wrap the
   // active EnvHttpProxyAgent instead of being replaced by a bare proxy dispatcher.
   ensureGlobalUndiciEnvProxyDispatcher();
-  ensureGlobalUndiciStreamTimeouts({
+  ensureGlobalUndiciDispatcherStreamTimeouts({
     timeoutMs: Math.max(params.timeoutMs, DEFAULT_UNDICI_STREAM_TIMEOUT_MS),
   });
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -60,6 +60,7 @@ type AttemptSpawnWorkspaceHoisted = {
   sessionManagerOpenMock: UnknownMock;
   resolveSandboxContextMock: UnknownMock;
   ensureGlobalUndiciEnvProxyDispatcherMock: UnknownMock;
+  ensureGlobalUndiciDispatcherStreamTimeoutsMock: UnknownMock;
   ensureGlobalUndiciStreamTimeoutsMock: UnknownMock;
   buildEmbeddedMessageActionDiscoveryInputMock: UnknownMock;
   createOpenClawCodingToolsMock: UnknownMock;
@@ -125,6 +126,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const sessionManagerOpenMock = vi.fn();
   const resolveSandboxContextMock = vi.fn();
   const ensureGlobalUndiciEnvProxyDispatcherMock = vi.fn();
+  const ensureGlobalUndiciDispatcherStreamTimeoutsMock = vi.fn();
   const ensureGlobalUndiciStreamTimeoutsMock = vi.fn();
   const buildEmbeddedMessageActionDiscoveryInputMock = vi.fn((params: unknown) => params);
   const createOpenClawCodingToolsMock = vi.fn(() => []);
@@ -193,6 +195,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
     sessionManagerOpenMock,
     resolveSandboxContextMock,
     ensureGlobalUndiciEnvProxyDispatcherMock,
+    ensureGlobalUndiciDispatcherStreamTimeoutsMock,
     ensureGlobalUndiciStreamTimeoutsMock,
     buildEmbeddedMessageActionDiscoveryInputMock,
     createOpenClawCodingToolsMock,
@@ -287,6 +290,8 @@ vi.mock("../../../infra/net/undici-global-dispatcher.js", () => ({
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS: 120_000,
   ensureGlobalUndiciEnvProxyDispatcher: (...args: unknown[]) =>
     hoisted.ensureGlobalUndiciEnvProxyDispatcherMock(...args),
+  ensureGlobalUndiciDispatcherStreamTimeouts: (...args: unknown[]) =>
+    hoisted.ensureGlobalUndiciDispatcherStreamTimeoutsMock(...args),
   ensureGlobalUndiciStreamTimeouts: (...args: unknown[]) =>
     hoisted.ensureGlobalUndiciStreamTimeoutsMock(...args),
 }));
@@ -792,6 +797,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.sessionManagerOpenMock.mockReset().mockReturnValue(hoisted.sessionManager);
   hoisted.resolveSandboxContextMock.mockReset();
   hoisted.ensureGlobalUndiciEnvProxyDispatcherMock.mockReset();
+  hoisted.ensureGlobalUndiciDispatcherStreamTimeoutsMock.mockReset();
   hoisted.ensureGlobalUndiciStreamTimeoutsMock.mockReset();
   hoisted.buildEmbeddedMessageActionDiscoveryInputMock
     .mockReset()

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.timeout.test.ts
@@ -2,14 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS: 30 * 60 * 1000,
+  ensureGlobalUndiciDispatcherStreamTimeouts: vi.fn(),
   ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
-  ensureGlobalUndiciStreamTimeouts: vi.fn(),
 }));
 
 vi.mock("../../../infra/net/undici-global-dispatcher.js", () => ({
   DEFAULT_UNDICI_STREAM_TIMEOUT_MS: mocks.DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+  ensureGlobalUndiciDispatcherStreamTimeouts: mocks.ensureGlobalUndiciDispatcherStreamTimeouts,
   ensureGlobalUndiciEnvProxyDispatcher: mocks.ensureGlobalUndiciEnvProxyDispatcher,
-  ensureGlobalUndiciStreamTimeouts: mocks.ensureGlobalUndiciStreamTimeouts,
 }));
 
 import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
@@ -17,14 +17,14 @@ import { configureEmbeddedAttemptHttpRuntime } from "./attempt-http-runtime.js";
 describe("runEmbeddedAttempt undici timeout wiring", () => {
   beforeEach(() => {
     mocks.ensureGlobalUndiciEnvProxyDispatcher.mockReset();
-    mocks.ensureGlobalUndiciStreamTimeouts.mockReset();
+    mocks.ensureGlobalUndiciDispatcherStreamTimeouts.mockReset();
   });
 
   it("does not lower global undici stream tuning below the shared default", () => {
     configureEmbeddedAttemptHttpRuntime({ timeoutMs: 123_456 });
 
     expect(mocks.ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
-    expect(mocks.ensureGlobalUndiciStreamTimeouts).toHaveBeenCalledWith({
+    expect(mocks.ensureGlobalUndiciDispatcherStreamTimeouts).toHaveBeenCalledWith({
       timeoutMs: mocks.DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     });
   });
@@ -35,7 +35,7 @@ describe("runEmbeddedAttempt undici timeout wiring", () => {
     configureEmbeddedAttemptHttpRuntime({ timeoutMs });
 
     expect(mocks.ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
-    expect(mocks.ensureGlobalUndiciStreamTimeouts).toHaveBeenCalledWith({
+    expect(mocks.ensureGlobalUndiciDispatcherStreamTimeouts).toHaveBeenCalledWith({
       timeoutMs,
     });
   });

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1139,8 +1139,6 @@ describe("fetchWithSsrFGuard hardening", () => {
   });
 
   it("inherits the configured global stream timeout for guarded direct dispatchers", async () => {
-    const { getGlobalDispatcher, setGlobalDispatcher } = await import("undici");
-    const previousDispatcher = getGlobalDispatcher();
     try {
       ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });
       (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
@@ -1168,7 +1166,6 @@ describe("fetchWithSsrFGuard hardening", () => {
       });
       await result.release();
     } finally {
-      setGlobalDispatcher(previousDispatcher);
       resetGlobalUndiciStreamTimeoutsForTests();
     }
   });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,6 +1,5 @@
 import type { Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
-import { captureHttpExchange } from "../../proxy-capture/runtime.js";
 import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import { hasProxyEnvConfigured, shouldUseEnvHttpProxyForUrl } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
@@ -95,6 +94,11 @@ type GuardedFetchPresetOptions = Omit<
 >;
 
 const DEFAULT_MAX_REDIRECTS = 3;
+const OPENCLAW_DEBUG_PROXY_ENABLED = "OPENCLAW_DEBUG_PROXY_ENABLED";
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
 
 export function withStrictGuardedFetchMode(params: GuardedFetchPresetOptions): GuardedFetchOptions {
   return { ...params, mode: GUARDED_FETCH_MODE.STRICT };
@@ -230,6 +234,36 @@ export function retainSafeHeadersForCrossOriginRedirectHeaders(
   headers?: HeadersInit,
 ): Record<string, string> | undefined {
   return retainSafeRedirectHeaders(headers);
+}
+
+async function captureGuardedFetchExchange(params: {
+  url: string;
+  method: string;
+  requestHeaders?: Headers | Record<string, string> | undefined;
+  requestBody?: BodyInit | Buffer | string | null;
+  response: Response;
+  transport?: "http" | "sse";
+  capture: GuardedFetchOptions["capture"];
+  auditContext?: string;
+}): Promise<void> {
+  if (params.capture === false || !isTruthyEnvValue(process.env[OPENCLAW_DEBUG_PROXY_ENABLED])) {
+    return;
+  }
+  const { captureHttpExchange } = await import("../../proxy-capture/runtime.js");
+  captureHttpExchange({
+    url: params.url,
+    method: params.method,
+    requestHeaders: params.requestHeaders,
+    requestBody: params.requestBody,
+    response: params.response,
+    transport: params.transport,
+    flowId: params.capture?.flowId,
+    meta: {
+      captureOrigin: "guarded-fetch",
+      ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+      ...params.capture?.meta,
+    },
+  });
 }
 
 function retainSafeHeadersForCrossOriginRedirect(init?: RequestInit): RequestInit | undefined {
@@ -433,23 +467,17 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
         ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
         : await defaultFetch(parsedUrl.toString(), init);
 
-      if (params.capture !== false) {
-        captureHttpExchange({
-          url: parsedUrl.toString(),
-          method: currentInit?.method ?? "GET",
-          requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
-          requestBody:
-            (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
-          response,
-          transport: "http",
-          flowId: params.capture?.flowId,
-          meta: {
-            captureOrigin: "guarded-fetch",
-            ...(params.auditContext ? { auditContext: params.auditContext } : {}),
-            ...params.capture?.meta,
-          },
-        });
-      }
+      await captureGuardedFetchExchange({
+        url: parsedUrl.toString(),
+        method: currentInit?.method ?? "GET",
+        requestHeaders: currentInit?.headers as Headers | Record<string, string> | undefined,
+        requestBody:
+          (currentInit as (RequestInit & { body?: BodyInit | null }) | undefined)?.body ?? null,
+        response,
+        transport: "http",
+        capture: params.capture,
+        auditContext: params.auditContext,
+      });
 
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -14,13 +14,13 @@ const ORIGINAL_PROXY_ENV = Object.fromEntries(
 ) as Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>;
 
 const {
-  ProxyAgent,
   EnvHttpProxyAgent,
   MockUndiciFormData,
   undiciFetch,
   proxyAgentSpy,
   envAgentSpy,
   getLastAgent,
+  loadUndiciRuntimeDeps,
 } = vi.hoisted(() => {
   const undiciFetch = vi.fn();
   const proxyAgentSpy = vi.fn();
@@ -53,6 +53,12 @@ const {
       envAgentSpy(options);
     }
   }
+  const loadUndiciRuntimeDeps = vi.fn(() => ({
+    ProxyAgent,
+    EnvHttpProxyAgent,
+    FormData: MockUndiciFormData,
+    fetch: undiciFetch,
+  }));
 
   return {
     ProxyAgent,
@@ -62,16 +68,14 @@ const {
     proxyAgentSpy,
     envAgentSpy,
     getLastAgent: () => ProxyAgent.lastCreated,
+    loadUndiciRuntimeDeps,
   };
 });
 
-const mockedModuleIds = ["undici"] as const;
+const mockedModuleIds = ["./undici-runtime.js"] as const;
 
-vi.mock("undici", () => ({
-  ProxyAgent,
-  EnvHttpProxyAgent,
-  FormData: MockUndiciFormData,
-  fetch: undiciFetch,
+vi.mock("./undici-runtime.js", () => ({
+  loadUndiciRuntimeDeps,
 }));
 
 let getProxyUrlFromFetch: typeof import("./proxy-fetch.js").getProxyUrlFromFetch;
@@ -248,6 +252,7 @@ describe("resolveProxyFetchFromEnv", () => {
 
   it("returns undefined when no proxy env vars are set", () => {
     expect(resolveProxyFetchFromEnv({})).toBeUndefined();
+    expect(loadUndiciRuntimeDeps).not.toHaveBeenCalled();
   });
 
   it("returns proxy fetch using EnvHttpProxyAgent when HTTPS_PROXY is set", async () => {

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,12 +1,7 @@
-import {
-  EnvHttpProxyAgent,
-  FormData as UndiciFormData,
-  ProxyAgent,
-  fetch as undiciFetch,
-} from "undici";
 import { logWarn } from "../../logger.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
+import { loadUndiciRuntimeDeps, type UndiciRuntimeDeps } from "./undici-runtime.js";
 
 export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
 type ProxyFetchWithMetadata = typeof fetch & {
@@ -22,7 +17,14 @@ function isFormDataLike(value: unknown): value is FormData {
   );
 }
 
-function appendFormDataEntry(target: UndiciFormData, key: string, value: FormDataEntryValue): void {
+type UndiciFormDataCtor = NonNullable<UndiciRuntimeDeps["FormData"]>;
+type UndiciFormDataInstance = InstanceType<UndiciFormDataCtor>;
+
+function appendFormDataEntry(
+  target: UndiciFormDataInstance,
+  key: string,
+  value: FormDataEntryValue,
+): void {
   if (typeof value === "string") {
     target.append(key, value);
     return;
@@ -35,7 +37,10 @@ function appendFormDataEntry(target: UndiciFormData, key: string, value: FormDat
   target.append(key, value);
 }
 
-function normalizeInitForUndici(init: RequestInit | undefined): RequestInit | undefined {
+function normalizeInitForUndici(
+  init: RequestInit | undefined,
+  UndiciFormData: UndiciFormDataCtor,
+): RequestInit | undefined {
   if (!init) {
     return init;
   }
@@ -58,8 +63,13 @@ function normalizeInitForUndici(init: RequestInit | undefined): RequestInit | un
  * Uses undici's ProxyAgent under the hood.
  */
 export function makeProxyFetch(proxyUrl: string): typeof fetch {
-  let agent: ProxyAgent | null = null;
-  const resolveAgent = (): ProxyAgent => {
+  const {
+    ProxyAgent,
+    FormData: UndiciFormData = globalThis.FormData as unknown as UndiciFormDataCtor,
+    fetch: undiciFetch,
+  } = loadUndiciRuntimeDeps();
+  let agent: InstanceType<UndiciRuntimeDeps["ProxyAgent"]> | null = null;
+  const resolveAgent = (): InstanceType<UndiciRuntimeDeps["ProxyAgent"]> => {
     if (!agent) {
       agent = new ProxyAgent(proxyUrl);
     }
@@ -69,7 +79,7 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   // on stream/body internals. Single cast at the boundary keeps the rest type-safe.
   const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(input as string | URL, {
-      ...(normalizeInitForUndici(init) as Record<string, unknown>),
+      ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
       dispatcher: resolveAgent(),
     }) as unknown as Promise<Response>) as ProxyFetchWithMetadata;
   Object.defineProperty(proxyFetch, PROXY_FETCH_PROXY_URL, {
@@ -104,10 +114,15 @@ export function resolveProxyFetchFromEnv(
     return undefined;
   }
   try {
+    const {
+      EnvHttpProxyAgent,
+      FormData: UndiciFormData = globalThis.FormData as unknown as UndiciFormDataCtor,
+      fetch: undiciFetch,
+    } = loadUndiciRuntimeDeps();
     const agent = new EnvHttpProxyAgent(proxyOptions);
     return ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
-        ...(normalizeInitForUndici(init) as Record<string, unknown>),
+        ...(normalizeInitForUndici(init, UndiciFormData) as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>) as typeof fetch;
   } catch (err) {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -106,32 +106,24 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue(undefined);
   });
 
-  it("replaces direct Agent dispatcher with extended stream timeouts when no env proxy is configured", () => {
+  it("records timeout bridge without importing undici when no env proxy is configured", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
 
     ensureGlobalUndiciStreamTimeouts();
 
-    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next).toBeInstanceOf(Agent);
-    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.connect).toEqual({
-      autoSelectFamily: true,
-      autoSelectFamilyAttemptTimeout: 300,
-    });
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
   });
 
-  it("does not initialize the undici global dispatcher during no-proxy bootstrap", () => {
+  it("does not initialize the undici global dispatcher in a no-proxy subprocess", () => {
     const moduleUrl = pathToFileURL(path.resolve("src/infra/net/undici-global-dispatcher.ts")).href;
     const source = `
       const dispatcherKey = Symbol.for("undici.globalDispatcher.1");
       const mod = await import(${JSON.stringify(moduleUrl)});
-      mod.ensureGlobalUndiciEnvProxyDispatcher();
+      mod.ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });
       if (globalThis[dispatcherKey] !== undefined) {
         throw new Error("undici global dispatcher was initialized");
       }
@@ -222,12 +214,8 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
   it("does not lower global stream timeouts below the default floor", () => {
     ensureGlobalUndiciStreamTimeouts({ timeoutMs: 15_000 });
 
-    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next).toBeInstanceOf(Agent);
-    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
@@ -238,12 +226,8 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
     ensureGlobalUndiciStreamTimeouts({ timeoutMs });
 
-    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next).toBeInstanceOf(Agent);
-    expect(next.options?.bodyTimeout).toBe(timeoutMs);
-    expect(next.options?.headersTimeout).toBe(timeoutMs);
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(timeoutMs);
   });
 

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -79,6 +79,7 @@ vi.mock("../wsl.js", () => ({
 import { isWSL2Sync } from "../wsl.js";
 import { hasEnvHttpProxyAgentConfigured, resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
 let DEFAULT_UNDICI_STREAM_TIMEOUT_MS: typeof import("./undici-global-dispatcher.js").DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
+let ensureGlobalUndiciDispatcherStreamTimeouts: typeof import("./undici-global-dispatcher.js").ensureGlobalUndiciDispatcherStreamTimeouts;
 let ensureGlobalUndiciEnvProxyDispatcher: typeof import("./undici-global-dispatcher.js").ensureGlobalUndiciEnvProxyDispatcher;
 let ensureGlobalUndiciStreamTimeouts: typeof import("./undici-global-dispatcher.js").ensureGlobalUndiciStreamTimeouts;
 let forceResetGlobalDispatcher: typeof import("./undici-global-dispatcher.js").forceResetGlobalDispatcher;
@@ -90,6 +91,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     undiciGlobalDispatcherModule = await import("./undici-global-dispatcher.js");
     ({
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+      ensureGlobalUndiciDispatcherStreamTimeouts,
       ensureGlobalUndiciEnvProxyDispatcher,
       ensureGlobalUndiciStreamTimeouts,
       forceResetGlobalDispatcher,
@@ -148,6 +150,26 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     );
 
     expect(output.trim()).toBe("ok");
+  });
+
+  it("explicitly tunes the global dispatcher when requested for embedded attempts", () => {
+    getDefaultAutoSelectFamily.mockReturnValue(false);
+
+    ensureGlobalUndiciDispatcherStreamTimeouts({ timeoutMs: 1_900_000 });
+
+    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options).toEqual({
+      bodyTimeout: 1_900_000,
+      headersTimeout: 1_900_000,
+      connect: {
+        autoSelectFamily: false,
+        autoSelectFamilyAttemptTimeout: 300,
+      },
+    });
+    expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(1_900_000);
   });
 
   it("replaces EnvHttpProxyAgent dispatcher while preserving env-proxy mode", () => {

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -106,24 +106,32 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue(undefined);
   });
 
-  it("records timeout bridge without importing undici when no env proxy is configured", () => {
+  it("replaces direct Agent dispatcher with extended stream timeouts when no env proxy is configured", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
 
     ensureGlobalUndiciStreamTimeouts();
 
-    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.connect).toEqual({
+      autoSelectFamily: true,
+      autoSelectFamilyAttemptTimeout: 300,
+    });
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
   });
 
-  it("does not initialize the undici global dispatcher in a no-proxy subprocess", () => {
+  it("does not initialize the undici global dispatcher during no-proxy bootstrap", () => {
     const moduleUrl = pathToFileURL(path.resolve("src/infra/net/undici-global-dispatcher.ts")).href;
     const source = `
       const dispatcherKey = Symbol.for("undici.globalDispatcher.1");
       const mod = await import(${JSON.stringify(moduleUrl)});
-      mod.ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });
+      mod.ensureGlobalUndiciEnvProxyDispatcher();
       if (globalThis[dispatcherKey] !== undefined) {
         throw new Error("undici global dispatcher was initialized");
       }
@@ -214,8 +222,12 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
   it("does not lower global stream timeouts below the default floor", () => {
     ensureGlobalUndiciStreamTimeouts({ timeoutMs: 15_000 });
 
-    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
       DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
     );
@@ -226,8 +238,12 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
     ensureGlobalUndiciStreamTimeouts({ timeoutMs });
 
-    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
-    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next).toBeInstanceOf(Agent);
+    expect(next.options?.bodyTimeout).toBe(timeoutMs);
+    expect(next.options?.headersTimeout).toBe(timeoutMs);
     expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(timeoutMs);
   });
 

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -1,14 +1,17 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   Agent,
   EnvHttpProxyAgent,
   ProxyAgent,
-  getGlobalDispatcher,
   setGlobalDispatcher,
   setCurrentDispatcher,
   getCurrentDispatcher,
   getDefaultAutoSelectFamily,
+  loadUndiciGlobalDispatcherDeps,
 } = vi.hoisted(() => {
   class Agent {
     constructor(public readonly options?: Record<string, unknown>) {}
@@ -34,6 +37,12 @@ const {
   };
   const getCurrentDispatcher = () => currentDispatcher;
   const getDefaultAutoSelectFamily = vi.fn(() => undefined as boolean | undefined);
+  const loadUndiciGlobalDispatcherDeps = vi.fn(() => ({
+    Agent,
+    EnvHttpProxyAgent,
+    getGlobalDispatcher,
+    setGlobalDispatcher,
+  }));
 
   return {
     Agent,
@@ -44,17 +53,11 @@ const {
     setCurrentDispatcher,
     getCurrentDispatcher,
     getDefaultAutoSelectFamily,
+    loadUndiciGlobalDispatcherDeps,
   };
 });
 
-const mockedModuleIds = ["node:net", "undici", "./proxy-env.js", "../wsl.js"] as const;
-
-vi.mock("undici", () => ({
-  Agent,
-  EnvHttpProxyAgent,
-  getGlobalDispatcher,
-  setGlobalDispatcher,
-}));
+const mockedModuleIds = ["node:net", "./proxy-env.js", "./undici-runtime.js", "../wsl.js"] as const;
 
 vi.mock("node:net", () => ({
   getDefaultAutoSelectFamily,
@@ -63,6 +66,10 @@ vi.mock("node:net", () => ({
 vi.mock("./proxy-env.js", () => ({
   hasEnvHttpProxyAgentConfigured: vi.fn(() => false),
   resolveEnvHttpProxyAgentOptions: vi.fn(() => undefined),
+}));
+
+vi.mock("./undici-runtime.js", () => ({
+  loadUndiciGlobalDispatcherDeps,
 }));
 
 vi.mock("../wsl.js", () => ({
@@ -99,24 +106,53 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue(undefined);
   });
 
-  it("replaces default Agent dispatcher with extended stream timeouts", () => {
+  it("records timeout bridge without importing undici when no env proxy is configured", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
 
     ensureGlobalUndiciStreamTimeouts();
 
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next).toBeInstanceOf(Agent);
-    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.connect).toEqual({
-      autoSelectFamily: true,
-      autoSelectFamilyAttemptTimeout: 300,
-    });
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
+      DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+    );
+  });
+
+  it("does not initialize the undici global dispatcher in a no-proxy subprocess", () => {
+    const moduleUrl = pathToFileURL(path.resolve("src/infra/net/undici-global-dispatcher.ts")).href;
+    const source = `
+      const dispatcherKey = Symbol.for("undici.globalDispatcher.1");
+      const mod = await import(${JSON.stringify(moduleUrl)});
+      mod.ensureGlobalUndiciStreamTimeouts({ timeoutMs: 1_900_000 });
+      if (globalThis[dispatcherKey] !== undefined) {
+        throw new Error("undici global dispatcher was initialized");
+      }
+      console.log("ok");
+    `;
+    const env = { ...process.env };
+    for (const key of [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "ALL_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "all_proxy",
+    ]) {
+      delete env[key];
+    }
+
+    const output = execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", source],
+      { cwd: process.cwd(), encoding: "utf8", env },
+    );
+
+    expect(output.trim()).toBe("ok");
   });
 
   it("replaces EnvHttpProxyAgent dispatcher while preserving env-proxy mode", () => {
     getDefaultAutoSelectFamily.mockReturnValue(false);
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
     setCurrentDispatcher(new EnvHttpProxyAgent());
 
     ensureGlobalUndiciStreamTimeouts();
@@ -133,6 +169,7 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
   });
 
   it("preserves explicit env proxy options when replacing EnvHttpProxyAgent dispatcher", () => {
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue({
       httpProxy: "socks5://proxy.test:1080",
       httpsProxy: "socks5://proxy.test:1080",
@@ -165,6 +202,8 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
   it("is idempotent for unchanged dispatcher kind and network policy", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new EnvHttpProxyAgent());
 
     ensureGlobalUndiciStreamTimeouts();
     ensureGlobalUndiciStreamTimeouts();
@@ -175,10 +214,11 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
   it("does not lower global stream timeouts below the default floor", () => {
     ensureGlobalUndiciStreamTimeouts({ timeoutMs: 15_000 });
 
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next.options?.bodyTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
-    expect(next.options?.headersTimeout).toBe(DEFAULT_UNDICI_STREAM_TIMEOUT_MS);
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(
+      DEFAULT_UNDICI_STREAM_TIMEOUT_MS,
+    );
   });
 
   it("honors explicit global stream timeouts above the default floor", () => {
@@ -186,13 +226,14 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
 
     ensureGlobalUndiciStreamTimeouts({ timeoutMs });
 
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
-    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next.options?.bodyTimeout).toBe(timeoutMs);
-    expect(next.options?.headersTimeout).toBe(timeoutMs);
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+    expect(undiciGlobalDispatcherModule._globalUndiciStreamTimeoutMs).toBe(timeoutMs);
   });
 
   it("re-applies when autoSelectFamily decision changes", () => {
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new EnvHttpProxyAgent());
     getDefaultAutoSelectFamily.mockReturnValue(true);
     ensureGlobalUndiciStreamTimeouts();
 
@@ -210,12 +251,14 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
   it("disables autoSelectFamily on WSL2 to avoid IPv6 connectivity issues", () => {
     getDefaultAutoSelectFamily.mockReturnValue(true);
     vi.mocked(isWSL2Sync).mockReturnValue(true);
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    setCurrentDispatcher(new EnvHttpProxyAgent());
 
     ensureGlobalUndiciStreamTimeouts();
 
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
-    expect(next).toBeInstanceOf(Agent);
+    expect(next).toBeInstanceOf(EnvHttpProxyAgent);
     expect(next.options?.connect).toEqual({
       autoSelectFamily: false,
       autoSelectFamilyAttemptTimeout: 300,
@@ -313,11 +356,26 @@ describe("forceResetGlobalDispatcher", () => {
     vi.mocked(resolveEnvHttpProxyAgentOptions).mockReturnValue(undefined);
   });
 
-  it("replaces an EnvHttpProxyAgent with a direct Agent when proxy env is cleared", () => {
+  it("does not import undici when proxy env is cleared", () => {
     setCurrentDispatcher(new EnvHttpProxyAgent());
 
     forceResetGlobalDispatcher();
 
+    expect(loadUndiciGlobalDispatcherDeps).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("restores a direct Agent when clearing a proxy dispatcher installed by OpenClaw", () => {
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(true);
+    ensureGlobalUndiciEnvProxyDispatcher();
+    expect(getCurrentDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+
+    vi.clearAllMocks();
+    vi.mocked(hasEnvHttpProxyAgentConfigured).mockReturnValue(false);
+
+    forceResetGlobalDispatcher();
+
+    expect(loadUndiciGlobalDispatcherDeps).toHaveBeenCalledTimes(1);
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     expect(getCurrentDispatcher()).toBeInstanceOf(Agent);
   });

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -99,10 +99,17 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   }
   const timeoutMs = Math.max(DEFAULT_UNDICI_STREAM_TIMEOUT_MS, Math.floor(timeoutMsRaw));
   _globalUndiciStreamTimeoutMs = timeoutMs;
+  if (!hasEnvHttpProxyAgentConfigured()) {
+    lastAppliedTimeoutKey = null;
+    return;
+  }
   const runtime = loadUndiciGlobalDispatcherDeps();
-  const { Agent, EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
+  const { EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
   const kind = resolveCurrentDispatcherKind(runtime);
   if (kind === null) {
+    return;
+  }
+  if (kind !== "env-proxy") {
     return;
   }
 
@@ -114,23 +121,13 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
   const connect = createUndiciAutoSelectFamilyConnectOptions(autoSelectFamily);
   try {
-    if (kind === "env-proxy") {
-      const proxyOptions = {
-        ...resolveEnvHttpProxyAgentOptions(),
-        bodyTimeout: timeoutMs,
-        headersTimeout: timeoutMs,
-        ...(connect ? { connect } : {}),
-      } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
-      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
-    } else {
-      setGlobalDispatcher(
-        new Agent({
-          bodyTimeout: timeoutMs,
-          headersTimeout: timeoutMs,
-          ...(connect ? { connect } : {}),
-        }),
-      );
-    }
+    const proxyOptions = {
+      ...resolveEnvHttpProxyAgentOptions(),
+      bodyTimeout: timeoutMs,
+      headersTimeout: timeoutMs,
+      ...(connect ? { connect } : {}),
+    } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
+    setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
     lastAppliedTimeoutKey = nextKey;
   } catch {
     // Best-effort hardening only.

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -49,9 +49,17 @@ function resolveDispatcherKey(params: {
   return `${params.kind}:${params.timeoutMs}:${autoSelectToken}`;
 }
 
+function resolveStreamTimeoutMs(opts?: { timeoutMs?: number }): number | null {
+  const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMsRaw)) {
+    return null;
+  }
+  return Math.max(DEFAULT_UNDICI_STREAM_TIMEOUT_MS, Math.floor(timeoutMsRaw));
+}
+
 function resolveCurrentDispatcherKind(
   runtime: Pick<UndiciGlobalDispatcherDeps, "getGlobalDispatcher">,
-): DispatcherKind | null {
+): Exclude<DispatcherKind, "unsupported"> | null {
   let dispatcher: unknown;
   try {
     dispatcher = runtime.getGlobalDispatcher();
@@ -92,27 +100,12 @@ export function ensureGlobalUndiciEnvProxyDispatcher(): void {
   }
 }
 
-export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
-  const timeoutMsRaw = opts?.timeoutMs ?? DEFAULT_UNDICI_STREAM_TIMEOUT_MS;
-  if (!Number.isFinite(timeoutMsRaw)) {
-    return;
-  }
-  const timeoutMs = Math.max(DEFAULT_UNDICI_STREAM_TIMEOUT_MS, Math.floor(timeoutMsRaw));
-  _globalUndiciStreamTimeoutMs = timeoutMs;
-  if (!hasEnvHttpProxyAgentConfigured()) {
-    lastAppliedTimeoutKey = null;
-    return;
-  }
-  const runtime = loadUndiciGlobalDispatcherDeps();
-  const { EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
-  const kind = resolveCurrentDispatcherKind(runtime);
-  if (kind === null) {
-    return;
-  }
-  if (kind !== "env-proxy") {
-    return;
-  }
-
+function applyGlobalDispatcherStreamTimeouts(params: {
+  runtime: UndiciGlobalDispatcherDeps;
+  kind: Exclude<DispatcherKind, "unsupported">;
+  timeoutMs: number;
+}): void {
+  const { runtime, kind, timeoutMs } = params;
   const autoSelectFamily = resolveUndiciAutoSelectFamily();
   const nextKey = resolveDispatcherKey({ kind, timeoutMs, autoSelectFamily });
   if (lastAppliedTimeoutKey === nextKey) {
@@ -121,17 +114,63 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
   const connect = createUndiciAutoSelectFamilyConnectOptions(autoSelectFamily);
   try {
-    const proxyOptions = {
-      ...resolveEnvHttpProxyAgentOptions(),
-      bodyTimeout: timeoutMs,
-      headersTimeout: timeoutMs,
-      ...(connect ? { connect } : {}),
-    } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
-    setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
+    if (kind === "env-proxy") {
+      const proxyOptions = {
+        ...resolveEnvHttpProxyAgentOptions(),
+        bodyTimeout: timeoutMs,
+        headersTimeout: timeoutMs,
+        ...(connect ? { connect } : {}),
+      } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
+      runtime.setGlobalDispatcher(new runtime.EnvHttpProxyAgent(proxyOptions));
+    } else {
+      runtime.setGlobalDispatcher(
+        new runtime.Agent({
+          bodyTimeout: timeoutMs,
+          headersTimeout: timeoutMs,
+          ...(connect ? { connect } : {}),
+        }),
+      );
+    }
     lastAppliedTimeoutKey = nextKey;
   } catch {
     // Best-effort hardening only.
   }
+}
+
+export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }): void {
+  const timeoutMs = resolveStreamTimeoutMs(opts);
+  if (timeoutMs === null) {
+    return;
+  }
+  _globalUndiciStreamTimeoutMs = timeoutMs;
+  if (!hasEnvHttpProxyAgentConfigured()) {
+    lastAppliedTimeoutKey = null;
+    return;
+  }
+  const runtime = loadUndiciGlobalDispatcherDeps();
+  const kind = resolveCurrentDispatcherKind(runtime);
+  if (kind === null) {
+    return;
+  }
+  if (kind !== "env-proxy") {
+    return;
+  }
+
+  applyGlobalDispatcherStreamTimeouts({ runtime, kind, timeoutMs });
+}
+
+export function ensureGlobalUndiciDispatcherStreamTimeouts(opts?: { timeoutMs?: number }): void {
+  const timeoutMs = resolveStreamTimeoutMs(opts);
+  if (timeoutMs === null) {
+    return;
+  }
+  _globalUndiciStreamTimeoutMs = timeoutMs;
+  const runtime = loadUndiciGlobalDispatcherDeps();
+  const kind = resolveCurrentDispatcherKind(runtime);
+  if (kind === null) {
+    return;
+  }
+  applyGlobalDispatcherStreamTimeouts({ runtime, kind, timeoutMs });
 }
 
 export function resetGlobalUndiciStreamTimeoutsForTests(): void {

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -1,9 +1,12 @@
-import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 import { hasEnvHttpProxyAgentConfigured, resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
 import {
   createUndiciAutoSelectFamilyConnectOptions,
   resolveUndiciAutoSelectFamily,
 } from "./undici-family-policy.js";
+import {
+  loadUndiciGlobalDispatcherDeps,
+  type UndiciGlobalDispatcherDeps,
+} from "./undici-runtime.js";
 
 export const DEFAULT_UNDICI_STREAM_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -46,10 +49,12 @@ function resolveDispatcherKey(params: {
   return `${params.kind}:${params.timeoutMs}:${autoSelectToken}`;
 }
 
-function resolveCurrentDispatcherKind(): DispatcherKind | null {
+function resolveCurrentDispatcherKind(
+  runtime: Pick<UndiciGlobalDispatcherDeps, "getGlobalDispatcher">,
+): DispatcherKind | null {
   let dispatcher: unknown;
   try {
-    dispatcher = getGlobalDispatcher();
+    dispatcher = runtime.getGlobalDispatcher();
   } catch {
     return null;
   }
@@ -63,13 +68,15 @@ export function ensureGlobalUndiciEnvProxyDispatcher(): void {
   if (!shouldUseEnvProxy) {
     return;
   }
+  const runtime = loadUndiciGlobalDispatcherDeps();
+  const { EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
   if (lastAppliedProxyBootstrap) {
-    if (resolveCurrentDispatcherKind() === "env-proxy") {
+    if (resolveCurrentDispatcherKind(runtime) === "env-proxy") {
       return;
     }
     lastAppliedProxyBootstrap = false;
   }
-  const currentKind = resolveCurrentDispatcherKind();
+  const currentKind = resolveCurrentDispatcherKind(runtime);
   if (currentKind === null) {
     return;
   }
@@ -92,8 +99,17 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   }
   const timeoutMs = Math.max(DEFAULT_UNDICI_STREAM_TIMEOUT_MS, Math.floor(timeoutMsRaw));
   _globalUndiciStreamTimeoutMs = timeoutMs;
-  const kind = resolveCurrentDispatcherKind();
+  if (!hasEnvHttpProxyAgentConfigured()) {
+    lastAppliedTimeoutKey = null;
+    return;
+  }
+  const runtime = loadUndiciGlobalDispatcherDeps();
+  const { EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
+  const kind = resolveCurrentDispatcherKind(runtime);
   if (kind === null) {
+    return;
+  }
+  if (kind !== "env-proxy") {
     return;
   }
 
@@ -105,23 +121,13 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
   const connect = createUndiciAutoSelectFamilyConnectOptions(autoSelectFamily);
   try {
-    if (kind === "env-proxy") {
-      const proxyOptions = {
-        ...resolveEnvHttpProxyAgentOptions(),
-        bodyTimeout: timeoutMs,
-        headersTimeout: timeoutMs,
-        ...(connect ? { connect } : {}),
-      } as ConstructorParameters<typeof EnvHttpProxyAgent>[0];
-      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
-    } else {
-      setGlobalDispatcher(
-        new Agent({
-          bodyTimeout: timeoutMs,
-          headersTimeout: timeoutMs,
-          ...(connect ? { connect } : {}),
-        }),
-      );
-    }
+    const proxyOptions = {
+      ...resolveEnvHttpProxyAgentOptions(),
+      bodyTimeout: timeoutMs,
+      headersTimeout: timeoutMs,
+      ...(connect ? { connect } : {}),
+    } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
+    setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
     lastAppliedTimeoutKey = nextKey;
   } catch {
     // Best-effort hardening only.
@@ -140,17 +146,29 @@ export function resetGlobalUndiciStreamTimeoutsForTests(): void {
  */
 export function forceResetGlobalDispatcher(): void {
   lastAppliedTimeoutKey = null;
+  if (!hasEnvHttpProxyAgentConfigured()) {
+    if (!lastAppliedProxyBootstrap) {
+      return;
+    }
+    lastAppliedProxyBootstrap = false;
+    try {
+      const { Agent, setGlobalDispatcher } = loadUndiciGlobalDispatcherDeps();
+      setGlobalDispatcher(new Agent());
+    } catch {
+      // Best-effort reset only.
+    }
+    return;
+  }
   lastAppliedProxyBootstrap = false;
   try {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = loadUndiciGlobalDispatcherDeps();
     const proxyOptions = resolveEnvHttpProxyAgentOptions();
-    if (hasEnvHttpProxyAgentConfigured()) {
-      setGlobalDispatcher(
-        new EnvHttpProxyAgent(proxyOptions as ConstructorParameters<typeof EnvHttpProxyAgent>[0]),
-      );
-      lastAppliedProxyBootstrap = true;
-    } else {
-      setGlobalDispatcher(new Agent());
-    }
+    setGlobalDispatcher(
+      new EnvHttpProxyAgent(
+        proxyOptions as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0],
+      ),
+    );
+    lastAppliedProxyBootstrap = true;
   } catch {
     // Best-effort reset only.
   }

--- a/src/infra/net/undici-global-dispatcher.ts
+++ b/src/infra/net/undici-global-dispatcher.ts
@@ -99,17 +99,10 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
   }
   const timeoutMs = Math.max(DEFAULT_UNDICI_STREAM_TIMEOUT_MS, Math.floor(timeoutMsRaw));
   _globalUndiciStreamTimeoutMs = timeoutMs;
-  if (!hasEnvHttpProxyAgentConfigured()) {
-    lastAppliedTimeoutKey = null;
-    return;
-  }
   const runtime = loadUndiciGlobalDispatcherDeps();
-  const { EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
+  const { Agent, EnvHttpProxyAgent, setGlobalDispatcher } = runtime;
   const kind = resolveCurrentDispatcherKind(runtime);
   if (kind === null) {
-    return;
-  }
-  if (kind !== "env-proxy") {
     return;
   }
 
@@ -121,13 +114,23 @@ export function ensureGlobalUndiciStreamTimeouts(opts?: { timeoutMs?: number }):
 
   const connect = createUndiciAutoSelectFamilyConnectOptions(autoSelectFamily);
   try {
-    const proxyOptions = {
-      ...resolveEnvHttpProxyAgentOptions(),
-      bodyTimeout: timeoutMs,
-      headersTimeout: timeoutMs,
-      ...(connect ? { connect } : {}),
-    } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
-    setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
+    if (kind === "env-proxy") {
+      const proxyOptions = {
+        ...resolveEnvHttpProxyAgentOptions(),
+        bodyTimeout: timeoutMs,
+        headersTimeout: timeoutMs,
+        ...(connect ? { connect } : {}),
+      } as ConstructorParameters<UndiciGlobalDispatcherDeps["EnvHttpProxyAgent"]>[0];
+      setGlobalDispatcher(new EnvHttpProxyAgent(proxyOptions));
+    } else {
+      setGlobalDispatcher(
+        new Agent({
+          bodyTimeout: timeoutMs,
+          headersTimeout: timeoutMs,
+          ...(connect ? { connect } : {}),
+        }),
+      );
+    }
     lastAppliedTimeoutKey = nextKey;
   } catch {
     // Best-effort hardening only.

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -11,6 +11,11 @@ export type UndiciRuntimeDeps = {
   fetch: typeof import("undici").fetch;
 };
 
+export type UndiciGlobalDispatcherDeps = Pick<UndiciRuntimeDeps, "Agent" | "EnvHttpProxyAgent"> & {
+  getGlobalDispatcher: typeof import("undici").getGlobalDispatcher;
+  setGlobalDispatcher: typeof import("undici").setGlobalDispatcher;
+};
+
 type UndiciAgentOptions = ConstructorParameters<UndiciRuntimeDeps["Agent"]>[0];
 type UndiciEnvHttpProxyAgentOptions = ConstructorParameters<
   UndiciRuntimeDeps["EnvHttpProxyAgent"]
@@ -50,6 +55,17 @@ function isUndiciRuntimeDeps(value: unknown): value is UndiciRuntimeDeps {
   );
 }
 
+function isUndiciGlobalDispatcherDeps(value: unknown): value is UndiciGlobalDispatcherDeps {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as UndiciGlobalDispatcherDeps).Agent === "function" &&
+    typeof (value as UndiciGlobalDispatcherDeps).EnvHttpProxyAgent === "function" &&
+    typeof (value as UndiciGlobalDispatcherDeps).getGlobalDispatcher === "function" &&
+    typeof (value as UndiciGlobalDispatcherDeps).setGlobalDispatcher === "function"
+  );
+}
+
 export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
   const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
   if (isUndiciRuntimeDeps(override)) {
@@ -64,6 +80,22 @@ export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
     FormData: undici.FormData,
     ProxyAgent: undici.ProxyAgent,
     fetch: undici.fetch,
+  };
+}
+
+export function loadUndiciGlobalDispatcherDeps(): UndiciGlobalDispatcherDeps {
+  const override = (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY];
+  if (isUndiciGlobalDispatcherDeps(override)) {
+    return override;
+  }
+
+  const require = createRequire(import.meta.url);
+  const undici = require("undici") as typeof import("undici");
+  return {
+    Agent: undici.Agent,
+    EnvHttpProxyAgent: undici.EnvHttpProxyAgent,
+    getGlobalDispatcher: undici.getGlobalDispatcher,
+    setGlobalDispatcher: undici.setGlobalDispatcher,
   };
 }
 

--- a/src/plugin-sdk/fetch-runtime.test.ts
+++ b/src/plugin-sdk/fetch-runtime.test.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("plugin SDK fetch runtime", () => {
+  it("does not initialize the undici global dispatcher on import", () => {
+    const moduleUrl = pathToFileURL(path.resolve("src/plugin-sdk/fetch-runtime.ts")).href;
+    const source = `
+      const dispatcherKey = Symbol.for("undici.globalDispatcher.1");
+      await import(${JSON.stringify(moduleUrl)});
+      if (globalThis[dispatcherKey] !== undefined) {
+        throw new Error("undici global dispatcher was initialized");
+      }
+      console.log("ok");
+    `;
+    const env = { ...process.env };
+    for (const key of [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "ALL_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "all_proxy",
+      "OPENCLAW_DEBUG_PROXY_ENABLED",
+    ]) {
+      delete env[key];
+    }
+
+    const output = execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", source],
+      { cwd: process.cwd(), encoding: "utf8", env },
+    );
+
+    expect(output.trim()).toBe("ok");
+  });
+});

--- a/src/proxy-capture/env.ts
+++ b/src/proxy-capture/env.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Agent } from "node:http";
+import { createRequire } from "node:module";
 import process from "node:process";
-import { HttpsProxyAgent } from "https-proxy-agent";
 import {
   resolveDebugProxyBlobDir,
   resolveDebugProxyCertDir,
@@ -28,6 +28,14 @@ export type DebugProxySettings = {
 };
 
 let cachedImplicitSessionId: string | undefined;
+let cachedHttpsProxyAgent: typeof import("https-proxy-agent").HttpsProxyAgent | undefined;
+
+function loadHttpsProxyAgent(): typeof import("https-proxy-agent").HttpsProxyAgent {
+  cachedHttpsProxyAgent ??= (
+    createRequire(import.meta.url)("https-proxy-agent") as typeof import("https-proxy-agent")
+  ).HttpsProxyAgent;
+  return cachedHttpsProxyAgent;
+}
 
 function isTruthy(value: string | undefined): boolean {
   return value === "1" || value === "true" || value === "yes" || value === "on";
@@ -80,6 +88,7 @@ export function createDebugProxyWebSocketAgent(settings: DebugProxySettings): Ag
   if (!settings.enabled || !settings.proxyUrl) {
     return undefined;
   }
+  const HttpsProxyAgent = loadHttpsProxyAgent();
   return new HttpsProxyAgent(settings.proxyUrl);
 }
 


### PR DESCRIPTION
## Summary

- Problem: external channel plugin startup could import OpenClaw's packaged Undici proxy helpers on a clean no-proxy path, changing process-level fetch behavior before the plugin called `globalThis.fetch`.
- Why it matters: `openclaw channels login --channel openclaw-weixin` failed for `@tencent-weixin/openclaw-weixin@2.4.1` with `TypeError: fetch failed` even though the same request worked in plain Node fetch.
- What changed: lazy-load Undici dispatcher/proxy dependencies only when OpenClaw actually creates a proxy fetch or proxy dispatcher, while keeping the guarded-fetch timeout bridge and proxy reset behavior intact.
- What did NOT change (scope boundary): no plugin code is changed, no proxy env contract is removed, and no configured proxy path is intentionally bypassed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #78007
- Related #78040
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Tencent Weixin channel login failed before QR startup because the plugin's plain fetch request was rejected after OpenClaw loaded packaged Undici helpers.
- Real environment tested: source checkout on macOS with isolated `HOME`, isolated `OPENCLAW_STATE_DIR`, and `@tencent-weixin/openclaw-weixin@2.4.1` installed through `openclaw plugins install`.
- Exact steps or command run after this patch:
  1. `pnpm openclaw plugins install @tencent-weixin/openclaw-weixin@2.4.1 --pin`
  2. `pnpm openclaw channels login --channel openclaw-weixin --verbose`
- Evidence after fix:

```text
[plugins] loading openclaw-weixin from /private/tmp/openclaw-78007.Ez0VWR/.openclaw/npm/node_modules/@tencent-weixin/openclaw-weixin/dist/index.js
[plugins] loaded 1 plugin(s) (1 attempted) in 1516.5ms
用手机微信扫描以下二维码，以继续连接：
若二维码未能显示或无法使用，你可以访问以下链接以继续：
https://liteapp.weixin.qq.com/q/7GiQu1?qrcode=3e04d58f044ba6b007fc02cca258bf48&bot_type=3
```

- Observed result after fix: the login flow reaches QR startup instead of failing at `TypeError: fetch failed`.
- What was not tested: scanning the QR code and completing the Weixin account-linking flow.
- Before evidence:

```text
Failed to start login: TypeError: fetch failed
Channel login failed: Error: Failed to start login: TypeError: fetch failed
```

Trace before fix showed the underlying cause:

```text
UND_ERR_INVALID_ARG: invalid content-length header
```

## Root Cause (if applicable)

- Root cause: `src/infra/net/proxy-fetch.ts` imported Undici at module load time. That module is exported through plugin runtime helper surfaces, so loading external plugin code could initialize Undici's package dispatcher state even when no proxy was configured. With the current Undici dependency, that changed Node global fetch behavior and caused plugin requests with explicit `Content-Length` to fail.
- Missing detection / guardrail: there was no regression test proving clean no-proxy startup does not initialize Undici global dispatcher state.
- Contributing context (if known): the affected plugin sends an explicit `Content-Length` header; plain Node fetch accepts the request, but OpenClaw's import side effect made the same request fail.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/infra/net/undici-global-dispatcher.test.ts`
  - `src/infra/net/proxy-fetch.test.ts`
  - `src/infra/net/fetch-guard.ssrf.test.ts`
- Scenario the test should lock in: no-proxy timeout setup and proxy helper import must not initialize Undici global dispatcher state; proxy fetch and env proxy paths must still lazy-load and use Undici when needed.
- Why this is the smallest reliable guardrail: the regression was an import-time side effect, so a subprocess assertion against the global dispatcher symbol catches the exact failure class without requiring live third-party auth.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

External channel plugins that use plain `fetch()` no longer inherit OpenClaw's packaged Undici dispatcher behavior on clean no-proxy startup. This fixes the Weixin QR login regression in #78007.

## Diagram (if applicable)

```text
Before:
plugin load -> SDK/runtime helper import -> proxy-fetch imports Undici -> plugin fetch fails

After:
plugin load -> SDK/runtime helper import -> no Undici import unless proxy fetch is created -> plugin fetch reaches QR login
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout; Blacksmith Testbox for remote validation
- Runtime/container: source checkout, Node 24, pnpm 10
- Model/provider: N/A
- Integration/channel: `@tencent-weixin/openclaw-weixin@2.4.1`
- Relevant config (redacted): isolated state dir with only the installed plugin enabled

### Steps

1. Install `@tencent-weixin/openclaw-weixin@2.4.1` into an isolated state dir.
2. Run `pnpm openclaw channels login --channel openclaw-weixin --verbose`.
3. Confirm the command reaches QR login output instead of failing with `TypeError: fetch failed`.

### Expected

- The Weixin login request reaches QR login startup.

### Actual

- After this patch, the command reaches QR login startup.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- `pnpm test src/infra/net/proxy-fetch.test.ts src/infra/net/undici-global-dispatcher.test.ts src/infra/net/fetch-guard.ssrf.test.ts`
- Same targeted test command passed in Blacksmith Testbox.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/infra/net/proxy-fetch.ts src/infra/net/proxy-fetch.test.ts src/infra/net/undici-runtime.ts src/infra/net/undici-global-dispatcher.ts src/infra/net/undici-global-dispatcher.test.ts src/infra/net/fetch-guard.ssrf.test.ts`
- `git diff --check`
- Real isolated `openclaw channels login --channel openclaw-weixin --verbose` reached QR login output.

Edge cases checked:

- No-proxy timeout setup does not initialize Undici global dispatcher state.
- Env proxy setup still installs `EnvHttpProxyAgent`.
- Proxy fetch still creates `ProxyAgent` lazily.
- FormData normalization still strips stale `content-length`/`content-type` in proxy fetch paths.
- Clearing a proxy dispatcher installed by OpenClaw still restores a direct dispatcher.

What I did **not** verify:

- Full Weixin account-linking after QR scan.
- Full repo test suite.

Note: `pnpm check:changed` was run in Blacksmith Testbox after rebase and failed in `tsgo:core:test` on `src/agents/model-fallback.test.ts`, which this PR does not touch:

```text
src/agents/model-fallback.test.ts(1091,22): error TS2339: Property 'expectedReason' does not exist on type ...
src/agents/model-fallback.test.ts(1093,60): error TS2339: Property 'expectedReason' does not exist on type ...
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: proxy paths could stop loading Undici too early.
  - Mitigation: proxy fetch and env proxy dispatcher tests assert lazy creation still loads and uses the expected Undici agents.
- Risk: direct guarded fetches could lose timeout propagation.
  - Mitigation: guarded fetch tests still assert the timeout bridge is inherited by direct guarded dispatchers.
