### PR TITLE
fix: report gateway draining in readiness

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -50,7 +50,7 @@ import {
   pinActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
-import { getTotalQueueSize } from "../process/command-queue.js";
+import { getTotalQueueSize, isGatewayDraining } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearSecretsRuntimeSnapshot,
@@ -812,6 +812,7 @@ export async function startGatewayServer(
     startedAt: serverStartedAt,
     getStartupPending: () => !startupSidecarsReady,
     getStartupPendingReason: () => startupPendingReason,
+    getGatewayDraining: isGatewayDraining,
     getEventLoopHealth: readinessEventLoopHealth.snapshot,
     shouldSkipChannelReadiness: () =>
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -65,6 +65,7 @@ function createReadinessHarness(params: {
   accounts: Record<string, Partial<ChannelAccountSnapshot>>;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: Parameters<typeof createReadinessChecker>[0]["getStartupPendingReason"];
+  getGatewayDraining?: Parameters<typeof createReadinessChecker>[0]["getGatewayDraining"];
   getEventLoopHealth?: Parameters<typeof createReadinessChecker>[0]["getEventLoopHealth"];
   shouldSkipChannelReadiness?: Parameters<
     typeof createReadinessChecker
@@ -80,6 +81,7 @@ function createReadinessHarness(params: {
       startedAt,
       getStartupPending: params.getStartupPending,
       getStartupPendingReason: params.getStartupPendingReason,
+      getGatewayDraining: params.getGatewayDraining,
       getEventLoopHealth: params.getEventLoopHealth,
       shouldSkipChannelReadiness: params.shouldSkipChannelReadiness,
       cacheTtlMs: params.cacheTtlMs,
@@ -146,6 +148,45 @@ describe("createReadinessChecker", () => {
       expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
 
       startupPending = false;
+      expect(readiness()).toEqual({ ready: true, failing: [], uptimeMs: 300_000 });
+      expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reports not ready while the gateway command queue is draining for restart", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        startedAgoMs: 5 * 60_000,
+        accounts: {},
+        getGatewayDraining: () => true,
+        cacheTtlMs: 1_000,
+      });
+      expect(readiness()).toEqual({
+        ready: false,
+        failing: ["gateway-draining"],
+        uptimeMs: 300_000,
+      });
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not cache gateway-draining readiness", () => {
+    withReadinessClock(() => {
+      let gatewayDraining = true;
+      const { manager, readiness } = createReadinessHarness({
+        startedAgoMs: 5 * 60_000,
+        accounts: {},
+        getGatewayDraining: () => gatewayDraining,
+        cacheTtlMs: 1_000,
+      });
+      expect(readiness()).toEqual({
+        ready: false,
+        failing: ["gateway-draining"],
+        uptimeMs: 300_000,
+      });
+      expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();
+
+      gatewayDraining = false;
       expect(readiness()).toEqual({ ready: true, failing: [], uptimeMs: 300_000 });
       expect(manager.getRuntimeSnapshot).toHaveBeenCalledTimes(1);
     });

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -38,6 +38,7 @@ export function createReadinessChecker(deps: {
   startedAt: number;
   getStartupPending?: () => boolean;
   getStartupPendingReason?: () => string | undefined;
+  getGatewayDraining?: () => boolean;
   getEventLoopHealth?: () => GatewayEventLoopHealth | undefined;
   shouldSkipChannelReadiness?: () => boolean;
   cacheTtlMs?: number;
@@ -54,6 +55,12 @@ export function createReadinessChecker(deps: {
       const reason = deps.getStartupPendingReason?.() ?? "startup-sidecars";
       return withEventLoopHealth(
         { ready: false, failing: [reason], uptimeMs },
+        deps.getEventLoopHealth,
+      );
+    }
+    if (deps.getGatewayDraining?.()) {
+      return withEventLoopHealth(
+        { ready: false, failing: ["gateway-draining"], uptimeMs },
         deps.getEventLoopHealth,
       );
     }

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -30,6 +30,7 @@ let getActiveTaskCount: CommandQueueModule["getActiveTaskCount"];
 let getCommandLaneSnapshot: CommandQueueModule["getCommandLaneSnapshot"];
 let getCommandLaneSnapshots: CommandQueueModule["getCommandLaneSnapshots"];
 let getQueueSize: CommandQueueModule["getQueueSize"];
+let isGatewayDraining: CommandQueueModule["isGatewayDraining"];
 let markGatewayDraining: CommandQueueModule["markGatewayDraining"];
 let resetAllLanes: CommandQueueModule["resetAllLanes"];
 let resetCommandLane: CommandQueueModule["resetCommandLane"];
@@ -72,6 +73,7 @@ describe("command queue", () => {
       getCommandLaneSnapshot,
       getCommandLaneSnapshots,
       getQueueSize,
+      isGatewayDraining,
       markGatewayDraining,
       resetAllLanes,
       resetCommandLane,
@@ -498,7 +500,9 @@ describe("command queue", () => {
   });
 
   it("rejects new enqueues with GatewayDrainingError after markGatewayDraining", async () => {
+    expect(isGatewayDraining()).toBe(false);
     markGatewayDraining();
+    expect(isGatewayDraining()).toBe(true);
     await expect(enqueueCommand(async () => "blocked")).rejects.toBeInstanceOf(
       GatewayDrainingError,
     );

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -308,6 +308,10 @@ export function markGatewayDraining(): void {
   getQueueState().gatewayDraining = true;
 }
 
+export function isGatewayDraining(): boolean {
+  return getQueueState().gatewayDraining === true;
+}
+
 export function setCommandLaneConcurrency(lane: string, maxConcurrent: number) {
   const cleaned = normalizeLane(lane);
   const state = getLaneState(cleaned);


### PR DESCRIPTION
## Summary

Fixes #78136 by making gateway readiness reflect the command-queue restart drain gate. While `GatewayDrainingError` would reject new model/tool work, `/readyz` now returns not-ready with `gateway-draining`; `/healthz` remains shallow liveness.

## Changes

- Export `isGatewayDraining()` from the command queue runtime.
- Wire gateway readiness to the command-queue drain flag.
- Avoid caching the transient draining readiness state.
- Add regression tests for the readiness mismatch and queue drain-state accessor.

## Testing

- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/test-projects.mjs src/process/command-queue.test.ts` — passed (23 tests)
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server/readiness.test.ts` — passed (15 tests)
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" pnpm oxfmt --check src/process/command-queue.ts src/process/command-queue.test.ts src/gateway/server/readiness.ts src/gateway/server/readiness.test.ts src/gateway/server.impl.ts` — passed
- `git diff --check` — passed
- `PATH="/tmp/openclaw-pnpm-shim:$PATH" node scripts/check-changed.mjs` — failed in core test typecheck on unrelated pre-existing `src/agents/model-fallback.test.ts` errors (`expectedReason` missing at lines 1091/1093); core production typecheck passed.

Fixes openclaw/openclaw#78136
